### PR TITLE
ref: Stop double-processing minidumps, step 2

### DIFF
--- a/src/sentry/lang/native/minidump.py
+++ b/src/sentry/lang/native/minidump.py
@@ -48,6 +48,7 @@ def is_minidump_event(data):
 
 
 def is_unreal_exception_stacktrace(data):
+    # TODO(markus): Remove after unreal portable callstacks are parsed in enhancers
     exceptions = get_path(data, 'exception', 'values', filter=True)
     return get_path(exceptions, 0, 'mechanism', 'type') == 'unreal'
 

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -12,6 +12,7 @@ from sentry.cache import default_cache
 from sentry.coreapi import cache_key_for_event
 from sentry.plugins import Plugin2
 from sentry.lang.native.minidump import get_attached_minidump, is_minidump_event, merge_symbolicator_minidump_response
+from sentry.lang.native.unreal import is_unreal_event, reprocess_unreal_crash
 from sentry.lang.native.symbolizer import Symbolizer, SymbolicationFailed
 from sentry.lang.native.symbolicator import run_symbolicator, merge_symbolicator_image, create_minidump_task, handle_symbolicator_response_status
 from sentry.lang.native.utils import get_sdk_from_event, handle_symbolication_failed, cpu_name_from_data, \
@@ -394,8 +395,14 @@ class NativePlugin(Plugin2):
     can_disable = False
 
     def get_event_enhancers(self, data):
+        rv = []
         if is_minidump_event(data):
-            return [reprocess_minidump]
+            rv.append(reprocess_minidump)
+
+        if is_unreal_event(data):
+            rv.append(reprocess_unreal_crash)
+
+        return rv
 
     def get_stacktrace_processors(self, data, stacktrace_infos, platforms, **kwargs):
         if any(platform in NativeStacktraceProcessor.supported_platforms for platform in platforms):

--- a/src/sentry/lang/native/unreal.py
+++ b/src/sentry/lang/native/unreal.py
@@ -31,13 +31,16 @@ def reprocess_unreal_crash(data):
 
     images = get_path(data, 'debug_meta', 'images', filter=True, default=())
     exception = get_path(data, 'exception', 'values', 0)
-    if not exception:
-        return
 
     frames = parse_portable_callstack(portable_call_stack, images)
-    if frames:
+    if not frames:
+        return
+
+    if exception:
         exception['mechanism'] = {'type': 'unreal', 'handled': False, 'synthetic': True}
         exception['stacktrace'] = {'frames': frames}
+    else:
+        data['stacktrace'] = {'frames': frames}
 
     return data
 

--- a/src/sentry/lang/native/unreal.py
+++ b/src/sentry/lang/native/unreal.py
@@ -16,6 +16,32 @@ _portable_callstack_regexp = re.compile(r'''(?x)
 ''')
 
 
+def is_unreal_event(data):
+    """Whether this event is an Unreal crash that should be processed in
+    enhancers. For the legacy codepath this still returns False."""
+    return get_path(data, 'contexts', 'unreal', 'type') == 'unreal'
+
+
+def reprocess_unreal_crash(data):
+    context = get_path(data, 'contexts', 'unreal')
+    portable_call_stack = get_path(context, 'portable_call_stack')
+
+    if not portable_call_stack:
+        return
+
+    images = get_path(data, 'debug_meta', 'images', filter=True, default=())
+    exception = get_path(data, 'exception', 'values', 0)
+    if not exception:
+        return
+
+    frames = parse_portable_callstack(portable_call_stack, images)
+    if frames:
+        exception['mechanism'] = {'type': 'unreal', 'handled': False, 'synthetic': True}
+        exception['stacktrace'] = {'frames': frames}
+
+    return data
+
+
 def process_unreal_crash(payload, user_id, environment, event):
     """Initial processing of the event from the Unreal Crash Reporter data.
     Processes the raw bytes of the unreal crash by returning a Unreal4Crash"""
@@ -124,7 +150,7 @@ def parse_portable_callstack(portable_callstack, images):
     return frames
 
 
-def merge_unreal_context_event(unreal_context, event, project):
+def merge_unreal_context_event(unreal_context, event, project, refactor_enabled=False):
     """Merges the context from an Unreal Engine 4 crash
     with the given event."""
     runtime_prop = unreal_context.get('runtime_properties')
@@ -168,15 +194,23 @@ def merge_unreal_context_event(unreal_context, event, project):
 
     portable_callstack = runtime_prop.pop('portable_call_stack', None)
     if portable_callstack is not None:
-        images = get_path(event, 'debug_meta', 'images', filter=True, default=())
-        frames = parse_portable_callstack(portable_callstack, images)
+        if refactor_enabled:
+            set_path(event, 'contexts', 'unreal', 'type', value='unreal')
+            set_path(event, 'contexts', 'unreal', 'portable_call_stack',
+                     value=portable_callstack)
+            # TODO(markus): Add other stuff from extra here. Make sure trimming
+            # will not be a problem for portable_call_stack then!
+        else:
+            # TODO(markus): Remove after refactor rolled out
+            images = get_path(event, 'debug_meta', 'images', filter=True, default=())
+            frames = parse_portable_callstack(portable_callstack, images)
 
-        if len(frames) > 0:
-            exception = get_path(event, 'exception', 'values', 0)
-            if exception:
-                # This property is required for correct behavior of symbolicator codepath.
-                exception['mechanism'] = {'type': 'unreal', 'handled': False, 'synthetic': True}
-            event['stacktrace'] = {'frames': frames}
+            if len(frames) > 0:
+                exception = get_path(event, 'exception', 'values', 0)
+                if exception:
+                    # This property is required for correct behavior of symbolicator codepath.
+                    exception['mechanism'] = {'type': 'unreal', 'handled': False, 'synthetic': True}
+                event['stacktrace'] = {'frames': frames}
 
     # drop modules. minidump processing adds 'images loaded'
     runtime_prop.pop('modules', None)

--- a/src/sentry/lang/native/unreal.py
+++ b/src/sentry/lang/native/unreal.py
@@ -31,15 +31,16 @@ def reprocess_unreal_crash(data):
 
     images = get_path(data, 'debug_meta', 'images', filter=True, default=())
     exception = get_path(data, 'exception', 'values', 0)
-    if not exception:
-        return
 
     frames = parse_portable_callstack(portable_call_stack, images)
     if not frames:
         return
 
-    exception['mechanism'] = {'type': 'unreal', 'handled': False, 'synthetic': True}
-    exception['stacktrace'] = {'frames': frames}
+    if exception:
+        exception['mechanism'] = {'type': 'unreal', 'handled': False, 'synthetic': True}
+        exception['stacktrace'] = {'frames': frames}
+    else:
+        data['stacktrace'] = {'frames': frames}
 
     return data
 
@@ -73,44 +74,33 @@ def unreal_attachment_type(unreal_file):
 
 def merge_apple_crash_report(apple_crash_report, event):
     event['platform'] = 'native'
-    event['level'] = 'info'
 
     timestamp = apple_crash_report.get('timestamp')
     if timestamp:
         event['timestamp'] = timestamp
 
-    exception = get_path(event, 'exception', 'values', 0)
-
     event['threads'] = []
-
     for thread in apple_crash_report['threads']:
         crashed = thread.get('crashed')
-        event_thread = {
+        event['threads'].append({
             'id': thread.get('id'),
             'name': thread.get('name'),
             'crashed': crashed,
-        }
-        event['threads'].append(event_thread)
-
-        stacktrace = {
-            'frames': [{
-                'instruction_addr': frame.get('instruction_addr'),
-                'package': frame.get('module'),
-                'lineno': frame.get('lineno'),
-                'filename': frame.get('filename'),
-            } for frame in reversed(thread.get('frames', []))],
-            'registers': thread.get('registers', []),
-        }
-
+            'stacktrace': {
+                'frames': [{
+                    'instruction_addr': frame.get('instruction_addr'),
+                    'package': frame.get('module'),
+                    'lineno': frame.get('lineno'),
+                    'filename': frame.get('filename'),
+                } for frame in reversed(thread.get('frames', []))],
+                'registers': thread.get('registers', []),
+            },
+        })
         if crashed:
             event['level'] = 'fatal'
 
-        if crashed and exception:
-            exception['mechanism'] = {'type': 'unreal', 'handled': False, 'synthetic': True}
-            exception['stacktrace'] = stacktrace
-        else:
-            # TODO(markus): Remove after unreal endpoint refactor is rolled out
-            event_thread['stacktrace'] = stacktrace
+    if event.get('level') is None:
+        event['level'] = 'info'
 
     metadata = apple_crash_report.get('metadata')
     if metadata:
@@ -171,12 +161,8 @@ def merge_unreal_context_event(unreal_context, event, project, refactor_enabled=
         return
 
     message = runtime_prop.pop('error_message', None)
-    exception = get_path(event, 'exception', 'values', 0)
     if message is not None:
         event['message'] = message
-        if exception:
-            exception.pop('type', None)
-            exception['value'] = message
 
     username = runtime_prop.pop('username', None)
     if username is not None:
@@ -223,6 +209,7 @@ def merge_unreal_context_event(unreal_context, event, project, refactor_enabled=
             frames = parse_portable_callstack(portable_callstack, images)
 
             if len(frames) > 0:
+                exception = get_path(event, 'exception', 'values', 0)
                 if exception:
                     # This property is required for correct behavior of symbolicator codepath.
                     exception['mechanism'] = {'type': 'unreal', 'handled': False, 'synthetic': True}

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -176,7 +176,8 @@ register('store.projects-normalize-in-rust-percent-opt-in', default=0.0)  # unus
 # From 0.0 to 1.0: Randomly disable normalization code in interfaces when loading from db
 register('store.empty-interface-sample-rate', default=0.0)
 
-# Symbolicator
+# Symbolicator refactors
+# - Disabling minidump stackwalking in endpoints
 register('symbolicator.minidump-refactor-projects-opt-in', type=Sequence, default=[])
 register('symbolicator.minidump-refactor-projects-opt-out', type=Sequence, default=[])
 register('symbolicator.minidump-refactor-random-sampling', default=0.0)

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -768,7 +768,7 @@ class MinidumpView(StoreView):
         refactor_enabled = _minidump_refactor_enabled(project.id)
         metrics.incr(
             'symbolicator.minidump-refactor-enabled',
-            tags={'value': refactor_enabled}
+            tags={'value': refactor_enabled, 'endpoint': 'minidump'}
         )
 
         if refactor_enabled:
@@ -845,22 +845,33 @@ class UnrealView(StoreView):
         attachments_enabled = features.has('organizations:event-attachments',
                                            project.organization, actor=request.user)
 
+        has_crash_data = False
+
         attachments = []
         event = {'event_id': uuid.uuid4().hex}
         try:
             unreal = process_unreal_crash(request.body, request.GET.get(
                 'UserID'), request.GET.get('AppEnvironment'), event)
-            process_state = unreal.process_minidump()
+
+            refactor_enabled = _minidump_refactor_enabled(project.id)
+            metrics.incr(
+                'symbolicator.minidump-refactor-enabled',
+                tags={'value': refactor_enabled, 'endpoint': 'unreal'}
+            )
+
+            if refactor_enabled:
+                process_state = None
+            else:
+                process_state = unreal.process_minidump()
+
             if process_state:
                 merge_process_state_event(event, process_state)
             else:
+                # TODO(markus): Remove after refactor rolled out
                 apple_crash_report = unreal.get_apple_crash_report()
                 if apple_crash_report:
                     merge_apple_crash_report(apple_crash_report, event)
-                else:
-                    track_outcome(project.organization_id, project.id, None,
-                                  Outcome.INVALID, "missing_minidump_unreal")
-                    raise APIError("missing minidump in unreal crash report")
+                    has_crash_data = True
         except (ProcessMinidumpError, Unreal4Error) as e:
             minidumps_logger.exception(e)
             track_outcome(
@@ -874,7 +885,8 @@ class UnrealView(StoreView):
         try:
             unreal_context = unreal.get_context()
             if unreal_context is not None:
-                merge_unreal_context_event(unreal_context, event, project)
+                merge_unreal_context_event(unreal_context, event, project,
+                                           refactor_enabled=refactor_enabled)
         except Unreal4Error as e:
             # we'll continue without the context data
             minidumps_logger.exception(e)
@@ -896,6 +908,11 @@ class UnrealView(StoreView):
                 merge_attached_breadcrumbs(file.open_stream(), event)
                 continue
 
+            if file.type == "minidump":
+                if refactor_enabled:
+                    write_minidump_placeholder(event)
+                has_crash_data = True
+
             # Always store the minidump in attachments so we can access it during
             # processing, regardless of the event-attachments feature. This will
             # allow us to stack walk again with CFI once symbols are loaded.
@@ -905,6 +922,12 @@ class UnrealView(StoreView):
                     data=file.open_stream().read(),
                     type=unreal_attachment_type(file),
                 ))
+
+        if not has_crash_data:
+            track_outcome(project.organization_id, project.id, None,
+                          Outcome.INVALID, "missing_minidump_unreal")
+            raise APIError("missing minidump or apple crash report in unreal \
+                           crash report")
 
         event_id = self.process(
             request,

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -849,15 +849,20 @@ class UnrealView(StoreView):
 
         attachments = []
         event = {'event_id': uuid.uuid4().hex}
+
+        refactor_enabled = _minidump_refactor_enabled(project.id)
+
+        metrics.incr(
+            'symbolicator.minidump-refactor-enabled',
+            tags={'value': refactor_enabled, 'endpoint': 'unreal'}
+        )
+
+        if refactor_enabled:
+            write_minidump_placeholder(event)
+
         try:
             unreal = process_unreal_crash(request.body, request.GET.get(
                 'UserID'), request.GET.get('AppEnvironment'), event)
-
-            refactor_enabled = _minidump_refactor_enabled(project.id)
-            metrics.incr(
-                'symbolicator.minidump-refactor-enabled',
-                tags={'value': refactor_enabled, 'endpoint': 'unreal'}
-            )
 
             if refactor_enabled:
                 process_state = None
@@ -922,9 +927,6 @@ class UnrealView(StoreView):
                     data=file.open_stream().read(),
                     type=unreal_attachment_type(file),
                 ))
-
-        if is_minidump and refactor_enabled:
-            write_minidump_placeholder(event)
 
         if not refactor_enabled and not is_apple_crash_report and not is_minidump:
             track_outcome(project.organization_id, project.id, None,

--- a/tests/symbolicator/snapshots/SymbolicatorRefactoredUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorRefactoredUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-20T15:08:58.046203Z'
+created: '2019-05-21T10:30:07.398211Z'
 creator: sentry
 source: tests/symbolicator/test_unreal_full.py
 ---
@@ -29,7 +29,145 @@ contexts:
       + 12234 libsystem_pthread 0x00000000ffffffff + ffffffff libsystem_pthread 0x00000000ffffffff
       + ffffffff libsystem_pthread 0x00000000ffffffff + ffffffff
     type: unreal
-exception: null
+exception:
+  values:
+  - mechanism:
+      handled: false
+      synthetic: true
+      type: unreal
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff30932234'
+        package: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x1095aab27'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x108b6fd8e'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x108b65169'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x108b55d76'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10c28647e'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10c2a6f41'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10ce48e4a'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10ce4f8f5'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10cfadb9e'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10c2e4621'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10cfe80be'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10bc5eb21'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10bc5fc29'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10bc3b85b'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x1090a0132'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff30932234'
+        package: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x1095aab27'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x108b6fd8e'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x108b65169'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x108b55d76'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10c28647e'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10c2a6f41'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10ce48e4a'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10ce4f8f5'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10cfadb9e'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10c2e4621'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10cfe80be'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10bc5eb21'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10bc5fc29'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10bc3b85b'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x1090a0132'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+    type: Unreal
 extra:
   app_default_locate: en-AT
   base_dir: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/YetAnotherMac/Binaries/Mac/
@@ -107,72 +245,7 @@ extra:
   root_dir: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/
   seconds_since_start: 0
   time_of_crash: 636826526632420000
-stacktrace:
-  frames:
-  - in_app: false
-    instruction_addr: '0x7fff30932234'
-    package: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x1095aab27'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x108b6fd8e'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x108b65169'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x108b55d76'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10c28647e'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10c2a6f41'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10ce48e4a'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10ce4f8f5'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10cfadb9e'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10c2e4621'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10cfe80be'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10bc5eb21'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10bc5fc29'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10bc3b85b'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x1090a0132'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
+stacktrace: null
 threads:
   values:
   - crashed: false

--- a/tests/symbolicator/snapshots/SymbolicatorRefactoredUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorRefactoredUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-20T15:08:58.046203Z'
+created: '2019-05-21T08:47:39.066704Z'
 creator: sentry
 source: tests/symbolicator/test_unreal_full.py
 ---
@@ -29,7 +29,145 @@ contexts:
       + 12234 libsystem_pthread 0x00000000ffffffff + ffffffff libsystem_pthread 0x00000000ffffffff
       + ffffffff libsystem_pthread 0x00000000ffffffff + ffffffff
     type: unreal
-exception: null
+exception:
+  values:
+  - mechanism:
+      handled: false
+      synthetic: true
+      type: unreal
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff30932234'
+        package: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x1095aab27'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x108b6fd8e'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x108b65169'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x108b55d76'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10c28647e'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10c2a6f41'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10ce48e4a'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10ce4f8f5'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10cfadb9e'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10c2e4621'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10cfe80be'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10bc5eb21'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10bc5fc29'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10bc3b85b'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x1090a0132'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff30932234'
+        package: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x1095aab27'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x108b6fd8e'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x108b65169'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x108b55d76'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10c28647e'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10c2a6f41'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10ce48e4a'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10ce4f8f5'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10cfadb9e'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10c2e4621'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10cfe80be'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10bc5eb21'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10bc5fc29'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x10bc3b85b'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+      - in_app: false
+        instruction_addr: '0x1090a0132'
+        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+        trust: prewalked
+    value: ' SEGV_MAPERR at 0x88'
 extra:
   app_default_locate: en-AT
   base_dir: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/YetAnotherMac/Binaries/Mac/
@@ -107,72 +245,7 @@ extra:
   root_dir: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/
   seconds_since_start: 0
   time_of_crash: 636826526632420000
-stacktrace:
-  frames:
-  - in_app: false
-    instruction_addr: '0x7fff30932234'
-    package: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x1095aab27'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x108b6fd8e'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x108b65169'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x108b55d76'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10c28647e'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10c2a6f41'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10ce48e4a'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10ce4f8f5'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10cfadb9e'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10c2e4621'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10cfe80be'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10bc5eb21'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10bc5fc29'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x10bc3b85b'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
-  - in_app: false
-    instruction_addr: '0x1090a0132'
-    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-    trust: prewalked
+stacktrace: null
 threads:
   values:
   - crashed: false
@@ -345,168 +418,6 @@ threads:
         package: libsystem_kernel.dylib
   - crashed: true
     id: 5
-    raw_stacktrace:
-      frames:
-      - in_app: false
-        instruction_addr: '0x7fff61c7f425'
-        package: libsystem_pthread.dylib
-      - in_app: false
-        instruction_addr: '0x7fff61c832a7'
-        package: libsystem_pthread.dylib
-      - in_app: false
-        instruction_addr: '0x7fff61c8033d'
-        package: libsystem_pthread.dylib
-      - in_app: false
-        instruction_addr: '0x7fff36d4a234'
-        package: Foundation
-      - in_app: false
-        instruction_addr: '0x1095aab27'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x108b6fd8e'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x108b65169'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x108b55d76'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10c28647e'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10c2a6f41'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10ce48e4a'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10ce4f8f5'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10cfadb9e'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10c2e4621'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10cfe80be'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10bc5eb21'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10bc5fc29'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10bc3b85b'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x1090a0132'
-        package: YetAnotherMac
-      registers:
-        cs: '0x2b'
-        fs: '0x0'
-        gs: '0x0'
-        r10: '0x0'
-        r11: '0xffffffff'
-        r12: '0x8'
-        r13: '0x11e800b00'
-        r14: '0x1'
-        r15: '0x0'
-        r8: '0x3'
-        r9: '0x10'
-        rax: '0x20261bb4775b008f'
-        rbp: '0x700015a616d0'
-        rbx: '0x0'
-        rcx: '0x1288266c0'
-        rdi: '0x0'
-        rdx: '0x1'
-        rflags: '0x10206'
-        rip: '0x1090a0132'
-        rsi: '0x0'
-        rsp: '0x700015a613f0'
-    stacktrace:
-      frames:
-      - in_app: false
-        instruction_addr: '0x7fff61c7f425'
-        package: libsystem_pthread.dylib
-      - in_app: false
-        instruction_addr: '0x7fff61c832a7'
-        package: libsystem_pthread.dylib
-      - in_app: false
-        instruction_addr: '0x7fff61c8033d'
-        package: libsystem_pthread.dylib
-      - in_app: false
-        instruction_addr: '0x7fff36d4a234'
-        package: Foundation
-      - in_app: false
-        instruction_addr: '0x1095aab27'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x108b6fd8e'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x108b65169'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x108b55d76'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10c28647e'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10c2a6f41'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10ce48e4a'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10ce4f8f5'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10cfadb9e'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10c2e4621'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10cfe80be'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10bc5eb21'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10bc5fc29'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x10bc3b85b'
-        package: YetAnotherMac
-      - in_app: false
-        instruction_addr: '0x1090a0132'
-        package: YetAnotherMac
-      registers:
-        cs: '0x2b'
-        fs: '0x0'
-        gs: '0x0'
-        r10: '0x0'
-        r11: '0xffffffff'
-        r12: '0x8'
-        r13: '0x11e800b00'
-        r14: '0x1'
-        r15: '0x0'
-        r8: '0x3'
-        r9: '0x10'
-        rax: '0x20261bb4775b008f'
-        rbp: '0x700015a616d0'
-        rbx: '0x0'
-        rcx: '0x1288266c0'
-        rdi: '0x0'
-        rdx: '0x1'
-        rflags: '0x10206'
-        rip: '0x1090a0132'
-        rsi: '0x0'
-        rsp: '0x700015a613f0'
   - crashed: false
     id: 6
     raw_stacktrace:

--- a/tests/symbolicator/snapshots/SymbolicatorRefactoredUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorRefactoredUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-21T08:47:39.066704Z'
+created: '2019-05-20T15:08:58.046203Z'
 creator: sentry
 source: tests/symbolicator/test_unreal_full.py
 ---
@@ -29,145 +29,7 @@ contexts:
       + 12234 libsystem_pthread 0x00000000ffffffff + ffffffff libsystem_pthread 0x00000000ffffffff
       + ffffffff libsystem_pthread 0x00000000ffffffff + ffffffff
     type: unreal
-exception:
-  values:
-  - mechanism:
-      handled: false
-      synthetic: true
-      type: unreal
-    raw_stacktrace:
-      frames:
-      - in_app: false
-        instruction_addr: '0x7fff30932234'
-        package: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x1095aab27'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x108b6fd8e'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x108b65169'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x108b55d76'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10c28647e'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10c2a6f41'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10ce48e4a'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10ce4f8f5'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10cfadb9e'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10c2e4621'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10cfe80be'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10bc5eb21'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10bc5fc29'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10bc3b85b'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x1090a0132'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-    stacktrace:
-      frames:
-      - in_app: false
-        instruction_addr: '0x7fff30932234'
-        package: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x1095aab27'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x108b6fd8e'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x108b65169'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x108b55d76'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10c28647e'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10c2a6f41'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10ce48e4a'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10ce4f8f5'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10cfadb9e'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10c2e4621'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10cfe80be'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10bc5eb21'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10bc5fc29'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x10bc3b85b'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-      - in_app: false
-        instruction_addr: '0x1090a0132'
-        package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
-        trust: prewalked
-    value: ' SEGV_MAPERR at 0x88'
+exception: null
 extra:
   app_default_locate: en-AT
   base_dir: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/YetAnotherMac/Binaries/Mac/
@@ -245,7 +107,72 @@ extra:
   root_dir: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/
   seconds_since_start: 0
   time_of_crash: 636826526632420000
-stacktrace: null
+stacktrace:
+  frames:
+  - in_app: false
+    instruction_addr: '0x7fff30932234'
+    package: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x1095aab27'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x108b6fd8e'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x108b65169'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x108b55d76'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10c28647e'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10c2a6f41'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10ce48e4a'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10ce4f8f5'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10cfadb9e'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10c2e4621'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10cfe80be'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10bc5eb21'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10bc5fc29'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10bc3b85b'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x1090a0132'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
 threads:
   values:
   - crashed: false
@@ -418,6 +345,168 @@ threads:
         package: libsystem_kernel.dylib
   - crashed: true
     id: 5
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff36d4a234'
+        package: Foundation
+      - in_app: false
+        instruction_addr: '0x1095aab27'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b6fd8e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b65169'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b55d76'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c28647e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c2a6f41'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10ce48e4a'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10ce4f8f5'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10cfadb9e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c2e4621'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10cfe80be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc5eb21'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc5fc29'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc3b85b'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1090a0132'
+        package: YetAnotherMac
+      registers:
+        cs: '0x2b'
+        fs: '0x0'
+        gs: '0x0'
+        r10: '0x0'
+        r11: '0xffffffff'
+        r12: '0x8'
+        r13: '0x11e800b00'
+        r14: '0x1'
+        r15: '0x0'
+        r8: '0x3'
+        r9: '0x10'
+        rax: '0x20261bb4775b008f'
+        rbp: '0x700015a616d0'
+        rbx: '0x0'
+        rcx: '0x1288266c0'
+        rdi: '0x0'
+        rdx: '0x1'
+        rflags: '0x10206'
+        rip: '0x1090a0132'
+        rsi: '0x0'
+        rsp: '0x700015a613f0'
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff36d4a234'
+        package: Foundation
+      - in_app: false
+        instruction_addr: '0x1095aab27'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b6fd8e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b65169'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b55d76'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c28647e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c2a6f41'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10ce48e4a'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10ce4f8f5'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10cfadb9e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c2e4621'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10cfe80be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc5eb21'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc5fc29'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc3b85b'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1090a0132'
+        package: YetAnotherMac
+      registers:
+        cs: '0x2b'
+        fs: '0x0'
+        gs: '0x0'
+        r10: '0x0'
+        r11: '0xffffffff'
+        r12: '0x8'
+        r13: '0x11e800b00'
+        r14: '0x1'
+        r15: '0x0'
+        r8: '0x3'
+        r9: '0x10'
+        rax: '0x20261bb4775b008f'
+        rbp: '0x700015a616d0'
+        rbx: '0x0'
+        rcx: '0x1288266c0'
+        rdi: '0x0'
+        rdx: '0x1'
+        rflags: '0x10206'
+        rip: '0x1090a0132'
+        rsi: '0x0'
+        rsp: '0x700015a613f0'
   - crashed: false
     id: 6
     raw_stacktrace:

--- a/tests/symbolicator/snapshots/SymbolicatorRefactoredUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorRefactoredUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
@@ -1,0 +1,3237 @@
+---
+created: '2019-05-20T13:26:53.072229Z'
+creator: sentry
+source: tests/symbolicator/test_unreal_full.py
+---
+contexts:
+  device:
+    memory_size: 17179869184
+    model: MacBookPro14,3
+    type: device
+  gpu:
+    name: Radeon Pro 560
+    type: gpu
+  os:
+    build: 18A391
+    name: macOS
+    raw_description: Mac OS X 10.14.0 (18A391)
+    type: os
+    version: 10.14.0
+exception: null
+extra:
+  app_default_locate: en-AT
+  base_dir: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/YetAnotherMac/Binaries/Mac/
+  build_configuration: Development
+  build_version: ++UE4+Release-4.21-CL-4613538
+  crash_guid: UE4CC-Mac-C4D618F60F46F8E48017259A587AC54E_0000
+  crash_reporter_client_version: '1.0'
+  crash_type: Crash
+  engine_mode: Game
+  engine_version: 4.21.1-4613538+++UE4+Release-4.21
+  epic_account_id: 2e7d369327054a448be6c8d3601213cb
+  executable_name: YetAnotherMac
+  game_name: UE4-YetAnotherMac
+  is_assert: false
+  is_ensure: false
+  is_internal_build: false
+  is_source_distribution: false
+  is_ue4_release: true
+  language_lcid: 9
+  legacy_call_stack: 'AActor::IsPendingKillPending() const Address = 0x1090a0132 (filename
+    not found) [in YetAnotherMac]
+
+    AActor::Destroy(bool, bool) Address = 0x10bc3b85b (filename not found) [in YetAnotherMac]
+
+    AActor::BeginPlay() Address = 0x10bc5fc29 (filename not found) [in YetAnotherMac]
+
+    AActor::DispatchBeginPlay() Address = 0x10bc5eb21 (filename not found) [in YetAnotherMac]
+
+    AWorldSettings::NotifyBeginPlay() Address = 0x10cfe80be (filename not found) [in
+    YetAnotherMac]
+
+    AGameStateBase::HandleBeginPlay() Address = 0x10c2e4621 (filename not found) [in
+    YetAnotherMac]
+
+    UWorld::BeginPlay() Address = 0x10cfadb9e (filename not found) [in YetAnotherMac]
+
+    UEngine::LoadMap(FWorldContext&, FURL, UPendingNetGame*, FString&) Address = 0x10ce4f8f5
+    (filename not found) [in YetAnotherMac]
+
+    UEngine::Browse(FWorldContext&, FURL, FString&) Address = 0x10ce48e4a (filename
+    not found) [in YetAnotherMac]
+
+    UGameInstance::StartGameInstance() Address = 0x10c2a6f41 (filename not found)
+    [in YetAnotherMac]
+
+    UGameEngine::Start() Address = 0x10c28647e (filename not found) [in YetAnotherMac]
+
+    FEngineLoop::Init() Address = 0x108b55d76 (filename not found) [in YetAnotherMac]
+
+    GuardedMain(wchar_t const*) Address = 0x108b65169 (filename not found) [in YetAnotherMac]
+
+    -[UE4AppDelegate runGameThread:] Address = 0x108b6fd8e (filename not found) [in
+    YetAnotherMac]
+
+    -[FCocoaGameThread main] Address = 0x1095aab27 (filename not found) [in YetAnotherMac]
+
+    Unknown() Address = 0x7fff36d4a234 (filename not found) [in Foundation]
+
+    _pthread_body Address = 0x7fff61c8033d (filename not found) [in libsystem_pthread.dylib]
+
+    _pthread_start Address = 0x7fff61c832a7 (filename not found) [in libsystem_pthread.dylib]
+
+    thread_start Address = 0x7fff61c7f425 (filename not found) [in libsystem_pthread.dylib]'
+  login_id: ebff51ef3c4878627823eebd9ff40eb4
+  machine_id: EBFF51EF3C4878627823EEBD9FF40EB4
+  memory_stats_page_size: 4096
+  memory_stats_total_phsysical_gb: 16
+  memory_stats_total_virtual: 20401094656
+  misc_cpu_brand: GenericCPUBrand
+  misc_cpu_vendor: GenuineIntel
+  misc_number_of_cores: 4
+  misc_number_of_cores_inc_hyperthread: 8
+  platform_name: MacNoEditor
+  process_id: 49028
+  root_dir: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/
+  seconds_since_start: 0
+  time_of_crash: 636826526632420000
+stacktrace:
+  frames:
+  - in_app: false
+    instruction_addr: '0x7fff30932234'
+    package: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x1095aab27'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x108b6fd8e'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x108b65169'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x108b55d76'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10c28647e'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10c2a6f41'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10ce48e4a'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10ce4f8f5'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10cfadb9e'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10c2e4621'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10cfe80be'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10bc5eb21'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10bc5fc29'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10bc3b85b'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x1090a0132'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+threads:
+  values:
+  - crashed: false
+    id: 0
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61a8e085'
+        package: libdyld.dylib
+      - in_app: false
+        instruction_addr: '0x108b702a6'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b7092b'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff31f4375d'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff31f496fa'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff31f4a95b'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff33c8d348'
+        package: HIToolbox
+      - in_app: false
+        instruction_addr: '0x7fff33c8d5cb'
+        package: HIToolbox
+      - in_app: false
+        instruction_addr: '0x7fff33c8d895'
+        package: HIToolbox
+      - in_app: false
+        instruction_addr: '0x7fff349f3ce4'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f45ad'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f505e'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c2a'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61a8e085'
+        package: libdyld.dylib
+      - in_app: false
+        instruction_addr: '0x108b702a6'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b7092b'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff31f4375d'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff31f496fa'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff31f4a95b'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff33c8d348'
+        package: HIToolbox
+      - in_app: false
+        instruction_addr: '0x7fff33c8d5cb'
+        package: HIToolbox
+      - in_app: false
+        instruction_addr: '0x7fff33c8d895'
+        package: HIToolbox
+      - in_app: false
+        instruction_addr: '0x7fff349f3ce4'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f45ad'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f505e'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c2a'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 1
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 2
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 3
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 4
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: true
+    id: 5
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff36d4a234'
+        package: Foundation
+      - in_app: false
+        instruction_addr: '0x1095aab27'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b6fd8e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b65169'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b55d76'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c28647e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c2a6f41'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10ce48e4a'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10ce4f8f5'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10cfadb9e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c2e4621'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10cfe80be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc5eb21'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc5fc29'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc3b85b'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1090a0132'
+        package: YetAnotherMac
+      registers:
+        cs: '0x2b'
+        fs: '0x0'
+        gs: '0x0'
+        r10: '0x0'
+        r11: '0xffffffff'
+        r12: '0x8'
+        r13: '0x11e800b00'
+        r14: '0x1'
+        r15: '0x0'
+        r8: '0x3'
+        r9: '0x10'
+        rax: '0x20261bb4775b008f'
+        rbp: '0x700015a616d0'
+        rbx: '0x0'
+        rcx: '0x1288266c0'
+        rdi: '0x0'
+        rdx: '0x1'
+        rflags: '0x10206'
+        rip: '0x1090a0132'
+        rsi: '0x0'
+        rsp: '0x700015a613f0'
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff36d4a234'
+        package: Foundation
+      - in_app: false
+        instruction_addr: '0x1095aab27'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b6fd8e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b65169'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b55d76'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c28647e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c2a6f41'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10ce48e4a'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10ce4f8f5'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10cfadb9e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c2e4621'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10cfe80be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc5eb21'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc5fc29'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc3b85b'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1090a0132'
+        package: YetAnotherMac
+      registers:
+        cs: '0x2b'
+        fs: '0x0'
+        gs: '0x0'
+        r10: '0x0'
+        r11: '0xffffffff'
+        r12: '0x8'
+        r13: '0x11e800b00'
+        r14: '0x1'
+        r15: '0x0'
+        r8: '0x3'
+        r9: '0x10'
+        rax: '0x20261bb4775b008f'
+        rbp: '0x700015a616d0'
+        rbx: '0x0'
+        rcx: '0x1288266c0'
+        rdi: '0x0'
+        rdx: '0x1'
+        rflags: '0x10206'
+        rip: '0x1090a0132'
+        rsi: '0x0'
+        rsp: '0x700015a613f0'
+  - crashed: false
+    id: 6
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff31f53581'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff349f3ce4'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f45ad'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f505e'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c2a'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff31f53581'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff349f3ce4'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f45ad'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f505e'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c2a'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 7
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 8
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 9
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 10
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 11
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 12
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 13
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 14
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 15
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 16
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1097a01a8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094358c3'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1097a01a8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094358c3'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 17
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 18
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 19
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 20
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 21
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 22
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 23
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 24
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x70001989cba0'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x70001989cba0'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 25
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 26
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1096b1e4d'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61b55724'
+        package: libsystem_c.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bca876'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1096b1e4d'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61b55724'
+        package: libsystem_c.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bca876'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 27
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108e4c4c5'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108e4c4c5'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 28
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 29
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 30
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 31
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 32
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a44a1eb'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a44a1eb'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 33
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a874ab6'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094358c3'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a874ab6'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094358c3'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 34
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a875ba7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a86402c'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109435e23'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c7c83da'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c7f8302'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1093cd746'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1093c61d9'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1093c3c67'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1092abd6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109266ff1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61c74969'
+        package: libsystem_platform.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a875ba7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a86402c'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109435e23'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c7c83da'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c7f8302'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1093cd746'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1093c61d9'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1093c3c67'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1092abd6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109266ff1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61c74969'
+        package: libsystem_platform.dylib
+  - crashed: false
+    id: 35
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a87c821'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109481b6e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61b55724'
+        package: libsystem_c.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bca876'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a87c821'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109481b6e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61b55724'
+        package: libsystem_c.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bca876'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 36
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 37
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 38
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 39
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 40
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 41
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 42
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 43
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 44
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bbea8b8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bbea8b8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 45
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10dc214e1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10dc214e1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 46
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 47
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 48
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 49
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 50
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 51
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 52
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61a4db5a'
+        package: libdispatch.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61a40b19'
+        package: libdispatch.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c7e'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61a4db5a'
+        package: libdispatch.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61a40b19'
+        package: libdispatch.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c7e'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 53
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff344410d6'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff344415ee'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff34441b84'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff3444580d'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff3444589a'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c2a'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff344410d6'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff344415ee'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff34441b84'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff3444580d'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff3444589a'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c2a'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 54
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10be5f7ce'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094358c3'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10be5f7ce'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094358c3'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib

--- a/tests/symbolicator/snapshots/SymbolicatorRefactoredUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorRefactoredUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-20T13:26:53.072229Z'
+created: '2019-05-20T15:08:58.046203Z'
 creator: sentry
 source: tests/symbolicator/test_unreal_full.py
 ---
@@ -17,6 +17,18 @@ contexts:
     raw_description: Mac OS X 10.14.0 (18A391)
     type: os
     version: 10.14.0
+  unreal:
+    portable_call_stack: YetAnotherMac 0x000000000864e000 + a52132 YetAnotherMac 0x000000000864e000
+      + 35ed85b YetAnotherMac 0x000000000864e000 + 3611c29 YetAnotherMac 0x000000000864e000
+      + 3610b21 YetAnotherMac 0x000000000864e000 + 499a0be YetAnotherMac 0x000000000864e000
+      + 3c96621 YetAnotherMac 0x000000000864e000 + 495fb9e YetAnotherMac 0x000000000864e000
+      + 48018f5 YetAnotherMac 0x000000000864e000 + 47fae4a YetAnotherMac 0x000000000864e000
+      + 3c58f41 YetAnotherMac 0x000000000864e000 + 3c3847e YetAnotherMac 0x000000000864e000
+      + 507d76 YetAnotherMac 0x000000000864e000 + 517169 YetAnotherMac 0x000000000864e000
+      + 521d8e YetAnotherMac 0x000000000864e000 + f5cb27 Foundation 0x0000000036d38000
+      + 12234 libsystem_pthread 0x00000000ffffffff + ffffffff libsystem_pthread 0x00000000ffffffff
+      + ffffffff libsystem_pthread 0x00000000ffffffff + ffffffff
+    type: unreal
 exception: null
 extra:
   app_default_locate: en-AT

--- a/tests/symbolicator/snapshots/SymbolicatorRefactoredUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorRefactoredUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-15T18:30:37.284060Z'
+created: '2019-05-20T12:34:55.129778Z'
 creator: sentry
 source: tests/symbolicator/test_unreal_full.py
 ---
@@ -16,6 +16,18 @@ contexts:
     name: Windows 10
     type: os
     version: 10.0.17134
+  unreal:
+    portable_call_stack: YetAnother 0x00000000544e0000 + 703394 YetAnother 0x00000000544e0000
+      + 281f2ee YetAnother 0x00000000544e0000 + 2a26dd3 YetAnother 0x00000000544e0000
+      + 2a4f984 YetAnother 0x00000000544e0000 + 355e77e YetAnother 0x00000000544e0000
+      + 3576186 YetAnother 0x00000000544e0000 + 8acc56 YetAnother 0x00000000544e0000
+      + 8acf00 YetAnother 0x00000000544e0000 + 35c121d YetAnother 0x00000000544e0000
+      + 35cfb58 YetAnother 0x00000000544e0000 + 2eb082f YetAnother 0x00000000544e0000
+      + 2eb984f YetAnother 0x00000000544e0000 + 2d1cd39 YetAnother 0x00000000544e0000
+      + 325258 YetAnother 0x00000000544e0000 + 334e4c YetAnother 0x00000000544e0000
+      + 334eaa YetAnother 0x00000000544e0000 + 3429e6 YetAnother 0x00000000544e0000
+      + 44e73c6 KERNEL32 0x000000000fd40000 + 13034 ntdll 0x0000000010060000 + 71471
+    type: unreal
 exception:
   values:
   - mechanism:

--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
@@ -1,0 +1,3237 @@
+---
+created: '2019-05-20T13:26:45.889169Z'
+creator: sentry
+source: tests/symbolicator/test_unreal_full.py
+---
+contexts:
+  device:
+    memory_size: 17179869184
+    model: MacBookPro14,3
+    type: device
+  gpu:
+    name: Radeon Pro 560
+    type: gpu
+  os:
+    build: 18A391
+    name: macOS
+    raw_description: Mac OS X 10.14.0 (18A391)
+    type: os
+    version: 10.14.0
+exception: null
+extra:
+  app_default_locate: en-AT
+  base_dir: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/YetAnotherMac/Binaries/Mac/
+  build_configuration: Development
+  build_version: ++UE4+Release-4.21-CL-4613538
+  crash_guid: UE4CC-Mac-C4D618F60F46F8E48017259A587AC54E_0000
+  crash_reporter_client_version: '1.0'
+  crash_type: Crash
+  engine_mode: Game
+  engine_version: 4.21.1-4613538+++UE4+Release-4.21
+  epic_account_id: 2e7d369327054a448be6c8d3601213cb
+  executable_name: YetAnotherMac
+  game_name: UE4-YetAnotherMac
+  is_assert: false
+  is_ensure: false
+  is_internal_build: false
+  is_source_distribution: false
+  is_ue4_release: true
+  language_lcid: 9
+  legacy_call_stack: 'AActor::IsPendingKillPending() const Address = 0x1090a0132 (filename
+    not found) [in YetAnotherMac]
+
+    AActor::Destroy(bool, bool) Address = 0x10bc3b85b (filename not found) [in YetAnotherMac]
+
+    AActor::BeginPlay() Address = 0x10bc5fc29 (filename not found) [in YetAnotherMac]
+
+    AActor::DispatchBeginPlay() Address = 0x10bc5eb21 (filename not found) [in YetAnotherMac]
+
+    AWorldSettings::NotifyBeginPlay() Address = 0x10cfe80be (filename not found) [in
+    YetAnotherMac]
+
+    AGameStateBase::HandleBeginPlay() Address = 0x10c2e4621 (filename not found) [in
+    YetAnotherMac]
+
+    UWorld::BeginPlay() Address = 0x10cfadb9e (filename not found) [in YetAnotherMac]
+
+    UEngine::LoadMap(FWorldContext&, FURL, UPendingNetGame*, FString&) Address = 0x10ce4f8f5
+    (filename not found) [in YetAnotherMac]
+
+    UEngine::Browse(FWorldContext&, FURL, FString&) Address = 0x10ce48e4a (filename
+    not found) [in YetAnotherMac]
+
+    UGameInstance::StartGameInstance() Address = 0x10c2a6f41 (filename not found)
+    [in YetAnotherMac]
+
+    UGameEngine::Start() Address = 0x10c28647e (filename not found) [in YetAnotherMac]
+
+    FEngineLoop::Init() Address = 0x108b55d76 (filename not found) [in YetAnotherMac]
+
+    GuardedMain(wchar_t const*) Address = 0x108b65169 (filename not found) [in YetAnotherMac]
+
+    -[UE4AppDelegate runGameThread:] Address = 0x108b6fd8e (filename not found) [in
+    YetAnotherMac]
+
+    -[FCocoaGameThread main] Address = 0x1095aab27 (filename not found) [in YetAnotherMac]
+
+    Unknown() Address = 0x7fff36d4a234 (filename not found) [in Foundation]
+
+    _pthread_body Address = 0x7fff61c8033d (filename not found) [in libsystem_pthread.dylib]
+
+    _pthread_start Address = 0x7fff61c832a7 (filename not found) [in libsystem_pthread.dylib]
+
+    thread_start Address = 0x7fff61c7f425 (filename not found) [in libsystem_pthread.dylib]'
+  login_id: ebff51ef3c4878627823eebd9ff40eb4
+  machine_id: EBFF51EF3C4878627823EEBD9FF40EB4
+  memory_stats_page_size: 4096
+  memory_stats_total_phsysical_gb: 16
+  memory_stats_total_virtual: 20401094656
+  misc_cpu_brand: GenericCPUBrand
+  misc_cpu_vendor: GenuineIntel
+  misc_number_of_cores: 4
+  misc_number_of_cores_inc_hyperthread: 8
+  platform_name: MacNoEditor
+  process_id: 49028
+  root_dir: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/UE4/
+  seconds_since_start: 0
+  time_of_crash: 636826526632420000
+stacktrace:
+  frames:
+  - in_app: false
+    instruction_addr: '0x7fff30932234'
+    package: /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x1095aab27'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x108b6fd8e'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x108b65169'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x108b55d76'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10c28647e'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10c2a6f41'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10ce48e4a'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10ce4f8f5'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10cfadb9e'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10c2e4621'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10cfe80be'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10bc5eb21'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10bc5fc29'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x10bc3b85b'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+  - in_app: false
+    instruction_addr: '0x1090a0132'
+    package: /Users/bruno/Documents/Unreal Projects/YetAnotherMac/MacNoEditor/YetAnotherMac.app/Contents/MacOS/YetAnotherMac
+    trust: prewalked
+threads:
+  values:
+  - crashed: false
+    id: 0
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61a8e085'
+        package: libdyld.dylib
+      - in_app: false
+        instruction_addr: '0x108b702a6'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b7092b'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff31f4375d'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff31f496fa'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff31f4a95b'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff33c8d348'
+        package: HIToolbox
+      - in_app: false
+        instruction_addr: '0x7fff33c8d5cb'
+        package: HIToolbox
+      - in_app: false
+        instruction_addr: '0x7fff33c8d895'
+        package: HIToolbox
+      - in_app: false
+        instruction_addr: '0x7fff349f3ce4'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f45ad'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f505e'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c2a'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61a8e085'
+        package: libdyld.dylib
+      - in_app: false
+        instruction_addr: '0x108b702a6'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b7092b'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff31f4375d'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff31f496fa'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff31f4a95b'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff33c8d348'
+        package: HIToolbox
+      - in_app: false
+        instruction_addr: '0x7fff33c8d5cb'
+        package: HIToolbox
+      - in_app: false
+        instruction_addr: '0x7fff33c8d895'
+        package: HIToolbox
+      - in_app: false
+        instruction_addr: '0x7fff349f3ce4'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f45ad'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f505e'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c2a'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 1
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 2
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 3
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 4
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: true
+    id: 5
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff36d4a234'
+        package: Foundation
+      - in_app: false
+        instruction_addr: '0x1095aab27'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b6fd8e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b65169'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b55d76'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c28647e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c2a6f41'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10ce48e4a'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10ce4f8f5'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10cfadb9e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c2e4621'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10cfe80be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc5eb21'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc5fc29'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc3b85b'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1090a0132'
+        package: YetAnotherMac
+      registers:
+        cs: '0x2b'
+        fs: '0x0'
+        gs: '0x0'
+        r10: '0x0'
+        r11: '0xffffffff'
+        r12: '0x8'
+        r13: '0x11e800b00'
+        r14: '0x1'
+        r15: '0x0'
+        r8: '0x3'
+        r9: '0x10'
+        rax: '0x20261bb4775b008f'
+        rbp: '0x700015a616d0'
+        rbx: '0x0'
+        rcx: '0x1288266c0'
+        rdi: '0x0'
+        rdx: '0x1'
+        rflags: '0x10206'
+        rip: '0x1090a0132'
+        rsi: '0x0'
+        rsp: '0x700015a613f0'
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff36d4a234'
+        package: Foundation
+      - in_app: false
+        instruction_addr: '0x1095aab27'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b6fd8e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b65169'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108b55d76'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c28647e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c2a6f41'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10ce48e4a'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10ce4f8f5'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10cfadb9e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c2e4621'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10cfe80be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc5eb21'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc5fc29'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bc3b85b'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1090a0132'
+        package: YetAnotherMac
+      registers:
+        cs: '0x2b'
+        fs: '0x0'
+        gs: '0x0'
+        r10: '0x0'
+        r11: '0xffffffff'
+        r12: '0x8'
+        r13: '0x11e800b00'
+        r14: '0x1'
+        r15: '0x0'
+        r8: '0x3'
+        r9: '0x10'
+        rax: '0x20261bb4775b008f'
+        rbp: '0x700015a616d0'
+        rbx: '0x0'
+        rcx: '0x1288266c0'
+        rdi: '0x0'
+        rdx: '0x1'
+        rflags: '0x10206'
+        rip: '0x1090a0132'
+        rsi: '0x0'
+        rsp: '0x700015a613f0'
+  - crashed: false
+    id: 6
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff31f53581'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff349f3ce4'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f45ad'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f505e'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c2a'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff31f53581'
+        package: AppKit
+      - in_app: false
+        instruction_addr: '0x7fff349f3ce4'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f45ad'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff349f505e'
+        package: CoreFoundation
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c2a'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 7
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 8
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 9
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 10
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 11
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 12
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 13
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 14
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 15
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109432156'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094312e8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109433182'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 16
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1097a01a8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094358c3'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1097a01a8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094358c3'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 17
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 18
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 19
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 20
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 21
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 22
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 23
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 24
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x70001989cba0'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x70001989cba0'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 25
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x54485244'
+      - in_app: false
+        instruction_addr: '0x7fff61c7f415'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc85be'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 26
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1096b1e4d'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61b55724'
+        package: libsystem_c.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bca876'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1096b1e4d'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61b55724'
+        package: libsystem_c.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bca876'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 27
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108e4c4c5'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108e4c4c5'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 28
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 29
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 30
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 31
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 32
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a44a1eb'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a44a1eb'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 33
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a874ab6'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094358c3'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a874ab6'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094358c3'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 34
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a875ba7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a86402c'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109435e23'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c7c83da'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c7f8302'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1093cd746'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1093c61d9'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1093c3c67'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1092abd6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109266ff1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61c74969'
+        package: libsystem_platform.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a875ba7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a86402c'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109435e23'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c7c83da'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10c7f8302'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1093cd746'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1093c61d9'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1093c3c67'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1092abd6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109266ff1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61c74969'
+        package: libsystem_platform.dylib
+  - crashed: false
+    id: 35
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a87c821'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109481b6e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61b55724'
+        package: libsystem_c.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bca876'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10a87c821'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109481b6e'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61b55724'
+        package: libsystem_c.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bca876'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 36
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 37
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 38
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 39
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 40
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 41
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 42
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 43
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x108ddca01'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 44
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bbea8b8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10bbea8b8'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 45
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10dc214e1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10dc214e1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 46
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 47
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 48
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 49
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 50
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 51
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10951d7f1'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482d68'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 52
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61a4db5a'
+        package: libdispatch.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61a40b19'
+        package: libdispatch.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c7e'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61a4db5a'
+        package: libdispatch.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61a40b19'
+        package: libdispatch.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c7e'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 53
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff344410d6'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff344415ee'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff34441b84'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff3444580d'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff3444589a'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c2a'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff344410d6'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff344415ee'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff34441b84'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff3444580d'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff3444589a'
+        package: CoreAudio
+      - in_app: false
+        instruction_addr: '0x7fff61bc6c2a'
+        package: libsystem_kernel.dylib
+  - crashed: false
+    id: 54
+    raw_stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10be5f7ce'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094358c3'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib
+    stacktrace:
+      frames:
+      - in_app: false
+        instruction_addr: '0x7fff61c7f425'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c832a7'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x7fff61c8033d'
+        package: libsystem_pthread.dylib
+      - in_app: false
+        instruction_addr: '0x1094ba0b7'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094dd7be'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x10be5f7ce'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109430351'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109434103'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x1094358c3'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x109482f6f'
+        package: YetAnotherMac
+      - in_app: false
+        instruction_addr: '0x7fff61bca1b2'
+        package: libsystem_kernel.dylib


### PR DESCRIPTION
Continuing https://github.com/getsentry/sentry/pull/13222, this moves parsing of unreal portable callstacks into enhancers.

**When deploying this, make sure to turn down the related sampling options back to 0**