### PR TITLE
fix(api): Fix Incident Details when Status change fails

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_details.py
+++ b/src/sentry/api/endpoints/organization_incident_details.py
@@ -58,7 +58,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
                     comment=result.get('comment'),
                 )
             except StatusAlreadyChangedError:
-                raise Response(
+                return Response(
                     'Status is already set to {}'.format(result['status']),
                     status=400,
                 )


### PR DESCRIPTION
Should return the API Response instead of trying to `raise`