### PR TITLE
feat(api): Add api to return activities associated with an incident (SEN-521)

### DIFF
--- a/src/sentry/api/bases/incident.py
+++ b/src/sentry/api/bases/incident.py
@@ -13,7 +13,7 @@ from sentry.incidents.models import Incident
 
 class IncidentPermission(OrganizationPermission):
     scope_map = {
-        'GET': ['org:read', 'org:write', 'org:admin'],
+        'GET': ['org:read', 'org:write', 'org:admin', 'project:read', 'project:write', 'project:admin'],
         'POST': ['org:write', 'org:admin', 'project:read', 'project:write', 'project:admin'],
         'PUT': ['org:write', 'org:admin', 'project:read', 'project:write', 'project:admin'],
     }

--- a/src/sentry/api/endpoints/organization_incident_activity_index.py
+++ b/src/sentry/api/endpoints/organization_incident_activity_index.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import
+
+from sentry.api.bases.incident import (
+    IncidentPermission,
+    IncidentEndpoint,
+)
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
+from sentry.incidents.logic import get_incident_activity
+
+
+class OrganizationIncidentActivityIndexEndpoint(IncidentEndpoint):
+    permission_classes = (IncidentPermission, )
+
+    def get(self, request, organization, incident):
+        if request.GET.get('desc', '1') == '1':
+            order_by = '-date_added'
+        else:
+            order_by = 'date_added'
+
+        return self.paginate(
+            request=request,
+            queryset=get_incident_activity(incident),
+            order_by=order_by,
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(x, request.user),
+        )

--- a/src/sentry/api/endpoints/organization_incident_comment_index.py
+++ b/src/sentry/api/endpoints/organization_incident_comment_index.py
@@ -22,7 +22,8 @@ class OrganizationIncidentCommentIndexEndpoint(IncidentEndpoint):
             activity = create_incident_activity(
                 incident,
                 IncidentActivityType.COMMENT,
-                user=request.user,
+                # XXX: Serialization fails if user is a `SimpleLazyObject`
+                user=request.user._wrapped,
                 comment=serializer.object['comment']
             )
             return Response(serialize(activity, request.user), status=201)

--- a/src/sentry/api/serializers/models/incidentseen.py
+++ b/src/sentry/api/serializers/models/incidentseen.py
@@ -4,11 +4,13 @@ import six
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.incidents.models import IncidentSeen
+from sentry.utils.db import attach_foreignkey
 
 
 @register(IncidentSeen)
 class IncidentSeenSerializer(Serializer):
     def get_attrs(self, item_list, user):
+        attach_foreignkey(item_list, IncidentSeen.user)
         user_map = {d['id']: d for d in serialize(set(i.user for i in item_list), user)}
 
         result = {}

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -81,6 +81,7 @@ from .endpoints.organization_shortid import ShortIdLookupEndpoint
 from .endpoints.organization_environments import OrganizationEnvironmentsEndpoint
 from .endpoints.organization_eventid import EventIdLookupEndpoint
 from .endpoints.organization_slugs import SlugsUpdateEndpoint
+from .endpoints.organization_incident_activity_index import OrganizationIncidentActivityIndexEndpoint
 from .endpoints.organization_incident_comment_index import OrganizationIncidentCommentIndexEndpoint
 from .endpoints.organization_incident_index import OrganizationIncidentIndexEndpoint
 from .endpoints.organization_issues_new import OrganizationIssuesNewEndpoint
@@ -417,9 +418,14 @@ urlpatterns = patterns(
 
     # Incidents
     url(
-        r'^organizations/(?P<organization_slug>[^\/]+)/incidents/$',
-        OrganizationIncidentIndexEndpoint.as_view(),
-        name='sentry-api-0-organization-incident-index'
+        r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/activity/$',
+        OrganizationIncidentActivityIndexEndpoint.as_view(),
+        name='sentry-api-0-organization-incident-activity'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/comments/$',
+        OrganizationIncidentCommentIndexEndpoint.as_view(),
+        name='sentry-api-0-organization-incident-comments'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/$',
@@ -427,9 +433,9 @@ urlpatterns = patterns(
         name='sentry-api-0-organization-incident-details'
     ),
     url(
-        r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/comments/$',
-        OrganizationIncidentCommentIndexEndpoint.as_view(),
-        name='sentry-api-0-organization-incident-comments'
+        r'^organizations/(?P<organization_slug>[^\/]+)/incidents/$',
+        OrganizationIncidentIndexEndpoint.as_view(),
+        name='sentry-api-0-organization-incident-index'
     ),
 
     url(

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -246,3 +246,9 @@ def get_incident_aggregates(incident):
 
 def subscribe_to_incident(incident, user):
     return IncidentSubscription.objects.get_or_create(incident=incident, user=user)
+
+
+def get_incident_activity(incident):
+    return IncidentActivity.objects.filter(
+        incident=incident,
+    ).select_related('user', 'event_stats_snapshot', 'incident')

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -159,6 +159,15 @@ class TimeSeriesSnapshot(Model):
         app_label = 'sentry'
         db_table = 'sentry_timeseriessnapshot'
 
+    @property
+    def snuba_values(self):
+        """
+        Returns values matching the snuba format, a list of dicts with 'time'
+        and 'count' keys.
+        :return:
+        """
+        return {'data': [{'time': time, 'count': count} for time, count in self.values]}
+
 
 class IncidentActivityType(Enum):
     CREATED = 0

--- a/tests/sentry/api/endpoints/test_organization_incident_activity_index.py
+++ b/tests/sentry/api/endpoints/test_organization_incident_activity_index.py
@@ -1,0 +1,84 @@
+from __future__ import absolute_import
+
+from datetime import timedelta
+
+from django.utils import timezone
+from exam import fixture
+
+from sentry.api.serializers import serialize
+from sentry.incidents.logic import (
+    create_incident_activity,
+    create_initial_event_stats_snapshot,
+)
+from sentry.incidents.models import IncidentActivityType
+from sentry.testutils import APITestCase
+
+
+class OrganizationIncidentActivityIndexTest(APITestCase):
+    endpoint = 'sentry-api-0-organization-incident-activity'
+
+    def setUp(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        self.login_as(self.user)
+
+    @fixture
+    def organization(self):
+        return self.create_organization(owner=self.create_user())
+
+    @fixture
+    def project(self):
+        return self.create_project(organization=self.organization)
+
+    @fixture
+    def user(self):
+        return self.create_user()
+
+    def test_no_perms(self):
+        incident = self.create_incident()
+        self.login_as(self.create_user())
+        with self.feature('organizations:incidents'):
+            resp = self.get_response(incident.organization.slug, incident.id)
+        assert resp.status_code == 403
+
+    def test_no_feature(self):
+        incident = self.create_incident()
+        resp = self.get_response(incident.organization.slug, incident.id)
+        assert resp.status_code == 404
+
+    def test_simple(self):
+        incident = self.create_incident(
+            date_started=timezone.now() - timedelta(hours=2),
+            projects=[self.project],
+            query='',
+        )
+        snapshot = create_initial_event_stats_snapshot(incident)
+        activities = [
+            create_incident_activity(
+                incident=incident,
+                activity_type=IncidentActivityType.CREATED,
+                user=self.user,
+                comment='hello',
+                event_stats_snapshot=snapshot,
+            ),
+            create_incident_activity(
+                incident=incident,
+                activity_type=IncidentActivityType.COMMENT,
+                user=self.user,
+                comment='goodbye',
+            ),
+        ]
+
+        expected = serialize(activities, user=self.user)
+
+        with self.feature('organizations:incidents'):
+            resp = self.get_valid_response(
+                incident.organization.slug,
+                incident.identifier,
+                desc=0,
+            )
+        assert resp.data == expected
+
+        expected.reverse()
+        with self.feature('organizations:incidents'):
+            resp = self.get_valid_response(incident.organization.slug, incident.identifier)
+        assert resp.data == expected

--- a/tests/sentry/api/endpoints/test_organization_incident_comment_index.py
+++ b/tests/sentry/api/endpoints/test_organization_incident_comment_index.py
@@ -47,7 +47,7 @@ class OrganizationIncidentCommentCreateEndpointTest(APITestCase):
         assert activity.type == IncidentActivityType.COMMENT.value
         assert activity.user == self.user
         assert activity.comment == comment
-        assert resp.data == serialize([activity])[0]
+        assert resp.data == serialize([activity], self.user)[0]
 
     def test_access(self):
         other_user = self.create_user()

--- a/tests/sentry/api/serializers/test_incident_activity.py
+++ b/tests/sentry/api/serializers/test_incident_activity.py
@@ -2,16 +2,26 @@
 
 from __future__ import absolute_import
 
+from datetime import timedelta
+from uuid import uuid4
 
 import six
+from django.utils import timezone
+from freezegun import freeze_time
 
 from sentry.api.serializers import serialize
 from sentry.incidents.models import IncidentActivityType
-from sentry.incidents.logic import create_incident_activity
-from sentry.testutils import TestCase
+from sentry.incidents.logic import (
+    create_incident_activity,
+    create_initial_event_stats_snapshot,
+)
+from sentry.testutils import (
+    SnubaTestCase,
+    TestCase,
+)
 
 
-class IncidentSerializerTest(TestCase):
+class IncidentActivitySerializerTest(TestCase, SnubaTestCase):
     def test_simple(self):
         activity = create_incident_activity(
             incident=self.create_incident(),
@@ -23,8 +33,65 @@ class IncidentSerializerTest(TestCase):
 
         assert result['id'] == six.text_type(activity.id)
         assert result['incidentIdentifier'] == six.text_type(activity.incident.identifier)
-        assert result['userId'] == six.text_type(activity.user_id)
+        assert result['user'] == serialize(activity.user)
         assert result['type'] == activity.type
         assert result['value'] is None
         assert result['previousValue'] is None
         assert result['comment'] == activity.comment
+        assert result['dateCreated'] == activity.date_added
+
+    def test_no_user(self):
+        activity = create_incident_activity(
+            incident=self.create_incident(),
+            activity_type=IncidentActivityType.COMMENT,
+            user=None,
+            comment='hello',
+        )
+        result = serialize(activity)
+
+        assert result['id'] == six.text_type(activity.id)
+        assert result['incidentIdentifier'] == six.text_type(activity.incident.identifier)
+        assert result['user'] is None
+        assert result['type'] == activity.type
+        assert result['value'] is None
+        assert result['previousValue'] is None
+        assert result['comment'] == activity.comment
+        assert result['dateCreated'] == activity.date_added
+
+    @freeze_time()
+    def test_event_stats(self):
+        for _ in range(2):
+            self.store_event(
+                data={
+                    'event_id': uuid4().hex,
+                    'fingerprint': ['group1'],
+                    'timestamp': (timezone.now() - timedelta(seconds=1)).isoformat()[:19]
+                },
+                project_id=self.project.id,
+            )
+        incident = self.create_incident(
+            date_started=timezone.now() - timedelta(hours=2),
+            projects=[self.project],
+            query='',
+        )
+        snapshot = create_initial_event_stats_snapshot(incident)
+        activity = create_incident_activity(
+            incident=incident,
+            activity_type=IncidentActivityType.COMMENT,
+            user=self.user,
+            comment='hello',
+            event_stats_snapshot=snapshot,
+        )
+        result = serialize(activity)
+
+        assert result['id'] == six.text_type(activity.id)
+        assert result['incidentIdentifier'] == six.text_type(activity.incident.identifier)
+        assert result['user'] == serialize(activity.user)
+        assert result['type'] == activity.type
+        assert result['value'] is None
+        assert result['previousValue'] is None
+        assert result['comment'] == activity.comment
+        event_stats = result['eventStats']['data']
+        assert [stat[1] for stat in event_stats[:-1]] == [[]] * len(event_stats[:-1])
+        assert event_stats[-1][1] == [{'count': 2}]
+        assert result['dateCreated'] == activity.date_added


### PR DESCRIPTION
Returns incident activity. Endpoint supports a `desc` parameter which defaults to 1. When 0 orders
results ascending.