### PR TITLE
ref(ui): Refactor `<Note>` to take flattened props 

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/group.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/group.jsx
@@ -107,18 +107,20 @@ export function assignToActor({id, actor}) {
     });
 }
 
-export function deleteNote(api, group, item) {
-  const index = GroupStore.removeActivity(group.id, item.id);
+export function deleteNote(api, group, id, oldText) {
+  const index = GroupStore.removeActivity(group.id, id);
   if (index === -1) {
     // I dunno, the id wasn't found in the GroupStore
     return Promise.reject(new Error('Group was not found in store'));
   }
 
-  const promise = api.requestPromise(`/issues/${group.id}/comments/${item.id}/`, {
+  const promise = api.requestPromise(`/issues/${group.id}/comments/${id}/`, {
     method: 'DELETE',
   });
 
-  promise.catch(() => GroupStore.addActivity(group.id, item, index));
+  promise.catch(() =>
+    GroupStore.addActivity(group.id, {id, data: {text: oldText}}, index)
+  );
 
   return promise;
 }
@@ -134,16 +136,15 @@ export function createNote(api, group, note) {
   return promise;
 }
 
-export function updateNote(api, group, item, note) {
-  const oldNote = item.data.text;
-  GroupStore.updateActivity(group.id, item.id, {text: note.text});
+export function updateNote(api, group, note, id, oldText) {
+  GroupStore.updateActivity(group.id, id, {text: note.text});
 
-  const promise = api.requestPromise(`/issues/${group.id}/comments/${item.id}/`, {
+  const promise = api.requestPromise(`/issues/${group.id}/comments/${id}/`, {
     method: 'PUT',
     data: note,
   });
 
-  promise.catch(() => GroupStore.updateActivity(group.id, item.id, {text: oldNote}));
+  promise.catch(() => GroupStore.updateActivity(group.id, id, {text: oldText}));
 
   return promise;
 }

--- a/src/sentry/static/sentry/app/components/activity/note/body.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/body.jsx
@@ -5,13 +5,13 @@ import marked from 'app/utils/marked';
 
 class NoteBody extends React.Component {
   static propTypes = {
-    item: PropTypes.object.isRequired,
+    text: PropTypes.string.isRequired,
   };
 
   render() {
-    const {className, item} = this.props;
+    const {className, text} = this.props;
 
-    const noteBody = marked(item.data.text);
+    const noteBody = marked(text);
     return (
       <div
         className={className}

--- a/src/sentry/static/sentry/app/components/activity/note/header.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/header.jsx
@@ -12,7 +12,7 @@ import EditorTools from './editorTools';
 
 class NoteHeader extends React.Component {
   static propTypes = {
-    author: PropTypes.object.isRequired,
+    authorName: PropTypes.string.isRequired,
     user: SentryTypes.User,
     onEdit: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
@@ -24,11 +24,11 @@ class NoteHeader extends React.Component {
   };
 
   render() {
-    const {author, onEdit, onDelete} = this.props;
+    const {authorName, onEdit, onDelete} = this.props;
 
     return (
       <div>
-        <ActivityAuthor>{author.name}</ActivityAuthor>
+        <ActivityAuthor>{authorName}</ActivityAuthor>
         {this.canEdit() && (
           <EditorTools>
             <Edit onClick={onEdit}>{t('Edit')}</Edit>

--- a/src/sentry/static/sentry/app/components/activity/note/index.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/index.jsx
@@ -15,6 +15,7 @@ class Note extends React.Component {
   static propTypes = {
     author: PropTypes.object.isRequired,
     item: PropTypes.object.isRequired,
+    text: PropTypes.string.isRequired,
     memberList: PropTypes.array.isRequired,
     teams: PropTypes.arrayOf(SentryTypes.Team).isRequired,
 
@@ -69,7 +70,16 @@ class Note extends React.Component {
   };
 
   render() {
-    const {item, author, teams, memberList, hideDate, minHeight, showTime} = this.props;
+    const {
+      item,
+      text,
+      author,
+      teams,
+      memberList,
+      hideDate,
+      minHeight,
+      showTime,
+    } = this.props;
 
     const activityItemProps = {
       hideDate,
@@ -92,7 +102,7 @@ class Note extends React.Component {
             />
           }
         >
-          <NoteBody item={item} />
+          <NoteBody text={text} />
         </ActivityItemWithEditing>
       );
     }
@@ -105,6 +115,7 @@ class Note extends React.Component {
           <NoteInput
             minHeight={minHeight}
             item={item}
+            text={text}
             onEditFinish={this.handleEditFinish}
             onUpdate={this.handleUpdate}
             onCreate={this.handleCreate}

--- a/src/sentry/static/sentry/app/components/activity/note/index.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/index.jsx
@@ -13,9 +13,21 @@ import NoteInput from './input';
 
 class Note extends React.Component {
   static propTypes = {
-    author: PropTypes.object.isRequired,
-    item: PropTypes.object.isRequired,
+    // String for author name to be displayed in header
+    // This is not completely derived from `props.user` because we can set a default from parent component
+    authorName: PropTypes.string.isRequired,
+
+    // This is the id of the note object from the server
+    // This is to indicate you are editing an existing item
+    modelId: PropTypes.string,
+
+    // The note text itself
     text: PropTypes.string.isRequired,
+
+    user: SentryTypes.User,
+
+    dateCreated: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
+
     memberList: PropTypes.array.isRequired,
     teams: PropTypes.arrayOf(SentryTypes.Team).isRequired,
 
@@ -35,12 +47,9 @@ class Note extends React.Component {
     onUpdate: PropTypes.func,
   };
 
-  constructor(...args) {
-    super(...args);
-    this.state = {
-      editing: false,
-    };
-  }
+  state = {
+    editing: false,
+  };
 
   handleEdit = () => {
     this.setState({editing: true});
@@ -51,9 +60,9 @@ class Note extends React.Component {
   };
 
   handleDelete = () => {
-    const {item, onDelete} = this.props;
+    const {onDelete} = this.props;
 
-    onDelete(item);
+    onDelete(this.props);
   };
 
   handleCreate = note => {
@@ -63,17 +72,19 @@ class Note extends React.Component {
   };
 
   handleUpdate = note => {
-    const {item, onUpdate} = this.props;
+    const {onUpdate} = this.props;
 
-    onUpdate(note, item);
+    onUpdate(note, this.props);
     this.setState({editing: false});
   };
 
   render() {
     const {
-      item,
+      modelId,
+      user,
+      dateCreated,
       text,
-      author,
+      authorName,
       teams,
       memberList,
       hideDate,
@@ -84,9 +95,9 @@ class Note extends React.Component {
     const activityItemProps = {
       hideDate,
       showTime,
-      id: `activity-item-${item.id}`,
-      author: {type: 'user', user: item.user},
-      date: item.dateCreated,
+      id: `activity-item-${modelId}`,
+      author: {type: 'user', user},
+      date: dateCreated,
     };
 
     if (!this.state.editing) {
@@ -95,8 +106,8 @@ class Note extends React.Component {
           {...activityItemProps}
           header={
             <NoteHeader
-              author={author}
-              user={item.user}
+              authorName={authorName}
+              user={user}
               onEdit={this.handleEdit}
               onDelete={this.handleDelete}
             />
@@ -113,8 +124,8 @@ class Note extends React.Component {
       <StyledActivityItem {...activityItemProps}>
         {() => (
           <NoteInput
+            modelId={modelId}
             minHeight={minHeight}
-            item={item}
             text={text}
             onEditFinish={this.handleEditFinish}
             onUpdate={this.handleUpdate}

--- a/src/sentry/static/sentry/app/components/activity/note/input.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/input.jsx
@@ -23,10 +23,9 @@ class NoteInput extends React.Component {
     memberList: PropTypes.array.isRequired,
 
     item: PropTypes.shape({
-      data: PropTypes.shape({
-        text: PropTypes.string,
-      }),
+      id: PropTypes.string,
     }),
+    text: PropTypes.string,
     defaultText: PropTypes.string,
     error: PropTypes.bool,
     errorJSON: PropTypes.shape({
@@ -60,9 +59,9 @@ class NoteInput extends React.Component {
   constructor(props) {
     super(props);
 
-    const {item} = props;
-    const existing = !!item;
-    const defaultText = existing ? item.data.text || '' : props.defaultText;
+    const {item, text} = props;
+    const existing = !!item && !!item.id;
+    const defaultText = existing ? text || '' : props.defaultText;
 
     this.memberMentions = [];
     this.teamMentions = [];

--- a/src/sentry/static/sentry/app/components/activity/note/input.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/input.jsx
@@ -22,11 +22,12 @@ class NoteInput extends React.Component {
     teams: PropTypes.arrayOf(SentryTypes.Team).isRequired,
     memberList: PropTypes.array.isRequired,
 
-    item: PropTypes.shape({
-      id: PropTypes.string,
-    }),
+    // This is the id of the note object from the server
+    // This is to indicate you are editing an existing item
+    modelId: PropTypes.string,
+
+    // The note text itself
     text: PropTypes.string,
-    defaultText: PropTypes.string,
     error: PropTypes.bool,
     errorJSON: PropTypes.shape({
       detail: PropTypes.shape({
@@ -51,7 +52,6 @@ class NoteInput extends React.Component {
 
   static defaultProps = {
     placeholder: t('Add a comment.\nTag users with @, or teams with #'),
-    defaultText: '',
     minHeight: 140,
     busy: false,
   };
@@ -59,9 +59,8 @@ class NoteInput extends React.Component {
   constructor(props) {
     super(props);
 
-    const {item, text} = props;
-    const existing = !!item && !!item.id;
-    const defaultText = existing ? text || '' : props.defaultText;
+    const {text} = props;
+    const defaultText = text || '';
 
     this.memberMentions = [];
     this.teamMentions = [];
@@ -99,7 +98,7 @@ class NoteInput extends React.Component {
   }
 
   submitForm = () => {
-    if (!!this.props.item) {
+    if (!!this.props.modelId) {
       this.update();
     } else {
       this.create();
@@ -121,12 +120,9 @@ class NoteInput extends React.Component {
     const {onUpdate} = this.props;
 
     if (onUpdate) {
-      onUpdate(
-        {
-          text: this.state.value,
-        },
-        this.props.item
-      );
+      onUpdate({
+        text: this.state.value,
+      });
     }
   };
 
@@ -160,7 +156,7 @@ class NoteInput extends React.Component {
     this.setState({value: e.target.value});
 
     if (this.props.onChange) {
-      this.props.onChange(e, {updating: !!this.props.item});
+      this.props.onChange(e, {updating: !!this.props.modelId});
     }
   };
 
@@ -190,9 +186,9 @@ class NoteInput extends React.Component {
 
   render() {
     const {preview, value} = this.state;
-    const {busy, item, error, placeholder, minHeight, errorJSON} = this.props;
+    const {modelId, busy, error, placeholder, minHeight, errorJSON} = this.props;
 
-    const existingItem = !!item;
+    const existingItem = !!modelId;
     const btnText = existingItem ? t('Save Comment') : t('Post Comment');
 
     const errorMessage =

--- a/src/sentry/static/sentry/app/components/activity/note/inputWithStorage.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/inputWithStorage.jsx
@@ -10,6 +10,7 @@ class NoteInputWithStorage extends React.Component {
   static propTypes = {
     storageKey: PropTypes.string.isRequired,
     itemKey: PropTypes.string.isRequired,
+    text: PropTypes.string,
     onLoad: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
     onChange: PropTypes.func,
@@ -55,7 +56,11 @@ class NoteInputWithStorage extends React.Component {
   };
 
   getValue = () => {
-    const {itemKey, onLoad} = this.props;
+    const {itemKey, text, onLoad} = this.props;
+
+    if (text) {
+      return text;
+    }
 
     const storageObj = this.fetchFromStorage();
 
@@ -121,8 +126,8 @@ class NoteInputWithStorage extends React.Component {
     // Make sure `this.props` does not override `onChange` and `onCreate`
     return (
       <NoteInput
-        defaultText={this.getValue()}
         {...this.props}
+        text={this.getValue()}
         onCreate={this.handleCreate}
         onChange={this.handleChange}
       />

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupActivity.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupActivity.jsx
@@ -165,6 +165,7 @@ class GroupActivity extends React.Component {
                   <ErrorBoundary mini key={`note-${item.id}`}>
                     <Note
                       item={item}
+                      text={item.data.text}
                       id={`note-${item.id}`}
                       author={{
                         name: authorName,

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/groupActivity.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/groupActivity.jsx
@@ -12,7 +12,6 @@ import {t} from 'app/locale';
 import {uniqueId} from 'app/utils/guid';
 import ActivityAuthor from 'app/components/activity/author';
 import ActivityItem from 'app/components/activity/item';
-import Avatar from 'app/components/avatar';
 import ConfigStore from 'app/stores/configStore';
 import ErrorBoundary from 'app/components/errorBoundary';
 import GroupActivityItem from 'app/views/groupDetails/shared/groupActivityItem';
@@ -45,13 +44,13 @@ class GroupActivity extends React.Component {
   getMemberList = (memberList, sessionUser) =>
     _.uniqBy(memberList, ({id}) => id).filter(({id}) => sessionUser.id !== id);
 
-  handleNoteDelete = async item => {
+  handleNoteDelete = async ({modelId, text: oldText}) => {
     const {api, group} = this.props;
 
     addLoadingMessage(t('Removing comment...'));
 
     try {
-      await deleteNote(api, group, item);
+      await deleteNote(api, group, modelId, oldText);
       clearIndicators();
     } catch (_err) {
       addErrorMessage(t('Failed to delete comment'));
@@ -92,7 +91,7 @@ class GroupActivity extends React.Component {
     }
   };
 
-  handleNoteUpdate = async (note, item) => {
+  handleNoteUpdate = async (note, {modelId, text: oldText}) => {
     const {api, group} = this.props;
 
     this.setState({
@@ -101,7 +100,7 @@ class GroupActivity extends React.Component {
     addLoadingMessage(t('Updating comment...'));
 
     try {
-      await updateNote(api, group, item, note);
+      await updateNote(api, group, note, modelId, oldText);
       this.setState({
         updateBusy: false,
       });
@@ -164,13 +163,11 @@ class GroupActivity extends React.Component {
                 return (
                   <ErrorBoundary mini key={`note-${item.id}`}>
                     <Note
-                      item={item}
                       text={item.data.text}
-                      id={`note-${item.id}`}
-                      author={{
-                        name: authorName,
-                        avatar: <Avatar user={item.user} size={38} />,
-                      }}
+                      modelId={item.id}
+                      user={item.user}
+                      dateCreated={item.dateCreated}
+                      authorName={authorName}
                       onDelete={this.handleNoteDelete}
                       onUpdate={this.handleNoteUpdate}
                       busy={this.state.updateBusy}

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/activity.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/activity.jsx
@@ -176,6 +176,7 @@ class Activity extends React.Component {
                           <Note
                             showTime
                             item={activity}
+                            text={activity.comment}
                             id={`note-${activity.id}`}
                             author={{
                               name: authorName,

--- a/tests/js/spec/components/activity/note/input.spec.jsx
+++ b/tests/js/spec/components/activity/note/input.spec.jsx
@@ -58,10 +58,10 @@ describe('NoteInput', function() {
     const defaultProps = {
       group: {project: {}, id: 'groupId'},
       item: {
-        data: {
-          text: 'an existing item',
-        },
+        id: 'item-id',
+        data: {text: 'an existing item'},
       },
+      text: 'an existing item',
       memberList: [],
       teams: [],
     };
@@ -104,7 +104,7 @@ describe('NoteInput', function() {
 
       expect(onUpdate).toHaveBeenCalledWith(
         {text: 'new item'},
-        {data: {text: 'an existing item'}}
+        {id: 'item-id', data: {text: 'an existing item'}}
       );
     });
 

--- a/tests/js/spec/components/activity/note/input.spec.jsx
+++ b/tests/js/spec/components/activity/note/input.spec.jsx
@@ -57,10 +57,7 @@ describe('NoteInput', function() {
   describe('Existing Item', function() {
     const defaultProps = {
       group: {project: {}, id: 'groupId'},
-      item: {
-        id: 'item-id',
-        data: {text: 'an existing item'},
-      },
+      modelId: 'item-id',
       text: 'an existing item',
       memberList: [],
       teams: [],
@@ -102,10 +99,7 @@ describe('NoteInput', function() {
 
       wrapper.find('textarea').simulate('keyDown', {key: 'Enter', ctrlKey: true});
 
-      expect(onUpdate).toHaveBeenCalledWith(
-        {text: 'new item'},
-        {id: 'item-id', data: {text: 'an existing item'}}
-      );
+      expect(onUpdate).toHaveBeenCalledWith({text: 'new item'});
     });
 
     it('canels editing and moves to preview mode', async function() {


### PR DESCRIPTION
Previously the component was tightly coupled to the Activity data model.
We need to refactor this a bit so it accepts a string for the note body because the model for Incident comments are a bit different. Along with this we are also pulling out other parts of the previous `item` object.