### PR TITLE
fix(adv search): Clarify error message

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -113,7 +113,8 @@ def validate_search_filter_permissions(organization, search_filters):
         for feature_condition, feature_name in advanced_search_features:
             if feature_condition(search_filter):
                 raise ValidationError(
-                    u'You need access to the advanced search feature to use {}'.format(
+                    u'You need access to the advanced search feature (available '
+                    'on the new Developer, Team, and Business plans) to use {}'.format(
                         feature_name),
                 )
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -429,7 +429,8 @@ class GroupListTest(APITestCase, SnubaTestCase):
             response = self.get_response(sort_by='date', query='!has:user')
             assert response.status_code == 400, response.data
             assert (
-                'You need access to the advanced search feature to use negative '
+                'You need access to the advanced search feature (available on '
+                'the new Developer, Team, and Business plans) to use negative '
                 'search' == response.data['detail']
             )
 


### PR DESCRIPTION
Right now, if you're on an `mm1` plan and you try to use negation or globbing, you see this:

![image](https://user-images.githubusercontent.com/14812505/58059020-1b60a800-7b20-11e9-9789-45b842006904.png)

This is confusing and leads to a lot of folks writing in to support.

New version:

![image](https://user-images.githubusercontent.com/14812505/58059258-eef95b80-7b20-11e9-81a4-f82e4cdf6e1e.png)

Concerns I have:

- On-prem has this off by default but could turn it on. Do we want to include them in the message?

- Nowhere else that I can find do we mention plans (a getsentry concern) in the sentry codebase, and my gut says we shouldn't break that barrier. One option is to link to the docs (where we mention plan restrictions left and right, ~and where as soon as https://github.com/getsentry/sentry-docs/pull/994 is merged, we'll explain the plan restrictions for advanced search, too~ including this one) instead. Thoughts?