### PR TITLE
feat(grouping): Move hardcoded in_app logic to enhancers

### DIFF
--- a/src/sentry/grouping/enhancement-configs/common:2019-03-23.txt
+++ b/src/sentry/grouping/enhancement-configs/common:2019-03-23.txt
@@ -1,9 +1,23 @@
 ## * The default configuration of stacktrace grouping enhancers
 
-# exclude common paths
-family:native path:/usr/lib/**                                    -app
-family:native path:/usr/local/lib/**                              -app
-family:native path:/usr/local/Cellar/**                           -app
+# iOS known apps
+family:native package:/var/containers/Bundle/Application/**          +app
+family:native package:/private/var/containers/Bundle/Application/**  +app
+
+# iOS apps in simulator
+family:native package:**/Developer/CoreSimulator/Devices/**          +app
+family:native package:**/Containers/Bundle/Application/**            +app
+
+# known well locations for unix paths
+family:native package:/lib/**                                        -app
+family:native package:/usr/lib/**                                    -app
+family:native path:/usr/local/lib/**                                 -app
+family:native path:/usr/local/Cellar/**                              -app
+family:native package:linux-gate.so*                                 -app
+
+# well known path components for mac paths
+family:native package:**.app/Contents/**                             +app
+family:native package:/Users/**                                      +app
 
 # rust common modules
 family:native function:std::*                                     -app
@@ -30,6 +44,12 @@ family:native function:_mh_execute_header                         -group -app
 family:native function:google_breakpad::*                         -app -group
 family:native function:google_breakpad::ExceptionHandler::SignalHandler ^-group -group
 family:native function:google_breakpad::ExceptionHandler::WriteMinidumpWithException ^-group -group
+
+# Support frameworks that are not in-app
+family:native package:**/Frameworks/libswift*.dylib                  -app
+family:native package:**/Frameworks/KSCrash.framework/**             -app
+family:native package:**/Frameworks/SentrySwift.framework/**         -app
+family:native package:**/Frameworks/Sentry.framework/**              -app
 
 # Sentry internal functions in Cocoa SDK
 family:native function:kscm_*                                     -app -group

--- a/src/sentry/grouping/enhancement-configs/legacy:2019-03-12.txt
+++ b/src/sentry/grouping/enhancement-configs/legacy:2019-03-12.txt
@@ -1,8 +1,31 @@
-## * The default configuration of stacktrace grouping enhancers
+## * The legacy configuration of stacktrace grouping enhancers
+
+# Support frameworks that are not in-app
+family:native package:**/Frameworks/libswift*.dylib                  -app
+family:native package:**/Frameworks/KSCrash.framework/**             -app
+family:native package:**/Frameworks/SentrySwift.framework/**         -app
+family:native package:**/Frameworks/Sentry.framework/**              -app
+
+# iOS known apps
+family:native package:/var/containers/Bundle/Application/**          +app
+family:native package:/private/var/containers/Bundle/Application/**  +app
+
+# iOS apps in simulator
+family:native package:**/Developer/CoreSimulator/Devices/**          +app
+family:native package:**/Containers/Bundle/Application/**            +app
+
+# known well locations for linux paths
+family:native package:/lib/**                                        -app
+family:native package:/usr/lib/**                                    -app
+family:native package:linux-gate.so*                                 -app
+
+# well known path components for mac paths
+family:native package:**.app/Contents/**                             +app
+family:native package:/Users/**                                      +app
 
 # Sentry internal functions in Cocoa SDK
-family:native function:kscm_*                                     -app -group
-family:native function:kscrash_*                                  -app -group
-family:native function:"?[KSCrash *"                              -app -group
-family:native function:"?[SentryClient *"                         -app -group
-family:native function:"?[RNSentry *"                             -app -group
+family:native function:kscm_*                                        -app -group
+family:native function:kscrash_*                                     -app -group
+family:native function:"?[KSCrash *"                                 -app -group
+family:native function:"?[SentryClient *"                            -app -group
+family:native function:"?[RNSentry *"                                -app -group

--- a/src/sentry/grouping/enhancement-configs/legacy:2019-03-12.txt
+++ b/src/sentry/grouping/enhancement-configs/legacy:2019-03-12.txt
@@ -1,11 +1,5 @@
 ## * The legacy configuration of stacktrace grouping enhancers
 
-# Support frameworks that are not in-app
-family:native package:**/Frameworks/libswift*.dylib                  -app
-family:native package:**/Frameworks/KSCrash.framework/**             -app
-family:native package:**/Frameworks/SentrySwift.framework/**         -app
-family:native package:**/Frameworks/Sentry.framework/**              -app
-
 # iOS known apps
 family:native package:/var/containers/Bundle/Application/**          +app
 family:native package:/private/var/containers/Bundle/Application/**  +app
@@ -22,6 +16,12 @@ family:native package:linux-gate.so*                                 -app
 # well known path components for mac paths
 family:native package:**.app/Contents/**                             +app
 family:native package:/Users/**                                      +app
+
+# Support frameworks that are not in-app
+family:native package:**/Frameworks/libswift*.dylib                  -app
+family:native package:**/Frameworks/KSCrash.framework/**             -app
+family:native package:**/Frameworks/SentrySwift.framework/**         -app
+family:native package:**/Frameworks/Sentry.framework/**              -app
 
 # Sentry internal functions in Cocoa SDK
 family:native function:kscm_*                                        -app -group

--- a/src/sentry/lang/native/plugin.py
+++ b/src/sentry/lang/native/plugin.py
@@ -273,7 +273,8 @@ class NativeStacktraceProcessor(StacktraceProcessor):
 
             obj = pf.data['obj']
             package = obj and obj.code_file
-            # TODO(ja): This should check for iOS specifically
+            # TODO(ja): This should check for iOS specifically.  Also
+            # check in symbolicator.py for handle_symbolicator_status
             if not package or not is_known_third_party(package):
                 continue
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -390,6 +390,9 @@ def handle_symbolicator_status(status, image, sdk_info, handle_symbolication_fai
         'missing'
     ):
         package = image.get('code_file')
+        # TODO(mitsuhiko): This check seems wrong?  This call seems to
+        # mirror the one in the ios symbol server support.  If we change
+        # one we need to change the other.
         if not package or is_known_third_party(package, sdk_info=sdk_info):
             return
 


### PR DESCRIPTION
This moves the current in-app logic that is hardcoded into the builtin enhancer
code.  With the grouping epoch code this lets us upgrade the defaults over time.