### PR TITLE
ref(unreal): Ignore portable callstack when minidump has enough frames

### DIFF
--- a/src/sentry/lang/native/unreal.py
+++ b/src/sentry/lang/native/unreal.py
@@ -23,6 +23,10 @@ def is_unreal_event(data):
 
 
 def reprocess_unreal_crash(data):
+    exception = get_path(data, 'exception', 'values', 0)
+    if len(get_path(exception, 'stacktrace', 'frames', filter=True) or ()) > 1:
+        return
+
     context = get_path(data, 'contexts', 'unreal')
     portable_call_stack = get_path(context, 'portable_call_stack')
 
@@ -33,10 +37,6 @@ def reprocess_unreal_crash(data):
 
     frames = parse_portable_callstack(portable_call_stack, images)
     if not frames:
-        return
-
-    exception = get_path(data, 'exception', 'values', 0)
-    if len(get_path(exception, 'stacktrace', 'frames', filter=True) or ()) > 1:
         return
 
     if not exception:

--- a/src/sentry/lang/native/unreal.py
+++ b/src/sentry/lang/native/unreal.py
@@ -36,6 +36,9 @@ def reprocess_unreal_crash(data):
         return
 
     exception = get_path(data, 'exception', 'values', 0)
+    if len(get_path(exception, 'stacktrace', 'frames', filter=True) or ()) > 1:
+        return
+
     if not exception:
         assert not data.get('stacktrace')
         exception = {'type': 'Unreal'}


### PR DESCRIPTION
See also https://github.com/getsentry/sentry/pull/13302 and related

* Unreal portable callstacks are now no longer overwriting the crashing thread's stacktrace if minidump processing created a "good" stacktrace (=stacktrace with more than 1 frame).