### PR TITLE
fix(ui): Sentry completely breaks if there is an unencoded `%` in URL

### DIFF
--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -95,7 +95,20 @@ if (window.__initialData) {
 
 const render = Component => {
   const rootEl = document.getElementById('blk_router');
-  ReactDOM.render(<Component />, rootEl);
+
+  try {
+    ReactDOM.render(<Component />, rootEl);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(
+      new Error(
+        'An unencoded "%" has appeared, it is super effective! (See https://github.com/ReactTraining/history/issues/505)'
+      )
+    );
+    if (err.message === 'URI malformed') {
+      window.location.assign(window.location.pathname);
+    }
+  }
 };
 
 // The password strength component is very heavyweight as it includes the

--- a/src/sentry/static/sentry/app/stores/configStore.jsx
+++ b/src/sentry/static/sentry/app/stores/configStore.jsx
@@ -32,8 +32,16 @@ const ConfigStore = Reflux.createStore({
       config.user.permissions = new Set(config.user.permissions);
       moment.tz.setDefault(config.user.options.timezone);
 
+      let queryString = {};
+
       // Parse query string for `lang`
-      const queryString = qs.parse(window.location.search) || {};
+      try {
+        queryString = qs.parse(window.location.search) || {};
+      } catch (err) {
+        // ignore if this fails to parse
+        // this can happen if we have an invalid query string
+        // e.g. unencoded "%"
+      }
 
       // Priority:
       // "?lang=en" --> user configuration options --> django request.LANGUAGE_CODE --> "en"


### PR DESCRIPTION
The `history` package automatically tries to decode the URI and will break if the URI has an unencoded `%`. This problem usually props up when users manually manipulate the URL since in-app navigation will properly handle encoding. Currently, when this happens, the user is greeted with a big empty page.

Instead, this change will redirect the user to the current path and strip all query strings so that we're able to at least load the Sentry app.

See https://github.com/ReactTraining/history/issues/505 - They merged a change that would make the `history` package not always attempt to decode the URI, but requires a major version bump (and corresponding updates to react-router).

Fixes JAVASCRIPT-7W0
Fixes JAVASCRIPT-5XJ