### PR TITLE
feat(api): Add endpoints to subscribe to/unsubscribe from an Incident (SEN-587)

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_subscription_index.py
+++ b/src/sentry/api/endpoints/organization_incident_subscription_index.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.bases.incident import (
+    IncidentEndpoint,
+    IncidentPermission,
+)
+from sentry.incidents.logic import (
+    subscribe_to_incident,
+    unsubscribe_from_incident,
+)
+
+
+class IncidentSubscriptionPermission(IncidentPermission):
+    scope_map = IncidentPermission.scope_map.copy()
+    scope_map['DELETE'] = [
+        'org:write',
+        'org:admin',
+        'project:read',
+        'project:write',
+        'project:admin',
+    ]
+
+
+class OrganizationIncidentSubscriptionIndexEndpoint(IncidentEndpoint):
+    permission_classes = (IncidentSubscriptionPermission, )
+
+    def post(self, request, organization, incident):
+        """
+        Subscribes the authenticated user to the incident.
+        ``````````````````````````````````````````````````
+        Subscribes the user to the incident. If they are already subscribed
+        then no-op.
+        :auth: required
+        """
+
+        subscribe_to_incident(incident, request.user)
+        return Response({}, status=201)
+
+    def delete(self, request, organization, incident):
+        """
+        Unsubscribes the authenticated user from the incident.
+        ``````````````````````````````````````````````````````
+        Unsubscribes the user from the incident. If they are not subscribed then
+        no-op.
+        :auth: required
+        """
+        unsubscribe_from_incident(incident, request.user)
+        return Response({}, status=200)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -84,6 +84,7 @@ from .endpoints.organization_slugs import SlugsUpdateEndpoint
 from .endpoints.organization_incident_activity_index import OrganizationIncidentActivityIndexEndpoint
 from .endpoints.organization_incident_comment_index import OrganizationIncidentCommentIndexEndpoint
 from .endpoints.organization_incident_index import OrganizationIncidentIndexEndpoint
+from .endpoints.organization_incident_subscription_index import OrganizationIncidentSubscriptionIndexEndpoint
 from .endpoints.organization_issues_new import OrganizationIssuesNewEndpoint
 from .endpoints.organization_issues_resolved_in_release import OrganizationIssuesResolvedInReleaseEndpoint
 from .endpoints.organization_member_details import OrganizationMemberDetailsEndpoint
@@ -442,6 +443,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/seen/$',
         OrganizationIncidentSeenEndpoint.as_view(),
         name='sentry-api-0-organization-incident-seen'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/subscriptions/$',
+        OrganizationIncidentSubscriptionIndexEndpoint.as_view(),
+        name='sentry-api-0-organization-incident-subscription-index'
     ),
 
     # Organizations

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -248,6 +248,10 @@ def subscribe_to_incident(incident, user):
     return IncidentSubscription.objects.get_or_create(incident=incident, user=user)
 
 
+def unsubscribe_from_incident(incident, user):
+    return IncidentSubscription.objects.filter(incident=incident, user=user).delete()
+
+
 def get_incident_activity(incident):
     return IncidentActivity.objects.filter(
         incident=incident,

--- a/tests/sentry/api/endpoints/test_organization_incident_subscription_index.py
+++ b/tests/sentry/api/endpoints/test_organization_incident_subscription_index.py
@@ -1,0 +1,100 @@
+from __future__ import absolute_import
+
+from exam import fixture
+
+from sentry.incidents.logic import subscribe_to_incident
+from sentry.incidents.models import IncidentSubscription
+from sentry.testutils import APITestCase
+
+
+class BaseOrganizationSubscriptionEndpointTest(object):
+    endpoint = 'sentry-api-0-organization-incident-subscription-index'
+
+    @fixture
+    def organization(self):
+        return self.create_organization()
+
+    @fixture
+    def project(self):
+        return self.create_project(organization=self.organization)
+
+    @fixture
+    def user(self):
+        return self.create_user()
+
+    def test_access(self):
+        other_user = self.create_user()
+        self.login_as(other_user)
+        other_team = self.create_team()
+        self.create_member(
+            user=self.user,
+            organization=self.organization,
+            role='member',
+            teams=[self.team],
+        )
+        other_project = self.create_project(teams=[other_team])
+        incident = self.create_incident(projects=[other_project])
+        with self.feature('organizations:incidents'):
+            resp = self.get_response(
+                self.organization.slug,
+                incident.identifier,
+                comment='hi',
+            )
+            assert resp.status_code == 403
+
+
+class OrganizationIncidentSubscribeEndpointTest(
+    BaseOrganizationSubscriptionEndpointTest,
+    APITestCase,
+):
+    method = 'post'
+
+    def test_simple(self):
+        self.create_member(
+            user=self.user,
+            organization=self.organization,
+            role='owner',
+            teams=[self.team],
+        )
+        self.login_as(self.user)
+        incident = self.create_incident()
+        with self.feature('organizations:incidents'):
+            self.get_valid_response(
+                self.organization.slug,
+                incident.identifier,
+                status_code=201,
+            )
+        sub = IncidentSubscription.objects.filter(
+            incident=incident,
+            user=self.user,
+        ).get()
+        assert sub.incident == incident
+        assert sub.user == self.user
+
+
+class OrganizationIncidentUnsubscribeEndpointTest(
+    BaseOrganizationSubscriptionEndpointTest,
+    APITestCase,
+):
+    method = 'delete'
+
+    def test_simple(self):
+        self.create_member(
+            user=self.user,
+            organization=self.organization,
+            role='owner',
+            teams=[self.team],
+        )
+        self.login_as(self.user)
+        incident = self.create_incident()
+        subscribe_to_incident(incident, self.user)
+        with self.feature('organizations:incidents'):
+            self.get_valid_response(
+                self.organization.slug,
+                incident.identifier,
+                status_code=200,
+            )
+        assert not IncidentSubscription.objects.filter(
+            incident=incident,
+            user=self.user,
+        ).exists()


### PR DESCRIPTION
Added these under incidents/subscriptions. A POST to the incident will subscribe the user, a DELETE
will unsubscribe them. No-ops if already subscribed or not subscribed respectively.