### PR TITLE
services: Enable support for logging metrics from service methods

### DIFF
--- a/src/sentry/metrics/logging.py
+++ b/src/sentry/metrics/logging.py
@@ -18,7 +18,7 @@ class LoggingBackend(MetricsBackend):
 
     def timing(self, key, value, instance=None, tags=None, sample_rate=1):
         logger.debug(
-            '%r: %g ms', key, value, extra={
+            '%r: %g ms', key, value * 1000, extra={
                 'instance': instance,
                 'tags': tags or {},
             }

--- a/src/sentry/nodestore/__init__.py
+++ b/src/sentry/nodestore/__init__.py
@@ -7,6 +7,7 @@ from sentry.utils.services import LazyServiceWrapper
 from .base import NodeStorage  # NOQA
 
 backend = LazyServiceWrapper(
-    NodeStorage, settings.SENTRY_NODESTORE, settings.SENTRY_NODESTORE_OPTIONS
+    NodeStorage, settings.SENTRY_NODESTORE, settings.SENTRY_NODESTORE_OPTIONS,
+    metrics_path='nodestore',
 )
 backend.expose(locals())

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -4,6 +4,7 @@ __all__ = ['timing', 'incr']
 
 import logging
 
+import functools
 from contextlib import contextmanager
 from django.conf import settings
 from random import random
@@ -130,3 +131,13 @@ def timer(key, instance=None, tags=None):
         tags['result'] = 'success'
     finally:
         timing(key, time() - start, instance, tags)
+
+
+def wraps(key, instance=None, tags=None):
+    def wrapper(f):
+        @functools.wraps(f)
+        def inner(*args, **kwargs):
+            with timer(key, instance=instance, tags=tags):
+                return f(*args, **kwargs)
+        return inner
+    return wrapper

--- a/tests/sentry/utils/test_metrics.py
+++ b/tests/sentry/utils/test_metrics.py
@@ -3,17 +3,17 @@ from __future__ import absolute_import
 import mock
 import pytest
 
-from sentry.utils.metrics import timer
+from sentry.utils import metrics
 
 
 def test_timer_success():
     with mock.patch('sentry.utils.metrics.timing') as timing:
-        with timer('key', tags={'foo': True}) as tags:
+        with metrics.timer('key', tags={'foo': True}) as tags:
             tags['bar'] = False
 
-        assert timing.call_count is 1
+        assert timing.call_count == 1
         args, kwargs = timing.call_args
-        assert args[0] is 'key'
+        assert args[0] == 'key'
         assert args[3] == {
             'foo': True,
             'bar': False,
@@ -28,13 +28,30 @@ class ExpectedError(Exception):
 def test_timer_failure():
     with mock.patch('sentry.utils.metrics.timing') as timing:
         with pytest.raises(ExpectedError):
-            with timer('key', tags={'foo': True}):
+            with metrics.timer('key', tags={'foo': True}):
                 raise ExpectedError
 
-        assert timing.call_count is 1
+        assert timing.call_count == 1
         args, kwargs = timing.call_args
-        assert args[0] is 'key'
+        assert args[0] == 'key'
         assert args[3] == {
             'foo': True,
             'result': 'failure',
+        }
+
+
+def test_wraps():
+    @metrics.wraps('key', tags={'foo': True})
+    def thing(a):
+        return a
+
+    with mock.patch('sentry.utils.metrics.timing') as timing:
+        thing(10) == 10
+
+        assert timing.call_count == 1
+        args, kwargs = timing.call_args
+        assert args[0] == 'key'
+        assert args[3] == {
+            'foo': True,
+            'result': 'success',
         }


### PR DESCRIPTION
And also turn on metrics for nodestore

cc @JTCunning 

```
In [10]: nodestore.get_multi(['foo'])
19:49:12 [WARNING] sentry.metrics: 'nodestore': 1.8568 ms (tags={'result': 'success', 'backend': 'sentry.nodestore.bigtable.BigtableNodeStorage'} instance=u'get_multi')
```