### PR TITLE
fix(issues) Fix issue deletion with no query

### DIFF
--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -35,7 +35,7 @@ export function paramsToQueryArgs(params) {
     ? {id: params.itemIds} // items matching array of itemids
     : params.query
     ? {query: params.query} // items matching search query
-    : undefined; // all items
+    : {}; // all items
 
   // only include environment if it is not null/undefined
   if (params.query && !isNil(params.environment)) {
@@ -43,7 +43,7 @@ export function paramsToQueryArgs(params) {
   }
 
   // only include projects if it is not null/undefined/an empty array
-  if (params.query && params.project && params.project.length) {
+  if (params.project && params.project.length) {
     p.project = params.project;
   }
 

--- a/tests/js/spec/api.spec.jsx
+++ b/tests/js/spec/api.spec.jsx
@@ -33,13 +33,13 @@ describe('api', function() {
       ).toEqual({query: 'is:unresolved'});
     });
 
-    it('should convert params w/o itemIds or query to undefined', function() {
+    it('should convert params w/o itemIds or query to empty object', function() {
       expect(
         paramsToQueryArgs({
           foo: 'bar',
           bar: 'baz', // paramsToQueryArgs ignores these
         })
-      ).toBeUndefined();
+      ).toEqual({});
     });
 
     it('should keep environment when query is provided', function() {
@@ -58,6 +58,29 @@ describe('api', function() {
           environment: null,
         })
       ).toEqual({query: 'is:unresolved'});
+    });
+
+    it('should handle non-empty projects', function() {
+      expect(
+        paramsToQueryArgs({
+          itemIds: [1, 2, 3],
+          project: [1],
+        })
+      ).toEqual({id: [1, 2, 3], project: [1]});
+
+      expect(
+        paramsToQueryArgs({
+          itemIds: [1, 2, 3],
+          project: [],
+        })
+      ).toEqual({id: [1, 2, 3]});
+
+      expect(
+        paramsToQueryArgs({
+          itemIds: [1, 2, 3],
+          project: null,
+        })
+      ).toEqual({id: [1, 2, 3]});
     });
   });
 
@@ -171,6 +194,22 @@ describe('api', function() {
       expect(api._wrapRequest).toHaveBeenCalledWith(
         '/projects/1337/1337/issues/',
         expect.objectContaining({query: {query: 'is:resolved'}}),
+        undefined
+      );
+    });
+
+    it('should apply project option', function() {
+      api.bulkUpdate({
+        orgId: '1337',
+        project: [99],
+        itemIds: [1, 2, 3],
+        data: {status: 'unresolved'},
+      });
+
+      expect(api._wrapRequest).toHaveBeenCalledTimes(1);
+      expect(api._wrapRequest).toHaveBeenCalledWith(
+        '/organizations/1337/issues/',
+        expect.objectContaining({query: {id: [1, 2, 3], project: [99]}}),
         undefined
       );
     });


### PR DESCRIPTION
Fix bulk deleting issues when there is no query selection. The previous logic would result in an error for users on plans that did not have the `global-views` feature which shouldn't be happening.

Fixes SEN-627