### PR TITLE
(fix): AuditLog Inbound Filters returned_state not assigned

### DIFF
--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -49,6 +49,9 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
             elif new_state - current_state:
                 returned_state = new_state - current_state
 
+            elif new_state == current_state:
+                returned_state = new_state
+
         if filter.id in ('browser-extensions', 'localhost', 'web-crawlers'):
             returned_state = filter.id
             removed = current_state - new_state


### PR DESCRIPTION
Returned_state is now assigned to a variable even if the state doesn't change.

Fixes: SENTRY-ART