### PR TITLE
ref(event-search): Fixed unhandled parse error.

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -478,7 +478,15 @@ class SearchVisitor(NodeVisitor):
 
 
 def parse_search_query(query):
-    tree = event_search_grammar.parse(query)
+    try:
+        tree = event_search_grammar.parse(query)
+    except IncompleteParseError as e:
+        raise InvalidSearchQuery(
+            '%s %s' % (
+                six.text_type(e),
+                'This is commonly caused by unmatched-parentheses.',
+            )
+        )
     return SearchVisitor().visit(tree)
 
 
@@ -600,11 +608,6 @@ def get_snuba_query_args(query=None, params=None):
         except ParseError as e:
             raise InvalidSearchQuery(
                 u'Parse error: %r (column %d)' % (e.expr.name, e.column())
-            )
-        except IncompleteParseError as e:
-            raise InvalidSearchQuery(
-                'Parse error: Search did not parse completely. This is commonly caused by unmatched-parenthesis. '
-                + six.text_type(e)
             )
 
     # Keys included as url params take precedent if same key is included in search

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -483,7 +483,7 @@ def parse_search_query(query):
     except IncompleteParseError as e:
         raise InvalidSearchQuery(
             '%s %s' % (
-                six.text_type(e),
+                u'Parse error: %r (column %d).' % (e.expr.name, e.column()),
                 'This is commonly caused by unmatched-parentheses.',
             )
         )

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -918,43 +918,30 @@ class ParseBooleanSearchQueryTest(TestCase):
         )]
 
     def test_malformed_groups(self):
-        error_text = "Rule 'search' matched in its entirety, but it didn't consume all the text. The non-matching portion of the text begins with"
         with pytest.raises(InvalidSearchQuery) as error:
             parse_search_query(
                 '(user.email:foo@example.com OR user.email:bar@example.com'
             )
-        assert six.text_type(error.value) == '%s %s %s' % (
-            error_text,
-            "'(user.email:foo@exam' (line 1, column 1).",
-            'This is commonly caused by unmatched-parentheses.'
-        )
+        assert six.text_type(
+            error.value) == "Parse error: 'search' (column 1). This is commonly caused by unmatched-parentheses."
         with pytest.raises(InvalidSearchQuery) as error:
             parse_search_query(
                 '((user.email:foo@example.com OR user.email:bar@example.com AND  user.email:bar@example.com)'
             )
-        assert six.text_type(error.value) == '%s %s %s' % (
-            error_text,
-            "'((user.email:foo@exa' (line 1, column 1).",
-            'This is commonly caused by unmatched-parentheses.',
-        )
+        assert six.text_type(
+            error.value) == "Parse error: 'search' (column 1). This is commonly caused by unmatched-parentheses."
         with pytest.raises(InvalidSearchQuery) as error:
             parse_search_query(
                 'user.email:foo@example.com OR user.email:bar@example.com)'
             )
-        assert six.text_type(error.value) == '%s %s %s' % (
-            error_text,
-            "')' (line 1, column 57).",
-            'This is commonly caused by unmatched-parentheses.'
-        )
+        assert six.text_type(
+            error.value) == "Parse error: 'search' (column 57). This is commonly caused by unmatched-parentheses."
         with pytest.raises(InvalidSearchQuery) as error:
             parse_search_query(
                 '(user.email:foo@example.com OR user.email:bar@example.com AND  user.email:bar@example.com))'
             )
-        assert six.text_type(error.value) == '%s %s %s' % (
-            error_text,
-            "')' (line 1, column 91).",
-            'This is commonly caused by unmatched-parentheses.'
-        )
+        assert six.text_type(
+            error.value) == "Parse error: 'search' (column 91). This is commonly caused by unmatched-parentheses."
 
     def test_grouping_without_boolean_terms(self):
         with pytest.raises(InvalidSearchQuery) as error:
@@ -966,10 +953,8 @@ class ParseBooleanSearchQueryTest(TestCase):
                 value=SearchValue(
                     raw_value='undefined is not an object (evaluating "function.name")'),
             )]
-        assert six.text_type(error.value) == '%s %s' % (
-            "Rule 'search' matched in its entirety, but it didn't consume all the text. The non-matching portion of the text begins with '(evaluating 'functio' (line 1, column 28).",
-            'This is commonly caused by unmatched-parentheses.',
-        )
+        assert six.text_type(
+            error.value) == "Parse error: 'search' (column 28). This is commonly caused by unmatched-parentheses."
 
 
 class GetSnubaQueryArgsTest(TestCase):

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -155,7 +155,7 @@ class OrganizationEventsEndpointTest(OrganizationEventsTestBase):
         response = self.client.get(url, {'query': 'hi \n there'}, format='json')
 
         assert response.status_code == 400, response.content
-        assert response.data['detail'] == "Parse error: 'search' (column 4)"
+        assert response.data['detail'] == "Parse error: 'search' (column 4). This is commonly caused by unmatched-parentheses."
 
     def test_project_filtering(self):
         user = self.create_user(is_staff=False, is_superuser=False)


### PR DESCRIPTION
The `IncompleteParseError` was previously unhandled for any error that didn't come through `get_snuba_query_args`. This fixes that issue.