### PR TITLE
feat(events-v2): Add events components to UI

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
@@ -1,11 +1,37 @@
 import React from 'react';
+import styled from 'react-emotion';
 import SentryTypes from 'app/sentryTypes';
+import space from 'app/styles/space';
+import SearchBar from 'app/views/organizationEvents/searchBar';
+
+import Table from './table';
+import Tags from './tags';
 
 export default class Events extends React.Component {
   static propTypes = {
+    organization: SentryTypes.Organization.isRequired,
     view: SentryTypes.EventView.isRequired,
   };
   render() {
-    return this.props.view.name;
+    const {organization, view} = this.props;
+    return (
+      <Container>
+        <div>
+          <StyledSearchBar organization={organization} />
+          <Table view={view} organization={organization} />
+        </div>
+        <Tags view={view} />
+      </Container>
+    );
   }
 }
+
+const Container = styled('div')`
+  display: grid;
+  grid-template-columns: auto 300px;
+  grid-gap: ${space(2)};
+`;
+
+const StyledSearchBar = styled(SearchBar)`
+  margin-bottom: ${space(2)};
+`;

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/tags.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/tags.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import SentryTypes from 'app/sentryTypes';
+import TagDistributionMeter from 'app/components/tagDistributionMeter';
+
+export default class Tags extends React.Component {
+  static propTypes = {
+    view: SentryTypes.EventView.isRequired,
+  };
+
+  renderTag(tag) {
+    return (
+      <TagDistributionMeter key={tag} title={tag} segments={[]}>
+        {tag}
+      </TagDistributionMeter>
+    );
+  }
+
+  render() {
+    return <div>{this.props.view.tags.map(tag => this.renderTag(tag))}</div>;
+  }
+}


### PR DESCRIPTION
Adds the search bar, tag distribution and table component to the events
page. These are mostly unconnected components right now.