### PR TITLE
fix(ui): Fix `<AttachmentUrl>` in Group Events

### DIFF
--- a/src/sentry/static/sentry/app/components/eventsTable/eventsTableRow.jsx
+++ b/src/sentry/static/sentry/app/components/eventsTable/eventsTableRow.jsx
@@ -40,7 +40,7 @@ class EventsTableRow extends React.Component {
   };
 
   renderCrashFileLink() {
-    const {event} = this.props;
+    const {event, projectId} = this.props;
     if (!event.crashFile) {
       return null;
     }
@@ -49,7 +49,7 @@ class EventsTableRow extends React.Component {
       event.crashFile.type === 'event.minidump' ? 'Minidump' : 'Crash file';
 
     return (
-      <AttachmentUrl>
+      <AttachmentUrl projectId={projectId} event={event} attachment={event.crashFile}>
         {downloadUrl =>
           downloadUrl && (
             <small>

--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -217,7 +217,7 @@ export const EventAttachment = PropTypes.shape({
   headers: PropTypes.object,
   size: PropTypes.number.isRequired,
   sha1: PropTypes.string.isRequired,
-  dateCreated: PropTypes.number,
+  dateCreated: PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(Date)]),
   type: PropTypes.string.isRequired,
 });
 

--- a/tests/js/fixtures/event.js
+++ b/tests/js/fixtures/event.js
@@ -4,6 +4,8 @@ export function Event(params) {
     message: 'ApiException',
     groupID: '1',
     eventID: '12345678901234567890123456789012',
+    dateCreated: '2019-05-21T18:01:48.762Z',
+    tags: [],
     ...params,
   };
 }

--- a/tests/js/spec/components/events/__snapshots__/crashContent.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/crashContent.spec.jsx.snap
@@ -4,10 +4,12 @@ exports[`CrashContent renders with meta data 1`] = `
 <CrashContent
   event={
     Object {
+      "dateCreated": "2019-05-21T18:01:48.762Z",
       "eventID": "12345678901234567890123456789012",
       "groupID": "1",
       "id": "1",
       "message": "ApiException",
+      "tags": Array [],
     }
   }
   exception={

--- a/tests/js/spec/views/groupDetails/__snapshots__/organizationGroupEvents.spec.jsx.snap
+++ b/tests/js/spec/views/groupDetails/__snapshots__/organizationGroupEvents.spec.jsx.snap
@@ -1,56 +1,196 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`groupEvents renders 1`] = `
-<div>
-  <div
-    style={
-      Object {
-        "marginBottom": 20,
-      }
-    }
+Array [
+  <tr>
+    <th>
+      ID
+    </th>
+  </tr>,
+  <tr
+    key="1"
   >
-    <SearchBar
-      defaultQuery=""
-      onSearch={[Function]}
-      placeholder="search event id, message, or tags"
-      query=""
-    />
-  </div>
-  <Panel
-    className="event-list"
+    <td>
+      <h5>
+        <Link
+          onlyActiveOnIndex={false}
+          style={Object {}}
+          to="/orgId/project-slug/issues/1/events/1/"
+        >
+          <a
+            onClick={[Function]}
+            style={Object {}}
+          >
+            <DateTime
+              date="2019-05-21T18:01:48.762Z"
+              seconds={true}
+            >
+              <time>
+                May 21, 2019 6:01:48 PM UTC
+              </time>
+            </DateTime>
+          </a>
+        </Link>
+        <small>
+          ApiException
+        </small>
+      </h5>
+    </td>
+  </tr>,
+  <tr
+    key="98654"
   >
-    <PanelBody
-      direction="column"
-      disablePadding={true}
-      flex={false}
-    >
-      <EventsTable
-        events={
-          Array [
+    <td>
+      <h5>
+        <Link
+          onlyActiveOnIndex={false}
+          style={Object {}}
+          to="/orgId/project-slug/issues/1/events/98654/"
+        >
+          <a
+            onClick={[Function]}
+            style={Object {}}
+          >
+            <DateTime
+              date="2019-05-21T18:00:23Z"
+              seconds={true}
+            >
+              <time>
+                May 21, 2019 6:00:23 PM UTC
+              </time>
+            </DateTime>
+          </a>
+        </Link>
+        <small>
+          TestException
+        </small>
+        <WithOrganizationMockWrapper
+          attachment={
             Object {
-              "eventID": "12345",
-              "groupID": "1",
-              "id": "1",
-              "message": "ApiException",
-            },
+              "dateCreated": "2019-05-21T18:01:48.762Z",
+              "headers": Object {
+                "Content-Type": "application/octet-stream",
+              },
+              "id": "12345",
+              "name": "name.dmp",
+              "sha1": "sha1",
+              "size": 123456,
+              "type": "event.minidump",
+            }
+          }
+          event={
             Object {
-              "eventID": "12346",
+              "crashFile": Object {
+                "dateCreated": "2019-05-21T18:01:48.762Z",
+                "headers": Object {
+                  "Content-Type": "application/octet-stream",
+                },
+                "id": "12345",
+                "name": "name.dmp",
+                "sha1": "sha1",
+                "size": 123456,
+                "type": "event.minidump",
+              },
+              "culprit": "",
+              "dateCreated": "2019-05-21T18:00:23Z",
+              "event.type": "error",
+              "eventID": "123456",
               "groupID": "1",
-              "id": "2",
+              "id": "98654",
+              "location": "main.js",
               "message": "TestException",
-            },
-          ]
-        }
-        groupId="1"
-        orgId="orgId"
-        projectId="project-slug"
-        tagList={Array []}
-      />
-    </PanelBody>
-  </Panel>
-  <Pagination
-    className="stream-pagination"
-    onCursor={[Function]}
-  />
-</div>
+              "platform": "native",
+              "projectID": "123",
+              "tags": Array [
+                Object {
+                  "key": "production",
+                  "value": "production",
+                },
+              ],
+              "title": "TestException",
+            }
+          }
+          projectId="project-slug"
+        >
+          <AttachmentUrl
+            attachment={
+              Object {
+                "dateCreated": "2019-05-21T18:01:48.762Z",
+                "headers": Object {
+                  "Content-Type": "application/octet-stream",
+                },
+                "id": "12345",
+                "name": "name.dmp",
+                "sha1": "sha1",
+                "size": 123456,
+                "type": "event.minidump",
+              }
+            }
+            event={
+              Object {
+                "crashFile": Object {
+                  "dateCreated": "2019-05-21T18:01:48.762Z",
+                  "headers": Object {
+                    "Content-Type": "application/octet-stream",
+                  },
+                  "id": "12345",
+                  "name": "name.dmp",
+                  "sha1": "sha1",
+                  "size": 123456,
+                  "type": "event.minidump",
+                },
+                "culprit": "",
+                "dateCreated": "2019-05-21T18:00:23Z",
+                "event.type": "error",
+                "eventID": "123456",
+                "groupID": "1",
+                "id": "98654",
+                "location": "main.js",
+                "message": "TestException",
+                "platform": "native",
+                "projectID": "123",
+                "tags": Array [
+                  Object {
+                    "key": "production",
+                    "value": "production",
+                  },
+                ],
+                "title": "TestException",
+              }
+            }
+            organization={
+              Object {
+                "access": Array [
+                  "org:read",
+                  "org:write",
+                  "org:admin",
+                  "org:integrations",
+                  "project:read",
+                  "project:write",
+                  "project:admin",
+                  "team:read",
+                  "team:write",
+                  "team:admin",
+                ],
+                "features": Array [],
+                "id": "3",
+                "name": "Organization Name",
+                "onboardingTasks": Array [],
+                "projects": Array [],
+                "scrapeJavaScript": true,
+                "slug": "org-slug",
+                "status": Object {
+                  "id": "active",
+                  "name": "active",
+                },
+                "teams": Array [],
+              }
+            }
+            projectId="project-slug"
+          />
+        </WithOrganizationMockWrapper>
+      </h5>
+    </td>
+  </tr>,
+]
 `;

--- a/tests/js/spec/views/groupDetails/__snapshots__/projectGroupEvents.spec.jsx.snap
+++ b/tests/js/spec/views/groupDetails/__snapshots__/projectGroupEvents.spec.jsx.snap
@@ -28,16 +28,20 @@ exports[`groupEvents renders 1`] = `
         events={
           Array [
             Object {
+              "dateCreated": "2019-05-21T18:01:48.762Z",
               "eventID": "12345",
               "groupID": "1",
               "id": "1",
               "message": "ApiException",
+              "tags": Array [],
             },
             Object {
+              "dateCreated": "2019-05-21T18:01:48.762Z",
               "eventID": "12346",
               "groupID": "1",
               "id": "2",
               "message": "TestException",
+              "tags": Array [],
             },
           ]
         }

--- a/tests/js/spec/views/groupDetails/organizationGroupEvents.spec.jsx
+++ b/tests/js/spec/views/groupDetails/organizationGroupEvents.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import {browserHistory} from 'react-router';
 
 import {GroupEvents} from 'app/views/groupDetails/organization/groupEvents';
@@ -9,32 +9,59 @@ const OrgnanizationGroupEvents = GroupEvents;
 
 describe('groupEvents', function() {
   let request;
+  const routerContext = TestStubs.routerContext();
+
   beforeEach(function() {
     request = MockApiClient.addMockResponse({
       url: '/issues/1/events/',
-      body: TestStubs.Events(),
+      body: [
+        TestStubs.Event({
+          eventID: '12345',
+          id: '1',
+          message: 'ApiException',
+          groupID: '1',
+        }),
+        TestStubs.Event({
+          crashFile: {
+            sha1: 'sha1',
+            name: 'name.dmp',
+            dateCreated: '2019-05-21T18:01:48.762Z',
+            headers: {'Content-Type': 'application/octet-stream'},
+            id: '12345',
+            size: 123456,
+            type: 'event.minidump',
+          },
+          culprit: '',
+          dateCreated: '2019-05-21T18:00:23Z',
+          'event.type': 'error',
+          eventID: '123456',
+          groupID: '1',
+          id: '98654',
+          location: 'main.js',
+          message: 'TestException',
+          platform: 'native',
+          projectID: '123',
+          tags: [{value: 'production', key: 'production'}],
+          title: 'TestException',
+        }),
+      ],
     });
 
     browserHistory.push = jest.fn();
   });
 
   it('renders', function() {
-    const component = shallow(
+    const component = mount(
       <OrgnanizationGroupEvents
         api={new MockApiClient()}
         group={TestStubs.Group()}
         params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
         location={{query: {}}}
       />,
-      {
-        context: {...TestStubs.router()},
-        childContextTypes: {
-          router: PropTypes.object,
-        },
-      }
+      routerContext
     );
 
-    expect(component).toMatchSnapshot();
+    expect(component.find('tr')).toMatchSnapshot();
   });
 
   it('handles search', function() {

--- a/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
@@ -76,6 +76,7 @@ exports[`SharedGroupDetails renders 1`] = `
                         "lastRelease": null,
                         "lastSeen": "2019-04-11T01:08:59Z",
                         "latestEvent": Object {
+                          "dateCreated": "2019-05-21T18:01:48.762Z",
                           "entries": Array [
                             Object {
                               "data": Object {
@@ -89,6 +90,7 @@ exports[`SharedGroupDetails renders 1`] = `
                           "groupID": "1",
                           "id": "1",
                           "message": "ApiException",
+                          "tags": Array [],
                         },
                         "level": "warning",
                         "logger": null,
@@ -187,6 +189,7 @@ exports[`SharedGroupDetails renders 1`] = `
                       <WithOrganizationMockWrapper
                         event={
                           Object {
+                            "dateCreated": "2019-05-21T18:01:48.762Z",
                             "entries": Array [
                               Object {
                                 "data": Object {
@@ -200,6 +203,7 @@ exports[`SharedGroupDetails renders 1`] = `
                             "groupID": "1",
                             "id": "1",
                             "message": "ApiException",
+                            "tags": Array [],
                           }
                         }
                         group={
@@ -219,6 +223,7 @@ exports[`SharedGroupDetails renders 1`] = `
                             "lastRelease": null,
                             "lastSeen": "2019-04-11T01:08:59Z",
                             "latestEvent": Object {
+                              "dateCreated": "2019-05-21T18:01:48.762Z",
                               "entries": Array [
                                 Object {
                                   "data": Object {
@@ -232,6 +237,7 @@ exports[`SharedGroupDetails renders 1`] = `
                               "groupID": "1",
                               "id": "1",
                               "message": "ApiException",
+                              "tags": Array [],
                             },
                             "level": "warning",
                             "logger": null,
@@ -315,6 +321,7 @@ exports[`SharedGroupDetails renders 1`] = `
                         <withApi(EventEntries)
                           event={
                             Object {
+                              "dateCreated": "2019-05-21T18:01:48.762Z",
                               "entries": Array [
                                 Object {
                                   "data": Object {
@@ -328,6 +335,7 @@ exports[`SharedGroupDetails renders 1`] = `
                               "groupID": "1",
                               "id": "1",
                               "message": "ApiException",
+                              "tags": Array [],
                             }
                           }
                           group={
@@ -347,6 +355,7 @@ exports[`SharedGroupDetails renders 1`] = `
                               "lastRelease": null,
                               "lastSeen": "2019-04-11T01:08:59Z",
                               "latestEvent": Object {
+                                "dateCreated": "2019-05-21T18:01:48.762Z",
                                 "entries": Array [
                                   Object {
                                     "data": Object {
@@ -360,6 +369,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                 "groupID": "1",
                                 "id": "1",
                                 "message": "ApiException",
+                                "tags": Array [],
                               },
                               "level": "warning",
                               "logger": null,
@@ -472,6 +482,7 @@ exports[`SharedGroupDetails renders 1`] = `
                             api={Client {}}
                             event={
                               Object {
+                                "dateCreated": "2019-05-21T18:01:48.762Z",
                                 "entries": Array [
                                   Object {
                                     "data": Object {
@@ -485,6 +496,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                 "groupID": "1",
                                 "id": "1",
                                 "message": "ApiException",
+                                "tags": Array [],
                               }
                             }
                             group={
@@ -504,6 +516,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                 "lastRelease": null,
                                 "lastSeen": "2019-04-11T01:08:59Z",
                                 "latestEvent": Object {
+                                  "dateCreated": "2019-05-21T18:01:48.762Z",
                                   "entries": Array [
                                     Object {
                                       "data": Object {
@@ -517,6 +530,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                   "groupID": "1",
                                   "id": "1",
                                   "message": "ApiException",
+                                  "tags": Array [],
                                 },
                                 "level": "warning",
                                 "logger": null,
@@ -632,6 +646,7 @@ exports[`SharedGroupDetails renders 1`] = `
                               <EventTags
                                 event={
                                   Object {
+                                    "dateCreated": "2019-05-21T18:01:48.762Z",
                                     "entries": Array [
                                       Object {
                                         "data": Object {
@@ -645,6 +660,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                     "groupID": "1",
                                     "id": "1",
                                     "message": "ApiException",
+                                    "tags": Array [],
                                   }
                                 }
                                 group={
@@ -664,6 +680,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                     "lastRelease": null,
                                     "lastSeen": "2019-04-11T01:08:59Z",
                                     "latestEvent": Object {
+                                      "dateCreated": "2019-05-21T18:01:48.762Z",
                                       "entries": Array [
                                         Object {
                                           "data": Object {
@@ -677,6 +694,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                       "groupID": "1",
                                       "id": "1",
                                       "message": "ApiException",
+                                      "tags": Array [],
                                     },
                                     "level": "warning",
                                     "logger": null,
@@ -778,6 +796,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                 }
                                 event={
                                   Object {
+                                    "dateCreated": "2019-05-21T18:01:48.762Z",
                                     "entries": Array [
                                       Object {
                                         "data": Object {
@@ -791,6 +810,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                     "groupID": "1",
                                     "id": "1",
                                     "message": "ApiException",
+                                    "tags": Array [],
                                   }
                                 }
                                 group={
@@ -810,6 +830,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                     "lastRelease": null,
                                     "lastSeen": "2019-04-11T01:08:59Z",
                                     "latestEvent": Object {
+                                      "dateCreated": "2019-05-21T18:01:48.762Z",
                                       "entries": Array [
                                         Object {
                                           "data": Object {
@@ -823,6 +844,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                       "groupID": "1",
                                       "id": "1",
                                       "message": "ApiException",
+                                      "tags": Array [],
                                     },
                                     "level": "warning",
                                     "logger": null,
@@ -892,6 +914,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                 <GroupEventDataSection
                                   event={
                                     Object {
+                                      "dateCreated": "2019-05-21T18:01:48.762Z",
                                       "entries": Array [
                                         Object {
                                           "data": Object {
@@ -905,6 +928,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                       "groupID": "1",
                                       "id": "1",
                                       "message": "ApiException",
+                                      "tags": Array [],
                                     }
                                   }
                                   group={
@@ -924,6 +948,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                       "lastRelease": null,
                                       "lastSeen": "2019-04-11T01:08:59Z",
                                       "latestEvent": Object {
+                                        "dateCreated": "2019-05-21T18:01:48.762Z",
                                         "entries": Array [
                                           Object {
                                             "data": Object {
@@ -937,6 +962,7 @@ exports[`SharedGroupDetails renders 1`] = `
                                         "groupID": "1",
                                         "id": "1",
                                         "message": "ApiException",
+                                        "tags": Array [],
                                       },
                                       "level": "warning",
                                       "logger": null,

--- a/tests/js/spec/views/userFeedback/__snapshots__/projectUserFeedback.spec.jsx.snap
+++ b/tests/js/spec/views/userFeedback/__snapshots__/projectUserFeedback.spec.jsx.snap
@@ -96,10 +96,12 @@ exports[`projectUserFeedback renders 1`] = `
             "dateCreated": "2018-12-20T00:00:00.000Z",
             "email": "lyn@sentry.io",
             "event": Object {
+              "dateCreated": "2019-05-21T18:01:48.762Z",
               "eventID": "12345678901234567890123456789012",
               "groupID": "1",
               "id": "1",
               "message": "ApiException",
+              "tags": Array [],
             },
             "id": "123",
             "issue": Object {


### PR DESCRIPTION
GroupEvents table was crashing when there were events with minidump crash files.

Fixes JAVASCRIPT-WCT