### PR TITLE
feat(events-v2): Add support for "project.name" field

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -50,8 +50,16 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         except InvalidSearchQuery as exc:
             raise OrganizationEventsError(exc.message)
 
-        fields = request.GET.getlist('fields')
+        fields = request.GET.getlist('fields')[:]
+
         if fields:
+            # If project.name is requested, get the project.id from Snuba so we
+            # can use this to look up the name in Sentry
+            if 'project.name' in fields:
+                fields.remove('project.name')
+                if 'project.id' not in fields:
+                    fields.append('project.id')
+
             snuba_args['selected_columns'] = fields
         else:
             raise OrganizationEventsError('No fields requested.')

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -41,9 +41,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 'Boolean search operator OR and AND not allowed in this search.')
         return snuba_args
 
-    def get_snuba_query_args_v2(self, request, organization):
-        params = self.get_filter_params(request, organization)
-
+    def get_snuba_query_args_v2(self, request, organization, params):
         query = request.GET.get('query')
         try:
             snuba_args = get_snuba_query_args(query=query, params=params)

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -18,6 +18,7 @@ from sentry.utils.snuba import (
     SnubaTSResult,
 )
 from sentry import features
+from sentry.models.project import Project
 
 
 class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
@@ -72,7 +73,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
     def get_v2(self, request, organization):
         try:
-            snuba_args = self.get_snuba_query_args_v2(request, organization)
+            params = self.get_filter_params(request, organization)
+            snuba_args = self.get_snuba_query_args_v2(request, organization, params)
         except OrganizationEventsError as exc:
             return Response({'detail': exc.message}, status=400)
         except NoProjects:
@@ -89,13 +91,14 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             return self.paginate(
                 request=request,
                 paginator=GenericOffsetPaginator(data_fn=data_fn),
-                on_results=lambda results: self.handle_results(request, organization, results),
+                on_results=lambda results: self.handle_results(
+                    request, organization, params['project_id'], results),
             )
 
-    def handle_results(self, request, organization, results):
-        projects = {}
-        for project in self.get_projects(request, organization):
-            projects[project.id] = project.slug
+    def handle_results(self, request, organization, project_ids, results):
+        projects = {p['id']: p['slug'] for p in Project.objects.filter(
+            organization=organization,
+            id__in=project_ids).values('id', 'slug')}
 
         fields = request.GET.getlist('fields')
 

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -92,6 +92,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]['project.name'] == project.slug
+        assert 'project.id' not in response.data[0]
         assert response.data[0]['environment'] == 'staging'
 
     def test_groupby(self):

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -68,6 +68,32 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[0]['project.id'] == project2.id
         assert response.data[0]['user.email'] == 'foo@example.com'
 
+    def test_project_name(self):
+        self.login_as(user=self.user)
+        project = self.create_project()
+        self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'environment': 'staging',
+                'timestamp': self.min_ago,
+            },
+            project_id=project.id,
+        )
+
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'fields': ['project.name', 'environment'],
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['project.name'] == project.slug
+        assert response.data[0]['environment'] == 'staging'
+
     def test_groupby(self):
         self.login_as(user=self.user)
         project = self.create_project()


### PR DESCRIPTION
If "project.name" is requested, we request project.id from Snuba then
map this back to the project slug.