### PR TITLE
fix: Renormalize snuba events

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -512,7 +512,7 @@ class SnubaEvent(EventCommon):
         node_id = SnubaEvent.generate_node_id(
             self.snuba_data['project_id'],
             self.snuba_data['event_id'])
-        self.data = NodeData(None, node_id, data=None)
+        self.data = NodeData(None, node_id, data=None, wrapper=EventDict)
 
     def __getattr__(self, name):
         """


### PR DESCRIPTION
SnubaEvents are not renormalize because they use `NodeData` directly. This patch adds the wrapper class to `NodeData` to do just that.

cc @mitsuhiko 
