### PR TITLE
feat(events-v2): Prevent mutations to event data object

### DIFF
--- a/src/sentry/static/sentry/app/utils.jsx
+++ b/src/sentry/static/sentry/app/utils.jsx
@@ -268,6 +268,19 @@ export function parsePeriodToHours(str) {
   }
 }
 
+export function deepFreeze(object) {
+  // Retrieve the property names defined on object
+  const propNames = Object.getOwnPropertyNames(object);
+  // Freeze properties before freezing self
+  for (const name of propNames) {
+    const value = object[name];
+
+    object[name] = value && typeof value === 'object' ? deepFreeze(value) : value;
+  }
+
+  return Object.freeze(object);
+}
+
 // re-export under utils
 export {parseLinkHeader, PendingChangeQueue, CursorPoller};
 

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
@@ -1,6 +1,6 @@
-import {cloneDeep} from 'lodash';
+import {deepFreeze} from 'app/utils';
 
-export const ALL_VIEWS = [
+export const ALL_VIEWS = deepFreeze([
   {
     id: 'all',
     name: 'All Events',
@@ -50,7 +50,7 @@ export const ALL_VIEWS = [
       'effective-directive',
     ],
   },
-];
+]);
 
 /**
  * "Special fields" do not map 1:1 to an single column in the event database,
@@ -96,7 +96,7 @@ export function fetchOrganizationEvents(api, orgSlug, view) {
  * @returns {Object}
  */
 export function getQuery(view) {
-  const data = cloneDeep(view.data);
+  const data = {...view.data};
   data.fields = data.fields.reduce((fields, field) => {
     if (SPECIAL_FIELDS.hasOwnProperty(field)) {
       fields.push(...SPECIAL_FIELDS[field]);

--- a/tests/js/spec/utils/utils.spec.jsx
+++ b/tests/js/spec/utils/utils.spec.jsx
@@ -5,6 +5,7 @@ import {
   explodeSlug,
   sortProjects,
   descopeFeatureName,
+  deepFreeze,
 } from 'app/utils';
 
 describe('utils.valueIsEqual', function() {
@@ -243,4 +244,24 @@ describe('utils.descopeFeatureName', function() {
     ['unknown-scope:feature', 'unknown-scope:feature'],
     ['', ''],
   ].map(([input, expected]) => expect(descopeFeatureName(input)).toEqual(expected));
+});
+
+describe('deepFreeze', function() {
+  it('throws error on attempt to mutate frozen object', function() {
+    const testObj = deepFreeze({foo: [1, 2, 3]});
+
+    [
+      () => {
+        testObj.foo.push(4);
+      },
+      () => {
+        testObj.bar = '';
+      },
+      () => {
+        delete testObj.foo;
+      },
+    ].forEach(fn => {
+      expect(fn).toThrow();
+    });
+  });
 });


### PR DESCRIPTION
Prevent mutations to view data that was caused by cloneDeep not working
as expected. Use spread syntax to shallow copy and deep freeze the object
to prevent this happening in future.