### PR TITLE
fix(app-platform): Delete Internal Integrations

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
@@ -133,7 +133,7 @@ export default class SentryApplicationRow extends React.PureComponent {
             </Box>
           ) : (
             <Box>
-              {app.status === 'unpublished' ? (
+              {app.status !== 'published' ? (
                 <Access access={['org:admin']}>
                   {({hasAccess}) => (
                     <React.Fragment>
@@ -147,6 +147,7 @@ export default class SentryApplicationRow extends React.PureComponent {
                           icon="icon-trash"
                         />
                       )}
+
                       {hasAccess && this.renderRemoveApp(app)}
                     </React.Fragment>
                   )}

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -113,6 +113,24 @@ describe('Organization Developer Settings', function() {
     });
   });
 
+  describe('with Internal Integrations', () => {
+    const internalIntegration = TestStubs.SentryApp({status: 'internal'});
+
+    Client.addMockResponse({
+      url: `/organizations/${org.slug}/sentry-apps/`,
+      body: [internalIntegration],
+    });
+
+    const wrapper = mount(
+      <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />,
+      routerContext
+    );
+
+    it('allows deleting', () => {
+      expect(wrapper.find('[icon="icon-trash"]').prop('disabled')).toEqual(false);
+    });
+  });
+
   describe('without Owner permissions', () => {
     const newOrg = TestStubs.Organization({access: ['org:read']});
     Client.addMockResponse({


### PR DESCRIPTION
Allow developers to delete Internal Integrations. Previously the code assumed only two states. We've introduced a third and this change ensures the correct logic in all states.