### PR TITLE
fix(api): Return a 429 from all apis when snuba returns a 429, rather than returning a 500. (SEN-660)

### DIFF
--- a/src/sentry/api/handlers.py
+++ b/src/sentry/api/handlers.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+from rest_framework.views import exception_handler
+from rest_framework.exceptions import Throttled
+
+from sentry.utils.snuba import RateLimitExceeded
+
+
+def custom_exception_handler(exc):
+    if isinstance(exc, RateLimitExceeded):
+        # If Snuba throws a RateLimitExceeded then it'll likely be available
+        # after another second.
+        exc = Throttled(wait=1)
+
+    return exception_handler(exc)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -780,6 +780,7 @@ LOGGING = {
 REST_FRAMEWORK = {
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
     'DEFAULT_PERMISSION_CLASSES': ('sentry.api.permissions.NoPermission', ),
+    'EXCEPTION_HANDLER': 'sentry.api.handlers.custom_exception_handler',
 }
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'

--- a/tests/sentry/api/test_handlers.py
+++ b/tests/sentry/api/test_handlers.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+
+from django.conf.urls import (
+    patterns,
+    url,
+)
+from rest_framework.permissions import AllowAny
+
+from sentry.api.base import Endpoint
+from sentry.utils.snuba import RateLimitExceeded
+from sentry.testutils import APITestCase
+
+
+class RateLimitedEndpoint(Endpoint):
+    permission_classes = (AllowAny, )
+
+    def get(self, request):
+        raise RateLimitExceeded()
+
+
+urlpatterns = patterns(
+    '',
+    url(
+        r'^/$',
+        RateLimitedEndpoint.as_view(),
+        name='sentry-test'
+    ),
+)
+
+
+class TestRateLimited(APITestCase):
+    endpoint = 'sentry-test'
+    urls = 'tests.sentry.api.test_handlers'
+
+    def test_simple(self):
+        self.login_as(self.user)
+        resp = self.get_response()
+        assert resp.status_code == 429
+        assert resp.data['detail'] == 'Request was throttled. Expected available in 1 second.'


### PR DESCRIPTION
At the moment, when Snuba returns a 429 (rate limited) we raise a `RateLimitExceeded` exception.
This isn't caught anywhere, so we end up returning a 500 to the user. Added a custom exception
handler to allow us to treat this correctly. If we find we're adding more exceptions here it might
make sense to keep a registry rather than if statements, but we can expand as needed.