### PR TITLE
misc(logging): Stop logging UserReport child deletions in bulk.

### DIFF
--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -6,7 +6,7 @@ import re
 from sentry.constants import ObjectStatus
 from sentry.utils.query import bulk_delete_objects
 
-_leaf_re = re.compile(r'^(Event|Group)(.+)')
+_leaf_re = re.compile(r'^(UserReport|Event|Group)(.+)')
 
 
 class BaseRelation(object):


### PR DESCRIPTION
This will prevent us from logging every query issued on child deletion per-Event.