### PR TITLE
feat(api): Add PUT/DELETE methods for Incident Comments

### DIFF
--- a/src/sentry/api/bases/incident.py
+++ b/src/sentry/api/bases/incident.py
@@ -16,6 +16,7 @@ class IncidentPermission(OrganizationPermission):
         'GET': ['org:read', 'org:write', 'org:admin', 'project:read', 'project:write', 'project:admin'],
         'POST': ['org:write', 'org:admin', 'project:read', 'project:write', 'project:admin'],
         'PUT': ['org:write', 'org:admin', 'project:read', 'project:write', 'project:admin'],
+        'DELETE': ['org:write', 'org:admin', 'project:read', 'project:write', 'project:admin'],
     }
 
 

--- a/src/sentry/api/endpoints/organization_incident_comment_details.py
+++ b/src/sentry/api/endpoints/organization_incident_comment_details.py
@@ -22,7 +22,7 @@ class CommentSerializer(serializers.Serializer):
 
 
 class CommentDetailsEndpoint(IncidentEndpoint):
-    def convert_args(self, request, incident_identifier, activity_id, *args, **kwargs):
+    def convert_args(self, request, activity_id, *args, **kwargs):
         # See GroupNotesDetailsEndpoint:
         #   We explicitly don't allow a request with an ApiKey
         #   since an ApiKey is bound to the Organization, not
@@ -33,7 +33,6 @@ class CommentDetailsEndpoint(IncidentEndpoint):
 
         args, kwargs = super(CommentDetailsEndpoint, self).convert_args(
             request,
-            incident_identifier,
             *args,
             **kwargs
         )

--- a/src/sentry/api/endpoints/organization_incident_comment_details.py
+++ b/src/sentry/api/endpoints/organization_incident_comment_details.py
@@ -1,0 +1,74 @@
+from __future__ import absolute_import
+
+from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.response import Response
+
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.bases.incident import (
+    IncidentEndpoint,
+    IncidentPermission,
+)
+from sentry.api.serializers import serialize
+from sentry.incidents.models import IncidentActivity
+from sentry.incidents.logic import (
+    delete_comment,
+    update_comment,
+)
+
+
+class CommentSerializer(serializers.Serializer):
+    comment = serializers.CharField(required=False)
+
+
+class OrganizationIncidentCommentDetailsEndpoint(IncidentEndpoint):
+    # See GroupNotesDetailsEndpoint:
+    #   We explicitly don't allow a request with an ApiKey
+    #   since an ApiKey is bound to the Organization, not
+    #   an individual. Not sure if we'd want to allow an ApiKey
+    #   to delete/update other users' comments
+    permission_classes = (IncidentPermission, )
+
+    def delete(self, request, organization, incident, activity_id):
+        """
+        Delete a comment
+        ````````````````
+        :auth: required
+        """
+
+        if not request.user.is_authenticated():
+            raise PermissionDenied(detail="Key doesn't have permission to delete Note")
+
+        try:
+            delete_comment(incident=incident, user=request.user, activity_id=activity_id)
+        except IncidentActivity.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        return Response(status=204)
+
+    def put(self, request, organization, incident, activity_id):
+        """
+        Update an existing comment
+        ``````````````````````````
+        :auth: required
+        """
+
+        if not request.user.is_authenticated():
+            raise PermissionDenied(detail="Key doesn't have permission to delete Note")
+
+        serializer = CommentSerializer(data=request.DATA)
+        if serializer.is_valid():
+            result = serializer.object
+
+            try:
+                comment = update_comment(
+                    incident=incident,
+                    activity_id=activity_id,
+                    user=request.user,
+                    comment=result.get('comment'),
+                )
+            except IncidentActivity.DoesNotExist:
+                raise ResourceDoesNotExist
+
+            return Response(serialize(comment, request.user), status=200)
+        return Response(serializer.errors, status=400)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -83,6 +83,7 @@ from .endpoints.organization_eventid import EventIdLookupEndpoint
 from .endpoints.organization_slugs import SlugsUpdateEndpoint
 from .endpoints.organization_incident_activity_index import OrganizationIncidentActivityIndexEndpoint
 from .endpoints.organization_incident_comment_index import OrganizationIncidentCommentIndexEndpoint
+from .endpoints.organization_incident_comment_details import OrganizationIncidentCommentDetailsEndpoint
 from .endpoints.organization_incident_index import OrganizationIncidentIndexEndpoint
 from .endpoints.organization_incident_subscription_index import OrganizationIncidentSubscriptionIndexEndpoint
 from .endpoints.organization_issues_new import OrganizationIssuesNewEndpoint
@@ -427,6 +428,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/comments/$',
         OrganizationIncidentCommentIndexEndpoint.as_view(),
         name='sentry-api-0-organization-incident-comments'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/comments/(?P<activity_id>[^\/]+)/$',
+        OrganizationIncidentCommentDetailsEndpoint.as_view(),
+        name='sentry-api-0-organization-incident-comment-details'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/$',

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -175,6 +175,23 @@ def create_incident_activity(
     )
 
 
+def update_comment(incident, activity_id, user, comment):
+    """
+    Specifically updates an IncidentActivity with type IncidentActivityType.COMMENT
+    """
+
+    return IncidentActivity.objects.get(
+        id=activity_id, user=user, incident=incident).update(comment=comment)
+
+
+def delete_comment(incident, activity_id, user):
+    """
+    Specifically deletes an IncidentActivity with type IncidentActivityType.COMMENT
+    """
+
+    return IncidentActivity.objects.get(id=activity_id, user=user, incident=incident).delete()
+
+
 def create_event_stat_snapshot(incident, start, end):
     """
     Creates an event stats snapshot for an incident in a given period of time.

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -175,21 +175,20 @@ def create_incident_activity(
     )
 
 
-def update_comment(incident, activity_id, user, comment):
+def update_comment(activity, comment):
     """
     Specifically updates an IncidentActivity with type IncidentActivityType.COMMENT
     """
 
-    return IncidentActivity.objects.get(
-        id=activity_id, user=user, incident=incident).update(comment=comment)
+    return activity.update(comment=comment)
 
 
-def delete_comment(incident, activity_id, user):
+def delete_comment(activity):
     """
     Specifically deletes an IncidentActivity with type IncidentActivityType.COMMENT
     """
 
-    return IncidentActivity.objects.get(id=activity_id, user=user, incident=incident).delete()
+    return activity.delete()
 
 
 def create_event_stat_snapshot(incident, start, end):

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -25,6 +25,8 @@ from sentry.incidents.models import (
     IncidentGroup,
     IncidentProject,
     IncidentSeen,
+    IncidentActivity,
+    IncidentActivityType,
 )
 from sentry.mediators import sentry_apps, sentry_app_installations, service_hooks
 from sentry.models import (
@@ -872,3 +874,16 @@ class Factories(object):
             for user in seen_by:
                 IncidentSeen.objects.create(incident=incident, user=user, last_seen=timezone.now())
         return incident
+
+    @staticmethod
+    def create_incident_comment(
+            incident, type=IncidentActivityType.COMMENT.value,
+            comment="test comment",
+            user=None,
+    ):
+        return IncidentActivity.objects.create(
+            incident=incident,
+            type=type,
+            comment=comment,
+            user=user,
+        )

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -26,7 +26,6 @@ from sentry.incidents.models import (
     IncidentProject,
     IncidentSeen,
     IncidentActivity,
-    IncidentActivityType,
 )
 from sentry.mediators import sentry_apps, sentry_app_installations, service_hooks
 from sentry.models import (
@@ -876,11 +875,7 @@ class Factories(object):
         return incident
 
     @staticmethod
-    def create_incident_comment(
-            incident, type=IncidentActivityType.COMMENT.value,
-            comment="test comment",
-            user=None,
-    ):
+    def create_incident_activity(incident, type, comment=None, user=None):
         return IncidentActivity.objects.create(
             incident=incident,
             type=type,

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -219,6 +219,11 @@ class Fixtures(object):
             organization=organization, projects=projects, *args, **kwargs
         )
 
+    def create_incident_comment(self, incident, *args, **kwargs):
+        return Factories.create_incident_comment(
+            incident=incident, *args, **kwargs
+        )
+
     @pytest.fixture(autouse=True)
     def _init_insta_snapshot(self, insta_snapshot):
         self.insta_snapshot = insta_snapshot

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from sentry.models import Activity, OrganizationMember, OrganizationMemberTeam
+from sentry.incidents.models import IncidentActivityType
 
 import pytest
 from django.utils.functional import cached_property
@@ -219,10 +220,14 @@ class Fixtures(object):
             organization=organization, projects=projects, *args, **kwargs
         )
 
-    def create_incident_comment(self, incident, *args, **kwargs):
-        return Factories.create_incident_comment(
+    def create_incident_activity(self, incident, *args, **kwargs):
+        return Factories.create_incident_activity(
             incident=incident, *args, **kwargs
         )
+
+    def create_incident_comment(self, incident, *args, **kwargs):
+        return self.create_incident_activity(
+            incident, type=IncidentActivityType.COMMENT.value, *args, **kwargs)
 
     @pytest.fixture(autouse=True)
     def _init_insta_snapshot(self, insta_snapshot):

--- a/tests/sentry/api/endpoints/test_organization_incident_comment_details.py
+++ b/tests/sentry/api/endpoints/test_organization_incident_comment_details.py
@@ -9,7 +9,7 @@ from sentry.incidents.models import (
 from sentry.testutils import APITestCase
 
 
-class OrganizationIncidentCommentDetailBase(object):
+class BaseIncidentCommentDetailsTest(object):
     endpoint = 'sentry-api-0-organization-incident-comment-details'
 
     def setUp(self):
@@ -64,7 +64,7 @@ class OrganizationIncidentCommentDetailBase(object):
 
 
 class OrganizationIncidentCommentUpdateEndpointTest(
-        OrganizationIncidentCommentDetailBase, APITestCase):
+        BaseIncidentCommentDetailsTest, APITestCase):
     method = 'put'
 
     def test_simple(self):
@@ -84,7 +84,7 @@ class OrganizationIncidentCommentUpdateEndpointTest(
 
 
 class OrganizationIncidentCommentDeleteEndpointTest(
-        OrganizationIncidentCommentDetailBase, APITestCase):
+        BaseIncidentCommentDetailsTest, APITestCase):
     method = 'delete'
 
     def test_simple(self):

--- a/tests/sentry/api/endpoints/test_organization_incident_comment_details.py
+++ b/tests/sentry/api/endpoints/test_organization_incident_comment_details.py
@@ -1,0 +1,115 @@
+from __future__ import absolute_import
+
+from exam import fixture
+
+from sentry.incidents.models import (
+    IncidentActivity,
+    IncidentActivityType,
+)
+from sentry.testutils import APITestCase
+
+
+class OrganizationIncidentCommentDetailBase(APITestCase):
+    @fixture
+    def organization(self):
+        return self.create_organization()
+
+    @fixture
+    def project(self):
+        return self.create_project(organization=self.organization)
+
+    @fixture
+    def user(self):
+        return self.create_user()
+
+
+class OrganizationIncidentCommentUpdateEndpointTest(OrganizationIncidentCommentDetailBase):
+    endpoint = 'sentry-api-0-organization-incident-comment-details'
+    method = 'put'
+
+    def test_simple(self):
+        self.create_member(
+            user=self.user,
+            organization=self.organization,
+            role='owner',
+            teams=[self.team],
+        )
+        self.login_as(self.user)
+        comment = 'hello'
+        self.incident = self.create_incident()
+        activity = self.create_incident_comment(self.incident, user=self.user)
+        with self.feature('organizations:incidents'):
+            self.get_valid_response(
+                self.organization.slug,
+                self.incident.identifier,
+                activity.id,
+                comment=comment,
+                status_code=200,
+            )
+        activity = IncidentActivity.objects.get(id=activity.id)
+        assert activity.type == IncidentActivityType.COMMENT.value
+        assert activity.user == self.user
+
+    def test_not_found(self):
+        self.create_member(
+            user=self.user,
+            organization=self.organization,
+            role='owner',
+            teams=[self.team],
+        )
+        self.login_as(self.user)
+        comment = 'hello'
+        self.incident = self.create_incident()
+        self.create_incident_comment(self.incident, user=self.user)
+        with self.feature('organizations:incidents'):
+            self.get_valid_response(
+                self.organization.slug,
+                self.incident.identifier,
+                123,
+                comment=comment,
+                status_code=404,
+            )
+
+
+class OrganizationIncidentCommentDeleteEndpointTest(OrganizationIncidentCommentDetailBase):
+    endpoint = 'sentry-api-0-organization-incident-comment-details'
+    method = 'delete'
+
+    def test_simple(self):
+        self.create_member(
+            user=self.user,
+            organization=self.organization,
+            role='owner',
+            teams=[self.team],
+        )
+        self.login_as(self.user)
+        self.incident = self.create_incident()
+        activity = self.create_incident_comment(self.incident, user=self.user)
+        with self.feature('organizations:incidents'):
+            self.get_valid_response(
+                self.organization.slug,
+                self.incident.identifier,
+                activity.id,
+                status_code=204,
+            )
+        assert not IncidentActivity.objects.filter(id=activity.id).exists()
+
+    def test_not_found(self):
+        self.create_member(
+            user=self.user,
+            organization=self.organization,
+            role='owner',
+            teams=[self.team],
+        )
+        self.login_as(self.user)
+        comment = 'hello'
+        self.incident = self.create_incident()
+        self.create_incident_comment(self.incident, user=self.user)
+        with self.feature('organizations:incidents'):
+            self.get_valid_response(
+                self.organization.slug,
+                self.incident.identifier,
+                123,
+                comment=comment,
+                status_code=404,
+            )


### PR DESCRIPTION
Users can edit/delete their own comments for incidents.

Fixes SEN-668
Fixes SEN-669