### PR TITLE
fix(onboarding): Correct onboarding survey hook name

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -766,7 +766,7 @@ function routes() {
             path=":projectId/configure/:platform/"
             component={errorHandler(OnboardingConfigure)}
           />
-          {hook('routes:onboarding')}
+          {hook('routes:onboarding-survey')}
         </Route>
       </Route>
       <Route component={errorHandler(OrganizationDetails)}>


### PR DESCRIPTION
This hook's name was incorrectly changed in #13108. This corrects it fixing [JAVASCRIPT-Y3S](https://sentry.io/organizations/sentry/issues/1038840257/?project=11276&query=url%3A%22https%3A%2F%2Fsentry.io%2Fclipchamp%2Fcreate%2Fdashboard%2F%22&statsPeriod=14d)