### PR TITLE
fix(onboarding): Correct hookname in hookStore

### DIFF
--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -35,7 +35,7 @@ const validHookNames = new Set([
 
   // Onboarding experience
   // TODO(epurkhiser): These all should become less getsentry specific
-  'routes:onboarding',
+  'routes:onboarding-survey',
   'utils:onboarding-survey-url',
   'sidebar:onboarding-assets',
   'onboarding:invite-members',


### PR DESCRIPTION
Just causing a warning. The onboarding survey works fine.