### PR TITLE
feat: Allow dashed event ids in API and searches

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -25,7 +25,7 @@ from sentry.search.utils import (
     parse_query,
 )
 from sentry.utils.apidocs import scenario, attach_scenarios
-from sentry.utils.validators import is_event_id
+from sentry.utils.validators import normalize_event_id
 from sentry.utils.snuba import raw_query
 
 
@@ -147,8 +147,9 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
         if query:
             q = Q(message__icontains=query)
 
-            if is_event_id(query):
-                q |= Q(event_id__exact=query)
+            event_id = normalize_event_id(query)
+            if event_id:
+                q |= Q(event_id__exact=event_id)
 
             events = events.filter(q)
 

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -17,7 +17,7 @@ from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import get_date_range_from_params, InvalidParams
 from sentry.models import Group, GroupStatus
 from sentry.search.snuba.backend import SnubaSearchBackend
-from sentry.utils.validators import is_event_id
+from sentry.utils.validators import normalize_event_id
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
 
@@ -115,15 +115,16 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         query = request.GET.get('query', '').strip()
         if query:
             # check to see if we've got an event ID
-            if is_event_id(query):
+            event_id = normalize_event_id(query)
+            if event_id:
                 groups = list(
-                    Group.objects.filter_by_event_id(project_ids, query)
+                    Group.objects.filter_by_event_id(project_ids, event_id)
                 )
                 if len(groups) == 1:
                     response = Response(
                         serialize(
                             groups, request.user, serializer(
-                                matching_event_id=query
+                                matching_event_id=event_id
                             )
                         )
                     )

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -20,7 +20,7 @@ from sentry.models.savedsearch import DEFAULT_SAVED_SEARCH_QUERIES
 from sentry.signals import advanced_search
 from sentry.utils.apidocs import attach_scenarios, scenario
 from sentry.utils.cursors import CursorResult
-from sentry.utils.validators import is_event_id
+from sentry.utils.validators import normalize_event_id
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
 
@@ -143,14 +143,15 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         if query:
             matching_group = None
             matching_event = None
-            if is_event_id(query):
+            event_id = normalize_event_id(query)
+            if event_id:
                 # check to see if we've got an event ID
                 try:
-                    matching_group = Group.objects.from_event_id(project, query)
+                    matching_group = Group.objects.from_event_id(project, event_id)
                 except Group.DoesNotExist:
                     pass
                 else:
-                    matching_event = Event.objects.from_event_id(query, project.id)
+                    matching_event = Event.objects.from_event_id(event_id, project.id)
                     if matching_event is not None:
                         Event.objects.bind_nodes([matching_event], 'data')
             elif matching_group is None:

--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from sentry.api.event_search import get_snuba_query_args
 from sentry.models import SnubaEvent
 from sentry.utils.snuba import raw_query
-from sentry.utils.validators import is_event_id
+from sentry.utils.validators import normalize_event_id
 from sentry.api.serializers import serialize
 
 
@@ -14,9 +14,10 @@ def get_direct_hit_response(request, query, snuba_params, referrer):
     Checks whether a query is a direct hit for an event, and if so returns
     a response. Otherwise returns None
     """
-    if is_event_id(query):
+    event_id = normalize_event_id(query)
+    if event_id:
         snuba_args = get_snuba_query_args(
-            query=u'id:{}'.format(query),
+            query=u'id:{}'.format(event_id),
             params=snuba_params)
 
         results = raw_query(

--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -25,7 +25,7 @@ from sentry import nodestore
 from sentry.db.models.fields import BoundedBigIntegerField
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
-from sentry.utils.validators import is_event_id
+from sentry.utils.validators import normalize_event_id
 
 from .query import create_or_update
 
@@ -271,7 +271,7 @@ class BaseManager(Manager):
             if key != pk_name:
                 return self.get_from_cache(**{pk_name: retval})
 
-            if type(retval) != self.model:
+            if not isinstance(retval, self.model):
                 if settings.DEBUG:
                     raise ValueError('Unexpected value type returned from cache')
                 logger.error('Cache response returned invalid value %r', retval)
@@ -328,7 +328,8 @@ class SnubaEventManager:
         """
         from sentry.models import SnubaEvent, Event
 
-        if not is_event_id(id_or_event_id):
+        event_id = normalize_event_id(id_or_event_id)
+        if not event_id:
             logger.warning('Attempt to fetch SnubaEvent by primary key', exc_info=True, extra={
                 'stack': True
             })
@@ -338,9 +339,9 @@ class SnubaEventManager:
             if not event:
                 return None
 
-            id_or_event_id = event.event_id
+            event_id = event.event_id
 
-        return SnubaEvent.get_event(project_id, id_or_event_id)
+        return SnubaEvent.get_event(project_id, event_id)
 
 
 class EventManager(BaseManager):
@@ -397,11 +398,13 @@ class EventManager(BaseManager):
                     )
             except ObjectDoesNotExist:
                 pass
-        # If it was not found as a PK, and its a possible event_id, search by that instead.
-        if project_id is not None and event is None and is_event_id(id_or_event_id):
+        # If it was not found as a PK, and its a possible event_id, search by
+        # that instead.
+        event_id = normalize_event_id(id_or_event_id)
+        if project_id is not None and event is None and event_id:
             try:
                 event = self.get(
-                    event_id=id_or_event_id,
+                    event_id=event_id,
                     project_id=project_id,
                 )
             except ObjectDoesNotExist:

--- a/src/sentry/utils/validators.py
+++ b/src/sentry/utils/validators.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import
 
 import ipaddress
-import re
 import six
-
-EVENT_ID_RE = re.compile(r'^[a-fA-F0-9]{32}$')
+import uuid
 
 
 def validate_ip(value, required=True):
@@ -24,8 +22,12 @@ def is_float(var):
     return True
 
 
-def is_event_id(value):
+def normalize_event_id(value):
     try:
-        return bool(EVENT_ID_RE.match(value))
-    except TypeError:
-        return False
+        return uuid.UUID(value).hex
+    except (TypeError, AttributeError, ValueError):
+        return None
+
+
+def is_event_id(value):
+    return normalize_event_id(value) is not None

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -17,7 +17,7 @@ from sentry.web.helpers import render_to_response
 from sentry.signals import user_feedback_received
 from sentry.utils import json
 from sentry.utils.http import is_valid_origin, origin_from_request
-from sentry.utils.validators import is_event_id
+from sentry.utils.validators import normalize_event_id
 
 GENERIC_ERROR = _('An unknown error occurred while submitting your report. Please try again.')
 FORM_ERROR = _('Some fields were invalid. Please correct the errors and try again.')
@@ -119,12 +119,12 @@ class ErrorPageEmbedView(View):
             return self._smart_response(
                 request, {'eventId': 'Missing or invalid parameter.'}, status=400)
 
-        if event_id and not is_event_id(event_id):
+        normalized_event_id = normalize_event_id(event_id)
+        if normalized_event_id:
+            event_id = normalized_event_id
+        elif event_id:
             return self._smart_response(
                 request, {'eventId': 'Missing or invalid parameter.'}, status=400)
-
-        # XXX(dcramer): enforce case insensitivty by coercing this to a lowercase string
-        event_id = event_id.lower()
 
         key = self._get_project_key(request)
         if not key:

--- a/tests/sentry/utils/test_validators.py
+++ b/tests/sentry/utils/test_validators.py
@@ -10,6 +10,7 @@ def test_is_event_id():
     assert is_event_id('B802415F-7531-431C-AA27-F5C0BF923302')
     assert is_event_id(b'b802415f7531431caa27f5c0bf923302')
 
+    assert not is_event_id('')
     assert not is_event_id('b802415f7531431caa')
     assert not is_event_id('XXXX415f7531431caa27f5c0bf92XXXX')
     assert not is_event_id(4711)
@@ -29,6 +30,7 @@ def test_normalize_event_id():
     assert normalize_event_id(
         b'b802415f7531431caa27f5c0bf923302') == 'b802415f7531431caa27f5c0bf923302'
 
+    assert normalize_event_id('') is None
     assert normalize_event_id('b802415f7531431caa') is None
     assert normalize_event_id('XXXX415f7531431caa27f5c0bf92XXXX') is None
     assert normalize_event_id(4711) is None

--- a/tests/sentry/utils/test_validators.py
+++ b/tests/sentry/utils/test_validators.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+
+from sentry.utils.validators import is_event_id, normalize_event_id
+
+
+def test_is_event_id():
+    assert is_event_id('b802415f7531431caa27f5c0bf923302')
+    assert is_event_id('B802415F7531431CAA27F5C0BF923302')
+    assert is_event_id('b802415f-7531-431c-aa27-f5c0bf923302')
+    assert is_event_id('B802415F-7531-431C-AA27-F5C0BF923302')
+    assert is_event_id(b'b802415f7531431caa27f5c0bf923302')
+
+    assert not is_event_id('b802415f7531431caa')
+    assert not is_event_id('XXXX415f7531431caa27f5c0bf92XXXX')
+    assert not is_event_id(4711)
+    assert not is_event_id(False)
+    assert not is_event_id(None)
+
+
+def test_normalize_event_id():
+    assert normalize_event_id(
+        'b802415f7531431caa27f5c0bf923302') == 'b802415f7531431caa27f5c0bf923302'
+    assert normalize_event_id(
+        'B802415F7531431CAA27F5C0BF923302') == 'b802415f7531431caa27f5c0bf923302'
+    assert normalize_event_id(
+        'b802415f-7531-431c-aa27-f5c0bf923302') == 'b802415f7531431caa27f5c0bf923302'
+    assert normalize_event_id(
+        'B802415F-7531-431C-AA27-F5C0BF923302') == 'b802415f7531431caa27f5c0bf923302'
+    assert normalize_event_id(
+        b'b802415f7531431caa27f5c0bf923302') == 'b802415f7531431caa27f5c0bf923302'
+
+    assert normalize_event_id('b802415f7531431caa') is None
+    assert normalize_event_id('XXXX415f7531431caa27f5c0bf92XXXX') is None
+    assert normalize_event_id(4711) is None
+    assert normalize_event_id(False) is None
+    assert normalize_event_id(None) is None


### PR DESCRIPTION
Some of our endpoints return the event ID in a dashed representation, such as the minidump endpoint. This is required by external clients which might otherwise fail. However, our API does not recognize these as event identifiers.

This PR normalizes event identifiers in all cases before using them in search.