### PR TITLE
feat(grouping): Reject single frame stacktraces if there are stacktraces with more frames

### DIFF
--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -109,15 +109,15 @@ register_strategy_config(
         'expect-staple:v1',
         'hpkp:v1',
         'csp:v1',
-        'threads:v1',
-        'stacktrace:v1',
-        'chained-exception:v1',
+        'threads:v2',
+        'stacktrace:v2',
+        'chained-exception:v2',
         'template:v1',
         'message:v2',
     ],
     delegates=[
         'frame:v3',
-        'stacktrace:v1',
+        'stacktrace:v2',
         'single-exception:v2',
     ],
     changelog='''
@@ -127,6 +127,8 @@ register_strategy_config(
           versions.
         * JavaScript stacktraces involving source maps are likely to group
           better.
+        * single frames in a stacktrace are not considered if another variant
+          has more frames.
     '''
 )
 

--- a/tests/sentry/grouping/grouping_inputs/native-single-frame-stacktrace.json
+++ b/tests/sentry/grouping/grouping_inputs/native-single-frame-stacktrace.json
@@ -1,0 +1,21966 @@
+{
+  "culprit": "objc_msgSend",
+  "event_id": "b7a82d7f53344fa190ea7bcd8fab6aed",
+  "platform": "cocoa",
+  "logger": "",
+  "threads": {
+    "values": [
+      {
+        "current": false,
+        "crashed": true,
+        "id": 0
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b0"
+            },
+            {
+              "function": "_dispatch_worker_thread2",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98cc"
+            },
+            {
+              "function": "_dispatch_root_queue_drain",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db9028"
+            },
+            {
+              "function": "_dispatch_queue_override_invoke",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac9d0",
+              "instruction_addr": "0x1a6179c78"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d0"
+            },
+            {
+              "function": "escape::async<T>::lambda::operator()",
+              "abs_path": "/Users/travis/project../../../shared/escape/include/escape/core/Async.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN6escape5asyncIZN3pro15LayerThumbnails13setThumbnailsERKN6apollo5layerEE3$_2JEEEvOT_DpOT0_ENKUlPvE_clESD_",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/escape/include/escape/core/Async.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void escape::async<proj::LayerThumbnails::setThumbnails(apollo::layer const&)::$_2, >(proj::LayerThumbnails::setThumbnails(apollo::layer const&)::$_2&&, &&...)::{lambda(void*)#1}::operator()(void*) const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1006a9790",
+              "lineno": 44
+            },
+            {
+              "function": "escape::async<T>::lambda::__invoke",
+              "abs_path": "/Users/travis/project../../../shared/escape/include/escape/core/Async.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN6escape5asyncIZN3pro15LayerThumbnails13setThumbnailsERKN6apollo5layerEE3$_2JEEEvOT_DpOT0_ENUlPvE_8__invokeESD_",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/escape/include/escape/core/Async.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void escape::async<proj::LayerThumbnails::setThumbnails(apollo::layer const&)::$_2, >(proj::LayerThumbnails::setThumbnails(apollo::layer const&)::$_2&&, &&...)::{lambda(void*)#1}::__invoke(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1006a9790",
+              "lineno": 41
+            },
+            {
+              "function": "std::__1::__packaged_task_function<T>::operator()",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/future",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNKSt3__124__packaged_task_functionIFvvEEclEv",
+              "image_addr": "0x100564000",
+              "filename": "future",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "std::__1::__packaged_task_function<void ()>::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10068de34",
+              "lineno": 1998
+            },
+            {
+              "function": "std::__1::packaged_task<T>::operator()",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/future",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__113packaged_taskIFvvEEclEv",
+              "image_addr": "0x100564000",
+              "filename": "future",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "std::__1::packaged_task<void ()>::operator()()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10068de28",
+              "lineno": 2218
+            },
+            {
+              "function": "proj::LayerThumbnails::setThumbnails::lambda::operator()",
+              "abs_path": "/Users/travis/projectsources/ios/layers/LayerThumbnails.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN3pro15LayerThumbnails13setThumbnailsERKN6apollo5layerEENK3$_2clEv",
+              "image_addr": "0x100564000",
+              "filename": "LayerThumbnails.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "proj::LayerThumbnails::setThumbnails(apollo::layer const&)::$_2::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1006a9030",
+              "lineno": 145
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeIRZN3pro15LayerThumbnails13setThumbnailsERKN6apollo5layerEE3$_2JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS9_DpOSA_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeIRZN3pro15LayerThumbnails13setThumbnailsERKN6apollo5layerEE3$_2JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS9_DpOSA_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4339,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1006a8fd8"
+            },
+            {
+              "function": "_ZNSt3__1L15__apply_functorIZN3pro15LayerThumbnails13setThumbnailsERKN6apollo5layerEE3$_2NS_5tupleIJEEEJES9_EENS_13__bind_returnIT_T0_T2_Xsr22__is_valid_bind_returnISB_SC_SD_EE5valueEE4typeERSB_RSC_NS_15__tuple_indicesIJXspT1_EEEEOSD_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/functional",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L15__apply_functorIZN3pro15LayerThumbnails13setThumbnailsERKN6apollo5layerEE3$_2NS_5tupleIJEEEJES9_EENS_13__bind_returnIT_T0_T2_Xsr22__is_valid_bind_returnISB_SC_SD_EE5valueEE4typeERSB_RSC_NS_15__tuple_indicesIJXspT1_EEEEOSD_",
+              "image_addr": "0x100564000",
+              "filename": "functional",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2216,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1006a8fd8"
+            },
+            {
+              "function": "_ZNSt3__16__bindIZN3pro15LayerThumbnails13setThumbnailsERKN6apollo5layerEE3$_2JEEclIJEEENS_13__bind_returnIS7_NS_5tupleIJEEENSB_IJDpOT_EEEXsr22__is_valid_bind_returnIS7_SC_SG_EE5valueEE4typeESF_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/functional",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__16__bindIZN3pro15LayerThumbnails13setThumbnailsERKN6apollo5layerEE3$_2JEEclIJEEENS_13__bind_returnIS7_NS_5tupleIJEEENSB_IJDpOT_EEEXsr22__is_valid_bind_returnIS7_SC_SG_EE5valueEE4typeESF_",
+              "image_addr": "0x100564000",
+              "filename": "functional",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2249,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1006a8fd8"
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeIRNS_6__bindIZN3pro15LayerThumbnails13setThumbnailsERKN6apollo5layerEE3$_2JEEEJEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOSB_DpOSC_",
+              "abs_path": "/Users/travis/proj/proj/projects/proj",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeIRNS_6__bindIZN3pro15LayerThumbnails13setThumbnailsERKN6apollo5layerEE3$_2JEEEJEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOSB_DpOSC_",
+              "image_addr": "0x100564000",
+              "filename": "proj",
+              "symbol_addr": "0x100635e34",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1006a8fd8"
+            },
+            {
+              "function": "std::__1::__packaged_task_func<T>::operator()",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/future",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__120__packaged_task_funcINS_6__bindIZN3pro15LayerThumbnails13setThumbnailsERKN6apollo5layerEE3$_2JEEENS_9allocatorIS9_EEFvvEEclEv",
+              "image_addr": "0x100564000",
+              "filename": "future",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "std::__1::__packaged_task_func<std::__1::__bind<proj::LayerThumbnails::setThumbnails(apollo::layer const&)::$_2, >, std::__1::allocator<std::__1::__bind<proj::LayerThumbnails::setThumbnails(apollo::layer const&)::$_2, > >, void ()>::operator()()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1006a8fd8",
+              "lineno": 1821
+            },
+            {
+              "function": "proj::LayerThumbnails::generateCompositeThumbnail",
+              "abs_path": "/Users/travis/projectsources/ios/layers/LayerThumbnails.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3pro15LayerThumbnails26generateCompositeThumbnailERKNSt3__110shared_ptrIN6escape5ImageEEES7_m",
+              "image_addr": "0x100564000",
+              "filename": "LayerThumbnails.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "proj::LayerThumbnails::generateCompositeThumbnail(std::__1::shared_ptr<escape::Image> const&, std::__1::shared_ptr<escape::Image> const&, unsigned long)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1006a83a8",
+              "lineno": 197
+            },
+            {
+              "function": "escape::GC::DrawImage",
+              "abs_path": "/Users/travis/proj/shared/escape/src/core/platform/ios/ios_GC.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6escape2GC9DrawImageERKNS_5ImageERKNS_9RectangleE",
+              "image_addr": "0x100564000",
+              "filename": "ios_GC.mm",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "escape::GC::DrawImage(escape::Image const&, escape::Rectangle const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1036efea8",
+              "lineno": 103
+            },
+            {
+              "function": "CGContextDrawImageWithOptions",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x2130f0468",
+              "instruction_addr": "0x19ff89640"
+            },
+            {
+              "function": "ripc_DrawImage",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x213106154",
+              "instruction_addr": "0x19ff9f39c"
+            },
+            {
+              "function": "ripc_AcquireRIPImageData",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x212ef7860",
+              "instruction_addr": "0x19fd909b4"
+            },
+            {
+              "function": "CGSImageDataLock",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x2130e98ac",
+              "instruction_addr": "0x19ff82c50"
+            },
+            {
+              "function": "img_data_lock",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x2130eb518",
+              "instruction_addr": "0x19ff8617c"
+            },
+            {
+              "function": "img_interpolate_read",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x2130e8fa4",
+              "instruction_addr": "0x2130e9284"
+            },
+            {
+              "function": "resample_band",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x213068f0c",
+              "instruction_addr": "0x21306936c"
+            },
+            {
+              "function": "resample_byte_h_4cpp_armv7",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x212f97404",
+              "instruction_addr": "0x212f97470"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x212f97470",
+            "x29": "0x16f9ac170",
+            "x28": "0xed",
+            "x25": "0x11af70cc0",
+            "x24": "0x8",
+            "x27": "0x72",
+            "x26": "0x6",
+            "x21": "0x280ec9470",
+            "x20": "0x0",
+            "x23": "0x16f9ac1e0",
+            "x22": "0x11af6fe00",
+            "fp": "0x16f9ac170",
+            "x8": "0x20",
+            "x9": "0x6",
+            "x2": "0x154",
+            "x3": "0x80",
+            "x0": "0x11af6fe80",
+            "x1": "0x11af70408",
+            "x6": "0x16f9ac1e0",
+            "x7": "0x0",
+            "x4": "0x111e37000",
+            "x5": "0x16f9ac108",
+            "sp": "0x16f9ac0a0",
+            "lr": "0x213069370",
+            "x18": "0x0",
+            "x19": "0x14c",
+            "x10": "0x6",
+            "x11": "0x11544bc00",
+            "x12": "0x111e362c0",
+            "x13": "0x11544bc20",
+            "x14": "0x54",
+            "x15": "0x11af70400",
+            "x16": "0x11544bd54",
+            "x17": "0x8"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98d0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db902c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac9d0",
+              "instruction_addr": "0x210dacc7c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1006a9794"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10068de38"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1006a9034"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1006a83ac"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1036efeac"
+            },
+            {
+              "function": "CGContextDrawImageWithOptions",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x2130f0468",
+              "instruction_addr": "0x2130f0644"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x213106154",
+              "instruction_addr": "0x2131063a0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x212ef7860",
+              "instruction_addr": "0x212ef79b8"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x2130e98ac",
+              "instruction_addr": "0x2130e9c54"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x2130eb518",
+              "instruction_addr": "0x2130ed180"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x2130e8fa4",
+              "instruction_addr": "0x2130e9288"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x213068f0c",
+              "instruction_addr": "0x213069370"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+              "image_addr": "0x212ef3000",
+              "in_app": false,
+              "symbol_addr": "0x212f97404",
+              "instruction_addr": "0x212f97470"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x212f97470",
+            "x29": "0x16f9ac170",
+            "x28": "0xed",
+            "x25": "0x11af70cc0",
+            "x24": "0x8",
+            "x27": "0x72",
+            "x26": "0x6",
+            "x21": "0x280ec9470",
+            "x20": "0x0",
+            "x23": "0x16f9ac1e0",
+            "x22": "0x11af6fe00",
+            "fp": "0x16f9ac170",
+            "x8": "0x20",
+            "x9": "0x6",
+            "x2": "0x154",
+            "x3": "0x80",
+            "x0": "0x11af6fe80",
+            "x1": "0x11af70408",
+            "x6": "0x16f9ac1e0",
+            "x7": "0x0",
+            "x4": "0x111e37000",
+            "x5": "0x16f9ac108",
+            "sp": "0x16f9ac0a0",
+            "lr": "0x213069370",
+            "x18": "0x0",
+            "x19": "0x14c",
+            "x10": "0x6",
+            "x11": "0x11544bc00",
+            "x12": "0x111e362c0",
+            "x13": "0x11544bc20",
+            "x14": "0x54",
+            "x15": "0x11af70400",
+            "x16": "0x11544bd54",
+            "x17": "0x8"
+          }
+        },
+        "id": 1,
+        "crashed": false
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "__NSThread__start__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e4d30c",
+              "instruction_addr": "0x211e4d6e0"
+            },
+            {
+              "function": "-[UIEventFetcher threadMain]",
+              "package": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
+              "image_addr": "0x23c87f000",
+              "in_app": false,
+              "symbol_addr": "0x23d21f4b8",
+              "instruction_addr": "0x1f077953c"
+            },
+            {
+              "function": "-[NSRunLoop(NSRunLoop) runUntilDate:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d20dfc",
+              "instruction_addr": "0x1bfd79e58"
+            },
+            {
+              "function": "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d20ea0",
+              "instruction_addr": "0x1d818dfc8"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113531a0",
+              "instruction_addr": "0x211353350"
+            },
+            {
+              "function": "__CFRunLoopRun",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211353674",
+              "instruction_addr": "0x211353bc0"
+            },
+            {
+              "function": "__CFRunLoopServiceMachPort",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211358bc8",
+              "instruction_addr": "0x211358cb0"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f5959c"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x16fa39db0",
+            "x28": "0x1",
+            "x25": "0x0",
+            "x24": "0x7000806",
+            "x27": "0xc00",
+            "x26": "0x7000806",
+            "x21": "0x2a03",
+            "x20": "0xffffffff",
+            "x23": "0x16fa39ec0",
+            "x22": "0xc00",
+            "fp": "0x16fa39db0",
+            "x8": "0xfffffbbf",
+            "x9": "0x7000000",
+            "x2": "0x0",
+            "x3": "0xc00",
+            "x0": "0x16fa39ec0",
+            "x1": "0x7000806",
+            "x6": "0x0",
+            "x7": "0x70400805",
+            "x4": "0x2a03",
+            "x5": "0xffffffff",
+            "sp": "0x16fa39d60",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x7000000",
+            "x11": "0xb2f458c708",
+            "x12": "0x16e3600",
+            "x13": "0x119036b",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x0"
+          }
+        },
+        "name": "com.apple.uikit.eventfetch-thread",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e4d30c",
+              "instruction_addr": "0x211e4d6e4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
+              "image_addr": "0x23c87f000",
+              "in_app": false,
+              "symbol_addr": "0x23d21f4b8",
+              "instruction_addr": "0x23d21f540"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d20dfc",
+              "instruction_addr": "0x211d20e5c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d20ea0",
+              "instruction_addr": "0x211d20fcc"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113531a0",
+              "instruction_addr": "0x211353354"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211353674",
+              "instruction_addr": "0x211353bc4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211358bc8",
+              "instruction_addr": "0x211358cb4"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f595a0"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x16fa39db0",
+            "x28": "0x1",
+            "x25": "0x0",
+            "x24": "0x7000806",
+            "x27": "0xc00",
+            "x26": "0x7000806",
+            "x21": "0x2a03",
+            "x20": "0xffffffff",
+            "x23": "0x16fa39ec0",
+            "x22": "0xc00",
+            "fp": "0x16fa39db0",
+            "x8": "0xfffffbbf",
+            "x9": "0x7000000",
+            "x2": "0x0",
+            "x3": "0xc00",
+            "x0": "0x16fa39ec0",
+            "x1": "0x7000806",
+            "x6": "0x0",
+            "x7": "0x70400805",
+            "x4": "0x2a03",
+            "x5": "0xffffffff",
+            "sp": "0x16fa39d60",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x7000000",
+            "x11": "0xb2f458c708",
+            "x12": "0x16e3600",
+            "x13": "0x119036b",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x0"
+          }
+        },
+        "id": 2
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "start_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210feac10",
+              "instruction_addr": "0x210feacd0"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x0",
+            "pc": "0x210feacd0",
+            "x29": "0x0",
+            "x28": "0x0",
+            "x25": "0x0",
+            "x24": "0x0",
+            "x27": "0x0",
+            "x26": "0x0",
+            "x21": "0x0",
+            "x20": "0x0",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x16fad0000",
+            "x3": "0x16fb52b80",
+            "x0": "0x16fb53000",
+            "x1": "0x4f07",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x4f4004",
+            "x5": "0x1",
+            "sp": "0x16fb52a50",
+            "lr": "0x0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x0",
+            "x11": "0x0",
+            "x12": "0x0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x0",
+            "x17": "0x0"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210feac10",
+              "instruction_addr": "0x210feacd0"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x0",
+            "pc": "0x210feacd0",
+            "x29": "0x0",
+            "x28": "0x0",
+            "x25": "0x0",
+            "x24": "0x0",
+            "x27": "0x0",
+            "x26": "0x0",
+            "x21": "0x0",
+            "x20": "0x0",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x16fad0000",
+            "x3": "0x16fb52b80",
+            "x0": "0x16fb53000",
+            "x1": "0x4f07",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x4f4004",
+            "x5": "0x1",
+            "sp": "0x16fb52a50",
+            "lr": "0x0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x0",
+            "x11": "0x0",
+            "x12": "0x0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x0",
+            "x17": "0x0"
+          }
+        },
+        "id": 3,
+        "crashed": false
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "apollo::serial_queue::run",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/path_include/apollo/dispatch.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6apollo12serial_queue3runEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/path_include/apollo/dispatch.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "apollo::serial_queue::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10092a1f0",
+              "lineno": 340
+            },
+            {
+              "function": "apollo::serial_queue::serial_queue::lambda::operator()",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/path_include/apollo/dispatch.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN6apollo12serial_queueC1EPKcENKUlvE_clEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/path_include/apollo/dispatch.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "apollo::serial_queue::serial_queue(char const*)::{lambda()#1}::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10092a1e8",
+              "lineno": 350
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeIZN6apollo12serial_queueC1EPKcEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeIZN6apollo12serial_queueC1EPKcEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4339,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10092a1d0"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L16__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEZN6apollo12serial_queueC1EPKcEUlvE_JEJEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, apollo::serial_queue::serial_queue(char const*)::{lambda()#1}, , >(std::__1::tuple<std::__1::unique_ptr<std::__1::__th...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10092a1d0",
+              "lineno": 342
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEZN6apollo12serial_queueC1EPKcEUlvE_EEEEEPvSD_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, apollo::serial_queue::serial_queue(char const*)::{lambda()#1}> >(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10092a1d0",
+              "lineno": 352
+            },
+            {
+              "function": "apollo::task::operator()",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/path_include/apollo/dispatch.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6apollo4taskclEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/path_include/apollo/dispatch.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "apollo::task::operator()()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100920854",
+              "lineno": 177
+            },
+            {
+              "function": "std::__1::deque<T>::empty",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/path_include/apollo/dispatch.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNKSt3__15dequeIN6apollo4taskENS_9allocatorIS2_EEE5emptyEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/path_include/apollo/dispatch.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "std::__1::deque<apollo::task, std::__1::allocator<apollo::task> >::empty() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100920848",
+              "lineno": 430
+            },
+            {
+              "function": "apollo::serial_queue::execute_one",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/path_include/apollo/dispatch.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6apollo12serial_queue11execute_oneEb",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/path_include/apollo/dispatch.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "apollo::serial_queue::execute_one(bool)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100920818",
+              "lineno": 426
+            },
+            {
+              "function": "std::artemis::detail::apply_impl<T>",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/path_include/artemis/cpp17/tuple.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt7artemis6detail10apply_implIZZN6apollo8renderer14implementation9coroutine5awaitIZNS5_5startEvEUlRT_T0_E_EEvOS7_ENUlvE_clEvEUlvE_NSt3__15tupleIJEEEJEEEDcSB_OS9_NSE_16integer_sequenceImJXspT1_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/path_include/artemis/cpp17/tuple.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "decltype(auto) std::artemis::detail::apply_impl<void apollo::renderer::implementation::coroutine::await<apollo::renderer::implementation::coroutine::start()::{lambda(auto:1&, auto:2)#1}>(apollo::renderer::implementation::coroutine::start()::{lambda(auto...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1009fbf88",
+              "lineno": 36
+            },
+            {
+              "function": "std::artemis::apply<T>",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/path_include/artemis/cpp17/tuple.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt7artemis5applyIZZN6apollo8renderer14implementation9coroutine5awaitIZNS4_5startEvEUlRT_T0_E_EEvOS6_ENUlvE_clEvEUlvE_NSt3__15tupleIJEEEEEDcSA_OS8_",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/path_include/artemis/cpp17/tuple.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "decltype(auto) std::artemis::apply<void apollo::renderer::implementation::coroutine::await<apollo::renderer::implementation::coroutine::start()::{lambda(auto:1&, auto:2)#1}>(apollo::renderer::implementation::coroutine::start()::{lambda(auto:1&, auto:2)#...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1009fbf88",
+              "lineno": 43
+            },
+            {
+              "function": "apollo::async<T>::lambda::operator()",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/path_include/apollo/dispatch.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN6apollo5asyncINSt3__18functionIFvNS_4taskEEEEPFvSt13exception_ptrEZZNS_8renderer14implementation9coroutine5awaitIZNSB_5startEvEUlRT_T0_E_EEvOSD_ENUlvE_clEvEUlvE_JEEEvRKSD_OSF_OT1_DpOT2_ENUlvE_clEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/path_include/apollo/dispatch.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void apollo::async<std::__1::function<void (apollo::task)>, void (*)(std::exception_ptr), void apollo::renderer::implementation::coroutine::await<apollo::renderer::implementation::coroutine::start()::{lambda(auto:1&, auto:2)#1}>(apollo::renderer::implem...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1009fbf88",
+              "lineno": 622
+            },
+            {
+              "function": "apollo::package_task_error_handler<T>::lambda::operator()<T>",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/path_include/apollo/dispatch.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN6apollo26package_task_error_handlerIZNS_5asyncINSt3__18functionIFvNS_4taskEEEEPFvSt13exception_ptrEZZNS_8renderer14implementation9coroutine5awaitIZNSC_5startEvEUlRT_T0_E_EEvOSE_ENUlvE_clEvEUlvE_JEEEvRKSE_OSG_OT1_DpOT2_EUlvE_S9_EEDaSI_SN_ENUlDpOT_E_clIJEEESU_SX_",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/path_include/apollo/dispatch.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": " auto apollo::package_task_error_handler<void apollo::async<std::__1::function<void (apollo::task)>, void (*)(std::exception_ptr), void apollo::renderer::implementation::coroutine::await<apollo::renderer::implementation::coroutine::start()::{lambda(auto...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1009fbf84",
+              "lineno": 608
+            },
+            {
+              "function": "apollo::task::model<T>::invoke",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/path_include/apollo/dispatch.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6apollo4task5modelIZNS_26package_task_error_handlerIZNS_5asyncINSt3__18functionIFvS0_EEEPFvSt13exception_ptrEZZNS_8renderer14implementation9coroutine5awaitIZNSD_5startEvEUlRT_T0_E_EEvOSF_ENUlvE_clEvEUlvE_JEEEvRKSF_OSH_OT1_DpOT2_EUlvE_SA_EEDaSJ_SO_EUlDpOT_E_E6invokeEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/path_include/apollo/dispatch.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "apollo::task::model<auto apollo::package_task_error_handler<void apollo::async<std::__1::function<void (apollo::task)>, void (*)(std::exception_ptr), void apollo::renderer::implementation::coroutine::await<apollo::renderer::implementation::coroutine::st...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1009fbf84",
+              "lineno": 126
+            },
+            {
+              "function": "apollo::renderer::implementation::coroutine::start::lambda::operator()<T>",
+              "abs_path": "/Users/travis/proj/proj/libapollo/renderer.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN6apollo8renderer14implementation9coroutine5startEvENKUlRT_T0_E_clIS2_NS1_7requestEEEDaS4_S5_",
+              "image_addr": "0x100564000",
+              "filename": "renderer.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "auto apollo::renderer::implementation::coroutine::start()::{lambda(auto:1&, auto:2)#1}::operator()<apollo::renderer::implementation::coroutine, apollo::renderer::implementation::request>(apollo::renderer::implementation::coroutine&, apollo::renderer::im...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1009fc068",
+              "lineno": 331
+            },
+            {
+              "function": "apollo::renderer::implementation::coroutine::await<T>::lambda::operator()::lambda::operator()",
+              "abs_path": "/Users/travis/proj/proj/libapollo/renderer.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZZN6apollo8renderer14implementation9coroutine5awaitIZNS2_5startEvEUlRT_T0_E_EEvOS4_ENUlvE_clEvENUlvE_clEv",
+              "image_addr": "0x100564000",
+              "filename": "renderer.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void apollo::renderer::implementation::coroutine::await<apollo::renderer::implementation::coroutine::start()::{lambda(auto:1&, auto:2)#1}>(apollo::renderer::implementation::coroutine::start()::{lambda(auto:1&, auto:2)#1}&&)::{lambda()#1}::operator()()::...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1009fc04c",
+              "lineno": 364
+            },
+            {
+              "function": "apollo::renderer::implementation::coroutine::receive",
+              "abs_path": "/Users/travis/proj/proj/libapollo/renderer.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6apollo8renderer14implementation9coroutine7receiveENS1_7requestE",
+              "image_addr": "0x100564000",
+              "filename": "renderer.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "apollo::renderer::implementation::coroutine::receive(apollo::renderer::implementation::request)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1009fc1e0",
+              "lineno": 356
+            },
+            {
+              "function": "apollo::renderer::implementation::coroutine::ants_and_foreground",
+              "abs_path": "/Users/travis/proj/proj/libapollo/renderer.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6apollo8renderer14implementation9coroutine19ants_and_foregroundENS1_7requestE",
+              "image_addr": "0x100564000",
+              "filename": "renderer.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "apollo::renderer::implementation::coroutine::ants_and_foreground(apollo::renderer::implementation::request)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1009fc4a0",
+              "lineno": 439
+            },
+            {
+              "function": "apollo::renderer::implementation::coroutine::foreground",
+              "abs_path": "/Users/travis/proj/proj/libapollo/renderer.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6apollo8renderer14implementation9coroutine10foregroundENS1_7requestE",
+              "image_addr": "0x100564000",
+              "filename": "renderer.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "apollo::renderer::implementation::coroutine::foreground(apollo::renderer::implementation::request)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1009fcab4",
+              "lineno": 472
+            },
+            {
+              "function": "apollo::render_image",
+              "abs_path": "/Users/travis/proj/proj/libapollo/renderer.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6apollo12render_imageEP14TImageDocumentRKNS_3boxIiEEfRS3_b",
+              "image_addr": "0x100564000",
+              "filename": "renderer.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "apollo::render_image(TImageDocument*, apollo::box<int> const&, float, apollo::box<int>&, bool)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1009fad4c",
+              "lineno": 263
+            },
+            {
+              "function": "RenderDocumentAtCurZoomFactor",
+              "abs_path": "/Users/travis/proj/proj/sources/UImageDraw.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_Z29RenderDocumentAtCurZoomFactorPK14TImageDocumentb",
+              "image_addr": "0x100564000",
+              "filename": "UImageDraw.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "RenderDocumentAtCurZoomFactor(TImageDocument const*, bool)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d05320",
+              "lineno": 21461
+            },
+            {
+              "function": "TImageView::DrawViewRect",
+              "abs_path": "/Users/travis/proj/proj/sources/UImageView.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN10TImageView12DrawViewRectERKNSt3__110shared_ptrI15TDrawingContextEERK6UIRect",
+              "image_addr": "0x100564000",
+              "filename": "UImageView.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "TImageView::DrawViewRect(std::__1::shared_ptr<TDrawingContext> const&, UIRect const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x101cc46a0",
+              "lineno": 12559
+            },
+            {
+              "function": "TImageView::AboutToDraw",
+              "abs_path": "/Users/travis/proj/proj/sources/UImageView.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN10TImageView11AboutToDrawEP14TImageDocumentRK5VRectsb",
+              "image_addr": "0x100564000",
+              "filename": "UImageView.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "TImageView::AboutToDraw(TImageDocument*, VRect const&, short, bool)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x101cbffb8",
+              "lineno": 9928
+            },
+            {
+              "function": "TImageDocument::BuildDataForDisplay",
+              "abs_path": "/Users/travis/proj/proj/sources/UImageDocument.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN14TImageDocument19BuildDataForDisplayERK5VRectsRK10ChannelMapbbb",
+              "image_addr": "0x100564000",
+              "filename": "UImageDocument.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "TImageDocument::BuildDataForDisplay(VRect const&, short, ChannelMap const&, bool, bool, bool)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100e67714",
+              "lineno": 16504
+            },
+            {
+              "function": "TLayer::BuildDataForDisplay",
+              "abs_path": "/Users/travis/proj/proj/sources/ULayer.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6TLayer19BuildDataForDisplayERK5VRects10ChannelMapbbb",
+              "image_addr": "0x100564000",
+              "filename": "ULayer.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "TLayer::BuildDataForDisplay(VRect const&, short, ChannelMap, bool, bool, bool)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1020902d8",
+              "lineno": 1058
+            },
+            {
+              "function": "TLayer::MakeLayerPixelsValid",
+              "abs_path": "/Users/travis/proj/proj/sources/ULayer.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6TLayer20MakeLayerPixelsValidERK5VRectsP21GlobalMergeParameters",
+              "image_addr": "0x100564000",
+              "filename": "ULayer.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "TLayer::MakeLayerPixelsValid(VRect const&, short, GlobalMergeParameters*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102091478",
+              "lineno": 3012
+            },
+            {
+              "function": "CompCore::State::Push<T>",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../proj/compositecore/CompGraph.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore5State4PushINS_9ImageTempENS_5ImageEEEvT_RKT0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../proj/compositecore/CompGraph.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void CompCore::State::Push<CompCore::ImageTemp, CompCore::Image>(CompCore::ImageTemp, CompCore::Image const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100aab728",
+              "lineno": 223
+            },
+            {
+              "function": "CompCore::State::PushDst",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../proj/compositecore/CompGraph.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore5State7PushDstERKNS_5ImageE",
+              "image_addr": "0x100564000",
+              "filename": "../../../proj/compositecore/CompGraph.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::State::PushDst(CompCore::Image const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100aab720",
+              "lineno": 229
+            },
+            {
+              "function": "CompCore::State::State",
+              "abs_path": "/Users/travis/proj/proj/compositecore/CompGraph.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore5StateC2ERKNS_7GlobalsERKNS_5ImageERKNS_5SliceE",
+              "image_addr": "0x100564000",
+              "filename": "CompGraph.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::State::State(CompCore::Globals const&, CompCore::Image const&, CompCore::Slice const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100aab720",
+              "lineno": 325
+            },
+            {
+              "function": "CompCore::Image::Image",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../proj/compositecore/CompImage.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore5ImageC1ERKS0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../proj/compositecore/CompImage.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::Image::Image(CompCore::Image const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100ab5fac",
+              "lineno": 2131
+            },
+            {
+              "function": "std::__1::allocator<T>::construct<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__19allocatorIN8CompCore5ImageEE9constructIS2_JRKS2_EEEvPT_DpOT0_",
+              "image_addr": "0x100564000",
+              "filename": "memory",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::allocator<CompCore::Image>::construct<CompCore::Image, CompCore::Image const&>(CompCore::Image*, CompCore::Image const&&&...)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100ab5fa8",
+              "lineno": 1825
+            },
+            {
+              "function": "std::__1::allocator_traits<T>::__construct<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__116allocator_traitsINS_9allocatorIN8CompCore5ImageEEEE11__constructIS3_JRKS3_EEEvNS_17integral_constantIbLb1EEERS4_PT_DpOT0_",
+              "image_addr": "0x100564000",
+              "filename": "memory",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::allocator_traits<std::__1::allocator<CompCore::Image> >::__construct<CompCore::Image, CompCore::Image const&>(std::__1::integral_constant<bool, true>, std::__1::allocator<CompCore::Image>&, CompCore::Image*, CompCore::Image const&&&...)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100ab5fa8",
+              "lineno": 1717
+            },
+            {
+              "function": "std::__1::allocator_traits<T>::construct<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__116allocator_traitsINS_9allocatorIN8CompCore5ImageEEEE9constructIS3_JRKS3_EEEvRS4_PT_DpOT0_",
+              "image_addr": "0x100564000",
+              "filename": "memory",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::allocator_traits<std::__1::allocator<CompCore::Image> >::construct<CompCore::Image, CompCore::Image const&>(std::__1::allocator<CompCore::Image>&, CompCore::Image*, CompCore::Image const&&&...)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100ab5fa8",
+              "lineno": 1560
+            },
+            {
+              "function": "std::__1::vector<T>::__push_back_slow_path<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/vector",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__16vectorIN8CompCore5ImageENS_9allocatorIS2_EEE21__push_back_slow_pathIRKS2_EEvOT_",
+              "image_addr": "0x100564000",
+              "filename": "vector",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::vector<CompCore::Image, std::__1::allocator<CompCore::Image> >::__push_back_slow_path<CompCore::Image const&>(CompCore::Image const&&&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100ab5fa8",
+              "lineno": 1613
+            },
+            {
+              "function": "CompCore::Image::Image",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../proj/compositecore/CompImage.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore5ImageC2ERKS0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../proj/compositecore/CompImage.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::Image::Image(CompCore::Image const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100a9caec",
+              "lineno": 2134
+            },
+            {
+              "function": "CompCore::Source::SetValue",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../proj/compositecore/CompImage.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore6Source8SetValueERKNS_5SliceERKNS_5ValueE",
+              "image_addr": "0x100564000",
+              "filename": "../../../proj/compositecore/CompImage.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::Source::SetValue(CompCore::Slice const&, CompCore::Value const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100ae6ca8",
+              "lineno": 1516
+            },
+            {
+              "function": "CompCore::Image::Flush",
+              "abs_path": "/Users/travis/proj/proj/compositecore/CompImage.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNK8CompCore5Image5FlushEv",
+              "image_addr": "0x100564000",
+              "filename": "CompImage.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::Image::Flush() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100ae6c9c",
+              "lineno": 1156
+            },
+            {
+              "function": "CompCore::MetalCompositor::SetValue::lambda::operator()",
+              "abs_path": "/Users/travis/proj/proj/compositecore/metal/MetalCompositor.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8CompCore15MetalCompositor8SetValueERKN10PSCompCore8PSSourceERKNS_5SliceERKNS_5ValueEENK4$_10clES7_",
+              "image_addr": "0x100564000",
+              "filename": "MetalCompositor.mm",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::MetalCompositor::SetValue(PSCompCore::PSSource const&, CompCore::Slice const&, CompCore::Value const&)::$_10::operator()(CompCore::Slice const&) const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100af90c0",
+              "lineno": 880
+            },
+            {
+              "function": "CompCore::SliceTiles<T>::end",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../proj/compositecore/CompImage.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore10SliceTilesIKNS_6SourceEE3endEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../proj/compositecore/CompImage.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::SliceTiles<CompCore::Source const>::end()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100af90a8",
+              "lineno": 3211
+            },
+            {
+              "function": "CompCore::BitSet<T>::Iter::Iter",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../proj/compositecore/CompImage.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore6BitSetINS_12ChannelIndexELm5EE4IterC1ES2_",
+              "image_addr": "0x100564000",
+              "filename": "../../../proj/compositecore/CompImage.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::BitSet<CompCore::ChannelIndex, (unsigned long)5>::Iter::Iter(CompCore::BitSet<CompCore::ChannelIndex, (unsigned long)5>)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100af9070",
+              "lineno": 3210
+            },
+            {
+              "function": "CompCore::BitSet<T>::begin",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../proj/compositecore/CompImage.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNK8CompCore6BitSetINS_12ChannelIndexELm5EE5beginEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../proj/compositecore/CompImage.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::BitSet<CompCore::ChannelIndex, (unsigned long)5>::begin() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100af9030",
+              "lineno": 75
+            },
+            {
+              "function": "CompCore::BitSet<T>::Iter::Iter",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../proj/compositecore/CompImage.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore6BitSetItLm8EE4IterC1ES1_",
+              "image_addr": "0x100564000",
+              "filename": "../../../proj/compositecore/CompImage.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::BitSet<unsigned short, (unsigned long)8>::Iter::Iter(CompCore::BitSet<unsigned short, (unsigned long)8>)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100af9028",
+              "lineno": 3209
+            },
+            {
+              "function": "CompCore::BitSet<T>::begin",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../proj/compositecore/CompImage.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNK8CompCore6BitSetItLm8EE5beginEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../proj/compositecore/CompImage.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::BitSet<unsigned short, (unsigned long)8>::begin() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100af8fe0",
+              "lineno": 75
+            },
+            {
+              "function": "CompCore::MetalCompositor::SetValue::lambda::operator()",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../proj/compositecore/CompImage.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8CompCore15MetalCompositor8SetValueERKN10PSCompCore8PSSourceERKNS_5SliceERKNS_5ValueEENK4$_10clES7_",
+              "image_addr": "0x100564000",
+              "filename": "../../../proj/compositecore/CompImage.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::MetalCompositor::SetValue(PSCompCore::PSSource const&, CompCore::Slice const&, CompCore::Value const&)::$_10::operator()(CompCore::Slice const&) const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100af8fd4",
+              "lineno": 3208
+            },
+            {
+              "function": "CompCore::IterateSourceTiles<T>",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../proj/compositecore/CompImage.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore18IterateSourceTilesIZNS_15MetalCompositor8SetValueERKN10PSCompCore8PSSourceERKNS_5SliceERKNS_5ValueEE4$_10EEvS8_RKNS_6SourceET_",
+              "image_addr": "0x100564000",
+              "filename": "../../../proj/compositecore/CompImage.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void CompCore::IterateSourceTiles<CompCore::MetalCompositor::SetValue(PSCompCore::PSSource const&, CompCore::Slice const&, CompCore::Value const&)::$_10>(CompCore::Slice const&, CompCore::Source const&, CompCore::MetalCompositor::SetValue(PSCompCore::PS...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100af8f9c",
+              "lineno": 3206
+            },
+            {
+              "function": "CompCore::MetalCompositor::SetValue",
+              "abs_path": "/Users/travis/proj/proj/compositecore/metal/MetalCompositor.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore15MetalCompositor8SetValueERKN10PSCompCore8PSSourceERKNS_5SliceERKNS_5ValueE",
+              "image_addr": "0x100564000",
+              "filename": "MetalCompositor.mm",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::MetalCompositor::SetValue(PSCompCore::PSSource const&, CompCore::Slice const&, CompCore::Value const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100af8f6c",
+              "lineno": 878
+            },
+            {
+              "function": "CompCore::MetalCompositor::BufferValue",
+              "abs_path": "/Users/travis/proj/proj/compositecore/metal/MetalCompositor.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore15MetalCompositor11BufferValueERKN10PSCompCore8PSSourceERKNS_5SliceERKNS_5ValueE",
+              "image_addr": "0x100564000",
+              "filename": "MetalCompositor.mm",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::MetalCompositor::BufferValue(PSCompCore::PSSource const&, CompCore::Slice const&, CompCore::Value const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100af8b2c",
+              "lineno": 858
+            },
+            {
+              "function": "CompCore::MetalCompositor::FillGPUImageTile",
+              "abs_path": "/Users/travis/proj/proj/compositecore/metal/MetalCompositor.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore15MetalCompositor16FillGPUImageTileENSt3__110shared_ptrINS_14GPUVMTileMetalEEEhRKNS_4RectIxEE",
+              "image_addr": "0x100564000",
+              "filename": "MetalCompositor.mm",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::MetalCompositor::FillGPUImageTile(std::__1::shared_ptr<CompCore::GPUVMTileMetal>, unsigned char, CompCore::Rect<long long> const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100af8ed8"
+            },
+            {
+              "function": "CompCore::CompCoreGPU::MetalCompositePipelines::FillBufferWithValue",
+              "abs_path": "/Users/travis/proj/proj/compositecore/metal/MetalCompositePipelines.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8CompCore11CompCoreGPU23MetalCompositePipelines19FillBufferWithValueEPU19objcproto9MTLBuffer11objc_objectmmh",
+              "image_addr": "0x100564000",
+              "filename": "MetalCompositePipelines.mm",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "CompCore::CompCoreGPU::MetalCompositePipelines::FillBufferWithValue(objc_object objcproto9MTLBuffer*, unsigned long, unsigned long, unsigned char)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100afead4",
+              "lineno": 748
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Extensions/AGXMetalA7.bundle/AGXMetalA7",
+              "image_addr": "0x2316a9000",
+              "in_app": false,
+              "symbol_addr": "0x0",
+              "instruction_addr": "0x2316b3f44"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Extensions/AGXMetalA7.bundle/AGXMetalA7",
+              "image_addr": "0x2316a9000",
+              "in_app": false,
+              "symbol_addr": "0x0",
+              "instruction_addr": "0x23172a8b0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Extensions/AGXMetalA7.bundle/AGXMetalA7",
+              "image_addr": "0x2316a9000",
+              "in_app": false,
+              "symbol_addr": "0x0",
+              "instruction_addr": "0x23172a190"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Extensions/AGXMetalA7.bundle/AGXMetalA7",
+              "image_addr": "0x2316a9000",
+              "in_app": false,
+              "symbol_addr": "0x0",
+              "instruction_addr": "0x23172e308"
+            },
+            {
+              "function": "MTLIOAccelCommandBufferStorageAllocResourceAtIndex",
+              "package": "/System/Library/Frameworks/Metal.framework/Metal",
+              "image_addr": "0x2134a4000",
+              "in_app": false,
+              "symbol_addr": "0x2134fff84",
+              "instruction_addr": "0x21350001c"
+            },
+            {
+              "function": "MTLIOAccelResourcePoolCreatePooledResource",
+              "package": "/System/Library/Frameworks/Metal.framework/Metal",
+              "image_addr": "0x2134a4000",
+              "in_app": false,
+              "symbol_addr": "0x2134c1698",
+              "instruction_addr": "0x2134c17f0"
+            },
+            {
+              "function": "-[MTLIOAccelResource setPurgeableState:]",
+              "package": "/System/Library/Frameworks/Metal.framework/Metal",
+              "image_addr": "0x2134a4000",
+              "in_app": false,
+              "symbol_addr": "0x2134d9cd8",
+              "instruction_addr": "0x2134d9d60"
+            },
+            {
+              "function": "IOAccelResourceSetPurgeable",
+              "package": "/System/Library/PrivateFrameworks/IOAccelerator.framework/IOAccelerator",
+              "image_addr": "0x213498000",
+              "in_app": false,
+              "symbol_addr": "0x21349baf8",
+              "instruction_addr": "0x21349bb5c"
+            },
+            {
+              "function": "IOConnectCallMethod",
+              "package": "/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit",
+              "image_addr": "0x21161e000",
+              "in_app": false,
+              "symbol_addr": "0x2116241b0",
+              "instruction_addr": "0x211624258"
+            },
+            {
+              "function": "io_connect_method",
+              "package": "/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit",
+              "image_addr": "0x21161e000",
+              "in_app": false,
+              "symbol_addr": "0x21168a4c4",
+              "instruction_addr": "0x21168a65c"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f5959c"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x80000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x16fbd9620",
+            "x28": "0x16fbd95c8",
+            "x25": "0x64",
+            "x24": "0x3",
+            "x27": "0x16fbda7c0",
+            "x26": "0x3",
+            "x21": "0x5d0b",
+            "x20": "0x0",
+            "x23": "0x16fbd9638",
+            "x22": "0x10bc",
+            "fp": "0x16fbd9620",
+            "x8": "0xfffffbbf",
+            "x9": "0x0",
+            "x2": "0x64",
+            "x3": "0x10bc",
+            "x0": "0x0",
+            "x1": "0x3",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x5d0b",
+            "x5": "0x0",
+            "sp": "0x16fbd95d0",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x10",
+            "x11": "0x0",
+            "x12": "0x2812c5460",
+            "x13": "0x1a249ab8961",
+            "x14": "0x11bd3c460",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x2134d9cd8"
+          }
+        },
+        "name": "com.company.proj",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10092a1f4"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100920858"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1009fbf8c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1009fc06c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1009fc1e4"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1009fc4a4"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1009fcab8"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1009fad50"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d05324"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x101cc46a4"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x101cbffbc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100e67718"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1020902dc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10209147c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100aab72c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100ab5fb0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100a9caf0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100ae6cac"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100af90c4"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100af8b30"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100af8edc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100afead8"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Extensions/AGXMetalA7.bundle/AGXMetalA7",
+              "image_addr": "0x2316a9000",
+              "in_app": false,
+              "symbol_addr": "0x0",
+              "instruction_addr": "0x2316b3f44"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Extensions/AGXMetalA7.bundle/AGXMetalA7",
+              "image_addr": "0x2316a9000",
+              "in_app": false,
+              "symbol_addr": "0x0",
+              "instruction_addr": "0x23172a8b0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Extensions/AGXMetalA7.bundle/AGXMetalA7",
+              "image_addr": "0x2316a9000",
+              "in_app": false,
+              "symbol_addr": "0x0",
+              "instruction_addr": "0x23172a190"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Extensions/AGXMetalA7.bundle/AGXMetalA7",
+              "image_addr": "0x2316a9000",
+              "in_app": false,
+              "symbol_addr": "0x0",
+              "instruction_addr": "0x23172e308"
+            },
+            {
+              "function": "MTLIOAccelCommandBufferStorageAllocResourceAtIndex",
+              "package": "/System/Library/Frameworks/Metal.framework/Metal",
+              "image_addr": "0x2134a4000",
+              "in_app": false,
+              "symbol_addr": "0x2134fff84",
+              "instruction_addr": "0x213500020"
+            },
+            {
+              "function": "MTLIOAccelResourcePoolCreatePooledResource",
+              "package": "/System/Library/Frameworks/Metal.framework/Metal",
+              "image_addr": "0x2134a4000",
+              "in_app": false,
+              "symbol_addr": "0x2134c1698",
+              "instruction_addr": "0x2134c17f4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Metal.framework/Metal",
+              "image_addr": "0x2134a4000",
+              "in_app": false,
+              "symbol_addr": "0x2134d9cd8",
+              "instruction_addr": "0x2134d9d64"
+            },
+            {
+              "function": "IOAccelResourceSetPurgeable",
+              "package": "/System/Library/PrivateFrameworks/IOAccelerator.framework/IOAccelerator",
+              "image_addr": "0x213498000",
+              "in_app": false,
+              "symbol_addr": "0x21349baf8",
+              "instruction_addr": "0x21349bb60"
+            },
+            {
+              "function": "IOConnectCallMethod",
+              "package": "/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit",
+              "image_addr": "0x21161e000",
+              "in_app": false,
+              "symbol_addr": "0x2116241b0",
+              "instruction_addr": "0x21162425c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit",
+              "image_addr": "0x21161e000",
+              "in_app": false,
+              "symbol_addr": "0x21168a4c4",
+              "instruction_addr": "0x21168a660"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f595a0"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x80000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x16fbd9620",
+            "x28": "0x16fbd95c8",
+            "x25": "0x64",
+            "x24": "0x3",
+            "x27": "0x16fbda7c0",
+            "x26": "0x3",
+            "x21": "0x5d0b",
+            "x20": "0x0",
+            "x23": "0x16fbd9638",
+            "x22": "0x10bc",
+            "fp": "0x16fbd9620",
+            "x8": "0xfffffbbf",
+            "x9": "0x0",
+            "x2": "0x64",
+            "x3": "0x10bc",
+            "x0": "0x0",
+            "x1": "0x3",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x5d0b",
+            "x5": "0x0",
+            "sp": "0x16fbd95d0",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x10",
+            "x11": "0x0",
+            "x12": "0x2812c5460",
+            "x13": "0x1a249ab8961",
+            "x14": "0x11bd3c460",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x2134d9cd8"
+          }
+        },
+        "id": 4
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "package": "/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEPFvPN7bmalloc9ScavengerEES9_EEEEEPvSD_",
+              "image_addr": "0x21849f000",
+              "in_app": false,
+              "symbol_addr": "0x21852e3bc",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (*)(bmalloc::Scavenger*), bmalloc::Scavenger*> >(void*)",
+              "instruction_addr": "0x1dd6d33e0"
+            },
+            {
+              "function": "bmalloc::Scavenger::threadEntryPoint",
+              "package": "/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore",
+              "symbol": "_ZN7bmalloc9Scavenger16threadEntryPointEPS0_",
+              "image_addr": "0x21849f000",
+              "in_app": false,
+              "symbol_addr": "0x21852c998",
+              "raw_function": "bmalloc::Scavenger::threadEntryPoint(bmalloc::Scavenger*)",
+              "instruction_addr": "0x1dd6d19a0"
+            },
+            {
+              "function": "bmalloc::Scavenger::threadRunLoop",
+              "package": "/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore",
+              "symbol": "_ZN7bmalloc9Scavenger13threadRunLoopEv",
+              "image_addr": "0x21849f000",
+              "in_app": false,
+              "symbol_addr": "0x21852d17c",
+              "raw_function": "bmalloc::Scavenger::threadRunLoop()",
+              "instruction_addr": "0x233d12228"
+            },
+            {
+              "function": "std::__1::condition_variable_any::wait<T>",
+              "package": "/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore",
+              "symbol": "_ZNSt3__122condition_variable_any4waitINS_11unique_lockIN7bmalloc5MutexEEEEEvRT_",
+              "image_addr": "0x21849f000",
+              "in_app": false,
+              "symbol_addr": "0x2185291cc",
+              "raw_function": "void std::__1::condition_variable_any::wait<std::__1::unique_lock<bmalloc::Mutex> >(std::__1::unique_lock<bmalloc::Mutex>&)",
+              "instruction_addr": "0x233d0e234"
+            },
+            {
+              "function": "std::__1::condition_variable::wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "raw_function": "std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)",
+              "instruction_addr": "0x21053c08c"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x16fc6ae20",
+            "x28": "0xc80c0f70",
+            "x25": "0x16fc6b000",
+            "x24": "0x600",
+            "x27": "0xd1c",
+            "x26": "0x800",
+            "x21": "0x2",
+            "x20": "0x10874e900",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x16fc6ae20",
+            "x8": "0x16fc6adb0",
+            "x9": "0x701",
+            "x2": "0x600",
+            "x3": "0x0",
+            "x0": "0x10874e900",
+            "x1": "0x70100000800",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x16fc6adb0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2818e8078",
+            "x10": "0x2818e8090",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "JavaScriptCore bmalloc scavenger",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore",
+              "image_addr": "0x21849f000",
+              "in_app": false,
+              "symbol_addr": "0x21852e3bc",
+              "instruction_addr": "0x21852e3e4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore",
+              "image_addr": "0x21849f000",
+              "in_app": false,
+              "symbol_addr": "0x21852c998",
+              "instruction_addr": "0x21852c9a4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore",
+              "image_addr": "0x21849f000",
+              "in_app": false,
+              "symbol_addr": "0x21852d17c",
+              "instruction_addr": "0x21852d22c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/JavaScriptCore.framework/JavaScriptCore",
+              "image_addr": "0x21849f000",
+              "in_app": false,
+              "symbol_addr": "0x2185291cc",
+              "instruction_addr": "0x218529238"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "instruction_addr": "0x21053c090"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x16fc6ae20",
+            "x28": "0xc80c0f70",
+            "x25": "0x16fc6b000",
+            "x24": "0x600",
+            "x27": "0xd1c",
+            "x26": "0x800",
+            "x21": "0x2",
+            "x20": "0x10874e900",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x16fc6ae20",
+            "x8": "0x16fc6adb0",
+            "x9": "0x701",
+            "x2": "0x600",
+            "x3": "0x0",
+            "x0": "0x10874e900",
+            "x1": "0x70100000800",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x16fc6adb0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2818e8078",
+            "x10": "0x2818e8090",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 5
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "RunWebThread",
+              "package": "/System/Library/PrivateFrameworks/WebCore.framework/WebCore",
+              "symbol": "_ZL12RunWebThreadPv",
+              "image_addr": "0x219be4000",
+              "in_app": false,
+              "symbol_addr": "0x219fad228",
+              "raw_function": "RunWebThread(void*)",
+              "instruction_addr": "0x234e8e47c"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113531a0",
+              "instruction_addr": "0x211353350"
+            },
+            {
+              "function": "__CFRunLoopRun",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211353674",
+              "instruction_addr": "0x211353bc0"
+            },
+            {
+              "function": "__CFRunLoopServiceMachPort",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211358bc8",
+              "instruction_addr": "0x211358cb0"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f5959c"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x16fd3e060",
+            "x28": "0x1",
+            "x25": "0x0",
+            "x24": "0x7000806",
+            "x27": "0xc00",
+            "x26": "0x7000806",
+            "x21": "0x5903",
+            "x20": "0xffffffff",
+            "x23": "0x16fd3e170",
+            "x22": "0xc00",
+            "fp": "0x16fd3e060",
+            "x8": "0xfffffbbf",
+            "x9": "0x7000000",
+            "x2": "0x0",
+            "x3": "0xc00",
+            "x0": "0x16fd3e170",
+            "x1": "0x7000806",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x5903",
+            "x5": "0xffffffff",
+            "sp": "0x16fd3e010",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x7000000",
+            "x11": "0xb2f458c708",
+            "x12": "0x16e3600",
+            "x13": "0x3e027d",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x0"
+          }
+        },
+        "name": "WebThread",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/PrivateFrameworks/WebCore.framework/WebCore",
+              "image_addr": "0x219be4000",
+              "in_app": false,
+              "symbol_addr": "0x219fad228",
+              "instruction_addr": "0x219fad480"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113531a0",
+              "instruction_addr": "0x211353354"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211353674",
+              "instruction_addr": "0x211353bc4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211358bc8",
+              "instruction_addr": "0x211358cb4"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f595a0"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x16fd3e060",
+            "x28": "0x1",
+            "x25": "0x0",
+            "x24": "0x7000806",
+            "x27": "0xc00",
+            "x26": "0x7000806",
+            "x21": "0x5903",
+            "x20": "0xffffffff",
+            "x23": "0x16fd3e170",
+            "x22": "0xc00",
+            "fp": "0x16fd3e060",
+            "x8": "0xfffffbbf",
+            "x9": "0x7000000",
+            "x2": "0x0",
+            "x3": "0xc00",
+            "x0": "0x16fd3e170",
+            "x1": "0x7000806",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x5903",
+            "x5": "0xffffffff",
+            "sp": "0x16fd3e010",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x7000000",
+            "x11": "0xb2f458c708",
+            "x12": "0x16e3600",
+            "x13": "0x3e027d",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x0"
+          }
+        },
+        "id": 6
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "VMIOProcessorFunc",
+              "abs_path": "/Users/travis/proj/proj/sources/CVMHooksMac.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_Z17VMIOProcessorFuncPv",
+              "image_addr": "0x100564000",
+              "filename": "CVMHooksMac.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "VMIOProcessorFunc(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x101c864d8",
+              "lineno": 239
+            },
+            {
+              "function": "RemoveResultFromVMQueue",
+              "abs_path": "/Users/travis/proj/proj/sources/CVMHooksMac.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_Z23RemoveResultFromVMQueuePP16PosixForkIOParam",
+              "image_addr": "0x100564000",
+              "filename": "CVMHooksMac.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "RemoveResultFromVMQueue(PosixForkIOParam**)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x101c862fc",
+              "lineno": 209
+            },
+            {
+              "function": "boost::condition_variable_any::wait<T>",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost22condition_variable_any4waitINS_11unique_lockINS_15recursive_mutexEEE23RequestInQueueOrExitingEEvRT_T0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::condition_variable_any::wait<boost::unique_lock<boost::recursive_mutex>, RequestInQueueOrExiting>(boost::unique_lock<boost::recursive_mutex>&, RequestInQueueOrExiting)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x101c8639c",
+              "lineno": 215
+            },
+            {
+              "function": "boost::condition_variable_any::wait<T>",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost22condition_variable_any4waitINS_11unique_lockINS_15recursive_mutexEEEEEvRT_",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::condition_variable_any::wait<boost::unique_lock<boost::recursive_mutex> >(boost::unique_lock<boost::recursive_mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10147b624",
+              "lineno": 199
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x16fdcae10",
+            "x28": "0x0",
+            "x25": "0x16fdcb000",
+            "x24": "0x300",
+            "x27": "0x0",
+            "x26": "0x400",
+            "x21": "0x2",
+            "x20": "0x104c40aa0",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x16fdcae10",
+            "x8": "0x16fdcada0",
+            "x9": "0x301",
+            "x2": "0x300",
+            "x3": "0x0",
+            "x0": "0x104c40aa0",
+            "x1": "0x30100000400",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x16fdcada0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x104c40a60",
+            "x10": "0x104c40a78",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x101c864dc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x101c86300"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x101c863a0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10147b628"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x16fdcae10",
+            "x28": "0x0",
+            "x25": "0x16fdcb000",
+            "x24": "0x300",
+            "x27": "0x0",
+            "x26": "0x400",
+            "x21": "0x2",
+            "x20": "0x104c40aa0",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x16fdcae10",
+            "x8": "0x16fdcada0",
+            "x9": "0x301",
+            "x2": "0x300",
+            "x3": "0x0",
+            "x0": "0x104c40aa0",
+            "x1": "0x30100000400",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x16fdcada0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x104c40a60",
+            "x10": "0x104c40a78",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 7,
+        "crashed": false
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeI13ThreadFunctorJEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS2_DpOS3_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeI13ThreadFunctorJEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS2_DpOS3_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4339,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102bbf6e4"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L16__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEE13ThreadFunctorJEJEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ThreadFunctor, , >(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102bbf6e4",
+              "lineno": 342
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEE13ThreadFunctorEEEEEPvS9_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, ThreadFunctor> >(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102bbf6e0",
+              "lineno": 352
+            },
+            {
+              "function": "ThreadFunctor::operator()",
+              "abs_path": "/Users/travis/proj/plugins/extensions/mpsupport/threadsupport.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN13ThreadFunctorclEv",
+              "image_addr": "0x100564000",
+              "filename": "threadsupport.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "ThreadFunctor::operator()()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102bbf7e4",
+              "lineno": 343
+            },
+            {
+              "function": "_dispatch_semaphore_wait_slow",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab218"
+            },
+            {
+              "function": "_dispatch_sema4_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa794"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x16fe56eb0",
+            "x28": "0x0",
+            "x25": "0x0",
+            "x24": "0x0",
+            "x27": "0x0",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281fc9220",
+            "x23": "0x0",
+            "x22": "0x104e5c000",
+            "fp": "0x16fe56eb0",
+            "x8": "0x29d03",
+            "x9": "0x0",
+            "x2": "0xffffffff",
+            "x3": "0x10221e5f0",
+            "x0": "0x29d03",
+            "x1": "0xffffffffffffffff",
+            "x6": "0x210",
+            "x7": "0x210",
+            "x4": "0x1",
+            "x5": "0x102217644",
+            "sp": "0x16fe56ea0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281fc9260",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0xff",
+            "x13": "0x3",
+            "x14": "0x0",
+            "x15": "0xff",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x119c1c3c0"
+          }
+        },
+        "name": "MPSupport Worker",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x102bbf6e8"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x102bbf7e8"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab21c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa798"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x16fe56eb0",
+            "x28": "0x0",
+            "x25": "0x0",
+            "x24": "0x0",
+            "x27": "0x0",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281fc9220",
+            "x23": "0x0",
+            "x22": "0x104e5c000",
+            "fp": "0x16fe56eb0",
+            "x8": "0x29d03",
+            "x9": "0x0",
+            "x2": "0xffffffff",
+            "x3": "0x10221e5f0",
+            "x0": "0x29d03",
+            "x1": "0xffffffffffffffff",
+            "x6": "0x210",
+            "x7": "0x210",
+            "x4": "0x1",
+            "x5": "0x102217644",
+            "sp": "0x16fe56ea0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281fc9260",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0xff",
+            "x13": "0x3",
+            "x14": "0x0",
+            "x15": "0xff",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x119c1c3c0"
+          }
+        },
+        "id": 8
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "tbb::internal::rml::private_worker::thread_routine",
+              "abs_path": "/Users/travis/proj/shared/intel-tbb/src/tbb/private_server.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3tbb8internal3rml14private_worker14thread_routineEPv",
+              "image_addr": "0x100564000",
+              "filename": "private_server.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "tbb::internal::rml::private_worker::thread_routine(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103024484",
+              "lineno": 223
+            },
+            {
+              "function": "tbb::internal::rml::private_worker::run",
+              "abs_path": "/Users/travis/proj/shared/intel-tbb/src/tbb/private_server.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3tbb8internal3rml14private_worker3runEv",
+              "image_addr": "0x100564000",
+              "filename": "private_server.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "tbb::internal::rml::private_worker::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103024594",
+              "lineno": 277
+            },
+            {
+              "function": "tbb::internal::binary_semaphore::P",
+              "abs_path": "/Users/travis/proj/shared/projects/tbb/../../../shared/intel-tbb/src/tbb/semaphore.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3tbb8internal16binary_semaphore1PEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/intel-tbb/src/tbb/semaphore.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "tbb::internal::binary_semaphore::P()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103024a34",
+              "lineno": 181
+            },
+            {
+              "function": "rml::internal::thread_monitor::commit_wait",
+              "abs_path": "/Users/travis/proj/shared/projects/tbb/../../../shared/intel-tbb/src/rml/include/../server/thread_monitor.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3rml8internal14thread_monitor11commit_waitERNS1_6cookieE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/intel-tbb/src/rml/include/../server/thread_monitor.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "rml::internal::thread_monitor::commit_wait(rml::internal::thread_monitor::cookie&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103024a30",
+              "lineno": 259
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x170262ea0",
+            "x28": "0xffffff00",
+            "x25": "0x1093e8028",
+            "x24": "0x0",
+            "x27": "0xff",
+            "x26": "0x0",
+            "x21": "0x24",
+            "x20": "0x24",
+            "x23": "0x0",
+            "x22": "0x1093e8028",
+            "fp": "0x170262ea0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x2806ae7b8",
+            "x3": "0x210f9c130",
+            "x0": "0x29f03",
+            "x1": "0x170262ec8",
+            "x6": "0x12d",
+            "x7": "0x12d",
+            "x4": "0xc849d39a",
+            "x5": "0xff",
+            "sp": "0x170262e50",
+            "lr": "0x103024a38",
+            "x18": "0x0",
+            "x19": "0x1093e8020",
+            "x10": "0x6a",
+            "x11": "0x7fb",
+            "x12": "0x7fd",
+            "x13": "0x0",
+            "x14": "0xf3206800",
+            "x15": "0xd",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x73200000"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103024488"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103024598"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103024a38"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x170262ea0",
+            "x28": "0xffffff00",
+            "x25": "0x1093e8028",
+            "x24": "0x0",
+            "x27": "0xff",
+            "x26": "0x0",
+            "x21": "0x24",
+            "x20": "0x24",
+            "x23": "0x0",
+            "x22": "0x1093e8028",
+            "fp": "0x170262ea0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x2806ae7b8",
+            "x3": "0x210f9c130",
+            "x0": "0x29f03",
+            "x1": "0x170262ec8",
+            "x6": "0x12d",
+            "x7": "0x12d",
+            "x4": "0xc849d39a",
+            "x5": "0xff",
+            "sp": "0x170262e50",
+            "lr": "0x103024a38",
+            "x18": "0x0",
+            "x19": "0x1093e8020",
+            "x10": "0x6a",
+            "x11": "0x7fb",
+            "x12": "0x7fd",
+            "x13": "0x0",
+            "x14": "0xf3206800",
+            "x15": "0xd",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x73200000"
+          }
+        },
+        "id": 9,
+        "crashed": false
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreMotion.framework/CoreMotion",
+              "image_addr": "0x216c02000",
+              "in_app": false,
+              "symbol_addr": "0x0",
+              "instruction_addr": "0x216c77240"
+            },
+            {
+              "function": "CFRunLoopRun",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211354060",
+              "instruction_addr": "0x1bf3ad0ac"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113531a0",
+              "instruction_addr": "0x211353350"
+            },
+            {
+              "function": "__CFRunLoopRun",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211353674",
+              "instruction_addr": "0x211353bc0"
+            },
+            {
+              "function": "__CFRunLoopServiceMachPort",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211358bc8",
+              "instruction_addr": "0x211358cb0"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f5959c"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x1702edfd0",
+            "x28": "0x1",
+            "x25": "0x0",
+            "x24": "0x7000806",
+            "x27": "0xc00",
+            "x26": "0x7000806",
+            "x21": "0x29403",
+            "x20": "0xffffffff",
+            "x23": "0x1702ee0e0",
+            "x22": "0xc00",
+            "fp": "0x1702edfd0",
+            "x8": "0xfffffbbf",
+            "x9": "0x7000000",
+            "x2": "0x0",
+            "x3": "0xc00",
+            "x0": "0x1702ee0e0",
+            "x1": "0x7000806",
+            "x6": "0x0",
+            "x7": "0x2477fc000",
+            "x4": "0x29403",
+            "x5": "0xffffffff",
+            "sp": "0x1702edf80",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x7000000",
+            "x11": "0xb2f458c708",
+            "x12": "0x16e3600",
+            "x13": "0x4dfc",
+            "x14": "0x500",
+            "x15": "0x50000000000",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x50000000500"
+          }
+        },
+        "name": "com.apple.CoreMotion.MotionThread",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreMotion.framework/CoreMotion",
+              "image_addr": "0x216c02000",
+              "in_app": false,
+              "symbol_addr": "0x0",
+              "instruction_addr": "0x216c77240"
+            },
+            {
+              "function": "CFRunLoopRun",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211354060",
+              "instruction_addr": "0x2113540b0"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113531a0",
+              "instruction_addr": "0x211353354"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211353674",
+              "instruction_addr": "0x211353bc4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211358bc8",
+              "instruction_addr": "0x211358cb4"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f595a0"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x1702edfd0",
+            "x28": "0x1",
+            "x25": "0x0",
+            "x24": "0x7000806",
+            "x27": "0xc00",
+            "x26": "0x7000806",
+            "x21": "0x29403",
+            "x20": "0xffffffff",
+            "x23": "0x1702ee0e0",
+            "x22": "0xc00",
+            "fp": "0x1702edfd0",
+            "x8": "0xfffffbbf",
+            "x9": "0x7000000",
+            "x2": "0x0",
+            "x3": "0xc00",
+            "x0": "0x1702ee0e0",
+            "x1": "0x7000806",
+            "x6": "0x0",
+            "x7": "0x2477fc000",
+            "x4": "0x29403",
+            "x5": "0xffffffff",
+            "sp": "0x1702edf80",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x7000000",
+            "x11": "0xb2f458c708",
+            "x12": "0x16e3600",
+            "x13": "0x4dfc",
+            "x14": "0x500",
+            "x15": "0x50000000000",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x50000000500"
+          }
+        },
+        "id": 10
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "__NSThread__start__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e4d30c",
+              "instruction_addr": "0x211e4d6e0"
+            },
+            {
+              "function": "-[__CoreSchedulingSetRunnable runForever]",
+              "package": "/System/Library/Frameworks/CFNetwork.framework/CFNetwork",
+              "image_addr": "0x21196b000",
+              "in_app": false,
+              "symbol_addr": "0x21196c674",
+              "instruction_addr": "0x21196c748"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113531a0",
+              "instruction_addr": "0x211353350"
+            },
+            {
+              "function": "__CFRunLoopRun",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211353674",
+              "instruction_addr": "0x211353bc0"
+            },
+            {
+              "function": "__CFRunLoopServiceMachPort",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211358bc8",
+              "instruction_addr": "0x211358cb0"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f5959c"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x170379d60",
+            "x28": "0x1",
+            "x25": "0x0",
+            "x24": "0x7000806",
+            "x27": "0xc00",
+            "x26": "0x7000806",
+            "x21": "0x27403",
+            "x20": "0xffffffff",
+            "x23": "0x170379e70",
+            "x22": "0xc00",
+            "fp": "0x170379d60",
+            "x8": "0xfffffbbf",
+            "x9": "0x7000000",
+            "x2": "0x0",
+            "x3": "0xc00",
+            "x0": "0x170379e70",
+            "x1": "0x7000806",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x27403",
+            "x5": "0xffffffff",
+            "sp": "0x170379d10",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x7000000",
+            "x11": "0xb2f458c708",
+            "x12": "0x16e3600",
+            "x13": "0x168df",
+            "x14": "0x100",
+            "x15": "0x10000000000",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x10000000100"
+          }
+        },
+        "name": "com.apple.CFNetwork.CustomProtocols",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e4d30c",
+              "instruction_addr": "0x211e4d6e4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CFNetwork.framework/CFNetwork",
+              "image_addr": "0x21196b000",
+              "in_app": false,
+              "symbol_addr": "0x21196c674",
+              "instruction_addr": "0x21196c74c"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113531a0",
+              "instruction_addr": "0x211353354"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211353674",
+              "instruction_addr": "0x211353bc4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211358bc8",
+              "instruction_addr": "0x211358cb4"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f595a0"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x170379d60",
+            "x28": "0x1",
+            "x25": "0x0",
+            "x24": "0x7000806",
+            "x27": "0xc00",
+            "x26": "0x7000806",
+            "x21": "0x27403",
+            "x20": "0xffffffff",
+            "x23": "0x170379e70",
+            "x22": "0xc00",
+            "fp": "0x170379d60",
+            "x8": "0xfffffbbf",
+            "x9": "0x7000000",
+            "x2": "0x0",
+            "x3": "0xc00",
+            "x0": "0x170379e70",
+            "x1": "0x7000806",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x27403",
+            "x5": "0xffffffff",
+            "sp": "0x170379d10",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x7000000",
+            "x11": "0xb2f458c708",
+            "x12": "0x16e3600",
+            "x13": "0x168df",
+            "x14": "0x100",
+            "x15": "0x10000000000",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x10000000100"
+          }
+        },
+        "id": 11
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "sentrycrashccd_init",
+              "package": "/private/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Frameworks/Sentry.framework/Sentry",
+              "image_addr": "0x106214000",
+              "in_app": false,
+              "symbol_addr": "0x106236944",
+              "instruction_addr": "0x106236c9c"
+            },
+            {
+              "function": "sleep",
+              "package": "/usr/lib/system/libsystem_c.dylib",
+              "image_addr": "0x210e64000",
+              "in_app": false,
+              "symbol_addr": "0x210edc340",
+              "instruction_addr": "0x2203e5368"
+            },
+            {
+              "function": "nanosleep",
+              "package": "/usr/lib/system/libsystem_c.dylib",
+              "image_addr": "0x210e64000",
+              "in_app": false,
+              "symbol_addr": "0x210edc498",
+              "instruction_addr": "0x210edc568"
+            },
+            {
+              "function": "__semwait_signal",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f653f8",
+              "instruction_addr": "0x210f65400"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f65400",
+            "x29": "0x170492a80",
+            "x28": "0x10626e000",
+            "x25": "0x10626e000",
+            "x24": "0x10626c000",
+            "x27": "0x10626e000",
+            "x26": "0x10626e000",
+            "x21": "0x2a",
+            "x20": "0x170492aa0",
+            "x23": "0x3f",
+            "x22": "0x2b",
+            "fp": "0x170492a80",
+            "x8": "0x2499e99e0",
+            "x9": "0x23",
+            "x2": "0x1",
+            "x3": "0x1",
+            "x0": "0x903",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x3c",
+            "x5": "0x0",
+            "sp": "0x170492a50",
+            "lr": "0x210edc56c",
+            "x18": "0x0",
+            "x19": "0x170492a90",
+            "x10": "0x11",
+            "x11": "0x17a0c1",
+            "x12": "0x11b98b000",
+            "x13": "0xfff",
+            "x14": "0x0",
+            "x15": "0x100",
+            "x16": "0x14e",
+            "x17": "0xb400000"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "sentrycrashccd_init",
+              "package": "/private/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Frameworks/Sentry.framework/Sentry",
+              "image_addr": "0x106214000",
+              "in_app": false,
+              "symbol_addr": "0x106236944",
+              "instruction_addr": "0x106236c9c"
+            },
+            {
+              "function": "sleep",
+              "package": "/usr/lib/system/libsystem_c.dylib",
+              "image_addr": "0x210e64000",
+              "in_app": false,
+              "symbol_addr": "0x210edc340",
+              "instruction_addr": "0x210edc36c"
+            },
+            {
+              "function": "nanosleep",
+              "package": "/usr/lib/system/libsystem_c.dylib",
+              "image_addr": "0x210e64000",
+              "in_app": false,
+              "symbol_addr": "0x210edc498",
+              "instruction_addr": "0x210edc56c"
+            },
+            {
+              "function": "__semwait_signal",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f653f8",
+              "instruction_addr": "0x210f65400"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f65400",
+            "x29": "0x170492a80",
+            "x28": "0x10626e000",
+            "x25": "0x10626e000",
+            "x24": "0x10626c000",
+            "x27": "0x10626e000",
+            "x26": "0x10626e000",
+            "x21": "0x2a",
+            "x20": "0x170492aa0",
+            "x23": "0x3f",
+            "x22": "0x2b",
+            "fp": "0x170492a80",
+            "x8": "0x2499e99e0",
+            "x9": "0x23",
+            "x2": "0x1",
+            "x3": "0x1",
+            "x0": "0x903",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x3c",
+            "x5": "0x0",
+            "sp": "0x170492a50",
+            "lr": "0x210edc56c",
+            "x18": "0x0",
+            "x19": "0x170492a90",
+            "x10": "0x11",
+            "x11": "0x17a0c1",
+            "x12": "0x11b98b000",
+            "x13": "0xfff",
+            "x14": "0x0",
+            "x15": "0x100",
+            "x16": "0x14e",
+            "x17": "0xb400000"
+          }
+        },
+        "id": 12,
+        "crashed": false
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "sentrycrashcm_machexception_getAPI",
+              "package": "/private/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Frameworks/Sentry.framework/Sentry",
+              "image_addr": "0x106214000",
+              "in_app": false,
+              "symbol_addr": "0x10623077c",
+              "instruction_addr": "0x106230b84"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f5959c"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x17051ec50",
+            "x28": "0x0",
+            "x25": "0x0",
+            "x24": "0x2",
+            "x27": "0x0",
+            "x26": "0x2",
+            "x21": "0x26c07",
+            "x20": "0x0",
+            "x23": "0x17051ec90",
+            "x22": "0x248",
+            "fp": "0x17051ec50",
+            "x8": "0xfffffbbf",
+            "x9": "0x2499e9a90",
+            "x2": "0x0",
+            "x3": "0x248",
+            "x0": "0x17051ec90",
+            "x1": "0x2",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x26c07",
+            "x5": "0x0",
+            "sp": "0x17051ec00",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x5f4",
+            "x11": "0x24beb9c2c",
+            "x12": "0x24beb9c2c",
+            "x13": "0x4",
+            "x14": "0x1",
+            "x15": "0x881",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x0"
+          }
+        },
+        "name": "SentryCrash Exception Handler (Secondary)",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "sentrycrashcm_machexception_getAPI",
+              "package": "/private/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Frameworks/Sentry.framework/Sentry",
+              "image_addr": "0x106214000",
+              "in_app": false,
+              "symbol_addr": "0x10623077c",
+              "instruction_addr": "0x106230b84"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f595a0"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x17051ec50",
+            "x28": "0x0",
+            "x25": "0x0",
+            "x24": "0x2",
+            "x27": "0x0",
+            "x26": "0x2",
+            "x21": "0x26c07",
+            "x20": "0x0",
+            "x23": "0x17051ec90",
+            "x22": "0x248",
+            "fp": "0x17051ec50",
+            "x8": "0xfffffbbf",
+            "x9": "0x2499e9a90",
+            "x2": "0x0",
+            "x3": "0x248",
+            "x0": "0x17051ec90",
+            "x1": "0x2",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x26c07",
+            "x5": "0x0",
+            "sp": "0x17051ec00",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x5f4",
+            "x11": "0x24beb9c2c",
+            "x12": "0x24beb9c2c",
+            "x13": "0x4",
+            "x14": "0x1",
+            "x15": "0x881",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x0"
+          }
+        },
+        "id": 13
+      },
+      {
+        "current": true,
+        "stacktrace": {
+          "frames": null
+        },
+        "id": 14,
+        "name": "SentryCrash Exception Handler (Primary)",
+        "crashed": false
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::asio::io_context::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio10io_context3runEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::io_context::run()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103358aa4"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c080"
+            },
+            {
+              "function": "boost::asio::detail::kqueue_reactor::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail14kqueue_reactor3runElRNS1_8op_queueINS1_19scheduler_operationEEE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::kqueue_reactor::run(long, boost::asio::detail::op_queue<boost::asio::detail::scheduler_operation>&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c280"
+            },
+            {
+              "function": "kevent",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f668ec",
+              "instruction_addr": "0x210f668f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f668f4",
+            "x29": "0x170636d70",
+            "x28": "0x0",
+            "x25": "0x119dc0640",
+            "x24": "0x119dc0688",
+            "x27": "0x119dc0688",
+            "x26": "0x170636e38",
+            "x21": "0x0",
+            "x20": "0x119dc05c0",
+            "x23": "0x119dc0648",
+            "x22": "0x2800bb000",
+            "fp": "0x170636d70",
+            "x8": "0x2800bb058",
+            "x9": "0x10000000102",
+            "x2": "0x0",
+            "x3": "0x170635918",
+            "x0": "0x17",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x170636cf8",
+            "x4": "0x80",
+            "x5": "0x1706358f8",
+            "sp": "0x1706358b0",
+            "lr": "0x10335c284",
+            "x18": "0x0",
+            "x19": "0x170636e38",
+            "x10": "0x10000000100",
+            "x11": "0x0",
+            "x12": "0x1",
+            "x13": "0x10000000102",
+            "x14": "0x0",
+            "x15": "0x85",
+            "x16": "0x16b",
+            "x17": "0x23000000"
+          }
+        },
+        "name": "cs.BackgroundTimer",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103358aa8"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c084"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c284"
+            },
+            {
+              "function": "kevent",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f668ec",
+              "instruction_addr": "0x210f668f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f668f4",
+            "x29": "0x170636d70",
+            "x28": "0x0",
+            "x25": "0x119dc0640",
+            "x24": "0x119dc0688",
+            "x27": "0x119dc0688",
+            "x26": "0x170636e38",
+            "x21": "0x0",
+            "x20": "0x119dc05c0",
+            "x23": "0x119dc0648",
+            "x22": "0x2800bb000",
+            "fp": "0x170636d70",
+            "x8": "0x2800bb058",
+            "x9": "0x10000000102",
+            "x2": "0x0",
+            "x3": "0x170635918",
+            "x0": "0x17",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x170636cf8",
+            "x4": "0x80",
+            "x5": "0x1706358f8",
+            "sp": "0x1706358b0",
+            "lr": "0x10335c284",
+            "x18": "0x0",
+            "x19": "0x170636e38",
+            "x10": "0x10000000100",
+            "x11": "0x0",
+            "x12": "0x1",
+            "x13": "0x10000000102",
+            "x14": "0x0",
+            "x15": "0x85",
+            "x16": "0x16b",
+            "x17": "0x23000000"
+          }
+        },
+        "id": 15
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "musync::Actor::runWorker",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6musync5Actor9runWorkerEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "musync::Actor::runWorker()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1031a55cc"
+            },
+            {
+              "function": "boost::detail::function::void_function_obj_invoker0<T>::invoke",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost6detail8function26void_function_obj_invoker0IZN6musync5Actor9runWorkerEvE3$_0vE6invokeERNS1_15function_bufferE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::detail::function::void_function_obj_invoker0<musync::Actor::runWorker()::$_0, void>::invoke(boost::detail::function::function_buffer&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1031a7748"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c048"
+            },
+            {
+              "function": "boost::asio::detail::posix_event::wait<T>",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail11posix_event4waitINS1_27conditionally_enabled_mutex11scoped_lockEEEvRT_",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::posix_event::wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock>(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c8d4"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1706c2a40",
+            "x28": "0x0",
+            "x25": "0x1706c3000",
+            "x24": "0x0",
+            "x27": "0x119dc2448",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x119dc2408",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1706c2a40",
+            "x8": "0x1706c29d0",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x119dc2408",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1706c29d0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x119dc23b8",
+            "x10": "0x119dc23d0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.actor.shell",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1031a55d0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1031a774c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c04c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c8d8"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1706c2a40",
+            "x28": "0x0",
+            "x25": "0x1706c3000",
+            "x24": "0x0",
+            "x27": "0x119dc2448",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x119dc2408",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1706c2a40",
+            "x8": "0x1706c29d0",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x119dc2408",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1706c29d0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x119dc23b8",
+            "x10": "0x119dc23d0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 16
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "sync_core::execution::ActionExecutorImpl<T>::runWorker",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9sync_core9execution18ActionExecutorImplINSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEES8_E9runWorkerEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sync_core::execution::ActionExecutorImpl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::runWorker()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1034d540c"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c14c"
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::do_complete",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN9sync_core9execution18ActionExecutorImplINSt3__112basic_stringIcNSA_11char_traitsIcEENSA_9allocatorIcEEEESG_EENSA_10shared_ptrINS8_16ExecutionContextISG_SG_EEEEEENS3_5list2INS3_5va...",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, sync_core::execution::ActionExecutorImpl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1...",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1034d72e8"
+            },
+            {
+              "function": "boost::asio::asio_handler_invoke<T>",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio19asio_handler_invokeINS_3_bi6bind_tIvNS_4_mfi3mf1IvN9sync_core9execution18ActionExecutorImplINSt3__112basic_stringIcNS9_11char_traitsIcEENS9_9allocatorIcEEEESF_EENS9_10shared_ptrINS7_16ExecutionContextISF_SF_EEEEEENS2_5list2INS2_5valueIPS...",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::asio_handler_invoke<boost::_bi::bind_t<void, boost::_mfi::mf1<void, sync_core::execution::ActionExecutorImpl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::...",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1034d73b8"
+            },
+            {
+              "function": "boost::_bi::list2<T>::operator()<T>",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost3_bi5list2INS0_5valueIPN9sync_core9execution18ActionExecutorImplINSt3__112basic_stringIcNS6_11char_traitsIcEENS6_9allocatorIcEEEESC_EEEENS2_INS6_10shared_ptrINS4_16ExecutionContextISC_SC_EEEEEEEclINS_4_mfi3mf1IvSD_SJ_EENS0_5list0EEEvNS0_4typeIvEERT_RT0_i",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::_bi::list2<boost::_bi::value<sync_core::execution::ActionExecutorImpl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> ...",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1034d7400"
+            },
+            {
+              "function": "boost::_mfi::mf1<T>::operator()",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNK5boost4_mfi3mf1IvN9sync_core9execution18ActionExecutorImplINSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEESB_EENS5_10shared_ptrINS3_16ExecutionContextISB_SB_EEEEEclEPSC_SG_",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::_mfi::mf1<void, sync_core::execution::ActionExecutorImpl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::sha...",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1034d747c"
+            },
+            {
+              "function": "sync_core::execution::ActionExecutorImpl<T>::executeNextAction",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9sync_core9execution18ActionExecutorImplINSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEES8_E17executeNextActionENS2_10shared_ptrINS0_16ExecutionContextIS8_S8_EEEE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sync_core::execution::ActionExecutorImpl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::executeNextAction(std::__1::shared_p...",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1034d7e0c"
+            },
+            {
+              "function": "sync_core::execution::ActionSchedulerImpl<T>::scheduleNextAction",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9sync_core9execution19ActionSchedulerImplINSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEES8_E18scheduleNextActionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sync_core::execution::ActionSchedulerImpl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::scheduleNextAction()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1034b6a70"
+            },
+            {
+              "function": "sync_core::execution::NodeAction::execute",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9sync_core9execution10NodeAction7executeEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sync_core::execution::NodeAction::execute()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103493d30"
+            },
+            {
+              "function": "sync_core::execution::AssetCopyAction::copyFile",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9sync_core9execution15AssetCopyAction8copyFileEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sync_core::execution::AssetCopyAction::copyFile()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10349b6a4"
+            },
+            {
+              "function": "sync_core::execution::AssetCopyAction::copyFileDirect",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9sync_core9execution15AssetCopyAction14copyFileDirectEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sync_core::execution::AssetCopyAction::copyFileDirect()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10349bfb8"
+            },
+            {
+              "function": "sync_core::execution::AssetCopyAction::doCopyFile",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9sync_core9execution15AssetCopyAction10doCopyFileEN7sibcrux3SIB8CStringTIDsNS3_11SibStrTraitIDsNS3_14ChTraitsSingleIDsEEEEEES9_",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sync_core::execution::AssetCopyAction::doCopyFile(sibcrux::SIB::CStringT<char16_t, sibcrux::SIB::SibStrTrait<char16_t, sibcrux::SIB::ChTraitsSingle<char16_t> > >, sibcrux::SIB::CStringT<char16_t, sibcrux::SIB::SibStrTrait<char16_t, sibcrux::SIB::ChTrait...",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10349cf84"
+            },
+            {
+              "function": "sibcrux::AcslSvcFS::UploadFile",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN7sibcrux9AcslSvcFS10UploadFileERNS_12GsFileToReadERKNS_9CFileInfoERKNS_3SIB8CStringTIDsNS6_11SibStrTraitIDsNS6_14ChTraitsSingleIDsEEEEEERNS_10SibTermErrERSC_PNS_15DCXSnapshotInfoE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sibcrux::AcslSvcFS::UploadFile(sibcrux::GsFileToRead&, sibcrux::CFileInfo const&, sibcrux::SIB::CStringT<char16_t, sibcrux::SIB::SibStrTrait<char16_t, sibcrux::SIB::ChTraitsSingle<char16_t> > > const&, sibcrux::SibTermErr&, sibcrux::SIB::CStringT<char16...",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10352c16c"
+            },
+            {
+              "function": "sibcrux::AcslSvcFS::delegateSyncToDCXLib",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN7sibcrux9AcslSvcFS20delegateSyncToDCXLibEPNS_15DCXSnapshotInfoERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEEPFbxxPvxESC_RjRS9_",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sibcrux::AcslSvcFS::delegateSyncToDCXLib(sibcrux::DCXSnapshotInfo*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, bool (*)(long long, long long, void*, long long), void*, unsigned int&, std::__1::basic_str...",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10352a278"
+            },
+            {
+              "function": "SyncAttributes::waitForCompletion",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN14SyncAttributes17waitForCompletionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "SyncAttributes::waitForCompletion()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103266b04"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17074d4b0",
+            "x28": "0x17074dd88",
+            "x25": "0x17074f000",
+            "x24": "0x0",
+            "x27": "0x283eac500",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x119ea2e38",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17074d4b0",
+            "x8": "0x17074d440",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x119ea2e38",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17074d440",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x119ea2df8",
+            "x10": "0x119ea2e10",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.worker.ActionExecutor",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1034d5410"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c150"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1034d72ec"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1034d73bc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1034d7404"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1034d7480"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1034d7e10"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1034b6a74"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103493d34"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10349b6a8"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10349bfbc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10349cf88"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10352c170"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10352a27c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103266b08"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17074d4b0",
+            "x28": "0x17074dd88",
+            "x25": "0x17074f000",
+            "x24": "0x0",
+            "x27": "0x283eac500",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x119ea2e38",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17074d4b0",
+            "x8": "0x17074d440",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x119ea2e38",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17074d440",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x119ea2df8",
+            "x10": "0x119ea2e10",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 17
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "musync::Actor::runWorker",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6musync5Actor9runWorkerEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "musync::Actor::runWorker()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1031a55cc"
+            },
+            {
+              "function": "boost::detail::function::void_function_obj_invoker0<T>::invoke",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost6detail8function26void_function_obj_invoker0IZN6musync5Actor9runWorkerEvE3$_0vE6invokeERNS1_15function_bufferE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::detail::function::void_function_obj_invoker0<musync::Actor::runWorker()::$_0, void>::invoke(boost::detail::function::function_buffer&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1031a7748"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c048"
+            },
+            {
+              "function": "boost::asio::detail::posix_event::wait<T>",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail11posix_event4waitINS1_27conditionally_enabled_mutex11scoped_lockEEEvRT_",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::posix_event::wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock>(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c8d4"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1707daa40",
+            "x28": "0x0",
+            "x25": "0x1707db000",
+            "x24": "0x3400",
+            "x27": "0x119dc2558",
+            "x26": "0x3500",
+            "x21": "0x2",
+            "x20": "0x119dc2518",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1707daa40",
+            "x8": "0x1707da9d0",
+            "x9": "0x3401",
+            "x2": "0x3400",
+            "x3": "0x0",
+            "x0": "0x119dc2518",
+            "x1": "0x340100003500",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1707da9d0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x119dc24c8",
+            "x10": "0x119dc24e0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.actor.app",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1031a55d0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1031a774c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c04c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c8d8"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1707daa40",
+            "x28": "0x0",
+            "x25": "0x1707db000",
+            "x24": "0x3400",
+            "x27": "0x119dc2558",
+            "x26": "0x3500",
+            "x21": "0x2",
+            "x20": "0x119dc2518",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1707daa40",
+            "x8": "0x1707da9d0",
+            "x9": "0x3401",
+            "x2": "0x3400",
+            "x3": "0x0",
+            "x0": "0x119dc2518",
+            "x1": "0x340100003500",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1707da9d0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x119dc24c8",
+            "x10": "0x119dc24e0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 18
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "__NSThread__start__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e4d30c",
+              "instruction_addr": "0x2270496e0"
+            },
+            {
+              "function": "-[__CoreSchedulingSetRunnable runForever]",
+              "package": "/System/Library/Frameworks/CFNetwork.framework/CFNetwork",
+              "image_addr": "0x21196b000",
+              "in_app": false,
+              "symbol_addr": "0x21196c674",
+              "instruction_addr": "0x1d7dd9748"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113531a0",
+              "instruction_addr": "0x22654f350"
+            },
+            {
+              "function": "__CFRunLoopRun",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211353674",
+              "instruction_addr": "0x22654fbc0"
+            },
+            {
+              "function": "__CFRunLoopServiceMachPort",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211358bc8",
+              "instruction_addr": "0x226554cb0"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f5959c"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x170865d60",
+            "x28": "0x1",
+            "x25": "0x0",
+            "x24": "0x7000806",
+            "x27": "0xc00",
+            "x26": "0x7000806",
+            "x21": "0x26503",
+            "x20": "0xffffffff",
+            "x23": "0x170865e70",
+            "x22": "0xc00",
+            "fp": "0x170865d60",
+            "x8": "0xfffffbbf",
+            "x9": "0x7000000",
+            "x2": "0x0",
+            "x3": "0xc00",
+            "x0": "0x170865e70",
+            "x1": "0x7000806",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x26503",
+            "x5": "0xffffffff",
+            "sp": "0x170865d10",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x7000000",
+            "x11": "0xb2f458c708",
+            "x12": "0x16e3600",
+            "x13": "0x5e84d",
+            "x14": "0x2300",
+            "x15": "0x230000000000",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x230000002300"
+          }
+        },
+        "name": "com.apple.NSURLConnectionLoader",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e4d30c",
+              "instruction_addr": "0x211e4d6e4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CFNetwork.framework/CFNetwork",
+              "image_addr": "0x21196b000",
+              "in_app": false,
+              "symbol_addr": "0x21196c674",
+              "instruction_addr": "0x21196c74c"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113531a0",
+              "instruction_addr": "0x211353354"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211353674",
+              "instruction_addr": "0x211353bc4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211358bc8",
+              "instruction_addr": "0x211358cb4"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f595a0"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x170865d60",
+            "x28": "0x1",
+            "x25": "0x0",
+            "x24": "0x7000806",
+            "x27": "0xc00",
+            "x26": "0x7000806",
+            "x21": "0x26503",
+            "x20": "0xffffffff",
+            "x23": "0x170865e70",
+            "x22": "0xc00",
+            "fp": "0x170865d60",
+            "x8": "0xfffffbbf",
+            "x9": "0x7000000",
+            "x2": "0x0",
+            "x3": "0xc00",
+            "x0": "0x170865e70",
+            "x1": "0x7000806",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x26503",
+            "x5": "0xffffffff",
+            "sp": "0x170865d10",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x7000000",
+            "x11": "0xb2f458c708",
+            "x12": "0x16e3600",
+            "x13": "0x5e84d",
+            "x14": "0x2300",
+            "x15": "0x230000000000",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x230000002300"
+          }
+        },
+        "id": 19
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__18__invokeIM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEPS1_JS7_EvEEDTcldsdeclsr3std3__1E7forwardIT0_Efp0_Efp_spclsr3std3__1E7forwardIT1_Efp1_EEEOT_OSB_DpOSC_",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__18__invokeIM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEPS1_JS7_EvEEDTcldsdeclsr3std3__1E7forwardIT0_Efp0_Efp_spclsr3std3__1E7forwardIT1_Efp1_EEEOT_OSB_DpOSC_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4232,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed2dc"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__116__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEJPS6_SC_EJLm2ELm3EEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (GenericThreadPool::*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >), Ge...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed2a8",
+              "lineno": 336
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEPS7_SD_EEEEEPvSI_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (GenericThreadPool::*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocat...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed2a4",
+              "lineno": 346
+            },
+            {
+              "function": "GenericThreadPool::worker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/cosylib/inprocessprovider/project/mac/../../../../cosylite/include/GenericThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN17GenericThreadPool6workerENSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../../cosylite/include/GenericThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "GenericThreadPool::worker(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ecf98",
+              "lineno": 278
+            },
+            {
+              "function": "ThreadSafeQueue<T>::waitPop",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/cosylib/inprocessprovider/project/mac/../../../../cosylite/include/ThreadSafeQueue.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN15ThreadSafeQueueINSt3__110unique_ptrIN17GenericThreadPool11IThreadTaskENS0_14default_deleteIS3_EEEEE7waitPopERS6_",
+              "image_addr": "0x100564000",
+              "filename": "../../../../cosylite/include/ThreadSafeQueue.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "ThreadSafeQueue<std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_delete<GenericThreadPool::IThreadTask> > >::waitPop(std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_delete<GenericThreadPool::IThreadTask> >&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed534",
+              "lineno": 53
+            },
+            {
+              "function": "std::__1::condition_variable::wait<T>",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable4waitIZN15ThreadSafeQueueINS_10unique_ptrIN17GenericThreadPool11IThreadTaskENS_14default_deleteIS5_EEEEE7waitPopERS8_EUlvE_EEvRNS_11unique_lockINS_5mutexEEET_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::condition_variable::wait<ThreadSafeQueue<std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_delete<GenericThreadPool::IThreadTask> > >::waitPop(std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_del...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed5fc",
+              "lineno": 375
+            },
+            {
+              "function": "std::__1::condition_variable::wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "raw_function": "std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)",
+              "instruction_addr": "0x21053c08c"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1708f2e50",
+            "x28": "0x0",
+            "x25": "0x1708f3000",
+            "x24": "0x2c00",
+            "x27": "0x0",
+            "x26": "0x2e00",
+            "x21": "0x2",
+            "x20": "0x104ab6af8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1708f2e50",
+            "x8": "0x1708f2de0",
+            "x9": "0x2c00",
+            "x2": "0x2c00",
+            "x3": "0x0",
+            "x0": "0x104ab6af8",
+            "x1": "0x2c0000002e00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1708f2de0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x104ab6a88",
+            "x10": "0x104ab6aa0",
+            "x11": "0x10000000102",
+            "x12": "0x20a0",
+            "x13": "0x100",
+            "x14": "0x0",
+            "x15": "0x100",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "NotificationCosylibThread1",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ed2e0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ecf9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ed538"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ed600"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "instruction_addr": "0x21053c090"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1708f2e50",
+            "x28": "0x0",
+            "x25": "0x1708f3000",
+            "x24": "0x2c00",
+            "x27": "0x0",
+            "x26": "0x2e00",
+            "x21": "0x2",
+            "x20": "0x104ab6af8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1708f2e50",
+            "x8": "0x1708f2de0",
+            "x9": "0x2c00",
+            "x2": "0x2c00",
+            "x3": "0x0",
+            "x0": "0x104ab6af8",
+            "x1": "0x2c0000002e00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1708f2de0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x104ab6a88",
+            "x10": "0x104ab6aa0",
+            "x11": "0x10000000102",
+            "x12": "0x20a0",
+            "x13": "0x100",
+            "x14": "0x0",
+            "x15": "0x100",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 20
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__18__invokeIM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEPS1_JS7_EvEEDTcldsdeclsr3std3__1E7forwardIT0_Efp0_Efp_spclsr3std3__1E7forwardIT1_Efp1_EEEOT_OSB_DpOSC_",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__18__invokeIM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEPS1_JS7_EvEEDTcldsdeclsr3std3__1E7forwardIT0_Efp0_Efp_spclsr3std3__1E7forwardIT1_Efp1_EEEOT_OSB_DpOSC_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4232,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed2dc"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__116__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEJPS6_SC_EJLm2ELm3EEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (GenericThreadPool::*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >), Ge...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed2a8",
+              "lineno": 336
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEPS7_SD_EEEEEPvSI_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (GenericThreadPool::*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocat...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed2a4",
+              "lineno": 346
+            },
+            {
+              "function": "GenericThreadPool::worker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/cosylib/inprocessprovider/project/mac/../../../../cosylite/include/GenericThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN17GenericThreadPool6workerENSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../../cosylite/include/GenericThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "GenericThreadPool::worker(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ecf98",
+              "lineno": 278
+            },
+            {
+              "function": "ThreadSafeQueue<T>::waitPop",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/cosylib/inprocessprovider/project/mac/../../../../cosylite/include/ThreadSafeQueue.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN15ThreadSafeQueueINSt3__110unique_ptrIN17GenericThreadPool11IThreadTaskENS0_14default_deleteIS3_EEEEE7waitPopERS6_",
+              "image_addr": "0x100564000",
+              "filename": "../../../../cosylite/include/ThreadSafeQueue.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "ThreadSafeQueue<std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_delete<GenericThreadPool::IThreadTask> > >::waitPop(std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_delete<GenericThreadPool::IThreadTask> >&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed534",
+              "lineno": 53
+            },
+            {
+              "function": "std::__1::condition_variable::wait<T>",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable4waitIZN15ThreadSafeQueueINS_10unique_ptrIN17GenericThreadPool11IThreadTaskENS_14default_deleteIS5_EEEEE7waitPopERS8_EUlvE_EEvRNS_11unique_lockINS_5mutexEEET_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::condition_variable::wait<ThreadSafeQueue<std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_delete<GenericThreadPool::IThreadTask> > >::waitPop(std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_del...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed5fc",
+              "lineno": 375
+            },
+            {
+              "function": "std::__1::condition_variable::wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "raw_function": "std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)",
+              "instruction_addr": "0x21053c08c"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17097ee50",
+            "x28": "0x0",
+            "x25": "0x17097f000",
+            "x24": "0x2d00",
+            "x27": "0x0",
+            "x26": "0x2f00",
+            "x21": "0x2",
+            "x20": "0x104ab6af8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17097ee50",
+            "x8": "0x17097ede0",
+            "x9": "0x2d00",
+            "x2": "0x2d00",
+            "x3": "0x0",
+            "x0": "0x104ab6af8",
+            "x1": "0x2d0000002f00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17097ede0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x104ab6a88",
+            "x10": "0x104ab6aa0",
+            "x11": "0x10000000102",
+            "x12": "0x20a0",
+            "x13": "0x100",
+            "x14": "0x0",
+            "x15": "0x100",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "NotificationCosylibThread2",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ed2e0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ecf9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ed538"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ed600"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "instruction_addr": "0x21053c090"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17097ee50",
+            "x28": "0x0",
+            "x25": "0x17097f000",
+            "x24": "0x2d00",
+            "x27": "0x0",
+            "x26": "0x2f00",
+            "x21": "0x2",
+            "x20": "0x104ab6af8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17097ee50",
+            "x8": "0x17097ede0",
+            "x9": "0x2d00",
+            "x2": "0x2d00",
+            "x3": "0x0",
+            "x0": "0x104ab6af8",
+            "x1": "0x2d0000002f00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17097ede0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x104ab6a88",
+            "x10": "0x104ab6aa0",
+            "x11": "0x10000000102",
+            "x12": "0x20a0",
+            "x13": "0x100",
+            "x14": "0x0",
+            "x15": "0x100",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 21
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeIMN3acp5local4impl22InProcessRequestWorkerEFvvEPS4_JEvEEDTcldsdeclsr3std3__1E7forwardIT0_Efp0_Efp_spclsr3std3__1E7forwardIT1_Efp1_EEEOT_OS8_DpOS9_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeIMN3acp5local4impl22InProcessRequestWorkerEFvvEPS4_JEvEEDTcldsdeclsr3std3__1E7forwardIT0_Efp0_Efp_spclsr3std3__1E7forwardIT1_Efp1_EEEOT_OS8_DpOS9_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4280,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10243a65c"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L16__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEMN3acp5local4impl22InProcessRequestWorkerEFvvEJPS9_EJLm2EEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (acp::local::impl::InProcessRequestWorker::*)(), acp::local::impl::InProcessRequestWorker*, (unsigned long)2>(std...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10243a644",
+              "lineno": 342
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEMN3acp5local4impl22InProcessRequestWorkerEFvvEPSA_EEEEEPvSF_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (acp::local::impl::InProcessRequestWorker::*)(), acp::local::impl::InProcessRequestWorker*> >(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10243a644",
+              "lineno": 352
+            },
+            {
+              "function": "std::__1::this_thread::sleep_for<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__111this_thread9sleep_forIxNS_5ratioILl1ELl1000EEEEEvRKNS_6chrono8durationIT_T0_EE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::this_thread::sleep_for<long long, std::__1::ratio<(long)1, (long)1000> >(std::__1::chrono::duration<long long, std::__1::ratio<(long)1, (long)1000> > const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1024398ec",
+              "lineno": 448
+            },
+            {
+              "function": "acp::local::impl::InProcessRequestWorker::inProcessRequest",
+              "abs_path": "/Users/travis/proj/shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/AsyncRequestProcessor/source/InProcessRequestWorker.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl22InProcessRequestWorker16inProcessRequestEv",
+              "image_addr": "0x100564000",
+              "filename": "InProcessRequestWorker.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::InProcessRequestWorker::inProcessRequest()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1024398b4",
+              "lineno": 108
+            },
+            {
+              "function": "std::__1::this_thread::sleep_for",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__111this_thread9sleep_forERKNS_6chrono8durationIxNS_5ratioILl1ELl1000000000EEEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21057f044",
+              "raw_function": "std::__1::this_thread::sleep_for(std::__1::chrono::duration<long long, std::__1::ratio<(long)1, (long)1000000000> > const&)",
+              "instruction_addr": "0x1c0943090"
+            },
+            {
+              "function": "nanosleep",
+              "package": "/usr/lib/system/libsystem_c.dylib",
+              "image_addr": "0x210e64000",
+              "in_app": false,
+              "symbol_addr": "0x210edc498",
+              "instruction_addr": "0x1c7e40568"
+            },
+            {
+              "function": "__semwait_signal",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f653f8",
+              "instruction_addr": "0x1c7ec9400"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f65400",
+            "x29": "0x170a0ada0",
+            "x28": "0x280093500",
+            "x25": "0x1049dcbff",
+            "x24": "0x1",
+            "x27": "0x16aded40fa3",
+            "x26": "0x1049dcc10",
+            "x21": "0x280a980c0",
+            "x20": "0x170a0adb0",
+            "x23": "0x170a0add0",
+            "x22": "0x280093500",
+            "fp": "0x170a0ada0",
+            "x8": "0x2499e99e0",
+            "x9": "0x23",
+            "x2": "0x1",
+            "x3": "0x1",
+            "x0": "0x903",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x104cde061",
+            "x4": "0x0",
+            "x5": "0x1dcd6500",
+            "sp": "0x170a0ad70",
+            "lr": "0x210edc56c",
+            "x18": "0x0",
+            "x19": "0x170a0adb0",
+            "x10": "0x11",
+            "x11": "0xb2f458c708",
+            "x12": "0x16e3600",
+            "x13": "0xbd50f",
+            "x14": "0x0",
+            "x15": "0x35",
+            "x16": "0x14e",
+            "x17": "0x3fe00000"
+          }
+        },
+        "name": "ACPLSDKWorkerThread2",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10243a660"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1024398f0"
+            },
+            {
+              "function": "_ZNSt3__111this_thread9sleep_forERKNS_6chrono8durationIxNS_5ratioILl1ELl1000000000EEEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21057f044",
+              "instruction_addr": "0x21057f094"
+            },
+            {
+              "function": "nanosleep",
+              "package": "/usr/lib/system/libsystem_c.dylib",
+              "image_addr": "0x210e64000",
+              "in_app": false,
+              "symbol_addr": "0x210edc498",
+              "instruction_addr": "0x210edc56c"
+            },
+            {
+              "function": "__semwait_signal",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f653f8",
+              "instruction_addr": "0x210f65400"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f65400",
+            "x29": "0x170a0ada0",
+            "x28": "0x280093500",
+            "x25": "0x1049dcbff",
+            "x24": "0x1",
+            "x27": "0x16aded40fa3",
+            "x26": "0x1049dcc10",
+            "x21": "0x280a980c0",
+            "x20": "0x170a0adb0",
+            "x23": "0x170a0add0",
+            "x22": "0x280093500",
+            "fp": "0x170a0ada0",
+            "x8": "0x2499e99e0",
+            "x9": "0x23",
+            "x2": "0x1",
+            "x3": "0x1",
+            "x0": "0x903",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x104cde061",
+            "x4": "0x0",
+            "x5": "0x1dcd6500",
+            "sp": "0x170a0ad70",
+            "lr": "0x210edc56c",
+            "x18": "0x0",
+            "x19": "0x170a0adb0",
+            "x10": "0x11",
+            "x11": "0xb2f458c708",
+            "x12": "0x16e3600",
+            "x13": "0xbd50f",
+            "x14": "0x0",
+            "x15": "0x35",
+            "x16": "0x14e",
+            "x17": "0x3fe00000"
+          }
+        },
+        "id": 22
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__18__invokeIM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEPS1_JS7_EvEEDTcldsdeclsr3std3__1E7forwardIT0_Efp0_Efp_spclsr3std3__1E7forwardIT1_Efp1_EEEOT_OSB_DpOSC_",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__18__invokeIM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEPS1_JS7_EvEEDTcldsdeclsr3std3__1E7forwardIT0_Efp0_Efp_spclsr3std3__1E7forwardIT1_Efp1_EEEOT_OSB_DpOSC_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4232,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed2dc"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__116__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEJPS6_SC_EJLm2ELm3EEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (GenericThreadPool::*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >), Ge...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed2a8",
+              "lineno": 336
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEPS7_SD_EEEEEPvSI_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (GenericThreadPool::*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocat...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed2a4",
+              "lineno": 346
+            },
+            {
+              "function": "GenericThreadPool::worker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/cosylib/inprocessprovider/project/mac/../../../../cosylite/include/GenericThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN17GenericThreadPool6workerENSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../../cosylite/include/GenericThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "GenericThreadPool::worker(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ecf98",
+              "lineno": 278
+            },
+            {
+              "function": "ThreadSafeQueue<T>::waitPop",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/cosylib/inprocessprovider/project/mac/../../../../cosylite/include/ThreadSafeQueue.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN15ThreadSafeQueueINSt3__110unique_ptrIN17GenericThreadPool11IThreadTaskENS0_14default_deleteIS3_EEEEE7waitPopERS6_",
+              "image_addr": "0x100564000",
+              "filename": "../../../../cosylite/include/ThreadSafeQueue.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "ThreadSafeQueue<std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_delete<GenericThreadPool::IThreadTask> > >::waitPop(std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_delete<GenericThreadPool::IThreadTask> >&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed534",
+              "lineno": 53
+            },
+            {
+              "function": "std::__1::condition_variable::wait<T>",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable4waitIZN15ThreadSafeQueueINS_10unique_ptrIN17GenericThreadPool11IThreadTaskENS_14default_deleteIS5_EEEEE7waitPopERS8_EUlvE_EEvRNS_11unique_lockINS_5mutexEEET_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::condition_variable::wait<ThreadSafeQueue<std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_delete<GenericThreadPool::IThreadTask> > >::waitPop(std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_del...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed5fc",
+              "lineno": 375
+            },
+            {
+              "function": "std::__1::condition_variable::wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "raw_function": "std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)",
+              "instruction_addr": "0x21053c08c"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170a96e50",
+            "x28": "0x0",
+            "x25": "0x170a97000",
+            "x24": "0xd00",
+            "x27": "0x0",
+            "x26": "0xf00",
+            "x21": "0x2",
+            "x20": "0x104ab6a28",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170a96e50",
+            "x8": "0x170a96de0",
+            "x9": "0xd00",
+            "x2": "0xd00",
+            "x3": "0x0",
+            "x0": "0x104ab6a28",
+            "x1": "0xd0000000f00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170a96de0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x104ab69b8",
+            "x10": "0x104ab69d0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "ResponseCosylibThread1",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ed2e0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ecf9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ed538"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ed600"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "instruction_addr": "0x21053c090"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170a96e50",
+            "x28": "0x0",
+            "x25": "0x170a97000",
+            "x24": "0xd00",
+            "x27": "0x0",
+            "x26": "0xf00",
+            "x21": "0x2",
+            "x20": "0x104ab6a28",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170a96e50",
+            "x8": "0x170a96de0",
+            "x9": "0xd00",
+            "x2": "0xd00",
+            "x3": "0x0",
+            "x0": "0x104ab6a28",
+            "x1": "0xd0000000f00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170a96de0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x104ab69b8",
+            "x10": "0x104ab69d0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 23
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__18__invokeIM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEPS1_JS7_EvEEDTcldsdeclsr3std3__1E7forwardIT0_Efp0_Efp_spclsr3std3__1E7forwardIT1_Efp1_EEEOT_OSB_DpOSC_",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__18__invokeIM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEPS1_JS7_EvEEDTcldsdeclsr3std3__1E7forwardIT0_Efp0_Efp_spclsr3std3__1E7forwardIT1_Efp1_EEEOT_OSB_DpOSC_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4232,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed2dc"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__116__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEJPS6_SC_EJLm2ELm3EEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (GenericThreadPool::*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >), Ge...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed2a8",
+              "lineno": 336
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEM17GenericThreadPoolFvNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEEEPS7_SD_EEEEEPvSI_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (GenericThreadPool::*)(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocat...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed2a4",
+              "lineno": 346
+            },
+            {
+              "function": "GenericThreadPool::worker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/cosylib/inprocessprovider/project/mac/../../../../cosylite/include/GenericThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN17GenericThreadPool6workerENSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../../cosylite/include/GenericThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "GenericThreadPool::worker(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ecf98",
+              "lineno": 278
+            },
+            {
+              "function": "ThreadSafeQueue<T>::waitPop",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/cosylib/inprocessprovider/project/mac/../../../../cosylite/include/ThreadSafeQueue.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN15ThreadSafeQueueINSt3__110unique_ptrIN17GenericThreadPool11IThreadTaskENS0_14default_deleteIS3_EEEEE7waitPopERS6_",
+              "image_addr": "0x100564000",
+              "filename": "../../../../cosylite/include/ThreadSafeQueue.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "ThreadSafeQueue<std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_delete<GenericThreadPool::IThreadTask> > >::waitPop(std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_delete<GenericThreadPool::IThreadTask> >&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed534",
+              "lineno": 53
+            },
+            {
+              "function": "std::__1::condition_variable::wait<T>",
+              "abs_path": "/Applications/Xcode_9.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable4waitIZN15ThreadSafeQueueINS_10unique_ptrIN17GenericThreadPool11IThreadTaskENS_14default_deleteIS5_EEEEE7waitPopERS8_EUlvE_EEvRNS_11unique_lockINS_5mutexEEET_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::condition_variable::wait<ThreadSafeQueue<std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_delete<GenericThreadPool::IThreadTask> > >::waitPop(std::__1::unique_ptr<GenericThreadPool::IThreadTask, std::__1::default_del...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030ed5fc",
+              "lineno": 375
+            },
+            {
+              "function": "std::__1::condition_variable::wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "raw_function": "std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)",
+              "instruction_addr": "0x21053c08c"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170b22e50",
+            "x28": "0x0",
+            "x25": "0x170b23000",
+            "x24": "0xe00",
+            "x27": "0x0",
+            "x26": "0x1000",
+            "x21": "0x2",
+            "x20": "0x104ab6a28",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170b22e50",
+            "x8": "0x170b22de0",
+            "x9": "0xe00",
+            "x2": "0xe00",
+            "x3": "0x0",
+            "x0": "0x104ab6a28",
+            "x1": "0xe0000001000",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170b22de0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x104ab69b8",
+            "x10": "0x104ab69d0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "ResponseCosylibThread2",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ed2e0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ecf9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ed538"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030ed600"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "instruction_addr": "0x21053c090"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170b22e50",
+            "x28": "0x0",
+            "x25": "0x170b23000",
+            "x24": "0xe00",
+            "x27": "0x0",
+            "x26": "0x1000",
+            "x21": "0x2",
+            "x20": "0x104ab6a28",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170b22e50",
+            "x8": "0x170b22de0",
+            "x9": "0xe00",
+            "x2": "0xe00",
+            "x3": "0x0",
+            "x0": "0x104ab6a28",
+            "x1": "0xe0000001000",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170b22de0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x104ab69b8",
+            "x10": "0x104ab69d0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 24
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeIMN3acp5local4impl22RequestProcessorWorkerEFvvEPS4_JEvEEDTcldsdeclsr3std3__1E7forwardIT0_Efp0_Efp_spclsr3std3__1E7forwardIT1_Efp1_EEEOT_OS8_DpOS9_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeIMN3acp5local4impl22RequestProcessorWorkerEFvvEPS4_JEvEEDTcldsdeclsr3std3__1E7forwardIT0_Efp0_Efp_spclsr3std3__1E7forwardIT1_Efp1_EEEOT_OS8_DpOS9_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4280,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10243774c"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L16__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEMN3acp5local4impl22RequestProcessorWorkerEFvvEJPS9_EJLm2EEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (acp::local::impl::RequestProcessorWorker::*)(), acp::local::impl::RequestProcessorWorker*, (unsigned long)2>(std...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102437734",
+              "lineno": 342
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEMN3acp5local4impl22RequestProcessorWorkerEFvvEPSA_EEEEEPvSF_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (acp::local::impl::RequestProcessorWorker::*)(), acp::local::impl::RequestProcessorWorker*> >(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102437734",
+              "lineno": 352
+            },
+            {
+              "function": "acp::local::impl::RequestProcessorWorker::schedulerThread",
+              "abs_path": "/Users/travis/proj/shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/AsyncRequestProcessor/source/RequestProcessorWorker.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl22RequestProcessorWorker15schedulerThreadEv",
+              "image_addr": "0x100564000",
+              "filename": "RequestProcessorWorker.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::RequestProcessorWorker::schedulerThread()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102437008",
+              "lineno": 57
+            },
+            {
+              "function": "std::__1::condition_variable::wait<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable4waitIZN15ThreadSafeQueueINS_10shared_ptrIN3acp5local4impl17ACPLClientRequestEEEE7waitPopERS8_EUlvE_EEvRNS_11unique_lockINS_5mutexEEET_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::condition_variable::wait<ThreadSafeQueue<std::__1::shared_ptr<acp::local::impl::ACPLClientRequest> >::waitPop(std::__1::shared_ptr<acp::local::impl::ACPLClientRequest>&)::{lambda()#1}>(std::__1::unique_lock<std::__1::mutex>&, ThreadSafeQu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1024373e0",
+              "lineno": 375
+            },
+            {
+              "function": "ThreadSafeQueue<T>::waitPop",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/AsyncRequestProcessor/include/ThreadSafeQueue.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN15ThreadSafeQueueINSt3__110shared_ptrIN3acp5local4impl17ACPLClientRequestEEEE7waitPopERS6_",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/AsyncRequestProcessor/include/ThreadSafeQueue.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "ThreadSafeQueue<std::__1::shared_ptr<acp::local::impl::ACPLClientRequest> >::waitPop(std::__1::shared_ptr<acp::local::impl::ACPLClientRequest>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1024373c4",
+              "lineno": 133
+            },
+            {
+              "function": "std::__1::condition_variable::wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "raw_function": "std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)",
+              "instruction_addr": "0x21053c08c"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170baed90",
+            "x28": "0x170baee30",
+            "x25": "0x170baf000",
+            "x24": "0xb00",
+            "x27": "0x3236",
+            "x26": "0xc00",
+            "x21": "0x2",
+            "x20": "0x2807f59b8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170baed90",
+            "x8": "0x170baed20",
+            "x9": "0xb01",
+            "x2": "0xb00",
+            "x3": "0x0",
+            "x0": "0x2807f59b8",
+            "x1": "0xb0100000c00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170baed20",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2807f5948",
+            "x10": "0x2807f5960",
+            "x11": "0x10000000102",
+            "x12": "0x20a0",
+            "x13": "0x100",
+            "x14": "0x0",
+            "x15": "0x100",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "ACPLSDKWorkerThread1",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x102437750"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10243700c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1024373e4"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "instruction_addr": "0x21053c090"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170baed90",
+            "x28": "0x170baee30",
+            "x25": "0x170baf000",
+            "x24": "0xb00",
+            "x27": "0x3236",
+            "x26": "0xc00",
+            "x21": "0x2",
+            "x20": "0x2807f59b8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170baed90",
+            "x8": "0x170baed20",
+            "x9": "0xb01",
+            "x2": "0xb00",
+            "x3": "0x0",
+            "x0": "0x2807f59b8",
+            "x1": "0xb0100000c00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170baed20",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2807f5948",
+            "x10": "0x2807f5960",
+            "x11": "0x10000000102",
+            "x12": "0x20a0",
+            "x13": "0x100",
+            "x14": "0x0",
+            "x15": "0x100",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 25
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeIZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeIZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4339,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e8"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L16__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEJEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}, , >(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e8",
+              "lineno": 342
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEZN3acp5local4impl10ThreadPoolC1EvEUlvE_EEEEEPvSD_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}> >(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e4",
+              "lineno": 352
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::ThreadPool::lambda::operator()",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN3acp5local4impl10ThreadPoolC1EvENKUlvE_clEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f8cc",
+              "lineno": 124
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::Task",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl10ThreadPool4TaskEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::Task()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fa68",
+              "lineno": 68
+            },
+            {
+              "function": "std::__1::condition_variable::wait<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable4waitIZN3acp5local4impl10ThreadPool8next_jobEvEUlvE_EEvRNS_11unique_lockINS_5mutexEEET_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::condition_variable::wait<acp::local::impl::ThreadPool::next_job()::{lambda()#1}>(std::__1::unique_lock<std::__1::mutex>&, acp::local::impl::ThreadPool::next_job()::{lambda()#1})",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fb84",
+              "lineno": 375
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::next_job",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl10ThreadPool8next_jobEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::next_job()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fb64",
+              "lineno": 85
+            },
+            {
+              "function": "std::__1::condition_variable::wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "raw_function": "std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)",
+              "instruction_addr": "0x21053c08c"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170c3adc0",
+            "x28": "0x0",
+            "x25": "0x170c3b000",
+            "x24": "0x6b00",
+            "x27": "0x0",
+            "x26": "0x7100",
+            "x21": "0x2",
+            "x20": "0x11b94ca50",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170c3adc0",
+            "x8": "0x170c3ad50",
+            "x9": "0x6b00",
+            "x2": "0x6b00",
+            "x3": "0x0",
+            "x0": "0x11b94ca50",
+            "x1": "0x6b0000007100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170c3ad50",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94cac0",
+            "x10": "0x11b94cad8",
+            "x11": "0x40000000402",
+            "x12": "0x20a0",
+            "x13": "0x400",
+            "x14": "0x0",
+            "x15": "0x400",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "ACPLSDKThreadpoolThread0",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242f7ec"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242f8d0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242fa6c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242fb88"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "instruction_addr": "0x21053c090"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170c3adc0",
+            "x28": "0x0",
+            "x25": "0x170c3b000",
+            "x24": "0x6b00",
+            "x27": "0x0",
+            "x26": "0x7100",
+            "x21": "0x2",
+            "x20": "0x11b94ca50",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170c3adc0",
+            "x8": "0x170c3ad50",
+            "x9": "0x6b00",
+            "x2": "0x6b00",
+            "x3": "0x0",
+            "x0": "0x11b94ca50",
+            "x1": "0x6b0000007100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170c3ad50",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94cac0",
+            "x10": "0x11b94cad8",
+            "x11": "0x40000000402",
+            "x12": "0x20a0",
+            "x13": "0x400",
+            "x14": "0x0",
+            "x15": "0x400",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 26
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeIZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeIZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4339,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e8"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L16__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEJEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}, , >(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e8",
+              "lineno": 342
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEZN3acp5local4impl10ThreadPoolC1EvEUlvE_EEEEEPvSD_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}> >(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e4",
+              "lineno": 352
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::ThreadPool::lambda::operator()",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN3acp5local4impl10ThreadPoolC1EvENKUlvE_clEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f8cc",
+              "lineno": 124
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::Task",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl10ThreadPool4TaskEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::Task()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fa68",
+              "lineno": 68
+            },
+            {
+              "function": "std::__1::condition_variable::wait<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable4waitIZN3acp5local4impl10ThreadPool8next_jobEvEUlvE_EEvRNS_11unique_lockINS_5mutexEEET_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::condition_variable::wait<acp::local::impl::ThreadPool::next_job()::{lambda()#1}>(std::__1::unique_lock<std::__1::mutex>&, acp::local::impl::ThreadPool::next_job()::{lambda()#1})",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fb84",
+              "lineno": 375
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::next_job",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl10ThreadPool8next_jobEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::next_job()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fb64",
+              "lineno": 85
+            },
+            {
+              "function": "std::__1::condition_variable::wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "raw_function": "std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)",
+              "instruction_addr": "0x21053c08c"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170cc6dc0",
+            "x28": "0x0",
+            "x25": "0x170cc7000",
+            "x24": "0x6800",
+            "x27": "0x0",
+            "x26": "0x6e00",
+            "x21": "0x2",
+            "x20": "0x11b94ca50",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170cc6dc0",
+            "x8": "0x170cc6d50",
+            "x9": "0x6800",
+            "x2": "0x6800",
+            "x3": "0x0",
+            "x0": "0x11b94ca50",
+            "x1": "0x680000006e00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170cc6d50",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94cac0",
+            "x10": "0x11b94cad8",
+            "x11": "0x40000000402",
+            "x12": "0x20a0",
+            "x13": "0x400",
+            "x14": "0x0",
+            "x15": "0x400",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "ACPLSDKThreadpoolThread1",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242f7ec"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242f8d0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242fa6c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242fb88"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "instruction_addr": "0x21053c090"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170cc6dc0",
+            "x28": "0x0",
+            "x25": "0x170cc7000",
+            "x24": "0x6800",
+            "x27": "0x0",
+            "x26": "0x6e00",
+            "x21": "0x2",
+            "x20": "0x11b94ca50",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170cc6dc0",
+            "x8": "0x170cc6d50",
+            "x9": "0x6800",
+            "x2": "0x6800",
+            "x3": "0x0",
+            "x0": "0x11b94ca50",
+            "x1": "0x680000006e00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170cc6d50",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94cac0",
+            "x10": "0x11b94cad8",
+            "x11": "0x40000000402",
+            "x12": "0x20a0",
+            "x13": "0x400",
+            "x14": "0x0",
+            "x15": "0x400",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 27
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeIZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeIZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4339,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e8"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L16__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEJEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}, , >(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e8",
+              "lineno": 342
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEZN3acp5local4impl10ThreadPoolC1EvEUlvE_EEEEEPvSD_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}> >(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e4",
+              "lineno": 352
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::ThreadPool::lambda::operator()",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN3acp5local4impl10ThreadPoolC1EvENKUlvE_clEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f8cc",
+              "lineno": 124
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::Task",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl10ThreadPool4TaskEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::Task()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fa68",
+              "lineno": 68
+            },
+            {
+              "function": "std::__1::condition_variable::wait<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable4waitIZN3acp5local4impl10ThreadPool8next_jobEvEUlvE_EEvRNS_11unique_lockINS_5mutexEEET_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::condition_variable::wait<acp::local::impl::ThreadPool::next_job()::{lambda()#1}>(std::__1::unique_lock<std::__1::mutex>&, acp::local::impl::ThreadPool::next_job()::{lambda()#1})",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fb84",
+              "lineno": 375
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::next_job",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl10ThreadPool8next_jobEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::next_job()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fb64",
+              "lineno": 85
+            },
+            {
+              "function": "std::__1::condition_variable::wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "raw_function": "std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)",
+              "instruction_addr": "0x21053c08c"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170d52dc0",
+            "x28": "0x0",
+            "x25": "0x170d53000",
+            "x24": "0x6900",
+            "x27": "0x0",
+            "x26": "0x6f00",
+            "x21": "0x2",
+            "x20": "0x11b94ca50",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170d52dc0",
+            "x8": "0x170d52d50",
+            "x9": "0x6900",
+            "x2": "0x6900",
+            "x3": "0x0",
+            "x0": "0x11b94ca50",
+            "x1": "0x690000006f00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170d52d50",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94cac0",
+            "x10": "0x11b94cad8",
+            "x11": "0x40000000402",
+            "x12": "0x20a0",
+            "x13": "0x400",
+            "x14": "0x0",
+            "x15": "0x400",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "ACPLSDKThreadpoolThread2",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242f7ec"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242f8d0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242fa6c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242fb88"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "instruction_addr": "0x21053c090"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170d52dc0",
+            "x28": "0x0",
+            "x25": "0x170d53000",
+            "x24": "0x6900",
+            "x27": "0x0",
+            "x26": "0x6f00",
+            "x21": "0x2",
+            "x20": "0x11b94ca50",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170d52dc0",
+            "x8": "0x170d52d50",
+            "x9": "0x6900",
+            "x2": "0x6900",
+            "x3": "0x0",
+            "x0": "0x11b94ca50",
+            "x1": "0x690000006f00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170d52d50",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94cac0",
+            "x10": "0x11b94cad8",
+            "x11": "0x40000000402",
+            "x12": "0x20a0",
+            "x13": "0x400",
+            "x14": "0x0",
+            "x15": "0x400",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 28
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeIZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeIZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4339,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e8"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L16__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEJEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}, , >(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e8",
+              "lineno": 342
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEZN3acp5local4impl10ThreadPoolC1EvEUlvE_EEEEEPvSD_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}> >(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e4",
+              "lineno": 352
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::ThreadPool::lambda::operator()",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN3acp5local4impl10ThreadPoolC1EvENKUlvE_clEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f8cc",
+              "lineno": 124
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::Task",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl10ThreadPool4TaskEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::Task()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fa68",
+              "lineno": 68
+            },
+            {
+              "function": "std::__1::condition_variable::wait<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable4waitIZN3acp5local4impl10ThreadPool8next_jobEvEUlvE_EEvRNS_11unique_lockINS_5mutexEEET_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::condition_variable::wait<acp::local::impl::ThreadPool::next_job()::{lambda()#1}>(std::__1::unique_lock<std::__1::mutex>&, acp::local::impl::ThreadPool::next_job()::{lambda()#1})",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fb84",
+              "lineno": 375
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::next_job",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl10ThreadPool8next_jobEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::next_job()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fb64",
+              "lineno": 85
+            },
+            {
+              "function": "std::__1::condition_variable::wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "raw_function": "std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)",
+              "instruction_addr": "0x21053c08c"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170ddedc0",
+            "x28": "0x0",
+            "x25": "0x170ddf000",
+            "x24": "0x6c00",
+            "x27": "0x0",
+            "x26": "0x7200",
+            "x21": "0x2",
+            "x20": "0x11b94ca50",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170ddedc0",
+            "x8": "0x170dded50",
+            "x9": "0x6c00",
+            "x2": "0x6c00",
+            "x3": "0x0",
+            "x0": "0x11b94ca50",
+            "x1": "0x6c0000007200",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170dded50",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94cac0",
+            "x10": "0x11b94cad8",
+            "x11": "0x40000000402",
+            "x12": "0x20a0",
+            "x13": "0x400",
+            "x14": "0x0",
+            "x15": "0x400",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "ACPLSDKThreadpoolThread3",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242f7ec"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242f8d0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242fa6c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242fb88"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "instruction_addr": "0x21053c090"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170ddedc0",
+            "x28": "0x0",
+            "x25": "0x170ddf000",
+            "x24": "0x6c00",
+            "x27": "0x0",
+            "x26": "0x7200",
+            "x21": "0x2",
+            "x20": "0x11b94ca50",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170ddedc0",
+            "x8": "0x170dded50",
+            "x9": "0x6c00",
+            "x2": "0x6c00",
+            "x3": "0x0",
+            "x0": "0x11b94ca50",
+            "x1": "0x6c0000007200",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170dded50",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94cac0",
+            "x10": "0x11b94cad8",
+            "x11": "0x40000000402",
+            "x12": "0x20a0",
+            "x13": "0x400",
+            "x14": "0x0",
+            "x15": "0x400",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 29
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeIZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeIZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4339,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e8"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L16__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEJEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}, , >(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e8",
+              "lineno": 342
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEZN3acp5local4impl10ThreadPoolC1EvEUlvE_EEEEEPvSD_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}> >(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e4",
+              "lineno": 352
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::ThreadPool::lambda::operator()",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN3acp5local4impl10ThreadPoolC1EvENKUlvE_clEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f8cc",
+              "lineno": 124
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::Task",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl10ThreadPool4TaskEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::Task()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fa68",
+              "lineno": 68
+            },
+            {
+              "function": "std::__1::condition_variable::wait<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable4waitIZN3acp5local4impl10ThreadPool8next_jobEvEUlvE_EEvRNS_11unique_lockINS_5mutexEEET_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::condition_variable::wait<acp::local::impl::ThreadPool::next_job()::{lambda()#1}>(std::__1::unique_lock<std::__1::mutex>&, acp::local::impl::ThreadPool::next_job()::{lambda()#1})",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fb84",
+              "lineno": 375
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::next_job",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl10ThreadPool8next_jobEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::next_job()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fb64",
+              "lineno": 85
+            },
+            {
+              "function": "std::__1::condition_variable::wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "raw_function": "std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)",
+              "instruction_addr": "0x21053c08c"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170e6adc0",
+            "x28": "0x0",
+            "x25": "0x170e6b000",
+            "x24": "0x6d00",
+            "x27": "0x0",
+            "x26": "0x7300",
+            "x21": "0x2",
+            "x20": "0x11b94ca50",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170e6adc0",
+            "x8": "0x170e6ad50",
+            "x9": "0x6d00",
+            "x2": "0x6d00",
+            "x3": "0x0",
+            "x0": "0x11b94ca50",
+            "x1": "0x6d0000007300",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170e6ad50",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94cac0",
+            "x10": "0x11b94cad8",
+            "x11": "0x40000000402",
+            "x12": "0x20a0",
+            "x13": "0x400",
+            "x14": "0x0",
+            "x15": "0x400",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "ACPLSDKThreadpoolThread4",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242f7ec"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242f8d0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242fa6c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242fb88"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "instruction_addr": "0x21053c090"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170e6adc0",
+            "x28": "0x0",
+            "x25": "0x170e6b000",
+            "x24": "0x6d00",
+            "x27": "0x0",
+            "x26": "0x7300",
+            "x21": "0x2",
+            "x20": "0x11b94ca50",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170e6adc0",
+            "x8": "0x170e6ad50",
+            "x9": "0x6d00",
+            "x2": "0x6d00",
+            "x3": "0x0",
+            "x0": "0x11b94ca50",
+            "x1": "0x6d0000007300",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170e6ad50",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94cac0",
+            "x10": "0x11b94cad8",
+            "x11": "0x40000000402",
+            "x12": "0x20a0",
+            "x13": "0x400",
+            "x14": "0x0",
+            "x15": "0x400",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 30
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeIZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeIZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS6_DpOS7_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4339,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e8"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L16__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEEZN3acp5local4impl10ThreadPoolC1EvEUlvE_JEJEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}, , >(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e8",
+              "lineno": 342
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEZN3acp5local4impl10ThreadPoolC1EvEUlvE_EEEEEPvSD_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}> >(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f7e4",
+              "lineno": 352
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::ThreadPool::lambda::operator()",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN3acp5local4impl10ThreadPoolC1EvENKUlvE_clEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::ThreadPool()::{lambda()#1}::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242f8cc",
+              "lineno": 124
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::Task",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl10ThreadPool4TaskEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::Task()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fa68",
+              "lineno": 68
+            },
+            {
+              "function": "std::__1::condition_variable::wait<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable4waitIZN3acp5local4impl10ThreadPool8next_jobEvEUlvE_EEvRNS_11unique_lockINS_5mutexEEET_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::condition_variable::wait<acp::local::impl::ThreadPool::next_job()::{lambda()#1}>(std::__1::unique_lock<std::__1::mutex>&, acp::local::impl::ThreadPool::next_job()::{lambda()#1})",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fb84",
+              "lineno": 375
+            },
+            {
+              "function": "acp::local::impl::ThreadPool::next_job",
+              "abs_path": "/Users/travis/proj/shared/projects/acpl/../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN3acp5local4impl10ThreadPool8next_jobEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/source/impl/utilities/common/include/ThreadPool.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "acp::local::impl::ThreadPool::next_job()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10242fb64",
+              "lineno": 85
+            },
+            {
+              "function": "std::__1::condition_variable::wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "raw_function": "std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&)",
+              "instruction_addr": "0x20c31108c"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170ef6dc0",
+            "x28": "0x0",
+            "x25": "0x170ef7000",
+            "x24": "0x6a00",
+            "x27": "0x0",
+            "x26": "0x7000",
+            "x21": "0x2",
+            "x20": "0x11b94ca50",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170ef6dc0",
+            "x8": "0x170ef6d50",
+            "x9": "0x6a00",
+            "x2": "0x6a00",
+            "x3": "0x0",
+            "x0": "0x11b94ca50",
+            "x1": "0x6a0000007000",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170ef6d50",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94cac0",
+            "x10": "0x11b94cad8",
+            "x11": "0x40000000402",
+            "x12": "0x20a0",
+            "x13": "0x400",
+            "x14": "0x0",
+            "x15": "0x400",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "ACPLSDKThreadpoolThread5",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242f7ec"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242f8d0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242fa6c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10242fb88"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c078",
+              "instruction_addr": "0x21053c090"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x170ef6dc0",
+            "x28": "0x0",
+            "x25": "0x170ef7000",
+            "x24": "0x6a00",
+            "x27": "0x0",
+            "x26": "0x7000",
+            "x21": "0x2",
+            "x20": "0x11b94ca50",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x170ef6dc0",
+            "x8": "0x170ef6d50",
+            "x9": "0x6a00",
+            "x2": "0x6a00",
+            "x3": "0x0",
+            "x0": "0x11b94ca50",
+            "x1": "0x6a0000007000",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x170ef6d50",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94cac0",
+            "x10": "0x11b94cad8",
+            "x11": "0x40000000402",
+            "x12": "0x20a0",
+            "x13": "0x400",
+            "x14": "0x0",
+            "x15": "0x400",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 31
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b0"
+            },
+            {
+              "function": "_dispatch_worker_thread2",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98cc"
+            },
+            {
+              "function": "_dispatch_root_queue_drain",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db9028"
+            },
+            {
+              "function": "_dispatch_async_redirect_invoke",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6d8"
+            },
+            {
+              "function": "_dispatch_continuation_pop$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad014"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d0"
+            },
+            {
+              "function": "_dispatch_call_block_and_release",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a34"
+            },
+            {
+              "function": "__NSOQSchedule_f",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dce8"
+            },
+            {
+              "function": "-[__NSOperationInternal _start:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37904"
+            },
+            {
+              "function": "-[NSBlockOperation main]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d3841c"
+            },
+            {
+              "function": "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf64"
+            },
+            {
+              "function": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/mac/MacThreadPool.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "image_addr": "0x100564000",
+              "filename": "MacThreadPool.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 45,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103059000"
+            },
+            {
+              "function": "gude::WorkSchedulerImpl::workerCallback",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/xplat/WorkSchedulerImpl.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN4gude17WorkSchedulerImpl14workerCallbackEv",
+              "image_addr": "0x100564000",
+              "filename": "WorkSchedulerImpl.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "gude::WorkSchedulerImpl::workerCallback()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10304633c",
+              "lineno": 248
+            },
+            {
+              "function": "-[GUDERequestNSURL startWork]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL startWork]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2066,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054c98"
+            },
+            {
+              "function": "-[GUDERequestNSURL playRequest]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL playRequest]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2029,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054744"
+            },
+            {
+              "function": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 1645,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103052058"
+            },
+            {
+              "function": "_dispatch_semaphore_wait_slow",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab218"
+            },
+            {
+              "function": "_dispatch_sema4_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa794"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x170f829e0",
+            "x28": "0x58",
+            "x25": "0x280df4280",
+            "x24": "0x10411d6cd",
+            "x27": "0x280df4280",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c561c0",
+            "x23": "0x5a",
+            "x22": "0x11be1a160",
+            "fp": "0x170f829e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x210e0b22c",
+            "x0": "0x16f0f",
+            "x1": "0x0",
+            "x6": "0x11bd473e0",
+            "x7": "0x170f80bdc",
+            "x4": "0x9a",
+            "x5": "0x16",
+            "sp": "0x170f829d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c56200",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98d0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db902c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6dc"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad018"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a38"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dcec"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37908"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d38420"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf68"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103059004"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103046340"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054c9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054748"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10305205c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab21c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa798"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x170f829e0",
+            "x28": "0x58",
+            "x25": "0x280df4280",
+            "x24": "0x10411d6cd",
+            "x27": "0x280df4280",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c561c0",
+            "x23": "0x5a",
+            "x22": "0x11be1a160",
+            "fp": "0x170f829e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x210e0b22c",
+            "x0": "0x16f0f",
+            "x1": "0x0",
+            "x6": "0x11bd473e0",
+            "x7": "0x170f80bdc",
+            "x4": "0x9a",
+            "x5": "0x16",
+            "sp": "0x170f829d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c56200",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "id": 32,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b0"
+            },
+            {
+              "function": "_dispatch_worker_thread2",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98cc"
+            },
+            {
+              "function": "_dispatch_root_queue_drain",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db9028"
+            },
+            {
+              "function": "_dispatch_async_redirect_invoke",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x1dd9fd794"
+            },
+            {
+              "function": "_dispatch_continuation_pop$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad014"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d0"
+            },
+            {
+              "function": "_dispatch_call_block_and_release",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a34"
+            },
+            {
+              "function": "__NSOQSchedule_f",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dce8"
+            },
+            {
+              "function": "-[__NSOperationInternal _start:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37904"
+            },
+            {
+              "function": "-[NSBlockOperation main]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d3841c"
+            },
+            {
+              "function": "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf64"
+            },
+            {
+              "function": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/mac/MacThreadPool.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "image_addr": "0x100564000",
+              "filename": "MacThreadPool.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 45,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103059000"
+            },
+            {
+              "function": "gude::WorkSchedulerImpl::workerCallback",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/xplat/WorkSchedulerImpl.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN4gude17WorkSchedulerImpl14workerCallbackEv",
+              "image_addr": "0x100564000",
+              "filename": "WorkSchedulerImpl.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "gude::WorkSchedulerImpl::workerCallback()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10304633c",
+              "lineno": 248
+            },
+            {
+              "function": "-[GUDERequestNSURL startWork]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL startWork]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2066,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054c98"
+            },
+            {
+              "function": "-[GUDERequestNSURL playRequest]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL playRequest]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2029,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054744"
+            },
+            {
+              "function": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 1645,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103052058"
+            },
+            {
+              "function": "_dispatch_semaphore_wait_slow",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab218"
+            },
+            {
+              "function": "_dispatch_sema4_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa794"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x17109a9e0",
+            "x28": "0x58",
+            "x25": "0x280de9180",
+            "x24": "0x10411d6cd",
+            "x27": "0x280de9180",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c50dc0",
+            "x23": "0x5a",
+            "x22": "0x11b973420",
+            "fp": "0x17109a9e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x210e0b22c",
+            "x0": "0x1a603",
+            "x1": "0x0",
+            "x6": "0x11bcf4e90",
+            "x7": "0x171098bdc",
+            "x4": "0x9a",
+            "x5": "0x16",
+            "sp": "0x17109a9d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c50e00",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98d0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db902c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac798"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad018"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a38"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dcec"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37908"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d38420"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf68"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103059004"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103046340"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054c9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054748"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10305205c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab21c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa798"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x17109a9e0",
+            "x28": "0x58",
+            "x25": "0x280de9180",
+            "x24": "0x10411d6cd",
+            "x27": "0x280de9180",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c50dc0",
+            "x23": "0x5a",
+            "x22": "0x11b973420",
+            "fp": "0x17109a9e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x210e0b22c",
+            "x0": "0x1a603",
+            "x1": "0x0",
+            "x6": "0x11bcf4e90",
+            "x7": "0x171098bdc",
+            "x4": "0x9a",
+            "x5": "0x16",
+            "sp": "0x17109a9d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c50e00",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "id": 33,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b0"
+            },
+            {
+              "function": "_dispatch_worker_thread2",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98cc"
+            },
+            {
+              "function": "_dispatch_root_queue_drain",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db9028"
+            },
+            {
+              "function": "_dispatch_async_redirect_invoke",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6d8"
+            },
+            {
+              "function": "_dispatch_continuation_pop$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad014"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d0"
+            },
+            {
+              "function": "_dispatch_call_block_and_release",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a34"
+            },
+            {
+              "function": "__NSOQSchedule_f",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dce8"
+            },
+            {
+              "function": "-[__NSOperationInternal _start:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37904"
+            },
+            {
+              "function": "-[NSBlockOperation main]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d3841c"
+            },
+            {
+              "function": "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf64"
+            },
+            {
+              "function": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/mac/MacThreadPool.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "image_addr": "0x100564000",
+              "filename": "MacThreadPool.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 45,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103059000"
+            },
+            {
+              "function": "gude::WorkSchedulerImpl::workerCallback",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/xplat/WorkSchedulerImpl.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN4gude17WorkSchedulerImpl14workerCallbackEv",
+              "image_addr": "0x100564000",
+              "filename": "WorkSchedulerImpl.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "gude::WorkSchedulerImpl::workerCallback()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10304633c",
+              "lineno": 248
+            },
+            {
+              "function": "-[GUDERequestNSURL startWork]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL startWork]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2066,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054c98"
+            },
+            {
+              "function": "-[GUDERequestNSURL playRequest]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL playRequest]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2029,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054744"
+            },
+            {
+              "function": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 1645,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103052058"
+            },
+            {
+              "function": "_dispatch_semaphore_wait_slow",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab218"
+            },
+            {
+              "function": "_dispatch_sema4_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa794"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x1711269e0",
+            "x28": "0x58",
+            "x25": "0x280de05a0",
+            "x24": "0x10411d6cd",
+            "x27": "0x280de05a0",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c214a0",
+            "x23": "0x5a",
+            "x22": "0x11b95ab20",
+            "fp": "0x1711269e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x171126888",
+            "x0": "0x1b713",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x1",
+            "x5": "0x0",
+            "sp": "0x1711269d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c214e0",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98d0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db902c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6dc"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad018"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a38"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dcec"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37908"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d38420"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf68"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103059004"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103046340"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054c9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054748"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10305205c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab21c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa798"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x1711269e0",
+            "x28": "0x58",
+            "x25": "0x280de05a0",
+            "x24": "0x10411d6cd",
+            "x27": "0x280de05a0",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c214a0",
+            "x23": "0x5a",
+            "x22": "0x11b95ab20",
+            "fp": "0x1711269e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x171126888",
+            "x0": "0x1b713",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x1",
+            "x5": "0x0",
+            "sp": "0x1711269d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c214e0",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "id": 34,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b0"
+            },
+            {
+              "function": "_dispatch_worker_thread2",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98cc"
+            },
+            {
+              "function": "_dispatch_root_queue_drain",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db9028"
+            },
+            {
+              "function": "_dispatch_async_redirect_invoke",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6d8"
+            },
+            {
+              "function": "_dispatch_continuation_pop$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad014"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d0"
+            },
+            {
+              "function": "_dispatch_call_block_and_release",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a34"
+            },
+            {
+              "function": "__NSOQSchedule_f",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dce8"
+            },
+            {
+              "function": "-[__NSOperationInternal _start:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37904"
+            },
+            {
+              "function": "-[NSBlockOperation main]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d3841c"
+            },
+            {
+              "function": "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf64"
+            },
+            {
+              "function": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/mac/MacThreadPool.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "image_addr": "0x100564000",
+              "filename": "MacThreadPool.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 45,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103059000"
+            },
+            {
+              "function": "gude::WorkSchedulerImpl::workerCallback",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/xplat/WorkSchedulerImpl.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN4gude17WorkSchedulerImpl14workerCallbackEv",
+              "image_addr": "0x100564000",
+              "filename": "WorkSchedulerImpl.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "gude::WorkSchedulerImpl::workerCallback()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10304633c",
+              "lineno": 248
+            },
+            {
+              "function": "-[GUDERequestNSURL startWork]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL startWork]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2066,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054c98"
+            },
+            {
+              "function": "-[GUDERequestNSURL playRequest]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL playRequest]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2029,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054744"
+            },
+            {
+              "function": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 1645,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103052058"
+            },
+            {
+              "function": "_dispatch_semaphore_wait_slow",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab218"
+            },
+            {
+              "function": "_dispatch_sema4_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa794"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x1711b29e0",
+            "x28": "0x58",
+            "x25": "0x280dd83c0",
+            "x24": "0x10411d6cd",
+            "x27": "0x280dd83c0",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c30460",
+            "x23": "0x5a",
+            "x22": "0x11b925800",
+            "fp": "0x1711b29e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x1711b2888",
+            "x0": "0x1e603",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x1",
+            "x5": "0x0",
+            "sp": "0x1711b29d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c304a0",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98d0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db902c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6dc"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad018"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a38"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dcec"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37908"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d38420"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf68"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103059004"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103046340"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054c9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054748"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10305205c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab21c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa798"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x1711b29e0",
+            "x28": "0x58",
+            "x25": "0x280dd83c0",
+            "x24": "0x10411d6cd",
+            "x27": "0x280dd83c0",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c30460",
+            "x23": "0x5a",
+            "x22": "0x11b925800",
+            "fp": "0x1711b29e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x1711b2888",
+            "x0": "0x1e603",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x1",
+            "x5": "0x0",
+            "sp": "0x1711b29d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c304a0",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "id": 35,
+        "crashed": false
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "musync::Actor::runWorker",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6musync5Actor9runWorkerEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "musync::Actor::runWorker()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1031a55cc"
+            },
+            {
+              "function": "boost::detail::function::void_function_obj_invoker0<T>::invoke",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost6detail8function26void_function_obj_invoker0IZN6musync5Actor9runWorkerEvE3$_0vE6invokeERNS1_15function_bufferE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::detail::function::void_function_obj_invoker0<musync::Actor::runWorker()::$_0, void>::invoke(boost::detail::function::function_buffer&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1031a7748"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c048"
+            },
+            {
+              "function": "boost::asio::detail::posix_event::wait<T>",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail11posix_event4waitINS1_27conditionally_enabled_mutex11scoped_lockEEEvRT_",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::posix_event::wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock>(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c8d4"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17123ea40",
+            "x28": "0x0",
+            "x25": "0x17123f000",
+            "x24": "0xf00",
+            "x27": "0x119e0a738",
+            "x26": "0x1000",
+            "x21": "0x2",
+            "x20": "0x119e0a6f8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17123ea40",
+            "x8": "0x17123e9d0",
+            "x9": "0xf01",
+            "x2": "0xf00",
+            "x3": "0x0",
+            "x0": "0x119e0a6f8",
+            "x1": "0xf0100001000",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17123e9d0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x119e0a6a8",
+            "x10": "0x119e0a6c0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.actor.B0D3D0AC590C41DF0A495E82@AdobeID",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1031a55d0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1031a774c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c04c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c8d8"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17123ea40",
+            "x28": "0x0",
+            "x25": "0x17123f000",
+            "x24": "0xf00",
+            "x27": "0x119e0a738",
+            "x26": "0x1000",
+            "x21": "0x2",
+            "x20": "0x119e0a6f8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17123ea40",
+            "x8": "0x17123e9d0",
+            "x9": "0xf01",
+            "x2": "0xf00",
+            "x3": "0x0",
+            "x0": "0x119e0a6f8",
+            "x1": "0xf0100001000",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17123e9d0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x119e0a6a8",
+            "x10": "0x119e0a6c0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 36
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b0"
+            },
+            {
+              "function": "_dispatch_worker_thread2",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98cc"
+            },
+            {
+              "function": "_dispatch_root_queue_drain",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db9028"
+            },
+            {
+              "function": "_dispatch_async_redirect_invoke",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6d8"
+            },
+            {
+              "function": "_dispatch_continuation_pop$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad014"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d0"
+            },
+            {
+              "function": "_dispatch_call_block_and_release",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a34"
+            },
+            {
+              "function": "__NSOQSchedule_f",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dce8"
+            },
+            {
+              "function": "-[__NSOperationInternal _start:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37904"
+            },
+            {
+              "function": "-[NSBlockOperation main]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d3841c"
+            },
+            {
+              "function": "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf64"
+            },
+            {
+              "function": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/mac/MacThreadPool.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "image_addr": "0x100564000",
+              "filename": "MacThreadPool.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 45,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103059000"
+            },
+            {
+              "function": "gude::WorkSchedulerImpl::workerCallback",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/xplat/WorkSchedulerImpl.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN4gude17WorkSchedulerImpl14workerCallbackEv",
+              "image_addr": "0x100564000",
+              "filename": "WorkSchedulerImpl.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "gude::WorkSchedulerImpl::workerCallback()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10304633c",
+              "lineno": 248
+            },
+            {
+              "function": "-[GUDERequestNSURL startWork]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL startWork]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2066,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054c98"
+            },
+            {
+              "function": "-[GUDERequestNSURL playRequest]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL playRequest]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2029,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054744"
+            },
+            {
+              "function": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 1645,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103052058"
+            },
+            {
+              "function": "_dispatch_semaphore_wait_slow",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab218"
+            },
+            {
+              "function": "_dispatch_sema4_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa794"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x1712ca9e0",
+            "x28": "0x58",
+            "x25": "0x280de17c0",
+            "x24": "0x10411d6cd",
+            "x27": "0x280de17c0",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c229e0",
+            "x23": "0x5a",
+            "x22": "0x11b959870",
+            "fp": "0x1712ca9e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x1712ca888",
+            "x0": "0x1c003",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x1",
+            "x5": "0x0",
+            "sp": "0x1712ca9d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c22a20",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98d0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db902c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6dc"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad018"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a38"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dcec"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37908"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d38420"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf68"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103059004"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103046340"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054c9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054748"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10305205c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab21c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa798"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x1712ca9e0",
+            "x28": "0x58",
+            "x25": "0x280de17c0",
+            "x24": "0x10411d6cd",
+            "x27": "0x280de17c0",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c229e0",
+            "x23": "0x5a",
+            "x22": "0x11b959870",
+            "fp": "0x1712ca9e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x1712ca888",
+            "x0": "0x1c003",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x1",
+            "x5": "0x0",
+            "sp": "0x1712ca9d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c22a20",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "id": 37,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "start_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210feac10",
+              "instruction_addr": "0x1d7457cd0"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x0",
+            "pc": "0x210feacd0",
+            "x29": "0x0",
+            "x28": "0x0",
+            "x25": "0x0",
+            "x24": "0x0",
+            "x27": "0x0",
+            "x26": "0x0",
+            "x21": "0x0",
+            "x20": "0x0",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1712d4000",
+            "x3": "0x171356b80",
+            "x0": "0x171357000",
+            "x1": "0x1ad1f",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x4f4006",
+            "x5": "0x1",
+            "sp": "0x171356b70",
+            "lr": "0x0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x0",
+            "x11": "0x0",
+            "x12": "0x0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x0",
+            "x17": "0x0"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210feac10",
+              "instruction_addr": "0x210feacd0"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x0",
+            "pc": "0x210feacd0",
+            "x29": "0x0",
+            "x28": "0x0",
+            "x25": "0x0",
+            "x24": "0x0",
+            "x27": "0x0",
+            "x26": "0x0",
+            "x21": "0x0",
+            "x20": "0x0",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1712d4000",
+            "x3": "0x171356b80",
+            "x0": "0x171357000",
+            "x1": "0x1ad1f",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x4f4006",
+            "x5": "0x1",
+            "sp": "0x171356b70",
+            "lr": "0x0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x0",
+            "x11": "0x0",
+            "x12": "0x0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x0",
+            "x17": "0x0"
+          }
+        },
+        "id": 38,
+        "crashed": false
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "musync::Actor::runWorker",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6musync5Actor9runWorkerEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "musync::Actor::runWorker()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1031a55cc"
+            },
+            {
+              "function": "boost::detail::function::void_function_obj_invoker0<T>::invoke",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost6detail8function26void_function_obj_invoker0IZN6musync5Actor9runWorkerEvE3$_0vE6invokeERNS1_15function_bufferE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::detail::function::void_function_obj_invoker0<musync::Actor::runWorker()::$_0, void>::invoke(boost::detail::function::function_buffer&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1031a7748"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c080"
+            },
+            {
+              "function": "boost::asio::detail::kqueue_reactor::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail14kqueue_reactor3runElRNS1_8op_queueINS1_19scheduler_operationEEE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::kqueue_reactor::run(long, boost::asio::detail::op_queue<boost::asio::detail::scheduler_operation>&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c280"
+            },
+            {
+              "function": "kevent",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f668ec",
+              "instruction_addr": "0x2137f78f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f668f4",
+            "x29": "0x1713e2a60",
+            "x28": "0x0",
+            "x25": "0x11bc12d30",
+            "x24": "0x11bc12d78",
+            "x27": "0x11bc12d78",
+            "x26": "0x1713e2b28",
+            "x21": "0x0",
+            "x20": "0x11bc12cb0",
+            "x23": "0x11bc12d38",
+            "x22": "0x280094a00",
+            "fp": "0x1713e2a60",
+            "x8": "0x280094a58",
+            "x9": "0x2",
+            "x2": "0x0",
+            "x3": "0x1713e1608",
+            "x0": "0x0",
+            "x1": "0x0",
+            "x6": "0x65",
+            "x7": "0x11b9485b0",
+            "x4": "0x80",
+            "x5": "0x1713e15e8",
+            "sp": "0x1713e15a0",
+            "lr": "0x10335c284",
+            "x18": "0x0",
+            "x19": "0x1713e2b28",
+            "x10": "0x0",
+            "x11": "0x0",
+            "x12": "0x1",
+            "x13": "0x2",
+            "x14": "0x0",
+            "x15": "0x4e",
+            "x16": "0x16b",
+            "x17": "0x2fa00000"
+          }
+        },
+        "name": "cs.actor.cloudnative",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1031a55d0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1031a774c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c084"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c284"
+            },
+            {
+              "function": "kevent",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f668ec",
+              "instruction_addr": "0x210f668f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f668f4",
+            "x29": "0x1713e2a60",
+            "x28": "0x0",
+            "x25": "0x11bc12d30",
+            "x24": "0x11bc12d78",
+            "x27": "0x11bc12d78",
+            "x26": "0x1713e2b28",
+            "x21": "0x0",
+            "x20": "0x11bc12cb0",
+            "x23": "0x11bc12d38",
+            "x22": "0x280094a00",
+            "fp": "0x1713e2a60",
+            "x8": "0x280094a58",
+            "x9": "0x2",
+            "x2": "0x0",
+            "x3": "0x1713e1608",
+            "x0": "0x0",
+            "x1": "0x0",
+            "x6": "0x65",
+            "x7": "0x11b9485b0",
+            "x4": "0x80",
+            "x5": "0x1713e15e8",
+            "sp": "0x1713e15a0",
+            "lr": "0x10335c284",
+            "x18": "0x0",
+            "x19": "0x1713e2b28",
+            "x10": "0x0",
+            "x11": "0x0",
+            "x12": "0x1",
+            "x13": "0x2",
+            "x14": "0x0",
+            "x15": "0x4e",
+            "x16": "0x16b",
+            "x17": "0x2fa00000"
+          }
+        },
+        "id": 39
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "std::__1::function<T>::operator()",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/functional",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNKSt3__18functionIFvvEEclEv",
+              "image_addr": "0x100564000",
+              "filename": "functional",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "std::__1::function<void ()>::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1025d5c04",
+              "lineno": 1913
+            },
+            {
+              "function": "_ZNSt3__1L8__invokeINS_8functionIFvvEEEJEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS4_DpOS5_",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/type_traits",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L8__invokeINS_8functionIFvvEEEJEEEDTclclsr3std3__1E7forwardIT_Efp_Espclsr3std3__1E7forwardIT0_Efp0_EEEOS4_DpOS5_",
+              "image_addr": "0x100564000",
+              "filename": "type_traits",
+              "symbol_addr": "0x100635e34",
+              "lineno": 4339,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1025d5bf4"
+            },
+            {
+              "function": "std::__1::__thread_execute<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__1L16__thread_executeINS_10unique_ptrINS_15__thread_structENS_14default_deleteIS2_EEEENS_8functionIFvvEEEJEJEEEvRNS_5tupleIJT_T0_DpT1_EEENS_15__tuple_indicesIJXspT2_EEEE",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, std::__1::function<void ()>, , >(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_del...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1025d5bf4",
+              "lineno": 342
+            },
+            {
+              "function": "std::__1::__thread_proxy<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEENS_8functionIFvvEEEEEEEEPvSB_",
+              "image_addr": "0x100564000",
+              "filename": "thread",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, std::__1::function<void ()> > >(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1025d5bf4",
+              "lineno": 352
+            },
+            {
+              "function": "std::__1::condition_variable::wait_until<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable10wait_untilINS_6chrono12steady_clockENS2_8durationIxNS_5ratioILl1ELl1000000000EEEEEZZN8AdobeDCX5Timer20generateExecFunctionERKNS_10shared_ptrINS9_4ImplEEEbENKUlvE_clEvEUlvE_EEbRNS_11unique_lockINS_5mutexEEERKNS2_10time_pointIT_T0_EET1_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "bool std::__1::condition_variable::wait_until<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<(long)1, (long)1000000000> >, AdobeDCX::Timer::generateExecFunction(std::__1::shared_ptr<AdobeDCX::Timer::Impl> const&, b...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1025d5908",
+              "lineno": 396
+            },
+            {
+              "function": "std::__1::condition_variable::wait_for<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable8wait_forIxNS_5ratioILl1ELl1000EEEZZN8AdobeDCX5Timer20generateExecFunctionERKNS_10shared_ptrINS5_4ImplEEEbENKUlvE_clEvEUlvE_EEbRNS_11unique_lockINS_5mutexEEERKNS_6chrono8durationIT_T0_EET1_",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "bool std::__1::condition_variable::wait_for<long long, std::__1::ratio<(long)1, (long)1000>, AdobeDCX::Timer::generateExecFunction(std::__1::shared_ptr<AdobeDCX::Timer::Impl> const&, bool)::{lambda()#1}::operator()() const::{lambda()#1}>(std::__1::uniqu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1025d58f4",
+              "lineno": 430
+            },
+            {
+              "function": "AdobeDCX::Timer::generateExecFunction::lambda::operator()",
+              "abs_path": "/Users/travis/proj/shared/projects/dcx/../../../shared/ps-acp-local/acp-local/acp.local/resource/dcx-cpp/src/private/Timer.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8AdobeDCX5Timer20generateExecFunctionERKNSt3__110shared_ptrINS0_4ImplEEEbENKUlvE_clEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/ps-acp-local/acp-local/acp.local/resource/dcx-cpp/src/private/Timer.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::Timer::generateExecFunction(std::__1::shared_ptr<AdobeDCX::Timer::Impl> const&, bool)::{lambda()#1}::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1025d58c0",
+              "lineno": 92
+            },
+            {
+              "function": "std::__1::condition_variable::wait_for<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable8wait_forIxNS_5ratioILl1ELl1000000000EEEEENS_9cv_statusERNS_11unique_lockINS_5mutexEEERKNS_6chrono8durationIT_T0_EE",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "std::__1::cv_status std::__1::condition_variable::wait_for<long long, std::__1::ratio<(long)1, (long)1000000000> >(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::duration<long long, std::__1::ratio<(long)1, (long)1000000000> > const&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100929148"
+            },
+            {
+              "function": "std::__1::condition_variable::wait_until<T>",
+              "abs_path": "/Applications/Xcode_10.2/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZNSt3__118condition_variable10wait_untilINS_6chrono12steady_clockENS2_8durationIxNS_5ratioILl1ELl1000000000EEEEEEENS_9cv_statusERNS_11unique_lockINS_5mutexEEERKNS2_10time_pointIT_T0_EE",
+              "image_addr": "0x100564000",
+              "filename": "__mutex_base",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "std::__1::cv_status std::__1::condition_variable::wait_until<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<(long)1, (long)1000000000> > >(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1009290f8",
+              "lineno": 384
+            },
+            {
+              "function": "std::__1::condition_variable::__do_timed_wait",
+              "package": "/usr/lib/libc++.1.dylib",
+              "symbol": "_ZNSt3__118condition_variable15__do_timed_waitERNS_11unique_lockINS_5mutexEEENS_6chrono10time_pointINS5_12system_clockENS5_8durationIxNS_5ratioILl1ELl1000000000EEEEEEE",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c0c8",
+              "raw_function": "std::__1::condition_variable::__do_timed_wait(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<(long)1, (long)1000000000> > >)",
+              "instruction_addr": "0x1b2be5124"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1714fae40",
+            "x28": "0x0",
+            "x25": "0x1714fb000",
+            "x24": "0x0",
+            "x27": "0x0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x280683088",
+            "x23": "0x3b9ab7ef",
+            "x22": "0xe0f",
+            "fp": "0x1714fae40",
+            "x8": "0x1714fadd0",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x280683088",
+            "x1": "0x100000100",
+            "x6": "0xe0f",
+            "x7": "0x3b9ab7ef",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1714fadd0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x280683048",
+            "x10": "0x280683060",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1025d5c08"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1025d590c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10092914c"
+            },
+            {
+              "function": "_ZNSt3__118condition_variable15__do_timed_waitERNS_11unique_lockINS_5mutexEEENS_6chrono10time_pointINS5_12system_clockENS5_8durationIxNS_5ratioILl1ELl1000000000EEEEEEE",
+              "package": "/usr/lib/libc++.1.dylib",
+              "image_addr": "0x210534000",
+              "in_app": false,
+              "symbol_addr": "0x21053c0c8",
+              "instruction_addr": "0x21053c128"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1714fae40",
+            "x28": "0x0",
+            "x25": "0x1714fb000",
+            "x24": "0x0",
+            "x27": "0x0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x280683088",
+            "x23": "0x3b9ab7ef",
+            "x22": "0xe0f",
+            "fp": "0x1714fae40",
+            "x8": "0x1714fadd0",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x280683088",
+            "x1": "0x100000100",
+            "x6": "0xe0f",
+            "x7": "0x3b9ab7ef",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1714fadd0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x280683048",
+            "x10": "0x280683060",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 40,
+        "crashed": false
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "musync::Actor::runWorker",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6musync5Actor9runWorkerEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "musync::Actor::runWorker()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1031a55cc"
+            },
+            {
+              "function": "boost::detail::function::void_function_obj_invoker0<T>::invoke",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost6detail8function26void_function_obj_invoker0IZN6musync5Actor9runWorkerEvE3$_0vE6invokeERNS1_15function_bufferE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::detail::function::void_function_obj_invoker0<musync::Actor::runWorker()::$_0, void>::invoke(boost::detail::function::function_buffer&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1031a7748"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c048"
+            },
+            {
+              "function": "boost::asio::detail::posix_event::wait<T>",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail11posix_event4waitINS1_27conditionally_enabled_mutex11scoped_lockEEEvRT_",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::posix_event::wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock>(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c8d4"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x171586a40",
+            "x28": "0x0",
+            "x25": "0x171587000",
+            "x24": "0x100",
+            "x27": "0x119e00908",
+            "x26": "0x200",
+            "x21": "0x2",
+            "x20": "0x119e008c8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x171586a40",
+            "x8": "0x1715869d0",
+            "x9": "0x101",
+            "x2": "0x100",
+            "x3": "0x0",
+            "x0": "0x119e008c8",
+            "x1": "0x10100000200",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1715869d0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x119e00878",
+            "x10": "0x119e00890",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.actor.asset_store.cloudnative",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1031a55d0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1031a774c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c04c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c8d8"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x171586a40",
+            "x28": "0x0",
+            "x25": "0x171587000",
+            "x24": "0x100",
+            "x27": "0x119e00908",
+            "x26": "0x200",
+            "x21": "0x2",
+            "x20": "0x119e008c8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x171586a40",
+            "x8": "0x1715869d0",
+            "x9": "0x101",
+            "x2": "0x100",
+            "x3": "0x0",
+            "x0": "0x119e008c8",
+            "x1": "0x10100000200",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1715869d0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x119e00878",
+            "x10": "0x119e00890",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 41
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::detail::thread_data<T>::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost6detail11thread_dataINS_3_bi6bind_tIvPFvN9AdobeACSL11ACSLLPEntryEENS2_5list1INS2_5valueIS5_EEEEEEE3runEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::detail::thread_data<boost::_bi::bind_t<void, void (*)(AdobeACSL::ACSLLPEntry), boost::_bi::list1<boost::_bi::value<AdobeACSL::ACSLLPEntry> > > >::run()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10313a928"
+            },
+            {
+              "function": "boost::_bi::list1<T>::operator()<T>",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost3_bi5list1INS0_5valueIN9AdobeACSL11ACSLLPEntryEEEEclIPFvS4_ENS0_5list0EEEvNS0_4typeIvEERT_RT0_i",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::_bi::list1<boost::_bi::value<AdobeACSL::ACSLLPEntry> >::operator()<void (*)(AdobeACSL::ACSLLPEntry), boost::_bi::list0>(boost::_bi::type<void>, void (*&)(AdobeACSL::ACSLLPEntry), boost::_bi::list0&, int)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10313ab94"
+            },
+            {
+              "function": "AdobeACSL::LongPollProcessor",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSLL17LongPollProcessorENS_11ACSLLPEntryE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::LongPollProcessor(AdobeACSL::ACSLLPEntry)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103138e0c"
+            },
+            {
+              "function": "AdobeACSL::ACSLSyncServerInf::DoLongPoll",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL17ACSLSyncServerInf10DoLongPollENS_14ACSLAuthHandleERNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEES9_",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::ACSLSyncServerInf::DoLongPoll(AdobeACSL::ACSLAuthHandle, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103165258"
+            },
+            {
+              "function": "AdobeACSL::ACSLSyncServerInf::waitForRequestToComplete",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL17ACSLSyncServerInf24waitForRequestToCompleteENSt3__110shared_ptrINS_17SkyeFacadeRequestEEE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::ACSLSyncServerInf::waitForRequestToComplete(std::__1::shared_ptr<AdobeACSL::SkyeFacadeRequest>)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103161edc"
+            },
+            {
+              "function": "AdobeACSL::SkyeFacadeRequest::waitForResponse",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL17SkyeFacadeRequest15waitForResponseEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::SkyeFacadeRequest::waitForResponse()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10315e92c"
+            },
+            {
+              "function": "AdobeACSL::SynchronousRequestContext::waitForCompletion",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL25SynchronousRequestContext17waitForCompletionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::SynchronousRequestContext::waitForCompletion()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103142688"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x16fac5570",
+            "x28": "0x16fac5e98",
+            "x25": "0x16fac7000",
+            "x24": "0x0",
+            "x27": "0x16fac58e0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803eabd8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x16fac5570",
+            "x8": "0x16fac5500",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803eabd8",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x16fac5500",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803eab98",
+            "x10": "0x2803eabb0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.longpoll.B0D3D0AC590C41DF0A495E82@AdobeID",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10313a92c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10313ab98"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103138e10"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10316525c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103161ee0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10315e930"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10314268c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x16fac5570",
+            "x28": "0x16fac5e98",
+            "x25": "0x16fac7000",
+            "x24": "0x0",
+            "x27": "0x16fac58e0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803eabd8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x16fac5570",
+            "x8": "0x16fac5500",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803eabd8",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x16fac5500",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803eab98",
+            "x10": "0x2803eabb0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 42
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "musync::JobRunner::runSync",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6musync9JobRunner7runSyncEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "musync::JobRunner::runSync()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10321fc7c"
+            },
+            {
+              "function": "sibcrux::CsSyncJob::RunEventBasedSync",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN7sibcrux9CsSyncJob17RunEventBasedSyncEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sibcrux::CsSyncJob::RunEventBasedSync()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103305a80"
+            },
+            {
+              "function": "sibcrux::CsSyncJob::RunEventBasedSyncIteration",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN7sibcrux9CsSyncJob26RunEventBasedSyncIterationERb",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sibcrux::CsSyncJob::RunEventBasedSyncIteration(bool&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103305d50"
+            },
+            {
+              "function": "sibcrux::CSyncJobFromList::RunChangeAnalyzeSyncWorker",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN7sibcrux16CSyncJobFromList26RunChangeAnalyzeSyncWorkerERNS_10SibTermErrERNS_3SIB8CStringTIDsNS3_11SibStrTraitIDsNS3_14ChTraitsSingleIDsEEEEEE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sibcrux::CSyncJobFromList::RunChangeAnalyzeSyncWorker(sibcrux::SibTermErr&, sibcrux::SIB::CStringT<char16_t, sibcrux::SIB::SibStrTrait<char16_t, sibcrux::SIB::ChTraitsSingle<char16_t> > >&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10350f82c"
+            },
+            {
+              "function": "sibcrux::CSyncJob::DoSync",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN7sibcrux8CSyncJob6DoSyncERNS_3SIB8CStringTIDsNS1_11SibStrTraitIDsNS1_14ChTraitsSingleIDsEEEEEERNS_10SibTermErrES8_",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sibcrux::CSyncJob::DoSync(sibcrux::SIB::CStringT<char16_t, sibcrux::SIB::SibStrTrait<char16_t, sibcrux::SIB::ChTraitsSingle<char16_t> > >&, sibcrux::SibTermErr&, sibcrux::SIB::CStringT<char16_t, sibcrux::SIB::SibStrTrait<char16_t, sibcrux::SIB::ChTraits...",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103503e64"
+            },
+            {
+              "function": "sibcrux::CSyncJob::GenerateAndExecuteActions",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN7sibcrux8CSyncJob25GenerateAndExecuteActionsERNS_10SibTermErrERNS_3SIB8CStringTIDsNS3_11SibStrTraitIDsNS3_14ChTraitsSingleIDsEEEEEE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sibcrux::CSyncJob::GenerateAndExecuteActions(sibcrux::SibTermErr&, sibcrux::SIB::CStringT<char16_t, sibcrux::SIB::SibStrTrait<char16_t, sibcrux::SIB::ChTraitsSingle<char16_t> > >&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103502ee0"
+            },
+            {
+              "function": "sync_core::SyncCoreImpl::generateAndExecuteActions",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9sync_core12SyncCoreImpl25generateAndExecuteActionsERN7sibcrux8CSyncJobE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sync_core::SyncCoreImpl::generateAndExecuteActions(sibcrux::CSyncJob&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1034c40a4"
+            },
+            {
+              "function": "sync_core::execution::ActionExecutorImpl<T>::add",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9sync_core9execution18ActionExecutorImplINSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEES8_E3addENS2_10shared_ptrINS0_15ActionSchedulerIS8_S8_EEEEy",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sync_core::execution::ActionExecutorImpl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::add(std::__1::shared_ptr<sync_core::...",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1034d5870"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17172a3d0",
+            "x28": "0x0",
+            "x25": "0x17172b000",
+            "x24": "0x0",
+            "x27": "0x0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x17172a768",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17172a3d0",
+            "x8": "0x17172a360",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x17172a768",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17172a360",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x17172a728",
+            "x10": "0x17172a740",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.jobrunner.cloudnative",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10321fc80"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103305a84"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103305d54"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10350f830"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103503e68"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103502ee4"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1034c40a8"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1034d5874"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17172a3d0",
+            "x28": "0x0",
+            "x25": "0x17172b000",
+            "x24": "0x0",
+            "x27": "0x0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x17172a768",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17172a3d0",
+            "x8": "0x17172a360",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x17172a768",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17172a360",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x17172a728",
+            "x10": "0x17172a740",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 43
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "sync_core::execution::ActionExecutorImpl<T>::runWorker",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9sync_core9execution18ActionExecutorImplINSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEES8_E9runWorkerEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "sync_core::execution::ActionExecutorImpl<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >::runWorker()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1034d540c"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c048"
+            },
+            {
+              "function": "boost::asio::detail::posix_event::wait<T>",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail11posix_event4waitINS1_27conditionally_enabled_mutex11scoped_lockEEEvRT_",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::posix_event::wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock>(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c8d4"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1717b6ad0",
+            "x28": "0x0",
+            "x25": "0x1717b7000",
+            "x24": "0x100",
+            "x27": "0x11b94f898",
+            "x26": "0x200",
+            "x21": "0x2",
+            "x20": "0x11b94f858",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1717b6ad0",
+            "x8": "0x1717b6a60",
+            "x9": "0x101",
+            "x2": "0x100",
+            "x3": "0x0",
+            "x0": "0x11b94f858",
+            "x1": "0x10100000200",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1717b6a60",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94f808",
+            "x10": "0x11b94f820",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.worker.ActionExecutor",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1034d5410"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c04c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c8d8"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1717b6ad0",
+            "x28": "0x0",
+            "x25": "0x1717b7000",
+            "x24": "0x100",
+            "x27": "0x11b94f898",
+            "x26": "0x200",
+            "x21": "0x2",
+            "x20": "0x11b94f858",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1717b6ad0",
+            "x8": "0x1717b6a60",
+            "x9": "0x101",
+            "x2": "0x100",
+            "x3": "0x0",
+            "x0": "0x11b94f858",
+            "x1": "0x10100000200",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1717b6a60",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b94f808",
+            "x10": "0x11b94f820",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 44
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "Halide::Runtime::Internal::spawn_thread_helper",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6Halide7Runtime8Internal19spawn_thread_helperEPv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "Halide::Runtime::Internal::spawn_thread_helper(void*)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102af8024"
+            },
+            {
+              "function": "Halide::Runtime::Internal::worker_thread",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6Halide7Runtime8Internal13worker_threadEPv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "Halide::Runtime::Internal::worker_thread(void*)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102af7fb0"
+            },
+            {
+              "function": "Halide::Runtime::Internal::worker_thread_already_locked",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6Halide7Runtime8Internal28worker_thread_already_lockedEPNS1_4workE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "Halide::Runtime::Internal::worker_thread_already_locked(Halide::Runtime::Internal::work*)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102af6fdc"
+            },
+            {
+              "function": "halide_cond_wait",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "halide_cond_wait",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102af769c"
+            },
+            {
+              "function": "Halide::Runtime::Internal::Synchronization::park",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN6Halide7Runtime8Internal15Synchronization4parkEyRNS2_15parking_controlE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "Halide::Runtime::Internal::Synchronization::park(unsigned long long, Halide::Runtime::Internal::Synchronization::parking_control&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x102af79fc"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17100ed10",
+            "x28": "0x0",
+            "x25": "0x17100f000",
+            "x24": "0x0",
+            "x27": "0x1",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x17100ed70",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17100ed10",
+            "x8": "0x17100eca0",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x17100ed70",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17100eca0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x17100ed30",
+            "x10": "0x17100ed48",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x102af8028"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x102af7fb4"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x102af6fe0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x102af76a0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x102af7a00"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17100ed10",
+            "x28": "0x0",
+            "x25": "0x17100f000",
+            "x24": "0x0",
+            "x27": "0x1",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x17100ed70",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17100ed10",
+            "x8": "0x17100eca0",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x17100ed70",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17100eca0",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x17100ed30",
+            "x10": "0x17100ed48",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 45,
+        "crashed": false
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::asio::io_context::run",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio10io_context3runEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::io_context::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc468",
+              "lineno": 62
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper9runWorkerEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc454",
+              "lineno": 119
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c14c"
+            },
+            {
+              "function": "boost_asio_handler_invoke_helpers::invoke<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN33boost_asio_handler_invoke_helpers6invokeIN5boost3_bi6bind_tIvNS1_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS6_23RequestAndContextHolderEEENS2_5list2INS2_5valueIPS7_EENSC_IS9_EEEEEESH_EEvRT_RT0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost_asio_handler_invoke_helpers::invoke<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_b...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fee00",
+              "lineno": 37
+            },
+            {
+              "function": "boost::asio::detail::handler_work<T>::complete<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail12handler_workINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEENS0_15system_executorEE8completeISI_EEvRT_RSI_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::handler_work<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::value...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 82
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::ptr::reset",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE3ptr5resetEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 70
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::do_complete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE11do_completeEPvPNS1_19scheduler_operationERKNS_6system10error_codeEm",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedd4",
+              "lineno": 63
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform::lambda::operator()",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderEENK3$_1clEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd804",
+              "lineno": 235
+            },
+            {
+              "function": "AdobeACSL::RetryHandler::doWithRetries<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../acsl/include/acsl/RetryHandler.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL12RetryHandler13doWithRetriesIZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS2_23RequestAndContextHolderEE3$_1EENS_9ACSLErrorET_",
+              "image_addr": "0x100564000",
+              "filename": "../../../acsl/include/acsl/RetryHandler.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::ACSLError AdobeACSL::RetryHandler::doWithRetries<AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1>(AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd7cc",
+              "lineno": 59
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd76c",
+              "lineno": 226
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper24waitForRequestToCompleteENSt3__110shared_ptrINS_23RequestAndContextHolderEEE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete(std::__1::shared_ptr<AdobeDCX::RequestAndContextHolder>)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fcbd8",
+              "lineno": 110
+            },
+            {
+              "function": "AdobeACSL::SynchronousRequestContext::waitForCompletion",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL25SynchronousRequestContext17waitForCompletionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::SynchronousRequestContext::waitForCompletion()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103142688"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1719e62b0",
+            "x28": "0x1719e68b8",
+            "x25": "0x1719e7000",
+            "x24": "0x0",
+            "x27": "0x1719e67d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803c2368",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1719e62b0",
+            "x8": "0x1719e6240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803c2368",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1719e6240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803c2328",
+            "x10": "0x2803c2340",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.worker.DcxHTTPSession",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fc46c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c150"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fee04"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fd808"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fcbdc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10314268c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1719e62b0",
+            "x28": "0x1719e68b8",
+            "x25": "0x1719e7000",
+            "x24": "0x0",
+            "x27": "0x1719e67d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803c2368",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1719e62b0",
+            "x8": "0x1719e6240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803c2368",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1719e6240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803c2328",
+            "x10": "0x2803c2340",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 46
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::asio::io_context::run",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio10io_context3runEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::io_context::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc468",
+              "lineno": 62
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper9runWorkerEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc454",
+              "lineno": 119
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c14c"
+            },
+            {
+              "function": "boost_asio_handler_invoke_helpers::invoke<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN33boost_asio_handler_invoke_helpers6invokeIN5boost3_bi6bind_tIvNS1_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS6_23RequestAndContextHolderEEENS2_5list2INS2_5valueIPS7_EENSC_IS9_EEEEEESH_EEvRT_RT0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost_asio_handler_invoke_helpers::invoke<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_b...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fee00",
+              "lineno": 37
+            },
+            {
+              "function": "boost::asio::detail::handler_work<T>::complete<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail12handler_workINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEENS0_15system_executorEE8completeISI_EEvRT_RSI_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::handler_work<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::value...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 82
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::ptr::reset",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE3ptr5resetEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 70
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::do_complete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE11do_completeEPvPNS1_19scheduler_operationERKNS_6system10error_codeEm",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedd4",
+              "lineno": 63
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform::lambda::operator()",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderEENK3$_1clEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd804",
+              "lineno": 235
+            },
+            {
+              "function": "AdobeACSL::RetryHandler::doWithRetries<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../acsl/include/acsl/RetryHandler.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL12RetryHandler13doWithRetriesIZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS2_23RequestAndContextHolderEE3$_1EENS_9ACSLErrorET_",
+              "image_addr": "0x100564000",
+              "filename": "../../../acsl/include/acsl/RetryHandler.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::ACSLError AdobeACSL::RetryHandler::doWithRetries<AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1>(AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd7cc",
+              "lineno": 59
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd76c",
+              "lineno": 226
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper24waitForRequestToCompleteENSt3__110shared_ptrINS_23RequestAndContextHolderEEE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete(std::__1::shared_ptr<AdobeDCX::RequestAndContextHolder>)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fcbd8",
+              "lineno": 110
+            },
+            {
+              "function": "AdobeACSL::SynchronousRequestContext::waitForCompletion",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL25SynchronousRequestContext17waitForCompletionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::SynchronousRequestContext::waitForCompletion()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103142688"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x171a722b0",
+            "x28": "0x171a728b8",
+            "x25": "0x171a73000",
+            "x24": "0x0",
+            "x27": "0x171a727d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803c0fb8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x171a722b0",
+            "x8": "0x171a72240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803c0fb8",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x171a72240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803c0f78",
+            "x10": "0x2803c0f90",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.worker.DcxHTTPSession",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fc46c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c150"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fee04"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fd808"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fcbdc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10314268c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x171a722b0",
+            "x28": "0x171a728b8",
+            "x25": "0x171a73000",
+            "x24": "0x0",
+            "x27": "0x171a727d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803c0fb8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x171a722b0",
+            "x8": "0x171a72240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803c0fb8",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x171a72240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803c0f78",
+            "x10": "0x2803c0f90",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 47
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b0"
+            },
+            {
+              "function": "_dispatch_worker_thread2",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98cc"
+            },
+            {
+              "function": "_dispatch_root_queue_drain",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db9028"
+            },
+            {
+              "function": "_dispatch_async_redirect_invoke",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6d8"
+            },
+            {
+              "function": "_dispatch_continuation_pop$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad014"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d0"
+            },
+            {
+              "function": "_dispatch_call_block_and_release",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a34"
+            },
+            {
+              "function": "__NSOQSchedule_f",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dce8"
+            },
+            {
+              "function": "-[__NSOperationInternal _start:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37904"
+            },
+            {
+              "function": "-[NSBlockOperation main]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d3841c"
+            },
+            {
+              "function": "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf64"
+            },
+            {
+              "function": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/mac/MacThreadPool.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "image_addr": "0x100564000",
+              "filename": "MacThreadPool.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 45,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103059000"
+            },
+            {
+              "function": "gude::WorkSchedulerImpl::workerCallback",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/xplat/WorkSchedulerImpl.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN4gude17WorkSchedulerImpl14workerCallbackEv",
+              "image_addr": "0x100564000",
+              "filename": "WorkSchedulerImpl.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "gude::WorkSchedulerImpl::workerCallback()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10304633c",
+              "lineno": 248
+            },
+            {
+              "function": "-[GUDERequestNSURL startWork]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL startWork]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2066,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054c98"
+            },
+            {
+              "function": "-[GUDERequestNSURL playRequest]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL playRequest]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2029,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054744"
+            },
+            {
+              "function": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 1645,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103052058"
+            },
+            {
+              "function": "_dispatch_semaphore_wait_slow",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab218"
+            },
+            {
+              "function": "_dispatch_sema4_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa794"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x171ca29e0",
+            "x28": "0x58",
+            "x25": "0x280d60280",
+            "x24": "0x10411d6cd",
+            "x27": "0x280d60280",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281db22b0",
+            "x23": "0x5a",
+            "x22": "0x11bd50df0",
+            "fp": "0x171ca29e0",
+            "x8": "0x0",
+            "x9": "0x80001200",
+            "x2": "0x28",
+            "x3": "0x30",
+            "x0": "0x2c403",
+            "x1": "0x3",
+            "x6": "0x0",
+            "x7": "0x171ca0bdc",
+            "x4": "0x53c0b",
+            "x5": "0x0",
+            "sp": "0x171ca29d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281db22f0",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98d0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db902c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6dc"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad018"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a38"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dcec"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37908"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d38420"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf68"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103059004"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103046340"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054c9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054748"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10305205c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab21c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa798"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x171ca29e0",
+            "x28": "0x58",
+            "x25": "0x280d60280",
+            "x24": "0x10411d6cd",
+            "x27": "0x280d60280",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281db22b0",
+            "x23": "0x5a",
+            "x22": "0x11bd50df0",
+            "fp": "0x171ca29e0",
+            "x8": "0x0",
+            "x9": "0x80001200",
+            "x2": "0x28",
+            "x3": "0x30",
+            "x0": "0x2c403",
+            "x1": "0x3",
+            "x6": "0x0",
+            "x7": "0x171ca0bdc",
+            "x4": "0x53c0b",
+            "x5": "0x0",
+            "sp": "0x171ca29d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281db22f0",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "id": 48,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b0"
+            },
+            {
+              "function": "_dispatch_worker_thread2",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98cc"
+            },
+            {
+              "function": "_dispatch_root_queue_drain",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db9028"
+            },
+            {
+              "function": "_dispatch_async_redirect_invoke",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6d8"
+            },
+            {
+              "function": "_dispatch_continuation_pop$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad014"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d0"
+            },
+            {
+              "function": "_dispatch_call_block_and_release",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a34"
+            },
+            {
+              "function": "__NSOQSchedule_f",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dce8"
+            },
+            {
+              "function": "-[__NSOperationInternal _start:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37904"
+            },
+            {
+              "function": "-[NSBlockOperation main]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d3841c"
+            },
+            {
+              "function": "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf64"
+            },
+            {
+              "function": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/mac/MacThreadPool.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "image_addr": "0x100564000",
+              "filename": "MacThreadPool.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 45,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103059000"
+            },
+            {
+              "function": "gude::WorkSchedulerImpl::workerCallback",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/xplat/WorkSchedulerImpl.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN4gude17WorkSchedulerImpl14workerCallbackEv",
+              "image_addr": "0x100564000",
+              "filename": "WorkSchedulerImpl.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "gude::WorkSchedulerImpl::workerCallback()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10304633c",
+              "lineno": 248
+            },
+            {
+              "function": "-[GUDERequestNSURL startWork]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL startWork]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2066,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054c98"
+            },
+            {
+              "function": "-[GUDERequestNSURL playRequest]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL playRequest]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2029,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054744"
+            },
+            {
+              "function": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 1645,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103052058"
+            },
+            {
+              "function": "_dispatch_semaphore_wait_slow",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab218"
+            },
+            {
+              "function": "_dispatch_sema4_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa794"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x171dba9e0",
+            "x28": "0x58",
+            "x25": "0x280d60320",
+            "x24": "0x10411d6cd",
+            "x27": "0x280d60320",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281db23f0",
+            "x23": "0x5a",
+            "x22": "0x11bd52840",
+            "fp": "0x171dba9e0",
+            "x8": "0x0",
+            "x9": "0x80001200",
+            "x2": "0x28",
+            "x3": "0x30",
+            "x0": "0x53907",
+            "x1": "0x3",
+            "x6": "0x0",
+            "x7": "0x171db8bdc",
+            "x4": "0x53a03",
+            "x5": "0x0",
+            "sp": "0x171dba9d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281db2430",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98d0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db902c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6dc"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad018"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a38"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dcec"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37908"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d38420"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf68"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103059004"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103046340"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054c9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054748"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10305205c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab21c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa798"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x171dba9e0",
+            "x28": "0x58",
+            "x25": "0x280d60320",
+            "x24": "0x10411d6cd",
+            "x27": "0x280d60320",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281db23f0",
+            "x23": "0x5a",
+            "x22": "0x11bd52840",
+            "fp": "0x171dba9e0",
+            "x8": "0x0",
+            "x9": "0x80001200",
+            "x2": "0x28",
+            "x3": "0x30",
+            "x0": "0x53907",
+            "x1": "0x3",
+            "x6": "0x0",
+            "x7": "0x171db8bdc",
+            "x4": "0x53a03",
+            "x5": "0x0",
+            "sp": "0x171dba9d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281db2430",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "id": 49,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b0"
+            },
+            {
+              "function": "_dispatch_worker_thread2",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98cc"
+            },
+            {
+              "function": "_dispatch_root_queue_drain",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db9028"
+            },
+            {
+              "function": "_dispatch_async_redirect_invoke",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6d8"
+            },
+            {
+              "function": "_dispatch_continuation_pop$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad014"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d0"
+            },
+            {
+              "function": "_dispatch_call_block_and_release",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a34"
+            },
+            {
+              "function": "__NSOQSchedule_f",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dce8"
+            },
+            {
+              "function": "-[__NSOperationInternal _start:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37904"
+            },
+            {
+              "function": "-[NSBlockOperation main]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d3841c"
+            },
+            {
+              "function": "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf64"
+            },
+            {
+              "function": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/mac/MacThreadPool.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "image_addr": "0x100564000",
+              "filename": "MacThreadPool.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 45,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103059000"
+            },
+            {
+              "function": "gude::WorkSchedulerImpl::workerCallback",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/xplat/WorkSchedulerImpl.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN4gude17WorkSchedulerImpl14workerCallbackEv",
+              "image_addr": "0x100564000",
+              "filename": "WorkSchedulerImpl.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "gude::WorkSchedulerImpl::workerCallback()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10304633c",
+              "lineno": 248
+            },
+            {
+              "function": "-[GUDERequestNSURL startWork]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL startWork]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2066,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054c98"
+            },
+            {
+              "function": "-[GUDERequestNSURL playRequest]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL playRequest]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2029,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054744"
+            },
+            {
+              "function": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 1645,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103052058"
+            },
+            {
+              "function": "_dispatch_semaphore_wait_slow",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab218"
+            },
+            {
+              "function": "_dispatch_sema4_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa794"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x171e469e0",
+            "x28": "0x58",
+            "x25": "0x2817ac3f0",
+            "x24": "0x10411d6cd",
+            "x27": "0x2817ac3f0",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281db2ad0",
+            "x23": "0x3c",
+            "x22": "0x11bd4e3b0",
+            "fp": "0x171e469e0",
+            "x8": "0x0",
+            "x9": "0x80001200",
+            "x2": "0x28",
+            "x3": "0x30",
+            "x0": "0x2c70f",
+            "x1": "0x3",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x5381b",
+            "x5": "0x0",
+            "sp": "0x171e469d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281db2b10",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98d0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db902c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6dc"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad018"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a38"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dcec"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37908"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d38420"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf68"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103059004"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103046340"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054c9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054748"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10305205c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab21c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa798"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x171e469e0",
+            "x28": "0x58",
+            "x25": "0x2817ac3f0",
+            "x24": "0x10411d6cd",
+            "x27": "0x2817ac3f0",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281db2ad0",
+            "x23": "0x3c",
+            "x22": "0x11bd4e3b0",
+            "fp": "0x171e469e0",
+            "x8": "0x0",
+            "x9": "0x80001200",
+            "x2": "0x28",
+            "x3": "0x30",
+            "x0": "0x2c70f",
+            "x1": "0x3",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x5381b",
+            "x5": "0x0",
+            "sp": "0x171e469d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281db2b10",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "id": 50,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x1b3691110"
+            },
+            {
+              "function": "_dispatch_workloop_worker_thread",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dba254",
+              "instruction_addr": "0x1b34634a4"
+            },
+            {
+              "function": "_dispatch_lane_invoke$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db1c90",
+              "instruction_addr": "0x1f8bcae38"
+            },
+            {
+              "function": "_dispatch_lane_serial_drain$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db10d0",
+              "instruction_addr": "0x1f8bca1e8"
+            },
+            {
+              "function": "_dispatch_source_invoke$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dbca88",
+              "instruction_addr": "0x1c7d20fa0"
+            },
+            {
+              "function": "_dispatch_continuation_pop$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad014"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d0"
+            },
+            {
+              "function": "-[_MTLCommandQueue _submitAvailableCommandBuffers]",
+              "package": "/System/Library/Frameworks/Metal.framework/Metal",
+              "image_addr": "0x2134a4000",
+              "in_app": false,
+              "symbol_addr": "0x21350cae4",
+              "instruction_addr": "0x1ce5e5db0"
+            },
+            {
+              "function": "-[MTLIOAccelCommandQueue submitCommandBuffers:count:]",
+              "package": "/System/Library/Frameworks/Metal.framework/Metal",
+              "image_addr": "0x2134a4000",
+              "in_app": false,
+              "symbol_addr": "0x2134dbb24",
+              "instruction_addr": "0x1ce5b4da8"
+            },
+            {
+              "function": "IOAccelCommandQueueSubmitCommandBuffers",
+              "package": "/System/Library/PrivateFrameworks/IOAccelerator.framework/IOAccelerator",
+              "image_addr": "0x213498000",
+              "in_app": false,
+              "symbol_addr": "0x21349b294",
+              "instruction_addr": "0x1ce574330"
+            },
+            {
+              "function": "IOConnectCallMethod",
+              "package": "/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit",
+              "image_addr": "0x21161e000",
+              "in_app": false,
+              "symbol_addr": "0x2116241b0",
+              "instruction_addr": "0x2136b9258"
+            },
+            {
+              "function": "io_connect_method",
+              "package": "/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit",
+              "image_addr": "0x21161e000",
+              "in_app": false,
+              "symbol_addr": "0x21168a4c4",
+              "instruction_addr": "0x19e52365c"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x22615559c"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x2261560f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x80000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x171f5cfa0",
+            "x28": "0x171f5cf38",
+            "x25": "0x74",
+            "x24": "0x3",
+            "x27": "0x171f5e140",
+            "x26": "0x3",
+            "x21": "0x1f957",
+            "x20": "0x0",
+            "x23": "0x171f5cfb8",
+            "x22": "0x10bc",
+            "fp": "0x171f5cfa0",
+            "x8": "0xfffffbbf",
+            "x9": "0x0",
+            "x2": "0x74",
+            "x3": "0x10bc",
+            "x0": "0x0",
+            "x1": "0x3",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x1f957",
+            "x5": "0x0",
+            "sp": "0x171f5cf50",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x10",
+            "x11": "0x171f5e1c0",
+            "x12": "0x0",
+            "x13": "0x61a248d8f8d5",
+            "x14": "0x37",
+            "x15": "0xd",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x213508d20"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe8114"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dba254",
+              "instruction_addr": "0x210dba4a8"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db1c90",
+              "instruction_addr": "0x210db1e3c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db10d0",
+              "instruction_addr": "0x210db11ec"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dbca88",
+              "instruction_addr": "0x210dbcfa4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad018"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Metal.framework/Metal",
+              "image_addr": "0x2134a4000",
+              "in_app": false,
+              "symbol_addr": "0x21350cae4",
+              "instruction_addr": "0x21350cdb4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Metal.framework/Metal",
+              "image_addr": "0x2134a4000",
+              "in_app": false,
+              "symbol_addr": "0x2134dbb24",
+              "instruction_addr": "0x2134dbdac"
+            },
+            {
+              "function": "IOAccelCommandQueueSubmitCommandBuffers",
+              "package": "/System/Library/PrivateFrameworks/IOAccelerator.framework/IOAccelerator",
+              "image_addr": "0x213498000",
+              "in_app": false,
+              "symbol_addr": "0x21349b294",
+              "instruction_addr": "0x21349b334"
+            },
+            {
+              "function": "IOConnectCallMethod",
+              "package": "/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit",
+              "image_addr": "0x21161e000",
+              "in_app": false,
+              "symbol_addr": "0x2116241b0",
+              "instruction_addr": "0x21162425c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit",
+              "image_addr": "0x21161e000",
+              "in_app": false,
+              "symbol_addr": "0x21168a4c4",
+              "instruction_addr": "0x21168a660"
+            },
+            {
+              "function": "mach_msg",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f59558",
+              "instruction_addr": "0x210f595a0"
+            },
+            {
+              "function": "mach_msg_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a0ec",
+              "instruction_addr": "0x210f5a0f4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x80000000",
+            "pc": "0x210f5a0f4",
+            "x29": "0x171f5cfa0",
+            "x28": "0x171f5cf38",
+            "x25": "0x74",
+            "x24": "0x3",
+            "x27": "0x171f5e140",
+            "x26": "0x3",
+            "x21": "0x1f957",
+            "x20": "0x0",
+            "x23": "0x171f5cfb8",
+            "x22": "0x10bc",
+            "fp": "0x171f5cfa0",
+            "x8": "0xfffffbbf",
+            "x9": "0x0",
+            "x2": "0x74",
+            "x3": "0x10bc",
+            "x0": "0x0",
+            "x1": "0x3",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x1f957",
+            "x5": "0x0",
+            "sp": "0x171f5cf50",
+            "lr": "0x210f595a0",
+            "x18": "0x0",
+            "x19": "0x0",
+            "x10": "0x10",
+            "x11": "0x171f5e1c0",
+            "x12": "0x0",
+            "x13": "0x61a248d8f8d5",
+            "x14": "0x37",
+            "x15": "0xd",
+            "x16": "0xffffffffffffffe1",
+            "x17": "0x213508d20"
+          }
+        },
+        "id": 51,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b0"
+            },
+            {
+              "function": "_dispatch_worker_thread2",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98cc"
+            },
+            {
+              "function": "_dispatch_root_queue_drain",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db9028"
+            },
+            {
+              "function": "_dispatch_async_redirect_invoke",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6d8"
+            },
+            {
+              "function": "_dispatch_continuation_pop$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad014"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d0"
+            },
+            {
+              "function": "_dispatch_call_block_and_release",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a34"
+            },
+            {
+              "function": "__NSOQSchedule_f",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dce8"
+            },
+            {
+              "function": "-[__NSOperationInternal _start:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37904"
+            },
+            {
+              "function": "-[NSBlockOperation main]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d3841c"
+            },
+            {
+              "function": "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf64"
+            },
+            {
+              "function": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/mac/MacThreadPool.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "image_addr": "0x100564000",
+              "filename": "MacThreadPool.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 45,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103059000"
+            },
+            {
+              "function": "gude::WorkSchedulerImpl::workerCallback",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/xplat/WorkSchedulerImpl.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN4gude17WorkSchedulerImpl14workerCallbackEv",
+              "image_addr": "0x100564000",
+              "filename": "WorkSchedulerImpl.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "gude::WorkSchedulerImpl::workerCallback()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10304633c",
+              "lineno": 248
+            },
+            {
+              "function": "-[GUDERequestNSURL startWork]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL startWork]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2066,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054c98"
+            },
+            {
+              "function": "-[GUDERequestNSURL playRequest]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL playRequest]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2029,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054744"
+            },
+            {
+              "function": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 1645,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103052058"
+            },
+            {
+              "function": "_dispatch_semaphore_wait_slow",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab218"
+            },
+            {
+              "function": "_dispatch_sema4_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa794"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x171fea9e0",
+            "x28": "0x58",
+            "x25": "0x280dd4780",
+            "x24": "0x10411d6cd",
+            "x27": "0x280dd4780",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c5ac60",
+            "x23": "0x5a",
+            "x22": "0x119deff60",
+            "fp": "0x171fea9e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x171fea888",
+            "x0": "0x52e03",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x1",
+            "x5": "0x0",
+            "sp": "0x171fea9d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c5aca0",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98d0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db902c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6dc"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad018"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a38"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dcec"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37908"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d38420"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf68"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103059004"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103046340"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054c9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054748"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10305205c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab21c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa798"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x171fea9e0",
+            "x28": "0x58",
+            "x25": "0x280dd4780",
+            "x24": "0x10411d6cd",
+            "x27": "0x280dd4780",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c5ac60",
+            "x23": "0x5a",
+            "x22": "0x119deff60",
+            "fp": "0x171fea9e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x171fea888",
+            "x0": "0x52e03",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x1",
+            "x5": "0x0",
+            "sp": "0x171fea9d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c5aca0",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "id": 52,
+        "crashed": false
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::asio::io_context::run",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio10io_context3runEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::io_context::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc468",
+              "lineno": 62
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper9runWorkerEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc454",
+              "lineno": 119
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c14c"
+            },
+            {
+              "function": "boost_asio_handler_invoke_helpers::invoke<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN33boost_asio_handler_invoke_helpers6invokeIN5boost3_bi6bind_tIvNS1_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS6_23RequestAndContextHolderEEENS2_5list2INS2_5valueIPS7_EENSC_IS9_EEEEEESH_EEvRT_RT0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost_asio_handler_invoke_helpers::invoke<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_b...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fee00",
+              "lineno": 37
+            },
+            {
+              "function": "boost::asio::detail::handler_work<T>::complete<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail12handler_workINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEENS0_15system_executorEE8completeISI_EEvRT_RSI_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::handler_work<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::value...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 82
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::ptr::reset",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE3ptr5resetEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 70
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::do_complete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE11do_completeEPvPNS1_19scheduler_operationERKNS_6system10error_codeEm",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedd4",
+              "lineno": 63
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform::lambda::operator()",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderEENK3$_1clEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd804",
+              "lineno": 235
+            },
+            {
+              "function": "AdobeACSL::RetryHandler::doWithRetries<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../acsl/include/acsl/RetryHandler.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL12RetryHandler13doWithRetriesIZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS2_23RequestAndContextHolderEE3$_1EENS_9ACSLErrorET_",
+              "image_addr": "0x100564000",
+              "filename": "../../../acsl/include/acsl/RetryHandler.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::ACSLError AdobeACSL::RetryHandler::doWithRetries<AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1>(AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd7cc",
+              "lineno": 59
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd76c",
+              "lineno": 226
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper24waitForRequestToCompleteENSt3__110shared_ptrINS_23RequestAndContextHolderEEE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete(std::__1::shared_ptr<AdobeDCX::RequestAndContextHolder>)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fcbd8",
+              "lineno": 110
+            },
+            {
+              "function": "AdobeACSL::SynchronousRequestContext::waitForCompletion",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL25SynchronousRequestContext17waitForCompletionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::SynchronousRequestContext::waitForCompletion()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103142688"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1718422b0",
+            "x28": "0x1718428b8",
+            "x25": "0x171843000",
+            "x24": "0x0",
+            "x27": "0x1718427d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803c7268",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1718422b0",
+            "x8": "0x171842240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803c7268",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x171842240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803c7228",
+            "x10": "0x2803c7240",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.worker.DcxHTTPSession",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fc46c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c150"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fee04"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fd808"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fcbdc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10314268c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1718422b0",
+            "x28": "0x1718428b8",
+            "x25": "0x171843000",
+            "x24": "0x0",
+            "x27": "0x1718427d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803c7268",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1718422b0",
+            "x8": "0x171842240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803c7268",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x171842240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803c7228",
+            "x10": "0x2803c7240",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 53
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::asio::io_context::run",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio10io_context3runEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::io_context::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc468",
+              "lineno": 62
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper9runWorkerEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc454",
+              "lineno": 119
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c14c"
+            },
+            {
+              "function": "boost_asio_handler_invoke_helpers::invoke<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN33boost_asio_handler_invoke_helpers6invokeIN5boost3_bi6bind_tIvNS1_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS6_23RequestAndContextHolderEEENS2_5list2INS2_5valueIPS7_EENSC_IS9_EEEEEESH_EEvRT_RT0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost_asio_handler_invoke_helpers::invoke<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_b...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fee00",
+              "lineno": 37
+            },
+            {
+              "function": "boost::asio::detail::handler_work<T>::complete<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail12handler_workINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEENS0_15system_executorEE8completeISI_EEvRT_RSI_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::handler_work<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::value...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 82
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::ptr::reset",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE3ptr5resetEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 70
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::do_complete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE11do_completeEPvPNS1_19scheduler_operationERKNS_6system10error_codeEm",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedd4",
+              "lineno": 63
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform::lambda::operator()",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderEENK3$_1clEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd804",
+              "lineno": 235
+            },
+            {
+              "function": "AdobeACSL::RetryHandler::doWithRetries<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../acsl/include/acsl/RetryHandler.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL12RetryHandler13doWithRetriesIZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS2_23RequestAndContextHolderEE3$_1EENS_9ACSLErrorET_",
+              "image_addr": "0x100564000",
+              "filename": "../../../acsl/include/acsl/RetryHandler.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::ACSLError AdobeACSL::RetryHandler::doWithRetries<AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1>(AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd7cc",
+              "lineno": 59
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd76c",
+              "lineno": 226
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper24waitForRequestToCompleteENSt3__110shared_ptrINS_23RequestAndContextHolderEEE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete(std::__1::shared_ptr<AdobeDCX::RequestAndContextHolder>)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fcbd8",
+              "lineno": 110
+            },
+            {
+              "function": "AdobeACSL::SynchronousRequestContext::waitForCompletion",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL25SynchronousRequestContext17waitForCompletionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::SynchronousRequestContext::waitForCompletion()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103142688"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x171c162b0",
+            "x28": "0x171c168b8",
+            "x25": "0x171c17000",
+            "x24": "0x0",
+            "x27": "0x171c167d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803f6548",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x171c162b0",
+            "x8": "0x171c16240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803f6548",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x171c16240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803f6508",
+            "x10": "0x2803f6520",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.worker.DcxHTTPSession",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fc46c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c150"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fee04"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fd808"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fcbdc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10314268c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x171c162b0",
+            "x28": "0x171c168b8",
+            "x25": "0x171c17000",
+            "x24": "0x0",
+            "x27": "0x171c167d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803f6548",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x171c162b0",
+            "x8": "0x171c16240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803f6548",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x171c16240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803f6508",
+            "x10": "0x2803f6520",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 54
+      },
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::asio::io_context::run",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio10io_context3runEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::io_context::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc468",
+              "lineno": 62
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper9runWorkerEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc454",
+              "lineno": 119
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c14c"
+            },
+            {
+              "function": "boost_asio_handler_invoke_helpers::invoke<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN33boost_asio_handler_invoke_helpers6invokeIN5boost3_bi6bind_tIvNS1_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS6_23RequestAndContextHolderEEENS2_5list2INS2_5valueIPS7_EENSC_IS9_EEEEEESH_EEvRT_RT0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost_asio_handler_invoke_helpers::invoke<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_b...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fee00",
+              "lineno": 37
+            },
+            {
+              "function": "boost::asio::detail::handler_work<T>::complete<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail12handler_workINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEENS0_15system_executorEE8completeISI_EEvRT_RSI_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::handler_work<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::value...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 82
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::ptr::reset",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE3ptr5resetEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 70
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::do_complete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE11do_completeEPvPNS1_19scheduler_operationERKNS_6system10error_codeEm",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedd4",
+              "lineno": 63
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform::lambda::operator()",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderEENK3$_1clEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd804",
+              "lineno": 235
+            },
+            {
+              "function": "AdobeACSL::RetryHandler::doWithRetries<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../acsl/include/acsl/RetryHandler.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL12RetryHandler13doWithRetriesIZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS2_23RequestAndContextHolderEE3$_1EENS_9ACSLErrorET_",
+              "image_addr": "0x100564000",
+              "filename": "../../../acsl/include/acsl/RetryHandler.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::ACSLError AdobeACSL::RetryHandler::doWithRetries<AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1>(AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd7cc",
+              "lineno": 59
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd76c",
+              "lineno": 226
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper24waitForRequestToCompleteENSt3__110shared_ptrINS_23RequestAndContextHolderEEE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete(std::__1::shared_ptr<AdobeDCX::RequestAndContextHolder>)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fcbd8",
+              "lineno": 110
+            },
+            {
+              "function": "AdobeACSL::SynchronousRequestContext::waitForCompletion",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL25SynchronousRequestContext17waitForCompletionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::SynchronousRequestContext::waitForCompletion()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103142688"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x171afe2b0",
+            "x28": "0x171afe8b8",
+            "x25": "0x171aff000",
+            "x24": "0x0",
+            "x27": "0x171afe7d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803fd198",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x171afe2b0",
+            "x8": "0x171afe240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803fd198",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x171afe240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803fd158",
+            "x10": "0x2803fd170",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "name": "cs.worker.DcxHTTPSession",
+        "current": false,
+        "crashed": false,
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fc46c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c150"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fee04"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fd808"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fcbdc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10314268c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x171afe2b0",
+            "x28": "0x171afe8b8",
+            "x25": "0x171aff000",
+            "x24": "0x0",
+            "x27": "0x171afe7d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803fd198",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x171afe2b0",
+            "x8": "0x171afe240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803fd198",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x171afe240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803fd158",
+            "x10": "0x2803fd170",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 55
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::asio::io_context::run",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio10io_context3runEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::io_context::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc468",
+              "lineno": 62
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper9runWorkerEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc454",
+              "lineno": 119
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c14c"
+            },
+            {
+              "function": "boost_asio_handler_invoke_helpers::invoke<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN33boost_asio_handler_invoke_helpers6invokeIN5boost3_bi6bind_tIvNS1_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS6_23RequestAndContextHolderEEENS2_5list2INS2_5valueIPS7_EENSC_IS9_EEEEEESH_EEvRT_RT0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost_asio_handler_invoke_helpers::invoke<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_b...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fee00",
+              "lineno": 37
+            },
+            {
+              "function": "boost::asio::detail::handler_work<T>::complete<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail12handler_workINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEENS0_15system_executorEE8completeISI_EEvRT_RSI_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::handler_work<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::value...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 82
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::ptr::reset",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE3ptr5resetEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 70
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::do_complete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE11do_completeEPvPNS1_19scheduler_operationERKNS_6system10error_codeEm",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedd4",
+              "lineno": 63
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform::lambda::operator()",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderEENK3$_1clEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd804",
+              "lineno": 235
+            },
+            {
+              "function": "AdobeACSL::RetryHandler::doWithRetries<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../acsl/include/acsl/RetryHandler.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL12RetryHandler13doWithRetriesIZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS2_23RequestAndContextHolderEE3$_1EENS_9ACSLErrorET_",
+              "image_addr": "0x100564000",
+              "filename": "../../../acsl/include/acsl/RetryHandler.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::ACSLError AdobeACSL::RetryHandler::doWithRetries<AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1>(AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd7cc",
+              "lineno": 59
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd76c",
+              "lineno": 226
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper24waitForRequestToCompleteENSt3__110shared_ptrINS_23RequestAndContextHolderEEE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete(std::__1::shared_ptr<AdobeDCX::RequestAndContextHolder>)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fcbd8",
+              "lineno": 110
+            },
+            {
+              "function": "AdobeACSL::SynchronousRequestContext::waitForCompletion",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL25SynchronousRequestContext17waitForCompletionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::SynchronousRequestContext::waitForCompletion()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103142688"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x171b8a2b0",
+            "x28": "0x171b8a8b8",
+            "x25": "0x171b8b000",
+            "x24": "0x0",
+            "x27": "0x171b8a7d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803faea8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x171b8a2b0",
+            "x8": "0x171b8a240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803faea8",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x171b8a240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803fae68",
+            "x10": "0x2803fae80",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fc46c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c150"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fee04"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fd808"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fcbdc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10314268c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x171b8a2b0",
+            "x28": "0x171b8a8b8",
+            "x25": "0x171b8b000",
+            "x24": "0x0",
+            "x27": "0x171b8a7d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803faea8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x171b8a2b0",
+            "x8": "0x171b8a240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803faea8",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x171b8a240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803fae68",
+            "x10": "0x2803fae80",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 56,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b0"
+            },
+            {
+              "function": "_dispatch_worker_thread2",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98cc"
+            },
+            {
+              "function": "_dispatch_root_queue_drain",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db9028"
+            },
+            {
+              "function": "_dispatch_async_redirect_invoke",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6d8"
+            },
+            {
+              "function": "_dispatch_continuation_pop$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad014"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d0"
+            },
+            {
+              "function": "_dispatch_call_block_and_release",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a34"
+            },
+            {
+              "function": "__NSOQSchedule_f",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dce8"
+            },
+            {
+              "function": "-[__NSOperationInternal _start:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37904"
+            },
+            {
+              "function": "-[NSBlockOperation main]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d3841c"
+            },
+            {
+              "function": "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf64"
+            },
+            {
+              "function": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/mac/MacThreadPool.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "image_addr": "0x100564000",
+              "filename": "MacThreadPool.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 45,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103059000"
+            },
+            {
+              "function": "gude::WorkSchedulerImpl::workerCallback",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/xplat/WorkSchedulerImpl.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN4gude17WorkSchedulerImpl14workerCallbackEv",
+              "image_addr": "0x100564000",
+              "filename": "WorkSchedulerImpl.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "gude::WorkSchedulerImpl::workerCallback()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10304633c",
+              "lineno": 248
+            },
+            {
+              "function": "-[GUDERequestNSURL startWork]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL startWork]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2066,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054c98"
+            },
+            {
+              "function": "-[GUDERequestNSURL playRequest]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL playRequest]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2029,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054744"
+            },
+            {
+              "function": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 1645,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103052058"
+            },
+            {
+              "function": "_dispatch_semaphore_wait_slow",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab218"
+            },
+            {
+              "function": "_dispatch_sema4_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa794"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x1704069e0",
+            "x28": "0x58",
+            "x25": "0x280de3a20",
+            "x24": "0x10411d6cd",
+            "x27": "0x280de3a20",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c5d680",
+            "x23": "0x5a",
+            "x22": "0x11b943a90",
+            "fp": "0x1704069e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x170406888",
+            "x0": "0x51737",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x1",
+            "x5": "0x0",
+            "sp": "0x1704069d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c5d6c0",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98d0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db902c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6dc"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad018"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a38"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dcec"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37908"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d38420"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf68"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103059004"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103046340"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054c9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054748"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10305205c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab21c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa798"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x1704069e0",
+            "x28": "0x58",
+            "x25": "0x280de3a20",
+            "x24": "0x10411d6cd",
+            "x27": "0x280de3a20",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c5d680",
+            "x23": "0x5a",
+            "x22": "0x11b943a90",
+            "fp": "0x1704069e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x170406888",
+            "x0": "0x51737",
+            "x1": "0x0",
+            "x6": "0x0",
+            "x7": "0x403",
+            "x4": "0x1",
+            "x5": "0x0",
+            "sp": "0x1704069d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c5d6c0",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "id": 57,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x1c903d1b0"
+            },
+            {
+              "function": "_dispatch_worker_thread2",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x1c8e0e8cc"
+            },
+            {
+              "function": "_dispatch_root_queue_drain",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x21364a028"
+            },
+            {
+              "function": "_dispatch_async_redirect_invoke",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x18720d6d8"
+            },
+            {
+              "function": "_dispatch_continuation_pop$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x1c7d11014"
+            },
+            {
+              "function": "_dispatch_client_callout",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x1cfe557d0"
+            },
+            {
+              "function": "_dispatch_call_block_and_release",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x1cfe54a34"
+            },
+            {
+              "function": "__NSOQSchedule_f",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x23823ace8"
+            },
+            {
+              "function": "-[__NSOperationInternal _start:]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x238144904"
+            },
+            {
+              "function": "-[NSBlockOperation main]",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x23814541c"
+            },
+            {
+              "function": "__NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x238238f64"
+            },
+            {
+              "function": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/mac/MacThreadPool.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "___ZN4gude13MacThreadPool9addWorkerEv_block_invoke",
+              "image_addr": "0x100564000",
+              "filename": "MacThreadPool.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 45,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103059000"
+            },
+            {
+              "function": "gude::WorkSchedulerImpl::workerCallback",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/src/xplat/WorkSchedulerImpl.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN4gude17WorkSchedulerImpl14workerCallbackEv",
+              "image_addr": "0x100564000",
+              "filename": "WorkSchedulerImpl.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "gude::WorkSchedulerImpl::workerCallback()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10304633c",
+              "lineno": 248
+            },
+            {
+              "function": "-[GUDERequestNSURL startWork]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL startWork]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2066,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054c98"
+            },
+            {
+              "function": "-[GUDERequestNSURL playRequest]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL playRequest]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 2029,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103054744"
+            },
+            {
+              "function": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/resources/company/GUDE/gude-sdk/projects/native/gude/build/mac/GudeRequestNSURL.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "-[GUDERequestNSURL sendAndReceiveData:]",
+              "image_addr": "0x100564000",
+              "filename": "GudeRequestNSURL.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 1645,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103052058"
+            },
+            {
+              "function": "_dispatch_semaphore_wait_slow",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x1c7d0f218"
+            },
+            {
+              "function": "_dispatch_sema4_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x1c7d0e794"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x1c7ebe130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x171d2e9e0",
+            "x28": "0x58",
+            "x25": "0x280dd4820",
+            "x24": "0x10411d6cd",
+            "x27": "0x280dd4820",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c407d0",
+            "x23": "0x5a",
+            "x22": "0x11b9b0910",
+            "fp": "0x171d2e9e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x210e0b22c",
+            "x0": "0x5540f",
+            "x1": "0x0",
+            "x6": "0x11b9254d0",
+            "x7": "0x171d2cbdc",
+            "x4": "0x9a",
+            "x5": "0x1e",
+            "sp": "0x171d2e9d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c40810",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_wqthread",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7fe4",
+              "instruction_addr": "0x210fe81b4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db9850",
+              "instruction_addr": "0x210db98d0"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210db8eb8",
+              "instruction_addr": "0x210db902c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dac484",
+              "instruction_addr": "0x210dac6dc"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dace7c",
+              "instruction_addr": "0x210dad018"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e087c4",
+              "instruction_addr": "0x210e087d4"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210e07a20",
+              "instruction_addr": "0x210e07a38"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2dbdc",
+              "instruction_addr": "0x211e2dcec"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d37624",
+              "instruction_addr": "0x211d37908"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211d383d8",
+              "instruction_addr": "0x211d38420"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/Foundation.framework/Foundation",
+              "image_addr": "0x211d19000",
+              "in_app": false,
+              "symbol_addr": "0x211e2bf58",
+              "instruction_addr": "0x211e2bf68"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103059004"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103046340"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054c9c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103054748"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10305205c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210dab190",
+              "instruction_addr": "0x210dab21c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdispatch.dylib",
+              "image_addr": "0x210da8000",
+              "in_app": false,
+              "symbol_addr": "0x210daa780",
+              "instruction_addr": "0x210daa798"
+            },
+            {
+              "function": "semaphore_wait_trap",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f5a128",
+              "instruction_addr": "0x210f5a130"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x60000000",
+            "pc": "0x210f5a130",
+            "x29": "0x171d2e9e0",
+            "x28": "0x58",
+            "x25": "0x280dd4820",
+            "x24": "0x10411d6cd",
+            "x27": "0x280dd4820",
+            "x26": "0x0",
+            "x21": "0xffffffffffffffff",
+            "x20": "0x281c407d0",
+            "x23": "0x5a",
+            "x22": "0x11b9b0910",
+            "fp": "0x171d2e9e0",
+            "x8": "0x0",
+            "x9": "0x0",
+            "x2": "0x1045b5c28",
+            "x3": "0x210e0b22c",
+            "x0": "0x5540f",
+            "x1": "0x0",
+            "x6": "0x11b9254d0",
+            "x7": "0x171d2cbdc",
+            "x4": "0x9a",
+            "x5": "0x1e",
+            "sp": "0x171d2e9d0",
+            "lr": "0x210daa798",
+            "x18": "0x0",
+            "x19": "0x281c40810",
+            "x10": "0xffffffffffffffff",
+            "x11": "0x0",
+            "x12": "0x11a918740",
+            "x13": "0x1a2499edf61",
+            "x14": "0x5",
+            "x15": "0x0",
+            "x16": "0xffffffffffffffdc",
+            "x17": "0x2112c4f08"
+          }
+        },
+        "id": 58,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::asio::io_context::run",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio10io_context3runEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::io_context::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc468",
+              "lineno": 62
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper9runWorkerEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc454",
+              "lineno": 119
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c14c"
+            },
+            {
+              "function": "boost_asio_handler_invoke_helpers::invoke<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN33boost_asio_handler_invoke_helpers6invokeIN5boost3_bi6bind_tIvNS1_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS6_23RequestAndContextHolderEEENS2_5list2INS2_5valueIPS7_EENSC_IS9_EEEEEESH_EEvRT_RT0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost_asio_handler_invoke_helpers::invoke<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_b...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fee00",
+              "lineno": 37
+            },
+            {
+              "function": "boost::asio::detail::handler_work<T>::complete<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail12handler_workINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEENS0_15system_executorEE8completeISI_EEvRT_RSI_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::handler_work<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::value...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 82
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::ptr::reset",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE3ptr5resetEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 70
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::do_complete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE11do_completeEPvPNS1_19scheduler_operationERKNS_6system10error_codeEm",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedd4",
+              "lineno": 63
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform::lambda::operator()",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderEENK3$_1clEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd804",
+              "lineno": 235
+            },
+            {
+              "function": "AdobeACSL::RetryHandler::doWithRetries<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../acsl/include/acsl/RetryHandler.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL12RetryHandler13doWithRetriesIZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS2_23RequestAndContextHolderEE3$_1EENS_9ACSLErrorET_",
+              "image_addr": "0x100564000",
+              "filename": "../../../acsl/include/acsl/RetryHandler.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::ACSLError AdobeACSL::RetryHandler::doWithRetries<AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1>(AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd7cc",
+              "lineno": 59
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd76c",
+              "lineno": 226
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper24waitForRequestToCompleteENSt3__110shared_ptrINS_23RequestAndContextHolderEEE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete(std::__1::shared_ptr<AdobeDCX::RequestAndContextHolder>)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fcbd8",
+              "lineno": 110
+            },
+            {
+              "function": "AdobeACSL::SynchronousRequestContext::waitForCompletion",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL25SynchronousRequestContext17waitForCompletionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::SynchronousRequestContext::waitForCompletion()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103142688"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1718ce2b0",
+            "x28": "0x1718ce8b8",
+            "x25": "0x1718cf000",
+            "x24": "0x0",
+            "x27": "0x1718ce7d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803fef98",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1718ce2b0",
+            "x8": "0x1718ce240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803fef98",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1718ce240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803fef58",
+            "x10": "0x2803fef70",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fc46c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c150"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fee04"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fd808"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fcbdc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10314268c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x1718ce2b0",
+            "x28": "0x1718ce8b8",
+            "x25": "0x1718cf000",
+            "x24": "0x0",
+            "x27": "0x1718ce7d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803fef98",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x1718ce2b0",
+            "x8": "0x1718ce240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803fef98",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x1718ce240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803fef58",
+            "x10": "0x2803fef70",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 59,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::asio::io_context::run",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio10io_context3runEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::io_context::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc468",
+              "lineno": 62
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper9runWorkerEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc454",
+              "lineno": 119
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c14c"
+            },
+            {
+              "function": "boost_asio_handler_invoke_helpers::invoke<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN33boost_asio_handler_invoke_helpers6invokeIN5boost3_bi6bind_tIvNS1_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS6_23RequestAndContextHolderEEENS2_5list2INS2_5valueIPS7_EENSC_IS9_EEEEEESH_EEvRT_RT0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost_asio_handler_invoke_helpers::invoke<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_b...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fee00",
+              "lineno": 37
+            },
+            {
+              "function": "boost::asio::detail::handler_work<T>::complete<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail12handler_workINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEENS0_15system_executorEE8completeISI_EEvRT_RSI_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::handler_work<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::value...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 82
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::ptr::reset",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE3ptr5resetEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 70
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::do_complete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE11do_completeEPvPNS1_19scheduler_operationERKNS_6system10error_codeEm",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedd4",
+              "lineno": 63
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform::lambda::operator()",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderEENK3$_1clEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd804",
+              "lineno": 235
+            },
+            {
+              "function": "AdobeACSL::RetryHandler::doWithRetries<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../acsl/include/acsl/RetryHandler.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL12RetryHandler13doWithRetriesIZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS2_23RequestAndContextHolderEE3$_1EENS_9ACSLErrorET_",
+              "image_addr": "0x100564000",
+              "filename": "../../../acsl/include/acsl/RetryHandler.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::ACSLError AdobeACSL::RetryHandler::doWithRetries<AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1>(AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd7cc",
+              "lineno": 59
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd76c",
+              "lineno": 226
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper24waitForRequestToCompleteENSt3__110shared_ptrINS_23RequestAndContextHolderEEE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete(std::__1::shared_ptr<AdobeDCX::RequestAndContextHolder>)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fcbd8",
+              "lineno": 110
+            },
+            {
+              "function": "AdobeACSL::SynchronousRequestContext::waitForCompletion",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL25SynchronousRequestContext17waitForCompletionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::SynchronousRequestContext::waitForCompletion()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103142688"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17146e2b0",
+            "x28": "0x17146e8b8",
+            "x25": "0x17146f000",
+            "x24": "0x0",
+            "x27": "0x17146e7d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803ebbc8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17146e2b0",
+            "x8": "0x17146e240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803ebbc8",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17146e240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803ebb88",
+            "x10": "0x2803ebba0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fc46c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c150"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fee04"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fd808"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fcbdc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10314268c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17146e2b0",
+            "x28": "0x17146e8b8",
+            "x25": "0x17146f000",
+            "x24": "0x0",
+            "x27": "0x17146e7d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803ebbc8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17146e2b0",
+            "x8": "0x17146e240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803ebbc8",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17146e240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803ebb88",
+            "x10": "0x2803ebba0",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 60,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::asio::io_context::run",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio10io_context3runEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::io_context::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc468",
+              "lineno": 62
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper9runWorkerEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc454",
+              "lineno": 119
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c14c"
+            },
+            {
+              "function": "boost_asio_handler_invoke_helpers::invoke<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN33boost_asio_handler_invoke_helpers6invokeIN5boost3_bi6bind_tIvNS1_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS6_23RequestAndContextHolderEEENS2_5list2INS2_5valueIPS7_EENSC_IS9_EEEEEESH_EEvRT_RT0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost_asio_handler_invoke_helpers::invoke<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_b...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fee00",
+              "lineno": 37
+            },
+            {
+              "function": "boost::asio::detail::handler_work<T>::complete<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail12handler_workINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEENS0_15system_executorEE8completeISI_EEvRT_RSI_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::handler_work<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::value...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 82
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::ptr::reset",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE3ptr5resetEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 70
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::do_complete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE11do_completeEPvPNS1_19scheduler_operationERKNS_6system10error_codeEm",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedd4",
+              "lineno": 63
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform::lambda::operator()",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderEENK3$_1clEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd804",
+              "lineno": 235
+            },
+            {
+              "function": "AdobeACSL::RetryHandler::doWithRetries<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../acsl/include/acsl/RetryHandler.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL12RetryHandler13doWithRetriesIZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS2_23RequestAndContextHolderEE3$_1EENS_9ACSLErrorET_",
+              "image_addr": "0x100564000",
+              "filename": "../../../acsl/include/acsl/RetryHandler.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::ACSLError AdobeACSL::RetryHandler::doWithRetries<AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1>(AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd7cc",
+              "lineno": 59
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd76c",
+              "lineno": 226
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper24waitForRequestToCompleteENSt3__110shared_ptrINS_23RequestAndContextHolderEEE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete(std::__1::shared_ptr<AdobeDCX::RequestAndContextHolder>)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fcbd8",
+              "lineno": 110
+            },
+            {
+              "function": "AdobeACSL::SynchronousRequestContext::waitForCompletion",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL25SynchronousRequestContext17waitForCompletionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::SynchronousRequestContext::waitForCompletion()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103142688"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17195a2b0",
+            "x28": "0x17195a8b8",
+            "x25": "0x17195b000",
+            "x24": "0x0",
+            "x27": "0x17195a7d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803e90a8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17195a2b0",
+            "x8": "0x17195a240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803e90a8",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17195a240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803e9068",
+            "x10": "0x2803e9080",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fc46c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c150"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fee04"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fd808"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fcbdc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10314268c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x17195a2b0",
+            "x28": "0x17195a8b8",
+            "x25": "0x17195b000",
+            "x24": "0x0",
+            "x27": "0x17195a7d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803e90a8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x17195a2b0",
+            "x8": "0x17195a240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803e90a8",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x17195a240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803e9068",
+            "x10": "0x2803e9080",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 61,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe721c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::asio::io_context::run",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio10io_context3runEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::io_context::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc468",
+              "lineno": 62
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper9runWorkerEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc454",
+              "lineno": 119
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c14c"
+            },
+            {
+              "function": "boost_asio_handler_invoke_helpers::invoke<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN33boost_asio_handler_invoke_helpers6invokeIN5boost3_bi6bind_tIvNS1_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS6_23RequestAndContextHolderEEENS2_5list2INS2_5valueIPS7_EENSC_IS9_EEEEEESH_EEvRT_RT0_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_invoke_helpers.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost_asio_handler_invoke_helpers::invoke<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_b...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fee00",
+              "lineno": 37
+            },
+            {
+              "function": "boost::asio::detail::handler_work<T>::complete<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail12handler_workINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEENS0_15system_executorEE8completeISI_EEvRT_RSI_",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/handler_work.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::handler_work<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::value...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 82
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::ptr::reset",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE3ptr5resetEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedf8",
+              "lineno": 70
+            },
+            {
+              "function": "boost::asio::detail::completion_handler<T>::do_complete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail18completion_handlerINS_3_bi6bind_tIvNS_4_mfi3mf1IvN8AdobeDCX25DcxHTTPSessionImplWrapperEPNS7_23RequestAndContextHolderEEENS3_5list2INS3_5valueIPS8_EENSD_ISA_EEEEEEE11do_completeEPvPNS1_19scheduler_operationERKNS_6system10error_codeEm",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/detail/completion_handler.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::completion_handler<boost::_bi::bind_t<void, boost::_mfi::mf1<void, AdobeDCX::DcxHTTPSessionImplWrapper, AdobeDCX::RequestAndContextHolder*>, boost::_bi::list2<boost::_bi::value<AdobeDCX::DcxHTTPSessionImplWrapper*>, boost::_bi::valu...",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fedd4",
+              "lineno": 63
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform::lambda::operator()",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderEENK3$_1clEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1::operator()() const",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd804",
+              "lineno": 235
+            },
+            {
+              "function": "AdobeACSL::RetryHandler::doWithRetries<T>",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../acsl/include/acsl/RetryHandler.h",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL12RetryHandler13doWithRetriesIZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS2_23RequestAndContextHolderEE3$_1EENS_9ACSLErrorET_",
+              "image_addr": "0x100564000",
+              "filename": "../../../acsl/include/acsl/RetryHandler.h",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::ACSLError AdobeACSL::RetryHandler::doWithRetries<AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1>(AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)::$_1)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd7cc",
+              "lineno": 59
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper7performEPNS_23RequestAndContextHolderE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::perform(AdobeDCX::RequestAndContextHolder*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fd76c",
+              "lineno": 226
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper24waitForRequestToCompleteENSt3__110shared_ptrINS_23RequestAndContextHolderEEE",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::waitForRequestToComplete(std::__1::shared_ptr<AdobeDCX::RequestAndContextHolder>)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fcbd8",
+              "lineno": 110
+            },
+            {
+              "function": "AdobeACSL::SynchronousRequestContext::waitForCompletion",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN9AdobeACSL25SynchronousRequestContext17waitForCompletionEv",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeACSL::SynchronousRequestContext::waitForCompletion()",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103142688"
+            },
+            {
+              "function": "boost::condition_variable::wait",
+              "abs_path": "/Users/travis/proj/proj/projects/apollo/../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost18condition_variable4waitERNS_11unique_lockINS_5mutexEEE",
+              "image_addr": "0x100564000",
+              "filename": "../../../shared/source_library/boost/boost/thread/pthread/condition_variable.hpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::condition_variable::wait(boost::unique_lock<boost::mutex>&)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100d76304",
+              "lineno": 81
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x171ed22b0",
+            "x28": "0x171ed28b8",
+            "x25": "0x171ed3000",
+            "x24": "0x0",
+            "x27": "0x171ed27d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803ebda8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x171ed22b0",
+            "x8": "0x171ed2240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803ebda8",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x171ed2240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803ebd68",
+            "x10": "0x2803ebd80",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fc46c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c150"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fee04"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fd808"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fcbdc"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10314268c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100d76308"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x171ed22b0",
+            "x28": "0x171ed28b8",
+            "x25": "0x171ed3000",
+            "x24": "0x0",
+            "x27": "0x171ed27d0",
+            "x26": "0x100",
+            "x21": "0x2",
+            "x20": "0x2803ebda8",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x171ed22b0",
+            "x8": "0x171ed2240",
+            "x9": "0x1",
+            "x2": "0x0",
+            "x3": "0x0",
+            "x0": "0x2803ebda8",
+            "x1": "0x100000100",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x171ed2240",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x2803ebd68",
+            "x10": "0x2803ebd80",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 62,
+        "crashed": false
+      },
+      {
+        "current": false,
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x2261e321c"
+            },
+            {
+              "function": "_pthread_body",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x2261e32bc"
+            },
+            {
+              "function": "boost::(anonymous namespace)::thread_proxy",
+              "abs_path": "/Users/lan/code/lan/coresync/main/rebar/resources/third-party/boost/lib/iOS/boost_1_66_0/libs/thread/src/pthread/thread.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost12_GLOBAL__N_112thread_proxyEPv",
+              "image_addr": "0x100564000",
+              "filename": "libs/thread/src/pthread/thread.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::(anonymous namespace)::thread_proxy(void*)",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x103113540",
+              "lineno": 171
+            },
+            {
+              "function": "boost::asio::io_context::run",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/project/mac/../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio10io_context3runEv",
+              "image_addr": "0x100564000",
+              "filename": "../../../resources/third-party/boost_libraries/boost/asio/impl/io_context.ipp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::io_context::run()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc468",
+              "lineno": 62
+            },
+            {
+              "function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker",
+              "abs_path": "/Users/passofar/src/coresync/main/rebar/coresynclib/src/dcx/DcxHTTPSessionImplWrapper.cpp",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN8AdobeDCX25DcxHTTPSessionImplWrapper9runWorkerEv",
+              "image_addr": "0x100564000",
+              "filename": "DcxHTTPSessionImplWrapper.cpp",
+              "symbol_addr": "0x100635e34",
+              "raw_function": "AdobeDCX::DcxHTTPSessionImplWrapper::runWorker()",
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x1030fc454",
+              "lineno": 119
+            },
+            {
+              "function": "boost::asio::detail::scheduler::run",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler3runERNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::run(boost::system::error_code&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335be54"
+            },
+            {
+              "function": "boost::asio::detail::scheduler::do_run_one",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail9scheduler10do_run_oneERNS1_27conditionally_enabled_mutex11scoped_lockERNS1_21scheduler_thread_infoERKNS_6system10error_codeE",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c048"
+            },
+            {
+              "function": "boost::asio::detail::posix_event::wait<T>",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "_ZN5boost4asio6detail11posix_event4waitINS1_27conditionally_enabled_mutex11scoped_lockEEEvRT_",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "raw_function": "void boost::asio::detail::posix_event::wait<boost::asio::detail::conditionally_enabled_mutex::scoped_lock>(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&)",
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x10335c8d4"
+            },
+            {
+              "function": "_pthread_cond_wait$VARIANT$mp",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x2261dbcf4"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x226160ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x172076ad0",
+            "x28": "0x0",
+            "x25": "0x172077000",
+            "x24": "0x1e00",
+            "x27": "0x11b9bc0d8",
+            "x26": "0x1f00",
+            "x21": "0x2",
+            "x20": "0x11b9bc098",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x172076ad0",
+            "x8": "0x172076a60",
+            "x9": "0x1e01",
+            "x2": "0x1e00",
+            "x3": "0x0",
+            "x0": "0x11b9bc098",
+            "x1": "0x1e0100001f00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x172076a60",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b9bc048",
+            "x10": "0x11b9bc060",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe71f4",
+              "instruction_addr": "0x210fe7220"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fe7240",
+              "instruction_addr": "0x210fe72c0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x103113544"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x1030fc46c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335be58"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c04c"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x10335c8d8"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libsystem_pthread.dylib",
+              "image_addr": "0x210fdc000",
+              "in_app": false,
+              "symbol_addr": "0x210fdfa7c",
+              "instruction_addr": "0x210fdfcf8"
+            },
+            {
+              "function": "__psynch_cvwait",
+              "package": "/usr/lib/system/libsystem_kernel.dylib",
+              "image_addr": "0x210f42000",
+              "in_app": false,
+              "symbol_addr": "0x210f64edc",
+              "instruction_addr": "0x210f64ee4"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x40000000",
+            "pc": "0x210f64ee4",
+            "x29": "0x172076ad0",
+            "x28": "0x0",
+            "x25": "0x172077000",
+            "x24": "0x1e00",
+            "x27": "0x11b9bc0d8",
+            "x26": "0x1f00",
+            "x21": "0x2",
+            "x20": "0x11b9bc098",
+            "x23": "0x0",
+            "x22": "0x0",
+            "fp": "0x172076ad0",
+            "x8": "0x172076a60",
+            "x9": "0x1e01",
+            "x2": "0x1e00",
+            "x3": "0x0",
+            "x0": "0x11b9bc098",
+            "x1": "0x1e0100001f00",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x0",
+            "x5": "0xa0",
+            "sp": "0x172076a60",
+            "lr": "0x210fdfcf8",
+            "x18": "0x0",
+            "x19": "0x11b9bc048",
+            "x10": "0x11b9bc060",
+            "x11": "0x2",
+            "x12": "0x20a0",
+            "x13": "0x0",
+            "x14": "0x0",
+            "x15": "0x0",
+            "x16": "0x131",
+            "x17": "0x0"
+          }
+        },
+        "id": 63,
+        "crashed": false
+      }
+    ]
+  },
+  "fingerprint": [
+    "{{ default }}"
+  ],
+  "exception": {
+    "values": [
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "start",
+              "package": "/usr/lib/system/libdyld.dylib",
+              "image_addr": "0x210e18000",
+              "in_app": false,
+              "symbol_addr": "0x210e198dc",
+              "instruction_addr": "0x22d5228dc"
+            },
+            {
+              "function": "main",
+              "abs_path": "/Users/travis/projectsources/ios/main.mm",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "symbol": "main",
+              "image_addr": "0x100564000",
+              "filename": "main.mm",
+              "symbol_addr": "0x100635e34",
+              "lineno": 25,
+              "in_app": true,
+              "data": {
+                "symbolicator_status": "symbolicated"
+              },
+              "instruction_addr": "0x100635eb0"
+            },
+            {
+              "function": "UIApplicationMain",
+              "package": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
+              "image_addr": "0x23c87f000",
+              "in_app": false,
+              "symbol_addr": "0x23d139a94",
+              "instruction_addr": "0x259f05b64"
+            },
+            {
+              "function": "GSEventRunModal",
+              "package": "/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices",
+              "image_addr": "0x213549000",
+              "in_app": false,
+              "symbol_addr": "0x213553734",
+              "instruction_addr": "0x22fc5c798"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113531a0",
+              "instruction_addr": "0x211353350"
+            },
+            {
+              "function": "__CFRunLoopRun",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211353674",
+              "instruction_addr": "0x1b83e4dfc"
+            },
+            {
+              "function": "_CFAutoreleasePoolPop",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113d4f24",
+              "instruction_addr": "0x2228e9f3c"
+            },
+            {
+              "function": "(anonymous namespace)::AutoreleasePoolPage::pop",
+              "package": "/usr/lib/libobjc.A.dylib",
+              "symbol": "_ZN12_GLOBAL__N_119AutoreleasePoolPage3popEPv",
+              "image_addr": "0x21059d000",
+              "in_app": false,
+              "symbol_addr": "0x2105bc8fc",
+              "raw_function": "(anonymous namespace)::AutoreleasePoolPage::pop(void*)",
+              "instruction_addr": "0x1c37f1b98"
+            },
+            {
+              "function": "objc_object::sidetable_release",
+              "package": "/usr/lib/libobjc.A.dylib",
+              "symbol": "_ZN11objc_object17sidetable_releaseEb",
+              "image_addr": "0x21059d000",
+              "in_app": false,
+              "symbol_addr": "0x2105bc0ac",
+              "raw_function": "objc_object::sidetable_release(bool)",
+              "instruction_addr": "0x2105bc1e4"
+            },
+            {
+              "function": "objc_msgSend",
+              "package": "/usr/lib/libobjc.A.dylib",
+              "image_addr": "0x21059d000",
+              "in_app": false,
+              "symbol_addr": "0x2105ba520",
+              "instruction_addr": "0x1bfda353c"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x20000000",
+            "pc": "0x2105ba53c",
+            "x29": "0x16f89a780",
+            "x28": "0x2800e0f10",
+            "x25": "0x2499e4d00",
+            "x24": "0xfffffffd7e8383a0",
+            "x27": "0x16f89acd0",
+            "x26": "0x2800e0f08",
+            "x21": "0x2499e4d00",
+            "x20": "0x1",
+            "x23": "0x105296ca0",
+            "x22": "0x1",
+            "fp": "0x16f89a780",
+            "x8": "0x2499e4f90",
+            "x9": "0x0",
+            "x2": "0x2822ceab0",
+            "x3": "0x210f9c130",
+            "x0": "0x2817c7c60",
+            "x1": "0x23d65ea27",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x11bd3a680",
+            "x5": "0x12",
+            "sp": "0x16f89a730",
+            "lr": "0x2105bc1e8",
+            "x18": "0x0",
+            "x19": "0x2817c7c60",
+            "x10": "0x10059eaa4",
+            "x11": "0x21057038c",
+            "x12": "0x204aa0ae4",
+            "x13": "0x1042d4e50",
+            "x14": "0x1",
+            "x15": "0xffffffffffffffff",
+            "x16": "0x1042d4e50",
+            "x17": "0xf800000"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/system/libdyld.dylib",
+              "image_addr": "0x210e18000",
+              "in_app": false,
+              "symbol_addr": "0x210e198dc",
+              "instruction_addr": "0x210e198e0"
+            },
+            {
+              "function": "main",
+              "package": "/var/containers/Bundle/Application/FF62912A-8BCC-4C00-A695-339277B68C5A/Company Proj.app/Company Proj",
+              "image_addr": "0x100564000",
+              "in_app": true,
+              "symbol_addr": "0x100635e34",
+              "instruction_addr": "0x100635eb4"
+            },
+            {
+              "function": "UIApplicationMain",
+              "package": "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
+              "image_addr": "0x23c87f000",
+              "in_app": false,
+              "symbol_addr": "0x23d139a94",
+              "instruction_addr": "0x23d139b68"
+            },
+            {
+              "function": "GSEventRunModal",
+              "package": "/System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices",
+              "image_addr": "0x213549000",
+              "in_app": false,
+              "symbol_addr": "0x213553734",
+              "instruction_addr": "0x21355379c"
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113531a0",
+              "instruction_addr": "0x211353354"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x211353674",
+              "instruction_addr": "0x211353e00"
+            },
+            {
+              "function": "_CFAutoreleasePoolPop",
+              "package": "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+              "image_addr": "0x2112af000",
+              "in_app": false,
+              "symbol_addr": "0x2113d4f24",
+              "instruction_addr": "0x2113d4f40"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/libobjc.A.dylib",
+              "image_addr": "0x21059d000",
+              "in_app": false,
+              "symbol_addr": "0x2105bc8fc",
+              "instruction_addr": "0x2105bcb9c"
+            },
+            {
+              "function": "<redacted>",
+              "package": "/usr/lib/libobjc.A.dylib",
+              "image_addr": "0x21059d000",
+              "in_app": false,
+              "symbol_addr": "0x2105bc0ac",
+              "instruction_addr": "0x2105bc1e8"
+            },
+            {
+              "function": "objc_msgSend",
+              "package": "/usr/lib/libobjc.A.dylib",
+              "image_addr": "0x21059d000",
+              "in_app": false,
+              "symbol_addr": "0x2105ba520",
+              "instruction_addr": "0x2105ba53c"
+            }
+          ],
+          "registers": {
+            "cpsr": "0x20000000",
+            "pc": "0x2105ba53c",
+            "x29": "0x16f89a780",
+            "x28": "0x2800e0f10",
+            "x25": "0x2499e4d00",
+            "x24": "0xfffffffd7e8383a0",
+            "x27": "0x16f89acd0",
+            "x26": "0x2800e0f08",
+            "x21": "0x2499e4d00",
+            "x20": "0x1",
+            "x23": "0x105296ca0",
+            "x22": "0x1",
+            "fp": "0x16f89a780",
+            "x8": "0x2499e4f90",
+            "x9": "0x0",
+            "x2": "0x2822ceab0",
+            "x3": "0x210f9c130",
+            "x0": "0x2817c7c60",
+            "x1": "0x23d65ea27",
+            "x6": "0x0",
+            "x7": "0x0",
+            "x4": "0x11bd3a680",
+            "x5": "0x12",
+            "sp": "0x16f89a730",
+            "lr": "0x2105bc1e8",
+            "x18": "0x0",
+            "x19": "0x2817c7c60",
+            "x10": "0x10059eaa4",
+            "x11": "0x21057038c",
+            "x12": "0x204aa0ae4",
+            "x13": "0x1042d4e50",
+            "x14": "0x1",
+            "x15": "0xffffffffffffffff",
+            "x16": "0x1042d4e50",
+            "x17": "0xf800000"
+          }
+        },
+        "value": "dealloc > XTUM >\nAttempted to dereference garbage pointer 0x204aa0ae4.",
+        "thread_id": 0,
+        "mechanism": {
+          "type": "mach",
+          "meta": {
+            "signal": {
+              "code": 0,
+              "number": 10,
+              "code_name": "BUS_NOOP",
+              "name": "SIGBUS"
+            },
+            "mach_exception": {
+              "exception": 1,
+              "code": 78252772,
+              "subcode": 8,
+              "name": "EXC_BAD_ACCESS"
+            }
+          },
+          "data": {
+            "relevant_address": "0x0000000204aa0ae4"
+          },
+          "handled": false
+        },
+        "type": "EXC_BAD_ACCESS"
+      }
+    ]
+  },
+  "release": "com.company.proj.mobile.yo-0.19.0"
+}

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined:2019_04_07/native_single_frame_stacktrace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined:2019_04_07/native_single_frame_stacktrace.pysnap
@@ -1,0 +1,88 @@
+---
+created: '2019-05-23T09:51:39.320977Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: '273a31ec3c2404ac14222418a4618ef7'
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            function*
+              u'start'
+          frame* (marked in-app by grouping enhancement rule (family:native package:/var/containers/Bundle/Application/**))
+            filename*
+              u'main.mm'
+            function*
+              u'main'
+          frame (non app frame)
+            function*
+              u'UIApplicationMain'
+          frame (non app frame)
+            function*
+              u'GSEventRunModal'
+          frame (non app frame)
+            function*
+              u'CFRunLoopRunSpecific'
+          frame (non app frame)
+            function*
+              u'__CFRunLoopRun'
+          frame (non app frame)
+            function*
+              u'_CFAutoreleasePoolPop'
+          frame (non app frame)
+            function* (isolated function)
+              u'(anonymous namespace)::AutoreleasePoolPage::pop'
+          frame (non app frame)
+            function* (isolated function)
+              u'objc_object::sidetable_release'
+          frame (non app frame)
+            function*
+              u'objc_msgSend'
+        type*
+          u'EXC_BAD_ACCESS'
+      threads (ignored because contains 64 threads)
+--------------------------------------------------------------------------
+system:
+  hash: 'a9b819dcd26864d66c32e5a74df2b5cc'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              u'start'
+          frame* (marked in-app by grouping enhancement rule (family:native package:/var/containers/Bundle/Application/**))
+            filename*
+              u'main.mm'
+            function*
+              u'main'
+          frame*
+            function*
+              u'UIApplicationMain'
+          frame*
+            function*
+              u'GSEventRunModal'
+          frame*
+            function*
+              u'CFRunLoopRunSpecific'
+          frame*
+            function*
+              u'__CFRunLoopRun'
+          frame*
+            function*
+              u'_CFAutoreleasePoolPop'
+          frame*
+            function* (isolated function)
+              u'(anonymous namespace)::AutoreleasePoolPage::pop'
+          frame*
+            function* (isolated function)
+              u'objc_object::sidetable_release'
+          frame*
+            function*
+              u'objc_msgSend'
+        type*
+          u'EXC_BAD_ACCESS'
+      threads (ignored because contains 64 threads)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/native_single_frame_stacktrace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy:2019_03_12/native_single_frame_stacktrace.pysnap
@@ -1,0 +1,108 @@
+---
+created: '2019-05-23T09:51:41.175182Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: None
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame (non app frame)
+            function (function name is used only if module or filename are available)
+              u'start'
+          frame* (marked in-app by grouping enhancement rule (family:native package:/var/containers/Bundle/Application/**))
+            filename* (stripped to basename)
+              u'main.mm'
+            symbol*
+              u'main'
+            function (symbol takes precedence)
+              u'main'
+            lineno (symbol takes precedence)
+              25
+          frame (non app frame)
+            function (function name is used only if module or filename are available)
+              u'UIApplicationMain'
+          frame (non app frame)
+            function (function name is used only if module or filename are available)
+              u'GSEventRunModal'
+          frame (non app frame)
+            function (function name is used only if module or filename are available)
+              u'CFRunLoopRunSpecific'
+          frame (non app frame)
+            function (function name is used only if module or filename are available)
+              u'__CFRunLoopRun'
+          frame (non app frame)
+            function (function name is used only if module or filename are available)
+              u'_CFAutoreleasePoolPop'
+          frame (non app frame)
+            symbol (symbol is used only if module or filename are available)
+              u'_ZN12_GLOBAL__N_119AutoreleasePoolPage3popEPv'
+            function (function name is used only if module or filename are available)
+              u'(anonymous namespace)::AutoreleasePoolPage::pop(void*)'
+          frame (non app frame)
+            symbol (symbol is used only if module or filename are available)
+              u'_ZN11objc_object17sidetable_releaseEb'
+            function (function name is used only if module or filename are available)
+              u'objc_object::sidetable_release(bool)'
+          frame (non app frame)
+            function (function name is used only if module or filename are available)
+              u'objc_msgSend'
+        type*
+          u'EXC_BAD_ACCESS'
+        value (stacktrace and type take precedence)
+          u'dealloc > XTUM >\nAttempted to dereference garbage pointer 0x204aa0ae4.'
+      threads (ignored because contains 64 threads)
+--------------------------------------------------------------------------
+system:
+  hash: '273a31ec3c2404ac14222418a4618ef7'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame (marked out of app by grouping enhancement rule (family:native package:/usr/lib/**))
+            function (function name is used only if module or filename are available)
+              u'start'
+          frame* (marked in-app by grouping enhancement rule (family:native package:/var/containers/Bundle/Application/**))
+            filename* (stripped to basename)
+              u'main.mm'
+            symbol*
+              u'main'
+            function (symbol takes precedence)
+              u'main'
+            lineno (symbol takes precedence)
+              25
+          frame
+            function (function name is used only if module or filename are available)
+              u'UIApplicationMain'
+          frame
+            function (function name is used only if module or filename are available)
+              u'GSEventRunModal'
+          frame
+            function (function name is used only if module or filename are available)
+              u'CFRunLoopRunSpecific'
+          frame
+            function (function name is used only if module or filename are available)
+              u'__CFRunLoopRun'
+          frame
+            function (function name is used only if module or filename are available)
+              u'_CFAutoreleasePoolPop'
+          frame (marked out of app by grouping enhancement rule (family:native package:/usr/lib/**))
+            symbol (symbol is used only if module or filename are available)
+              u'_ZN12_GLOBAL__N_119AutoreleasePoolPage3popEPv'
+            function (function name is used only if module or filename are available)
+              u'(anonymous namespace)::AutoreleasePoolPage::pop(void*)'
+          frame (marked out of app by grouping enhancement rule (family:native package:/usr/lib/**))
+            symbol (symbol is used only if module or filename are available)
+              u'_ZN11objc_object17sidetable_releaseEb'
+            function (function name is used only if module or filename are available)
+              u'objc_object::sidetable_release(bool)'
+          frame (marked out of app by grouping enhancement rule (family:native package:/usr/lib/**))
+            function (function name is used only if module or filename are available)
+              u'objc_msgSend'
+        type*
+          u'EXC_BAD_ACCESS'
+        value (stacktrace and type take precedence)
+          u'dealloc > XTUM >\nAttempted to dereference garbage pointer 0x204aa0ae4.'
+      threads (ignored because contains 64 threads)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_05/native_single_frame_stacktrace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_05/native_single_frame_stacktrace.pysnap
@@ -1,0 +1,88 @@
+---
+created: '2019-05-23T09:51:42.968573Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: '273a31ec3c2404ac14222418a4618ef7'
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            function*
+              u'start'
+          frame* (marked in-app by grouping enhancement rule (family:native package:/var/containers/Bundle/Application/**))
+            filename*
+              u'main.mm'
+            function*
+              u'main'
+          frame (non app frame)
+            function*
+              u'UIApplicationMain'
+          frame (non app frame)
+            function*
+              u'GSEventRunModal'
+          frame (non app frame)
+            function*
+              u'CFRunLoopRunSpecific'
+          frame (non app frame)
+            function*
+              u'__CFRunLoopRun'
+          frame (non app frame)
+            function*
+              u'_CFAutoreleasePoolPop'
+          frame (non app frame)
+            function* (isolated function)
+              u'(anonymous namespace)::AutoreleasePoolPage::pop'
+          frame (non app frame)
+            function* (isolated function)
+              u'objc_object::sidetable_release'
+          frame (non app frame)
+            function*
+              u'objc_msgSend'
+        type*
+          u'EXC_BAD_ACCESS'
+      threads (ignored because contains 64 threads)
+--------------------------------------------------------------------------
+system:
+  hash: 'a9b819dcd26864d66c32e5a74df2b5cc'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              u'start'
+          frame* (marked in-app by grouping enhancement rule (family:native package:/var/containers/Bundle/Application/**))
+            filename*
+              u'main.mm'
+            function*
+              u'main'
+          frame*
+            function*
+              u'UIApplicationMain'
+          frame*
+            function*
+              u'GSEventRunModal'
+          frame*
+            function*
+              u'CFRunLoopRunSpecific'
+          frame*
+            function*
+              u'__CFRunLoopRun'
+          frame*
+            function*
+              u'_CFAutoreleasePoolPop'
+          frame*
+            function* (isolated function)
+              u'(anonymous namespace)::AutoreleasePoolPage::pop'
+          frame*
+            function* (isolated function)
+              u'objc_object::sidetable_release'
+          frame*
+            function*
+              u'objc_msgSend'
+        type*
+          u'EXC_BAD_ACCESS'
+      threads (ignored because contains 64 threads)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_17/native_single_frame_stacktrace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_04_17/native_single_frame_stacktrace.pysnap
@@ -1,0 +1,92 @@
+---
+created: '2019-05-23T09:51:44.821865Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: '273a31ec3c2404ac14222418a4618ef7'
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            function*
+              u'start'
+          frame* (marked in-app by grouping enhancement rule (family:native package:/var/containers/Bundle/Application/**))
+            filename*
+              u'main.mm'
+            function*
+              u'main'
+          frame (non app frame)
+            function*
+              u'UIApplicationMain'
+          frame (non app frame)
+            function*
+              u'GSEventRunModal'
+          frame (non app frame)
+            function*
+              u'CFRunLoopRunSpecific'
+          frame (non app frame)
+            function*
+              u'__CFRunLoopRun'
+          frame (non app frame)
+            function*
+              u'_CFAutoreleasePoolPop'
+          frame (non app frame)
+            function*
+              u'(anonymous namespace)::AutoreleasePoolPage::pop'
+          frame (non app frame)
+            function*
+              u'objc_object::sidetable_release'
+          frame (non app frame)
+            function*
+              u'objc_msgSend'
+        type*
+          u'EXC_BAD_ACCESS'
+        value (ignored because stacktrace takes precedence)
+          u'dealloc > XTUM >\nAttempted to dereference garbage pointer 0x204aa0ae4.'
+      threads (ignored because contains 64 threads)
+--------------------------------------------------------------------------
+system:
+  hash: 'a9b819dcd26864d66c32e5a74df2b5cc'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              u'start'
+          frame* (marked in-app by grouping enhancement rule (family:native package:/var/containers/Bundle/Application/**))
+            filename*
+              u'main.mm'
+            function*
+              u'main'
+          frame*
+            function*
+              u'UIApplicationMain'
+          frame*
+            function*
+              u'GSEventRunModal'
+          frame*
+            function*
+              u'CFRunLoopRunSpecific'
+          frame*
+            function*
+              u'__CFRunLoopRun'
+          frame*
+            function*
+              u'_CFAutoreleasePoolPop'
+          frame*
+            function*
+              u'(anonymous namespace)::AutoreleasePoolPage::pop'
+          frame*
+            function*
+              u'objc_object::sidetable_release'
+          frame*
+            function*
+              u'objc_msgSend'
+        type*
+          u'EXC_BAD_ACCESS'
+        value (ignored because stacktrace takes precedence)
+          u'dealloc > XTUM >\nAttempted to dereference garbage pointer 0x204aa0ae4.'
+      threads (ignored because contains 64 threads)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/java_chained.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2019-05-08T07:29:42.412753Z'
+created: '2019-05-23T10:21:47.720189Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: '750486b8d8c51500fa0dfbb6f1577af0'
+  hash: None
   component:
-    app*
-      chained-exception*
+    app (exception of system takes precedence)
+      chained-exception (ignored because this variant's stacktrace only has a single meaningful frame)
         exception*
           stacktrace
             frame (non app frame)
@@ -394,8 +394,8 @@ app:
 default:
   hash: None
   component:
-    default (exception of app takes precedence)
-      message (exception of app takes precedence)
+    default (exception of system takes precedence)
+      message (exception of system takes precedence)
         u'Failed to start connector [Connector[HTTP/<float><int>]]'
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/native_single_frame_stacktrace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/native_single_frame_stacktrace.pysnap
@@ -1,0 +1,92 @@
+---
+created: '2019-05-23T10:21:48.609934Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: None
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant's stacktrace only has a single meaningful frame)
+        stacktrace*
+          frame (non app frame)
+            function*
+              u'start'
+          frame* (marked in-app by grouping enhancement rule (family:native package:/var/containers/Bundle/Application/**))
+            filename*
+              u'main.mm'
+            function*
+              u'main'
+          frame (non app frame)
+            function*
+              u'UIApplicationMain'
+          frame (non app frame)
+            function*
+              u'GSEventRunModal'
+          frame (non app frame)
+            function*
+              u'CFRunLoopRunSpecific'
+          frame (non app frame)
+            function*
+              u'__CFRunLoopRun'
+          frame (non app frame)
+            function*
+              u'_CFAutoreleasePoolPop'
+          frame (non app frame)
+            function*
+              u'(anonymous namespace)::AutoreleasePoolPage::pop'
+          frame (non app frame)
+            function*
+              u'objc_object::sidetable_release'
+          frame (non app frame)
+            function*
+              u'objc_msgSend'
+        type*
+          u'EXC_BAD_ACCESS'
+        value (ignored because stacktrace takes precedence)
+          u'dealloc > XTUM >\nAttempted to dereference garbage pointer 0x204aa0ae4.'
+      threads (ignored because contains 64 threads)
+--------------------------------------------------------------------------
+system:
+  hash: 'a9b819dcd26864d66c32e5a74df2b5cc'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              u'start'
+          frame* (marked in-app by grouping enhancement rule (family:native package:/var/containers/Bundle/Application/**))
+            filename*
+              u'main.mm'
+            function*
+              u'main'
+          frame*
+            function*
+              u'UIApplicationMain'
+          frame*
+            function*
+              u'GSEventRunModal'
+          frame*
+            function*
+              u'CFRunLoopRunSpecific'
+          frame*
+            function*
+              u'__CFRunLoopRun'
+          frame*
+            function*
+              u'_CFAutoreleasePoolPop'
+          frame*
+            function*
+              u'(anonymous namespace)::AutoreleasePoolPage::pop'
+          frame*
+            function*
+              u'objc_object::sidetable_release'
+          frame*
+            function*
+              u'objc_msgSend'
+        type*
+          u'EXC_BAD_ACCESS'
+        value (ignored because stacktrace takes precedence)
+          u'dealloc > XTUM >\nAttempted to dereference garbage pointer 0x204aa0ae4.'
+      threads (ignored because contains 64 threads)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/stacktrace_rust.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2019-05-08T07:29:42.835417Z'
+created: '2019-05-23T10:21:48.908889Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: 'eb87c1031dba55b67df86fb9fff59dc6'
+  hash: None
   component:
-    app*
-      exception*
+    app (exception of system takes precedence)
+      exception (ignored because this variant's stacktrace only has a single meaningful frame)
         stacktrace*
           frame (non app frame)
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle:2019_05_08/stacktrace_rust2.pysnap
@@ -1,13 +1,13 @@
 ---
-created: '2019-05-02T18:53:32.201919Z'
+created: '2019-05-23T10:21:48.954309Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: 'eb87c1031dba55b67df86fb9fff59dc6'
+  hash: None
   component:
-    app*
-      exception*
+    app (exception of system takes precedence)
+      exception (ignored because this variant's stacktrace only has a single meaningful frame)
         stacktrace*
           frame (non app frame)
             function*


### PR DESCRIPTION
This changes the 05-28 grouping config to no longer use single frame stacktraces for grouping if another stacktrace has more frames.