### PR TITLE
fix: Normalize minidumps after processing

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -20,7 +20,8 @@ from django.utils.encoding import force_text
 
 from sentry import buffer, eventtypes, eventstream, features, tagstore, tsdb, filters
 from sentry.constants import (
-    LOG_LEVELS, LOG_LEVELS_MAP, MAX_TAG_VALUE_LENGTH, DEFAULT_STORE_NORMALIZER_ARGS
+    DEFAULT_STORE_NORMALIZER_ARGS, LOG_LEVELS, LOG_LEVELS_MAP,
+    MAX_TAG_VALUE_LENGTH, MAX_SECS_IN_FUTURE, MAX_SECS_IN_PAST
 )
 from sentry.grouping.api import get_grouping_config_dict_for_project, \
     get_grouping_config_dict_for_event_data, load_grouping_config, \
@@ -37,7 +38,7 @@ from sentry.coreapi import (
 )
 from sentry.interfaces.base import get_interface
 from sentry.models import (
-    Activity, Environment, Event, EventDict, EventMapping, EventUser, Group,
+    Activity, Environment, Event, EventDict, EventError, EventMapping, EventUser, Group,
     GroupEnvironment, GroupHash, GroupLink, GroupRelease, GroupResolution, GroupStatus,
     Project, Release, ReleaseEnvironment, ReleaseProject,
     ReleaseProjectEnvironment, UserReport, Organization, EventAttachment

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -20,7 +20,7 @@ from django.utils.encoding import force_text
 
 from sentry import buffer, eventtypes, eventstream, features, tagstore, tsdb, filters
 from sentry.constants import (
-    LOG_LEVELS, LOG_LEVELS_MAP, VALID_PLATFORMS, MAX_TAG_VALUE_LENGTH,
+    LOG_LEVELS, LOG_LEVELS_MAP, MAX_TAG_VALUE_LENGTH, DEFAULT_STORE_NORMALIZER_ARGS
 )
 from sentry.grouping.api import get_grouping_config_dict_for_project, \
     get_grouping_config_dict_for_event_data, load_grouping_config, \
@@ -37,7 +37,7 @@ from sentry.coreapi import (
 )
 from sentry.interfaces.base import get_interface
 from sentry.models import (
-    Activity, Environment, Event, EventDict, EventError, EventMapping, EventUser, Group,
+    Activity, Environment, Event, EventDict, EventMapping, EventUser, Group,
     GroupEnvironment, GroupHash, GroupLink, GroupRelease, GroupResolution, GroupStatus,
     Project, Release, ReleaseEnvironment, ReleaseProject,
     ReleaseProjectEnvironment, UserReport, Organization, EventAttachment
@@ -57,7 +57,6 @@ from sentry.utils.data_filters import (
 )
 from sentry.utils.dates import to_timestamp
 from sentry.utils.db import is_postgres
-from sentry.utils.geo import rust_geoip
 from sentry.utils.safe import safe_execute, trim, get_path, setdefault_path
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
 from sentry.culprit import generate_culprit
@@ -66,9 +65,6 @@ from sentry.culprit import generate_culprit
 logger = logging.getLogger("sentry.events")
 
 
-MAX_SECS_IN_FUTURE = 60
-ALLOWED_FUTURE_DELTA = timedelta(seconds=MAX_SECS_IN_FUTURE)
-MAX_SECS_IN_PAST = 2592000  # 30 days
 SECURITY_REPORT_INTERFACES = (
     "csp",
     "hpkp",
@@ -355,21 +351,15 @@ class EventManager(object):
 
         from semaphore.processing import StoreNormalizer
         rust_normalizer = StoreNormalizer(
-            geoip_lookup=rust_geoip,
             project_id=self._project.id if self._project else None,
             client_ip=self._client_ip,
             client=self._auth.client if self._auth else None,
             key_id=six.text_type(self._key.id) if self._key else None,
             grouping_config=self._grouping_config,
             protocol_version=six.text_type(self.version) if self.version is not None else None,
-            stacktrace_frames_hard_limit=settings.SENTRY_STACKTRACE_FRAMES_HARD_LIMIT,
-            max_stacktrace_frames=settings.SENTRY_MAX_STACKTRACE_FRAMES,
-            valid_platforms=list(VALID_PLATFORMS),
-            max_secs_in_future=MAX_SECS_IN_FUTURE,
-            max_secs_in_past=MAX_SECS_IN_PAST,
-            enable_trimming=True,
             is_renormalize=self._is_renormalize,
             remove_other=self._remove_other,
+            **DEFAULT_STORE_NORMALIZER_ARGS
         )
 
         self._data = CanonicalKeyDict(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -181,3 +181,7 @@ register('store.empty-interface-sample-rate', default=0.0)
 register('symbolicator.minidump-refactor-projects-opt-in', type=Sequence, default=[])  # unused
 register('symbolicator.minidump-refactor-projects-opt-out', type=Sequence, default=[])  # unused
 register('symbolicator.minidump-refactor-random-sampling', default=0.0)  # unused
+
+
+# Normalization after processors
+register('store.normalize-after-processing', default=0.0)

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -18,7 +18,7 @@ from sentry.api.event_search import (
     InvalidSearchQuery,
 )
 from sentry.api.paginator import DateTimePaginator, SequencePaginator, Paginator
-from sentry.event_manager import ALLOWED_FUTURE_DELTA
+from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.models import Group
 from sentry.search.base import SearchBackend
 from sentry.utils import snuba, metrics

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -16,7 +16,10 @@ from time import time
 from django.conf import settings
 from django.utils import timezone
 
+from semaphore.processing import StoreNormalizer
+
 from sentry import features, reprocessing
+from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS
 from sentry.attachments import attachment_cache
 from sentry.cache import default_cache
 from sentry.tasks.base import instrumented_task
@@ -264,7 +267,14 @@ def _do_process_event(cache_key, start_time, event_id, process_task,
         data = dict(data.items())
 
     if has_changed:
+        # Run some of normalization again such that we don't:
+        # - persist e.g. incredibly large stacktraces from minidumps
+        # - store event timestamps that are older than our retention window
+        #   (also happening with minidumps)
+        normalizer = StoreNormalizer(remove_other=False, **DEFAULT_STORE_NORMALIZER_ARGS)
         issues = data.get('processing_issues')
+        data = normalizer.normalize_event(dict(data))
+
         try:
             if issues and create_failed_event(
                 cache_key, project_id, list(issues.values()),

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -278,7 +278,11 @@ def _do_process_event(cache_key, start_time, event_id, process_task,
             # - persist e.g. incredibly large stacktraces from minidumps
             # - store event timestamps that are older than our retention window
             #   (also happening with minidumps)
-            normalizer = StoreNormalizer(remove_other=False, **DEFAULT_STORE_NORMALIZER_ARGS)
+            normalizer = StoreNormalizer(
+                remove_other=False,
+                is_renormalize=True,
+                **DEFAULT_STORE_NORMALIZER_ARGS
+            )
             data = normalizer.normalize_event(dict(data))
 
         issues = data.get('processing_issues')

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 
 import logging
 from datetime import datetime
+import random
 import six
 
 from time import time
@@ -18,7 +19,7 @@ from django.utils import timezone
 
 from semaphore.processing import StoreNormalizer
 
-from sentry import features, reprocessing
+from sentry import features, reprocessing, options
 from sentry.constants import DEFAULT_STORE_NORMALIZER_ARGS
 from sentry.attachments import attachment_cache
 from sentry.cache import default_cache
@@ -41,6 +42,11 @@ REPROCESSING_DEFAULT = False
 
 # Attachment file types that are considered a crash report (PII relevant)
 CRASH_REPORT_TYPES = ('event.minidump', )
+
+
+def _should_normalize_after_processing():
+    value = options.get('store.normalize-after-processing')
+    return value and random.random() < value
 
 
 class RetryProcessing(Exception):
@@ -267,13 +273,15 @@ def _do_process_event(cache_key, start_time, event_id, process_task,
         data = dict(data.items())
 
     if has_changed:
-        # Run some of normalization again such that we don't:
-        # - persist e.g. incredibly large stacktraces from minidumps
-        # - store event timestamps that are older than our retention window
-        #   (also happening with minidumps)
-        normalizer = StoreNormalizer(remove_other=False, **DEFAULT_STORE_NORMALIZER_ARGS)
+        if _should_normalize_after_processing():
+            # Run some of normalization again such that we don't:
+            # - persist e.g. incredibly large stacktraces from minidumps
+            # - store event timestamps that are older than our retention window
+            #   (also happening with minidumps)
+            normalizer = StoreNormalizer(remove_other=False, **DEFAULT_STORE_NORMALIZER_ARGS)
+            data = normalizer.normalize_event(dict(data))
+
         issues = data.get('processing_issues')
-        data = normalizer.normalize_event(dict(data))
 
         try:
             if issues and create_failed_event(


### PR DESCRIPTION
I want to try this out because processing plugins might create too old timestamps or too big data.

This will possibly enable us to disable trimming in renormalization again.

cc @RaduW @jan-auer 