### PR TITLE
Fixed syntax error in 'exec' command handler

### DIFF
--- a/src/sentry/runner/commands/exec.py
+++ b/src/sentry/runner/commands/exec.py
@@ -86,7 +86,7 @@ def exec_(c, file):
         for line in c.splitlines():
             if line.startswith('from __future__'):
                 state = 1
-            elif line and not line.startswith('#', '"', "'") and state == 1:
+            elif line and not line.startswith(('#', '"', "'")) and state == 1:
                 state = 2
             if state == 2:
                 body.append(line)


### PR DESCRIPTION
The `startswith` method accepts a tuple as a first argument, without a tuple the following error appears every time we try to `exec` a file with `__future__` section:

```sh
root@5e166a9658d5:/usr/src/sentry# cat > test
from __future__ import absolute_import, unicode_literals, print_function

print('ok')
root@5e166a9658d5:/usr/src/sentry# sentry exec test
Traceback (most recent call last):
  File "/usr/local/bin/sentry", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/sentry/runner/__init__.py", line 162, in main
    cli(prog_name=get_prog(), obj={}, max_content_width=100)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/sentry/runner/commands/exec.py", line 89, in exec_
    elif line and not line.startswith('#', '"', "'") and state == 1:
TypeError: slice indices must be integers or None or have an __index__ method
```