### PR TITLE
test(selenium): Change `wait` timeout to 10 seconds (from 3s)

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -103,7 +103,7 @@ class Browser(object):
 
         return self
 
-    def wait_until_clickable(self, selector=None, timeout=3):
+    def wait_until_clickable(self, selector=None, timeout=10):
         """
         Waits until ``selector`` is visible and enabled to be clicked, or until ``timeout``
         is hit, whichever happens first.
@@ -121,7 +121,7 @@ class Browser(object):
 
         return self
 
-    def wait_until(self, selector=None, xpath=None, title=None, timeout=3):
+    def wait_until(self, selector=None, xpath=None, title=None, timeout=10):
         """
         Waits until ``selector`` is found in the browser, or until ``timeout``
         is hit, whichever happens first.
@@ -146,7 +146,7 @@ class Browser(object):
     def wait_until_test_id(self, selector):
         return self.wait_until('[data-test-id="%s"]' % (selector))
 
-    def wait_until_not(self, selector=None, title=None, timeout=3):
+    def wait_until_not(self, selector=None, title=None, timeout=10):
         """
         Waits until ``selector`` is NOT found in the browser, or until
         ``timeout`` is hit, whichever happens first.


### PR DESCRIPTION
getsentry acceptance tests have been very flakey recently, we updated the timeouts specifically in the flakey tests, and they seem to have helped. Lets bump the default timeout to 10seconds. This should not impact current test times unless all of your tests are failing and hitting the timeouts.

We should revert https://github.com/getsentry/getsentry/pull/2927 and https://github.com/getsentry/getsentry/pull/2925