### PR TITLE
fix(jira) Improve setup instructions

### DIFF
--- a/src/sentry/templates/sentry/integrations/jira-config.html
+++ b/src/sentry/templates/sentry/integrations/jira-config.html
@@ -38,6 +38,7 @@
     {% if login_required %}
       <div class="aui-message aui-message-info">
         <p>Please login to your Sentry account to access the Sentry Add-on configuration</p>
+        <p>You must disable your ad-blocker to install this integration, as it relies on 3rd-party cookies.</p>
       </div>
       <div class="signin">
         <a class="aui-button aui-button-default" href="{{ login_url }}" target="_blank">


### PR DESCRIPTION
Users often get stuck in login loops when trying to configure Jira as their browsers block 3rd party cookies. Unfortunately our integration setup relies on those. Hopefully by notifying users of that precondition more folks will be able to complete setup successfully.