### PR TITLE
fix(test) Use unittest where possible

### DIFF
--- a/tests/sentry/lang/javascript/test_cache.py
+++ b/tests/sentry/lang/javascript/test_cache.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
-from sentry.testutils import TestCase
 from sentry.lang.javascript.cache import SourceCache
+from unittest import TestCase
 
 
 class BasicCacheTest(TestCase):

--- a/tests/sentry/lang/javascript/test_errorlocale.py
+++ b/tests/sentry/lang/javascript/test_errorlocale.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, unicode_literals
 
 from copy import deepcopy
 
-from sentry.testutils import TestCase
 from sentry.lang.javascript.errorlocale import translate_message, translate_exception
+from unittest import TestCase
 
 
 class ErrorLocaleTest(TestCase):

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -4,6 +4,7 @@ import pytest
 import re
 import responses
 import six
+import unittest
 from symbolic import SourceMapTokenMatch
 
 from copy import deepcopy
@@ -319,7 +320,7 @@ class FetchFileTest(TestCase):
         assert exc.value.data['url'] == url
 
 
-class CacheControlTest(TestCase):
+class CacheControlTest(unittest.TestCase):
     def test_simple(self):
         headers = {'content-type': 'application/json', 'cache-control': 'max-age=120'}
         assert get_max_age(headers) == 120
@@ -361,7 +362,7 @@ class CacheControlTest(TestCase):
         assert get_max_age(headers) == CACHE_CONTROL_MIN
 
 
-class DiscoverSourcemapTest(TestCase):
+class DiscoverSourcemapTest(unittest.TestCase):
     # discover_sourcemap(result)
     def test_simple(self):
         result = http.UrlResult('http://example.com', {}, '', 200, None)
@@ -425,7 +426,7 @@ class DiscoverSourcemapTest(TestCase):
             discover_sourcemap(result)
 
 
-class GenerateModuleTest(TestCase):
+class GenerateModuleTest(unittest.TestCase):
     def test_simple(self):
         assert generate_module(None) == '<unknown module>'
         assert generate_module('http://example.com/foo.js') == 'foo'
@@ -512,7 +513,7 @@ class FetchSourcemapTest(TestCase):
             fetch_sourcemap('http://example.com')
 
 
-class TrimLineTest(TestCase):
+class TrimLineTest(unittest.TestCase):
     long_line = 'The public is more familiar with bad design than good design. It is, in effect, conditioned to prefer bad design, because that is what it lives with. The new becomes threatening, the old reassuring.'
 
     def test_simple(self):
@@ -534,7 +535,7 @@ class TrimLineTest(TestCase):
         ) == '{snip} gn. It is, in effect, conditioned to prefer bad design, because that is what it lives with. The new becomes threatening, the old reassuring.'
 
 
-class GenerateModulesTest(TestCase):
+class GenerateModulesTest(unittest.TestCase):
 
     def test_ensure_module_names(self):
         from sentry.lang.javascript.plugin import generate_modules
@@ -606,7 +607,7 @@ class GenerateModulesTest(TestCase):
         assert actual == expected
 
 
-class ErrorMappingTest(TestCase):
+class ErrorMappingTest(unittest.TestCase):
     @responses.activate
     def test_react_error_mapping_resolving(self):
         responses.add(

--- a/tests/sentry/lang/javascript/test_sourcemaps.py
+++ b/tests/sentry/lang/javascript/test_sourcemaps.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from symbolic import SourceMapView, SourceMapTokenMatch
-from sentry.testutils import TestCase
+from unittest import TestCase
 
 from sentry.utils import json
 


### PR DESCRIPTION
While looking into another issue I found a few test cases that can use unittest.TestCase as their base instead of sentry.testutils.TestCase. This gives a small speed bump as the database doesn't need to be reset on each test.