### PR TITLE
feat(events-v2) Rough in the events chart on events v2

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/events.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.jsx
@@ -30,6 +30,7 @@ export const doEventsRequest = (
     includePrevious,
     limit,
     query,
+    yAxis,
   }
 ) => {
   const shouldDoublePeriod = canIncludePreviousPeriod(includePrevious, period);
@@ -38,6 +39,7 @@ export const doEventsRequest = (
     project,
     environment,
     query,
+    yAxis,
   };
 
   // Doubling period for absolute dates is not accurate unless starting and

--- a/src/sentry/static/sentry/app/components/dropdownControl.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownControl.jsx
@@ -3,7 +3,9 @@ import React from 'react';
 
 import styled from 'react-emotion';
 import DropdownButton from 'app/components/dropdownButton';
+import MenuItem from 'app/components/menuItem';
 import DropdownMenu from 'app/components/dropdownMenu';
+import space from 'app/styles/space';
 
 /*
  * A higher level dropdown component that helps with building complete dropdowns
@@ -113,4 +115,24 @@ const MenuContainer = styled('ul')`
   display: ${p => (p.isOpen ? 'block' : 'none')};
 `;
 
+const DropdownItem = styled(MenuItem)`
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.gray2};
+
+  & a {
+    color: ${p => p.theme.foreground};
+    display: block;
+    padding: ${space(0.5)} ${space(2)};
+  }
+  & a:hover {
+    background: ${p => p.theme.offWhite};
+  }
+  &.active a,
+  &.active a:hover {
+    color: ${p => p.theme.white};
+    background: ${p => p.theme.purple};
+  }
+`;
+
 export default DropdownControl;
+export {DropdownItem};

--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
@@ -14,6 +14,7 @@ import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 
 import EventsRequest from './utils/eventsRequest';
+import YAxisSelector from './yAxisSelector';
 
 const DEFAULT_GET_CATEGORY = () => t('Events');
 
@@ -24,6 +25,7 @@ class EventsLineChart extends React.Component {
     releaseSeries: PropTypes.array,
     zoomRenderProps: PropTypes.object,
     timeseriesData: PropTypes.array,
+    showLegend: PropTypes.bool,
     previousTimeseriesData: PropTypes.object,
   };
 
@@ -50,13 +52,27 @@ class EventsLineChart extends React.Component {
       zoomRenderProps,
       timeseriesData,
       previousTimeseriesData,
+      showLegend,
       ...props
     } = this.props;
+
+    const legend = showLegend && {
+      right: 100,
+      top: 10,
+      selectedMode: false,
+      itemWidth: 15,
+      icon: 'line',
+      textStyle: {
+        lineHeight: 16,
+      },
+      data: ['Current Period', 'Previous Period'],
+    };
 
     return (
       <LineChart
         {...props}
         {...zoomRenderProps}
+        legend={legend}
         series={[...timeseriesData, ...releaseSeries]}
         seriesOptions={{
           showSymbol: false,
@@ -82,6 +98,16 @@ class EventsChart extends React.Component {
     end: PropTypes.instanceOf(Date),
     utc: PropTypes.bool,
     router: PropTypes.object,
+    showLegend: PropTypes.bool,
+    yAxisOptions: PropTypes.array,
+  };
+
+  state = {
+    yAxis: 'event_count',
+  };
+
+  handleYAxisChange = value => {
+    this.setState({yAxis: value});
   };
 
   render() {
@@ -95,6 +121,8 @@ class EventsChart extends React.Component {
       end,
       projects,
       environments,
+      showLegend,
+      yAxisOptions,
       ...props
     } = this.props;
     // Include previous only on relative dates (defaults to relative if no start and end)
@@ -123,6 +151,7 @@ class EventsChart extends React.Component {
             query={query}
             getCategory={DEFAULT_GET_CATEGORY}
             includePrevious={includePrevious}
+            yAxis={this.state.yAxis}
           >
             {({loading, reloading, timeseriesData, previousTimeseriesData}) => {
               return (
@@ -135,11 +164,19 @@ class EventsChart extends React.Component {
                     return (
                       <React.Fragment>
                         <TransparentLoadingMask visible={reloading} />
+                        {yAxisOptions && (
+                          <YAxisSelector
+                            selected={this.state.yAxis}
+                            options={yAxisOptions}
+                            onChange={this.handleYAxisChange}
+                          />
+                        )}
                         <EventsLineChart
                           {...zoomRenderProps}
                           loading={loading}
                           reloading={reloading}
                           utc={utc}
+                          showLegend={showLegend}
                           releaseSeries={releaseSeries}
                           timeseriesData={timeseriesData}
                           previousTimeseriesData={previousTimeseriesData}

--- a/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/utils/eventsRequest.jsx
@@ -84,10 +84,20 @@ class EventsRequest extends React.PureComponent {
      */
     timeAggregationSeriesName: PropTypes.string,
 
-    // Initial loading state
+    /**
+     * Initial loading state
+     */
     loading: PropTypes.bool,
 
+    /**
+     * Should loading be shown.
+     */
     showLoading: PropTypes.bool,
+
+    /**
+     * The yAxis being plotted
+     */
+    yAxis: PropTypes.string,
   };
 
   static defaultProps = {
@@ -229,7 +239,7 @@ class EventsRequest extends React.PureComponent {
   transformTimeseriesData = data => {
     return [
       {
-        seriesName: 'Events',
+        seriesName: 'Current Period',
         data: data.map(([timestamp, countsForTimestamp]) => ({
           name: timestamp * 1000,
           value: countsForTimestamp.reduce((acc, {count}) => acc + count, 0),

--- a/src/sentry/static/sentry/app/views/organizationEvents/yAxisSelector.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/yAxisSelector.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'react-emotion';
+import DropdownButton from 'app/components/dropdownButton';
+import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
+import space from 'app/styles/space';
+
+const YAxisSelector = props => {
+  const {options, onChange, selected} = props;
+  const selectedOption = options.find(opt => selected === opt.value);
+
+  return (
+    <Container>
+      <DropdownControl
+        menuOffset="29px"
+        button={({isOpen, getActorProps}) => (
+          <StyledDropdownButton
+            {...getActorProps({isStyled: true})}
+            size="zero"
+            isOpen={isOpen}
+          >
+            {selectedOption.label}
+          </StyledDropdownButton>
+        )}
+      >
+        {options.map(opt => (
+          <DropdownItem
+            key={opt.value}
+            onSelect={onChange}
+            eventKey={opt.value}
+            isActive={selected === opt.value}
+          >
+            {opt.label}
+          </DropdownItem>
+        ))}
+      </DropdownControl>
+    </Container>
+  );
+};
+
+const StyledDropdownButton = styled(
+  React.forwardRef((prop, ref) => <DropdownButton innerRef={ref} {...prop} />)
+)`
+  color: ${p => p.theme.gray2};
+  font-weight: normal;
+  height: ${space(4)};
+  padding: ${space(0.5)} ${space(1)};
+  background: ${p => p.theme.offWhite};
+  border-radius: ${p =>
+    p.isOpen
+      ? `0 ${p.theme.borderRadius} 0 0`
+      : `0 ${p.theme.borderRadius} 0 ${p.theme.borderRadius}`};
+`;
+
+const Container = styled('div')`
+  position: absolute;
+  /* compensate to have borders overlap */
+  top: -1px;
+  right: -1px;
+`;
+
+YAxisSelector.propTypes = {
+  options: PropTypes.array.isRequired,
+  onChange: PropTypes.func.isRequired,
+  selected: PropTypes.string,
+};
+
+export default YAxisSelector;

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {withRouter} from 'react-router';
 import styled from 'react-emotion';
 import SentryTypes from 'app/sentryTypes';
@@ -6,6 +7,8 @@ import space from 'app/styles/space';
 import SearchBar from 'app/views/organizationEvents/searchBar';
 import AsyncComponent from 'app/components/asyncComponent';
 import Pagination from 'app/components/pagination';
+import {Panel} from 'app/components/panels';
+import EventsChart from 'app/views/organizationEvents/eventsChart';
 
 import {getParams} from 'app/views/organizationEvents/utils/getParams';
 
@@ -15,8 +18,13 @@ import {getQuery} from './utils';
 
 class Events extends AsyncComponent {
   static propTypes = {
+    router: PropTypes.object,
     organization: SentryTypes.Organization.isRequired,
     view: SentryTypes.EventView.isRequired,
+  };
+
+  state = {
+    zoomed: false,
   };
 
   getEndpoints() {
@@ -43,17 +51,27 @@ class Events extends AsyncComponent {
     });
   };
 
+  handleZoom = () => this.setState({zoomed: true});
+
   renderLoading() {
     return this.renderBody();
   }
 
   renderBody() {
-    const {organization, view, location} = this.props;
+    const {organization, view, location, router} = this.props;
     const {data, dataPageLinks, loading} = this.state;
     const query = location.query.query || '';
 
     return (
-      <div>
+      <React.Fragment>
+        <Panel>
+          <EventsChart
+            router={router}
+            query={location.query.query}
+            organization={organization}
+            onZoom={this.handleZoom}
+          />
+        </Panel>
         <StyledSearchBar
           organization={organization}
           query={query}
@@ -71,7 +89,7 @@ class Events extends AsyncComponent {
           </div>
           <Tags view={view} />
         </Container>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
@@ -16,6 +16,11 @@ import Table from './table';
 import Tags from './tags';
 import {getQuery} from './utils';
 
+const CHART_AXIS_OPTIONS = [
+  {label: 'Count', value: 'event_count'},
+  {label: 'Users', value: 'user_count'},
+];
+
 class Events extends AsyncComponent {
   static propTypes = {
     router: PropTypes.object,
@@ -70,6 +75,8 @@ class Events extends AsyncComponent {
             query={location.query.query}
             organization={organization}
             onZoom={this.handleZoom}
+            showLegend
+            yAxisOptions={CHART_AXIS_OPTIONS}
           />
         </Panel>
         <StyledSearchBar

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
@@ -72,7 +72,7 @@ class Events extends AsyncComponent {
         <Panel>
           <EventsChart
             router={router}
-            query={location.query.query}
+            query={query}
             organization={organization}
             onZoom={this.handleZoom}
             showLegend

--- a/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/sortOptions.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
-import DropdownControl from 'app/components/dropdownControl';
-import MenuItem from 'app/components/menuItem';
+import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 
@@ -27,13 +26,13 @@ class SortOptions extends React.PureComponent {
 
   getMenuItem = key => {
     return (
-      <StyledMenuItem
+      <DropdownItem
         onSelect={this.onSelect}
         eventKey={key}
         isActive={this.state.sortKey === key}
       >
         {this.getSortLabel(key)}
-      </StyledMenuItem>
+      </DropdownItem>
     );
   };
 
@@ -86,23 +85,6 @@ const Container = styled('div')`
 const LabelText = styled('em')`
   font-style: normal;
   color: ${p => p.theme.gray2};
-`;
-
-const StyledMenuItem = styled(MenuItem)`
-  font-size: ${p => p.theme.fontSizeMedium};
-  & a {
-    color: ${p => p.theme.foreground};
-    display: block;
-    padding: ${space(0.5)} ${space(2)};
-  }
-  & a:hover {
-    background: ${p => p.theme.offWhite};
-  }
-  &.active a,
-  &.active a:hover {
-    color: ${p => p.theme.white};
-    background: ${p => p.theme.purple};
-  }
 `;
 
 export default SortOptions;

--- a/tests/js/spec/views/organizationEvents/eventsLineChart.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/eventsLineChart.spec.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import {Client} from 'app/api';
+import {EventsChart} from 'app/views/organizationEvents/eventsChart';
+import {mockZoomRange} from 'app-test/helpers/charts';
+import {initializeOrg} from 'app-test/helpers/initializeOrg';
+import {mount} from 'enzyme';
+
+describe('EventsChart > EventsLineChart', function() {
+  const {router, routerContext, org} = initializeOrg();
+  let wrapper;
+
+  beforeEach(function() {
+    mockZoomRange(1543449600000, 1543708800000);
+    Client.addMockResponse({
+      url: `/organizations/${org.slug}/events-stats/`,
+      method: 'GET',
+      body: {
+        data: [[1543449600, [20, 12]], [1543449601, [10, 5]]],
+      },
+    });
+
+    wrapper = mount(
+      <EventsChart
+        api={new MockApiClient()}
+        location={{query: {}}}
+        organization={org}
+        project={[]}
+        environment={[]}
+        period="14d"
+        start={null}
+        end={null}
+        utc={false}
+        router={router}
+        showLegend={true}
+      />,
+      routerContext
+    );
+  });
+
+  it('renders a legend if enabled', function() {
+    wrapper.update();
+
+    const lineChart = wrapper.find('LineChart');
+    expect(lineChart.props().legend).toHaveProperty('data');
+  });
+
+  it('responds to y-axis changes', function() {
+    const options = [
+      {label: 'users', value: 'user_count'},
+      {label: 'events', value: 'event_count'},
+    ];
+    wrapper.setProps({yAxisOptions: options});
+    wrapper.update();
+    const selector = wrapper.find('YAxisSelector');
+    expect(selector).toHaveLength(1);
+
+    // Open the selector
+    selector.find('StyledDropdownButton button').simulate('click');
+
+    // Click one of the options.
+    selector
+      .find('DropdownMenu MenuItem a')
+      .first()
+      .simulate('click');
+    wrapper.update();
+
+    const eventsRequest = wrapper.find('EventsRequest');
+    expect(eventsRequest.props().yAxis).toEqual('user_count');
+  });
+});


### PR DESCRIPTION
The API to fetch events by user count hasn't landed yet but this gets the ball rolling. I've adjusted the layout to match what it is the mockups as well.

<img width="1013" alt="Screen Shot 2019-05-24 at 3 49 18 PM" src="https://user-images.githubusercontent.com/24086/58353098-90432300-7e3b-11e9-8135-0721b91eff42.png">


Refs SEN-662