### PR TITLE
feat(events-v2): Implement aggregate counts on the events API

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -48,8 +48,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         except InvalidSearchQuery as exc:
             raise OrganizationEventsError(exc.message)
 
-        fields = request.GET.getlist('fields')[:]
-
+        fields = request.GET.getlist('field')[:]
         if fields:
             # If project.name is requested, get the project.id from Snuba so we
             # can use this to look up the name in Sentry
@@ -59,8 +58,10 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                     fields.append('project.id')
 
             snuba_args['selected_columns'] = fields
-        else:
-            raise OrganizationEventsError('No fields requested.')
+
+        aggregations = request.GET.getlist('aggregation')
+        if aggregations:
+            snuba_args['aggregations'] = [aggregation.split(',') for aggregation in aggregations]
 
         groupby = request.GET.getlist('groupby')
         if groupby:

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -98,7 +98,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             organization=organization,
             id__in=project_ids).values('id', 'slug')}
 
-        fields = request.GET.getlist('fields')
+        fields = request.GET.getlist('field')
 
         if 'project.name' in fields:
             for result in results:

--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -117,7 +117,7 @@ export const EventView = PropTypes.shape({
   data: PropTypes.shape({
     query: PropTypes.string.isRequired,
     fields: PropTypes.arrayOf(PropTypes.string).isRequired,
-    groupBy: PropTypes.arrayOf(PropTypes.string).isRequired,
+    groupby: PropTypes.arrayOf(PropTypes.string).isRequired,
     aggregations: PropTypes.arrayOf(PropTypes.array).isRequired,
     sort: PropTypes.string.isRequired,
   }).isRequired,

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -13,7 +13,7 @@ export const ALL_VIEWS = deepFreeze([
     data: {
       query: '',
       fields: ['event', 'event.type', 'project.name', 'user', 'time'],
-      groupBy: [],
+      groupby: [],
       aggregations: [],
       sort: '',
     },
@@ -31,9 +31,9 @@ export const ALL_VIEWS = deepFreeze([
     name: 'Errors',
     data: {
       query: '',
-      fields: ['project.name', 'fingerprint', 'count', 'user_count'],
-      groupBy: ['count', 'user_count', 'project.name'],
-      aggregations: [['count', null, 'count'], ['count', 'user', 'user_count']],
+      fields: [],
+      groupby: ['issue.id'],
+      aggregations: [['uniq', 'id', 'event_count'], ['uniq', 'user', 'user_count']],
       sort: '',
     },
     tags: ['error.type', 'project.name'],
@@ -43,9 +43,9 @@ export const ALL_VIEWS = deepFreeze([
     name: 'CSP',
     data: {
       query: '',
-      fields: ['project.name', 'count', 'user_count'],
-      groupBy: ['count', 'user_count', 'project.name'],
-      aggregations: [['count', null, 'count'], ['count', 'user', 'user_count']],
+      fields: [],
+      groupby: ['issue.id'],
+      aggregations: [['uniq', 'id', 'event_count'], ['uniq', 'user', 'user_count']],
       sort: '',
     },
     tags: [

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
@@ -28,7 +28,7 @@ export function getQuery(view) {
     return list;
   }, []);
 
-  data.fields = [...new Set(fields)];
+  data.field = [...new Set(fields)];
 
   return data;
 }

--- a/tests/js/spec/views/organizationEventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/utils.spec.jsx
@@ -26,7 +26,7 @@ describe('getQuery()', function() {
       tags: [],
     };
 
-    expect(getQuery(view).fields).toEqual([
+    expect(getQuery(view).field).toEqual([
       'title',
       'id',
       'project.name',


### PR DESCRIPTION
Support aggregations on the events API. Also renames `fields` -> `field` for
consistency and fixes typos with `groupBy` vs `groupby`.

Ref: SEN-666