### PR TITLE
feat(api): per-endpoint metric tags

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -151,6 +151,10 @@ class Endpoint(APIView):
         self.request = request
         self.headers = self.default_response_headers  # deprecate?
 
+        # Tags that will ultimately flow into the metrics backend at the end of
+        # the request (happens via middleware/stats.py).
+        request._metric_tags = {}
+
         if settings.SENTRY_API_RESPONSE_DELAY:
             time.sleep(settings.SENTRY_API_RESPONSE_DELAY / 1000.0)
 

--- a/src/sentry/api/endpoints/organization_sentry_apps.py
+++ b/src/sentry/api/endpoints/organization_sentry_apps.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import
 
-from sentry.api.bases import OrganizationEndpoint
+from sentry.api.bases import OrganizationEndpoint, add_integration_platform_metric_tag
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models import SentryApp
 
 
 class OrganizationSentryAppsEndpoint(OrganizationEndpoint):
+    @add_integration_platform_metric_tag
     def get(self, request, organization):
         queryset = SentryApp.objects.filter(
             owner=organization,

--- a/src/sentry/api/endpoints/sentry_app_components.py
+++ b/src/sentry/api/endpoints/sentry_app_components.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry.api.bases import OrganizationEndpoint, SentryAppBaseEndpoint
+from sentry.api.bases import (
+    OrganizationEndpoint, SentryAppBaseEndpoint, add_integration_platform_metric_tag,
+)
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.coreapi import APIError
@@ -21,6 +23,7 @@ class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
 
 
 class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
+    @add_integration_platform_metric_tag
     def get(self, request, organization):
         try:
             project = Project.objects.get(

--- a/src/sentry/testutils/helpers/faux.py
+++ b/src/sentry/testutils/helpers/faux.py
@@ -174,6 +174,12 @@ class Faux(object):
         return ', '.join(u'{}={!r}'.format(k, v) for k, v in six.iteritems(kwargs))
 
 
+class Mock(object):
+    def __init__(self, *args, **kwargs):
+        for k, v in six.iteritems(kwargs):
+            setattr(self, k, v)
+
+
 def faux(mock, call=None):
     if call is not None:
         return Faux(mock.mock_calls[call])

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.http import Http404
+from mock import patch
 
 from sentry.testutils import TestCase
 from sentry.api.bases.sentryapps import (
@@ -8,7 +9,9 @@ from sentry.api.bases.sentryapps import (
     SentryAppBaseEndpoint,
     SentryAppInstallationPermission,
     SentryAppInstallationBaseEndpoint,
+    add_integration_platform_metric_tag,
 )
+from sentry.testutils.helpers.faux import Mock
 
 
 class SentryAppPermissionTest(TestCase):
@@ -132,3 +135,21 @@ class SentryAppInstallationBaseEndpointTest(TestCase):
     def test_raises_when_sentry_app_not_found(self):
         with self.assertRaises(Http404):
             self.endpoint.convert_args(self.request, '1234')
+
+
+class AddIntegrationPlatformMetricTagTest(TestCase):
+    @patch('sentry.api.bases.sentryapps.add_request_metric_tags')
+    def test_record_platform_integration_metric(self, add_request_metric_tags):
+        @add_integration_platform_metric_tag
+        def get(self, request, *args, **kwargs):
+            pass
+
+        request = Mock()
+        endpoint = Mock(request=request)
+
+        get(endpoint, request)
+
+        add_request_metric_tags.assert_called_with(
+            request,
+            integration_platform=True,
+        )

--- a/tests/sentry/middleware/test_stats.py
+++ b/tests/sentry/middleware/test_stats.py
@@ -1,0 +1,75 @@
+from __future__ import absolute_import
+
+from django.test import RequestFactory
+from exam import fixture
+from mock import patch
+
+from sentry.middleware.stats import RequestTimingMiddleware, add_request_metric_tags
+from sentry.testutils import TestCase
+from sentry.testutils.helpers.faux import Mock
+
+
+class RequestTimingMiddlewareTest(TestCase):
+    middleware = fixture(RequestTimingMiddleware)
+    factory = fixture(RequestFactory)
+
+    @patch('sentry.utils.metrics.incr')
+    def test_records_default_api_metrics(self, incr):
+        request = self.factory.get('/')
+        request._view_path = '/'
+        response = Mock(status_code=200)
+
+        self.middleware.process_response(request, response)
+
+        incr.assert_called_with(
+            'view.response',
+            instance=request._view_path,
+            tags={
+                'method': 'GET',
+                'status_code': 200,
+            },
+            skip_internal=False,
+        )
+
+    @patch('sentry.utils.metrics.incr')
+    def test_records_endpoint_specific_metrics(self, incr):
+        request = self.factory.get('/')
+        request._view_path = '/'
+        request._metric_tags = {'a': 'b'}
+
+        response = Mock(status_code=200)
+
+        self.middleware.process_response(request, response)
+
+        incr.assert_called_with(
+            'view.response',
+            instance=request._view_path,
+            tags={
+                'method': 'GET',
+                'status_code': 200,
+                'a': 'b',
+            },
+            skip_internal=False,
+        )
+
+    @patch('sentry.utils.metrics.incr')
+    def test_add_request_metric_tags(self, incr):
+        request = self.factory.get('/')
+        request._view_path = '/'
+
+        add_request_metric_tags(request, foo='bar')
+
+        response = Mock(status_code=200)
+
+        self.middleware.process_response(request, response)
+
+        incr.assert_called_with(
+            'view.response',
+            instance=request._view_path,
+            tags={
+                'method': 'GET',
+                'status_code': 200,
+                'foo': 'bar',
+            },
+            skip_internal=False,
+        )


### PR DESCRIPTION
This allows endpoints to add tags to the resulting `view.response` metric that gets recorded in middleware.

The immediate use for this is to tag all Integration Platform endpoints with a corresponding tag so that we can easily group them together downstream in Datadog or whatever.