### PR TITLE
feat(api): Include related groups in `DetailedIncidentSerializer`

### DIFF
--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -11,6 +11,7 @@ from freezegun import freeze_time
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.incident import DetailedIncidentSerializer
 from sentry.incidents.logic import subscribe_to_incident
+from sentry.incidents.models import IncidentGroup
 from sentry.testutils import TestCase
 
 
@@ -46,3 +47,12 @@ class DetailedIncidentSerializerTest(TestCase):
         subscribe_to_incident(incident, self.user)
         result = serialize(incident, serializer=serializer, user=self.user)
         assert result['isSubscribed']
+
+    def test_groups(self):
+        incident = self.create_incident()
+        serializer = DetailedIncidentSerializer()
+        result = serialize(incident, serializer=serializer)
+        assert result['groups'] == []
+        IncidentGroup.objects.create(incident=incident, group=self.group)
+        result = serialize(incident, serializer=serializer)
+        assert result['groups'] == [self.group.id]


### PR DESCRIPTION
We need these for FE to be able to make event search queries.