### PR TITLE
feat(ui): Refresh Incidents activities and chart when status changes [SEN-683]

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/index.jsx
@@ -45,7 +45,15 @@ class ActivityContainer extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.incidentStatus !== this.props.incidentStatus) {
+    // Only refetch if incidentStatus changes.
+    //
+    // This component can mount before incident details is fully loaded.
+    // In which case, `incidentStatus` is null and we will be fetching via `cDM`
+    // There's no need to fetch this gets updated due to incident details being loaded
+    if (
+      prevProps.incidentStatus !== null &&
+      prevProps.incidentStatus !== this.props.incidentStatus
+    ) {
       this.fetchData();
     }
   }

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/index.jsx
@@ -24,9 +24,10 @@ function makeDefaultErrorJson() {
  * Allows user to leave a comment on an incidentId as well as
  * fetch and render existing activity items.
  */
-class ActivityContainer extends React.Component {
+class ActivityContainer extends React.PureComponent {
   static propTypes = {
     api: PropTypes.object.isRequired,
+    incidentStatus: PropTypes.number,
   };
 
   state = {
@@ -41,6 +42,12 @@ class ActivityContainer extends React.Component {
 
   componentDidMount() {
     this.fetchData();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.incidentStatus !== this.props.incidentStatus) {
+      this.fetchData();
+    }
   }
 
   async fetchData() {

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/index.jsx
@@ -73,8 +73,8 @@ class ActivityContainer extends React.Component {
       // This is passed as a key to NoteInput that re-mounts
       // (basically so we can reset text input to empty string)
       noteInputId: uniqueId(),
-      activities: [newActivity, ...(state.activities || [])],
       noteInputText: '',
+      activities: [newActivity, ...(state.activities || [])],
     }));
 
     try {

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
@@ -14,39 +14,22 @@ import theme from 'app/utils/theme';
 import Activity from './activity';
 import IncidentsSuspects from './suspects';
 
-const TABS = {
-  activity: {name: t('Activity'), component: Activity},
-};
-
 export default class DetailsBody extends React.Component {
   static propTypes = {
     incident: SentryTypes.Incident,
   };
-  constructor(props) {
-    super(props);
-    this.state = {
-      activeTab: Object.keys(TABS)[0],
-    };
-  }
-  handleToggle(tab) {
-    this.setState({activeTab: tab});
-  }
 
   render() {
     const {params, incident} = this.props;
-    const {activeTab} = this.state;
-    const ActiveComponent = TABS[activeTab].component;
 
     return (
       <StyledPageContent>
         <Main>
           <PageContent>
             <StyledNavTabs underlined={true}>
-              {Object.entries(TABS).map(([id, {name}]) => (
-                <li key={id} className={activeTab === id ? 'active' : ''}>
-                  <Link onClick={() => this.handleToggle(id)}>{name}</Link>
-                </li>
-              ))}
+              <li className="active">
+                <Link>{t('Activity')}</Link>
+              </li>
 
               <SeenByTab>
                 {incident && (
@@ -58,7 +41,7 @@ export default class DetailsBody extends React.Component {
                 )}
               </SeenByTab>
             </StyledNavTabs>
-            <ActiveComponent params={params} incident={incident} />
+            <Activity params={params} incidentStatus={incident && incident.status} />
           </PageContent>
         </Main>
         <Sidebar>

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
@@ -41,7 +41,10 @@ export default class DetailsBody extends React.Component {
                 )}
               </SeenByTab>
             </StyledNavTabs>
-            <Activity params={params} incidentStatus={incident && incident.status} />
+            <Activity
+              params={params}
+              incidentStatus={incident ? incident.status : null}
+            />
           </PageContent>
         </Main>
         <Sidebar>

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/chart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/chart.jsx
@@ -31,12 +31,13 @@ function getNearbyIndex(data, needle) {
   return index !== -1 ? index - 1 : data.length - 1;
 }
 
-export default class Chart extends React.Component {
+export default class Chart extends React.PureComponent {
   static propTypes = {
     data: PropTypes.arrayOf(PropTypes.number),
     detected: PropTypes.string,
     closed: PropTypes.string,
   };
+
   render() {
     const {data, detected, closed} = this.props;
 

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
@@ -85,13 +85,19 @@ class OrganizationIncidentDetails extends React.Component {
       incident: {...state.incident, status: newStatus},
     }));
 
-    updateStatus(api, orgId, incidentId, newStatus).catch(() => {
-      this.setState(state => ({
-        incident: {...state.incident, status},
-      }));
+    updateStatus(api, orgId, incidentId, newStatus)
+      .then(incident => {
+        // Update entire incident object because updating status can cause other parts
+        // of the model to change (e.g close date)
+        this.setState({incident});
+      })
+      .catch(() => {
+        this.setState(state => ({
+          incident: {...state.incident, status},
+        }));
 
-      addErrorMessage(t('An error occurred, your incident status was not changed.'));
-    });
+        addErrorMessage(t('An error occurred, your incident status was not changed.'));
+      });
   };
 
   render() {


### PR DESCRIPTION
Also adds some render optimizations when changing status

Fixes SEN-683


This depends on quite a few PRs, please review this commit range: https://github.com/getsentry/sentry/pull/13381/files/575a2f05eba205baa769b170fe19d7faf4f356b2..eecf88d7b2c035d87d5eb235e9d1c3f48ce4ef88