### PR TITLE
fix(ui) Make event chart tooltip color match line

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.jsx
@@ -271,6 +271,9 @@ class BaseChart extends React.Component {
                       color: theme.gray1,
                       type: 'dotted',
                     },
+                    itemStyle: {
+                      color: theme.gray1,
+                    },
                   })
                 ),
               ],


### PR DESCRIPTION
Presently the tooltip for previous period does not match the line colour used. Having them be the same makes the tooltip easier to understand and will allow the legend we want to add in v2 to match the line colour as well.

<img width="263" alt="Screen Shot 2019-05-24 at 10 47 57 AM" src="https://user-images.githubusercontent.com/24086/58336481-cbc8f780-7e11-11e9-9466-97935d51d1f6.png">

Refs SEN-662