### PR TITLE
feat(ui): Add header for chart in Incident details [SEN-696]

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
@@ -8,6 +8,7 @@ import Link from 'app/components/links/link';
 import NavTabs from 'app/components/navTabs';
 import SeenByList from 'app/components/seenByList';
 import SentryTypes from 'app/sentryTypes';
+import SideHeader from 'app/views/organizationIncidents/details/sideHeader';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 
@@ -63,6 +64,7 @@ export default class DetailsBody extends React.Component {
         </Main>
         <Sidebar>
           <PageContent>
+            <SideHeader>{t('Events in Incident')}</SideHeader>
             {incident && (
               <Chart
                 data={incident.eventStats.data}

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/sideHeader.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/sideHeader.jsx
@@ -1,0 +1,8 @@
+import styled from 'react-emotion';
+
+const SideHeader = styled('h6')`
+  color: ${p => p.theme.gray3};
+  font-weight: bold;
+  text-transform: uppercase;
+`;
+export default SideHeader;

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/suspects.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/suspects.jsx
@@ -4,6 +4,7 @@ import styled from 'react-emotion';
 
 import {Panel, PanelBody, PanelItem} from 'app/components/panels';
 import {t} from 'app/locale';
+import SideHeader from 'app/views/organizationIncidents/details/sideHeader';
 import space from 'app/styles/space';
 
 export default class Suspects extends React.Component {
@@ -21,7 +22,7 @@ export default class Suspects extends React.Component {
 
     return (
       <Container>
-        <h6>{t('Suspects')}</h6>
+        <SideHeader>{t('Suspects')}</SideHeader>
         {suspects && suspects.length > 0 && (
           <Panel>
             <PanelBody>


### PR DESCRIPTION
Adds a consistent header to the side content of Incident details.

![image](https://user-images.githubusercontent.com/79684/58355080-1bb2b900-7e28-11e9-886c-1e05a24f99ac.png)

Fixes SEN-696