### PR TITLE
fix(onboarding): Pass full organization to FirstEventIndicator

### DIFF
--- a/src/sentry/static/sentry/app/views/onboarding/projectSetup/eventWaiter.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/projectSetup/eventWaiter.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import {analytics} from 'app/utils/analytics';
 import SentryTypes from 'app/sentryTypes';
 import withApi from 'app/utils/withApi';
-import withOrganization from 'app/utils/withOrganization';
 
 const DEFAULT_POLL_INTERVAL = 5000;
 
@@ -105,4 +104,4 @@ class EventWaiter extends React.Component {
   }
 }
 
-export default withApi(withOrganization(EventWaiter));
+export default withApi(EventWaiter);

--- a/src/sentry/static/sentry/app/views/onboarding/projectSetup/firstEventIndicator.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/projectSetup/firstEventIndicator.jsx
@@ -40,7 +40,7 @@ const Waiting = props => (
   </StatusWrapper>
 );
 
-const Success = ({orgId, firstIssue, ...props}) => (
+const Success = ({organization, firstIssue, ...props}) => (
   <StatusWrapper {...props}>
     <ReceivedIndicator src="icon-checkmark-sm" />
     <PosedText>{t('First event was received!')}</PosedText>
@@ -48,7 +48,7 @@ const Success = ({orgId, firstIssue, ...props}) => (
       <PosedButton
         size="small"
         priority="primary"
-        to={`/organizations/${orgId}/issues/${firstIssue.id}/`}
+        to={`/organizations/${organization.slug}/issues/${firstIssue.id}/`}
       >
         {t('Take me to my event')}
       </PosedButton>

--- a/tests/js/spec/views/onboarding/projectSetup/firstEventIndicator.spec.jsx
+++ b/tests/js/spec/views/onboarding/projectSetup/firstEventIndicator.spec.jsx
@@ -8,7 +8,7 @@ describe('FirstEventIndicator', function() {
     const org = TestStubs.Organization();
 
     const wrapper = mount(
-      <Indicator orgId={org.slug} firstIssue={null} />,
+      <Indicator organization={org} firstIssue={null} />,
       TestStubs.routerContext()
     );
 
@@ -20,7 +20,7 @@ describe('FirstEventIndicator', function() {
       const org = TestStubs.Organization();
 
       const wrapper = mount(
-        <Indicator orgId={org.slug} firstIssue={{id: 1}} />,
+        <Indicator organization={org} firstIssue={{id: 1}} />,
         TestStubs.routerContext()
       );
 


### PR DESCRIPTION
This makes a bit more sense and is how the projectDocs were using it already.