### PR TITLE
chore: Vendor JSONField to fix runtime warnings and reduce future upgrade pain

### DIFF
--- a/src/sentry/db/models/fields/__init__.py
+++ b/src/sentry/db/models/fields/__init__.py
@@ -13,6 +13,7 @@ from .bounded import *  # NOQA
 from .citext import *  # NOQA
 from .encrypted import *  # NOQA
 from .foreignkey import *  # NOQA
+from .jsonfield import *  # NOQA
 from .gzippeddict import *  # NOQA
 from .node import *  # NOQA
 from .pickle import *  # NOQA

--- a/src/sentry/db/models/fields/encrypted.py
+++ b/src/sentry/db/models/fields/encrypted.py
@@ -8,8 +8,8 @@ import six
 
 from django.conf import settings
 from django.db.models import CharField, TextField
-from jsonfield import JSONField
 from picklefield.fields import PickledObjectField
+from sentry.db.models.fields.jsonfield import JSONField
 from sentry.db.models.utils import Creator
 from sentry.utils.encryption import decrypt, encrypt
 

--- a/src/sentry/db/models/fields/jsonfield.py
+++ b/src/sentry/db/models/fields/jsonfield.py
@@ -1,0 +1,189 @@
+from __future__ import absolute_import, unicode_literals
+import json
+import datetime
+import six
+
+from decimal import Decimal
+
+from django.core.exceptions import ValidationError
+from django.conf import settings
+from django.db import models, DatabaseError, transaction
+from django.utils.translation import ugettext_lazy as _
+from django.core.cache import cache
+
+__version__ = '0.9.13'
+
+DB_TYPE_CACHE_KEY = (
+    'django-jsonfield:db-type:%s' % __version__ +
+    '%(ENGINE)s:%(HOST)s:%(PORT)s:%(NAME)s'
+)
+
+
+def default(o):
+    if hasattr(o, 'to_json'):
+        return o.to_json()
+    if isinstance(o, Decimal):
+        return six.text_type(o)
+    if isinstance(o, datetime.datetime):
+        if o.tzinfo:
+            return o.strftime('%Y-%m-%dT%H:%M:%S%z')
+        return o.strftime("%Y-%m-%dT%H:%M:%S")
+    if isinstance(o, datetime.date):
+        return o.strftime("%Y-%m-%d")
+    if isinstance(o, datetime.time):
+        if o.tzinfo:
+            return o.strftime('%H:%M:%S%z')
+        return o.strftime("%H:%M:%S")
+
+    raise TypeError(repr(o) + " is not JSON serializable")
+
+
+class JSONField(six.with_metaclass(models.SubfieldBase, models.Field)):
+    """
+    A field that will ensure the data entered into it is valid JSON.
+    """
+    default_error_messages = {
+        'invalid': _("'%s' is not a valid JSON string.")
+    }
+    description = "JSON object"
+
+    def __init__(self, *args, **kwargs):
+        if not kwargs.get('null', False):
+            kwargs['default'] = kwargs.get('default', dict)
+        self.encoder_kwargs = {
+            'indent': kwargs.pop('indent', getattr(settings, 'JSONFIELD_INDENT', None))
+        }
+        super(JSONField, self).__init__(*args, **kwargs)
+        self.validate(self.get_default(), None)
+
+    def validate(self, value, model_instance):
+        if not self.null and value is None:
+            raise ValidationError(self.error_messages['null'])
+        try:
+            self.get_prep_value(value)
+        except BaseException:
+            raise ValidationError(self.error_messages['invalid'] % value)
+
+    def get_default(self):
+        if self.has_default():
+            default = self.default
+            if callable(default):
+                default = default()
+            if isinstance(default, six.string_types):
+                return json.loads(default)
+            return json.loads(json.dumps(default))
+        return super(JSONField, self).get_default()
+
+    def get_internal_type(self):
+        return 'TextField'
+
+    def db_type(self, connection):
+        cache_key = DB_TYPE_CACHE_KEY % connection.settings_dict
+        db_type = cache.get(cache_key)
+
+        if not db_type:
+            # Test to see if we support JSON querying.
+            cursor = connection.cursor()
+            try:
+                sid = transaction.savepoint(using=connection.alias)
+                cursor.execute('SELECT \'{}\'::json = \'{}\'::json;')
+            except DatabaseError:
+                transaction.savepoint_rollback(sid, using=connection.alias)
+                db_type = 'text'
+            else:
+                db_type = 'json'
+            cache.set(cache_key, db_type)
+
+        return db_type
+
+    def to_python(self, value):
+        if isinstance(value, six.string_types):
+            if value == "":
+                if self.null:
+                    return None
+                if self.blank:
+                    return ""
+            try:
+                value = json.loads(value)
+            except ValueError:
+                msg = self.error_messages['invalid'] % value
+                raise ValidationError(msg)
+        # TODO: Look for date/time/datetime objects within the structure?
+        return value
+
+    def get_db_prep_value(self, value, connection=None, prepared=None):
+        return self.get_prep_value(value)
+
+    def get_prep_value(self, value):
+        if value is None:
+            if not self.null and self.blank:
+                return ""
+            return None
+        return json.dumps(value, default=default, **self.encoder_kwargs)
+
+    def get_prep_lookup(self, lookup_type, value):
+        if lookup_type in ["exact", "iexact"]:
+            return self.to_python(self.get_prep_value(value))
+        if lookup_type == "in":
+            return [self.to_python(self.get_prep_value(v)) for v in value]
+        if lookup_type == "isnull":
+            return value
+        if lookup_type in ["contains", "icontains"]:
+            if isinstance(value, (list, tuple)):
+                raise TypeError("Lookup type %r not supported with argument of %s" % (
+                    lookup_type, type(value).__name__
+                ))
+                # Need a way co combine the values with '%', but don't escape that.
+                return self.get_prep_value(value)[1:-1].replace(', ', r'%')
+            if isinstance(value, dict):
+                return self.get_prep_value(value)[1:-1]
+            return self.to_python(self.get_prep_value(value))
+        raise TypeError('Lookup type %r not supported' % lookup_type)
+
+    def value_to_string(self, obj):
+        return self._get_val_from_obj(obj)
+
+
+class TypedJSONField(JSONField):
+    """
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.json_required_fields = kwargs.pop('required_fields', {})
+        self.json_validators = kwargs.pop('validators', [])
+
+        super(TypedJSONField, self).__init__(*args, **kwargs)
+
+    def cast_required_fields(self, obj):
+        if not obj:
+            return
+        for field_name, field_type in self.json_required_fields.items():
+            obj[field_name] = field_type.to_python(obj[field_name])
+
+    def to_python(self, value):
+        value = super(TypedJSONField, self).to_python(value)
+
+        if isinstance(value, list):
+            for item in value:
+                self.cast_required_fields(item)
+        else:
+            self.cast_required_fields(value)
+
+        return value
+
+    def validate(self, value, model_instance):
+        super(TypedJSONField, self).validate(value, model_instance)
+
+        for v in self.json_validators:
+            if isinstance(value, list):
+                for item in value:
+                    v(item)
+            else:
+                v(value)
+
+
+if 'south' in settings.INSTALLED_APPS:
+    from south.modelsinspector import add_introspection_rules
+    add_introspection_rules([], ['^jsonfield\.fields\.JSONField'])
+    add_introspection_rules([], ['^jsonfield\.fields\.TypedJSONField'])

--- a/src/sentry/models/discoversavedquery.py
+++ b/src/sentry/models/discoversavedquery.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from django.db import models, transaction
-from jsonfield import JSONField
+from sentry.db.models.fields import JSONField
 from sentry.db.models import (
     Model, FlexibleForeignKey, sane_repr
 )

--- a/src/sentry/models/externalissue.py
+++ b/src/sentry/models/externalissue.py
@@ -2,9 +2,13 @@ from __future__ import absolute_import, print_function
 
 from django.db import models
 from django.utils import timezone
-from jsonfield import JSONField
 
-from sentry.db.models import BoundedPositiveIntegerField, Model, sane_repr
+from sentry.db.models import (
+    BoundedPositiveIntegerField,
+    JSONField,
+    Model,
+    sane_repr
+)
 
 
 class ExternalIssue(Model):

--- a/src/sentry/models/featureadoption.py
+++ b/src/sentry/models/featureadoption.py
@@ -4,11 +4,16 @@ import logging
 
 from django.db import models, IntegrityError, transaction
 from django.utils import timezone
-from jsonfield import JSONField
 
 from sentry.adoption import manager
 from sentry.adoption.manager import UnknownFeature
-from sentry.db.models import (BaseManager, FlexibleForeignKey, Model, sane_repr)
+from sentry.db.models import (
+    BaseManager,
+    FlexibleForeignKey,
+    JSONField,
+    Model,
+    sane_repr
+)
 from sentry.utils import redis
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -25,10 +25,14 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import get_storage_class
 from django.db import models, transaction, IntegrityError
 from django.utils import timezone
-from jsonfield import JSONField
 
 from sentry.app import locks
-from sentry.db.models import (BoundedPositiveIntegerField, FlexibleForeignKey, Model)
+from sentry.db.models import (
+    BoundedPositiveIntegerField,
+    FlexibleForeignKey,
+    JSONField,
+    Model
+)
 from sentry.tasks.files import delete_file as delete_file_task
 from sentry.utils import metrics
 from sentry.utils.retries import TimedRetryPolicy

--- a/src/sentry/models/grouplink.py
+++ b/src/sentry/models/grouplink.py
@@ -10,9 +10,14 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
-from jsonfield import JSONField
 
-from sentry.db.models import Model, sane_repr, BoundedBigIntegerField, BoundedPositiveIntegerField
+from sentry.db.models import (
+    Model,
+    sane_repr,
+    BoundedBigIntegerField,
+    BoundedPositiveIntegerField,
+    JSONField,
+)
 
 
 class GroupLink(Model):

--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -4,10 +4,14 @@ from datetime import timedelta
 
 from django.db import models
 from django.utils import timezone
-from jsonfield import JSONField
 
 from sentry.db.models import (
-    BaseManager, BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
+    BaseManager,
+    BoundedPositiveIntegerField,
+    FlexibleForeignKey,
+    JSONField,
+    Model,
+    sane_repr
 )
 
 

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -11,10 +11,10 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import models, IntegrityError, transaction
 from django.utils import timezone
-from jsonfield import JSONField
 
 from sentry.db.models import (
-    BaseManager, BoundedBigIntegerField, BoundedPositiveIntegerField, FlexibleForeignKey, Model,
+    BaseManager, BoundedBigIntegerField, BoundedPositiveIntegerField,
+    FlexibleForeignKey, JSONField, Model,
     sane_repr
 )
 

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -14,7 +14,6 @@ import re
 from bitfield import BitField
 from uuid import uuid4
 
-from jsonfield import JSONField
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.db import models
@@ -24,7 +23,12 @@ from six.moves.urllib.parse import urlparse
 
 from sentry import options
 from sentry.db.models import (
-    Model, BaseManager, BoundedPositiveIntegerField, FlexibleForeignKey, sane_repr
+    Model,
+    BaseManager,
+    BoundedPositiveIntegerField,
+    FlexibleForeignKey,
+    JSONField,
+    sane_repr
 )
 
 _uuid4_re = re.compile(r'^[a-f0-9]{32}$')

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -2,14 +2,13 @@ from __future__ import absolute_import
 
 import operator
 
-from jsonfield import JSONField
 
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 
 from sentry.db.models import Model, sane_repr
-from sentry.db.models.fields import FlexibleForeignKey
+from sentry.db.models.fields import FlexibleForeignKey, JSONField
 from sentry.ownership.grammar import load_schema
 from functools import reduce
 

--- a/src/sentry/models/prompts_activity.py
+++ b/src/sentry/models/prompts_activity.py
@@ -3,9 +3,14 @@ from __future__ import absolute_import, print_function
 from django.db import models
 from django.conf import settings
 from django.utils import timezone
-from jsonfield import JSONField
 
-from sentry.db.models import (BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr)
+from sentry.db.models import (
+    BoundedPositiveIntegerField,
+    FlexibleForeignKey,
+    JSONField,
+    Model,
+    sane_repr
+)
 
 
 class PromptsActivity(Model):

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -15,12 +15,12 @@ import itertools
 from django.db import models, IntegrityError, transaction
 from django.db.models import F
 from django.utils import timezone
-from jsonfield import JSONField
 from time import time
 
 from sentry.app import locks
 from sentry.db.models import (
-    ArrayField, BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
+    ArrayField, BoundedPositiveIntegerField, FlexibleForeignKey,
+    JSONField, Model, sane_repr
 )
 
 from sentry.models import CommitFileChange

--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -3,10 +3,14 @@ from __future__ import absolute_import, print_function
 from django.db import models
 from django.db.models.signals import pre_delete
 from django.utils import timezone
-from jsonfield import JSONField
 
 from sentry.constants import ObjectStatus
-from sentry.db.models import (BoundedPositiveIntegerField, Model, sane_repr)
+from sentry.db.models import (
+    BoundedPositiveIntegerField,
+    JSONField,
+    Model,
+    sane_repr
+)
 from sentry.db.mixin import PendingDeletionMixin, delete_pending_deletion_option
 from sentry.signals import pending_delete
 

--- a/src/sentry/models/scheduledeletion.py
+++ b/src/sentry/models/scheduledeletion.py
@@ -4,10 +4,13 @@ from datetime import timedelta
 from django.db import models
 from django.db.models import get_model
 from django.utils import timezone
-from jsonfield import JSONField
 from uuid import uuid4
 
-from sentry.db.models import BoundedBigIntegerField, Model
+from sentry.db.models import (
+    BoundedBigIntegerField,
+    JSONField,
+    Model
+)
 
 
 def default_guid():

--- a/src/sentry/models/scheduledjob.py
+++ b/src/sentry/models/scheduledjob.py
@@ -2,9 +2,8 @@ from __future__ import absolute_import, print_function
 
 from django.db import models
 from django.utils import timezone
-from jsonfield import JSONField
 
-from sentry.db.models import (Model, sane_repr)
+from sentry.db.models import (JSONField, Model, sane_repr)
 
 
 def schedule_jobs(jobs):

--- a/src/sentry/models/widget.py
+++ b/src/sentry/models/widget.py
@@ -2,10 +2,15 @@ from __future__ import absolute_import, print_function
 
 from django.db import models
 from django.utils import timezone
-from jsonfield import JSONField
 
 from sentry.constants import ObjectStatus
-from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
+from sentry.db.models import (
+    BoundedPositiveIntegerField,
+    FlexibleForeignKey,
+    JSONField,
+    Model,
+    sane_repr
+)
 
 
 class TypesClass(object):

--- a/tests/sentry/db/models/fields/__init__.py
+++ b/tests/sentry/db/models/fields/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/db/models/fields/test_jsonfield.py
+++ b/tests/sentry/db/models/fields/test_jsonfield.py
@@ -1,0 +1,192 @@
+from __future__ import absolute_import
+
+from django.utils.encoding import force_text
+from django import forms
+from django.db import models
+
+from sentry.db.models.fields.jsonfield import JSONField
+from sentry.testutils import TestCase
+
+
+class JSONFieldTestModel(models.Model):
+    json = JSONField("test", null=True, blank=True)
+
+    class Meta:
+        app_label = 'sentry'
+
+
+class JSONFieldWithDefaultTestModel(models.Model):
+    json = JSONField(default={"sukasuka": "YAAAAAZ"})
+
+    class Meta:
+        app_label = 'sentry'
+
+
+class BlankJSONFieldTestModel(models.Model):
+    null_json = JSONField(null=True)
+    blank_json = JSONField(blank=True)
+
+    class Meta:
+        app_label = 'sentry'
+
+
+class CallableDefaultModel(models.Model):
+    json = JSONField(default=lambda: {'x': 2})
+
+    class Meta:
+        app_label = 'sentry'
+
+
+class JSONFieldTest(TestCase):
+    def test_json_field(self):
+        obj = JSONFieldTestModel(json='''{
+            "spam": "eggs"
+        }''')
+        self.assertEqual(obj.json, {'spam': 'eggs'})
+
+    def test_json_field_empty(self):
+        obj = JSONFieldTestModel(json='')
+        self.assertEqual(obj.json, None)
+
+    def test_json_field_save(self):
+        JSONFieldTestModel.objects.create(
+            id=10,
+            json='''{
+                "spam": "eggs"
+            }''',
+        )
+        obj2 = JSONFieldTestModel.objects.get(id=10)
+        self.assertEqual(obj2.json, {'spam': 'eggs'})
+
+    def test_json_field_save_empty(self):
+        JSONFieldTestModel.objects.create(id=10, json='')
+        obj2 = JSONFieldTestModel.objects.get(id=10)
+        self.assertEqual(obj2.json, None)
+
+    def test_db_prep_save(self):
+        field = JSONField("test")
+        field.set_attributes_from_name("json")
+        self.assertEqual(None, field.get_db_prep_save(None, connection=None))
+        self.assertEqual('{"spam": "eggs"}', field.get_db_prep_save(
+            {"spam": "eggs"}, connection=None))
+
+    def test_formfield(self):
+        field = JSONField("test")
+        field.set_attributes_from_name("json")
+        formfield = field.formfield()
+
+        self.assertEqual(type(formfield), forms.CharField)
+        self.assertEqual(type(formfield.widget), forms.Textarea)
+
+    def test_formfield_clean_blank(self):
+        field = JSONField("test")
+        formfield = field.formfield()
+        self.assertRaisesMessage(
+            forms.ValidationError,
+            force_text(formfield.error_messages['required']),
+            formfield.clean,
+            value='')
+
+    def test_formfield_clean_none(self):
+        field = JSONField("test")
+        formfield = field.formfield()
+        self.assertRaisesMessage(
+            forms.ValidationError,
+            force_text(formfield.error_messages['required']),
+            formfield.clean,
+            value=None)
+
+    def test_formfield_null_and_blank_clean_blank(self):
+        field = JSONField("test", null=True, blank=True)
+        formfield = field.formfield()
+        self.assertEqual(formfield.clean(value=''), '')
+
+    def test_formfield_blank_clean_blank(self):
+        field = JSONField("test", null=False, blank=True)
+        formfield = field.formfield()
+        self.assertEqual(formfield.clean(value=''), '')
+
+    def test_default_value(self):
+        obj = JSONFieldWithDefaultTestModel.objects.create()
+        obj = JSONFieldWithDefaultTestModel.objects.get(id=obj.id)
+        self.assertEqual(obj.json, {'sukasuka': 'YAAAAAZ'})
+
+    def test_query_object(self):
+        JSONFieldTestModel.objects.create(json={})
+        JSONFieldTestModel.objects.create(json={'foo': 'bar'})
+        self.assertEqual(2, JSONFieldTestModel.objects.all().count())
+        self.assertEqual(1, JSONFieldTestModel.objects.exclude(json={}).count())
+        self.assertEqual(1, JSONFieldTestModel.objects.filter(json={}).count())
+        self.assertEqual(1, JSONFieldTestModel.objects.filter(json={'foo': 'bar'}).count())
+        self.assertEqual(
+            1, JSONFieldTestModel.objects.filter(
+                json__contains={
+                    'foo': 'bar'}).count())
+        JSONFieldTestModel.objects.create(json={'foo': 'bar', 'baz': 'bing'})
+        self.assertEqual(
+            2, JSONFieldTestModel.objects.filter(
+                json__contains={
+                    'foo': 'bar'}).count())
+        # This next one is a bit hard to do without proper lookups, which I'm unlikely to implement.
+        # self.assertEqual(1, JSONFieldTestModel.objects.filter(json__contains={'baz':'bing', 'foo':'bar'}).count())
+        self.assertEqual(2, JSONFieldTestModel.objects.filter(json__contains='foo').count())
+        # This code needs to be implemented!
+        self.assertRaises(
+            TypeError,
+            lambda: JSONFieldTestModel.objects.filter(
+                json__contains=[
+                    'baz',
+                    'foo']))
+
+    def test_query_isnull(self):
+        JSONFieldTestModel.objects.create(json=None)
+        JSONFieldTestModel.objects.create(json={})
+        JSONFieldTestModel.objects.create(json={'foo': 'bar'})
+
+        self.assertEqual(1, JSONFieldTestModel.objects.filter(json=None).count())
+        self.assertEqual(None, JSONFieldTestModel.objects.get(json=None).json)
+
+    def test_jsonfield_blank(self):
+        BlankJSONFieldTestModel.objects.create(blank_json='', null_json=None)
+        obj = BlankJSONFieldTestModel.objects.get()
+        self.assertEqual(None, obj.null_json)
+        self.assertEqual("", obj.blank_json)
+        obj.save()
+        obj = BlankJSONFieldTestModel.objects.get()
+        self.assertEqual(None, obj.null_json)
+        self.assertEqual("", obj.blank_json)
+
+    def test_callable_default(self):
+        CallableDefaultModel.objects.create()
+        obj = CallableDefaultModel.objects.get()
+        self.assertEqual({'x': 2}, obj.json)
+
+    def test_callable_default_overridden(self):
+        CallableDefaultModel.objects.create(json={'x': 3})
+        obj = CallableDefaultModel.objects.get()
+        self.assertEqual({'x': 3}, obj.json)
+
+    def test_mutable_default_checking(self):
+        obj1 = JSONFieldWithDefaultTestModel()
+        obj2 = JSONFieldWithDefaultTestModel()
+
+        obj1.json['foo'] = 'bar'
+        self.assertNotIn('foo', obj2.json)
+
+    def test_invalid_json(self):
+        obj = JSONFieldTestModel()
+        obj.json = '{"foo": 2}'
+        self.assertIn('foo', obj.json)
+        with self.assertRaises(forms.ValidationError):
+            obj.json = '{"foo"}'
+
+    def test_invalid_json_default(self):
+        with self.assertRaises(ValueError):
+            JSONField('test', default='{"foo"}')
+
+
+class SavingModelsTest(TestCase):
+    def test_saving_null(self):
+        obj = BlankJSONFieldTestModel.objects.create(blank_json='', null_json=None)
+        self.assertEqual('', obj.blank_json)
+        self.assertEqual(None, obj.null_json)


### PR DESCRIPTION
The packaged version of this library contains metaclass warnings in Django1.8. We could upgrade but newer versions of the library are unwilling to serialize datetimes and decimal objects. Vendoring the library will allow us to maintain compatibility for our use cases and upgrade django at the same time.

Refs SEN-686