### PR TITLE
feat(api): Send emails to incident subscribers when someone comments, or on status changes (SEN-655)

### DIFF
--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -1,0 +1,70 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.incidents.models import (
+    IncidentActivity,
+    IncidentActivityType,
+    IncidentStatus,
+)
+from sentry.tasks.base import instrumented_task
+from sentry.utils.email import MessageBuilder
+from sentry.utils.http import absolute_uri
+
+
+@instrumented_task(name='sentry.incidents.tasks.send_subscriber_notifications')
+def send_subscriber_notifications(activity_id):
+    from sentry.incidents.logic import get_incident_subscribers
+    try:
+        activity = IncidentActivity.objects.select_related(
+            'incident',
+            'user',
+            'incident__organization',
+        ).get(
+            id=activity_id,
+        )
+    except IncidentActivity.DoesNotExist:
+        return
+
+    subscribers = get_incident_subscribers(activity.incident).select_related('user')
+    msg = generate_incident_activity_email(activity)
+    msg.send_async([sub.user.email for sub in subscribers if sub.user != activity.user])
+
+
+def generate_incident_activity_email(activity):
+    incident = activity.incident
+    return MessageBuilder(
+        subject=u'Activity on Incident {} (#{})'.format(incident.title, incident.identifier),
+        template=u'sentry/emails/incidents/activity.txt',
+        html_template=u'sentry/emails/incidents/activity.html',
+        type='incident.activity',
+        context=build_activity_context(activity),
+    )
+
+
+def build_activity_context(activity):
+    if activity.type == IncidentActivityType.COMMENT.value:
+        action = 'left a comment'
+    else:
+        action = 'changed status from %s to %s' % (
+            IncidentStatus(int(activity.previous_value)).name.lower(),
+            IncidentStatus(int(activity.value)).name.lower(),
+        )
+    incident = activity.incident
+
+    action = '%s on incident %s (#%s)' % (action, incident.title, incident.identifier)
+
+    return {
+        'user_name': activity.user.name if activity.user else 'Sentry',
+        'action': action,
+        'link': absolute_uri(reverse(
+            'sentry-incident',
+            kwargs={
+                'organization_slug': incident.organization.slug,
+                'incident_id': incident.identifier,
+            },
+        )),
+        'comment': activity.comment,
+        # TODO: Build unsubscribe page and link to it
+        'unsubscribe_link': '',
+    }

--- a/src/sentry/templates/sentry/emails/incidents/activity.html
+++ b/src/sentry/templates/sentry/emails/incidents/activity.html
@@ -1,0 +1,33 @@
+{% extends "sentry/emails/activity/generic.html" %}
+
+{% load sentry_avatars %}
+{% load sentry_helpers %}
+{% load sentry_assets %}
+
+{% block activity %}
+  <h3>{{ user_name }} {{ action }}</h3>
+
+  {% if enhanced_privacy %}
+    <div class="notice">
+      Details about this activity are not shown in this email since enhanced privacy
+      controls are enabled. For more details about this activity, <a href="{{ link }}">view on Sentry.</a>
+    </div>
+
+  {% else %}
+    {% if comment %}
+      <table class="note">
+        <tr>
+          <td class="avatar-column">
+            {% email_avatar user_name user_email size 48 %}
+          </td>
+          <td class="notch-column">
+            <img width="7" height="48" src="{% absolute_asset_url 'sentry' 'images/email/avatar-notch.png' %}">
+          </td>
+          <td>
+            <div class="note-body">{{ comment|urlize|linebreaks }}</div>
+          </td>
+        </tr>
+      </table>
+    {% endif %}
+  {% endif %}
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/incidents/activity.txt
+++ b/src/sentry/templates/sentry/emails/incidents/activity.txt
@@ -1,0 +1,22 @@
+{% spaceless %}
+{% autoescape off %}
+# New Incident Activity
+
+{{ user_name }} {{ action }}:
+{% if enhanced_privacy %}
+Details about this activity are not shown in this email since enhanced privacy
+controls are enabled. For more details about this activity, view on Sentry:
+{{ link }}.
+{% else %}
+Incident: {{ link }}
+{% if comment %}
+Comment Details:
+{{ comment }}
+{% endif %}
+
+{% endif %}
+
+Unsubscribe: {{ unsubscribe_link }}
+
+{% endautoescape %}
+{% endspaceless %}

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -10,6 +10,7 @@ from sentry.web.frontend.debug.debug_assigned_email import (
 )
 from sentry.web.frontend.debug.debug_trigger_error import (DebugTriggerErrorView)
 from sentry.web.frontend.debug.debug_error_embed import (DebugErrorPageEmbedView)
+from sentry.web.frontend.debug.debug_incident_activity_email import DebugIncidentActivityEmailView
 from sentry.web.frontend.debug.debug_invalid_identity_email import DebugInvalidIdentityEmailView
 from sentry.web.frontend.debug.debug_mfa_added_email import (DebugMfaAddedEmailView)
 from sentry.web.frontend.debug.debug_mfa_removed_email import (DebugMfaRemovedEmailView)
@@ -87,7 +88,7 @@ urlpatterns = patterns(
     url(r'^debug/mail/sso-linked/$', DebugSsoLinkedEmailView.as_view()),
     url(r'^debug/mail/sso-unlinked/$', DebugSsoUnlinkedEmailView.as_view()),
     url(r'^debug/mail/sso-unlinked/no-password$', DebugSsoUnlinkedNoPasswordEmailView.as_view()),
-
+    url(r'^debug/mail/incident-activity$', DebugIncidentActivityEmailView.as_view()),
     url(r'^debug/mail/setup-2fa/$', DebugSetup2faEmailView.as_view()),
 
     url(r'^debug/embed/error-page/$', DebugErrorPageEmbedView.as_view()),

--- a/src/sentry/web/frontend/debug/debug_incident_activity_email.py
+++ b/src/sentry/web/frontend/debug/debug_incident_activity_email.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import, print_function
+
+from sentry.models import User
+from django.views.generic import View
+
+from sentry.incidents.models import (
+    Incident,
+    IncidentActivity,
+    IncidentActivityType,
+)
+from sentry.models.organization import Organization
+from sentry.incidents.tasks import generate_incident_activity_email
+
+from .mail import MailPreview
+
+
+class DebugIncidentActivityEmailView(View):
+    def get(self, request):
+        organization = Organization(slug='myorg')
+        incident = Incident(
+            identifier=123,
+            organization=organization,
+            title='Something broke',
+        )
+        activity = IncidentActivity(
+            incident=incident,
+            user=User(name='Hello There'),
+            type=IncidentActivityType.COMMENT.value,
+            comment='hi'
+        )
+        email = generate_incident_activity_email(activity)
+        return MailPreview(
+            html_template=email.html_template,
+            text_template=email.template,
+            context=email.context,
+        ).render(request)

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -600,6 +600,11 @@ urlpatterns += patterns(
         name='sentry-stream'
     ),
     url(
+        r'^organizations/(?P<organization_slug>[\w_-]+)/incidents/(?P<incident_id>\d+)/$',
+        react_page_view,
+        name='sentry-incident',
+    ),
+    url(
         r'^(?P<organization_slug>[\w_-]+)/(?P<project_slug>[\w_-]+)/issues/(?P<group_id>\d+)/tags/(?P<key>[^\/]+)/export/$',
         GroupTagExportView.as_view(),
         name='sentry-group-tag-export'

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -1,0 +1,121 @@
+from __future__ import absolute_import
+
+from exam import patcher
+
+
+import six
+from django.core.urlresolvers import reverse
+
+from sentry.incidents.logic import (
+    create_incident_activity,
+    subscribe_to_incident,
+)
+from sentry.incidents.models import (
+    IncidentActivityType,
+    IncidentStatus,
+)
+from sentry.incidents.tasks import (
+    build_activity_context,
+    generate_incident_activity_email,
+    send_subscriber_notifications,
+)
+from sentry.testutils import TestCase
+from sentry.utils.http import absolute_uri
+
+
+class BaseIncidentActivityTest(object):
+    @property
+    def incident(self):
+        return self.create_incident(title='hello')
+
+
+class TestSendSubscriberNotifications(BaseIncidentActivityTest, TestCase):
+    send_async = patcher('sentry.utils.email.MessageBuilder.send_async')
+
+    def test_simple(self):
+        activity = create_incident_activity(
+            self.incident,
+            IncidentActivityType.COMMENT,
+            user=self.user,
+            comment='hello',
+        )
+        send_subscriber_notifications(activity.id)
+        subscribe_to_incident(activity.incident, self.user)
+        # User shouldn't receive an email for their own activity
+        self.send_async.assert_called_once_with([])
+        self.send_async.reset_mock()
+        user = self.create_user(email='test@test.com')
+        subscribe_to_incident(activity.incident, user)
+        send_subscriber_notifications(activity.id)
+        self.send_async.assert_called_once_with([user.email])
+
+
+class TestGenerateIncidentActivityEmail(BaseIncidentActivityTest, TestCase):
+    def test_simple(self):
+        activity = create_incident_activity(
+            self.incident,
+            IncidentActivityType.COMMENT,
+            user=self.user,
+            comment='hello',
+        )
+        incident = activity.incident
+        message = generate_incident_activity_email(activity)
+        assert message.subject == 'Activity on Incident {} (#{})'.format(
+            incident.title,
+            incident.identifier,
+        )
+        assert message.type == 'incident.activity'
+        assert message.context == build_activity_context(activity)
+
+
+class TestBuildActivityContext(BaseIncidentActivityTest, TestCase):
+    def run_test(
+        self,
+        activity,
+        expected_username,
+        expected_action,
+        expected_comment,
+    ):
+        incident = activity.incident
+        context = build_activity_context(activity)
+        assert context['user_name'] == expected_username
+        assert context['action'] == '%s on incident %s (#%s)' % (
+            expected_action,
+            activity.incident.title,
+            activity.incident.identifier,
+        )
+        assert context['link'] == absolute_uri(reverse(
+            'sentry-incident',
+            kwargs={
+                'organization_slug': incident.organization.slug,
+                'incident_id': incident.identifier,
+            },
+        ))
+        assert context['comment'] == expected_comment
+        assert context['unsubscribe_link'] == ''
+
+    def test_simple(self):
+        activity = create_incident_activity(
+            self.incident,
+            IncidentActivityType.COMMENT,
+            user=self.user,
+            comment='hello',
+        )
+        self.run_test(
+            activity,
+            expected_username=activity.user.name,
+            expected_action='left a comment',
+            expected_comment=activity.comment,
+        )
+        activity.type = IncidentActivityType.STATUS_CHANGE
+        activity.value = six.text_type(IncidentStatus.CLOSED.value)
+        activity.previous_value = six.text_type(IncidentStatus.CREATED.value)
+        self.run_test(
+            activity,
+            expected_username=activity.user.name,
+            expected_action='changed status from %s to %s' % (
+                IncidentStatus.CREATED.name.lower(),
+                IncidentStatus.CLOSED.name.lower(),
+            ),
+            expected_comment=activity.comment,
+        )


### PR DESCRIPTION
As per title. We send these emails to all subscribers unless they're the creator of the activity.

HTML email:
![Screenshot 2019-05-24 15 55 17](https://user-images.githubusercontent.com/6288560/58360395-786c9e80-7e3d-11e9-9982-4abc615c9b21.png)

Text email:
![Screenshot 2019-05-24 15 55 47](https://user-images.githubusercontent.com/6288560/58360411-86222400-7e3d-11e9-9b44-0925df0f3925.png)
