### PR TITLE
feat(events-v2) Add rough sketch of event modal

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -9,7 +9,7 @@ import ProjectLink from 'app/components/projectLink';
 import {Metadata} from 'app/sentryTypes';
 import EventOrGroupTitle from 'app/components/eventOrGroupTitle';
 import Tooltip from 'app/components/tooltip';
-import {isNativePlatform} from 'app/utils/platform';
+import {getMessage, getLocation} from 'app/utils/events';
 
 /**
  * Displays an event or group/issue title (i.e. in Stream)
@@ -43,33 +43,6 @@ class EventOrGroupHeader extends React.Component {
   static defaultProps = {
     includeLink: true,
   };
-
-  getMessage() {
-    const {data} = this.props;
-    const {metadata, type, culprit} = data || {};
-
-    switch (type) {
-      case 'error':
-        return metadata.value;
-      case 'csp':
-        return metadata.message;
-      case 'expectct':
-      case 'expectstaple':
-      case 'hpkp':
-        return '';
-      default:
-        return culprit || '';
-    }
-  }
-
-  getLocation() {
-    const {data} = this.props;
-    if (data.type === 'error' && isNativePlatform(data.platform)) {
-      const {metadata} = data || {};
-      return metadata.filename || null;
-    }
-    return null;
-  }
 
   getTitle() {
     const {hideIcons, hideLevel, includeLink, data, params} = this.props;
@@ -126,10 +99,10 @@ class EventOrGroupHeader extends React.Component {
   }
 
   render() {
-    const {className} = this.props;
+    const {className, data} = this.props;
     const cx = classNames('event-issue-header', className);
-    const message = this.getMessage();
-    const location = this.getLocation();
+    const location = getLocation(data);
+    const message = getMessage(data);
 
     return (
       <div className={cx}>

--- a/src/sentry/static/sentry/app/components/eventOrGroupTitle.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupTitle.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Metadata} from 'app/sentryTypes';
+import {getTitle} from 'app/utils/events';
 
 class EventOrGroupTitle extends React.Component {
   static propTypes = {
@@ -17,31 +18,11 @@ class EventOrGroupTitle extends React.Component {
       metadata: Metadata.isRequired,
       culprit: PropTypes.string,
     }),
+    style: PropTypes.object,
   };
 
   render() {
-    const {data} = this.props;
-    const {metadata, type, culprit} = data;
-    let {title} = data;
-    let subtitle = null;
-
-    if (type == 'error') {
-      subtitle = culprit;
-      if (metadata.type) {
-        title = metadata.type;
-      } else {
-        title = metadata.function || '<unknown>';
-      }
-    } else if (type == 'csp') {
-      title = metadata.directive;
-      subtitle = metadata.uri;
-    } else if (type === 'expectct' || type === 'expectstaple' || type === 'hpkp') {
-      title = metadata.message;
-      subtitle = metadata.origin;
-    } else if (type == 'default') {
-      title = metadata.title;
-    }
-
+    const {title, subtitle} = getTitle(this.props.data);
     if (subtitle) {
       return (
         <span style={this.props.style}>

--- a/src/sentry/static/sentry/app/utils/events.jsx
+++ b/src/sentry/static/sentry/app/utils/events.jsx
@@ -1,0 +1,57 @@
+import {isNativePlatform} from 'app/utils/platform';
+
+/**
+ * Extract the display message from an event.
+ */
+export function getMessage(event) {
+  const {metadata, type, culprit} = event;
+
+  switch (type) {
+    case 'error':
+      return metadata.value;
+    case 'csp':
+      return metadata.message;
+    case 'expectct':
+    case 'expectstaple':
+    case 'hpkp':
+      return '';
+    default:
+      return culprit || '';
+  }
+}
+
+/**
+ * Get the location from an event.
+ */
+export function getLocation(event) {
+  if (event.type === 'error' && isNativePlatform(event.platform)) {
+    const {metadata} = event || {};
+    return metadata.filename || null;
+  }
+  return null;
+}
+
+export function getTitle(event) {
+  const {metadata, type, culprit} = event;
+  let {title} = event;
+  let subtitle = null;
+
+  if (type == 'error') {
+    subtitle = culprit;
+    if (metadata.type) {
+      title = metadata.type;
+    } else {
+      title = metadata.function || '<unknown>';
+    }
+  } else if (type == 'csp') {
+    title = metadata.directive;
+    subtitle = metadata.uri;
+  } else if (type === 'expectct' || type === 'expectstaple' || type === 'hpkp') {
+    title = metadata.message;
+    subtitle = metadata.origin;
+  } else if (type == 'default') {
+    title = metadata.title;
+  }
+
+  return {title, subtitle};
+}

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'react-emotion';
+import qs from 'query-string';
 
 import {deepFreeze} from 'app/utils';
 import DynamicWrapper from 'app/components/dynamicWrapper';
@@ -69,21 +70,22 @@ export const ALL_VIEWS = deepFreeze([
 export const SPECIAL_FIELDS = {
   event: {
     fields: ['title', 'id', 'project.name'],
-    renderFunc: (data, {organization}) => (
-      // TODO(mark) retain query string parameters so back
-      // ends up on search results also hacking the projectId in
-      // is janky
-      <Container>
-        <Link
-          css={overflowEllipsis}
-          to={`/organizations/${org.slug}/events/?eventSlug=${data['project.name']}:${
-            data.id
-          }`}
-        >
-          {data.title}
-        </Link>
-      </Container>
-    ),
+    renderFunc: (data, {organization, location}) => {
+      const newQuery = qs.stringify({
+        ...location.query,
+        eventSlug: `${data['project.name']}:${data.id}`,
+      });
+      return (
+        <Container>
+          <Link
+            css={overflowEllipsis}
+            to={`/organizations/${organization.slug}/events/?${newQuery}`}
+          >
+            {data.title}
+          </Link>
+        </Container>
+      );
+    },
   },
   project: {
     fields: ['project.name'],

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -70,12 +70,15 @@ export const SPECIAL_FIELDS = {
   event: {
     fields: ['title', 'id', 'project.name'],
     renderFunc: (data, {organization}) => (
+      // TODO(mark) retain query string parameters so back
+      // ends up on search results also hacking the projectId in
+      // is janky
       <Container>
         <Link
           css={overflowEllipsis}
-          to={`/organizations/${organization.slug}/projects/${
-            data['project.name']
-          }/events/${data.id}/`}
+          to={`/organizations/${org.slug}/events/?eventSlug=${data['project.name']}:${
+            data.id
+          }`}
         >
           {data.title}
         </Link>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -80,6 +80,7 @@ export const SPECIAL_FIELDS = {
           <Link
             css={overflowEllipsis}
             to={`/organizations/${organization.slug}/events/?${newQuery}`}
+            data-test-id="event-title"
           >
             {data.title}
           </Link>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import styled from 'react-emotion';
+import {browserHistory} from 'react-router';
+import PropTypes from 'prop-types';
+
+import {t} from 'app/locale';
+import LoadingIndicator from 'app/components/loadingIndicator';
+import Button from 'app/components/button';
+import EventOrGroupHeader from 'app/components/eventOrGroupHeader';
+import EventDataSection from 'app/components/events/eventDataSection';
+import EventDevice from 'app/components/events/device';
+import EventExtraData from 'app/components/events/extraData';
+import EventPackageData from 'app/components/events/packageData';
+import NavTabs from 'app/components/navTabs';
+import NotFound from 'app/components/errors/notFound';
+import withApi from 'app/utils/withApi';
+import space from 'app/styles/space';
+import utils from 'app/utils';
+
+import {INTERFACES} from 'app/components/events/eventEntries';
+
+const OTHER_SECTIONS = {
+  context: EventExtraData,
+  packages: EventPackageData,
+  device: EventDevice,
+};
+
+class EventDetails extends React.Component {
+  static propTypes = {
+    api: PropTypes.object,
+    eventSlug: PropTypes.string.isRequired,
+  };
+
+  state = {
+    loading: true,
+    error: false,
+    event: null,
+    activeTab: null,
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.eventSlug != this.props.eventSlug) {
+      this.fetchData();
+    }
+  }
+
+  async fetchData() {
+    this.setState({loading: true, error: false});
+    const {orgId} = this.props.params;
+    const [projectId, eventId] = this.props.eventSlug.split(':');
+    try {
+      if (!projectId || !eventId) {
+        throw new Error('Invalid eventSlug.');
+      }
+      const response = await this.props.api.requestPromise(
+        `/projects/${orgId}/${projectId}/events/${eventId}/`
+      );
+      this.setState({
+        activeTab: response.entries[0].type,
+        event: response,
+        loading: false,
+      });
+    } catch (e) {
+      this.setState({error: true});
+    }
+  }
+
+  handleClose = event => {
+    event.preventDefault();
+    browserHistory.goBack();
+  };
+
+  handleTabChange = tab => this.setState({activeTab: tab});
+
+  renderBody() {
+    if (this.state.loading) {
+      return <LoadingIndicator />;
+    }
+    if (this.state.error) {
+      return <NotFound />;
+    }
+    const {event, activeTab} = this.state;
+
+    return (
+      <React.Fragment>
+        <EventOrGroupHeader
+          params={this.props.params}
+          data={this.state.event}
+          includeLink={false}
+        />
+        <NavTabs underlined={true}>
+          {event.entries.map(entry => {
+            if (!INTERFACES.hasOwnProperty(entry.type)) {
+              return null;
+            }
+            const type = entry.type;
+            const classname = type === activeTab ? 'active' : null;
+            return (
+              <li key={type} className={classname}>
+                <a
+                  href="#"
+                  onClick={() => {
+                    this.handleTabChange(type);
+                  }}
+                >
+                  {utils.toTitleCase(type)}
+                </a>
+              </li>
+            );
+          })}
+          {Object.keys(OTHER_SECTIONS).map(section => {
+            if (utils.objectIsEmpty(event[section])) {
+              return null;
+            }
+            const classname = section === activeTab ? 'active' : null;
+            return (
+              <li key={section} className={classname}>
+                <a
+                  href="#"
+                  onClick={() => {
+                    this.handleTabChange(section);
+                  }}
+                >
+                  {utils.toTitleCase(section)}
+                </a>
+              </li>
+            );
+          })}
+        </NavTabs>
+        {this.renderActiveTab(event, activeTab)}
+      </React.Fragment>
+    );
+  }
+
+  renderActiveTab(event, activeTab) {
+    const entry = event.entries.find(item => item.type === activeTab);
+    if (INTERFACES[activeTab]) {
+      const Component = INTERFACES[activeTab];
+      return (
+        <Component event={event} type={entry.type} data={entry.data} isShare={false} />
+      );
+    } else if (OTHER_SECTIONS[activeTab]) {
+      const Component = OTHER_SECTIONS[activeTab];
+      return <Component event={event} isShare={false} />;
+    } else {
+      /*eslint no-console:0*/
+      window.console &&
+        console.error &&
+        console.error('Unregistered interface: ' + entry.type);
+
+      return (
+        <EventDataSection event={event} type={entry.type} title={entry.type}>
+          <p>{t('There was an error rendering this data.')}</p>
+        </EventDataSection>
+      );
+    }
+  }
+
+  render() {
+    return (
+      <ModalContainer>
+        <CloseButton onClick={this.handleClose} size="zero" icon="icon-close" />
+        {this.renderBody()}
+      </ModalContainer>
+    );
+  }
+}
+
+const ModalContainer = styled('div')`
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  background: #fff;
+
+  margin: ${space(2)};
+  padding: ${space(2)};
+  border: 1px solid ${p => p.theme.borderLight};
+  border-radius: ${p => p.theme.borderRadius};
+  box-shadow: ${p => p.theme.dropShadowHeavy};
+
+  z-index: ${p => p.theme.zIndex.modal};
+`;
+
+const CloseButton = styled(Button)`
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  padding: 10px;
+  border-radius: 20px;
+  box-shadow: ${p => p.theme.dropShadowLight};
+`;
+
+export default withApi(EventDetails);

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -34,6 +34,7 @@ const OTHER_SECTIONS = {
 class EventDetails extends React.Component {
   static propTypes = {
     api: PropTypes.object,
+    params: PropTypes.object,
     eventSlug: PropTypes.string.isRequired,
   };
 

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import {t} from 'app/locale';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Button from 'app/components/button';
+import ErrorBoundary from 'app/components/errorBoundary';
 import EventOrGroupHeader from 'app/components/eventOrGroupHeader';
 import EventDataSection from 'app/components/events/eventDataSection';
 import EventDevice from 'app/components/events/device';
@@ -131,7 +132,9 @@ class EventDetails extends React.Component {
             );
           })}
         </NavTabs>
-        {this.renderActiveTab(event, activeTab)}
+        <ErrorBoundary message={t('Could not render event details')}>
+          {this.renderActiveTab(event, activeTab)}
+        </ErrorBoundary>
       </React.Fragment>
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -93,7 +93,6 @@ class EventDetails extends React.Component {
       return <NotFound />;
     }
     const {event, activeTab} = this.state;
-    const jsonUrl = 'TODO build this';
 
     return (
       <ColumnGrid>
@@ -144,15 +143,7 @@ class EventDetails extends React.Component {
           </ErrorBoundary>
         </ContentColumn>
         <SidebarColumn>
-          <SidebarBlock withSeparator>
-            <h5>ID {event.eventID}</h5>
-            <DateTime
-              date={getDynamicText({value: event.dateCreated, fixed: 'Dummy timestamp'})}
-            />
-            <ExternalLink href={jsonUrl} className="json-link">
-              JSON (<FileSize bytes={event.size} />)
-            </ExternalLink>
-          </SidebarBlock>
+          <EventMetadata event={event} />
           <SidebarBlock>
             <TagsTable tags={event.tags} />
           </SidebarBlock>
@@ -215,6 +206,36 @@ EventHeader.propTypes = {
   event: SentryTypes.Event.isRequired,
 };
 
+const EventMetadata = props => {
+  const jsonUrl = 'TODO build this';
+  const {event} = props;
+
+  return (
+    <SidebarBlock withSeparator>
+      <MetadataContainer>ID {event.eventID}</MetadataContainer>
+      <MetadataContainer>
+        <DateTime
+          date={getDynamicText({value: event.dateCreated, fixed: 'Dummy timestamp'})}
+        />
+        <ExternalLink href={jsonUrl} className="json-link">
+          JSON (<FileSize bytes={event.size} />)
+        </ExternalLink>
+      </MetadataContainer>
+    </SidebarBlock>
+  );
+};
+EventMetadata.propTypes = {
+  event: SentryTypes.Event.isRequired,
+};
+
+const MetadataContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+
+  color: ${p => p.theme.gray3};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
 const ColumnGrid = styled('div')`
   display: grid;
   grid-template-columns: 70% 1fr;
@@ -232,7 +253,7 @@ const SidebarColumn = styled('div')`
 
 const SidebarBlock = styled('div')`
   margin: 0 0 ${space(2)} 0;
-  padding: ${space(2)} 0;
+  padding: 0 0 ${space(2)} 0;
   ${p => (p.withSeparator ? `border-bottom: 1px solid ${p.theme.borderLight};` : '')}
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -4,12 +4,12 @@ import {browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
 
 import {t} from 'app/locale';
+import SentryTypes from 'app/sentryTypes';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Button from 'app/components/button';
 import DateTime from 'app/components/dateTime';
 import ErrorBoundary from 'app/components/errorBoundary';
 import ExternalLink from 'app/components/links/externalLink';
-import EventOrGroupHeader from 'app/components/eventOrGroupHeader';
 import EventDataSection from 'app/components/events/eventDataSection';
 import EventDevice from 'app/components/events/device';
 import EventExtraData from 'app/components/events/extraData';
@@ -21,6 +21,7 @@ import withApi from 'app/utils/withApi';
 import space from 'app/styles/space';
 import getDynamicText from 'app/utils/getDynamicText';
 import utils from 'app/utils';
+import {getMessage, getTitle} from 'app/utils/events';
 
 import {INTERFACES} from 'app/components/events/eventEntries';
 import TagsTable from './tagsTable';
@@ -97,11 +98,7 @@ class EventDetails extends React.Component {
     return (
       <ColumnGrid>
         <ContentColumn>
-          <EventOrGroupHeader
-            params={this.props.params}
-            data={this.state.event}
-            includeLink={false}
-          />
+          <EventHeader event={this.state.event} />
           <NavTabs underlined={true}>
             {event.entries.map(entry => {
               if (!INTERFACES.hasOwnProperty(entry.type)) {
@@ -166,10 +163,17 @@ class EventDetails extends React.Component {
 
   renderActiveTab(event, activeTab) {
     const entry = event.entries.find(item => item.type === activeTab);
+    const [projectId, _] = this.props.eventSlug.split(':');
     if (INTERFACES[activeTab]) {
       const Component = INTERFACES[activeTab];
       return (
-        <Component event={event} type={entry.type} data={entry.data} isShare={false} />
+        <Component
+          projectId={projectId}
+          event={event}
+          type={entry.type}
+          data={entry.data}
+          isShare={false}
+        />
       );
     } else if (OTHER_SECTIONS[activeTab]) {
       const Component = OTHER_SECTIONS[activeTab];
@@ -197,6 +201,19 @@ class EventDetails extends React.Component {
     );
   }
 }
+
+const EventHeader = props => {
+  const {title} = getTitle(props.event);
+  return (
+    <div>
+      <h2>{title}</h2>
+      <p>{getMessage(props.event)}</p>
+    </div>
+  );
+};
+EventHeader.propTypes = {
+  event: SentryTypes.Event.isRequired,
+};
 
 const ColumnGrid = styled('div')`
   display: grid;
@@ -227,7 +244,7 @@ const ModalContainer = styled('div')`
   background: #fff;
 
   margin: ${space(2)};
-  padding: ${space(2)};
+  padding: ${space(3)};
   border: 1px solid ${p => p.theme.borderLight};
   border-radius: ${p => p.theme.borderRadius};
   box-shadow: ${p => p.theme.dropShadowHeavy};

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
@@ -92,6 +92,7 @@ class Events extends AsyncComponent {
               data={data}
               isLoading={loading}
               onSearch={this.handleSearch}
+              location={location}
             />
             <Pagination pageLinks={dataPageLinks} />
           </div>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
@@ -13,6 +13,7 @@ import ListLink from 'app/components/links/listLink';
 import NoProjectMessage from 'app/components/noProjectMessage';
 
 import Events from './events';
+import EventDetails from './eventDetails';
 import {ALL_VIEWS} from './data';
 import {getCurrentView} from './utils';
 
@@ -46,6 +47,7 @@ export default class OrganizationEventsV2 extends React.Component {
 
   render() {
     const {organization, location} = this.props;
+    const {eventSlug} = location.query;
 
     return (
       <DocumentTitle title={`Events - ${organization.slug} - Sentry`}>
@@ -64,6 +66,13 @@ export default class OrganizationEventsV2 extends React.Component {
                 view={getCurrentView(location.query.view)}
               />
             </NoProjectMessage>
+            {eventSlug && (
+              <EventDetails
+                orgId={organization.slug}
+                params={this.props.params}
+                eventSlug={eventSlug}
+              />
+            )}
           </PageContent>
         </React.Fragment>
       </DocumentTitle>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/table.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/table.jsx
@@ -19,10 +19,11 @@ export default class Table extends React.Component {
     isLoading: PropTypes.bool,
     organization: SentryTypes.Organization.isRequired,
     onSearch: PropTypes.func.isRequired,
+    location: PropTypes.object,
   };
 
   renderBody() {
-    const {view, data, isLoading, organization, onSearch} = this.props;
+    const {view, data, isLoading, organization, onSearch, location} = this.props;
     const {fields} = view.data;
 
     if (isLoading) {
@@ -42,7 +43,7 @@ export default class Table extends React.Component {
         {fields.map(field => (
           <Cell key={field}>
             {SPECIAL_FIELDS.hasOwnProperty(field) ? (
-              SPECIAL_FIELDS[field].renderFunc(row, {organization, onSearch})
+              SPECIAL_FIELDS[field].renderFunc(row, {organization, onSearch, location})
             ) : (
               <QueryLink onClick={() => onSearch(`${field}:${row[field]}`)}>
                 {row[field]}

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/tagsTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/tagsTable.jsx
@@ -9,18 +9,20 @@ const TagsTable = props => {
     <div>
       <TagHeading>{t('Tags')}</TagHeading>
       <table>
-        {props.tags.map(tag => (
-          <StyledTr key={tag.key}>
-            <TagKey>{tag.key}</TagKey>
-            <TagValue>{tag.value}</TagValue>
-          </StyledTr>
-        ))}
+        <tbody>
+          {props.tags.map(tag => (
+            <StyledTr key={tag.key}>
+              <TagKey>{tag.key}</TagKey>
+              <TagValue>{tag.value}</TagValue>
+            </StyledTr>
+          ))}
+        </tbody>
       </table>
     </div>
   );
 };
 TagsTable.propTypes = {
-  tags: PropTypes.object.isRequired,
+  tags: PropTypes.array.isRequired,
 };
 
 const TagHeading = styled('h5')`

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/tagsTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/tagsTable.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import styled from 'react-emotion';
+import PropTypes from 'prop-types';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+
+const TagsTable = props => {
+  return (
+    <div>
+      <TagHeading>{t('Tags')}</TagHeading>
+      <table>
+        {props.tags.map(tag => (
+          <StyledTr key={tag.key}>
+            <TagKey>{tag.key}</TagKey>
+            <TagValue>{tag.value}</TagValue>
+          </StyledTr>
+        ))}
+      </table>
+    </div>
+  );
+};
+TagsTable.propTypes = {
+  tags: PropTypes.object.isRequired,
+};
+
+const TagHeading = styled('h5')`
+  text-transform: uppercase;
+  color: ${p => p.theme.gray3};
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin: 0 0 ${space(1)} ${space(1)};
+`;
+
+const StyledTr = styled('tr')`
+  &:nth-child(2n) td {
+    background: ${p => p.theme.offWhite};
+  }
+`;
+
+const TagKey = styled('td')`
+  color: ${p => p.theme.gray3};
+  padding: ${space(0.5)} ${space(1)};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const TagValue = styled(TagKey)`
+  text-align: right;
+`;
+
+export default TagsTable;

--- a/tests/js/spec/views/organizationEventsV2/index.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/index.spec.jsx
@@ -9,9 +9,23 @@ describe('OrganizationEventsV2', function() {
       url: '/organizations/org-slug/events/',
       body: [
         {
+          id: 'deadbeef',
+          title: 'Oh no something bad',
+          'project.name': 'project-slug',
           timestamp: '2019-05-23T22:12:48+00:00',
         },
       ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/events/deadbeef',
+      body: {
+        eventID: 'deadbeef',
+        title: 'Oh no something bad',
+        message: 'It was not good',
+        dateCreated: '2019-05-23T22:12:48+00:00',
+        entries: [],
+        tags: [{key: 'browser', value: 'Firefox'}],
+      },
     });
   });
 
@@ -38,5 +52,33 @@ describe('OrganizationEventsV2', function() {
 
     const content = wrapper.find('PageContent');
     expect(content.text()).toContain('You need at least one project to use this view');
+  });
+
+  it('generates links to modals', async function() {
+    const wrapper = mount(
+      <OrganizationEventsV2
+        organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
+        location={{query: {}}}
+      />,
+      TestStubs.routerContext()
+    );
+
+    const link = wrapper.find('Table Link[data-test-id="event-title"]').first();
+    expect(link.props().to).toEqual(expect.stringContaining('eventSlug=project-slug'));
+  });
+
+  it('opens a modal when eventSlug is present', async function() {
+    const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
+    const wrapper = mount(
+      <OrganizationEventsV2
+        organization={organization}
+        location={{query: {eventSlug: 'project-slug:deadbeef'}}}
+        params={{orgId: organization.slug}}
+      />,
+      TestStubs.routerContext()
+    );
+
+    const modal = wrapper.find('EventDetails');
+    expect(modal).toHaveLength(1);
   });
 });


### PR DESCRIPTION
This is a rough sketch of how the single event view could work. There are numerous prop-type warnings that I plan on addressing before merging this.

The styling is not perfect either as I wasn't sure on how the scrolling should be handled as the modal could be taller or shorter than the viewport and I wanted to discuss how that should be handled.

I wanted to get feedback on:

* The usage of the `eventSlug` query string parameter. The current APIs need both an event id and projectId. My thinking was that using a single parameter will allow us to have fewer query parameters to manage when handling history state.
* My plan for different modal types was to use the `renderFunc` features to trigger different modals for different event/issue types.
* The modals currently enter browser history. This was something we discussed briefly but I wanted to make sure folks were aligned on that decision.

Refs SEN-648