### PR TITLE
ref(events-v2): Remove redundant value from events view definition

### DIFF
--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -115,7 +115,6 @@ export const EventView = PropTypes.shape({
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   data: PropTypes.shape({
-    query: PropTypes.string.isRequired,
     fields: PropTypes.arrayOf(PropTypes.string).isRequired,
     groupby: PropTypes.arrayOf(PropTypes.string).isRequired,
     aggregations: PropTypes.arrayOf(PropTypes.array).isRequired,

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -13,7 +13,6 @@ export const ALL_VIEWS = deepFreeze([
     id: 'all',
     name: 'All Events',
     data: {
-      query: '',
       fields: ['event', 'event.type', 'project.name', 'user', 'time'],
       groupby: [],
       aggregations: [],
@@ -32,7 +31,6 @@ export const ALL_VIEWS = deepFreeze([
     id: 'errors',
     name: 'Errors',
     data: {
-      query: '',
       fields: [],
       groupby: ['issue.id'],
       aggregations: [['uniq', 'id', 'event_count'], ['uniq', 'user', 'user_count']],
@@ -44,7 +42,6 @@ export const ALL_VIEWS = deepFreeze([
     id: 'csp',
     name: 'CSP',
     data: {
-      query: '',
       fields: [],
       groupby: ['issue.id'],
       aggregations: [['uniq', 'id', 'event_count'], ['uniq', 'user', 'user_count']],


### PR DESCRIPTION
`query` isn't part of the predefined view - this always defaults to
empty unless the user has explicitly provided some input.