### PR TITLE
fix(api): Fix duplicates in incident list (SEN-699)

### DIFF
--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -64,7 +64,7 @@ class IncidentManager(BaseManager):
         return self.filter(
             organization=organization,
             projects__in=projects,
-        )
+        ).distinct()
 
     @TimedRetryPolicy.wrap(timeout=5, exceptions=(IntegrityError, ))
     def create(self, organization, **kwargs):

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -58,6 +58,10 @@ class FetchForOrganizationTest(TestCase):
             self.organization,
             [project],
         ))
+        assert [incident] == list(Incident.objects.fetch_for_organization(
+            self.organization,
+            [self.project, project],
+        ))
 
 
 class IncidentCreationTest(TestCase):


### PR DESCRIPTION
Checking for multiple projects can cause duplication due to joins.