### PR TITLE
feat(api): Add status filter to Incident index [SEN-687]

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_index.py
+++ b/src/sentry/api/endpoints/organization_incident_index.py
@@ -80,6 +80,14 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
             self.get_projects(request, organization),
         )
 
+        query_status = request.GET.get('status')
+
+        if query_status == 'open':
+            # status can be detected, created, or closed
+            incidents = incidents.exclude(status=IncidentStatus.CLOSED.value)
+        elif query_status == 'closed':
+            incidents = incidents.filter(status=IncidentStatus.CLOSED.value)
+
         return self.paginate(
             request,
             queryset=incidents,

--- a/tests/sentry/api/endpoints/test_organization_incident.py
+++ b/tests/sentry/api/endpoints/test_organization_incident.py
@@ -5,7 +5,7 @@ from exam import fixture
 from freezegun import freeze_time
 
 from sentry.api.serializers import serialize
-from sentry.incidents.models import Incident
+from sentry.incidents.models import Incident, IncidentStatus
 from sentry.testutils import APITestCase
 
 
@@ -27,11 +27,30 @@ class IncidentListEndpointTest(APITestCase):
     def test_simple(self):
         self.create_team(organization=self.organization, members=[self.user])
         incident = self.create_incident()
-        other_incident = self.create_incident()
+        other_incident = self.create_incident(status=IncidentStatus.CLOSED.value)
         self.login_as(self.user)
         with self.feature('organizations:incidents'):
             resp = self.get_valid_response(self.organization.slug)
         assert resp.data == serialize([incident, other_incident])
+
+    def test_filter_status(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        incident = self.create_incident()
+        closed_incident = self.create_incident(status=IncidentStatus.CLOSED.value)
+        self.login_as(self.user)
+
+        with self.feature('organizations:incidents'):
+            resp_closed = self.get_valid_response(
+                self.organization.slug, qs_params={
+                    'status': 'closed'})
+            resp_open = self.get_valid_response(
+                self.organization.slug, qs_params={
+                    'status': 'open'})
+
+        assert len(resp_closed.data) == 1
+        assert len(resp_open.data) == 1
+        assert resp_closed.data == serialize([closed_incident])
+        assert resp_open.data == serialize([incident])
 
     def test_no_feature(self):
         self.create_team(organization=self.organization, members=[self.user])

--- a/tests/sentry/api/endpoints/test_organization_incident.py
+++ b/tests/sentry/api/endpoints/test_organization_incident.py
@@ -41,11 +41,11 @@ class IncidentListEndpointTest(APITestCase):
 
         with self.feature('organizations:incidents'):
             resp_closed = self.get_valid_response(
-                self.organization.slug, qs_params={
-                    'status': 'closed'})
+                self.organization.slug, status='closed',
+            )
             resp_open = self.get_valid_response(
-                self.organization.slug, qs_params={
-                    'status': 'open'})
+                self.organization.slug, status='open'
+            )
 
         assert len(resp_closed.data) == 1
         assert len(resp_open.data) == 1


### PR DESCRIPTION
Can query for all, open, or closed incidents