### PR TITLE
feat(api): Change Incidents list order by date started, descending [SEN-692]

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_index.py
+++ b/src/sentry/api/endpoints/organization_incident_index.py
@@ -91,7 +91,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
         return self.paginate(
             request,
             queryset=incidents,
-            order_by='date_started',
+            order_by='-date_started',
             paginator_cls=OffsetPaginator,
             on_results=lambda x: serialize(x, request.user),
         )

--- a/tests/sentry/api/endpoints/test_organization_incident.py
+++ b/tests/sentry/api/endpoints/test_organization_incident.py
@@ -28,10 +28,12 @@ class IncidentListEndpointTest(APITestCase):
         self.create_team(organization=self.organization, members=[self.user])
         incident = self.create_incident()
         other_incident = self.create_incident(status=IncidentStatus.CLOSED.value)
+
         self.login_as(self.user)
         with self.feature('organizations:incidents'):
             resp = self.get_valid_response(self.organization.slug)
-        assert resp.data == serialize([incident, other_incident])
+
+        assert resp.data == serialize([other_incident, incident])
 
     def test_filter_status(self):
         self.create_team(organization=self.organization, members=[self.user])


### PR DESCRIPTION
Change Incidents list endpoint to return incidents ordered by newest first

Fixes SEN-692