### PR TITLE
feat(ui): Add message in Incidents list for creating an incident [SEN-694]

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
@@ -6,7 +6,8 @@ import styled from 'react-emotion';
 
 import {PageContent, PageHeader} from 'app/styles/organization';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
+import AlertLink from 'app/components/alertLink';
 import AsyncComponent from 'app/components/asyncComponent';
 import BetaTag from 'app/components/betaTag';
 import Button from 'app/components/button';
@@ -101,7 +102,9 @@ class OrganizationIncidentsList extends AsyncComponent {
 
 class OrganizationIncidentsListContainer extends React.Component {
   render() {
-    const {pathname, query} = this.props.location;
+    const {params, location} = this.props;
+    const {pathname, query} = location;
+    const {orgId} = params;
 
     const openIncidentsQuery = {...query, status: 'open'};
     const closedIncidentsQuery = {...query, status: 'closed'};
@@ -110,7 +113,7 @@ class OrganizationIncidentsListContainer extends React.Component {
     const status = query.status === undefined ? DEFAULT_QUERY_STATUS : query.status;
 
     return (
-      <DocumentTitle title={`Incidents - ${this.props.params.orgId} - Sentry`}>
+      <DocumentTitle title={`Incidents - ${orgId} - Sentry`}>
         <PageContent>
           <PageHeader>
             <PageHeading withMargins>
@@ -141,6 +144,18 @@ class OrganizationIncidentsListContainer extends React.Component {
               </Button>
             </div>
           </PageHeader>
+
+          <AlertLink
+            priority="warning"
+            to={`/organizations/${orgId}/issues/`}
+            icon="icon-circle-info"
+          >
+            {tct(
+              'To create a new incident, select one or more issues from the Issues view. Then, click the [create:Create Incident] button.',
+              {create: <em />}
+            )}
+          </AlertLink>
+
           <OrganizationIncidentsList {...this.props} />
         </PageContent>
       </DocumentTitle>


### PR DESCRIPTION
This adds a notice (that links to the Issues stream) for creating a new incident. Early user testing indicated that people would expect UI in the incidents view to create a new Incident.

![image](https://user-images.githubusercontent.com/79684/58517756-5aff4380-8161-11e9-891a-f6435f5fdad9.png)

Fixes SEN-694