### PR TITLE
ref(app-platform): Use event_id

### DIFF
--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -69,21 +69,21 @@ def send_alert_event(event, rule, sentry_app_id):
     event_context['url'] = absolute_uri(reverse('sentry-api-0-project-event-details', args=[
         project.organization.slug,
         project.slug,
-        event.id,
+        event.event_id,
     ]))
 
     if features.has('organizations:sentry10', organization):
         event_context['web_url'] = absolute_uri(reverse('sentry-organization-event-detail', args=[
             organization.slug,
             group.id,
-            event.id,
+            event.event_id,
         ]))
     else:
         event_context['web_url'] = absolute_uri(reverse('sentry-group-event', args=[
             organization.slug,
             project.slug,
             group.id,
-            event.id,
+            event.event_id,
         ]))
 
     # The URL has a regex OR in it ("|") which means `reverse` cannot generate

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -128,12 +128,12 @@ class TestSendAlertEvent(TestCase):
                     url=absolute_uri(reverse('sentry-api-0-project-event-details', args=[
                         self.organization.slug,
                         self.project.slug,
-                        event.id,
+                        event.event_id,
                     ])),
                     web_url=absolute_uri(reverse('sentry-organization-event-detail', args=[
                         self.organization.slug,
                         group.id,
-                        event.id,
+                        event.event_id,
                     ])),
                     issue_url=absolute_uri(
                         '/api/0/issues/{}/'.format(group.id),


### PR DESCRIPTION
Shouldn't use `event.id` anymore. Also `'sentry-api-0-project-event-details'` endpoint supports `event_id` as of https://github.com/getsentry/sentry/pull/10898.

FIXES SENTRY-AWV