### PR TITLE
feat(api): Add author when creating incident activity [SEN-700]

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_index.py
+++ b/src/sentry/api/endpoints/organization_incident_index.py
@@ -122,6 +122,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
                 date_detected=result.get('dateDetected', result['dateStarted']),
                 projects=result['projects'],
                 groups=groups,
+                user=request.user,
             )
             return Response(serialize(incident, request.user), status=201)
         return Response(serializer.errors, status=400)

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -41,6 +41,7 @@ def create_incident(
     detection_uuid=None,
     projects=None,
     groups=None,
+    user=None,
 ):
     assert status in (IncidentStatus.CREATED, IncidentStatus.DETECTED)
     if date_detected is None:
@@ -81,6 +82,7 @@ def create_incident(
             incident,
             activity_status,
             event_stats_snapshot=event_stats_snapshot,
+            user=user,
         )
     return incident
 

--- a/tests/sentry/api/endpoints/test_organization_incident.py
+++ b/tests/sentry/api/endpoints/test_organization_incident.py
@@ -5,7 +5,7 @@ from exam import fixture
 from freezegun import freeze_time
 
 from sentry.api.serializers import serialize
-from sentry.incidents.models import Incident, IncidentStatus
+from sentry.incidents.models import Incident, IncidentStatus, IncidentActivity
 from sentry.testutils import APITestCase
 
 
@@ -95,6 +95,10 @@ class IncidentCreateEndpointTest(APITestCase):
                 status_code=201,
             )
         assert resp.data == serialize([Incident.objects.get(id=resp.data['id'])])[0]
+
+        # should create an activity authored by user
+        activity = IncidentActivity.objects.get(incident_id=resp.data['id'])
+        assert activity.user == self.user
 
     def test_project_access(self):
         self.create_member(


### PR DESCRIPTION
When using the endpoint to create an incident, we should attach an author to the created activity item.

Fixes SEN-700