### PR TITLE
fix(ui): Fix date for create incident activity

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/item/bubble.jsx
+++ b/src/sentry/static/sentry/app/components/activity/item/bubble.jsx
@@ -11,6 +11,7 @@ const ActivityBubble = styled('div')`
   border: 1px solid ${p => p.borderColor || p.theme.borderLight};
   border-radius: ${p => p.theme.borderRadius};
   position: relative;
+  width: 100%; /* this is used in Incidents Details - a chart can cause overflow and won't resize properly */
 
   &:before {
     display: block;

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/activity.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/activity.jsx
@@ -28,6 +28,7 @@ class Activity extends React.Component {
   static propTypes = {
     api: PropTypes.object.isRequired,
     incidentId: PropTypes.string.isRequired,
+    incident: SentryTypes.Incident,
     loading: PropTypes.bool,
     error: PropTypes.bool,
     me: SentryTypes.User,
@@ -59,6 +60,7 @@ class Activity extends React.Component {
       error,
       me,
       incidentId,
+      incident,
       activities,
       noteInputId,
       createBusy,
@@ -148,6 +150,7 @@ class Activity extends React.Component {
                         <ErrorBoundary mini key={`note-${activity.id}`}>
                           <StatusItem
                             showTime
+                            incident={incident}
                             authorName={authorName}
                             activity={activity}
                           />

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/statusItem.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/statusItem.jsx
@@ -14,16 +14,20 @@ import SentryTypes from 'app/sentryTypes';
 /**
  * StatusItem renders status changes for Incidents
  *
- * For example, incident created, detected, or closed
+ * For example: incident created, detected, or closed
+ *
+ * Note `activity.dateCreated` refers to when the activity was created vs.
+ * `incident.dateStarted` which is when an incident was first detected or created
  */
 class StatusItem extends React.Component {
   static propTypes = {
     activity: SentryTypes.IncidentActivity.isRequired,
+    incident: SentryTypes.Incident,
     authorName: PropTypes.string,
   };
 
   render() {
-    const {activity, authorName} = this.props;
+    const {activity, authorName, incident} = this.props;
 
     const isCreated = activity.type === INCIDENT_ACTIVITY_TYPE.CREATED;
     const isDetected = activity.type === INCIDENT_ACTIVITY_TYPE.DETECTED;
@@ -60,7 +64,7 @@ class StatusItem extends React.Component {
         {activity.eventStats && (
           <Chart
             data={activity.eventStats.data}
-            detected={(isCreated || isDetected) && activity.dateCreated}
+            detected={(isCreated || isDetected) && incident && incident.dateStarted}
           />
         )}
       </ActivityItem>


### PR DESCRIPTION
The date that the chart was using for the red "incident started" date, was the activity date instead of the actual incident started date.

This also fixes the activity bubble width (chart was not re-rendering when resizing window).