### PR TITLE
feat(api): Make sure user still has access to an incident when sending notifications (SEN-656)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -487,6 +487,7 @@ CELERY_QUEUES = [
     Queue('events.reprocess_events', routing_key='events.reprocess_events'),
     Queue('events.save_event', routing_key='events.save_event'),
     Queue('files.delete', routing_key='files.delete'),
+    Queue('incidents.notify', routing_key='incidents.notify'),
     Queue('integrations', routing_key='integrations'),
     Queue('merge', routing_key='merge'),
     Queue('options', routing_key='options'),

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 
+from sentry.auth.access import from_user
 from sentry.incidents.models import (
     IncidentActivity,
     IncidentActivityType,
@@ -13,9 +14,15 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.linksign import generate_signed_link
 
 
-@instrumented_task(name='sentry.incidents.tasks.send_subscriber_notifications')
+@instrumented_task(
+    name='sentry.incidents.tasks.send_subscriber_notifications',
+    queue='incidents.notify',
+)
 def send_subscriber_notifications(activity_id):
-    from sentry.incidents.logic import get_incident_subscribers
+    from sentry.incidents.logic import (
+        get_incident_subscribers,
+        unsubscribe_from_incident,
+    )
     try:
         activity = IncidentActivity.objects.select_related(
             'incident',
@@ -34,9 +41,21 @@ def send_subscriber_notifications(activity_id):
     ):
         return
 
-    subscribers = get_incident_subscribers(activity.incident).select_related('user')
-    msg = generate_incident_activity_email(activity)
-    msg.send_async([sub.user.email for sub in subscribers if sub.user != activity.user])
+    # Check that the user still has access to at least one of the projects
+    # related to the incident. If not then unsubscribe them.
+    projects = list(activity.incident.projects.all())
+    emails = []
+    for subscriber in get_incident_subscribers(activity.incident).select_related('user'):
+        user = subscriber.user
+        access = from_user(user, activity.incident.organization)
+        if not any(project for project in projects if access.has_project_access(project)):
+            unsubscribe_from_incident(activity.incident, user)
+        elif user != activity.user:
+            emails.append(user.email)
+
+    if emails:
+        msg = generate_incident_activity_email(activity)
+        msg.send_async(emails)
 
 
 def generate_incident_activity_email(activity):

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -13,6 +13,7 @@ from sentry.incidents.logic import (
 from sentry.incidents.models import (
     IncidentActivityType,
     IncidentStatus,
+    IncidentSubscription,
 )
 from sentry.incidents.tasks import (
     build_activity_context,
@@ -41,14 +42,26 @@ class TestSendSubscriberNotifications(BaseIncidentActivityTest, TestCase):
             comment='hello',
         )
         send_subscriber_notifications(activity.id)
-        subscribe_to_incident(activity.incident, self.user)
         # User shouldn't receive an email for their own activity
-        self.send_async.assert_called_once_with([])
+        self.send_async.assert_not_called()  # NOQA
+
         self.send_async.reset_mock()
-        user = self.create_user(email='test@test.com')
-        subscribe_to_incident(activity.incident, user)
+        non_member_user = self.create_user(email='non_member@test.com')
+        subscribe_to_incident(activity.incident, non_member_user)
+
+        member_user = self.create_user(email='member@test.com')
+        self.create_member([self.team], user=member_user, organization=self.organization)
+        subscribe_to_incident(activity.incident, member_user)
         send_subscriber_notifications(activity.id)
-        self.send_async.assert_called_once_with([user.email])
+        self.send_async.assert_called_once_with([member_user.email])
+        assert not IncidentSubscription.objects.filter(
+            incident=activity.incident,
+            user=non_member_user,
+        ).exists()
+        assert IncidentSubscription.objects.filter(
+            incident=activity.incident,
+            user=member_user,
+        ).exists()
 
     def test_invalid_types(self):
         for activity_type in (IncidentActivityType.CREATED, IncidentActivityType.DETECTED):


### PR DESCRIPTION
Ensure that the user has access to at least one project on the incident before sending. If not,
unsubscribe them and don't send.