### PR TITLE
fix(native): Do not discard symbolicated frames

### DIFF
--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-27T11:48:16.638637Z'
+created: '2019-05-29T11:21:05.608393Z'
 creator: sentry
 source: tests/symbolicator/test_minidump_full.py
 ---
@@ -164,6 +164,28 @@ exception:
         instruction_addr: '0x750662c4'
         package: C:\Windows\System32\kernel32.dll
         trust: cfi
+      - abs_path: f:\dd\vctools\crt\vcstartup\src\startup\exe_common.inl
+        data:
+          symbolicator_status: symbolicated
+        filename: exe_common.inl
+        function: __scrt_common_main_seh
+        in_app: false
+        instruction_addr: '0x2a2d96'
+        lineno: 283
+        package: C:\projects\breakpad-tools\windows\Release\crash.exe
+        symbol: __scrt_common_main_seh
+        trust: cfi
+      - abs_path: c:\projects\breakpad-tools\windows\crash\main.cpp
+        data:
+          symbolicator_status: symbolicated
+        filename: main.cpp
+        function: main
+        in_app: false
+        instruction_addr: '0x2a2a3d'
+        lineno: 35
+        package: C:\projects\breakpad-tools\windows\Release\crash.exe
+        symbol: main
+        trust: context
       registers:
         eax: '0x0'
         ebp: '0x10ff670'
@@ -195,6 +217,28 @@ exception:
         instruction_addr: '0x750662c4'
         package: C:\Windows\System32\kernel32.dll
         trust: cfi
+      - abs_path: f:\dd\vctools\crt\vcstartup\src\startup\exe_common.inl
+        data:
+          symbolicator_status: symbolicated
+        filename: exe_common.inl
+        function: __scrt_common_main_seh
+        in_app: false
+        instruction_addr: '0x2a2d96'
+        lineno: 283
+        package: C:\projects\breakpad-tools\windows\Release\crash.exe
+        symbol: __scrt_common_main_seh
+        trust: cfi
+      - abs_path: c:\projects\breakpad-tools\windows\crash\main.cpp
+        data:
+          symbolicator_status: symbolicated
+        filename: main.cpp
+        function: main
+        in_app: false
+        instruction_addr: '0x2a2a3d'
+        lineno: 35
+        package: C:\projects\breakpad-tools\windows\Release\crash.exe
+        symbol: main
+        trust: context
       registers:
         eax: '0x0'
         ebp: '0x10ff670'

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_debug_id_resolving.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_debug_id_resolving.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-03T08:10:38.360935Z'
+created: '2019-05-29T11:21:36.394133Z'
 creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---
@@ -25,10 +25,16 @@ exception:
   values:
   - raw_stacktrace:
       frames:
-      - function: <unknown>
+      - abs_path: c:\projects\breakpad-tools\windows\crash\main.cpp
+        data:
+          symbolicator_status: symbolicated
+        filename: main.cpp
+        function: main
         in_app: false
         instruction_addr: '0x2a2a3d'
+        lineno: 35
         package: C:\projects\breakpad-tools\windows\Release\crash.exe
+        symbol: main
     stacktrace:
       frames:
       - abs_path: c:\projects\breakpad-tools\windows\crash\main.cpp

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_real_resolving.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_real_resolving.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-03T08:10:43.264420Z'
+created: '2019-05-29T11:21:42.668708Z'
 creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---
@@ -23,10 +23,16 @@ exception:
   values:
   - raw_stacktrace:
       frames:
-      - function: unknown
+      - abs_path: /tmp/hello.c
+        data:
+          symbolicator_status: symbolicated
+        filename: hello.c
+        function: main
         in_app: false
         instruction_addr: '0x100000fa0'
+        lineno: 1
         package: Foo.app/Contents/Foo
+        symbol: main
     stacktrace:
       frames:
       - abs_path: /tmp/hello.c

--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-27T11:48:31.427121Z'
+created: '2019-05-29T11:21:52.227050Z'
 creator: sentry
 source: tests/symbolicator/test_unreal_full.py
 ---
@@ -105,6 +105,35 @@ exception:
       handled: false
       synthetic: true
       type: minidump
+    raw_stacktrace:
+      frames:
+      - data:
+          symbolicator_status: symbolicated
+        function: AActor::IsPendingKillPending
+        in_app: false
+        instruction_addr: '0x7ff754be3394'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: AActor::IsPendingKillPending()
+        symbol: AActor::IsPendingKillPending()
+        trust: context
+      registers:
+        r10: '0x7ffef000'
+        r11: '0x23d82c75ab0'
+        r12: '0x23d82c7d000'
+        r13: '0x3'
+        r14: '0x23df8f48bc0'
+        r15: '0x23df9a35d48'
+        r8: '0x8c3f2cd401'
+        r9: '0x7ffe03a9c86e'
+        rax: '0x64'
+        rbp: '0x8c3f2cd650'
+        rbx: '0x0'
+        rcx: '0x0'
+        rdi: '0x1'
+        rdx: '0x0'
+        rip: '0x7ff754be3394'
+        rsi: '0x0'
+        rsp: '0x8c3f2cd4c0'
     stacktrace:
       frames:
       - data:


### PR DESCRIPTION
Impact:

* Whenever there's a symbolicated native stacktrace where at least one frame failed to resolve, all frames but the unresolved one are deleted.
* Mixed-platform stacktraces are completely broken.

This is the fastest fix I could think of, but we need to fix this properly.