### PR TITLE
dx(notion): Upgrade from `notion` to `volta`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ install-system-pkgs: node-version-check
 	@echo "--> Installing system packages (from Brewfile)"
 	@command -v brew 2>&1 > /dev/null && brew bundle || (echo 'WARNING: homebrew not found or brew bundle failed - skipping system dependencies.')
 	@echo "--> Installing yarn $(YARN_VERSION) (via npm)"
-	@$(volta --version 2>&1 > /dev/null || notion --version 2>&1 > /dev/null || npm install -g "yarn@$(YARN_VERSION)")
+	@$(volta --version 2>&1 > /dev/null || npm install -g "yarn@$(YARN_VERSION)")
 
 install-yarn-pkgs:
 	@echo "--> Installing Yarn packages (for development)"

--- a/package.json
+++ b/package.json
@@ -145,10 +145,6 @@
     "snapshot": "build-storybook && PERCY_TOKEN=$STORYBOOK_PERCY_TOKEN PERCY_PROJECT=$STORYBOOK_PERCY_PROJECT percy-storybook --widths=1280",
     "webpack-profile": "yarn -s webpack --profile --json > stats.json"
   },
-  "toolchain": {
-    "node": "8.15.1",
-    "yarn": "1.13.0"
-  },
   "volta": {
     "node": "8.15.1",
     "yarn": "1.13.0"


### PR DESCRIPTION
`notion` recently changed their name to `volta` (as to ease confusion with `notion.so`). volta yells at you if you have the old `toolchain` key defined, so let us upgrade.

Merge with https://github.com/getsentry/getsentry/pull/2942