### PR TITLE
fix(api): Fix task error on incident creation

### DIFF
--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -26,6 +26,13 @@ def send_subscriber_notifications(activity_id):
     except IncidentActivity.DoesNotExist:
         return
 
+    # Only send notifications for specific activity types.
+    if activity.type not in (
+        IncidentActivityType.COMMENT.value,
+        IncidentActivityType.STATUS_CHANGE.value,
+    ):
+        return
+
     subscribers = get_incident_subscribers(activity.incident).select_related('user')
     msg = generate_incident_activity_email(activity)
     msg.send_async([sub.user.email for sub in subscribers if sub.user != activity.user])

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -49,6 +49,13 @@ class TestSendSubscriberNotifications(BaseIncidentActivityTest, TestCase):
         send_subscriber_notifications(activity.id)
         self.send_async.assert_called_once_with([user.email])
 
+    def test_invalid_types(self):
+        for activity_type in (IncidentActivityType.CREATED, IncidentActivityType.DETECTED):
+            activity = create_incident_activity(self.incident, activity_type)
+            send_subscriber_notifications(activity.id)
+            self.send_async.assert_not_called()  # NOQA
+            self.send_async.reset_mock()
+
 
 class TestGenerateIncidentActivityEmail(BaseIncidentActivityTest, TestCase):
     def test_simple(self):


### PR DESCRIPTION
We try to send a notification on incident creation, but we don't need to because no one will be
subscribed to receive it. At the moment it errors due to us not expecting it, just no-op in this
case.