### PR TITLE
feat(ui): Disable "create new incident" when bulk selecting issues [SEN-689]

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/actionLink.jsx
+++ b/src/sentry/static/sentry/app/components/actions/actionLink.jsx
@@ -39,7 +39,7 @@ export default class ActionLink extends React.Component {
     if (shouldConfirm && !disabled) {
       return (
         <Confirm message={message} confirmText={confirmLabel} onConfirm={onAction}>
-          <a className={className} title={title}>
+          <a className={className} title={title} aria-label={title}>
             {' '}
             {children}
           </a>
@@ -49,6 +49,7 @@ export default class ActionLink extends React.Component {
       return (
         <a
           data-test-id={testId}
+          aria-label={title}
           className={classNames(className, {disabled})}
           onClick={disabled ? undefined : onAction}
           disabled={disabled}

--- a/src/sentry/static/sentry/app/views/stream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/stream/actions.jsx
@@ -343,6 +343,7 @@ const StreamActions = createReactClass({
     const resolveDisabled = !anySelected;
     const resolveDropdownDisabled = !(anySelected && projectId);
     const mergeDisabled = !(multiSelected && projectId);
+    const createNewIncidentDisabled = !anySelected || allInQuerySelected;
 
     return (
       <Sticky>
@@ -402,7 +403,7 @@ const StreamActions = createReactClass({
                 <ActionLink
                   className="btn btn-default btn-sm hidden-sm hidden-xs"
                   title={t('Create new incident')}
-                  disabled={!anySelected}
+                  disabled={createNewIncidentDisabled}
                   onAction={this.handleCreateIncident}
                 >
                   <IncidentLabel>
@@ -439,7 +440,7 @@ const StreamActions = createReactClass({
                 <MenuItem noAnchor={true}>
                   <ActionLink
                     className="hidden-md hidden-lg hidden-xl"
-                    disabled={!anySelected}
+                    disabled={createNewIncidentDisabled}
                     onAction={this.handleCreateIncident}
                     title={t('Create new incident')}
                   >

--- a/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
@@ -105,6 +105,7 @@ exports[`ResolveActions with confirmation step renders 1`] = `
           stopPropagation={false}
         >
           <a
+            aria-label="Resolve"
             className="btn btn-default btn-sm"
             onClick={[Function]}
             title="Resolve"
@@ -611,6 +612,7 @@ exports[`ResolveActions without confirmation renders 1`] = `
         title="Resolve"
       >
         <a
+          aria-label="Resolve"
           className="btn btn-default btn-sm"
           data-test-id="action-link-resolve"
           disabled={false}

--- a/tests/js/spec/views/stream/actions.spec.jsx
+++ b/tests/js/spec/views/stream/actions.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {mount, shallow} from 'enzyme';
 
 import {StreamActions} from 'app/views/stream/actions';
+import {initializeOrg} from 'app-test/helpers/initializeOrg';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 
 describe('StreamActions', function() {
@@ -15,6 +16,12 @@ describe('StreamActions', function() {
   describe('Bulk', function() {
     describe('Total results > bulk limit', function() {
       beforeAll(function() {
+        const {routerContext} = initializeOrg({
+          organization: {
+            features: ['incidents'],
+          },
+        });
+
         SelectedGroupStore.records = {};
         SelectedGroupStore.add([1, 2, 3]);
         wrapper = mount(
@@ -36,7 +43,7 @@ describe('StreamActions', function() {
             realtimeActive={false}
             statsPeriod="24h"
           />,
-          TestStubs.routerContext()
+          routerContext
         );
       });
 
@@ -49,6 +56,22 @@ describe('StreamActions', function() {
         wrapper.find('.stream-select-all-notice a').simulate('click');
 
         expect(wrapper.find('.stream-select-all-notice')).toMatchSnapshot();
+      });
+
+      it('has "Create Incidents" disabled', function() {
+        // Do not allow users to create incidents with "bulk" selection
+        expect(
+          wrapper
+            .find('a[aria-label="Create new incident"]')
+            .at(0)
+            .prop('disabled')
+        ).toBe(true);
+        expect(
+          wrapper
+            .find('a[aria-label="Create new incident"]')
+            .at(1)
+            .prop('disabled')
+        ).toBe(true);
       });
 
       it('bulk resolves', async function() {


### PR DESCRIPTION
This will disable the "Create new incident" button on issues stream when you bulk select issues. It does not really make sense to have an incident consisting of this many issues.

Fixes SEN-689