### PR TITLE
feat(app-platform): Add error.created hook event

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -842,6 +842,8 @@ SENTRY_FEATURES = {
     # Enable interface functionality to synchronize groups between sentry and
     # issues on external services.
     'organizations:integrations-issue-sync': True,
+    # Enable interface functionality to recieve event hooks.
+    'organizations:integrations-event-hooks': False,
     # Special feature flag primarily used on the sentry.io SAAS product for
     # easily enabling features while in early development.
     'organizations:internal-catchall': False,

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -31,6 +31,9 @@ EVENT_EXPANSION = {
         'issue.ignored',
         'issue.assigned',
     ],
+    'error': [
+        'error.created',
+    ]
 }
 
 # We present Webhook Subscriptions per-resource (Issue, Project, etc.), not
@@ -38,6 +41,7 @@ EVENT_EXPANSION = {
 # resources a Sentry App may subscribe to.
 VALID_EVENT_RESOURCES = (
     'issue',
+    'error',
 )
 
 REQUIRED_EVENT_PERMISSIONS = {

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -33,7 +33,7 @@ EVENT_EXPANSION = {
     ],
     'error': [
         'error.created',
-    ]
+    ],
 }
 
 # We present Webhook Subscriptions per-resource (Issue, Project, etc.), not
@@ -46,6 +46,7 @@ VALID_EVENT_RESOURCES = (
 
 REQUIRED_EVENT_PERMISSIONS = {
     'issue': 'event:read',
+    'error': 'event:read',
     'project': 'project:read',
     'member': 'member:read',
     'organization': 'org:read',

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -186,3 +186,8 @@ register('symbolicator.minidump-refactor-random-sampling', default=0.0)  # unuse
 # Normalization after processors
 register('store.normalize-after-processing', default=0.0)  # unused
 register('store.disable-trim-in-renormalization', default=0.0)
+
+# Post Process Error Hook Sampling
+register('post-process.use-error-hook-sampling', default=False)
+# From 0.0 to 1.0: Randomly enqueue process_resource_change task
+register('post-process.error-hook-sample-rate', default=0.0)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -190,6 +190,7 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
                 sender='Error',
                 instance_id=event.event_id,
                 project_id=event.project_id,
+                group_id=event.group_id,
             )
         if is_new:
             process_resource_change_bound.delay(

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -427,7 +427,10 @@ class PostProcessGroupTest(TestCase):
             is_new_group_environment=False,
         )
 
-        kwargs = {'project_id': self.project.id}
+        kwargs = {
+            'project_id': self.project.id,
+            'group_id': event.group.id,
+        }
         delay.assert_called_once_with(
             action='created',
             sender='Error',

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from mock import Mock, patch
 
 from sentry import tagstore
+from sentry import options
 from sentry.models import Group, GroupSnooze, GroupStatus, ProjectOwnership
 from sentry.ownership.grammar import Rule, Matcher, Owner, dump_schema
 from sentry.testutils import TestCase
@@ -513,6 +514,48 @@ class PostProcessGroupTest(TestCase):
         )
 
         assert not delay.called
+
+    @patch('sentry.tasks.sentry_apps.process_resource_change_bound.delay')
+    def test_processes_resource_change_task_uses_sampling_option(self, delay):
+        options.set('post-process.use-error-hook-sampling', True)
+        options.set('post-process.error-hook-sample-rate', 1)
+        event = self.store_event(
+            data={
+                'message': 'Foo bar',
+                'level': 'error',
+                'exception': {"type": "Foo", "value": "shits on fiah yo"},
+                'timestamp': timezone.now().isoformat()[:19]
+            },
+            project_id=self.project.id,
+            assert_no_errors=False
+        )
+
+        self.create_service_hook(
+            project=self.project,
+            organization=self.project.organization,
+            actor=self.user,
+            events=['error.created'],
+        )
+
+        post_process_group(
+            event=event,
+            is_new=False,
+            is_regression=False,
+            is_sample=False,
+            is_new_group_environment=False,
+        )
+
+        kwargs = {
+            'project_id': self.project.id,
+            'group_id': event.group.id,
+        }
+
+        delay.assert_called_once_with(
+            action='created',
+            sender='Error',
+            instance_id=event.event_id,
+            **kwargs
+        )
 
 
 class IndexEventTagsTest(TestCase):

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -254,7 +254,7 @@ class TestProcessResourceChange(TestCase):
 
         assert data['action'] == 'created'
         assert data['installation']['uuid'] == install.uuid
-        assert data['data']['error']['eventID'] == event.event_id
+        assert data['data']['error']['event_id'] == event.event_id
         assert faux(safe_urlopen).kwargs_contain('headers.Content-Type')
         assert faux(safe_urlopen).kwargs_contain('headers.Request-ID')
         assert faux(safe_urlopen).kwargs_contain('headers.Sentry-Hook-Resource')


### PR DESCRIPTION
**What is error.created?** 
`error.created` is similar to `event.created` except for that we limit the types to just `error`. Going forward this is safer so that we aren't forwarding just any old data (i.e csp events). 

**Does this affect project based Service Hooks?**
No. This only adds `error.created` to the options for the Sentry Integration Platform, and will only be an option if the org has the `integrations-event-hooks` flag. 

**Will we replace `event.created` in project based Service Hooks to be `error.created`?**
Possibly?

<hr>

**Other things to note:**
* Has support for `SnubaEvents`
* The event payload uses `.as_dict()` to be consistent with other events (`event_alert`) in the Sentry Integration Platform. This is different than the project based Service Hooks. 


cc @JTCunning @dcramer @mitsuhiko 