### PR TITLE
ref(events-v2) Use an object target instead building URLs

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'react-emotion';
-import qs from 'query-string';
 
 import {deepFreeze} from 'app/utils';
 import DynamicWrapper from 'app/components/dynamicWrapper';
@@ -71,17 +70,13 @@ export const SPECIAL_FIELDS = {
   event: {
     fields: ['title', 'id', 'project.name'],
     renderFunc: (data, {organization, location}) => {
-      const newQuery = qs.stringify({
-        ...location.query,
-        eventSlug: `${data['project.name']}:${data.id}`,
-      });
+      const target = {
+        pathname: `/organizations/${organization.slug}/events/`,
+        query: {...location.query, eventSlug: `${data['project.name']}:${data.id}`},
+      };
       return (
         <Container>
-          <Link
-            css={overflowEllipsis}
-            to={`/organizations/${organization.slug}/events/?${newQuery}`}
-            data-test-id="event-title"
-          >
+          <Link css={overflowEllipsis} to={target} data-test-id="event-title">
             {data.title}
           </Link>
         </Container>

--- a/tests/js/spec/views/organizationEventsV2/index.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/index.spec.jsx
@@ -64,7 +64,7 @@ describe('OrganizationEventsV2', function() {
     );
 
     const link = wrapper.find('Table Link[data-test-id="event-title"]').first();
-    expect(link.props().to).toEqual(expect.stringContaining('eventSlug=project-slug'));
+    expect(link.props().to.query).toEqual({eventSlug: 'project-slug:deadbeef'});
   });
 
   it('opens a modal when eventSlug is present', async function() {


### PR DESCRIPTION
Use `Link` feature to generate a URL from `pathname` and `query` instead of cooking up string URLs.

Refs SEN-648