### PR TITLE
fix(metrics): Fix recording wrong http status on API successes

### DIFF
--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -209,12 +209,12 @@ export class Client {
           Accept: 'application/json; charset=utf-8',
         },
         success: (...args) => {
-          const [resp] = args || [];
+          const [, , xhr] = args || [];
           metric.measure({
             name: 'app.api.request-success',
             start: `api-request-start-${id}`,
             data: {
-              status: resp && resp.status,
+              status: xhr && xhr.status,
             },
           });
           if (!isUndefined(options.success)) {


### PR DESCRIPTION
This was mistakenly trying to access the `status` key from the response data instead of the xhr response object.