### PR TITLE
ref(events-v2) Split up the EventDetails view better 

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.jsx
@@ -353,7 +353,7 @@ export default class AsyncComponent extends React.Component {
   }
 
   renderError(error, disableLog = false, disableReport = false) {
-    // 401s are captured by SudaModal, but may be passed back to AsyncComponent if they close the modal without identifying
+    // 401s are captured by SudoModal, but may be passed back to AsyncComponent if they close the modal without identifying
     const unauthorizedErrors = Object.values(this.state.errors).find(
       resp => resp && resp.status === 401
     );

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -3,259 +3,53 @@ import styled from 'react-emotion';
 import {browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
 
-import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
-import LoadingIndicator from 'app/components/loadingIndicator';
+import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
-import DateTime from 'app/components/dateTime';
-import ErrorBoundary from 'app/components/errorBoundary';
-import ExternalLink from 'app/components/links/externalLink';
-import EventDataSection from 'app/components/events/eventDataSection';
-import EventDevice from 'app/components/events/device';
-import EventExtraData from 'app/components/events/extraData';
-import EventPackageData from 'app/components/events/packageData';
-import FileSize from 'app/components/fileSize';
-import NavTabs from 'app/components/navTabs';
-import NotFound from 'app/components/errors/notFound';
 import withApi from 'app/utils/withApi';
 import space from 'app/styles/space';
-import getDynamicText from 'app/utils/getDynamicText';
-import utils from 'app/utils';
-import {getMessage, getTitle} from 'app/utils/events';
 
-import {INTERFACES} from 'app/components/events/eventEntries';
-import TagsTable from './tagsTable';
+import EventModalContent from './eventModalContent';
 
-const OTHER_SECTIONS = {
-  context: EventExtraData,
-  packages: EventPackageData,
-  device: EventDevice,
-};
-
-class EventDetails extends React.Component {
+class EventDetails extends AsyncComponent {
   static propTypes = {
-    api: PropTypes.object,
     params: PropTypes.object,
     eventSlug: PropTypes.string.isRequired,
   };
 
-  state = {
-    loading: true,
-    error: false,
-    event: null,
-    activeTab: null,
-  };
-
-  componentDidMount() {
-    this.fetchData();
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.eventSlug != this.props.eventSlug) {
-      this.fetchData();
-    }
-  }
-
-  async fetchData() {
-    this.setState({loading: true, error: false});
+  getEndpoints() {
     const {orgId} = this.props.params;
-    const [projectId, eventId] = this.props.eventSlug.split(':');
-    try {
-      if (!projectId || !eventId) {
-        throw new Error('Invalid eventSlug.');
-      }
-      const response = await this.props.api.requestPromise(
-        `/projects/${orgId}/${projectId}/events/${eventId}/`
-      );
-      this.setState({
-        activeTab: response.entries[0].type,
-        event: response,
-        loading: false,
-      });
-    } catch (e) {
-      this.setState({error: true});
-    }
+    const [projectId, eventId] = this.props.eventSlug.toString().split(':');
+
+    return [['event', `/projects/${orgId}/${projectId}/events/${eventId}/`]];
+  }
+
+  onRequestSuccess({data}) {
+    // Select the first interface as the active sub-tab
+    this.setState({activeTab: data.entries[0].type});
   }
 
   handleClose = event => {
     event.preventDefault();
-
     browserHistory.goBack();
   };
 
   handleTabChange = tab => this.setState({activeTab: tab});
 
   renderBody() {
-    if (this.state.loading) {
-      return <LoadingIndicator />;
-    }
-    if (this.state.error) {
-      return <NotFound />;
-    }
-    const {event, activeTab} = this.state;
-
-    return (
-      <ColumnGrid>
-        <ContentColumn>
-          <EventHeader event={this.state.event} />
-          <NavTabs underlined={true}>
-            {event.entries.map(entry => {
-              if (!INTERFACES.hasOwnProperty(entry.type)) {
-                return null;
-              }
-              const type = entry.type;
-              const classname = type === activeTab ? 'active' : null;
-              return (
-                <li key={type} className={classname}>
-                  <a
-                    href="#"
-                    onClick={evt => {
-                      evt.preventDefault();
-                      this.handleTabChange(type);
-                    }}
-                  >
-                    {utils.toTitleCase(type)}
-                  </a>
-                </li>
-              );
-            })}
-            {Object.keys(OTHER_SECTIONS).map(section => {
-              if (utils.objectIsEmpty(event[section])) {
-                return null;
-              }
-              const classname = section === activeTab ? 'active' : null;
-              return (
-                <li key={section} className={classname}>
-                  <a
-                    href="#"
-                    onClick={() => {
-                      this.handleTabChange(section);
-                    }}
-                  >
-                    {utils.toTitleCase(section)}
-                  </a>
-                </li>
-              );
-            })}
-          </NavTabs>
-          <ErrorBoundary message={t('Could not render event details')}>
-            {this.renderActiveTab(event, activeTab)}
-          </ErrorBoundary>
-        </ContentColumn>
-        <SidebarColumn>
-          <EventMetadata event={event} />
-          <SidebarBlock>
-            <TagsTable tags={event.tags} />
-          </SidebarBlock>
-        </SidebarColumn>
-      </ColumnGrid>
-    );
-  }
-
-  renderActiveTab(event, activeTab) {
-    const entry = event.entries.find(item => item.type === activeTab);
     const [projectId, _] = this.props.eventSlug.split(':');
-    if (INTERFACES[activeTab]) {
-      const Component = INTERFACES[activeTab];
-      return (
-        <Component
-          projectId={projectId}
-          event={event}
-          type={entry.type}
-          data={entry.data}
-          isShare={false}
-        />
-      );
-    } else if (OTHER_SECTIONS[activeTab]) {
-      const Component = OTHER_SECTIONS[activeTab];
-      return <Component event={event} isShare={false} />;
-    } else {
-      /*eslint no-console:0*/
-      window.console &&
-        console.error &&
-        console.error('Unregistered interface: ' + entry.type);
-
-      return (
-        <EventDataSection event={event} type={entry.type} title={entry.type}>
-          <p>{t('There was an error rendering this data.')}</p>
-        </EventDataSection>
-      );
-    }
-  }
-
-  render() {
     return (
       <ModalContainer>
         <CloseButton onClick={this.handleClose} size="zero" icon="icon-close" />
-        {this.renderBody()}
+        <EventModalContent
+          onTabChange={this.handleTabChange}
+          event={this.state.event}
+          activeTab={this.state.activeTab}
+          projectId={projectId}
+        />
       </ModalContainer>
     );
   }
 }
-
-const EventHeader = props => {
-  const {title} = getTitle(props.event);
-  return (
-    <div>
-      <h2>{title}</h2>
-      <p>{getMessage(props.event)}</p>
-    </div>
-  );
-};
-EventHeader.propTypes = {
-  event: SentryTypes.Event.isRequired,
-};
-
-const EventMetadata = props => {
-  const jsonUrl = 'TODO build this';
-  const {event} = props;
-
-  return (
-    <SidebarBlock withSeparator>
-      <MetadataContainer>ID {event.eventID}</MetadataContainer>
-      <MetadataContainer>
-        <DateTime
-          date={getDynamicText({value: event.dateCreated, fixed: 'Dummy timestamp'})}
-        />
-        <ExternalLink href={jsonUrl} className="json-link">
-          JSON (<FileSize bytes={event.size} />)
-        </ExternalLink>
-      </MetadataContainer>
-    </SidebarBlock>
-  );
-};
-EventMetadata.propTypes = {
-  event: SentryTypes.Event.isRequired,
-};
-
-const MetadataContainer = styled('div')`
-  display: flex;
-  justify-content: space-between;
-
-  color: ${p => p.theme.gray3};
-  font-size: ${p => p.theme.fontSizeMedium};
-`;
-
-const ColumnGrid = styled('div')`
-  display: grid;
-  grid-template-columns: 70% 1fr;
-  grid-template-rows: auto;
-  grid-column-gap: ${space(3)};
-`;
-
-const ContentColumn = styled('div')`
-  grid-column: 1 / 2;
-`;
-
-const SidebarColumn = styled('div')`
-  grid-column: 2 / 3;
-`;
-
-const SidebarBlock = styled('div')`
-  margin: 0 0 ${space(2)} 0;
-  padding: 0 0 ${space(2)} 0;
-  ${p => (p.withSeparator ? `border-bottom: 1px solid ${p.theme.borderLight};` : '')}
-`;
 
 const ModalContainer = styled('div')`
   position: absolute;

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
@@ -1,0 +1,213 @@
+import React from 'react';
+import styled from 'react-emotion';
+import PropTypes from 'prop-types';
+
+import {t} from 'app/locale';
+import SentryTypes from 'app/sentryTypes';
+import DateTime from 'app/components/dateTime';
+import ErrorBoundary from 'app/components/errorBoundary';
+import ExternalLink from 'app/components/links/externalLink';
+import EventDataSection from 'app/components/events/eventDataSection';
+import EventDevice from 'app/components/events/device';
+import EventExtraData from 'app/components/events/extraData';
+import EventPackageData from 'app/components/events/packageData';
+import FileSize from 'app/components/fileSize';
+import NavTabs from 'app/components/navTabs';
+import space from 'app/styles/space';
+import getDynamicText from 'app/utils/getDynamicText';
+import utils from 'app/utils';
+import {getMessage, getTitle} from 'app/utils/events';
+
+import {INTERFACES} from 'app/components/events/eventEntries';
+import TagsTable from './tagsTable';
+
+const OTHER_SECTIONS = {
+  context: EventExtraData,
+  packages: EventPackageData,
+  device: EventDevice,
+};
+
+/**
+ * Render the currently active event interface tab.
+ * Some but not all interface elements require a projectId.
+ */
+const ActiveTab = props => {
+  const {projectId, event, activeTab} = props;
+  if (!activeTab) {
+    return null;
+  }
+  const entry = event.entries.find(item => item.type === activeTab);
+  if (INTERFACES[activeTab]) {
+    const Component = INTERFACES[activeTab];
+    return (
+      <Component
+        projectId={projectId}
+        event={event}
+        type={entry.type}
+        data={entry.data}
+        isShare={false}
+      />
+    );
+  } else if (OTHER_SECTIONS[activeTab]) {
+    const Component = OTHER_SECTIONS[activeTab];
+    return <Component event={event} isShare={false} />;
+  } else {
+    /*eslint no-console:0*/
+    window.console &&
+      console.error &&
+      console.error('Unregistered interface: ' + activeTab);
+
+    return (
+      <EventDataSection event={event} type={entry.type} title={entry.type}>
+        <p>{t('There was an error rendering this data.')}</p>
+      </EventDataSection>
+    );
+  }
+};
+ActiveTab.propTypes = {
+  event: SentryTypes.Event.isRequired,
+  activeTab: PropTypes.string,
+  projectId: PropTypes.string.isRequired,
+};
+
+/**
+ * Render the columns and navigation elements inside the event modal view.
+ * Controlled by the EventDetails View.
+ */
+const EventModalContent = props => {
+  const {event, activeTab, projectId, onTabChange} = props;
+
+  return (
+    <ColumnGrid>
+      <ContentColumn>
+        <EventHeader event={event} />
+        <NavTabs underlined={true}>
+          {event.entries.map(entry => {
+            if (!INTERFACES.hasOwnProperty(entry.type)) {
+              return null;
+            }
+            const type = entry.type;
+            const classname = type === activeTab ? 'active' : null;
+            return (
+              <li key={type} className={classname}>
+                <a
+                  href="#"
+                  onClick={evt => {
+                    evt.preventDefault();
+                    onTabChange(type);
+                  }}
+                >
+                  {utils.toTitleCase(type)}
+                </a>
+              </li>
+            );
+          })}
+          {Object.keys(OTHER_SECTIONS).map(section => {
+            if (utils.objectIsEmpty(event[section])) {
+              return null;
+            }
+            const classname = section === activeTab ? 'active' : null;
+            return (
+              <li key={section} className={classname}>
+                <a
+                  href="#"
+                  onClick={evt => {
+                    evt.preventDefault();
+                    onTabChange(section);
+                  }}
+                >
+                  {utils.toTitleCase(section)}
+                </a>
+              </li>
+            );
+          })}
+        </NavTabs>
+        <ErrorBoundary message={t('Could not render event details')}>
+          <ActiveTab event={event} activeTab={activeTab} projectId={projectId} />
+        </ErrorBoundary>
+      </ContentColumn>
+      <SidebarColumn>
+        <EventMetadata event={event} />
+        <SidebarBlock>
+          <TagsTable tags={event.tags} />
+        </SidebarBlock>
+      </SidebarColumn>
+    </ColumnGrid>
+  );
+};
+EventModalContent.propTypes = {
+  ...ActiveTab.propTypes,
+  onTabChange: PropTypes.func.isRequired,
+};
+
+/**
+ * Render the header of the modal content
+ */
+const EventHeader = props => {
+  const {title} = getTitle(props.event);
+  return (
+    <div>
+      <h2>{title}</h2>
+      <p>{getMessage(props.event)}</p>
+    </div>
+  );
+};
+EventHeader.propTypes = {
+  event: SentryTypes.Event.isRequired,
+};
+
+/**
+ * Render metadata about the event and provide a link to the JSON blob
+ */
+const EventMetadata = props => {
+  const jsonUrl = 'TODO build this';
+  const {event} = props;
+
+  return (
+    <SidebarBlock withSeparator>
+      <MetadataContainer>ID {event.eventID}</MetadataContainer>
+      <MetadataContainer>
+        <DateTime
+          date={getDynamicText({value: event.dateCreated, fixed: 'Dummy timestamp'})}
+        />
+        <ExternalLink href={jsonUrl} className="json-link">
+          JSON (<FileSize bytes={event.size} />)
+        </ExternalLink>
+      </MetadataContainer>
+    </SidebarBlock>
+  );
+};
+EventMetadata.propTypes = {
+  event: SentryTypes.Event.isRequired,
+};
+
+const MetadataContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+
+  color: ${p => p.theme.gray3};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const ColumnGrid = styled('div')`
+  display: grid;
+  grid-template-columns: 70% 1fr;
+  grid-template-rows: auto;
+  grid-column-gap: ${space(3)};
+`;
+
+const ContentColumn = styled('div')`
+  grid-column: 1 / 2;
+`;
+
+const SidebarColumn = styled('div')`
+  grid-column: 2 / 3;
+`;
+
+const SidebarBlock = styled('div')`
+  margin: 0 0 ${space(2)} 0;
+  padding: 0 0 ${space(2)} 0;
+  ${p => (p.withSeparator ? `border-bottom: 1px solid ${p.theme.borderLight};` : '')}
+`;
+
+export default EventModalContent;

--- a/tests/js/spec/views/organizationEventsV2/index.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/index.spec.jsx
@@ -17,13 +17,21 @@ describe('OrganizationEventsV2', function() {
       ],
     });
     MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/events/deadbeef',
+      url: '/projects/org-slug/project-slug/events/deadbeef/',
       body: {
+        id: '1234',
+        size: 1200,
         eventID: 'deadbeef',
         title: 'Oh no something bad',
         message: 'It was not good',
         dateCreated: '2019-05-23T22:12:48+00:00',
-        entries: [],
+        entries: [
+          {
+            type: 'message',
+            message: 'bad stuff',
+            data: {},
+          },
+        ],
         tags: [{key: 'browser', value: 'Firefox'}],
       },
     });


### PR DESCRIPTION
Split the logic up so that there is only one stateful component and several controlled components that focus on presentation only.

Refs SEN-648