### PR TITLE
ref: Remove mixin and createReactClass usage in StacktraceContent

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.jsx
@@ -1,31 +1,23 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import Frame from 'app/components/events/interfaces/frame';
 import {t} from 'app/locale';
-import OrganizationState from 'app/mixins/organizationState';
 
-const StacktraceContent = createReactClass({
-  displayName: 'StacktraceContent',
-
-  propTypes: {
+export default class StacktraceContent extends React.Component {
+  static propTypes = {
     data: PropTypes.object.isRequired,
     includeSystemFrames: PropTypes.bool,
     expandFirstFrame: PropTypes.bool,
     platform: PropTypes.string,
     newestFirst: PropTypes.bool,
-  },
+  };
 
-  mixins: [OrganizationState],
+  static defaultProps = {
+    includeSystemFrames: true,
+    expandFirstFrame: true,
+  };
 
-  getDefaultProps() {
-    return {
-      includeSystemFrames: true,
-      expandFirstFrame: true,
-    };
-  },
-
-  renderOmittedFrames(firstFrameOmitted, lastFrameOmitted) {
+  renderOmittedFrames = (firstFrameOmitted, lastFrameOmitted) => {
     const props = {
       className: 'frame frames-omitted',
       key: 'omitted',
@@ -36,13 +28,13 @@ const StacktraceContent = createReactClass({
       lastFrameOmitted
     );
     return <li {...props}>{text}</li>;
-  },
+  };
 
-  frameIsVisible(frame, nextFrame) {
+  frameIsVisible = (frame, nextFrame) => {
     return (
       this.props.includeSystemFrames || frame.inApp || (nextFrame && nextFrame.inApp)
     );
-  },
+  };
 
   render() {
     const data = this.props.data;
@@ -133,7 +125,5 @@ const StacktraceContent = createReactClass({
         <ul>{frames}</ul>
       </div>
     );
-  },
-});
-
-export default StacktraceContent;
+  }
+}


### PR DESCRIPTION
The OrganizationState mixin was being included but wasn't used in any way.