### PR TITLE
fix(native): Assemble files with duplicate chunks correctly

### DIFF
--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -440,8 +440,10 @@ class File(Model):
         tf = tempfile.NamedTemporaryFile()
         with transaction.atomic():
             file_blobs = FileBlob.objects.filter(id__in=file_blob_ids).all()
-            # Make sure the blobs are sorted with the order provided
-            file_blobs = sorted(file_blobs, key=lambda blob: file_blob_ids.index(blob.id))
+
+            # Ensure blobs are in the order and duplication as provided
+            blobs_by_id = {blob.id: blob for blob in file_blobs}
+            file_blobs = [blobs_by_id[blob_id] for blob_id in file_blob_ids]
 
             new_checksum = sha1(b'')
             offset = 0


### PR DESCRIPTION
This fixes an issue where files are assembled incorrectly when they contain duplicate chunks. Previously, only the first occurrence of a duplicate chunks was assembled.

This example is taken from a real-world case. The file contains multiple empty chunks (8MB of zeros):

```
        "chunks": [
            "71dc926b84f211d70b9fa2135656e919304892f5",
            "5fde1cce603e6566d20da811c9c8bcccb044d4ae",
            "5fde1cce603e6566d20da811c9c8bcccb044d4ae",
            "5fde1cce603e6566d20da811c9c8bcccb044d4ae",
            "5fde1cce603e6566d20da811c9c8bcccb044d4ae",
            "5fde1cce603e6566d20da811c9c8bcccb044d4ae",
            "4a8519329aee2ac9779812b7360c84d957820899",
            "60421ce4cd2aae0196dae8a394734d3d0583c0fc",
            ...
        ]
```