### PR TITLE
fix(owners) Fix failure when ownership rules have bad owners

### DIFF
--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -87,11 +87,12 @@ class ProjectOwnership(Model):
                 score = candidate
                 owners = rule.owners
         actors = filter(None, resolve_actors(owners, project_id).values())
-        if len(actors):
-            return actors[0].resolve()
+
         # Can happen if the ownership rule references a user/team that no longer
         # is assigned to the project or has been removed from the org.
-        return None
+        if not actors:
+            return None
+        return actors[0].resolve()
 
     @classmethod
     def _matching_ownership_rules(cls, ownership, project_id, data):

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -87,7 +87,11 @@ class ProjectOwnership(Model):
                 score = candidate
                 owners = rule.owners
         actors = filter(None, resolve_actors(owners, project_id).values())
-        return actors[0].resolve()
+        if len(actors):
+            return actors[0].resolve()
+        # Can happen if the ownership rule references a user/team that no longer
+        # is assigned to the project or has been removed from the org.
+        return None
 
     @classmethod
     def _matching_ownership_rules(cls, ownership, project_id, data):


### PR DESCRIPTION
Ownership rules have no relational links to actual users in an organization. This means they can reference teams/users that are no longer are assigned to the project or no longer exist in the organization.

Fixes SENTRY-AXY