### PR TITLE
fix(store) Don't explode on garbage ignore patterns

### DIFF
--- a/src/sentry/utils/data_filters.py
+++ b/src/sentry/utils/data_filters.py
@@ -107,7 +107,12 @@ def is_valid_error_message(project, message):
     message = force_text(message).lower()
 
     for error in filtered_errors:
-        if fnmatch.fnmatch(message, error.lower()):
-            return False
+        try:
+            if fnmatch.fnmatch(message, error.lower()):
+                return False
+        except Exception:
+            # fnmatch raises a string when the pattern is bad.
+            # Patterns come from end users and can be full of mistakes.
+            pass
 
     return True

--- a/tests/sentry/utils/http/tests.py
+++ b/tests/sentry/utils/http/tests.py
@@ -321,6 +321,12 @@ class IsValidErrorMessageTestCase(TestCase):
         assert self.is_valid_error_message(None, ['ImportError*'])
         assert self.is_valid_error_message({}, ['ImportError*'])
 
+    def test_bad_characters_in_pattern(self):
+        patterns = [
+            u"*google_tag_manager['GTM-3TL3'].macro(...)*",
+        ]
+        assert self.is_valid_error_message('it bad', patterns)
+
 
 class OriginFromRequestTestCase(TestCase):
     def test_nothing(self):


### PR DESCRIPTION
Users make mistakes on their ignore patterns, we shouldn't fail to store events just because they are bad at filter patterns.

Fixes SENTRY-9H7