### PR TITLE
ref(minidump): Remove setting to cache minidump uploads

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1566,9 +1566,9 @@ SOUTH_TESTS_MIGRATE = os.environ.get('SOUTH_TESTS_MIGRATE', '0') == '1'
 TERMS_URL = None
 PRIVACY_URL = None
 
-# Toggles whether minidumps should be cached
+# DEPRECATED: Toggles whether minidumps should be cached
 SENTRY_MINIDUMP_CACHE = False
-# The location for cached minidumps
+# DEPRECATED: The location for cached minidumps
 SENTRY_MINIDUMP_PATH = '/tmp/minidump'
 
 # Relay

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1566,11 +1566,6 @@ SOUTH_TESTS_MIGRATE = os.environ.get('SOUTH_TESTS_MIGRATE', '0') == '1'
 TERMS_URL = None
 PRIVACY_URL = None
 
-# DEPRECATED: Toggles whether minidumps should be cached
-SENTRY_MINIDUMP_CACHE = False
-# DEPRECATED: The location for cached minidumps
-SENTRY_MINIDUMP_PATH = '/tmp/minidump'
-
 # Relay
 # List of PKs whitelisted by Sentry.  All relays here are always
 # registered as internal relays.

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -5,7 +5,6 @@ import math
 
 import jsonschema
 import logging
-import os
 import random
 import six
 import traceback
@@ -761,14 +760,6 @@ class MinidumpView(StoreView):
                 Outcome.INVALID,
                 "empty_minidump")
             raise APIError('Empty minidump upload received')
-
-        if settings.SENTRY_MINIDUMP_CACHE:
-            if not os.path.exists(settings.SENTRY_MINIDUMP_PATH):
-                os.mkdir(settings.SENTRY_MINIDUMP_PATH, 0o744)
-
-            with open('%s/%s.dmp' % (settings.SENTRY_MINIDUMP_PATH, event_id), 'wb') as out:
-                for chunk in minidump.chunks():
-                    out.write(chunk)
 
         # Always store the minidump in attachments so we can access it during
         # processing, regardless of the event-attachments feature. This will


### PR DESCRIPTION
Since all minidumps now go through symbolicator, caching them in the API is no longer necessary.