### PR TITLE
feat(ui): Load builtin symbol sources from API

### DIFF
--- a/src/sentry/api/endpoints/builtin_symbol_sources.py
+++ b/src/sentry/api/endpoints/builtin_symbol_sources.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+import six
+
+from django.conf import settings
+from sentry.api.base import Endpoint
+from sentry.api.serializers import serialize
+
+
+def normalize_symbol_source(key, source):
+    return {
+        'sentry_key': key,
+        'id': source['id'],
+        'name': source['name'],
+    }
+
+
+class BuiltinSymbolSourcesEndpoint(Endpoint):
+    permission_classes = ()
+
+    def get(self, request):
+        sources = [
+            normalize_symbol_source(key, source)
+            for key, source
+            in six.iteritems(settings.SENTRY_BUILTIN_SOURCES)
+        ]
+
+        sources.sort(key=lambda s: s['name'])
+        return Response(serialize(sources))

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -228,6 +228,7 @@ from .endpoints.event_file_committers import EventFileCommittersEndpoint
 from .endpoints.setup_wizard import SetupWizard
 from .endpoints.grouping_configs import GroupingConfigsEndpoint
 from .endpoints.grouping_enhancements import GroupingEnhancementsEndpoint
+from .endpoints.builtin_symbol_sources import BuiltinSymbolSourcesEndpoint
 
 
 urlpatterns = patterns(
@@ -1369,6 +1370,12 @@ urlpatterns = patterns(
     url(
         r'^grouping-enhancements/$', GroupingEnhancementsEndpoint.as_view(),
         name='sentry-api-0-grouping-enhancements'
+    ),
+
+    # Symbolicator Builtin Sources
+    url(
+        r'^builtin-symbol-sources/$', BuiltinSymbolSourcesEndpoint.as_view(),
+        name='sentry-api-0-builtin-symbol-sources',
     ),
 
     # Internal

--- a/src/sentry/static/sentry/app/data/forms/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectDebugFiles.jsx
@@ -12,18 +12,9 @@ export const fields = {
     help: t(
       'Configures which built-in repositories Sentry should use to resolve debug files.'
     ),
-    choices: [
-      ['microsoft', t('Microsoft')],
-      ['amd', t('AMD')],
-      ['autodesk', t('Autodesk')],
-      ['chromium', t('Chromium')],
-      ['citrix', t('Citrix')],
-      ['electron', t('Electron')],
-      ['intel', t('Intel')],
-      ['mozilla', t('Mozilla')],
-      ['nvidia', t('NVIDIA')],
-      ['unity', t('Unity')],
-    ],
+    choices: ({builtinSymbolSources}) =>
+      builtinSymbolSources &&
+      builtinSymbolSources.map(source => [source.sentry_id, t(source.name)]),
   },
   symbolSources: {
     name: 'symbolSources',

--- a/src/sentry/static/sentry/app/data/forms/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectDebugFiles.jsx
@@ -14,7 +14,7 @@ export const fields = {
     ),
     choices: ({builtinSymbolSources}) =>
       builtinSymbolSources &&
-      builtinSymbolSources.map(source => [source.sentry_id, t(source.name)]),
+      builtinSymbolSources.map(source => [source.sentry_key, t(source.name)]),
   },
   symbolSources: {
     name: 'symbolSources',

--- a/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/views/projectDebugFiles.jsx
@@ -66,8 +66,10 @@ class ProjectDebugSymbols extends AsyncComponent {
 
   getEndpoints() {
     const {orgId, projectId} = this.props.params;
+    const {organization} = this.context;
+    const features = new Set(organization.features);
 
-    return [
+    const endpoints = [
       ['project', `/projects/${orgId}/${projectId}/`],
       [
         'debugFiles',
@@ -75,6 +77,12 @@ class ProjectDebugSymbols extends AsyncComponent {
         {query: {query: this.props?.location?.query?.query}},
       ],
     ];
+
+    if (features.has('symbol-sources')) {
+      endpoints.push(['builtinSymbolSources', '/builtin-symbol-sources/']);
+    }
+
+    return endpoints;
   }
 
   onDelete(id) {
@@ -207,6 +215,10 @@ class ProjectDebugSymbols extends AsyncComponent {
     const features = new Set(organization.features);
     const access = new Set(organization.access);
 
+    const fieldProps = {
+      builtinSymbolSources: this.state.builtinSymbolSources,
+    };
+
     return (
       <React.Fragment>
         <SettingsPageHeader title={t('Debug Information Files')} />
@@ -236,6 +248,7 @@ class ProjectDebugSymbols extends AsyncComponent {
                 title={t('External Sources')}
                 disabled={!access.has('project:write')}
                 fields={[fields.builtinSymbolSources, fields.symbolSources]}
+                additionalFieldProps={fieldProps}
               />
             </Form>
           </>


### PR DESCRIPTION
Instead of hard-coding builtin symbol sources in the UI, load them from an API endpoint. The endpoint only exposes information relevant to the UI.

Requires https://github.com/getsentry/sentry/pull/13493
cc @untitaker 