### PR TITLE
fix(api) Update serializer max length to match database

### DIFF
--- a/src/sentry/api/serializers/rest_framework/release.py
+++ b/src/sentry/api/serializers/rest_framework/release.py
@@ -16,7 +16,7 @@ class ReleaseHeadCommitSerializerDeprecated(serializers.Serializer):
 
 class ReleaseHeadCommitSerializer(serializers.Serializer):
     commit = serializers.CharField(max_length=64)
-    repository = serializers.CharField(max_length=64)
+    repository = serializers.CharField(max_length=200)
     previousCommit = serializers.CharField(max_length=64, required=False)
 
 


### PR DESCRIPTION
`sentry_repository.name` is 200 bytes long. We should allow that same length when specifying refs during release creation or repositories with long names cannot have releases made.

Refs #13487