### PR TITLE
feat(native): Enable ios and microsoft symbols

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -587,7 +587,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 'processingIssues': attrs['processing_issues'],
                 'defaultEnvironment': attrs['options'].get('sentry:default_environment'),
                 'relayPiiConfig': attrs['options'].get('sentry:relay_pii_config'),
-                'builtinSymbolSources': attrs['options'].get('sentry:builtin_symbol_sources'),
+                'builtinSymbolSources': get_value_with_default('sentry:builtin_symbol_sources'),
                 'symbolSources': attrs['options'].get('sentry:symbol_sources'),
             }
         )

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1567,6 +1567,14 @@ TERMS_URL = None
 PRIVACY_URL = None
 
 # Internal sources for debug information files
+#
+# There are two special values in there: "microsoft" and "ios".  These are
+# added by default to any project created.  The "ios" source is currently
+# not enabled in the open source build of sentry because it points to a
+# sentry internal repository and it's unclear if these can be
+# redistributed under the Apple EULA.  If however someone configures their
+# own iOS source and name it 'ios' it will be enabled by default for all
+# projects.
 SENTRY_BUILTIN_SOURCES = {
     'microsoft': {
         'type': 'http',

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -284,7 +284,7 @@ def get_sources_for_project(project):
 
     # Add builtin sources last to ensure that custom sources have precedence
     # over our defaults.
-    builtin_sources = project.get_option('sentry:builtin_symbol_sources') or []
+    builtin_sources = project.get_option('sentry:builtin_symbol_sources')
     for key, source in six.iteritems(settings.SENTRY_BUILTIN_SOURCES):
         if key in builtin_sources:
             sources.append(source)

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -25,7 +25,6 @@ register(
     key='sentry:grouping_config',
     epoch_defaults={
         1: DEFAULT_GROUPING_CONFIG,
-        # 2: 'combined:2019-04-07',
     }
 )
 

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import
 from sentry.projectoptions import register
 
 # latest epoch
-LATEST_EPOCH = 1
+LATEST_EPOCH = 2
 
 # grouping related configs
 #
@@ -55,5 +55,16 @@ register(
     key='sentry:default_loader_version',
     epoch_defaults={
         1: '4.x',
+    }
+)
+
+# Default symbol sources.  The ios source does not exist by default and
+# will be skipped later.  The microsoft source exists by default and is
+# unlikely to be disabled.
+register(
+    key='sentry:builtin_symbol_sources',
+    epoch_defaults={
+        1: ['ios'],
+        2: ['ios', 'microsoft'],
     }
 )


### PR DESCRIPTION
The sources are now enabled by default automatically (depending on
epoch) even though the iOS source does not exist in the open source
build.  This is fine because a non existing source will be ignored.