### PR TITLE
fix(ui): Preserve query string when going to the events page from the # of events link

### DIFF
--- a/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
@@ -91,18 +91,6 @@ const GroupHeader = createReactClass({
     }
   },
 
-  searchTermWithoutQuery() {
-    const {location} = this.context;
-
-    const searchTermWithoutQuery = qs.stringify(omit(location.query, 'query'));
-
-    if (searchTermWithoutQuery.length <= 0) {
-      return '';
-    }
-
-    return `?${searchTermWithoutQuery}`;
-  },
-
   render() {
     const {project, group, params} = this.props;
     const projectFeatures = new Set(project ? project.features : []);
@@ -134,6 +122,12 @@ const GroupHeader = createReactClass({
     const baseUrl = params.projectId
       ? `/${orgId}/${params.projectId}/issues/`
       : `/organizations/${orgId}/issues/`;
+
+    const searchTermWithoutQuery = omit(location.query, 'query');
+    const eventRouteToObject = {
+      pathname: `${baseUrl}${groupId}/events/`,
+      query: searchTermWithoutQuery,
+    };
 
     return (
       <div className={className}>
@@ -198,7 +192,7 @@ const GroupHeader = createReactClass({
               )}
               <div className="count align-right m-l-1">
                 <h6 className="nav-header">{t('Events')}</h6>
-                <Link to={`${baseUrl}${groupId}/events/${this.searchTermWithoutQuery()}`}>
+                <Link to={eventRouteToObject}>
                   <Count className="count" value={group.count} />
                 </Link>
               </div>
@@ -257,7 +251,7 @@ const GroupHeader = createReactClass({
             {t('Tags')}
           </ListLink>
           <ListLink
-            to={`${baseUrl}${groupId}/events/${this.searchTermWithoutQuery()}`}
+            to={eventRouteToObject}
             isActive={() => location.pathname.endsWith('/events/')}
           >
             {t('Events')}

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
@@ -91,6 +91,18 @@ const GroupHeader = createReactClass({
     }
   },
 
+  searchTermWithoutQuery() {
+    const {location} = this.context;
+
+    const searchTermWithoutQuery = qs.stringify(omit(location.query, 'query'));
+
+    if (searchTermWithoutQuery.length <= 0) {
+      return '';
+    }
+
+    return `?${searchTermWithoutQuery}`;
+  },
+
   render() {
     const {project, group, params} = this.props;
     const projectFeatures = new Set(project ? project.features : []);
@@ -122,8 +134,6 @@ const GroupHeader = createReactClass({
     const baseUrl = params.projectId
       ? `/${orgId}/${params.projectId}/issues/`
       : `/organizations/${orgId}/issues/`;
-
-    const searchTermWithoutQuery = qs.stringify(omit(location.query, 'query'));
 
     return (
       <div className={className}>
@@ -188,7 +198,7 @@ const GroupHeader = createReactClass({
               )}
               <div className="count align-right m-l-1">
                 <h6 className="nav-header">{t('Events')}</h6>
-                <Link to={`${baseUrl}${groupId}/events/`}>
+                <Link to={`${baseUrl}${groupId}/events/${this.searchTermWithoutQuery()}`}>
                   <Count className="count" value={group.count} />
                 </Link>
               </div>
@@ -247,7 +257,7 @@ const GroupHeader = createReactClass({
             {t('Tags')}
           </ListLink>
           <ListLink
-            to={`${baseUrl}${groupId}/events/?${searchTermWithoutQuery}`}
+            to={`${baseUrl}${groupId}/events/${this.searchTermWithoutQuery()}`}
             isActive={() => location.pathname.endsWith('/events/')}
           >
             {t('Events')}

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
@@ -3,7 +3,6 @@ import {omit} from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import qs from 'query-string';
 import styled from 'react-emotion';
 
 import {fetchOrgMembers} from 'app/actionCreators/members';

--- a/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
+++ b/src/sentry/static/sentry/app/views/groupDetails/shared/header.jsx
@@ -205,7 +205,7 @@ const GroupHeader = createReactClass({
               <div className="count align-right m-l-1">
                 <h6 className="nav-header">{t('Users')}</h6>
                 {userCount !== 0 ? (
-                  <Link to={`${baseUrl}${groupId}/tags/user/`}>
+                  <Link to={`${baseUrl}${groupId}/tags/user/${location.search}`}>
                     <Count className="count" value={userCount} />
                   </Link>
                 ) : (


### PR DESCRIPTION
Preserve query string when going to the events page from the # of events link.

Lyn (@lynnagara) has pointed out that clicking on the "Events" tab (5th from the left) will preserve the query string.

<img width="1424" alt="Screen Shot 2019-06-03 at 3 31 44 PM" src="https://user-images.githubusercontent.com/139499/58829035-d0ad5880-8614-11e9-9055-46515c239dd4.png">



Fixes ISSUE-429
Fixes SEN-507