### PR TITLE
feat(api): Add endpoint to return suspect causes of an incident (SEN-578)

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_suspects_index.py
+++ b/src/sentry/api/endpoints/organization_incident_suspects_index.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+
+from itertools import islice
+
+from sentry.api.bases.incident import (
+    IncidentEndpoint,
+    IncidentPermission,
+)
+from sentry.incidents.logic import get_incident_suspects
+
+
+class OrganizationIncidentSuspectsIndexEndpoint(IncidentEndpoint):
+    permission_classes = (IncidentPermission, )
+
+    def get(self, request, organization, incident):
+        """
+        Fetches potential causes of an Incident.
+        ````````````````````````````````````````
+        Fetches potential causes of an Incident. Currently this is just suspect
+        commits for all related Groups.
+        :auth: required
+        """
+
+        # Only fetch suspects for projects that the user has access to
+        projects = [
+            project for project in incident.projects.all()
+            if request.access.has_project_access(project)
+        ]
+        suspects = islice(get_incident_suspects(incident, projects), 10)
+
+        # TODO: For now just hard coding this format, as we add in more formats
+        # we'll handle this in a more robust way.
+        return self.respond([{'type': 'commit', 'data': suspect} for suspect in suspects])

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -86,6 +86,7 @@ from .endpoints.organization_incident_comment_index import OrganizationIncidentC
 from .endpoints.organization_incident_comment_details import OrganizationIncidentCommentDetailsEndpoint
 from .endpoints.organization_incident_index import OrganizationIncidentIndexEndpoint
 from .endpoints.organization_incident_subscription_index import OrganizationIncidentSubscriptionIndexEndpoint
+from .endpoints.organization_incident_suspects_index import OrganizationIncidentSuspectsIndexEndpoint
 from .endpoints.organization_issues_new import OrganizationIssuesNewEndpoint
 from .endpoints.organization_issues_resolved_in_release import OrganizationIssuesResolvedInReleaseEndpoint
 from .endpoints.organization_member_details import OrganizationMemberDetailsEndpoint
@@ -454,6 +455,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/subscriptions/$',
         OrganizationIncidentSubscriptionIndexEndpoint.as_view(),
         name='sentry-api-0-organization-incident-subscription-index'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/incidents/(?P<incident_identifier>[^\/]+)/suspects/$',
+        OrganizationIncidentSuspectsIndexEndpoint.as_view(),
+        name='sentry-api-0-organization-incident-suspect-index'
     ),
 
     # Organizations

--- a/tests/sentry/api/endpoints/test_organization_incident_suspects_index.py
+++ b/tests/sentry/api/endpoints/test_organization_incident_suspects_index.py
@@ -1,0 +1,102 @@
+from __future__ import absolute_import
+
+from exam import fixture
+
+from sentry.models import Repository
+from sentry.testutils import APITestCase
+
+
+class OrganizationIncidentSuspectsListEndpointTest(APITestCase):
+    endpoint = 'sentry-api-0-organization-incident-suspect-index'
+    method = 'get'
+
+    @fixture
+    def organization(self):
+        return self.create_organization()
+
+    @fixture
+    def project(self):
+        return self.create_project(organization=self.organization)
+
+    @fixture
+    def user(self):
+        return self.create_user()
+
+    def test_simple(self):
+        self.create_member(
+            user=self.user,
+            organization=self.organization,
+            role='owner',
+            teams=[self.team],
+        )
+        self.login_as(self.user)
+        release = self.create_release(project=self.project, version='v12')
+
+        event = self.store_event(
+            data={
+                'fingerprint': ['group-1'],
+                'message': 'Kaboom!',
+                'platform': 'python',
+                'stacktrace': {
+                    'frames': [
+                        {
+                            "function": "set_commits",
+                            "abs_path": "/usr/src/sentry/src/sentry/models/release.py",
+                            "module": "sentry.models.release",
+                            "in_app": True,
+                            "lineno": 39,
+                            "filename": "sentry/models/release.py",
+                        }
+                    ]
+                },
+                'release': release.version,
+            },
+            project_id=self.project.id,
+        )
+        group = event.group
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name=self.organization.id,
+        )
+        commit_id = 'a' * 40
+        release.set_commits([
+            {
+                'id': commit_id,
+                'repository': self.repo.name,
+                'author_email': 'bob@example.com',
+                'author_name': 'Bob',
+                'message': 'i fixed a bug',
+                'patch_set': [
+                    {
+                        'path': 'src/sentry/models/release.py',
+                        'type': 'M',
+                    },
+                ]
+            },
+        ])
+        incident = self.create_incident(self.organization, groups=[group])
+        with self.feature('organizations:incidents'):
+            resp = self.get_valid_response(
+                self.organization.slug,
+                incident.identifier,
+            )
+        assert len(resp.data) == 1
+        suspect = resp.data[0]
+        assert suspect['type'] == 'commit'
+        assert suspect['data']['id'] == commit_id
+
+    def test_access(self):
+        other_user = self.create_user()
+        self.login_as(other_user)
+        other_team = self.create_team()
+        self.create_member(
+            user=self.user,
+            organization=self.organization,
+            role='member',
+            teams=[self.team],
+        )
+        other_project = self.create_project(teams=[other_team])
+        incident = self.create_incident(projects=[other_project])
+        with self.feature('organizations:incidents'):
+            resp = self.get_response(self.organization.slug, incident.identifier)
+            assert resp.status_code == 403


### PR DESCRIPTION
Initial version of this endpoint. Returns a list of suspects in format
```
{'type': '<type>', 'data': <arbitrary json blob for each type>}
```

At the moment we only return commits. The blob in `data` is similar to what we return for each
commit on the suspect commits endpoint, but we also embed the author into the commit info:
```
{'type': 'commit', 'data': {<commit_data>, 'author': <author>}}
```

Will be slow for the moment since we just calculate these for each group sequentially. Will follow
up with speed improvements (either caching or making the calculations fast).