### PR TITLE
feat(event-search): Add aggregate comparisons to events v2 endpoint

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -69,6 +69,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         fields = request.GET.getlist('field')[:]
         aggregations = []
         groupby = request.GET.getlist('groupby')
+        having = request.GET.getlist('having')
 
         if fields:
             # If project.name is requested, get the project.id from Snuba so we
@@ -86,10 +87,18 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                     aggregations.extend(special_field.get('aggregations', []))
                     groupby.extend(special_field.get('groupby', []))
 
+            for index, condition in enumerate(having):
+                condition = condition.split(',')
+                assert len(condition) == 3
+                having[index] = condition
+
             snuba_args['selected_columns'] = fields
 
         if aggregations:
             snuba_args['aggregations'] = aggregations
+
+        if having:
+            snuba_args['having'] = having
 
         if groupby:
             snuba_args['groupby'] = groupby

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -89,7 +89,9 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
             for index, condition in enumerate(having):
                 condition = condition.split(',')
-                assert len(condition) == 3
+                if len(condition) != 3:
+                    raise OrganizationEventsError(
+                        'having clause %s is not of the form: "column,operator,literal"' % having[index])
                 having[index] = condition
 
             snuba_args['selected_columns'] = fields

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -93,6 +93,8 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         if conditions:
             for condition in conditions:
                 field = condition[0]
+                if isinstance(field, (list, tuple)):
+                    continue
                 if field in SPECIAL_FIELDS:
                     aggregation_included = False
                     for aggregate in aggregations:

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -94,7 +94,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
         data_fn = partial(
             lambda **kwargs: transform_aliases_and_query(
-                skip_conditions=True, **kwargs)['data'],
+                **kwargs)['data'],
             referrer='api.organization-events-v2',
             **snuba_args
         )

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -94,7 +94,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
         data_fn = partial(
             lambda **kwargs: transform_aliases_and_query(
-                **kwargs)['data'],
+                skip_conditions=True, **kwargs)['data'],
             referrer='api.organization-events-v2',
             **snuba_args
         )

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -141,6 +141,9 @@ SEARCH_MAP = dict({
     'first_seen': 'first_seen',
     'last_seen': 'last_seen',
     'times_seen': 'times_seen',
+    # OrganizationEvents aggregations
+    'event_count': 'event_count',
+    'user_count': 'user_count',
 }, **SENTRY_SNUBA_MAP)
 no_conversion = set(['project_id', 'start', 'end'])
 
@@ -209,6 +212,8 @@ class SearchVisitor(NodeVisitor):
         'device.battery_level', 'device.charging', 'device.online',
         'device.simulator', 'error.handled', 'issue.id', 'stack.colno',
         'stack.in_app', 'stack.lineno', 'stack.stack_level',
+        # OrganizationEvents aggregations
+        'event_count', 'user_count',
 
     ])
     date_keys = set([

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -395,7 +395,7 @@ def transform_aliases_and_query(skip_conditions=False, **kwargs):
     arrayjoin = kwargs.get('arrayjoin')
     rollup = kwargs.get('rollup')
     orderby = kwargs.get('orderby')
-    having = kwargs.get('having')
+    having = kwargs.get('having', [])
 
     if selected_columns:
         for (idx, col) in enumerate(selected_columns):
@@ -442,20 +442,17 @@ def transform_aliases_and_query(skip_conditions=False, **kwargs):
         return cond
 
     if conditions:
-        kwargs['conditions'] = ([handle_condition(condition) for condition in conditions]
-                                if skip_conditions is False else conditions)
-    if having:
-        kwargs['having'] = []
-        for condition in having:
-            if not QUOTED_LITERAL_RE.match(condition[2]):
-                try:
-                    condition[2] = float(condition[2])
-                except ValueError:
-                    pass
+        kwargs['conditions'] = []
+        for condition in conditions:
             if condition[0] in derived_columns:
-                kwargs['having'].append(condition)
+                having.append(condition)
+            elif skip_conditions is False:
+                kwargs['conditions'].append(condition)
             else:
-                kwargs['having'].append(handle_condition(condition))
+                kwargs['conditions'].append(handle_condition(condition))
+
+    if having:
+        kwargs['having'] = having
 
     if orderby:
         order_by_column = orderby.lstrip('-')

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -444,9 +444,10 @@ def transform_aliases_and_query(skip_conditions=False, **kwargs):
     if conditions:
         kwargs['conditions'] = []
         for condition in conditions:
-            if condition[0] in derived_columns:
+            field = condition[0]
+            if not isinstance(field, (list, tuple)) and field in derived_columns:
                 having.append(condition)
-            elif skip_conditions is False:
+            elif skip_conditions:
                 kwargs['conditions'].append(condition)
             else:
                 kwargs['conditions'].append(handle_condition(condition))

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -395,6 +395,7 @@ def transform_aliases_and_query(skip_conditions=False, **kwargs):
     arrayjoin = kwargs.get('arrayjoin')
     rollup = kwargs.get('rollup')
     orderby = kwargs.get('orderby')
+    having = kwargs.get('having')
 
     if selected_columns:
         for (idx, col) in enumerate(selected_columns):
@@ -443,6 +444,18 @@ def transform_aliases_and_query(skip_conditions=False, **kwargs):
     if conditions:
         kwargs['conditions'] = ([handle_condition(condition) for condition in conditions]
                                 if skip_conditions is False else conditions)
+    if having:
+        kwargs['having'] = []
+        for condition in having:
+            if not QUOTED_LITERAL_RE.match(condition[2]):
+                try:
+                    condition[2] = float(condition[2])
+                except ValueError:
+                    pass
+            if condition[0] in derived_columns:
+                kwargs['having'].append(condition)
+            else:
+                kwargs['having'].append(handle_condition(condition))
 
     if orderby:
         order_by_column = orderby.lstrip('-')

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -339,3 +339,23 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[0]['issue.id'] == groups[1].id
         assert response.data[0]['event_count'] == 2
         assert response.data[0]['user_count'] == 2
+
+    def test_malformed_having(self):
+        self.login_as(user=self.user)
+        self.create_project()
+
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'field': ['issue_title', 'event_count', 'user_count'],
+                    'having': ['event_count,>'],
+                    'groupby': ['issue.id', 'project.id'],
+                    'orderby': 'issue.id'
+                },
+            )
+
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "detail": "having clause event_count,> is not of the form: \"column,operator,literal\""}

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -339,23 +339,3 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[0]['issue.id'] == groups[1].id
         assert response.data[0]['event_count'] == 2
         assert response.data[0]['user_count'] == 2
-
-    def test_malformed_having(self):
-        self.login_as(user=self.user)
-        self.create_project()
-
-        with self.feature('organizations:events-v2'):
-            response = self.client.get(
-                self.url,
-                format='json',
-                data={
-                    'field': ['issue_title', 'event_count', 'user_count'],
-                    'having': ['event_count,>'],
-                    'groupby': ['issue.id', 'project.id'],
-                    'orderby': 'issue.id'
-                },
-            )
-
-        assert response.status_code == 400, response.content
-        assert response.data == {
-            "detail": "having clause event_count,> is not of the form: \"column,operator,literal\""}

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -260,7 +260,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[1]['event_count'] == 2
         assert response.data[1]['user_count'] == 2
 
-    def test_special_field_with_having_conditions(self):
+    def test_aggregation_comparision(self):
         self.login_as(user=self.user)
         project = self.create_project()
         self.store_event(
@@ -327,6 +327,86 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
                 format='json',
                 data={
                     'field': ['issue_title', 'event_count', 'user_count'],
+                    'query': ['event_count:>1 user_count:>1'],
+                    'groupby': ['issue.id', 'project.id'],
+                    'orderby': 'issue.id'
+                },
+            )
+
+        assert response.status_code == 200, response.content
+
+        assert len(response.data) == 1
+        assert response.data[0]['issue.id'] == groups[1].id
+        assert response.data[0]['event_count'] == 2
+        assert response.data[0]['user_count'] == 2
+
+    def test_aggregation_comparision_not_displayed(self):
+        self.login_as(user=self.user)
+        project = self.create_project()
+        self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_1'],
+                'user': {
+                    'email': 'foo@example.com',
+                },
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'b' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_2'],
+                'user': {
+                    'email': 'foo@example.com',
+                },
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'c' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_2'],
+                'user': {
+                    'email': 'bar@example.com',
+                },
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'd' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_3'],
+                'user': {
+                    'email': 'bar@example.com',
+                },
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'e' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_3'],
+                'user': {
+                    'email': 'bar@example.com',
+                },
+            },
+            project_id=project.id,
+        )
+
+        groups = Group.objects.all()
+
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'field': ['issue_title', 'event_count'],
                     'query': ['event_count:>1 user_count:>1'],
                     'groupby': ['issue.id', 'project.id'],
                     'orderby': 'issue.id'

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -419,3 +419,75 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[0]['issue.id'] == groups[1].id
         assert response.data[0]['event_count'] == 2
         assert response.data[0]['user_count'] == 2
+
+    def test_aggregation_comparision_with_conditions(self):
+        self.login_as(user=self.user)
+        project = self.create_project()
+        self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_1'],
+                'user': {
+                    'email': 'foo@example.com',
+                },
+                'environment': 'prod',
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'b' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_2'],
+                'user': {
+                    'email': 'foo@example.com',
+                },
+                'environment': 'staging',
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'c' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_2'],
+                'user': {
+                    'email': 'foo@example.com',
+                },
+                'environment': 'prod',
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'd' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_2'],
+                'user': {
+                    'email': 'foo@example.com',
+                },
+                'environment': 'prod',
+            },
+            project_id=project.id,
+        )
+
+        groups = Group.objects.all()
+
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'field': ['issue_title', 'event_count'],
+                    'query': ['event_count:>1 user.email:foo@example.com environment:prod'],
+                    'groupby': ['issue.id', 'project.id'],
+                    'orderby': 'issue.id'
+                },
+            )
+
+        assert response.status_code == 200, response.content
+
+        assert len(response.data) == 1
+        assert response.data[0]['issue.id'] == groups[1].id
+        assert response.data[0]['event_count'] == 2

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -327,7 +327,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
                 format='json',
                 data={
                     'field': ['issue_title', 'event_count', 'user_count'],
-                    'having': ['event_count,>,1', 'user_count,>,1'],
+                    'query': ['event_count:>1 user_count:>1'],
                     'groupby': ['issue.id', 'project.id'],
                     'orderby': 'issue.id'
                 },

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -260,7 +260,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[1]['event_count'] == 2
         assert response.data[1]['user_count'] == 2
 
-    def test_aggregation_comparision(self):
+    def test_aggregation_comparison(self):
         self.login_as(user=self.user)
         project = self.create_project()
         self.store_event(
@@ -340,7 +340,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[0]['event_count'] == 2
         assert response.data[0]['user_count'] == 2
 
-    def test_aggregation_comparision_not_displayed(self):
+    def test_aggregation_comparison_not_displayed(self):
         self.login_as(user=self.user)
         project = self.create_project()
         self.store_event(
@@ -420,7 +420,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[0]['event_count'] == 2
         assert response.data[0]['user_count'] == 2
 
-    def test_aggregation_comparision_with_conditions(self):
+    def test_aggregation_comparison_with_conditions(self):
         self.login_as(user=self.user)
         project = self.create_project()
         self.store_event(

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -259,3 +259,97 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[1]['issue.id'] == groups[1].id
         assert response.data[1]['event_count'] == 2
         assert response.data[1]['user_count'] == 2
+
+    def test_special_field_with_conditions(self):
+        self.login_as(user=self.user)
+        project = self.create_project()
+        self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_1'],
+                'user': {
+                    'email': 'foo@example.com',
+                },
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'b' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_2'],
+                'user': {
+                    'email': 'foo@example.com',
+                },
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'c' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_2'],
+                'user': {
+                    'email': 'bar@example.com',
+                },
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'd' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_3'],
+                'user': {
+                    'email': 'foo@example.com',
+                },
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'e' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_3'],
+                'user': {
+                    'email': 'bar@example.com',
+                },
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'f' * 32,
+                'timestamp': self.min_ago,
+                'fingerprint': ['group_3'],
+                'user': {
+                    'email': 'foobar@example.com',
+                },
+            },
+            project_id=project.id,
+        )
+
+        groups = Group.objects.all()
+
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'field': ['issue_title', 'event_count', 'user_count'],
+                    'having': ['event_count,>,1', 'user_count,>,1'],
+                    'groupby': ['issue.id', 'project.id'],
+                    'orderby': 'issue.id'
+                },
+            )
+
+        assert response.status_code == 200, response.content
+
+        assert len(response.data) == 2
+        assert response.data[0]['issue.id'] == groups[1].id
+        assert response.data[0]['event_count'] == 2
+        assert response.data[0]['user_count'] == 2
+        assert response.data[1]['issue.id'] == groups[2].id
+        assert response.data[1]['event_count'] == 3
+        assert response.data[1]['user_count'] == 3

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -260,7 +260,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[1]['event_count'] == 2
         assert response.data[1]['user_count'] == 2
 
-    def test_special_field_with_conditions(self):
+    def test_special_field_with_having_conditions(self):
         self.login_as(user=self.user)
         project = self.create_project()
         self.store_event(
@@ -302,7 +302,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
                 'timestamp': self.min_ago,
                 'fingerprint': ['group_3'],
                 'user': {
-                    'email': 'foo@example.com',
+                    'email': 'bar@example.com',
                 },
             },
             project_id=project.id,
@@ -314,17 +314,6 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
                 'fingerprint': ['group_3'],
                 'user': {
                     'email': 'bar@example.com',
-                },
-            },
-            project_id=project.id,
-        )
-        self.store_event(
-            data={
-                'event_id': 'f' * 32,
-                'timestamp': self.min_ago,
-                'fingerprint': ['group_3'],
-                'user': {
-                    'email': 'foobar@example.com',
                 },
             },
             project_id=project.id,
@@ -346,10 +335,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
 
         assert response.status_code == 200, response.content
 
-        assert len(response.data) == 2
+        assert len(response.data) == 1
         assert response.data[0]['issue.id'] == groups[1].id
         assert response.data[0]['event_count'] == 2
         assert response.data[0]['user_count'] == 2
-        assert response.data[1]['issue.id'] == groups[2].id
-        assert response.data[1]['event_count'] == 3
-        assert response.data[1]['user_count'] == 3


### PR DESCRIPTION
Meant to satisfy `SEN-685` Extend search syntax to support comparisons with aggregate fields, e.g. `"count > 5"` 
