### PR TITLE
fix(saved-searches): line length limits

### DIFF
--- a/src/sentry/static/sentry/app/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip.jsx
@@ -43,6 +43,11 @@ class Tooltip extends React.Component {
      * Display mode for the container element
      */
     containerDisplayMode: PropTypes.oneOf(['block', 'inline-block', 'inline']),
+
+    /**
+    * Time to wait (in milliseconds) before showing the tooltip
+    */
+    delay: PropTypes.number,
   };
 
   static defaultProps = {
@@ -70,12 +75,27 @@ class Tooltip extends React.Component {
     this.tooltipId = domId('tooltip-');
   }
 
-  handleOpen = evt => {
+  setOpen = () => {
     this.setState({isOpen: true});
+  }
+
+  handleOpen = evt => {
+    const {delay} = this.props;
+
+    if (delay) {
+      this.delayTimeout = window.setTimeout(this.setOpen, delay)
+    } else {
+      this.setOpen();
+    }
   };
 
   handleClose = evt => {
     this.setState({isOpen: false});
+
+    if (this.delayTimeout) {
+      window.clearTimeout(this.delayTimeout);
+      this.delayTimeout = null;
+    }
   };
 
   renderTrigger(children, ref) {

--- a/src/sentry/static/sentry/app/components/tooltip.jsx
+++ b/src/sentry/static/sentry/app/components/tooltip.jsx
@@ -45,8 +45,8 @@ class Tooltip extends React.Component {
     containerDisplayMode: PropTypes.oneOf(['block', 'inline-block', 'inline']),
 
     /**
-    * Time to wait (in milliseconds) before showing the tooltip
-    */
+     * Time to wait (in milliseconds) before showing the tooltip
+     */
     delay: PropTypes.number,
   };
 
@@ -77,13 +77,13 @@ class Tooltip extends React.Component {
 
   setOpen = () => {
     this.setState({isOpen: true});
-  }
+  };
 
   handleOpen = evt => {
     const {delay} = this.props;
 
     if (delay) {
-      this.delayTimeout = window.setTimeout(this.setOpen, delay)
+      this.delayTimeout = window.setTimeout(this.setOpen, delay);
     } else {
       this.setOpen();
     }

--- a/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
@@ -8,6 +8,7 @@ import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownControl from 'app/components/dropdownControl';
+import Tooltip from 'app/components/tooltip';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
@@ -47,33 +48,40 @@ export default class OrganizationSavedSearchSelector extends React.Component {
       return <EmptyItem>{t("There don't seem to be any saved searches yet.")}</EmptyItem>;
     }
 
-    return savedSearchList.map(search => (
-      <MenuItem key={search.id}>
-        <MenuItemLink tabIndex="-1" onClick={() => onSavedSearchSelect(search)}>
-          <SearchTitle>{search.name}</SearchTitle>
-          <SearchQuery>{search.query}</SearchQuery>
-        </MenuItemLink>
-        {search.isGlobal === false && search.isPinned === false && (
-          <Access
-            organization={organization}
-            access={['org:write']}
-            renderNoAccessMessage={false}
-          >
-            <Confirm
-              onConfirm={() => onSavedSearchDelete(search)}
-              message={t('Are you sure you want to delete this saved search?')}
-              stopPropagation
+    return savedSearchList.map((search, index) => (
+      <Tooltip
+        title={(<span>{search.name} • <TooltipSearchQuery>{search.query}</TooltipSearchQuery></span>)}
+        containerDisplayMode="block"
+        delay={1000}
+        key={search.id}
+      >
+        <MenuItem last={index == savedSearchList.length - 1}>
+            <MenuItemLink tabIndex="-1" onClick={() => onSavedSearchSelect(search)}>
+              <SearchTitle>{search.name}</SearchTitle>
+              <SearchQuery>{search.query}</SearchQuery>
+            </MenuItemLink>
+          {search.isGlobal === false && search.isPinned === false && (
+            <Access
+              organization={organization}
+              access={['org:write']}
+              renderNoAccessMessage={false}
             >
-              <DeleteButton
-                borderless
-                title={t('Delete this saved search')}
-                icon="icon-trash"
-                size="zero"
-              />
-            </Confirm>
-          </Access>
-        )}
-      </MenuItem>
+              <Confirm
+                onConfirm={() => onSavedSearchDelete(search)}
+                message={t('Are you sure you want to delete this saved search?')}
+                stopPropagation
+              >
+                <DeleteButton
+                  borderless
+                  title={t('Delete this saved search')}
+                  icon="icon-trash"
+                  size="zero"
+                />
+              </Confirm>
+            </Access>
+          )}
+        </MenuItem>
+      </Tooltip>
     ));
   }
 
@@ -139,6 +147,12 @@ const SearchQuery = styled('code')`
   background: inherit;
 `;
 
+const TooltipSearchQuery = styled('span')`
+  color: ${p => p.theme.gray1};
+  font-weight: normal;
+  font-family: ${p => p.theme.text.familyMono};
+`;
+
 const DeleteButton = styled(Button)`
   color: ${p => p.theme.gray1};
   background: transparent;
@@ -155,25 +169,20 @@ const MenuItem = styled('li')`
   display: flex;
 
   position: relative;
-  border-bottom: 1px solid ${p => p.theme.borderLight};
+  border-bottom: ${p => !p.last ? `1px solid ${p.theme.borderLight}` : null};
   font-size: ${p => p.theme.fontSizeMedium};
   padding: 0;
 
-  &:last-child {
-    border-bottom: 0;
-  }
   & :hover {
     background: ${p => p.theme.offWhite};
-  }
-
-  & a {
-    display: block;
-    flex-grow: 1;
-    padding: ${space(1)} ${space(1.5)};
   }
 `;
 
 const MenuItemLink = styled('a')`
+  display: block;
+  flex-grow: 1;
+  padding: ${space(1)} ${space(1.5)};
+
   ${overflowEllipsis}
 `;
 

--- a/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
@@ -49,10 +49,10 @@ export default class OrganizationSavedSearchSelector extends React.Component {
 
     return savedSearchList.map(search => (
       <MenuItem key={search.id}>
-        <a tabIndex="-1" onClick={() => onSavedSearchSelect(search)}>
+        <MenuItemLink tabIndex="-1" onClick={() => onSavedSearchSelect(search)}>
           <SearchTitle>{search.name}</SearchTitle>
           <SearchQuery>{search.query}</SearchQuery>
-        </a>
+        </MenuItemLink>
         {search.isGlobal === false && search.isPinned === false && (
           <Access
             organization={organization}
@@ -81,7 +81,7 @@ export default class OrganizationSavedSearchSelector extends React.Component {
     return (
       <Container>
         <DropdownControl
-          menuWidth="375px"
+          menuWidth="35vw"
           blendWithActor
           button={({isOpen, getActorProps}) => (
             <StyledDropdownButton {...getActorProps({isStyled: true})} isOpen={isOpen}>
@@ -171,6 +171,10 @@ const MenuItem = styled('li')`
     flex-grow: 1;
     padding: ${space(1)} ${space(1.5)};
   }
+`;
+
+const MenuItemLink = styled('a')`
+  ${overflowEllipsis}
 `;
 
 const EmptyItem = styled('li')`

--- a/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/stream/organizationSavedSearchSelector.jsx
@@ -50,16 +50,20 @@ export default class OrganizationSavedSearchSelector extends React.Component {
 
     return savedSearchList.map((search, index) => (
       <Tooltip
-        title={(<span>{search.name} • <TooltipSearchQuery>{search.query}</TooltipSearchQuery></span>)}
+        title={
+          <span>
+            {search.name} • <TooltipSearchQuery>{search.query}</TooltipSearchQuery>
+          </span>
+        }
         containerDisplayMode="block"
         delay={1000}
         key={search.id}
       >
         <MenuItem last={index == savedSearchList.length - 1}>
-            <MenuItemLink tabIndex="-1" onClick={() => onSavedSearchSelect(search)}>
-              <SearchTitle>{search.name}</SearchTitle>
-              <SearchQuery>{search.query}</SearchQuery>
-            </MenuItemLink>
+          <MenuItemLink tabIndex="-1" onClick={() => onSavedSearchSelect(search)}>
+            <SearchTitle>{search.name}</SearchTitle>
+            <SearchQuery>{search.query}</SearchQuery>
+          </MenuItemLink>
           {search.isGlobal === false && search.isPinned === false && (
             <Access
               organization={organization}
@@ -169,7 +173,7 @@ const MenuItem = styled('li')`
   display: flex;
 
   position: relative;
-  border-bottom: ${p => !p.last ? `1px solid ${p.theme.borderLight}` : null};
+  border-bottom: ${p => (!p.last ? `1px solid ${p.theme.borderLight}` : null)};
   font-size: ${p => p.theme.fontSizeMedium};
   padding: 0;
 


### PR DESCRIPTION
saved searches can get very long:

<img width="869" alt="old-savies" src="https://user-images.githubusercontent.com/435981/58842408-eb86c980-8622-11e9-918d-21ade68388e5.png">

this causes several problems:

1. menu compactness can be severely downgraded by long queries, even pushing valuable content off the screen
2. the menu is difficult to scan, with wildly different line item heights 
3. menu hierarchy is out of whack, with longer queries demanding more screen space than shorter ones, even though they do not deserve it.

This pull adds an overflow ellipsis, elongates the menu to reduce the times it will be needed, and adds a tooltip with a one-second delay for those who wish to read the full query without a click. Cut-off points are similar to the previous cutoff points (~900px)

result:

![2019-06-04 17-22-47 2019-06-04 17_23_28](https://user-images.githubusercontent.com/435981/58924042-088ccc80-86f7-11e9-88de-5d19903fba12.gif)

