### PR TITLE
fix(releases): Fix empty state

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/list/organizationReleases/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/organizationReleases/index.jsx
@@ -92,7 +92,13 @@ class OrganizationReleases extends AsyncView {
       organization: {projects},
       selection,
     } = this.props;
-    const projectIds = new Set(selection.projects);
+
+    const projectIds = new Set(
+      selection.projects.length > 0
+        ? selection.projects
+        : projects.filter(p => p.isMember).map(p => parseInt(p.id, 10))
+    );
+
     const activeProjects = projects.filter(project =>
       projectIds.has(parseInt(project.id, 10))
     );

--- a/tests/js/spec/views/releases/list/organizationReleases.spec.jsx
+++ b/tests/js/spec/views/releases/list/organizationReleases.spec.jsx
@@ -56,12 +56,27 @@ describe('OrganizationReleases', function() {
     expect(releases.map(item => item.text())).toEqual(['abc', 'def']);
   });
 
-  it('renders no query state if project has a release', function() {
+  it('renders no query state if selected project has a release', function() {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/releases/',
       body: [],
     });
     organization.projects = [TestStubs.Project({latestRelease: 'abcdef'})];
+    wrapper = mount(
+      <OrganizationReleases {...props} />,
+      TestStubs.routerContext([{organization}])
+    );
+    const content = wrapper.find('PageContent');
+    expect(content.text()).toContain('Sorry, no releases match your filters');
+  });
+
+  it('renders no query state if any member project has a release and "All projects" is selected', function() {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/',
+      body: [],
+    });
+    organization.projects = [TestStubs.Project({latestRelease: 'abcdef'})];
+    props.selection = {projects: []};
     wrapper = mount(
       <OrganizationReleases {...props} />,
       TestStubs.routerContext([{organization}])


### PR DESCRIPTION
Fixes a bug where the set up releases landing page was being shown
incorrectly when "All projects" was selected. In this case we now look
through all member projects and check for a non-null latest release
value before displaying the setup CTA.