### PR TITLE
fix(make): Add additional setup steps to `make bootstrap`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,17 @@ PIP = LDFLAGS="$(LDFLAGS)" pip
 WEBPACK = NODE_ENV=production ./node_modules/.bin/webpack
 YARN_VERSION = 1.13.0
 
-bootstrap: install-system-pkgs develop create-db apply-migrations
+bootstrap: install-system-pkgs develop init-config run-dependent-services create-db apply-migrations
 
 develop: setup-git ensure-venv develop-only
 
 develop-only: update-submodules install-yarn-pkgs install-sentry-dev
+
+init-config:
+	sentry init --dev
+
+run-dependent-services:
+	sentry devservices up
 
 test: develop lint test-js test-python test-cli
 


### PR DESCRIPTION
The following were the sequence of commands I had to run to set up sentry:

```
make install-system-pkgs
make develop
sentry init --dev
sentry devservices up
make create-db 
make apply-migrations
```

This is essentially `make bootstrap` with the exception of these commands:

```
sentry init --dev
sentry devservices up
```

Otherwise `make bootstrap` will bork:

```
(redacted)

--> Creating 'sentry' database
createdb -h 127.0.0.1 -U postgres -E utf-8 sentry || true
createdb: could not connect to database template1: could not connect to server: Connection refused
    Is the server running on host "127.0.0.1" and accepting
    TCP/IP connections on port 5432?
--> Applying migrations
sentry upgrade
Error: Configuration file does not exist. Use 'sentry init' to initialize the file.
make: *** [apply-migrations] Error 1
(sentry)
✗ 2 me at Hoolibook-2018 in ~/aaa/projects/sentry/sentry on master
```

I'll update the dev set up docs accordingly on `sentry-docs` at https://github.com/getsentry/sentry-docs/pull/1037