### PR TITLE
fix(jira) Improve logging when jira has problems

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -433,17 +433,27 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         # all project metadata is expensive and wasteful. In the first run experience,
         # the user won't have a 'last used' project id so we need to iterate available
         # projects until we find one that we can get metadata for.
+        attempts = 0
         if len(jira_projects):
-            attempts = 0
             for fallback in jira_projects:
                 attempts += 1
                 meta = self.fetch_issue_create_meta(client, fallback['id'])
                 if meta:
-                    logging.info('jira.issue-create-meta.attempts', extra={
+                    logger.info('jira.get-issue-create-meta.attempts', extra={
                         'organization_id': self.organization_id,
                         'attempts': attempts,
                     })
                     return meta
+
+        jira_project_ids = 'no projects'
+        if len(jira_projects):
+            jira_project_ids = ','.join([project['key'] for project in jira_projects])
+
+        logger.info('jira.get-issue-create-meta.no-metadata', extra={
+            'organization_id': self.organization_id,
+            'attempts': attempts,
+            'jira_projects': jira_project_ids,
+        })
         raise IntegrationError(
             'Could not get issue create metadata for any Jira projects. '
             'Ensure that your project permissions are correct.'
@@ -453,16 +463,21 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         try:
             meta = client.get_create_meta_for_project(project_id)
         except ApiUnauthorized:
+            logger.info('jira.fetch-issue-create-meta.unauthorized', extra={
+                'organization_id': self.organization_id,
+                'jira_project': project_id,
+            })
             raise IntegrationError(
                 'Jira returned: Unauthorized. '
                 'Please check your configuration settings.'
             )
         except ApiError as exc:
             logger.info(
-                'jira.error-fetching-issue-config',
+                'jira.fetch-issue-create-meta.error',
                 extra={
                     'integration_id': self.model.id,
                     'organization_id': self.organization_id,
+                    'jira_project': project_id,
                     'error': exc.message,
                 }
             )


### PR DESCRIPTION
Improve logging when jira integrations have trouble getting project or issue create metadata. My hope is this lets us diagnose what is happening to a few customers in production.

Refs SEN-714