### PR TITLE
chore: Remove sentry10 conditional in python code

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -315,11 +315,7 @@ class Group(Model):
         super(Group, self).save(*args, **kwargs)
 
     def get_absolute_url(self, params=None):
-        from sentry import features
-        if features.has('organizations:sentry10', self.organization):
-            url = reverse('sentry-organization-issue', args=[self.organization.slug, self.id])
-        else:
-            url = reverse('sentry-group', args=[self.organization.slug, self.project.slug, self.id])
+        url = reverse('sentry-organization-issue', args=[self.organization.slug, self.id])
         if params:
             url = url + '?' + urlencode(params)
         return absolute_uri(url)

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -442,5 +442,8 @@ class Organization(Model):
             ip_address=ip_address
         )
 
+    def get_url_viewname(self):
+        return 'sentry-organization-issue-list'
+
     def get_url(self):
-        return reverse('sentry-organization-issue-list', args=[self.slug])
+        return reverse(self.get_url_viewname(), args=[self.slug])

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -442,12 +442,5 @@ class Organization(Model):
             ip_address=ip_address
         )
 
-    def get_url_viewname(self):
-        from sentry import features
-        if features.has('organizations:sentry10', self):
-            return 'sentry-organization-issue-list'
-        else:
-            return 'sentry-organization-home'
-
     def get_url(self):
-        return reverse(self.get_url_viewname(), args=[self.slug])
+        return reverse('sentry-organization-issue-list', args=[self.slug])

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -151,14 +151,9 @@ class Project(Model, PendingDeletionMixin):
         self.update_rev_for_option()
 
     def get_absolute_url(self, params=None):
-        from sentry import features
-        if features.has('organizations:sentry10', self.organization):
-            url = u'/organizations/{}/issues/'.format(self.organization.slug)
-            params = {} if params is None else params
-            params['project'] = self.id
-        else:
-            url = u'/{}/{}/'.format(self.organization.slug, self.slug)
-
+        url = u'/organizations/{}/issues/'.format(self.organization.slug)
+        params = {} if params is None else params
+        params['project'] = self.id
         if params:
             url = url + '?' + urlencode(params)
         return absolute_uri(url)

--- a/src/sentry/plugins/sentry_mail/activity/regression.py
+++ b/src/sentry/plugins/sentry_mail/activity/regression.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from sentry import features
 from sentry.utils.html import escape
 from sentry.utils.http import absolute_uri
 
@@ -15,17 +14,10 @@ class RegressionActivityEmail(ActivityEmail):
         data = self.activity.data
 
         if data.get('version'):
-            if features.has('organizations:sentry10', self.organization):
-                version_url = u'/organizations/{}/releases/{}/'.format(
-                    self.organization.slug,
-                    data['version']
-                )
-            else:
-                version_url = u'/{}/{}/releases/{}/'.format(
-                    self.organization.slug,
-                    self.project.slug,
-                    data['version'],
-                )
+            version_url = u'/organizations/{}/releases/{}/'.format(
+                self.organization.slug,
+                data['version']
+            )
 
             return u'{author} marked {an issue} as a regression in {version}', {
                 'version': data['version']

--- a/src/sentry/plugins/sentry_mail/activity/release.py
+++ b/src/sentry/plugins/sentry_mail/activity/release.py
@@ -188,7 +188,6 @@ class ReleaseActivityEmail(ActivityEmail):
         }
 
     def get_user_context(self, user):
-        from sentry import features
         if user.is_superuser or self.organization.flags.allow_joinleave:
             projects = self.projects
         else:
@@ -200,27 +199,15 @@ class ReleaseActivityEmail(ActivityEmail):
             )
             projects = [p for p in self.projects if p.id in team_projects]
 
-        has_new_links = features.has('organizations:sentry10', self.organization)
-        if has_new_links:
-            release_links = [
-                absolute_uri(
-                    u'/organizations/{}/releases/{}/?project={}'.format(
-                        self.organization.slug,
-                        self.release.version,
-                        p.id,
-                    )
-                ) for p in projects
-            ]
-        else:
-            release_links = [
-                absolute_uri(
-                    u'/{}/{}/releases/{}/'.format(
-                        self.organization.slug,
-                        p.slug,
-                        self.release.version,
-                    )
-                ) for p in projects
-            ]
+        release_links = [
+            absolute_uri(
+                u'/organizations/{}/releases/{}/?project={}'.format(
+                    self.organization.slug,
+                    self.release.version,
+                    p.id,
+                )
+            ) for p in projects
+        ]
 
         resolved_issue_counts = [self.group_counts_by_project.get(p.id, 0) for p in projects]
         return {

--- a/src/sentry/plugins/sentry_mail/activity/resolved_in_release.py
+++ b/src/sentry/plugins/sentry_mail/activity/resolved_in_release.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from sentry import features
 from sentry.utils.html import escape
 from sentry.utils.http import absolute_uri
 
@@ -14,18 +13,11 @@ class ResolvedInReleaseActivityEmail(ActivityEmail):
     def get_description(self):
         data = self.activity.data
 
-        if features.has('organizations:sentry10', self.organization):
-            url = u'/organizations/{}/releases/{}/?project={}'.format(
-                self.organization.slug,
-                data['version'],
-                self.project.id,
-            )
-        else:
-            url = u'/{}/{}/releases/{}/'.format(
-                self.organization.slug,
-                self.project.slug,
-                data['version'],
-            )
+        url = u'/organizations/{}/releases/{}/?project={}'.format(
+            self.organization.slug,
+            data['version'],
+            self.project.id,
+        )
 
         if data.get('version'):
             return u'{author} marked {an issue} as resolved in {version}', {

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -6,7 +6,6 @@ from celery.task import current
 from django.core.urlresolvers import reverse
 from requests.exceptions import RequestException
 
-from sentry import features
 from sentry.http import safe_urlopen
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils.http import absolute_uri
@@ -72,19 +71,11 @@ def send_alert_event(event, rule, sentry_app_id):
         event.event_id,
     ]))
 
-    if features.has('organizations:sentry10', organization):
-        event_context['web_url'] = absolute_uri(reverse('sentry-organization-event-detail', args=[
-            organization.slug,
-            group.id,
-            event.event_id,
-        ]))
-    else:
-        event_context['web_url'] = absolute_uri(reverse('sentry-group-event', args=[
-            organization.slug,
-            project.slug,
-            group.id,
-            event.event_id,
-        ]))
+    event_context['web_url'] = absolute_uri(reverse('sentry-organization-event-detail', args=[
+        organization.slug,
+        group.id,
+        event.event_id,
+    ]))
 
     # The URL has a regex OR in it ("|") which means `reverse` cannot generate
     # a valid URL (it can't know which option to pick). We have to manually

--- a/src/sentry/templates/sentry/emails/digests/body.txt
+++ b/src/sentry/templates/sentry/emails/digests/body.txt
@@ -4,8 +4,8 @@
 
 {% for rule, groups in digest.iteritems %}{{ rule.label }}
 {% for group, records in groups.iteritems %}
-* {{ group.title }} ({{ group.event_count }} event{{ group.event_count|pluralize }}, {{ group.user_count }} user{{ group.user_count|pluralize }}){% url 'sentry-group' group.organization.slug group.project.slug group.id as old_group_link %}{% url 'sentry-organization-issue' group.organization.slug group.id as new_group_link %}
-  {% feature organizations:sentry10 group.organization %}{% absolute_uri new_group_link %}?referrer=digest_email{% else %}{% absolute_uri old_group_link %}?referrer=digest_email{% endfeature %}
+* {{ group.title }} ({{ group.event_count }} event{{ group.event_count|pluralize }}, {{ group.user_count }} user{{ group.user_count|pluralize }}){% url 'sentry-organization-issue' group.organization.slug group.id as group_link %}
+  {% absolute_uri group_link %}?referrer=digest_email
 {% endfor %}
 {% endfor %}
 

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -130,11 +130,7 @@
               <em>=</em>
               <span>
               {% with query=tag_key|as_tag_alias|add:":\""|add:tag_value|add:"\""|urlencode %}
-              {% feature organizations:sentry10 group.project.organization %}
-                  <a href="{% absolute_uri '/organizations/{}/issues/' group.project.organization.slug %}?project={{ group.project.id }}&query={{ query }}">{{ tag_value|truncatechars:50 }}</a> {% if tag_value|is_url %}<a href="{{ tag_value }}" class="icon-share"></a>{% endif %}
-              {% else %}
-                  <a href="{% absolute_uri '/{}/{}/' group.project.organization.slug group.project.slug %}?query={{ query }}">{{ tag_value|truncatechars:50 }}</a> {% if tag_value|is_url %}<a href="{{ tag_value }}" class="icon-share"></a>{% endif %}
-              {% endfeature %}
+                <a href="{% absolute_uri '/organizations/{}/issues/' group.project.organization.slug %}?project={{ group.project.id }}&query={{ query }}">{{ tag_value|truncatechars:50 }}</a> {% if tag_value|is_url %}<a href="{{ tag_value }}" class="icon-share"></a>{% endif %}
               {% endwith %}
               </span>
           </li>

--- a/src/sentry/templates/sentry/emails/group_header.html
+++ b/src/sentry/templates/sentry/emails/group_header.html
@@ -25,11 +25,7 @@
             <span class="count">Seen <strong>{{ group.times_seen }}</strong> time{{ group.times_seen|pluralize }}.</span>
             <span class="last-seen pretty-date"> Last seen: {{ group.last_seen }} UTC</span>
             in
-            {% feature organizations:sentry10 group.organization %}
             <a href="{% absolute_uri new_stream_link %}?project={{group.project.id}}"><strong>{{ group.project.organization.slug }} / {{ group.project.slug }}</strong></a>
-            {% else %}
-            <a href="{% absolute_uri old_project_link %}"><strong>{{ group.project.organization.slug }} / {{ group.project.slug }}</strong></a>
-            {% endfeature %}
           </small>
         </p>
       </td>

--- a/src/sentry/web/frontend/debug/debug_new_release_email.py
+++ b/src/sentry/web/frontend/debug/debug_new_release_email.py
@@ -13,8 +13,6 @@ from sentry.utils.http import absolute_uri
 
 from .mail import MailPreview
 
-from sentry import features
-
 
 class DebugNewReleaseEmailView(View):
     def get(self, request):
@@ -56,27 +54,15 @@ class DebugNewReleaseEmailView(View):
             date_finished=datetime.datetime(2016, 10, 12, 15, 39, tzinfo=pytz.utc),
         )
 
-        has_new_links = features.has('organizations:sentry10', org)
-        if has_new_links:
-            release_links = [
-                absolute_uri(
-                    u'/organizations/{}/releases/{}/?project={}'.format(
-                        org.slug,
-                        release.version,
-                        p.id,
-                    )
-                ) for p in projects
-            ]
-        else:
-            release_links = [
-                absolute_uri(
-                    u'/{}/{}/releases/{}/'.format(
-                        org.slug,
-                        p.slug,
-                        release.version,
-                    )
-                ) for p in projects
-            ]
+        release_links = [
+            absolute_uri(
+                u'/organizations/{}/releases/{}/?project={}'.format(
+                    org.slug,
+                    release.version,
+                    p.id,
+                )
+            ) for p in projects
+        ]
 
         repos = [
             {

--- a/src/sentry/web/frontend/project_event.py
+++ b/src/sentry/web/frontend/project_event.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from django.http import HttpResponseRedirect, Http404
 from django.core.urlresolvers import reverse
-from sentry import features
 
 from sentry import options
 from sentry.models import Event, SnubaEvent
@@ -23,22 +22,11 @@ class ProjectEventRedirect(ProjectView):
         if event is None:
             raise Http404
 
-        if features.has('organizations:sentry10', organization, actor=request.user):
-            return HttpResponseRedirect(
-                reverse(
-                    'sentry-organization-event-detail',
-                    args=[
-                        organization.slug,
-                        event.group_id,
-                        event.id])
-            )
-
         return HttpResponseRedirect(
             reverse(
-                'sentry-group-event',
+                'sentry-organization-event-detail',
                 args=[
                     organization.slug,
-                    event.project.slug,
                     event.group_id,
                     event.id])
         )

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -183,45 +183,44 @@ class BitbucketIssueTest(APITestCase):
             },
         )
 
-        with self.feature('organizations:sentry10'):
-            installation = self.integration.get_installation(self.organization.id)
-            assert installation.get_create_issue_config(self.group) == [
-                {
-                    'name': 'repo',
-                    'required': True,
-                    'updatesForm': True,
-                    'type': 'select',
-                    'url': self.build_autocomplete_url(),
-                    'choices': self.repo_choices,
-                    'default': self.repo_choices[0][0],
-                    'label': 'Bitbucket Repository',
-                }, {
-                    'name': 'title',
-                    'label': 'Title',
-                    'default': u'message',
-                    'type': 'string',
-                    'required': True,
-                }, {
-                    'name': 'description',
-                    'label': 'Description',
-                    'default': u'Sentry Issue: [BAR-1](http://testserver/organizations/baz/issues/%d/?referrer=bitbucket_integration)\n\n```\nStacktrace (most recent call last):\n\n  File "sentry/models/foo.py", line 29, in build_msg\n    string_max_length=self.string_max_length)\n\nmessage\n```' % self.group.id,
-                    'type': 'textarea',
-                    'autosize': True,
-                    'maxRows': 10,
-                }, {
-                    'name': 'issue_type',
-                    'label': 'Issue type',
-                    'default': ISSUE_TYPES[0][0],
-                    'type': 'select',
-                    'choices': ISSUE_TYPES
-                }, {
-                    'name': 'priority',
-                    'label': 'Priority',
-                    'default': PRIORITIES[0][0],
-                    'type': 'select',
-                    'choices': PRIORITIES
-                }
-            ]
+        installation = self.integration.get_installation(self.organization.id)
+        assert installation.get_create_issue_config(self.group) == [
+            {
+                'name': 'repo',
+                'required': True,
+                'updatesForm': True,
+                'type': 'select',
+                'url': self.build_autocomplete_url(),
+                'choices': self.repo_choices,
+                'default': self.repo_choices[0][0],
+                'label': 'Bitbucket Repository',
+            }, {
+                'name': 'title',
+                'label': 'Title',
+                'default': u'message',
+                'type': 'string',
+                'required': True,
+            }, {
+                'name': 'description',
+                'label': 'Description',
+                'default': u'Sentry Issue: [BAR-1](http://testserver/organizations/baz/issues/%d/?referrer=bitbucket_integration)\n\n```\nStacktrace (most recent call last):\n\n  File "sentry/models/foo.py", line 29, in build_msg\n    string_max_length=self.string_max_length)\n\nmessage\n```' % self.group.id,
+                'type': 'textarea',
+                'autosize': True,
+                'maxRows': 10,
+            }, {
+                'name': 'issue_type',
+                'label': 'Issue type',
+                'default': ISSUE_TYPES[0][0],
+                'type': 'select',
+                'choices': ISSUE_TYPES
+            }, {
+                'name': 'priority',
+                'label': 'Priority',
+                'default': PRIORITIES[0][0],
+                'type': 'select',
+                'choices': PRIORITIES
+            }
+        ]
 
     @responses.activate
     def test_get_link_issue_config(self):

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -232,10 +232,9 @@ class GroupTest(TestCase):
         assert group.get_email_subject() == '%s - %s' % (group.qualified_short_id, group.title)
 
     def test_get_absolute_url(self):
-        with self.feature('organizations:sentry10'):
-            project = self.create_project(name='pumped-quagga')
-            group = self.create_group(project=project)
+        project = self.create_project(name='pumped-quagga')
+        group = self.create_group(project=project)
 
-            result = group.get_absolute_url({'environment': u'd\u00E9v'})
-            assert result == u'http://testserver/organizations/baz/issues/{}/?environment=d%C3%A9v'.format(
-                group.id)
+        result = group.get_absolute_url({'environment': u'd\u00E9v'})
+        assert result == u'http://testserver/organizations/baz/issues/{}/?environment=d%C3%A9v'.format(
+            group.id)

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -111,9 +111,8 @@ class TestSendAlertEvent(TestCase):
             kwargs={'sentry_app': self.sentry_app},
         )
 
-        with self.feature('organizations:sentry10'):
-            with self.tasks():
-                notify_sentry_app(event, [rule_future])
+        with self.tasks():
+            notify_sentry_app(event, [rule_future])
 
         data = json.loads(faux(safe_urlopen).kwargs['data'])
 

--- a/tests/sentry/web/frontend/test_home.py
+++ b/tests/sentry/web/frontend/test_home.py
@@ -43,4 +43,4 @@ class HomeTest(TestCase):
             resp = self.client.get(self.path)
 
         assert resp.status_code == 302
-        assert resp['Location'] == u'http://testserver/{}/'.format(org.slug)
+        assert resp['Location'] == u'http://testserver/organizations/{}/issues/'.format(org.slug)

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -23,14 +23,13 @@ class ProjectEventTest(TestCase):
         self.event = self.create_event(event_id='a' * 32, group=self.group)
 
     def test_redirect_to_event(self):
-        with self.feature('organizations:sentry10'):
-            resp = self.client.get(
-                reverse(
-                    'sentry-project-event-redirect',
-                    args=[
-                        self.org.slug,
-                        self.project.slug,
-                        'a' * 32]))
+        resp = self.client.get(
+            reverse(
+                'sentry-project-event-redirect',
+                args=[
+                    self.org.slug,
+                    self.project.slug,
+                    'a' * 32]))
         assert resp.status_code == 302
         assert resp['Location'] == '{}/organizations/{}/issues/{}/events/{}/'.format(
             options.get('system.url-prefix'),


### PR DESCRIPTION
Remove conditional logic for the sentry10 feature flag from emails, link generation and API endpoints.

Refs SEN-708