### PR TITLE
fix(app-platform): Render unpublished integrations

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/sentryAppComponents.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/sentryAppComponents.jsx
@@ -3,7 +3,8 @@ import SentryAppComponentsActions from 'app/actions/sentryAppComponentActions';
 export function fetchSentryAppComponents(api, orgSlug, projectId) {
   const componentsUri = `/organizations/${orgSlug}/sentry-app-components/?projectId=${projectId}`;
 
-  const promise = api.requestPromise(componentsUri);
-  promise.then(res => SentryAppComponentsActions.loadComponents(res));
-  return promise;
+  return api.requestPromise(componentsUri).then(res => {
+    SentryAppComponentsActions.loadComponents(res);
+    return res;
+  });
 }

--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.jsx
@@ -123,9 +123,8 @@ class ExternalIssueList extends AsyncComponent {
 
     return components.map(component => {
       const {sentryApp} = component;
-
       const installation = sentryAppInstallations.find(
-        i => i.sentryApp.uuid === sentryApp.uuid
+        i => i.app.uuid === sentryApp.uuid
       );
 
       const issue = (externalIssues || []).find(i => i.serviceType == sentryApp.slug);

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -27,7 +27,6 @@ const GroupSidebar = createReactClass({
     group: SentryTypes.Group,
     event: SentryTypes.Event,
     environments: PropTypes.arrayOf(SentryTypes.Environment),
-    sentryAppInstallations: PropTypes.array,
   },
 
   getInitialState() {
@@ -228,13 +227,7 @@ const GroupSidebar = createReactClass({
   },
 
   render() {
-    const {
-      group,
-      organization,
-      project,
-      environments,
-      sentryAppInstallations,
-    } = this.props;
+    const {group, organization, project, environments} = this.props;
     const projectId = project.slug;
 
     return (
@@ -254,7 +247,6 @@ const GroupSidebar = createReactClass({
             group={this.props.group}
             project={project}
             orgId={organization.slug}
-            sentryAppInstallations={sentryAppInstallations}
           />
         </ErrorBoundary>
 

--- a/src/sentry/static/sentry/app/stores/sentryAppStore.jsx
+++ b/src/sentry/static/sentry/app/stores/sentryAppStore.jsx
@@ -1,4 +1,5 @@
 import Reflux from 'reflux';
+import {uniqBy} from 'lodash';
 
 const SentryAppStore = Reflux.createStore({
   init() {
@@ -11,7 +12,14 @@ const SentryAppStore = Reflux.createStore({
 
   load(items) {
     this.items = items;
-    this.trigger(items);
+    this.deDup();
+    this.trigger(this.items);
+  },
+
+  add(...apps) {
+    apps.forEach(app => this.items.push(app));
+    this.deDup();
+    this.trigger(this.items);
   },
 
   get(slug) {
@@ -20,6 +28,10 @@ const SentryAppStore = Reflux.createStore({
 
   getAll() {
     return this.items;
+  },
+
+  deDup() {
+    this.items = uniqBy(this.items, i => i.uuid);
   },
 });
 

--- a/src/sentry/static/sentry/app/utils/fetchSentryAppInstallations.jsx
+++ b/src/sentry/static/sentry/app/utils/fetchSentryAppInstallations.jsx
@@ -3,10 +3,15 @@ import SentryAppStore from 'app/stores/sentryAppStore';
 
 const fetchSentryAppInstallations = (api, orgSlug) => {
   const sentryAppsUri = '/sentry-apps/';
+  const ownedSentryAppsUri = `/organizations/${orgSlug}/sentry-apps/`;
   const installsUri = `/organizations/${orgSlug}/sentry-app-installations/`;
 
   function updateSentryAppStore(sentryApps) {
     SentryAppStore.load(sentryApps);
+  }
+
+  function fetchOwnedSentryApps() {
+    api.requestPromise(ownedSentryAppsUri).then(apps => SentryAppStore.add(...apps));
   }
 
   function fetchInstalls() {
@@ -28,6 +33,7 @@ const fetchSentryAppInstallations = (api, orgSlug) => {
   api
     .requestPromise(sentryAppsUri)
     .then(updateSentryAppStore)
+    .then(fetchOwnedSentryApps)
     .then(fetchInstalls);
 };
 


### PR DESCRIPTION
A bug was causing Issue pages in Orgs that had an unpublished Integration installed to error out. This was only case for one or two Orgs, as far as I can tell (our test Orgs).

This fixes that bug and refactors some related things:

- Retrieve SentryAppInstallations from Store instead of passing down through components
- Handle when the "give me all SentryApps" and "give me all MY SentryApps" endpoints return the same records