### PR TITLE
feat(events-v2): Pass props to avoid withRouter

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {withRouter} from 'react-router';
 import styled from 'react-emotion';
 import {omit, isEqual} from 'lodash';
 import SentryTypes from 'app/sentryTypes';
@@ -23,7 +22,7 @@ const CHART_AXIS_OPTIONS = [
   {label: 'Users', value: 'user_count'},
 ];
 
-class Events extends AsyncComponent {
+export default class Events extends AsyncComponent {
   static propTypes = {
     router: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
@@ -132,5 +131,3 @@ const Container = styled('div')`
 const StyledSearchBar = styled(SearchBar)`
   margin-bottom: ${space(2)};
 `;
-
-export default withRouter(Events);

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
@@ -21,6 +21,7 @@ export default class OrganizationEventsV2 extends React.Component {
   static propTypes = {
     organization: SentryTypes.Organization.isRequired,
     location: PropTypes.object.isRequired,
+    router: PropTypes.object.isRequired,
   };
 
   renderTabs() {
@@ -46,7 +47,7 @@ export default class OrganizationEventsV2 extends React.Component {
   }
 
   render() {
-    const {organization, location} = this.props;
+    const {organization, location, router} = this.props;
     const {eventSlug} = location.query;
 
     return (
@@ -64,6 +65,8 @@ export default class OrganizationEventsV2 extends React.Component {
               <Events
                 organization={organization}
                 view={getCurrentView(location.query.view)}
+                location={location}
+                router={router}
               />
             </NoProjectMessage>
             {eventSlug && (

--- a/tests/js/spec/views/organizationEventsV2/index.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/index.spec.jsx
@@ -44,6 +44,7 @@ describe('OrganizationEventsV2', function() {
       <OrganizationEventsV2
         organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
         location={{query: {}}}
+        router={{}}
       />,
       TestStubs.routerContext()
     );
@@ -56,6 +57,7 @@ describe('OrganizationEventsV2', function() {
       <OrganizationEventsV2
         organization={TestStubs.Organization()}
         location={{query: {}}}
+        router={{}}
       />,
       TestStubs.routerContext()
     );
@@ -69,6 +71,7 @@ describe('OrganizationEventsV2', function() {
       <OrganizationEventsV2
         organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
         location={{query: {}}}
+        router={{}}
       />,
       TestStubs.routerContext()
     );
@@ -82,8 +85,9 @@ describe('OrganizationEventsV2', function() {
     const wrapper = mount(
       <OrganizationEventsV2
         organization={organization}
-        location={{query: {eventSlug: 'project-slug:deadbeef'}}}
         params={{orgId: organization.slug}}
+        location={{query: {eventSlug: 'project-slug:deadbeef'}}}
+        router={{}}
       />,
       TestStubs.routerContext()
     );
@@ -109,6 +113,7 @@ describe('OrganizationEventsV2', function() {
         organization={organization}
         params={{orgId: organization.slug}}
         location={routerContext.context.location}
+        router={{}}
       />,
       routerContext
     );
@@ -144,6 +149,7 @@ describe('OrganizationEventsV2', function() {
         organization={organization}
         params={{orgId: organization.slug}}
         location={routerContext.context.location}
+        router={{}}
       />,
       routerContext
     );


### PR DESCRIPTION
According to @billyvg withRouter can lead to double render issues.