### PR TITLE
fix(ui): Fix tag distribution meter bg color

### DIFF
--- a/src/sentry/static/sentry/app/components/tagDistributionMeter/index.jsx
+++ b/src/sentry/static/sentry/app/components/tagDistributionMeter/index.jsx
@@ -158,7 +158,6 @@ const Segment = styled(Link, {shouldForwardProp: isPropValid})`
 `;
 
 const Description = styled('span', {shouldForwardProp: isPropValid})`
-  background-color: #fff;
   position: absolute;
   text-align: right;
   top: -1px;


### PR DESCRIPTION
This component should inherit its background color, rather than be
explicitly set to white.