### PR TITLE
fix(app-platform): Allow removal of Internal Apps

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -6,7 +6,6 @@ from sentry import features
 from sentry.api.bases.sentryapps import SentryAppBaseEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import SentryAppSerializer
-from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Updater, Destroyer
 
 
@@ -68,7 +67,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                             actor=request.user):
             return Response(status=404)
 
-        if sentry_app.status == SentryAppStatus.UNPUBLISHED:
+        if sentry_app.is_unpublished or sentry_app.is_internal:
             Destroyer.run(
                 user=request.user,
                 sentry_app=sentry_app,

--- a/src/sentry/mediators/sentry_app_installations/destroyer.py
+++ b/src/sentry/mediators/sentry_app_installations/destroyer.py
@@ -12,6 +12,7 @@ class Destroyer(Mediator):
     install = Param('sentry.models.SentryAppInstallation')
     user = Param('sentry.models.User')
     request = Param('rest_framework.request.Request', required=False)
+    notify = Param(bool, default=True)
 
     def call(self):
         self._destroy_grant()
@@ -32,11 +33,12 @@ class Destroyer(Mediator):
             service_hooks.Destroyer.run(service_hook=hook)
 
     def _destroy_installation(self):
-        InstallationNotifier.run(
-            install=self.install,
-            user=self.user,
-            action='deleted',
-        )
+        if self.notify:
+            InstallationNotifier.run(
+                install=self.install,
+                user=self.user,
+                action='deleted',
+            )
         self.install.delete()
 
     def audit(self):

--- a/src/sentry/mediators/sentry_apps/destroyer.py
+++ b/src/sentry/mediators/sentry_apps/destroyer.py
@@ -10,19 +10,22 @@ from sentry.utils.audit import create_audit_entry
 class Destroyer(Mediator):
     sentry_app = Param('sentry.models.SentryApp')
     request = Param('rest_framework.request.Request', required=False)
+    user = Param('sentry.models.User')
 
     def call(self):
-        self._destroy_sentry_app_installations()
         self._destroy_api_application()
+        self._destroy_sentry_app_installations()
         self._destroy_proxy_user()
         self._destroy_sentry_app()
         return self.sentry_app
 
     def _destroy_sentry_app_installations(self):
         for install in self.sentry_app.installations.all():
+            notify = False if self.sentry_app.is_internal else True
             sentry_app_installations.Destroyer.run(
                 install=install,
                 user=self.sentry_app.proxy_user,
+                notify=notify,
             )
 
     def _destroy_api_application(self):

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -13,6 +13,7 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import MigrationWarnings from 'app/views/organizationIntegrations/migrationWarnings';
 import PermissionAlert from 'app/views/settings/organization/permissionAlert';
 import ProviderRow from 'app/views/organizationIntegrations/providerRow';
+import {removeSentryApp} from 'app/actionCreators/sentryApps';
 import SentryAppInstallations from 'app/views/organizationIntegrations/sentryAppInstallations';
 import SentryApplicationRow from 'app/views/settings/organizationDeveloperSettings/sentryApplicationRow';
 import SentryTypes from 'app/sentryTypes';
@@ -168,6 +169,7 @@ class OrganizationIntegrations extends AsyncComponent {
 
   renderInternalSentryApps(app, key) {
     const {organization} = this.props;
+
     return (
       <SentryApplicationRow
         key={`sentry-app-row-${key}`}
@@ -175,11 +177,22 @@ class OrganizationIntegrations extends AsyncComponent {
         api={this.api}
         showPublishStatus
         isInternal
+        onRemoveApp={() => this.onRemoveInternalApp(app)}
         organization={organization}
         app={app}
       />
     );
   }
+
+  onRemoveInternalApp = app => {
+    const apps = this.state.orgOwnedApps.filter(a => a.slug !== app.slug);
+    removeSentryApp(this.api, app).then(
+      () => {
+        this.setState({orgOwnedApps: apps});
+      },
+      () => {}
+    );
+  };
 
   renderBody() {
     const {reloading, orgOwnedApps, publishedApps, appInstalls} = this.state;

--- a/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
@@ -284,6 +284,32 @@ describe('OrganizationIntegrations', () => {
           wrapper.find('Panel [data-test-id="internal-integration-row"]').exists()
         ).toBe(true);
       });
+
+      it('removes an internal app', async function() {
+        const internalApp = {...sentryApp, status: 'internal'};
+        Client.addMockResponse({
+          url: `/organizations/${org.slug}/sentry-apps/`,
+          body: [internalApp],
+        });
+        Client.addMockResponse({
+          url: '/sentry-apps/',
+          body: [],
+        });
+        Client.addMockResponse({
+          url: `/sentry-apps/${internalApp.slug}/`,
+          method: 'DELETE',
+          statusCode: 200,
+        });
+
+        wrapper = mount(
+          <OrganizationIntegrations organization={org} params={params} />,
+          routerContext
+        );
+        wrapper.instance().onRemoveInternalApp(internalApp);
+        await tick();
+        wrapper.update();
+        expect(wrapper.instance().state.orgOwnedApps).toHaveLength(0);
+      });
     });
 
     describe('with installed integrations', () => {


### PR DESCRIPTION
* adds `removeSentryApp` for internal apps
* adds check for `is_internal` in the `/sentry-apps DELETE` endpoint
* adds `user` param for sentry apps `Destroyer`
* adds `notify` param for sentry apps `Destroyer`