### PR TITLE
fix(gitlab) Be clearer in requirements for GitLab

### DIFF
--- a/src/sentry/templates/sentry/integrations/gitlab-config.html
+++ b/src/sentry/templates/sentry/integrations/gitlab-config.html
@@ -50,6 +50,7 @@
 {% else %}
 <h3>{% trans "Step 1: Create a Sentry App in GitLab" %}</h3>
   <p>{% trans "To configure GitLab with Sentry, you will need to create a Sentry app in your GitLab instance." %}</p>
+  <p>{% trans "You'll also need to be a maintainer or owner in GitLab." %}</p>
   <ol>
     <li>{% trans "Navigate to the User Settings section of your GitLab instance." %} </li>
     <li>{% trans "In the sidebar, select 'Applications'." %}</li>


### PR DESCRIPTION
Call out that you have to be a maintainer/owner in GitLab in order to finish the integration. This is mentioned in the docs, but having it here will help folks who didn't know about the docs.

Fixes #13529