### PR TITLE
fix(ui) Fix z-index stacking of modals and assistant cues

### DIFF
--- a/src/sentry/static/sentry/app/utils/theme.jsx
+++ b/src/sentry/static/sentry/app/utils/theme.jsx
@@ -94,6 +94,8 @@ const theme = {
     // Sentry user feedback modal
     sentryErrorEmbed: 1090,
 
+    // If you change modal also update shared-components.less
+    // as the z-index for bootstrap modals lives there.
     modal: 10000,
     toast: 10001,
 

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1807,6 +1807,13 @@ ul.radio-inputs {
 */
 .modal-backdrop {
   background-color: @gray-dark;
+  // Match zIndex.modal in theme.jsx
+  z-index: 10000;
+}
+
+.modal {
+  // Match zIndex.modal in theme.jsx
+  z-index: 10000;
 }
 
 .modal-container {

--- a/src/sentry/static/sentry/less/variables.less
+++ b/src/sentry/static/sentry/less/variables.less
@@ -67,6 +67,5 @@
 
 // Z-Index
 @zindex-dropdown-backdrop: 990;
-@zindex-modal-background: 1040;
 @zindex-sidebar-panel: 100;
 @zindex-sticky-bar: 1000;


### PR DESCRIPTION
Assistant cues should stack *under* modal windows as modal windows should be focusing the user on the current task. Having an assistant overlay on top only distracts and confuses people.

![Screen Shot 2019-06-05 at 12 17 06 PM](https://user-images.githubusercontent.com/24086/58972594-e8f3b380-878b-11e9-8d87-2ed08f603512.png)
