### PR TITLE
fix(ui): Fix column title to be "Issue" instead of "Event"

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/shared/groupListHeader.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/shared/groupListHeader.jsx
@@ -8,7 +8,7 @@ class GroupListHeader extends React.Component {
     return (
       <PanelHeader disablePadding>
         <Box w={[8 / 12, 8 / 12, 6 / 12]} mx={2} flex="1" className="toolbar-header">
-          {t('Event')}
+          {t('Issue')}
         </Box>
         <Box w={160} mx={2} className="toolbar-header hidden-xs hidden-sm">
           {t('Last 24 hours')}


### PR DESCRIPTION
Since the table is actually displaying the list of groups/issues.

Fix for this:

![Screen Shot 2019-06-05 at 2 55 20 PM](https://user-images.githubusercontent.com/139499/58983533-100aaf00-87a5-11e9-8588-3a495864a8de.png)
