### PR TITLE
feat(2fa): Expose TOTP secret in the enrollment UI

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
@@ -18,12 +18,14 @@ import Button from 'app/components/button';
 import CircleIndicator from 'app/components/circleIndicator';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
+import Field from 'app/views/settings/components/forms/field';
 import {PanelItem} from 'app/components/panels';
 import Qrcode from 'app/components/qrcode';
 import RemoveConfirm from 'app/views/settings/account/accountSecurity/components/removeConfirm';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import U2fsign from 'app/components/u2f/u2fsign';
+import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
 
 const ENDPOINT = '/users/me/authenticators/';
 const PENDING_INVITE = 'pending-invite';
@@ -51,6 +53,11 @@ const getFields = ({authenticator, hasSentCode, onSmsReset, onSmsSubmit, onU2fTa
         <PanelItem key="qrcode" justify="center" p={2}>
           <Qrcode code={authenticator.qrcode} />
         </PanelItem>
+      ),
+      () => (
+        <Field key="secret" label={t('Authenticator secret')}>
+          <TextCopyInput>{authenticator.secret}</TextCopyInput>
+        </Field>
       ),
       ...form,
       () => (


### PR DESCRIPTION
This adds the TOTP secret to the UI for users that cannot scan the QR code.

![image](https://user-images.githubusercontent.com/7396/58985091-d785c800-87da-11e9-8b91-b1c6c197a61d.png)
