### PR TITLE
feat(api): Support user/team mentions in incident comments (SEN-652)

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_comment_index.py
+++ b/src/sentry/api/endpoints/organization_incident_comment_index.py
@@ -4,26 +4,43 @@ from rest_framework import serializers
 from rest_framework.response import Response
 
 from sentry.api.bases.incident import IncidentPermission, IncidentEndpoint
+from sentry.api.fields.actor import ActorField
 from sentry.api.serializers import serialize
+from sentry.api.serializers.rest_framework.list import ListField
+from sentry.api.serializers.rest_framework.mentions import (
+    extract_user_ids_from_mentions,
+    MentionsMixin,
+)
 from sentry.incidents.logic import create_incident_activity
 from sentry.incidents.models import IncidentActivityType
 
 
-class CommentSerializer(serializers.Serializer):
+class CommentSerializer(serializers.Serializer, MentionsMixin):
     comment = serializers.CharField(required=True)
+    mentions = ListField(child=ActorField(), required=False)
+    external_id = serializers.CharField(allow_none=True, required=False)
 
 
 class OrganizationIncidentCommentIndexEndpoint(IncidentEndpoint):
     permission_classes = (IncidentPermission, )
 
     def post(self, request, organization, incident):
-        serializer = CommentSerializer(data=request.DATA)
+        serializer = CommentSerializer(
+            data=request.DATA,
+            context={'projects': incident.projects.all(), 'organization_id': organization.id},
+        )
         if serializer.is_valid():
+            mentions = extract_user_ids_from_mentions(
+                organization.id,
+                serializer.object.get('mentions', []),
+            )
+            mentioned_user_ids = mentions['users'] | mentions['team_users']
             activity = create_incident_activity(
                 incident,
                 IncidentActivityType.COMMENT,
                 user=request.user,
-                comment=serializer.object['comment']
+                comment=serializer.object['comment'],
+                mentioned_user_ids=mentioned_user_ids,
             )
             return Response(serialize(activity, request.user), status=201)
         return Response(serializer.errors, status=400)

--- a/src/sentry/api/serializers/rest_framework/group_notes.py
+++ b/src/sentry/api/serializers/rest_framework/group_notes.py
@@ -4,56 +4,10 @@ from rest_framework import serializers
 
 from .list import ListField
 from sentry.api.fields.actor import ActorField
-
-from sentry.models import User, Team
-
-
-def seperate_actors(actors):
-    users = [actor for actor in actors if actor.type is User]
-    teams = [actor for actor in actors if actor.type is Team]
-
-    return {'users': users, 'teams': teams}
+from sentry.api.serializers.rest_framework.mentions import MentionsMixin
 
 
-def seperate_resolved_actors(actors):
-    users = [actor for actor in actors if isinstance(actor, User)]
-    teams = [actor for actor in actors if isinstance(actor, Team)]
-
-    return {'users': users, 'teams': teams}
-
-
-class NoteSerializer(serializers.Serializer):
+class NoteSerializer(serializers.Serializer, MentionsMixin):
     text = serializers.CharField()
     mentions = ListField(child=ActorField(), required=False)
     external_id = serializers.CharField(allow_none=True, required=False)
-
-    def validate_mentions(self, attrs, source):
-        if source in attrs and 'group' in self.context:
-
-            mentions = attrs[source]
-            seperated_actors = seperate_actors(mentions)
-            # Validate that all mentioned users exist and are on the project.
-            users = seperated_actors['users']
-
-            mentioned_user_ids = {user.id for user in users}
-
-            project = self.context['group'].project
-
-            user_ids = set(
-                project.member_set.filter(user_id__in=mentioned_user_ids)
-                .values_list('user_id', flat=True)
-            )
-
-            if len(mentioned_user_ids) > len(user_ids):
-                raise serializers.ValidationError('Cannot mention a non team member')
-
-            # Validate that all mentioned teams exist and are on the project.
-            teams = seperated_actors['teams']
-            mentioned_team_ids = {team.id for team in teams}
-
-            if len(mentioned_team_ids) > project.teams.filter(
-                    id__in={t.id for t in teams}).count():
-                raise serializers.ValidationError(
-                    'Mentioned team not found or not associated with project')
-
-        return attrs

--- a/src/sentry/api/serializers/rest_framework/mentions.py
+++ b/src/sentry/api/serializers/rest_framework/mentions.py
@@ -1,0 +1,82 @@
+from __future__ import absolute_import
+
+from rest_framework import serializers
+
+from sentry.api.fields.actor import Actor
+from sentry.models import (
+    Team,
+    User,
+)
+
+
+def extract_user_ids_from_mentions(organization_id, mentions):
+    """
+    Extracts user ids from a set of mentions. Mentions should be a list of
+    `Actor` instances. Returns a dictionary with 'users' and 'team_users' keys.
+    'users' is the user ids for all explicitly mentioned users, and 'team_users'
+    is all user ids from explicitly mentioned teams, excluding any already
+    mentioned users.
+    """
+    actors = Actor.resolve_many(mentions)
+    actor_mentions = seperate_resolved_actors(actors)
+
+    mentioned_team_users = list(
+        User.objects.get_from_teams(
+            organization_id,
+            actor_mentions['teams'],
+        ).exclude(id__in={u.id for u in actor_mentions['users']}).values_list(
+            'id',
+            flat=True,
+        )
+    )
+
+    return {
+        'users': set([user.id for user in actor_mentions['users']]),
+        'team_users': set(mentioned_team_users),
+    }
+
+
+def seperate_actors(actors):
+    users = [actor for actor in actors if actor.type is User]
+    teams = [actor for actor in actors if actor.type is Team]
+
+    return {'users': users, 'teams': teams}
+
+
+def seperate_resolved_actors(actors):
+    users = [actor for actor in actors if isinstance(actor, User)]
+    teams = [actor for actor in actors if isinstance(actor, Team)]
+
+    return {'users': users, 'teams': teams}
+
+
+class MentionsMixin(object):
+    def validate_mentions(self, attrs, source):
+        if source in attrs and 'projects' in self.context:
+
+            mentions = attrs[source]
+            seperated_actors = seperate_actors(mentions)
+            # Validate that all mentioned users exist and are on the project.
+            users = seperated_actors['users']
+
+            mentioned_user_ids = {user.id for user in users}
+
+            projects = self.context['projects']
+            organization_id = self.context['organization_id']
+            users = User.objects.get_from_projects(organization_id, projects)
+            user_ids = users.filter(id__in=mentioned_user_ids).values_list('id', flat=True)
+
+            if len(mentioned_user_ids) > len(user_ids):
+                raise serializers.ValidationError('Cannot mention a non team member')
+
+            # Validate that all mentioned teams exist and are on the project.
+            teams = seperated_actors['teams']
+            mentioned_team_ids = {team.id for team in teams}
+            if len(mentioned_team_ids) > Team.objects.filter(
+                id__in=mentioned_team_ids,
+                projectteam__project__in=projects,
+            ).count():
+                raise serializers.ValidationError(
+                    'Mentioned team not found or not associated with project')
+
+        return attrs

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -168,6 +168,7 @@ def create_incident_activity(
     previous_value=None,
     comment=None,
     event_stats_snapshot=None,
+    mentioned_user_ids=None,
 ):
     if activity_type == IncidentActivityType.COMMENT and user:
         subscribe_to_incident(incident, user)
@@ -182,6 +183,12 @@ def create_incident_activity(
         comment=comment,
         event_stats_snapshot=event_stats_snapshot,
     )
+
+    if mentioned_user_ids:
+        IncidentSubscription.objects.bulk_create([
+            IncidentSubscription(incident=incident, user_id=mentioned_user_id)
+            for mentioned_user_id in mentioned_user_ids
+        ])
     send_subscriber_notifications.apply_async(
         kwargs={'activity_id': activity.id},
         countdown=10,

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -25,7 +25,24 @@ audit_logger = logging.getLogger('sentry.audit.user')
 
 
 class UserManager(BaseManager, UserManager):
-    pass
+    def get_from_teams(self, organization_id, teams):
+        return User.objects.filter(
+            sentry_orgmember_set__organization_id=organization_id,
+            sentry_orgmember_set__organizationmemberteam__team__in=teams,
+            sentry_orgmember_set__organizationmemberteam__is_active=True,
+            is_active=True,
+        )
+
+    def get_from_projects(self, organization_id, projects):
+        """
+        Returns users associated with a project based on their teams.
+        """
+        return User.objects.filter(
+            sentry_orgmember_set__organization_id=organization_id,
+            sentry_orgmember_set__organizationmemberteam__team__projectteam__project__in=projects,
+            sentry_orgmember_set__organizationmemberteam__is_active=True,
+            is_active=True,
+        )
 
 
 class User(BaseModel, AbstractBaseUser):

--- a/tests/sentry/api/serializers/rest_framework/test_mentions.py
+++ b/tests/sentry/api/serializers/rest_framework/test_mentions.py
@@ -1,0 +1,52 @@
+from __future__ import absolute_import
+
+from sentry.api.fields.actor import Actor
+from sentry.api.serializers.rest_framework.mentions import extract_user_ids_from_mentions
+from sentry.models import (
+    Team,
+    User,
+)
+from sentry.testutils import TestCase
+
+
+class ExtractUserIdsFromMentionsTest(TestCase):
+    def test_users(self):
+        actor = Actor(self.user.id, User)
+        result = extract_user_ids_from_mentions(
+            self.organization.id,
+            [actor]
+        )
+        assert result['users'] == set([self.user.id])
+        assert result['team_users'] == set()
+
+        other_user = self.create_user()
+        result = extract_user_ids_from_mentions(
+            self.organization.id,
+            [actor, Actor(other_user.id, User)]
+        )
+        assert result['users'] == set([self.user.id, other_user.id])
+        assert result['team_users'] == set()
+
+    def test_teams(self):
+        member_user = self.create_user()
+        self.create_member(
+            user=member_user,
+            organization=self.organization,
+            role='member',
+            teams=[self.team],
+        )
+        actor = Actor(self.team.id, Team)
+        result = extract_user_ids_from_mentions(
+            self.organization.id,
+            [actor]
+        )
+        assert result['users'] == set()
+        assert result['team_users'] == set([self.user.id, member_user.id])
+
+        # Explicitly mentioned users shouldn't be included in team_users
+        result = extract_user_ids_from_mentions(
+            self.organization.id,
+            [Actor(member_user.id, User), actor]
+        )
+        assert result['users'] == set([member_user.id])
+        assert result['team_users'] == set([self.user.id])

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -92,3 +92,50 @@ class UserMergeToTest(TestCase):
 
         assert member.role == 'owner'
         assert list(member.teams.all().order_by('pk')) == [team_1, team_2, team_3]
+
+
+class GetUsersFromTeamsTest(TestCase):
+    def test(self):
+        user = self.create_user()
+        org = self.create_organization(name='foo', owner=user)
+        team = self.create_team(organization=org)
+        org2 = self.create_organization(name='bar', owner=None)
+        team2 = self.create_team(organization=org2)
+        user2 = self.create_user('foo@example.com')
+        self.create_member(user=user2, organization=org, role='admin', teams=[team])
+
+        assert list(User.objects.get_from_teams(org, [team])) == [user2]
+        user3 = self.create_user('bar@example.com')
+        self.create_member(
+            user=user3,
+            organization=org,
+            role='admin',
+            teams=[team],
+        )
+        assert set(list(User.objects.get_from_teams(org, [team]))) == set([user2, user3])
+        assert list(User.objects.get_from_teams(org2, [team])) == []
+        assert list(User.objects.get_from_teams(org2, [team2])) == []
+        self.create_member(user=user, organization=org2, role='member', teams=[team2])
+        assert list(User.objects.get_from_teams(org2, [team2])) == [user]
+
+
+class GetUsersFromProjectsTest(TestCase):
+    def test(self):
+        user = self.create_user()
+        org = self.create_organization(name='foo', owner=user)
+        team = self.create_team(organization=org)
+        project = self.create_project(organization=org, teams=[team])
+        org2 = self.create_organization(name='bar', owner=None)
+        team2 = self.create_team(organization=org2)
+        user2 = self.create_user('foo@example.com')
+        project2 = self.create_project(organization=org2, teams=[team2])
+        self.create_member(user=user2, organization=org, role='admin', teams=[team])
+
+        assert list(User.objects.get_from_projects(org, [project])) == [user2]
+        user3 = self.create_user('bar@example.com')
+        self.create_member(user=user3, organization=org, role='admin', teams=[team])
+        assert set(list(User.objects.get_from_projects(org, [project]))) == set([user2, user3])
+        assert list(User.objects.get_from_projects(org2, [project])) == []
+        assert list(User.objects.get_from_projects(org2, [project2])) == []
+        self.create_member(user=user, organization=org2, role='member', teams=[team2])
+        assert list(User.objects.get_from_projects(org2, [project2])) == [user]


### PR DESCRIPTION
This follows the same general pattern from issue comments. Users in comments should be sent like
`**@<name>**`, and a list of mentions should be passed in format `user:1234` or `team:1234`. When a user is mentioned they're automatically subscribed to the incident, and receive notifications like
other subscribers.