### PR TITLE
fix: Query the right set of issues when given no set of envs for a given first release

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -341,8 +341,6 @@ class SnubaSearchBackend(SearchBackend):
                 has_groupenvironment_join = 'sentry_groupenvironment' in group_queryset.query.alias_map
                 has_sentry_release_join = 'sentry_release' in group_queryset.query.alias_map
 
-                # a groupenvironment left outer join may duplicate rows,
-                # so we would only want distinct groups
                 if has_groupenvironment_join and has_sentry_release_join:
 
                     # if a sentry_groupenvironment join exists in group_queryset,
@@ -355,6 +353,8 @@ class SnubaSearchBackend(SearchBackend):
                     # then demote the join to be an inner join
                     group_queryset.query.demote_joins(['sentry_release'])
 
+                    # a groupenvironment left outer join may duplicate rows,
+                    # so we would only want distinct groups
                     group_queryset = group_queryset.distinct()
 
         now = timezone.now()

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -306,8 +306,8 @@ class SnubaSearchBackend(SearchBackend):
             group_queryset = QuerySetBuilder({
                 'first_release': QCallbackCondition(
                     lambda version: Q(
-                        groupenvironment__first_release__organization_id=projects[0].organization_id,
-                        groupenvironment__first_release__version=version,
+                        first_release__organization_id=projects[0].organization_id,
+                        first_release__version=version,
                         groupenvironment__environment_id__in=environment_ids,
                     )
                 ),

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -306,8 +306,9 @@ class SnubaSearchBackend(SearchBackend):
             group_queryset = QuerySetBuilder({
                 'first_release': QCallbackCondition(
                     lambda version: Q(
-                        first_release__organization_id=projects[0].organization_id,
-                        first_release__version=version,
+                        # if environment(s) are selected, we just filter on the group environment's first_release attribute.
+                        groupenvironment__first_release__organization_id=projects[0].organization_id,
+                        groupenvironment__first_release__version=version,
                         groupenvironment__environment_id__in=environment_ids,
                     )
                 ),

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -337,19 +337,18 @@ class SnubaSearchBackend(SearchBackend):
             has_groupenvironment_join = 'sentry_groupenvironment' in group_queryset.query.alias_map
             has_sentry_release_join = 'sentry_release' in group_queryset.query.alias_map
 
-            # if a sentry_groupenvironment join exists in group_queryset,
-            # then promote the join to be a left outer join
-            if has_groupenvironment_join:
-                group_queryset.query.promote_joins(['sentry_groupenvironment'])
-
-            # if a sentry_release join exists in group_queryset,
-            # then demote the join to be an inner join
-            if has_sentry_release_join:
-                group_queryset.query.demote_joins(['sentry_release'])
-
             # a groupenvironment left outer join may duplicate rows,
             # so we would only want distinct groups
             if has_groupenvironment_join and has_sentry_release_join:
+
+                # if a sentry_groupenvironment join exists in group_queryset,
+                # then promote the join to be a left outer join
+                group_queryset.query.promote_joins(['sentry_groupenvironment'])
+
+                # if a sentry_release join exists in group_queryset,
+                # then demote the join to be an inner join
+                group_queryset.query.demote_joins(['sentry_release'])
+
                 group_queryset = group_queryset.distinct()
 
         now = timezone.now()

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -321,12 +321,25 @@ class SnubaSearchBackend(SearchBackend):
             group_queryset = QuerySetBuilder({
                 'first_release': QCallbackCondition(
                     lambda version: Q(
-                        first_release__organization_id=projects[0].organization_id,
                         first_release__version=version,
+                        first_release__organization_id=projects[0].organization_id,
+                        groupenvironment__first_release__version=version,
                     ),
                 ),
                 'first_seen': ScalarCondition('first_seen'),
             }).build(group_queryset, search_filters)
+
+            # if a sentry_groupenvironment join exists in, group_queryset promote the join
+            # to be an outer join
+            if 'sentry_groupenvironment' in group_queryset.query.alias_map:
+                group_queryset.query.promote_joins(['sentry_groupenvironment'])
+
+            # if a sentry_release join exists in, group_queryset promote the join
+            # to be an inner join
+            if 'sentry_release' in group_queryset.query.alias_map:
+                group_queryset.query.demote_joins(['sentry_release'])
+
+            group_queryset = group_queryset.distinct()
 
         now = timezone.now()
         end = None

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -306,7 +306,8 @@ class SnubaSearchBackend(SearchBackend):
             group_queryset = QuerySetBuilder({
                 'first_release': QCallbackCondition(
                     lambda version: Q(
-                        # if environment(s) are selected, we just filter on the group environment's first_release attribute.
+                        # if environment(s) are selected, we just filter on the group
+                        # environment's first_release attribute.
                         groupenvironment__first_release__organization_id=projects[0].organization_id,
                         groupenvironment__first_release__version=version,
                         groupenvironment__environment_id__in=environment_ids,
@@ -322,16 +323,16 @@ class SnubaSearchBackend(SearchBackend):
             group_queryset = QuerySetBuilder({
                 'first_release': QCallbackCondition(
                     lambda release_version: Q(
-                        # if no specific environments are supplied, we choose any groups that has a specific first release
-                        # that matches the given release_version, (agnostic of environment)
+                        # if no specific environments are supplied, we either choose any
+                        # groups/issues whose first release matches the given release_version,
                         Q(
                             first_release_id__in=Release.objects.filter(
                                 version=release_version,
                                 organization_id=projects[0].organization_id
                             )
                         ) |
-                        # or choose any groups whose first occurrence in any environment and the latest release at
-                        # the time of the groups' occurrence matches the given release_version
+                        # or we choose any groups whose first occurrence in any environment and the latest release at
+                        # the time of the groups' first occurrence matches the given release_version
                         Q(
                             id__in=GroupEnvironment.objects.filter(
                                 first_release__version=release_version,

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -328,7 +328,7 @@ class SnubaSearchBackend(SearchBackend):
                         # or choose any groups whose first occurrence in any environment and the latest release at
                         # the time of the groups' occurrence matches the given release_version
                         Q(groupenvironment__first_release__version=release_version),
-                        groupenvironment__first_release__organization_id=projects[0].organization_id,
+                        first_release__organization_id=projects[0].organization_id
                     ),
                 ),
                 'first_seen': ScalarCondition('first_seen'),

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1229,7 +1229,10 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         )
         assert set(results) == set([self.group1])
 
-    def test_first_release_any_environments(self):
+    def test_first_release_any_or_no_environments(self):
+        # test scenarios for tickets:
+        # SEN-571
+        # ISSUE-432
 
         # create some releases
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1234,6 +1234,33 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         # SEN-571
         # ISSUE-432
 
+        # given the following setup:
+        #
+        # groups table:
+        # group    first_release
+        # A        1
+        # B        1
+        # C        2
+        #
+        # groupenvironments table:
+        # group    environment    first_release
+        # A        staging        1
+        # A        production     2
+        #
+        # when querying by first release, the appropriate set of groups should be displayed:
+        #
+        #     first_release: 1
+        #         env=[]: A, B
+        #         env=[production, staging]: A
+        #         env=[staging]: A
+        #         env=[production]: nothing
+        #
+        #     first_release: 2
+        #         env=[]: A, C
+        #         env=[production, staging]: A
+        #         env=[staging]: nothing
+        #         env=[production]: A
+
         # create some releases
 
         release_1_timestamp = self.base_datetime

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1173,8 +1173,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
 
     def test_first_release(self):
 
-        print("hi mom")
-
         # expect no groups within the results since there are no releases
 
         results = self.make_query(
@@ -1198,13 +1196,10 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         self.group1.first_release = release_1
         self.group1.save()
 
-        self.group3.first_release = release_1
-        self.group3.save()
-
         results = self.make_query(
             search_filter_query='first_release:%s' % release_1.version,
         )
-        assert set(results) == set([self.group1, self.group3])
+        assert set(results) == set([self.group1])
 
         # create another release
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1183,7 +1183,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         # expect no groups even though there is a release; since no group
         # is attached to a release
 
-        release_1 = self.create_release(self.project, date_added=datetime.now())
+        release_1 = self.create_release(self.project)
 
         results = self.make_query(
             search_filter_query='first_release:%s' % release_1.version,

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1296,8 +1296,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         )
 
         group_a = Group.objects.get(id=group_a_event_1.group.id)
-        assert group_a.id == group_a_event_1.group.id
-        assert group_a.id == group_a_event_2.group.id
 
         assert group_a.first_seen == group_a_event_1.datetime
         assert group_a.last_seen == group_a_event_2.datetime
@@ -1335,7 +1333,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         assert group_b_event_1.get_environment().name == u''  # has no environment
 
         group_b = Group.objects.get(id=group_b_event_1.group.id)
-        assert group_b.id == group_b_event_1.group.id
 
         assert group_b.first_seen == group_b.last_seen == group_b_event_1.datetime
 
@@ -1361,7 +1358,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         assert group_c_event_1.get_environment().name == u''  # has no environment
 
         group_c = Group.objects.get(id=group_c_event_1.group.id)
-        assert group_c.id == group_c_event_1.group.id
 
         assert group_c.first_seen == group_c.last_seen == group_c_event_1.datetime
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1295,7 +1295,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             project_id=self.project.id,
         )
 
-        group_a = Group.objects.get(id=group_a_event_1.group.id)
+        group_a = group_a_event_1.group
 
         # get the environments for group_a
 
@@ -1324,7 +1324,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         )
         assert group_b_event_1.get_environment().name == u''  # has no environment
 
-        group_b = Group.objects.get(id=group_b_event_1.group.id)
+        group_b = group_b_event_1.group
 
         # group_b_event_1 occurred before release_2 was created
         assert group_b_event_1.datetime < release_2_timestamp
@@ -1343,7 +1343,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         )
         assert group_c_event_1.get_environment().name == u''  # has no environment
 
-        group_c = Group.objects.get(id=group_c_event_1.group.id)
+        group_c = group_c_event_1.group
 
         # expect no groups since given release version does not exist
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1297,10 +1297,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
 
         group_a = Group.objects.get(id=group_a_event_1.group.id)
 
-        assert group_a.first_seen == group_a_event_1.datetime
-        assert group_a.last_seen == group_a_event_2.datetime
-        assert group_a.last_seen > group_a.first_seen
-
         # get the environments for group_a
 
         prod_env = group_a_event_2.get_environment()
@@ -1330,8 +1326,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
 
         group_b = Group.objects.get(id=group_b_event_1.group.id)
 
-        assert group_b.first_seen == group_b.last_seen == group_b_event_1.datetime
-
         # group_b_event_1 occurred before release_2 was created
         assert group_b_event_1.datetime < release_2_timestamp
 
@@ -1350,8 +1344,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         assert group_c_event_1.get_environment().name == u''  # has no environment
 
         group_c = Group.objects.get(id=group_c_event_1.group.id)
-
-        assert group_c.first_seen == group_c.last_seen == group_c_event_1.datetime
 
         # expect no groups since given release version does not exist
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1301,10 +1301,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         assert group_a.last_seen == group_a_event_2.datetime
         assert group_a.last_seen > group_a.first_seen
 
-        group_a.times_seen = 42
-        group_a.status = GroupStatus.UNRESOLVED
-        group_a.save()
-
         # get the environments for group_a
 
         prod_env = group_a_event_2.get_environment()
@@ -1339,10 +1335,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         # group_b_event_1 occurred before release_2 was created
         assert group_b_event_1.datetime < release_2_timestamp
 
-        group_b.times_seen = 422
-        group_b.status = GroupStatus.UNRESOLVED
-        group_b.save()
-
         # create an issue/group whose event that occur in no environments
         # but will be tied to release_2
 
@@ -1360,10 +1352,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         group_c = Group.objects.get(id=group_c_event_1.group.id)
 
         assert group_c.first_seen == group_c.last_seen == group_c_event_1.datetime
-
-        group_c.times_seen = 666
-        group_c.status = GroupStatus.UNRESOLVED
-        group_c.save()
 
         # expect no groups since given release version does not exist
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1263,13 +1263,8 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
 
         # create some releases
 
-        release_1_timestamp = self.base_datetime
-        release_1 = self.create_release(self.project, date_added=release_1_timestamp, version="release_1")
-
-        release_2_timestamp = release_1_timestamp + timedelta(days=2)
-        release_2 = self.create_release(self.project, date_added=release_2_timestamp, version="release_2")
-
-        assert release_2_timestamp > release_1_timestamp  # release_2 occurred after release_1
+        release_1 = self.create_release(self.project, version="release_1")
+        release_2 = self.create_release(self.project, version="release_2")
 
         # create an issue/group whose events that occur in 2 distinct environments
 
@@ -1277,9 +1272,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             data={
                 'fingerprint': ['group_a'],
                 'event_id': 'aaa' + ('1' * 29),
-                'message': 'group_a',
-                'environment': 'example_staging',
-                'timestamp': (release_1_timestamp + timedelta(days=1)).isoformat()[:19]
+                'environment': 'example_staging'
             },
             project_id=self.project.id,
         )
@@ -1288,9 +1281,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             data={
                 'fingerprint': ['group_a'],
                 'event_id': 'aaa' + ('2' * 29),
-                'message': 'group_a',
-                'environment': 'example_production',
-                'timestamp': (release_2_timestamp + timedelta(days=1)).isoformat()[:19]
+                'environment': 'example_production'
             },
             project_id=self.project.id,
         )
@@ -1308,17 +1299,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         group_b_event_1 = self.store_event(
             data={
                 'fingerprint': ['group_b'],
-                'event_id': 'bbb' + ('1' * 29),
-                'message': 'group_b',
-                'tags': {
-                    'server': 'example.com',
-                },
-                'timestamp': (release_1_timestamp + timedelta(days=1)).isoformat()[:19],
-                'stacktrace': {
-                    'frames': [{
-                        'module': 'group_b'
-                    }]
-                },
+                'event_id': 'bbb' + ('1' * 29)
             },
             project_id=self.project.id,
         )
@@ -1326,18 +1307,13 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
 
         group_b = group_b_event_1.group
 
-        # group_b_event_1 occurred before release_2 was created
-        assert group_b_event_1.datetime < release_2_timestamp
-
         # create an issue/group whose event that occur in no environments
         # but will be tied to release_2
 
         group_c_event_1 = self.store_event(
             data={
                 'fingerprint': ['group_c'],
-                'event_id': 'ccc' + ('1' * 29),
-                'message': 'group_c',
-                'timestamp': (release_2_timestamp + timedelta(days=1)).isoformat()[:19]
+                'event_id': 'ccc' + ('1' * 29)
             },
             project_id=self.project.id,
         )

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1279,15 +1279,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
                 'event_id': 'aaa' + ('1' * 29),
                 'message': 'group_a',
                 'environment': 'example_staging',
-                'tags': {
-                    'server': 'example.com',
-                },
-                'timestamp': (release_1_timestamp + timedelta(days=1)).isoformat()[:19],
-                'stacktrace': {
-                    'frames': [{
-                        'module': 'group_a'
-                    }]
-                },
+                'timestamp': (release_1_timestamp + timedelta(days=1)).isoformat()[:19]
             },
             project_id=self.project.id,
         )
@@ -1298,15 +1290,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
                 'event_id': 'aaa' + ('2' * 29),
                 'message': 'group_a',
                 'environment': 'example_production',
-                'tags': {
-                    'server': 'example.com',
-                },
-                'timestamp': (release_2_timestamp + timedelta(days=1)).isoformat()[:19],
-                'stacktrace': {
-                    'frames': [{
-                        'module': 'group_a'
-                    }]
-                },
+                'timestamp': (release_2_timestamp + timedelta(days=1)).isoformat()[:19]
             },
             project_id=self.project.id,
         )
@@ -1370,15 +1354,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
                 'fingerprint': ['group_c'],
                 'event_id': 'ccc' + ('1' * 29),
                 'message': 'group_c',
-                'tags': {
-                    'server': 'example.com',
-                },
-                'timestamp': (release_2_timestamp + timedelta(days=1)).isoformat()[:19],
-                'stacktrace': {
-                    'frames': [{
-                        'module': 'group_c'
-                    }]
-                },
+                'timestamp': (release_2_timestamp + timedelta(days=1)).isoformat()[:19]
             },
             project_id=self.project.id,
         )

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1264,10 +1264,10 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         # create some releases
 
         release_1_timestamp = self.base_datetime
-        release_1 = self.create_release(self.project, date_added=release_1_timestamp)
+        release_1 = self.create_release(self.project, date_added=release_1_timestamp, version="release_1")
 
         release_2_timestamp = release_1_timestamp + timedelta(days=2)
-        release_2 = self.create_release(self.project, date_added=release_2_timestamp)
+        release_2 = self.create_release(self.project, date_added=release_2_timestamp, version="release_2")
 
         assert release_2_timestamp > release_1_timestamp  # release_2 occurred after release_1
 
@@ -1347,12 +1347,8 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
 
         # expect no groups since given release version does not exist
 
-        non_existent_release = 'fake'
-        assert release_1.version != non_existent_release
-        assert release_2.version != non_existent_release
-
         results = self.make_query(
-            search_filter_query='first_release:%s' % non_existent_release,
+            search_filter_query='first_release:%s' % 'fake',
         )
 
         assert set(results) == set([])

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1320,24 +1320,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
 
         group_c = group_c_event_1.group
 
-        # group_a occured in staging environment, and the latest release at the time
-        # of this occurrence was release_1
-
-        GroupEnvironment.get_or_create(
-            group_id=group_a.id,
-            environment_id=staging_env.id,
-            defaults={'first_release_id': group_a.first_release.id}
-        )[0]
-
-        # group_a occured in production environment, and the latest release at the time
-        # of this occurrence was release_2
-
-        GroupEnvironment.get_or_create(
-            group_id=group_a.id,
-            environment_id=prod_env.id,
-            defaults={'first_release': group_a_event_2.release}
-        )[0]
-
         # query by release release_1
 
         results = self.make_query(

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1428,11 +1428,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         )
         assert set(results) == set([group_a])
 
-        results = self.make_query(
-            search_filter_query='first_release:%s' % release_2.version,
-        )
-        assert set(results) == set([])
-
         # set group_b's first_release to be release_1
 
         group_b.first_release = release_1
@@ -1443,27 +1438,18 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         )
         assert set(results) == set([group_a, group_b])
 
-        results = self.make_query(
-            search_filter_query='first_release:%s' % release_2.version,
-        )
-        assert set(results) == set([])
-
         # set group_c's first_release to be release_2
 
         group_c.first_release = release_2
         group_c.save()
 
         results = self.make_query(
-            search_filter_query='first_release:%s' % release_1.version,
-        )
-        assert set(results) == set([group_a, group_b])
-
-        results = self.make_query(
             search_filter_query='first_release:%s' % release_2.version,
         )
         assert set(results) == set([group_c])
 
-        #  groupenv(group_a, staging, release_1)
+        # group_a occured in staging environment, and the latest release at the time
+        # of this occurrence was release_1
 
         group_a_staging_env = GroupEnvironment.get_or_create(
             group_id=group_a.id,
@@ -1473,54 +1459,8 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         group_a_staging_env.first_release = release_1
         group_a_staging_env.save()
 
-        results = self.make_query(
-            search_filter_query='first_release:%s' % release_1.version,
-        )
-        assert set(results) == set([group_a, group_b])
-
-        results = self.make_query(
-            environments=[staging_env, prod_env],
-            search_filter_query='first_release:%s' % release_1.version,
-        )
-        # note that group_b does not show up since it has no events that occured in any environments
-        assert set(results) == set([group_a])
-
-        results = self.make_query(
-            environments=[staging_env],
-            search_filter_query='first_release:%s' % release_1.version,
-        )
-        assert set(results) == set([group_a])
-
-        results = self.make_query(
-            environments=[prod_env],
-            search_filter_query='first_release:%s' % release_1.version,
-        )
-        assert set(results) == set([])
-
-        results = self.make_query(
-            search_filter_query='first_release:%s' % release_2.version,
-        )
-        assert set(results) == set([group_c])
-
-        results = self.make_query(
-            environments=[staging_env, prod_env],
-            search_filter_query='first_release:%s' % release_2.version,
-        )
-        assert set(results) == set([])
-
-        results = self.make_query(
-            environments=[staging_env],
-            search_filter_query='first_release:%s' % release_2.version,
-        )
-        assert set(results) == set([])
-
-        results = self.make_query(
-            environments=[prod_env],
-            search_filter_query='first_release:%s' % release_2.version,
-        )
-        assert set(results) == set([])
-
-        #  groupenv(group_a, prod, release_2)
+        # group_a occured in production environment, and the latest release at the time
+        # of this occurrence was release_2
 
         group_a_prod_env = GroupEnvironment.get_or_create(
             group_id=group_a.id,
@@ -1530,6 +1470,8 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         group_a_prod_env.first_release = release_2
         group_a_prod_env.save()
 
+        # query by release release_1
+
         results = self.make_query(
             search_filter_query='first_release:%s' % release_1.version,
         )
@@ -1539,7 +1481,6 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             environments=[staging_env, prod_env],
             search_filter_query='first_release:%s' % release_1.version,
         )
-        # note that group_b does not show up since it has no events that occured in any environments
         assert set(results) == set([group_a])
 
         results = self.make_query(
@@ -1553,6 +1494,8 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             search_filter_query='first_release:%s' % release_1.version,
         )
         assert set(results) == set([])
+
+        # query by release release_2
 
         results = self.make_query(
             search_filter_query='first_release:%s' % release_2.version,


### PR DESCRIPTION
## TODO

- [x] need to touch base with Sara regarding this semantic change.
- [x] edit PR to include Dan's explanations + edit PR title
- [x] add tests

-----

When querying groups/issues when given no set of environments for a given first release (i.e. the query `first_release:<release_version>`), we either

- choose any groups/issues whose first release matches the given release_version,
- or we choose any groups whose first occurrence in any environment and the latest release at the time of the groups' first occurrence matches the given release_version.

### test scenario

```
given the following setup:

groups table:
group    first_release
A        1
B        1
C        2

groupenvironments table:
group    environment    first_release
A        staging        1
A        production     2

when querying by first release, the appropriate set of groups should be displayed:

    first_release: 1
        env=[]: A, B
        env=[production, staging]: A
        env=[staging]: A
        env=[production]: nothing
        
    first_release: 2
        env=[]: A, C
        env=[production, staging]: A
        env=[staging]: nothing
        env=[production]: A
```

--------


Fixes SEN-571
Fixes ISSUE-432