### PR TITLE
feat(app-platform): Add SHA to Internal slugs

### DIFF
--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -4,6 +4,7 @@ import six
 import uuid
 import hmac
 import itertools
+import hashlib
 
 from django.db import models
 from django.utils import timezone
@@ -169,6 +170,12 @@ class SentryApp(ParanoidModel, HasApiScopes):
         """
         if not self.slug:
             self.slug = slugify(self.name)
+
+        if self.is_internal:
+            self.slug = u'{}-{}'.format(
+                self.slug,
+                hashlib.sha1(self.owner.slug).hexdigest()[0:6],
+            )
 
     def build_signature(self, body):
         secret = self.application.client_secret

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import six
+import re
 
 from django.core.urlresolvers import reverse
 
@@ -404,7 +405,7 @@ class PostSentryAppsTest(SentryAppsTest):
 
         response = self._post(isInternal=True)
 
-        assert response.data['slug'] == 'myapp'
+        assert re.match(r'myapp\-[0-9a-zA-Z]+', response.data['slug'])
         assert response.data['status'] == SentryAppStatus.as_str(SentryAppStatus.INTERNAL)
 
     def _post(self, **kwargs):

--- a/tests/sentry/mediators/sentry_apps/test_internal_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_internal_creator.py
@@ -28,8 +28,8 @@ class TestInternalCreator(TestCase):
         )
 
     def test_creates_internal_sentry_app(self):
-        self.creator.call()
-        assert SentryApp.objects.filter(slug='nulldb').exists()
+        sentry_app = self.creator.call()
+        assert SentryApp.objects.filter(slug=sentry_app.slug).exists()
 
     def test_installs_to_org(self):
         sentry_app = self.creator.call()

--- a/tests/sentry/models/test_sentryapp.py
+++ b/tests/sentry/models/test_sentryapp.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import hashlib
+
 from sentry.constants import SentryAppStatus
 from sentry.testutils import TestCase
 from sentry.models import ApiApplication, SentryApp
@@ -24,6 +26,14 @@ class SentryAppTest(TestCase):
     def test_slug(self):
         self.sentry_app.save()
         assert self.sentry_app.slug == 'nulldb'
+
+    def test_internal_slug(self):
+        self.sentry_app.status = SentryAppStatus.INTERNAL
+        self.sentry_app.save()
+
+        assert self.sentry_app.slug == u'nulldb-{}'.format(
+            hashlib.sha1(self.org.slug).hexdigest()[0:6]
+        )
 
     def test_paranoid(self):
         self.sentry_app.save()


### PR DESCRIPTION
In order to prevent Internal Integrations from polluting the global namespace for Integrations, we add a suffix to the slug. The suffix is the first six digits of the SHA1 of the Org's name.