### PR TITLE
feat(events-v2) Fix 500 when group parameter is not an integer

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -68,8 +68,6 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         query = request.GET.get('query')
         try:
             snuba_args = get_snuba_query_args(query=query, params=params)
-        except ValueError as exc:
-            raise OrganizationEventsError(exc.message)
         except InvalidSearchQuery as exc:
             raise OrganizationEventsError(exc.message)
 

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -14,9 +14,6 @@ SPECIAL_FIELDS = {
     'issue_title': {
         'aggregations': [['anyHeavy', 'title', 'issue_title']],
     },
-    'last_event': {
-        'aggregations': [['max', 'id', 'last_event']],
-    },
     'last_seen': {
         'aggregations': [['max', 'timestamp', 'last_seen']],
     },

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -729,6 +729,36 @@ class OrganizationEventsStatsEndpointTest(OrganizationEventsTestBase):
         assert response.status_code == 200, response.content
         assert len(response.data['data']) == 0
 
+    def test_groupid_filter(self):
+        url = reverse(
+            'sentry-api-0-organization-events-stats',
+            kwargs={
+                'organization_slug': self.organization.slug,
+            }
+        )
+        url = '%s?%s' % (url, urlencode({
+            'start': self.day_ago.isoformat()[:19],
+            'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+            'interval': '1h',
+            'group': self.group.id
+        }))
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data['data'])
+
+    def test_groupid_filter_invalid_value(self):
+        url = reverse(
+            'sentry-api-0-organization-events-stats',
+            kwargs={
+                'organization_slug': self.organization.slug,
+            }
+        )
+        url = '%s?group=not-a-number' % (url,)
+        response = self.client.get(url, format='json')
+
+        assert response.status_code == 400, response.content
+
     def test_user_count(self):
         self.create_event(
             event_id='d' * 32,

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -204,7 +204,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
     def test_special_fields(self):
         self.login_as(user=self.user)
         project = self.create_project()
-        event1 = self.store_event(
+        self.store_event(
             data={
                 'event_id': 'a' * 32,
                 'timestamp': self.min_ago,
@@ -226,7 +226,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
             },
             project_id=project.id,
         )
-        event3 = self.store_event(
+        self.store_event(
             data={
                 'event_id': 'c' * 32,
                 'timestamp': self.min_ago,
@@ -245,7 +245,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
                 self.url,
                 format='json',
                 data={
-                    'field': ['issue_title', 'event_count', 'user_count', 'last_event'],
+                    'field': ['issue_title', 'event_count', 'user_count'],
                     'groupby': ['issue.id', 'project.id'],
                     'orderby': 'issue.id'
                 },
@@ -256,8 +256,6 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[0]['issue.id'] == groups[0].id
         assert response.data[0]['event_count'] == 1
         assert response.data[0]['user_count'] == 1
-        assert response.data[0]['last_event'] == event1.event_id
         assert response.data[1]['issue.id'] == groups[1].id
         assert response.data[1]['event_count'] == 2
         assert response.data[1]['user_count'] == 2
-        assert response.data[1]['last_event'] == event3.event_id

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -204,7 +204,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
     def test_special_fields(self):
         self.login_as(user=self.user)
         project = self.create_project()
-        self.store_event(
+        event1 = self.store_event(
             data={
                 'event_id': 'a' * 32,
                 'timestamp': self.min_ago,
@@ -226,7 +226,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
             },
             project_id=project.id,
         )
-        self.store_event(
+        event3 = self.store_event(
             data={
                 'event_id': 'c' * 32,
                 'timestamp': self.min_ago,
@@ -245,7 +245,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
                 self.url,
                 format='json',
                 data={
-                    'field': ['issue_title', 'event_count', 'user_count'],
+                    'field': ['issue_title', 'event_count', 'user_count', 'last_event'],
                     'groupby': ['issue.id', 'project.id'],
                     'orderby': 'issue.id'
                 },
@@ -256,6 +256,8 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[0]['issue.id'] == groups[0].id
         assert response.data[0]['event_count'] == 1
         assert response.data[0]['user_count'] == 1
+        assert response.data[0]['last_event'] == event1.event_id
         assert response.data[1]['issue.id'] == groups[1].id
         assert response.data[1]['event_count'] == 2
         assert response.data[1]['user_count'] == 2
+        assert response.data[1]['last_event'] == event3.event_id


### PR DESCRIPTION
~~When looking at a grouped view we need a singular event to spawn the event modal with. This adds a `last_event` field to the events API that will allow the frontend access to a single event. Right now I'm using `MAX(event_id)` which is not a proper solution. I wanted to use `argMax` but I couldn't figure out how to do that with the wrappers and snuba API. This will unblock the frontend work and I plan on circling back to this and properly solving getting the 'last' event.~~ I'll be using the `/latest` endpoint from #13553 instead.

I've fixed a 500 error that occurred when the `group` query parameter was empty or a non-integer value.

Refs SEN-716