### PR TITLE
feat(ui): Add/connect Incident Suspects to API [SEN-579]

### DIFF
--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -432,7 +432,7 @@ export const Incident = PropTypes.shape({
   totalEvents: PropTypes.number.isRequired,
   uniqueUsers: PropTypes.number.isRequired,
   isSubscribed: PropTypes.bool,
-  dateClosed: PropTypes.string.isRequired,
+  dateClosed: PropTypes.string,
   dateStarted: PropTypes.string.isRequired,
   dateDetected: PropTypes.string.isRequired,
   dateAdded: PropTypes.string.isRequired,

--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -419,13 +419,37 @@ export const SavedSearch = PropTypes.shape({
 export const Incident = PropTypes.shape({
   id: PropTypes.string.isRequired,
   identifier: PropTypes.string.isRequired,
+  organizationId: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   status: PropTypes.number.isRequired,
   query: PropTypes.string,
   projects: PropTypes.array.isRequired,
+  eventStats: PropTypes.shape({
+    data: PropTypes.arrayOf(
+      PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.array]))
+    ),
+  }),
   totalEvents: PropTypes.number.isRequired,
   uniqueUsers: PropTypes.number.isRequired,
-  isSubscribed: PropTypes.bool.isRequired,
+  isSubscribed: PropTypes.bool,
+  dateClosed: PropTypes.string.isRequired,
+  dateStarted: PropTypes.string.isRequired,
+  dateDetected: PropTypes.string.isRequired,
+  dateAdded: PropTypes.string.isRequired,
+});
+
+export const IncidentSuspectData = PropTypes.shape({
+  author: User,
+  dateCreated: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+  message: PropTypes.string,
+  repository: Repository,
+  score: PropTypes.number,
+});
+
+export const IncidentSuspect = PropTypes.shape({
+  type: PropTypes.oneOf(['commit']).isRequired,
+  data: IncidentSuspectData.isRequired,
 });
 
 export const Activity = PropTypes.shape({
@@ -983,6 +1007,8 @@ const SentryTypes = {
   Group,
   Incident,
   IncidentActivity,
+  IncidentSuspect,
+  IncidentSuspectData,
   Tag,
   Monitor,
   PageLinks,

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
@@ -15,7 +15,7 @@ import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 
 import Activity from './activity';
-import IncidentsSuspects from './suspects';
+import Suspects from './suspects';
 
 export default class DetailsBody extends React.Component {
   static propTypes = {
@@ -63,7 +63,7 @@ export default class DetailsBody extends React.Component {
               <ChartPlaceholder />
             )}
 
-            <IncidentsSuspects params={params} />
+            <Suspects params={params} />
 
             <div>
               <SidebarHeading>

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
@@ -63,7 +63,7 @@ export default class DetailsBody extends React.Component {
               <ChartPlaceholder />
             )}
 
-            <IncidentsSuspects suspects={[]} />
+            <IncidentsSuspects params={params} />
 
             <div>
               <SidebarHeading>

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
@@ -25,6 +25,9 @@ export default class DetailsBody extends React.Component {
   render() {
     const {params, incident} = this.props;
 
+    // Considered loading when there is no incident object
+    const loading = !incident;
+
     return (
       <StyledPageContent>
         <Main>
@@ -46,14 +49,15 @@ export default class DetailsBody extends React.Component {
             </StyledNavTabs>
             <Activity
               params={params}
-              incidentStatus={incident ? incident.status : null}
+              incidentStatus={!loading ? incident.status : null}
             />
           </PageContent>
         </Main>
         <Sidebar>
           <PageContent>
-            <SideHeader>{t('Events in Incident')}</SideHeader>
-            {incident ? (
+            <SideHeader loading={loading}>{t('Events in Incident')}</SideHeader>
+
+            {!loading ? (
               <Chart
                 data={incident.eventStats.data}
                 detected={incident.dateDetected}
@@ -66,14 +70,14 @@ export default class DetailsBody extends React.Component {
             <Suspects params={params} />
 
             <div>
-              <SidebarHeading>
-                Projects Affected ({incident ? incident.projects.length : '-'})
-              </SidebarHeading>
+              <SideHeader loading={loading}>
+                {t('Projects Affected')} ({!loading ? incident.projects.length : '-'})
+              </SideHeader>
 
-              {incident && (
+              {!loading && (
                 <div>
                   <Projects slugs={incident.projects} orgId={params.orgId}>
-                    {({projects, fetching}) => {
+                    {({projects}) => {
                       return projects.map(project => (
                         <StyledIdBadge key={project.slug} project={project} />
                       ));
@@ -134,12 +138,6 @@ const ChartPlaceholder = styled('div')`
   background-color: ${p => p.theme.offWhite};
   height: 190px;
   margin-bottom: 10px;
-`;
-
-const SidebarHeading = styled('h6')`
-  color: ${p => p.theme.gray3};
-  margin: ${space(2)} 0 ${space(1)} 0;
-  text-transform: uppercase;
 `;
 
 const StyledIdBadge = styled(IdBadge)`

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/sideHeader.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/sideHeader.jsx
@@ -1,8 +1,29 @@
+import React from 'react';
 import styled from 'react-emotion';
 
-const SideHeader = styled('h6')`
+import space from 'app/styles/space';
+
+const SideHeader = styled(function Styled({className, loading, children}) {
+  return (
+    <h6 className={className}>
+      <Title loading={loading}>{children}</Title>
+    </h6>
+  );
+})`
   color: ${p => p.theme.gray3};
   font-weight: bold;
+  margin-bottom: ${space(1)};
   text-transform: uppercase;
 `;
+
+const Title = styled('span')`
+  ${p =>
+    p.loading
+      ? `
+  background-color: ${p.theme.placeholderBackground};
+  color: ${p.theme.placeholderBackground};
+  `
+      : ''};
+`;
+
 export default SideHeader;

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/suspects.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/suspects.jsx
@@ -34,42 +34,46 @@ Message.propTypes = {
   suspect: SentryTypes.IncidentSuspectData,
 };
 
-class Suspects extends React.Component {
-  static propTypes = {
-    suspects: PropTypes.arrayOf(SentryTypes.IncidentSuspect),
-  };
+const Suspects = styled(
+  class Suspects extends React.Component {
+    static propTypes = {
+      suspects: PropTypes.arrayOf(SentryTypes.IncidentSuspect),
+    };
 
-  renderEmpty() {
-    return t('No suspects found');
+    renderEmpty() {
+      return t('No suspects found');
+    }
+
+    render() {
+      const {className, suspects} = this.props;
+
+      return (
+        <div className={className}>
+          <SideHeader>{t('Suspects')}</SideHeader>
+          {suspects && suspects.length > 0 && (
+            <Panel>
+              <PanelBody>
+                {suspects.map(({type, data}) => (
+                  <SuspectItem p={1} key={data.id}>
+                    <Type>{type}</Type>
+                    <Message type={type} suspect={data} />
+                    <AuthorRow>
+                      <IdBadge user={data.author} hideEmail />
+                      <LightTimeSince date={data.dateCreated} />
+                    </AuthorRow>
+                  </SuspectItem>
+                ))}
+              </PanelBody>
+            </Panel>
+          )}
+          {(!suspects || suspects.length === 0) && this.renderEmpty()}
+        </div>
+      );
+    }
   }
-
-  render() {
-    const {suspects} = this.props;
-
-    return (
-      <Container>
-        <SideHeader>{t('Suspects')}</SideHeader>
-        {suspects && suspects.length > 0 && (
-          <Panel>
-            <PanelBody>
-              {suspects.map(({type, data}) => (
-                <SuspectItem p={1} key={data.id}>
-                  <Type>{type}</Type>
-                  <Message type={type} suspect={data} />
-                  <AuthorRow>
-                    <IdBadge user={data.author} hideEmail />
-                    <LightTimeSince date={data.dateCreated} />
-                  </AuthorRow>
-                </SuspectItem>
-              ))}
-            </PanelBody>
-          </Panel>
-        )}
-        {(!suspects || suspects.length === 0) && this.renderEmpty()}
-      </Container>
-    );
-  }
-}
+)`
+  margin-top: ${space(1)};
+`;
 
 export default class SuspectsContainer extends AsyncComponent {
   getEndpoints() {
@@ -88,10 +92,6 @@ export default class SuspectsContainer extends AsyncComponent {
     );
   }
 }
-
-const Container = styled('div')`
-  margin-top: ${space(1)};
-`;
 
 const Type = styled('div')`
   text-transform: uppercase;

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/suspects.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/suspects.jsx
@@ -37,7 +37,8 @@ Message.propTypes = {
 const Suspects = styled(
   class Suspects extends React.Component {
     static propTypes = {
-      suspects: PropTypes.arrayOf(SentryTypes.IncidentSuspect),
+      suspects: PropTypes.arrayOf(SentryTypes.IncidentSuspect).isRequired,
+      loading: PropTypes.bool,
     };
 
     renderEmpty() {
@@ -45,34 +46,45 @@ const Suspects = styled(
     }
 
     render() {
-      const {className, suspects} = this.props;
+      const {className, loading, suspects} = this.props;
 
       return (
         <div className={className}>
-          <SideHeader>{t('Suspects')}</SideHeader>
-          {suspects && suspects.length > 0 && (
-            <Panel>
-              <PanelBody>
-                {suspects.map(({type, data}) => (
-                  <SuspectItem p={1} key={data.id}>
-                    <Type>{type}</Type>
-                    <Message type={type} suspect={data} />
-                    <AuthorRow>
-                      <IdBadge user={data.author} hideEmail />
-                      <LightTimeSince date={data.dateCreated} />
-                    </AuthorRow>
-                  </SuspectItem>
-                ))}
-              </PanelBody>
-            </Panel>
+          <SideHeader loading={loading}>
+            {t('Suspects')} ({loading || !suspects ? '-' : suspects.length})
+          </SideHeader>
+          {loading ? (
+            <Placeholder />
+          ) : (
+            suspects &&
+            suspects.length > 0 && (
+              <Panel>
+                <PanelBody>
+                  {suspects.map(({type, data}) => (
+                    <SuspectItem p={1} key={data.id}>
+                      <Type>{type}</Type>
+                      <Message type={type} suspect={data} />
+                      <AuthorRow>
+                        <IdBadge user={data.author} hideEmail />
+                        <LightTimeSince date={data.dateCreated} />
+                      </AuthorRow>
+                    </SuspectItem>
+                  ))}
+                </PanelBody>
+              </Panel>
+            )
           )}
-          {(!suspects || suspects.length === 0) && this.renderEmpty()}
         </div>
       );
     }
   }
 )`
   margin-top: ${space(1)};
+`;
+
+const Placeholder = styled('div')`
+  background-color: ${p => p.theme.placeholderBackground};
+  padding: ${space(4)};
 `;
 
 export default class SuspectsContainer extends AsyncComponent {

--- a/src/sentry/static/sentry/app/views/organizationIncidents/status.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/status.jsx
@@ -12,7 +12,7 @@ import {isOpen} from './utils';
 export default class Status extends React.Component {
   static propTypes = {
     className: PropTypes.string,
-    incident: SentryTypes.Incident.isRequired,
+    incident: SentryTypes.Incident,
   };
 
   render() {

--- a/tests/js/fixtures/incident.js
+++ b/tests/js/fixtures/incident.js
@@ -2,6 +2,11 @@ export function Incident(params) {
   return {
     id: '321',
     identifier: '123',
+    organizationId: '3',
+    dateClosed: '2019-04-19T19:44:05.963Z',
+    dateStarted: '2019-04-05T19:44:05.963Z',
+    dateDetected: '2019-04-05T19:44:05.963Z',
+    dateAdded: '2019-04-05T19:44:05.963Z',
     title: 'Too many Chrome errors',
     status: 0,
     projects: [],

--- a/tests/js/fixtures/incidentSuspectCommit.js
+++ b/tests/js/fixtures/incidentSuspectCommit.js
@@ -1,0 +1,18 @@
+import {Repository} from './repository';
+import {User} from './user';
+
+export function IncidentSuspectCommit(params = []) {
+  return {
+    data: {
+      repository: Repository(),
+      author: User(),
+      dateCreated: '2019-03-28T01:36:35.457Z',
+      score: 2,
+      message:
+        'feat: Do something to raven/base.py\nvenenatis curae tincidunt feugiat duis parturient metus',
+      id: 'ec85fa0c622c13a09cd27443132711551f45f504',
+      ...params,
+    },
+    type: 'commit',
+  };
+}

--- a/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
@@ -27,8 +27,16 @@ describe('IncidentDetails', function() {
       body: mockIncident,
     });
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/incidents/123/suspects/',
+      body: [TestStubs.IncidentSuspectCommit()],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/incidents/456/',
       statusCode: 404,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/incidents/456/suspects/',
+      body: [],
     });
     activitiesList = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/incidents/${
@@ -67,6 +75,15 @@ describe('IncidentDetails', function() {
         .at(2)
         .text()
     ).toBe('20');
+
+    expect(wrapper.find('SuspectItem')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('SuspectItem')
+        .at(0)
+        .find('MessageOverflow')
+        .text()
+    ).toBe('feat: Do something to raven/base.py');
   });
 
   it('handles invalid incident', async function() {


### PR DESCRIPTION
This fetches suspects from API and renders in sidebar

![image](https://user-images.githubusercontent.com/79684/59071832-27b16880-8875-11e9-9a37-d13493053346.png)


Fixes SEN-579
