### PR TITLE
ref(utils): Remove default / reexports from utils.jsx

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -4,6 +4,7 @@ import styled from 'react-emotion';
 
 import {analytics} from 'app/utils/analytics';
 import {logException} from 'app/utils/logging';
+import {objectIsEmpty} from 'app/utils';
 import {t} from 'app/locale';
 import BreadcrumbsInterface from 'app/components/events/interfaces/breadcrumbs';
 import CspInterface from 'app/components/events/interfaces/csp';
@@ -29,7 +30,6 @@ import SentryTypes from 'app/sentryTypes';
 import StacktraceInterface from 'app/components/events/interfaces/stacktrace';
 import TemplateInterface from 'app/components/events/interfaces/template';
 import ThreadsInterface from 'app/components/events/interfaces/threads';
-import utils from 'app/utils';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -141,7 +141,7 @@ class EventEntries extends React.Component {
     const features = organization ? new Set(organization.features) : new Set();
 
     const hasContext =
-      event && (!utils.objectIsEmpty(event.user) || !utils.objectIsEmpty(event.contexts));
+      event && (!objectIsEmpty(event.user) || !objectIsEmpty(event.contexts));
 
     if (!event) {
       return (
@@ -153,7 +153,7 @@ class EventEntries extends React.Component {
 
     return (
       <div className="entries">
-        {!utils.objectIsEmpty(event.errors) && <EventErrors event={event} />}{' '}
+        {!objectIsEmpty(event.errors) && <EventErrors event={event} />}{' '}
         {!isShare && !!group.firstRelease && (
           <EventCause event={event} orgId={orgId} projectId={project.slug} />
         )}
@@ -175,14 +175,14 @@ class EventEntries extends React.Component {
         />
         {this.renderEntries()}
         {hasContext && <EventContexts group={group} event={event} />}
-        {!utils.objectIsEmpty(event.context) && <EventExtraData event={event} />}
-        {!utils.objectIsEmpty(event.packages) && <EventPackageData event={event} />}
-        {!utils.objectIsEmpty(event.device) && <EventDevice event={event} />}
+        {!objectIsEmpty(event.context) && <EventExtraData event={event} />}
+        {!objectIsEmpty(event.packages) && <EventPackageData event={event} />}
+        {!objectIsEmpty(event.device) && <EventDevice event={event} />}
         {!isShare && features.has('event-attachments') && (
           <EventAttachments event={event} orgId={orgId} projectId={project.slug} />
         )}
-        {!utils.objectIsEmpty(event.sdk) && <EventSdk event={event} />}
-        {!utils.objectIsEmpty(event.sdk) && event.sdk.upstream.isNewer && (
+        {!objectIsEmpty(event.sdk) && <EventSdk event={event} />}
+        {!objectIsEmpty(event.sdk) && event.sdk.upstream.isNewer && (
           <div className="alert-block alert-info box">
             <span className="icon-exclamation" />
             {t(

--- a/src/sentry/static/sentry/app/components/events/userFeedback.jsx
+++ b/src/sentry/static/sentry/app/components/events/userFeedback.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
+import {nl2br, escape} from 'app/utils';
 import {t} from 'app/locale';
 import ActivityAuthor from 'app/components/activity/author';
 import ActivityItem from 'app/components/activity/item';
@@ -9,7 +10,6 @@ import Clipboard from 'app/components/clipboard';
 import InlineSvg from 'app/components/inlineSvg';
 import Link from 'app/components/links/link';
 import space from 'app/styles/space';
-import utils from 'app/utils';
 
 class EventUserFeedback extends React.Component {
   static propTypes = {
@@ -54,7 +54,7 @@ class EventUserFeedback extends React.Component {
         >
           <p
             dangerouslySetInnerHTML={{
-              __html: utils.nl2br(utils.escape(report.comments)),
+              __html: nl2br(escape(report.comments)),
             }}
           />
         </ActivityItem>

--- a/src/sentry/static/sentry/app/components/pagination.jsx
+++ b/src/sentry/static/sentry/app/components/pagination.jsx
@@ -1,10 +1,10 @@
+import {browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {browserHistory} from 'react-router';
 import {css} from 'react-emotion';
 
-import utils from 'app/utils';
 import {t} from 'app/locale';
+import parseLinkHeader from 'app/utils/parseLinkHeader';
 
 const streamCss = css`
   margin: 20px 0 0 0;
@@ -48,7 +48,7 @@ export default class Pagination extends React.Component {
     const path = this.props.to || location.pathname;
     const query = location.query;
 
-    const links = utils.parseLinkHeader(pageLinks);
+    const links = parseLinkHeader(pageLinks);
 
     let previousPageClassName = 'btn btn-default btn-lg prev';
     if (links.previous.results === false) {

--- a/src/sentry/static/sentry/app/utils.jsx
+++ b/src/sentry/static/sentry/app/utils.jsx
@@ -1,11 +1,5 @@
 import _ from 'lodash';
 
-// import/export sub-utils
-import parseLinkHeader from 'app/utils/parseLinkHeader';
-import PendingChangeQueue from 'app/utils/pendingChangeQueue';
-import CursorPoller from 'app/utils/cursorPoller';
-import StreamManager from 'app/utils/streamManager';
-
 function arrayIsEqual(arr, other, deep) {
   // if the other array is a falsy value, return
   if (!arr && !other) {
@@ -280,31 +274,3 @@ export function deepFreeze(object) {
 
   return Object.freeze(object);
 }
-
-// re-export under utils
-export {parseLinkHeader, PendingChangeQueue, CursorPoller};
-
-// backwards compatible default export for use w/ getsentry (exported
-// as a single object w/ function refs for consumption by getsentry)
-export default {
-  sortArray,
-  objectIsEmpty,
-  defined,
-  nl2br,
-  isUrl,
-  escape,
-  percent,
-  toTitleCase,
-  intcomma,
-  valueIsEqual,
-  parseLinkHeader,
-  buildUserId,
-  buildTeamId,
-  descopeFeatureName,
-
-  // external imports
-  objectToArray,
-  PendingChangeQueue,
-  StreamManager,
-  CursorPoller,
-};

--- a/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/events.jsx
@@ -1,20 +1,20 @@
-import * as Sentry from '@sentry/browser';
 import {Flex} from 'grid-emotion';
+import {browserHistory} from 'react-router';
 import {isEqual} from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
+import * as Sentry from '@sentry/browser';
 import styled from 'react-emotion';
-import {browserHistory} from 'react-router';
 
-import {addErrorMessage} from 'app/actionCreators/indicator';
 import {Panel} from 'app/components/panels';
+import {addErrorMessage} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
 import AsyncView from 'app/views/asyncView';
 import Feature from 'app/components/acl/feature';
 import Pagination from 'app/components/pagination';
 import SentryTypes from 'app/sentryTypes';
-import utils from 'app/utils';
+import parseLinkHeader from 'app/utils/parseLinkHeader';
 import withOrganization from 'app/utils/withOrganization';
 
 import {getParams} from './utils/getParams';
@@ -22,7 +22,7 @@ import EventsChart from './eventsChart';
 import EventsTable from './eventsTable';
 
 const parseRowFromLinks = (links, numRows) => {
-  links = utils.parseLinkHeader(links);
+  links = parseLinkHeader(links);
   if (!links.previous.results) {
     return `1-${numRows}`;
   }
@@ -171,7 +171,7 @@ class OrganizationEvents extends AsyncView {
     const {organization, location, router} = this.props;
     const {error, loading, reloading, events, eventsPageLinks} = this.state;
     const parsedLinks =
-      !loading && !error && eventsPageLinks ? utils.parseLinkHeader(eventsPageLinks) : {};
+      !loading && !error && eventsPageLinks ? parseLinkHeader(eventsPageLinks) : {};
 
     return (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
@@ -1,26 +1,26 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
-import PropTypes from 'prop-types';
 
+import {INTERFACES} from 'app/components/events/eventEntries';
+import {getMessage, getTitle} from 'app/utils/events';
+import {objectIsEmpty, toTitleCase} from 'app/utils';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import DateTime from 'app/components/dateTime';
 import ErrorBoundary from 'app/components/errorBoundary';
-import ExternalLink from 'app/components/links/externalLink';
 import EventDataSection from 'app/components/events/eventDataSection';
 import EventDevice from 'app/components/events/device';
 import EventExtraData from 'app/components/events/extraData';
 import EventPackageData from 'app/components/events/packageData';
+import ExternalLink from 'app/components/links/externalLink';
 import FileSize from 'app/components/fileSize';
 import NavTabs from 'app/components/navTabs';
-import space from 'app/styles/space';
+import SentryTypes from 'app/sentryTypes';
 import getDynamicText from 'app/utils/getDynamicText';
-import utils from 'app/utils';
-import {getMessage, getTitle} from 'app/utils/events';
+import space from 'app/styles/space';
 
-import {INTERFACES} from 'app/components/events/eventEntries';
-import TagsTable from './tagsTable';
 import LinkedIssuePreview from './linkedIssuePreview';
+import TagsTable from './tagsTable';
 
 const OTHER_SECTIONS = {
   context: EventExtraData,
@@ -101,13 +101,13 @@ const EventModalContent = props => {
                     onTabChange(type);
                   }}
                 >
-                  {utils.toTitleCase(type)}
+                  {toTitleCase(type)}
                 </a>
               </li>
             );
           })}
           {Object.keys(OTHER_SECTIONS).map(section => {
-            if (utils.objectIsEmpty(event[section])) {
+            if (objectIsEmpty(event[section])) {
               return null;
             }
             const classname = section === activeTab ? 'active' : null;
@@ -120,7 +120,7 @@ const EventModalContent = props => {
                     onTabChange(section);
                   }}
                 >
-                  {utils.toTitleCase(section)}
+                  {toTitleCase(section)}
                 </a>
               </li>
             );

--- a/src/sentry/static/sentry/app/views/organizationReleases/detail/groupList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/detail/groupList.jsx
@@ -1,21 +1,21 @@
+import {isEqual} from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import {isEqual} from 'lodash';
+import createReactClass from 'create-react-class';
 import qs from 'query-string';
 
-import SentryTypes from 'app/sentryTypes';
+import {Panel, PanelBody} from 'app/components/panels';
 import {fetchOrgMembers, indexMembersByProject} from 'app/actionCreators/members';
+import {t} from 'app/locale';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
 import GroupStore from 'app/stores/groupStore';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
+import SentryTypes from 'app/sentryTypes';
 import StreamGroup from 'app/components/stream/group';
-import utils from 'app/utils';
+import StreamManager from 'app/utils/streamManager';
 import withApi from 'app/utils/withApi';
-import {t} from 'app/locale';
-import EmptyStateWarning from 'app/components/emptyStateWarning';
-import {Panel, PanelBody} from 'app/components/panels';
 
 import GroupListHeader from './groupListHeader';
 
@@ -55,7 +55,7 @@ const GroupList = createReactClass({
   },
 
   componentWillMount() {
-    this._streamManager = new utils.StreamManager(GroupStore);
+    this._streamManager = new StreamManager(GroupStore);
 
     this.fetchData();
   },

--- a/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/overview.jsx
@@ -11,6 +11,7 @@ import qs from 'query-string';
 import {Client} from 'app/api';
 import {Panel, PanelBody} from 'app/components/panels';
 import {analytics} from 'app/utils/analytics';
+import {defined} from 'app/utils';
 import {
   deleteSavedSearch,
   fetchSavedSearches,
@@ -22,6 +23,7 @@ import {fetchOrganizationTags, fetchTagValues} from 'app/actionCreators/tags';
 import {getUtcDateString} from 'app/utils/dates';
 import {t} from 'app/locale';
 import ConfigStore from 'app/stores/configStore';
+import CursorPoller from 'app/utils/cursorPoller';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import ErrorRobot from 'app/components/errorRobot';
 import GroupStore from 'app/stores/groupStore';
@@ -32,10 +34,10 @@ import ProcessingIssueList from 'app/components/stream/processingIssueList';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 import SentryTypes from 'app/sentryTypes';
 import StreamGroup from 'app/components/stream/group';
+import StreamManager from 'app/utils/streamManager';
 import TagStore from 'app/stores/tagStore';
 import parseApiError from 'app/utils/parseApiError';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
-import utils from 'app/utils';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import withSavedSearches from 'app/utils/withSavedSearches';
@@ -94,8 +96,8 @@ const OrganizationStream = createReactClass({
 
   componentDidMount() {
     this.api = new Client();
-    this._streamManager = new utils.StreamManager(GroupStore);
-    this._poller = new utils.CursorPoller({
+    this._streamManager = new StreamManager(GroupStore);
+    this._poller = new CursorPoller({
       success: this.onRealtimePoll,
     });
 
@@ -231,7 +233,7 @@ const OrganizationStream = createReactClass({
     }
 
     // only include defined values.
-    return pickBy(params, v => utils.defined(v));
+    return pickBy(params, v => defined(v));
   },
 
   getFeatures() {


### PR DESCRIPTION
- The defaults export was not used by getsentry (as the comment mentioned), in fact, it is not even exported in the SentryApp global at all.

 - The re-exports were not used.