### PR TITLE
fix(api) Don't 500 on invalid data

### DIFF
--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -24,7 +24,10 @@ class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
         except ProjectKey.DoesNotExist:
             raise ResourceDoesNotExist
 
-        stat_args = self._parse_args(request)
+        try:
+            stat_args = self._parse_args(request)
+        except ValueError:
+            return Response({'detail': 'Invalid request data'}, status=400)
 
         stats = OrderedDict()
         for model, name in (

--- a/tests/sentry/api/endpoints/test_project_key_stats.py
+++ b/tests/sentry/api/endpoints/test_project_key_stats.py
@@ -32,6 +32,11 @@ class ProjectKeyStatsTest(APITestCase):
             assert point['total'] == 0
         assert len(response.data) == 24
 
+    def test_invalid_parameters(self):
+        url = self.path + '?resolution=1x'
+        response = self.client.get(url)
+        assert response.status_code == 400
+
     # This test can be removed once the TSDB metrics that were stored
     # under str(key_id) have expired out of redis.
     def test_str_key_id(self):


### PR DESCRIPTION
Our API shouldn't fail when given poorly formatted data.

Fixes SENTRY-AZW