### PR TITLE
feat(ui): Add `size` prop to `<EventOrGroupHeader>`

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -38,10 +38,12 @@ class EventOrGroupHeader extends React.Component {
     hideIcons: PropTypes.bool,
     hideLevel: PropTypes.bool,
     query: PropTypes.string,
+    size: PropTypes.oneOf(['small', 'normal']),
   };
 
   static defaultProps = {
     includeLink: true,
+    size: 'normal',
   };
 
   getTitle() {
@@ -99,16 +101,16 @@ class EventOrGroupHeader extends React.Component {
   }
 
   render() {
-    const {className, data} = this.props;
+    const {className, size, data} = this.props;
     const cx = classNames('event-issue-header', className);
     const location = getLocation(data);
     const message = getMessage(data);
 
     return (
       <div className={cx}>
-        <Title>{this.getTitle()}</Title>
-        {location && <Location>{location}</Location>}
-        {message && <Message>{message}</Message>}
+        <Title size={size}>{this.getTitle()}</Title>
+        {location && <Location size={size}>{location}</Location>}
+        {message && <Message size={size}>{message}</Message>}
       </div>
     );
   }
@@ -121,9 +123,17 @@ const truncateStyles = css`
   white-space: nowrap;
 `;
 
+const getMargin = ({size}) => {
+  if (size === 'small') {
+    return 'margin: 0;';
+  }
+
+  return 'margin: 0 0 5px';
+};
+
 const Title = styled('div')`
   ${truncateStyles};
-  margin: 0 0 5px;
+  ${getMargin};
   & em {
     font-size: 14px;
     font-style: normal;
@@ -134,10 +144,10 @@ const Title = styled('div')`
 
 const LocationWrapper = styled('div')`
   ${truncateStyles};
+  ${getMargin};
   direction: rtl;
   text-align: left;
   font-size: 14px;
-  margin: 0 0 5px;
   color: ${p => p.theme.gray3};
   span {
     direction: ltr;
@@ -155,8 +165,8 @@ function Location(props) {
 
 const Message = styled('div')`
   ${truncateStyles};
+  ${getMargin};
   font-size: 14px;
-  margin: 0 0 5px;
 `;
 
 const iconStyles = css`

--- a/tests/js/spec/components/__snapshots__/eventOrGroupHeader.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/eventOrGroupHeader.spec.jsx.snap
@@ -23,6 +23,7 @@ exports[`EventOrGroupHeader Event hides level tag 1`] = `
   includeLink={true}
   orgId="orgId"
   projectId="projectId"
+  size="normal"
 />
 `;
 
@@ -48,6 +49,7 @@ exports[`EventOrGroupHeader Event renders with \`type = csp\` 1`] = `
   includeLink={true}
   orgId="orgId"
   projectId="projectId"
+  size="normal"
 />
 `;
 
@@ -73,6 +75,7 @@ exports[`EventOrGroupHeader Event renders with \`type = default\` 1`] = `
   includeLink={true}
   orgId="orgId"
   projectId="projectId"
+  size="normal"
 />
 `;
 
@@ -98,6 +101,7 @@ exports[`EventOrGroupHeader Event renders with \`type = error\` 1`] = `
   includeLink={true}
   orgId="orgId"
   projectId="projectId"
+  size="normal"
 />
 `;
 
@@ -122,6 +126,7 @@ exports[`EventOrGroupHeader Group renders with \`type = csp\` 1`] = `
   includeLink={true}
   orgId="orgId"
   projectId="projectId"
+  size="normal"
 />
 `;
 
@@ -146,6 +151,7 @@ exports[`EventOrGroupHeader Group renders with \`type = default\` 1`] = `
   includeLink={true}
   orgId="orgId"
   projectId="projectId"
+  size="normal"
 />
 `;
 
@@ -170,5 +176,6 @@ exports[`EventOrGroupHeader Group renders with \`type = error\` 1`] = `
   includeLink={true}
   orgId="orgId"
   projectId="projectId"
+  size="normal"
 />
 `;

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -832,13 +832,17 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                   "setRouteLeaveHook": [MockFunction],
                                 }
                               }
+                              size="normal"
                             >
                               <div
                                 className="event-issue-header"
                               >
-                                <Title>
+                                <Title
+                                  size="normal"
+                                >
                                   <div
-                                    className="css-leroxf-Title-truncateStyles eex8od0"
+                                    className="css-10b3zgy-Title-truncateStyles eex8od0"
+                                    size="normal"
                                   >
                                     <ProjectLink
                                       style={
@@ -1024,6 +1028,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                                 "setRouteLeaveHook": [MockFunction],
                                               }
                                             }
+                                            size="normal"
                                             style={
                                               Object {
                                                 "fontWeight": 600,
@@ -1059,9 +1064,12 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                     </ProjectLink>
                                   </div>
                                 </Title>
-                                <Message>
+                                <Message
+                                  size="normal"
+                                >
                                   <div
-                                    className="css-y5cfdn-Message-truncateStyles eex8od2"
+                                    className="css-brsp21-Message-truncateStyles eex8od2"
+                                    size="normal"
                                   >
                                     Cannot read property 'length' of undefined
                                   </div>


### PR DESCRIPTION
This adds a `size` prop to `<EventOrGroupHeader>` to change margins for
text. Supports an additional `small` size.