### PR TITLE
Add more crawlers to the filter list

### DIFF
--- a/src/sentry/filters/web_crawlers.py
+++ b/src/sentry/filters/web_crawlers.py
@@ -39,6 +39,10 @@ CRAWLERS = re.compile(
             r'Slack',
             # Google indexing bot
             r'Calypso AppCrawler',
+            # Pingdom
+            r'pingdom',
+            # Lytics
+            r'lyticsbot'
         )
     ),
     re.I

--- a/tests/sentry/filters/test_web_crawlers.py
+++ b/tests/sentry/filters/test_web_crawlers.py
@@ -71,6 +71,16 @@ class WebCrawlersFilterTest(TestCase):
         )
         assert self.apply_filter(data)
 
+    def test_filters_pingdom_bot(self):
+        data = self.get_mock_data(
+            'Mozilla/5.0 (Unknown; Linux x86_64) AppleWebKit/534.34 (KHTML, like Gecko) PingdomTMS/0.8.5 Safari/534.34'
+        )
+        assert self.apply_filter(data)
+
+    def test_filters_lytics_bot(self):
+        data = self.get_mock_data('lyticsbot-external')
+        assert self.apply_filter(data)
+
     def test_filters_google_apis(self):
         data = self.get_mock_data('APIs-Google')
         assert not self.apply_filter(data)


### PR DESCRIPTION
If you have more insight on these bots (particularly Pingdom) can you confirm that you'd never want to see errors about it in Sentry? Did some poking around their site and I don't _think_ you'd want it, but it looks like the user agent needs to be fairly generic to catch it. 