### PR TITLE
ref(sentry10): Refactor event or group components

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.jsx
@@ -31,14 +31,6 @@ class EventOrGroupExtraDetails extends React.Component {
     project: SentryTypes.Project,
   };
 
-  getIssuesPath() {
-    const {orgId, projectId} = this.props.params;
-
-    return projectId
-      ? `/${orgId}/${projectId}/issues/`
-      : `/organizations/${orgId}/issues/`;
-  }
-
   render() {
     const {
       id,
@@ -52,9 +44,10 @@ class EventOrGroupExtraDetails extends React.Component {
       showAssignee,
       shortId,
       project,
+      params,
     } = this.props;
 
-    const issuesPath = this.getIssuesPath();
+    const issuesPath = `/organizations/${params.orgId}/issues/`;
 
     return (
       <GroupExtra align="center">

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -5,7 +5,6 @@ import styled, {css} from 'react-emotion';
 import classNames from 'classnames';
 import {capitalize} from 'lodash';
 
-import ProjectLink from 'app/components/projectLink';
 import {Metadata} from 'app/sentryTypes';
 import EventOrGroupTitle from 'app/components/eventOrGroupTitle';
 import Tooltip from 'app/components/tooltip';
@@ -48,7 +47,7 @@ class EventOrGroupHeader extends React.Component {
 
   getTitle() {
     const {hideIcons, hideLevel, includeLink, data, params} = this.props;
-    const {orgId, projectId} = params;
+    const {orgId} = params;
 
     const {id, level, groupID} = data || {};
     const isEvent = !!data.eventID;
@@ -56,9 +55,7 @@ class EventOrGroupHeader extends React.Component {
     const props = {};
     let Wrapper;
 
-    const basePath = projectId
-      ? `/${orgId}/${projectId}/issues/`
-      : `/organizations/${orgId}/issues/`;
+    const basePath = `/organizations/${orgId}/issues/`;
 
     if (includeLink) {
       props.to = {
@@ -69,11 +66,7 @@ class EventOrGroupHeader extends React.Component {
           this.props.query ? `?query=${window.encodeURIComponent(this.props.query)}` : ''
         }`,
       };
-      if (projectId) {
-        Wrapper = ProjectLink;
-      } else {
-        Wrapper = Link;
-      }
+      Wrapper = Link;
     } else {
       Wrapper = 'span';
     }

--- a/tests/js/spec/components/__snapshots__/eventOrGroupHeader.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/eventOrGroupHeader.spec.jsx.snap
@@ -21,7 +21,6 @@ exports[`EventOrGroupHeader Event hides level tag 1`] = `
   }
   hideLevel={true}
   includeLink={true}
-  orgId="orgId"
   projectId="projectId"
   size="normal"
 />
@@ -47,8 +46,11 @@ exports[`EventOrGroupHeader Event renders with \`type = csp\` 1`] = `
     }
   }
   includeLink={true}
-  orgId="orgId"
-  projectId="projectId"
+  params={
+    Object {
+      "orgId": "orgId",
+    }
+  }
   size="normal"
 />
 `;
@@ -73,8 +75,11 @@ exports[`EventOrGroupHeader Event renders with \`type = default\` 1`] = `
     }
   }
   includeLink={true}
-  orgId="orgId"
-  projectId="projectId"
+  params={
+    Object {
+      "orgId": "orgId",
+    }
+  }
   size="normal"
 />
 `;
@@ -99,8 +104,11 @@ exports[`EventOrGroupHeader Event renders with \`type = error\` 1`] = `
     }
   }
   includeLink={true}
-  orgId="orgId"
-  projectId="projectId"
+  params={
+    Object {
+      "orgId": "orgId",
+    }
+  }
   size="normal"
 />
 `;
@@ -124,8 +132,11 @@ exports[`EventOrGroupHeader Group renders with \`type = csp\` 1`] = `
     }
   }
   includeLink={true}
-  orgId="orgId"
-  projectId="projectId"
+  params={
+    Object {
+      "orgId": "orgId",
+    }
+  }
   size="normal"
 />
 `;
@@ -149,8 +160,11 @@ exports[`EventOrGroupHeader Group renders with \`type = default\` 1`] = `
     }
   }
   includeLink={true}
-  orgId="orgId"
-  projectId="projectId"
+  params={
+    Object {
+      "orgId": "orgId",
+    }
+  }
   size="normal"
 />
 `;
@@ -175,7 +189,6 @@ exports[`EventOrGroupHeader Group renders with \`type = error\` 1`] = `
   }
   includeLink={true}
   orgId="orgId"
-  projectId="projectId"
   size="normal"
 />
 `;

--- a/tests/js/spec/components/eventOrGroupHeader.spec.jsx
+++ b/tests/js/spec/components/eventOrGroupHeader.spec.jsx
@@ -26,7 +26,6 @@ describe('EventOrGroupHeader', function() {
       const component = shallow(
         <EventOrGroupHeader
           orgId="orgId"
-          projectId="projectId"
           data={{
             ...groupData,
             ...{
@@ -42,8 +41,7 @@ describe('EventOrGroupHeader', function() {
     it('renders with `type = csp`', function() {
       const component = shallow(
         <EventOrGroupHeader
-          orgId="orgId"
-          projectId="projectId"
+          params={{orgId: 'orgId'}}
           data={{
             ...groupData,
             ...{
@@ -59,8 +57,7 @@ describe('EventOrGroupHeader', function() {
     it('renders with `type = default`', function() {
       const component = shallow(
         <EventOrGroupHeader
-          orgId="orgId"
-          projectId="projectId"
+          params={{orgId: 'orgId'}}
           data={{
             ...groupData,
             ...{
@@ -86,8 +83,7 @@ describe('EventOrGroupHeader', function() {
     it('renders with `type = error`', function() {
       const component = shallow(
         <EventOrGroupHeader
-          orgId="orgId"
-          projectId="projectId"
+          params={{orgId: 'orgId'}}
           data={{
             ...eventData,
             ...{
@@ -103,8 +99,7 @@ describe('EventOrGroupHeader', function() {
     it('renders with `type = csp`', function() {
       const component = shallow(
         <EventOrGroupHeader
-          orgId="orgId"
-          projectId="projectId"
+          params={{orgId: 'orgId'}}
           data={{
             ...eventData,
             ...{
@@ -120,8 +115,7 @@ describe('EventOrGroupHeader', function() {
     it('renders with `type = default`', function() {
       const component = shallow(
         <EventOrGroupHeader
-          orgId="orgId"
-          projectId="projectId"
+          params={{orgId: 'orgId'}}
           data={{
             ...eventData,
             ...{
@@ -137,7 +131,6 @@ describe('EventOrGroupHeader', function() {
     it('hides level tag', function() {
       const component = shallow(
         <EventOrGroupHeader
-          orgId="orgId"
           projectId="projectId"
           hideLevel
           data={{

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -768,13 +768,13 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                     "calls": Array [
                                       Array [
                                         Object {
-                                          "pathname": "/org-slug/project-slug/issues/271/",
+                                          "pathname": "/organizations/org-slug/issues/271/",
                                           "search": "",
                                         },
                                       ],
                                       Array [
                                         Object {
-                                          "pathname": "/org-slug/project-slug/issues/",
+                                          "pathname": "/organizations/org-slug/issues/",
                                           "query": Object {
                                             "query": "logger:javascript",
                                           },
@@ -782,13 +782,13 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                       ],
                                       Array [
                                         Object {
-                                          "pathname": "/org-slug/project-slug/issues/271/",
+                                          "pathname": "/organizations/org-slug/issues/271/",
                                           "search": "",
                                         },
                                       ],
                                       Array [
                                         Object {
-                                          "pathname": "/org-slug/project-slug/issues/",
+                                          "pathname": "/organizations/org-slug/issues/",
                                           "query": Object {
                                             "query": "logger:javascript",
                                           },
@@ -844,7 +844,8 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                     className="css-10b3zgy-Title-truncateStyles eex8od0"
                                     size="normal"
                                   >
-                                    <ProjectLink
+                                    <Link
+                                      onlyActiveOnIndex={false}
                                       style={
                                         Object {
                                           "textDecoration": "line-through",
@@ -852,183 +853,176 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                       }
                                       to={
                                         Object {
-                                          "pathname": "/org-slug/project-slug/issues/271/",
+                                          "pathname": "/organizations/org-slug/issues/271/",
                                           "search": "",
                                         }
                                       }
                                     >
-                                      <Link
-                                        onlyActiveOnIndex={false}
+                                      <a
+                                        onClick={[Function]}
                                         style={
                                           Object {
                                             "textDecoration": "line-through",
                                           }
                                         }
-                                        to={
-                                          Object {
-                                            "pathname": "/org-slug/project-slug/issues/271/",
-                                            "search": "",
-                                          }
-                                        }
                                       >
-                                        <a
-                                          onClick={[Function]}
-                                          style={
+                                        <GroupLevel
+                                          level="error"
+                                        >
+                                          <div
+                                            className="css-1oawdkn-GroupLevel eex8od5"
+                                          >
+                                            <Tooltip
+                                              containerDisplayMode="inline-block"
+                                              position="top"
+                                              title="Error level: Error"
+                                            >
+                                              <Manager>
+                                                <Reference>
+                                                  <InnerReference
+                                                    setReferenceNode={[Function]}
+                                                  >
+                                                    <span
+                                                      aria-describedby="tooltip-123456"
+                                                      onBlur={[Function]}
+                                                      onFocus={[Function]}
+                                                      onMouseEnter={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                    />
+                                                  </InnerReference>
+                                                </Reference>
+                                              </Manager>
+                                            </Tooltip>
+                                          </div>
+                                        </GroupLevel>
+                                        <EventOrGroupTitle
+                                          data={
                                             Object {
-                                              "textDecoration": "line-through",
+                                              "annotations": Array [],
+                                              "assignedTo": null,
+                                              "count": "90",
+                                              "culprit": "length(app/views/groupSimilar/groupSimilarView)",
+                                              "firstSeen": "2017-07-10T18:32:43Z",
+                                              "hasSeen": false,
+                                              "id": "271",
+                                              "isBookmarked": false,
+                                              "isPublic": false,
+                                              "isSubscribed": true,
+                                              "lastSeen": "2017-07-24T23:41:44Z",
+                                              "level": "error",
+                                              "logger": "javascript",
+                                              "metadata": Object {
+                                                "type": "TypeError",
+                                                "value": "Cannot read property 'length' of undefined",
+                                              },
+                                              "numComments": 0,
+                                              "permalink": "http://localhost:8000/sentry/project-slug/issues/271/",
+                                              "project": Object {
+                                                "id": "123",
+                                                "name": "Internal",
+                                                "slug": "project-slug",
+                                              },
+                                              "shareId": "312e323731",
+                                              "shortId": "INTERNAL-4G",
+                                              "status": "resolved",
+                                              "statusDetails": Object {},
+                                              "subscriptionDetails": null,
+                                              "title": "TypeError: Cannot read property 'length' of undefined",
+                                              "type": "error",
+                                              "userCount": 3,
                                             }
                                           }
-                                        >
-                                          <GroupLevel
-                                            level="error"
-                                          >
-                                            <div
-                                              className="css-1oawdkn-GroupLevel eex8od5"
-                                            >
-                                              <Tooltip
-                                                containerDisplayMode="inline-block"
-                                                position="top"
-                                                title="Error level: Error"
-                                              >
-                                                <Manager>
-                                                  <Reference>
-                                                    <InnerReference
-                                                      setReferenceNode={[Function]}
-                                                    >
-                                                      <span
-                                                        aria-describedby="tooltip-123456"
-                                                        onBlur={[Function]}
-                                                        onFocus={[Function]}
-                                                        onMouseEnter={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                      />
-                                                    </InnerReference>
-                                                  </Reference>
-                                                </Manager>
-                                              </Tooltip>
-                                            </div>
-                                          </GroupLevel>
-                                          <EventOrGroupTitle
-                                            data={
-                                              Object {
-                                                "annotations": Array [],
-                                                "assignedTo": null,
-                                                "count": "90",
-                                                "culprit": "length(app/views/groupSimilar/groupSimilarView)",
-                                                "firstSeen": "2017-07-10T18:32:43Z",
-                                                "hasSeen": false,
-                                                "id": "271",
-                                                "isBookmarked": false,
-                                                "isPublic": false,
-                                                "isSubscribed": true,
-                                                "lastSeen": "2017-07-24T23:41:44Z",
-                                                "level": "error",
-                                                "logger": "javascript",
-                                                "metadata": Object {
-                                                  "type": "TypeError",
-                                                  "value": "Cannot read property 'length' of undefined",
-                                                },
-                                                "numComments": 0,
-                                                "permalink": "http://localhost:8000/sentry/project-slug/issues/271/",
-                                                "project": Object {
-                                                  "id": "123",
-                                                  "name": "Internal",
-                                                  "slug": "project-slug",
-                                                },
-                                                "shareId": "312e323731",
-                                                "shortId": "INTERNAL-4G",
-                                                "status": "resolved",
-                                                "statusDetails": Object {},
-                                                "subscriptionDetails": null,
-                                                "title": "TypeError: Cannot read property 'length' of undefined",
-                                                "type": "error",
-                                                "userCount": 3,
-                                              }
+                                          includeLink={true}
+                                          location={
+                                            Object {
+                                              "query": Object {},
                                             }
-                                            includeLink={true}
-                                            location={
-                                              Object {
+                                          }
+                                          params={
+                                            Object {
+                                              "groupId": "group-id",
+                                              "orgId": "org-slug",
+                                              "projectId": "project-slug",
+                                            }
+                                          }
+                                          router={
+                                            Object {
+                                              "createHref": [MockFunction] {
+                                                "calls": Array [
+                                                  Array [
+                                                    Object {
+                                                      "pathname": "/organizations/org-slug/issues/271/",
+                                                      "search": "",
+                                                    },
+                                                  ],
+                                                  Array [
+                                                    Object {
+                                                      "pathname": "/organizations/org-slug/issues/",
+                                                      "query": Object {
+                                                        "query": "logger:javascript",
+                                                      },
+                                                    },
+                                                  ],
+                                                  Array [
+                                                    Object {
+                                                      "pathname": "/organizations/org-slug/issues/271/",
+                                                      "search": "",
+                                                    },
+                                                  ],
+                                                  Array [
+                                                    Object {
+                                                      "pathname": "/organizations/org-slug/issues/",
+                                                      "query": Object {
+                                                        "query": "logger:javascript",
+                                                      },
+                                                    },
+                                                  ],
+                                                ],
+                                                "results": Array [
+                                                  Object {
+                                                    "type": "return",
+                                                    "value": undefined,
+                                                  },
+                                                  Object {
+                                                    "type": "return",
+                                                    "value": undefined,
+                                                  },
+                                                  Object {
+                                                    "type": "return",
+                                                    "value": undefined,
+                                                  },
+                                                  Object {
+                                                    "type": "return",
+                                                    "value": undefined,
+                                                  },
+                                                ],
+                                              },
+                                              "go": [MockFunction],
+                                              "goBack": [MockFunction],
+                                              "goForward": [MockFunction],
+                                              "isActive": [MockFunction],
+                                              "listen": [MockFunction],
+                                              "location": Object {
                                                 "query": Object {},
-                                              }
-                                            }
-                                            params={
-                                              Object {
+                                              },
+                                              "params": Object {
                                                 "groupId": "group-id",
                                                 "orgId": "org-slug",
                                                 "projectId": "project-slug",
-                                              }
+                                              },
+                                              "push": [MockFunction],
+                                              "replace": [MockFunction],
+                                              "setRouteLeaveHook": [MockFunction],
                                             }
-                                            router={
-                                              Object {
-                                                "createHref": [MockFunction] {
-                                                  "calls": Array [
-                                                    Array [
-                                                      Object {
-                                                        "pathname": "/org-slug/project-slug/issues/271/",
-                                                        "search": "",
-                                                      },
-                                                    ],
-                                                    Array [
-                                                      Object {
-                                                        "pathname": "/org-slug/project-slug/issues/",
-                                                        "query": Object {
-                                                          "query": "logger:javascript",
-                                                        },
-                                                      },
-                                                    ],
-                                                    Array [
-                                                      Object {
-                                                        "pathname": "/org-slug/project-slug/issues/271/",
-                                                        "search": "",
-                                                      },
-                                                    ],
-                                                    Array [
-                                                      Object {
-                                                        "pathname": "/org-slug/project-slug/issues/",
-                                                        "query": Object {
-                                                          "query": "logger:javascript",
-                                                        },
-                                                      },
-                                                    ],
-                                                  ],
-                                                  "results": Array [
-                                                    Object {
-                                                      "type": "return",
-                                                      "value": undefined,
-                                                    },
-                                                    Object {
-                                                      "type": "return",
-                                                      "value": undefined,
-                                                    },
-                                                    Object {
-                                                      "type": "return",
-                                                      "value": undefined,
-                                                    },
-                                                    Object {
-                                                      "type": "return",
-                                                      "value": undefined,
-                                                    },
-                                                  ],
-                                                },
-                                                "go": [MockFunction],
-                                                "goBack": [MockFunction],
-                                                "goForward": [MockFunction],
-                                                "isActive": [MockFunction],
-                                                "listen": [MockFunction],
-                                                "location": Object {
-                                                  "query": Object {},
-                                                },
-                                                "params": Object {
-                                                  "groupId": "group-id",
-                                                  "orgId": "org-slug",
-                                                  "projectId": "project-slug",
-                                                },
-                                                "push": [MockFunction],
-                                                "replace": [MockFunction],
-                                                "setRouteLeaveHook": [MockFunction],
-                                              }
+                                          }
+                                          size="normal"
+                                          style={
+                                            Object {
+                                              "fontWeight": 600,
                                             }
-                                            size="normal"
+                                          }
+                                        >
+                                          <span
                                             style={
                                               Object {
                                                 "fontWeight": 600,
@@ -1038,30 +1032,22 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                             <span
                                               style={
                                                 Object {
-                                                  "fontWeight": 600,
+                                                  "marginRight": 10,
                                                 }
                                               }
                                             >
-                                              <span
-                                                style={
-                                                  Object {
-                                                    "marginRight": 10,
-                                                  }
-                                                }
-                                              >
-                                                TypeError
-                                              </span>
-                                              <em
-                                                title="length(app/views/groupSimilar/groupSimilarView)"
-                                              >
-                                                length(app/views/groupSimilar/groupSimilarView)
-                                              </em>
-                                              <br />
+                                              TypeError
                                             </span>
-                                          </EventOrGroupTitle>
-                                        </a>
-                                      </Link>
-                                    </ProjectLink>
+                                            <em
+                                              title="length(app/views/groupSimilar/groupSimilarView)"
+                                            >
+                                              length(app/views/groupSimilar/groupSimilarView)
+                                            </em>
+                                            <br />
+                                          </span>
+                                        </EventOrGroupTitle>
+                                      </a>
+                                    </Link>
                                   </div>
                                 </Title>
                                 <Message
@@ -1163,13 +1149,13 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                     "calls": Array [
                                       Array [
                                         Object {
-                                          "pathname": "/org-slug/project-slug/issues/271/",
+                                          "pathname": "/organizations/org-slug/issues/271/",
                                           "search": "",
                                         },
                                       ],
                                       Array [
                                         Object {
-                                          "pathname": "/org-slug/project-slug/issues/",
+                                          "pathname": "/organizations/org-slug/issues/",
                                           "query": Object {
                                             "query": "logger:javascript",
                                           },
@@ -1177,13 +1163,13 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                       ],
                                       Array [
                                         Object {
-                                          "pathname": "/org-slug/project-slug/issues/271/",
+                                          "pathname": "/organizations/org-slug/issues/271/",
                                           "search": "",
                                         },
                                       ],
                                       Array [
                                         Object {
-                                          "pathname": "/org-slug/project-slug/issues/",
+                                          "pathname": "/organizations/org-slug/issues/",
                                           "query": Object {
                                             "query": "logger:javascript",
                                           },
@@ -1539,7 +1525,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                                   style={Object {}}
                                                   to={
                                                     Object {
-                                                      "pathname": "/org-slug/project-slug/issues/",
+                                                      "pathname": "/organizations/org-slug/issues/",
                                                       "query": Object {
                                                         "query": "logger:javascript",
                                                       },


### PR DESCRIPTION
We previously relied on checking for the presence of a projectId in the URL
to determine whether to show the Sentry 10 paths in these components. We
don't want to link to these old routes anymore.