### PR TITLE
fix(ui) Forward projectId prop into CrashContent

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -127,6 +127,7 @@ function findBestThread(threads) {
 class Thread extends React.Component {
   static propTypes = {
     event: SentryTypes.Event.isRequired,
+    projectId: PropTypes.string.isRequired,
     data: PropTypes.object.isRequired,
     stackView: PropTypes.string,
     stackType: PropTypes.string,
@@ -160,6 +161,7 @@ class Thread extends React.Component {
     const {
       data,
       event,
+      projectId,
       stackView,
       stackType,
       newestFirst,
@@ -184,6 +186,7 @@ class Thread extends React.Component {
             stackType={stackType}
             stackView={stackView}
             newestFirst={newestFirst}
+            projectId={projectId}
             exception={exception}
             stacktrace={stacktrace}
           />


### PR DESCRIPTION
The threads component was not forwarding its projectId prop which was causing raw dumps to fail for ios.

Refs ISSUE-493