### PR TITLE
fix: Properly wrap components in traditional HoC pattern

### DIFF
--- a/src/sentry/static/sentry/app/utils/errorHandler.jsx
+++ b/src/sentry/static/sentry/app/utils/errorHandler.jsx
@@ -2,17 +2,32 @@ import React from 'react';
 import RouteError from 'app/views/routeError';
 
 export default function errorHandler(Component) {
-  const originalRender = Component.prototype.render;
-  Component.prototype.render = function() {
-    try {
-      return originalRender.apply(this, arguments);
-    } catch (err) {
-      /*eslint no-console:0*/
+  class ErrorHandler extends React.Component {
+    static getDerivedStateFromError(error) {
       setTimeout(() => {
-        throw err;
+        throw error;
       });
-      return <RouteError error={err} component={this} />;
+
+      // Update state so the next render will show the fallback UI.
+      return {
+        hasError: true,
+        error,
+      };
     }
-  };
-  return Component;
+
+    state = {
+      hasError: false,
+      error: null,
+    };
+
+    render() {
+      if (this.state.hasError) {
+        return <RouteError error={this.state.error} />;
+      }
+
+      return <Component {...this.props} />;
+    }
+  }
+
+  return ErrorHandler;
 }


### PR DESCRIPTION
Refactor `errorHandler()` to be a proper HoC.

See https://reactjs.org/docs/higher-order-components.html#dont-mutate-the-original-component-use-composition

------

*Backstory:*

I was tracking down a very subtle bug on why certain components (i.e. the sidebar) weren't updating properly on a route change from `/settings/account/api/auth-tokens/` to `/organizations/sentry/`.

I began by refactoring `src/sentry/static/sentry/app/utils/errorHandler.jsx` to be a proper HoC; this implicitly fixes the bug I found.

------

The sidebar components will not re-render despite with this implementation:

```js
export default function errorHandler(Component) {
  return Component;
}
```

So, that rules out the in-place the `render()` Component mutation occurring within the `errorHandler()` function.

However, the following will properly update the sidebar because `errorHandler()` generates unique components and React's reconciliation strategy will unmount/mount these components:

```js
export default function errorHandler(Component) {
  const Foobar = (props) => {
      return(<Component {...props} />);
  }
  return Foobar;
}
```

This coerces the `OrganizationContext` component to unmount and re-mount to call this function: https://github.com/getsentry/sentry/blob/655f0555bac9876827c82c36cabd5ac9c1d99dfb/src/sentry/static/sentry/app/views/organizationContext.jsx#L64-L66

and refresh stale app state.

If instead, `OrganizationContext` had been re-rendered, then `componentDidUpdate()` would've been called instead:

https://github.com/getsentry/sentry/blob/655f0555bac9876827c82c36cabd5ac9c1d99dfb/src/sentry/static/sentry/app/views/organizationContext.jsx#L68-L85

This lifecycle will need some re-work to properly refresh state; which can be done within another PR.