### PR TITLE
build(babel): Add file and line #s to React JSX warnings

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -18,7 +18,10 @@ module.exports = {
   env: {
     production: {},
     development: {
-      plugins: [['emotion', {sourceMap: true, autoLabel: true}]],
+      plugins: [
+        ['emotion', {sourceMap: true, autoLabel: true}],
+        '@babel/plugin-transform-react-jsx-source',
+      ],
     },
     test: {
       plugins: [['emotion', {autoLabel: true}], 'dynamic-import-node'],

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
+    "@babel/plugin-transform-react-jsx-source": "^7.2.0",
     "@storybook/addon-a11y": "^4.1.3",
     "@storybook/addon-actions": "^4.1.3",
     "@storybook/addon-info": "^4.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,7 +698,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-jsx" "^7.2.0"
 
-"@babel/plugin-transform-react-jsx-source@^7.0.0":
+"@babel/plugin-transform-react-jsx-source@^7.0.0", "@babel/plugin-transform-react-jsx-source@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.2.0.tgz#20c8c60f0140f5dd3cd63418d452801cf3f7180f"
   integrity sha512-A32OkKTp4i5U6aE88GwwcuV4HAprUgHcTq0sSafLxjr6AW0QahrCRCjxogkbbcdtpbXkuTOlgpjophCxb6sh5g==
@@ -11108,12 +11108,7 @@ react-is@^16.4.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.2.tgz#84891b56c2b6d9efdee577cc83501dfc5ecead88"
   integrity sha512-rI3cGFj/obHbBz156PvErrS5xc6f1eWyTwyV4mo0vF2lGgXgS+mm7EKD5buLJq6jNgIagQescGSVG2YzgXt8Yg==
 
-react-is@^16.7.0:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
-  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
-
-react-is@^16.8.1, react-is@^16.8.6:
+react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==


### PR DESCRIPTION
This adds file name and line numbers to React warnings (only in dev).

![image](https://user-images.githubusercontent.com/79684/59200234-65580f00-8b5d-11e9-819c-14346b99e12e.png)
