### PR TITLE
ref: Fetch SDK versions from release registry

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1502,7 +1502,7 @@ SUDO_URL = 'sentry-sudo'
 
 # Endpoint to https://github.com/getsentry/sentry-release-registry, used for
 # alerting the user on outdated SDKs.
-SENTRY_RELEASE_REGISTRY_BASEURL = 'https://release-registry.services.sentry.io'
+SENTRY_RELEASE_REGISTRY_BASEURL = None
 
 # Hardcoded SDK versions for SDKs that do not have an entry in the release
 # registry.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1499,7 +1499,13 @@ EMAIL_SUBJECT_PREFIX = DEAD
 
 SUDO_URL = 'sentry-sudo'
 
-# TODO(dcramer): move this to sentry.io so it can be automated
+
+# Endpoint to https://github.com/getsentry/sentry-release-registry, used for
+# alerting the user on outdated SDKs.
+SENTRY_RELEASE_REGISTRY_BASEURL = 'https://release-registry.services.sentry.io'
+
+# Hardcoded SDK versions for SDKs that do not have an entry in the release
+# registry.
 SDK_VERSIONS = {
     'raven-js': '3.21.0',
     'raven-node': '2.3.0',
@@ -1507,18 +1513,8 @@ SDK_VERSIONS = {
     'raven-ruby': '2.7.1',
     'sentry-cocoa': '3.11.1',
     'sentry-java': '1.6.4',
-    'sentry.javascript.browser': '5.3.0',
-    'sentry.javascript.electron': '0.17.1',
-    'sentry.javascript.node': '5.3.0',
     'sentry-laravel': '1.0.2',
     'sentry-php': '2.0.1',
-    'sentry.python': '0.7.14',
-    'sentry.dotnet': '1.2.0',
-    'sentry.dotnet.aspnetcore': '1.2.0',
-    'sentry.dotnet.extensions.logging': '1.2.0',
-    'sentry.dotnet.log4net': '1.2.0',
-    'sentry.dotnet.serilog': '1.2.0',
-    'sentry.dotnet.nlog': '1.2.0',
 }
 
 SDK_URLS = {
@@ -1528,19 +1524,9 @@ SDK_URLS = {
     'raven-ruby': 'https://docs.sentry.io/clients/ruby/',
     'raven-swift': 'https://docs.sentry.io/clients/cocoa/',
     'sentry-java': 'https://docs.sentry.io/clients/java/',
-    'sentry.javascript.browser': 'https://docs.sentry.io/platforms/javascript/',
-    'sentry.javascript.electron': 'https://docs.sentry.io/platforms/javascript/electron/',
-    'sentry.javascript.node': 'https://docs.sentry.io/platforms/javascript/',
     'sentry-php': 'https://docs.sentry.io/platforms/php/',
     'sentry-laravel': 'https://docs.sentry.io/platforms/php/laravel/',
-    'sentry.python': 'https://docs.sentry.io/platforms/python/',
     'sentry-swift': 'https://docs.sentry.io/clients/cocoa/',
-    'sentry.dotnet': 'https://docs.sentry.io/platforms/dotnet/',
-    'sentry.dotnet.aspnetcore': 'https://docs.sentry.io/platforms/dotnet/aspnetcore/',
-    'sentry.dotnet.extensions.logging': 'https://docs.sentry.io/platforms/dotnet/microsoft-extensions-logging/',
-    'sentry.dotnet.log4net': 'https://docs.sentry.io/platforms/dotnet/log4net/',
-    'sentry.dotnet.serilog': 'https://docs.sentry.io/platforms/dotnet/serilog/',
-    'sentry.dotnet.nlog': 'https://docs.sentry.io/platforms/dotnet/nlog/',
 }
 
 DEPRECATED_SDKS = {

--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -1,11 +1,65 @@
 from __future__ import absolute_import
 
+import logging
+
 __all__ = ('Sdk', )
 
 from distutils.version import LooseVersion
 from django.conf import settings
 
 from sentry.interfaces.base import Interface, prune_empty_keys
+from sentry.net.http import Session
+from sentry.cache import default_cache
+
+
+logger = logging.getLogger(__name__)
+
+
+SDK_INDEX_CACHE_KEY = u'sentry:sdk-versions'
+
+
+def get_sdk_index():
+    value = default_cache.get(SDK_INDEX_CACHE_KEY)
+    if value is not None:
+        return value
+
+    base_url = settings.SENTRY_RELEASE_REGISTRY_BASEURL
+    if not base_url:
+        return {}
+
+    url = '%s/sdks' % (base_url,)
+
+    try:
+        with Session() as session:
+            response = session.get(url, timeout=1)
+            response.raise_for_status()
+            json = response.json()
+    except Exception:
+        logger.exception("Failed to fetch version index from release registry")
+        json = {}
+
+    default_cache.set(SDK_INDEX_CACHE_KEY, json, 3600)
+    return json
+
+
+def get_sdk_versions():
+    try:
+        rv = settings.SDK_VERSIONS
+        rv.update((key, info['value']) for (key, info) in get_sdk_index().items())
+        return rv
+    except Exception:
+        logger.exception("sentry-release-registry.sdk-versions")
+        return {}
+
+
+def get_sdk_urls():
+    try:
+        rv = settings.SDK_URLS
+        rv.update((key, info['docs_url']) for (key, info) in get_sdk_versions())
+        return rv
+    except Exception:
+        logger.exception("sentry-release-registry.sdk-urls")
+        return {}
 
 
 def get_with_prefix(d, k, default=None, delimiter=":"):
@@ -69,7 +123,7 @@ class Sdk(Interface):
         })
 
     def get_api_context(self, is_public=False, platform=None):
-        newest_version = get_with_prefix(settings.SDK_VERSIONS, self.name)
+        newest_version = get_with_prefix(get_sdk_versions(), self.name)
         newest_name = get_with_prefix(settings.DEPRECATED_SDKS, self.name, self.name)
 
         if newest_version is not None:
@@ -91,7 +145,7 @@ class Sdk(Interface):
                 # when this is correct we can make it available
                 # 'version': newest_version,
                 'isNewer': is_newer,
-                'url': get_with_prefix(settings.SDK_URLS, newest_name),
+                'url': get_with_prefix(get_sdk_urls(), newest_name),
             },
         }
 


### PR DESCRIPTION
Not sure whether we want to allow onprem users to use the registry. If not, we should move the value to getsentry.