### PR TITLE
chore(build) Only run safety once during lint stage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,10 +117,10 @@ matrix:
       name: 'Linter'
       env: TEST_SUITE=lint
       install:
+        - SENTRY_LIGHT_BUILD=1 pip install -e ".[dev,tests,optional]"
         - find "$NODE_DIR" -type d -empty -delete
         - nvm install
         - npm install -g "yarn@${YARN_VERSION}"
-        - pip install -r requirements-dev.txt
         - yarn install --pure-lockfile
 
     - <<: *postgres_default

--- a/Makefile
+++ b/Makefile
@@ -250,12 +250,12 @@ scan-python:
 	bin/scan
 	@echo ""
 
-travis-scan-postgres: scan-python
+travis-scan-postgres: scan-noop
 travis-scan-acceptance: travis-noop
-travis-scan-snuba: scan-python
+travis-scan-snuba: travis-noop
 travis-scan-symbolicator: travis-noop
 travis-scan-js: travis-noop
 travis-scan-cli: travis-noop
 travis-scan-dist: travis-noop
-travis-scan-lint: travis-noop
-travis-scan-riak: scan-python
+travis-scan-lint: scan-python
+travis-scan-riak: travis-noop

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ scan-python:
 	bin/scan
 	@echo ""
 
-travis-scan-postgres: scan-noop
+travis-scan-postgres: travis-noop
 travis-scan-acceptance: travis-noop
 travis-scan-snuba: travis-noop
 travis-scan-symbolicator: travis-noop


### PR DESCRIPTION
Instead or running safety 5 times we can run it once during the lint stage. While we do have to install a few more dependencies in the lint stage we might end up saving time overall.