### PR TITLE
fix: Don't re-throw error in a setTimeout()

### DIFF
--- a/src/sentry/static/sentry/app/utils/errorHandler.jsx
+++ b/src/sentry/static/sentry/app/utils/errorHandler.jsx
@@ -4,10 +4,6 @@ import RouteError from 'app/views/routeError';
 export default function errorHandler(Component) {
   class ErrorHandler extends React.Component {
     static getDerivedStateFromError(error) {
-      setTimeout(() => {
-        throw error;
-      });
-
       // Update state so the next render will show the fallback UI.
       return {
         hasError: true,
@@ -16,6 +12,8 @@ export default function errorHandler(Component) {
     }
 
     state = {
+      // we are explicit if an error has been thrown since errors thrown are not guaranteed
+      // to be truthy (e.g. throw null).
       hasError: false,
       error: null,
     };

--- a/src/sentry/static/sentry/app/utils/errorHandler.jsx
+++ b/src/sentry/static/sentry/app/utils/errorHandler.jsx
@@ -18,6 +18,14 @@ export default function errorHandler(Component) {
       error: null,
     };
 
+    componentDidCatch(error, info) {
+      // eslint-disable-next-line no-console
+      console.error(
+        'Component stack trace caught in <ErrorHandler />:',
+        info.componentStack
+      );
+    }
+
     render() {
       if (this.state.hasError) {
         return <RouteError error={this.state.error} />;


### PR DESCRIPTION
This PR is a follow up on https://github.com/getsentry/sentry/pull/13605

-----

This `setTimeout()` was previously introduced in https://github.com/getsentry/sentry/pull/4443