### PR TITLE
ref(sentry10): Remove Sentry 10 references from tests

### DIFF
--- a/tests/acceptance/test_dashboard.py
+++ b/tests/acceptance/test_dashboard.py
@@ -58,44 +58,42 @@ class DashboardTest(AcceptanceTestCase, SnubaTestCase):
 
     def test_no_issues(self):
         # I think no "activity" would be more accurate?
-        with self.feature('organizations:sentry10'):
-            self.project.update(first_event=None)
-            self.browser.get(self.path)
-            self.browser.wait_until_not('.loading-indicator')
-            self.browser.wait_until_test_id('awaiting-events')
-            self.browser.snapshot('org dash no issues')
+        self.project.update(first_event=None)
+        self.browser.get(self.path)
+        self.browser.wait_until_not('.loading-indicator')
+        self.browser.wait_until_test_id('awaiting-events')
+        self.browser.snapshot('org dash no issues')
 
     def test_one_issue(self):
-        with self.feature('organizations:sentry10'):
-            self.init_snuba()
+        self.init_snuba()
 
-            event_data = load_data('python')
-            event_data['event_id'] = 'd964fdbd649a4cf8bfc35d18082b6b0e'
-            event_data['timestamp'] = 1452683305
-            event = self.store_event(
-                project_id=self.project.id,
-                data=event_data,
-                assert_no_errors=False
-            )
-            event.group.update(
-                first_seen=datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
-                last_seen=datetime(2018, 1, 13, 3, 8, 25, tzinfo=timezone.utc),
-            )
-            GroupAssignee.objects.create(
-                user=self.user,
-                group=event.group,
-                project=self.project,
-            )
-            OrganizationOnboardingTask.objects.create_or_update(
-                organization_id=self.project.organization_id,
-                task=OnboardingTask.FIRST_EVENT,
-                status=OnboardingTaskStatus.COMPLETE,
-            )
-            self.project.update(first_event=timezone.now())
-            self.browser.get(self.path)
-            self.browser.wait_until_not('.loading-indicator')
-            self.browser.wait_until('[data-test-id] figure')
-            self.browser.snapshot('org dash one issue')
+        event_data = load_data('python')
+        event_data['event_id'] = 'd964fdbd649a4cf8bfc35d18082b6b0e'
+        event_data['timestamp'] = 1452683305
+        event = self.store_event(
+            project_id=self.project.id,
+            data=event_data,
+            assert_no_errors=False
+        )
+        event.group.update(
+            first_seen=datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
+            last_seen=datetime(2018, 1, 13, 3, 8, 25, tzinfo=timezone.utc),
+        )
+        GroupAssignee.objects.create(
+            user=self.user,
+            group=event.group,
+            project=self.project,
+        )
+        OrganizationOnboardingTask.objects.create_or_update(
+            organization_id=self.project.organization_id,
+            task=OnboardingTask.FIRST_EVENT,
+            status=OnboardingTaskStatus.COMPLETE,
+        )
+        self.project.update(first_event=timezone.now())
+        self.browser.get(self.path)
+        self.browser.wait_until_not('.loading-indicator')
+        self.browser.wait_until('[data-test-id] figure')
+        self.browser.snapshot('org dash one issue')
 
 
 class EmptyDashboardTest(AcceptanceTestCase):
@@ -117,7 +115,6 @@ class EmptyDashboardTest(AcceptanceTestCase):
         self.path = u'/organizations/{}/projects/'.format(self.org.slug)
 
     def test_new_dashboard_empty(self):
-        with self.feature('organizations:sentry10'):
-            self.browser.get(self.path)
-            self.browser.wait_until_not('.loading-indicator')
-            self.browser.snapshot('new dashboard empty')
+        self.browser.get(self.path)
+        self.browser.wait_until_not('.loading-indicator')
+        self.browser.snapshot('new dashboard empty')

--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -63,18 +63,17 @@ class EmailTestCase(AcceptanceTestCase):
         )
 
     def test_emails(self):
-        with self.feature('organizations:sentry10'):
-            for url, name in EMAILS:
-                # HTML output is captured as a snapshot
-                self.browser.get(self.build_url(url, 'html'))
-                self.browser.wait_until('#preview')
-                self.browser.snapshot(u'{} email html'.format(name))
+        for url, name in EMAILS:
+            # HTML output is captured as a snapshot
+            self.browser.get(self.build_url(url, 'html'))
+            self.browser.wait_until('#preview')
+            self.browser.snapshot(u'{} email html'.format(name))
 
-                # Text output is asserted against static fixture files
-                self.browser.get(self.build_url(url, 'txt'))
-                self.browser.wait_until('#preview')
-                elem = self.browser.find_element_by_css_selector('#preview pre')
-                text_src = elem.get_attribute('innerHTML')
+            # Text output is asserted against static fixture files
+            self.browser.get(self.build_url(url, 'txt'))
+            self.browser.wait_until('#preview')
+            elem = self.browser.find_element_by_css_selector('#preview pre')
+            text_src = elem.get_attribute('innerHTML')
 
-                fixture_src = read_txt_email_fixture(name)
-                assert fixture_src == text_src
+            fixture_src = read_txt_email_fixture(name)
+            assert fixture_src == text_src

--- a/tests/acceptance/test_issue_details_workflow.py
+++ b/tests/acceptance/test_issue_details_workflow.py
@@ -46,13 +46,12 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         event = self.create_sample_event(
             platform='python',
         )
-        with self.feature('organizations:sentry10'):
-            self.page.visit_issue(self.org.slug, event.group.id)
-            self.page.resolve_issue()
+        self.page.visit_issue(self.org.slug, event.group.id)
+        self.page.resolve_issue()
 
-            res = self.page.api_issue_get(event.group.id)
-            assert res.status_code == 200, res
-            assert res.data['status'] == 'resolved'
+        res = self.page.api_issue_get(event.group.id)
+        assert res.status_code == 200, res
+        assert res.data['status'] == 'resolved'
 
     def test_ignore_basic(self):
         event = self.create_sample_event(

--- a/tests/acceptance/test_onboarding.py
+++ b/tests/acceptance/test_onboarding.py
@@ -26,25 +26,24 @@ class OrganizationOnboardingTest(AcceptanceTestCase):
     @mock.patch('sentry.models.ProjectKey.generate_api_key',
                 return_value='031667ea1758441f92c7995a428d2d14')
     def test_onboarding(self, generate_api_key):
-        with self.feature('organizations:sentry10'):
-            self.browser.get('/onboarding/%s/' % self.org.slug)
-            self.browser.wait_until('.onboarding-container')
-            self.browser.wait_until_not('.loading-indicator')
-            self.browser.snapshot(name='onboarding-choose-platform')
+        self.browser.get('/onboarding/%s/' % self.org.slug)
+        self.browser.wait_until('.onboarding-container')
+        self.browser.wait_until_not('.loading-indicator')
+        self.browser.snapshot(name='onboarding-choose-platform')
 
-            self.browser.click('[data-test-id="platform-javascript-angular"]')
-            self.browser.click('[data-test-id="create-project"]')
+        self.browser.click('[data-test-id="platform-javascript-angular"]')
+        self.browser.click('[data-test-id="create-project"]')
 
-            self.browser.wait_until('.onboarding-Configure')
-            self.browser.wait_until_not('.loading-indicator')
+        self.browser.wait_until('.onboarding-Configure')
+        self.browser.wait_until_not('.loading-indicator')
 
-            project = Project.objects.get(organization=self.org)
-            assert project.name == 'Angular'
-            assert project.platform == 'javascript-angular'
+        project = Project.objects.get(organization=self.org)
+        assert project.name == 'Angular'
+        assert project.platform == 'javascript-angular'
 
-            self.browser.snapshot(name='onboarding-configure-project')
-            self.browser.click('[data-test-id="configure-done"]')
-            self.browser.wait_until_not('.loading-indicator')
+        self.browser.snapshot(name='onboarding-configure-project')
+        self.browser.click('[data-test-id="configure-done"]')
+        self.browser.wait_until_not('.loading-indicator')
 
-            assert self.browser.element_exists('.robot')
-            assert self.browser.element_exists_by_test_id('install-instructions')
+        assert self.browser.element_exists('.robot')
+        assert self.browser.element_exists_by_test_id('install-instructions')

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -36,19 +36,17 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
     def test_with_onboarding(self):
         self.project.update(first_event=None)
-        with self.feature(['organizations:sentry10', 'organizations:discover']):
-            self.browser.get(self.path)
-            self.wait_until_loaded()
-            self.browser.wait_until_test_id('awaiting-events')
-            self.browser.snapshot('organization issues onboarding')
+        self.browser.get(self.path)
+        self.wait_until_loaded()
+        self.browser.wait_until_test_id('awaiting-events')
+        self.browser.snapshot('organization issues onboarding')
 
     def test_with_no_results(self):
         self.project.update(first_event=timezone.now())
-        with self.feature(['organizations:sentry10', 'organizations:discover']):
-            self.browser.get(self.path)
-            self.wait_until_loaded()
-            self.browser.wait_until_test_id('empty-state')
-            self.browser.snapshot('organization issues no results')
+        self.browser.get(self.path)
+        self.wait_until_loaded()
+        self.browser.wait_until_test_id('empty-state')
+        self.browser.snapshot('organization issues no results')
 
     @patch('django.utils.timezone.now')
     def test_with_results(self, mock_now):
@@ -71,16 +69,15 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
             },
             project_id=self.project.id
         )
-        with self.feature(['organizations:sentry10', 'organizations:discover']):
-            self.browser.get(self.path)
-            self.wait_until_loaded()
-            self.browser.wait_until('.event-issue-header')
-            self.browser.snapshot('organization issues with issues')
+        self.browser.get(self.path)
+        self.wait_until_loaded()
+        self.browser.wait_until('.event-issue-header')
+        self.browser.snapshot('organization issues with issues')
 
-            groups = self.browser.find_elements_by_class_name('event-issue-header')
-            assert len(groups) == 2
-            assert 'oh snap' in groups[0].text
-            assert 'oh no' in groups[1].text
+        groups = self.browser.find_elements_by_class_name('event-issue-header')
+        assert len(groups) == 2
+        assert 'oh snap' in groups[0].text
+        assert 'oh no' in groups[1].text
 
     def wait_until_loaded(self):
         self.browser.wait_until_not('.loading')

--- a/tests/acceptance/test_organization_releases.py
+++ b/tests/acceptance/test_organization_releases.py
@@ -26,23 +26,21 @@ class OrganizationReleasesTest(AcceptanceTestCase):
             self.org.slug)
 
     def test_with_releases(self):
-        with self.feature('organizations:sentry10'):
-            release = self.create_release(
-                project=self.project,
-                version='1.0',
-            )
-            self.create_group(
-                first_release=release,
-                project=self.project,
-                message='Foo bar',
-            )
-            self.project.update(first_event=timezone.now())
-            self.browser.get(self.path)
-            self.browser.wait_until_not('.loading')
-            self.browser.snapshot('organization releases with releases')
+        release = self.create_release(
+            project=self.project,
+            version='1.0',
+        )
+        self.create_group(
+            first_release=release,
+            project=self.project,
+            message='Foo bar',
+        )
+        self.project.update(first_event=timezone.now())
+        self.browser.get(self.path)
+        self.browser.wait_until_not('.loading')
+        self.browser.snapshot('organization releases with releases')
 
     def test_with_no_releases(self):
-        with self.feature('organizations:sentry10'):
-            self.browser.get(self.path)
-            self.browser.wait_until_not('.loading')
-            self.browser.snapshot('organization releases without releases')
+        self.browser.get(self.path)
+        self.browser.wait_until_not('.loading')
+        self.browser.snapshot('organization releases without releases')

--- a/tests/acceptance/test_organization_user_feedback.py
+++ b/tests/acceptance/test_organization_user_feedback.py
@@ -26,21 +26,19 @@ class OrganizationUserFeedbackTest(AcceptanceTestCase):
         self.project.update(first_event=timezone.now())
 
     def test(self):
-        with self.feature('organizations:sentry10'):
-            self.create_userreport(
-                date_added=timezone.now(),
-                group=self.group,
-                project=self.project)
-            self.browser.get(self.path)
-            self.browser.wait_until_not('.loading-indicator')
-            self.browser.wait_until('[data-test-id="user-feedback-list"]')
-            self.browser.snapshot('organization user feedback')
+        self.create_userreport(
+            date_added=timezone.now(),
+            group=self.group,
+            project=self.project)
+        self.browser.get(self.path)
+        self.browser.wait_until_not('.loading-indicator')
+        self.browser.wait_until('[data-test-id="user-feedback-list"]')
+        self.browser.snapshot('organization user feedback')
 
     def test_empty(self):
-        with self.feature('organizations:sentry10'):
-            self.browser.get(self.path)
-            self.browser.wait_until_not('.loading-indicator')
-            self.browser.snapshot('organization user feedback - empty')
+        self.browser.get(self.path)
+        self.browser.wait_until_not('.loading-indicator')
+        self.browser.snapshot('organization user feedback - empty')
 
     def test_no_access(self):
         self.browser.get(self.path)

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -287,17 +287,5 @@ describe('Sidebar', function() {
       wrapper.update();
       expect(wrapper.find('SidebarPanel')).toHaveLength(0);
     });
-
-    it('hides assigned, bookmarks, history, activity and stats for sentry10', function() {
-      const sentry10Org = TestStubs.Organization({features: ['sentry10']});
-      wrapper = createWrapper();
-      wrapper.setProps({organization: sentry10Org});
-      wrapper.update();
-      const labels = wrapper.find('SidebarItemLabel').map(node => node.text());
-      expect(labels).toHaveLength(10);
-      expect(labels).not.toContain('Assigned to me');
-      expect(labels).not.toContain('Bookmarked issues');
-      expect(labels).not.toContain('Recently viewed');
-    });
   });
 });

--- a/tests/js/spec/views/organizationProjectsDashboard/index.spec.jsx
+++ b/tests/js/spec/views/organizationProjectsDashboard/index.spec.jsx
@@ -118,12 +118,8 @@ describe('OrganizationDashboard', function() {
         TestStubs.routerContext()
       );
       const emptyState = wrapper.find('NoProjectMessage');
-      const favorites = wrapper.find('TeamSection[data-test-id="favorites"]');
       const teamSection = wrapper.find('TeamSection');
       expect(emptyState).toHaveLength(0);
-      // Note: we have a project that is bookmarked but there is no Favorites section
-      // We removed this as part of sentry 10
-      expect(favorites).toHaveLength(0);
       expect(teamSection).toHaveLength(1);
     });
 
@@ -268,8 +264,6 @@ describe('OrganizationDashboard', function() {
         routerContext
       );
 
-      // Favorites = ~3~0 + 6 for first team
-      // Note: Favorites does not exist in sentry10
       expect(loadStatsSpy).toHaveBeenCalledTimes(6);
       expect(mock).not.toHaveBeenCalled();
 


### PR DESCRIPTION
This behavior has been mainlined, we no longer need to explicitly turn
on the sentry10 flag in tests