### PR TITLE
fix(API): Allow range in `commit` parameter of org releases endpoint as per docs

### DIFF
--- a/src/sentry/api/serializers/rest_framework/release.py
+++ b/src/sentry/api/serializers/rest_framework/release.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 
 from sentry.api.serializers.rest_framework import CommitSerializer, ListField
 from sentry.api.fields.user import UserField
-from sentry.constants import MAX_COMMIT_LENGTH, MAX_VERSION_LENGTH
+from sentry.constants import COMMIT_RANGE_DELIMITER, MAX_COMMIT_LENGTH, MAX_VERSION_LENGTH
 from sentry.models import Release
 
 
@@ -15,9 +15,37 @@ class ReleaseHeadCommitSerializerDeprecated(serializers.Serializer):
 
 
 class ReleaseHeadCommitSerializer(serializers.Serializer):
-    commit = serializers.CharField(max_length=MAX_COMMIT_LENGTH)
+    commit = serializers.CharField()
     repository = serializers.CharField(max_length=200)
     previousCommit = serializers.CharField(max_length=MAX_COMMIT_LENGTH, required=False)
+
+    def validate_commit(self, attrs, source):
+        """
+        Value can be either a single commit or a commit range (1a2b3c..6f5e4d)
+        """
+        value = attrs[source]
+
+        if COMMIT_RANGE_DELIMITER in value:
+            startCommit, endCommit = value.split(COMMIT_RANGE_DELIMITER)
+
+            if not startCommit or not endCommit:
+                raise serializers.ValidationError(
+                    'Commit cannot begin or end with %s' %
+                    COMMIT_RANGE_DELIMITER)
+
+            if len(startCommit) > MAX_COMMIT_LENGTH or len(endCommit) > MAX_COMMIT_LENGTH:
+                raise serializers.ValidationError(
+                    'Start or end commit too long - max is %s chars each' %
+                    MAX_COMMIT_LENGTH)
+
+            return attrs
+
+        if len(value) > MAX_COMMIT_LENGTH:
+            raise serializers.ValidationError(
+                'Commit too long - max is %s chars' %
+                MAX_COMMIT_LENGTH)
+
+        return attrs
 
 
 class ReleaseSerializer(serializers.Serializer):

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -16,7 +16,6 @@ from sentry.api.endpoints.organization_releases import (
 )
 from sentry.constants import (
     BAD_RELEASE_CHARS,
-    COMMIT_RANGE_DELIMITER,
     MAX_COMMIT_LENGTH,
     MAX_VERSION_LENGTH,
 )
@@ -948,16 +947,16 @@ class OrganizationReleaseCommitRangesTest(SetRefsTestCase):
             {
                 'repository': 'test/repo',
                 'previousCommit': None,
-                'commit': 'previous-commit-id%scurrent-commit-id' % COMMIT_RANGE_DELIMITER,
+                'commit': 'previous-commit-id..current-commit-id',
             },
             {
                 'repository': 'test/repo',
                 'previousCommit': 'previous-commit-will-be-ignored',
-                'commit': 'previous-commit-id-2%scurrent-commit-id-2' % COMMIT_RANGE_DELIMITER,
+                'commit': 'previous-commit-id-2..current-commit-id-2',
             },
             {
                 'repository': 'test/repo',
-                'commit': 'previous-commit-id-3%scurrent-commit-id-3' % COMMIT_RANGE_DELIMITER,
+                'commit': 'previous-commit-id-3..current-commit-id-3',
             },
         ]
 
@@ -1521,7 +1520,7 @@ class ReleaseHeadCommitSerializerTest(TestCase):
         super(ReleaseHeadCommitSerializerTest, self).setUp()
         self.repo_name = 'repo/name'
         self.commit = 'b' * 40
-        self.commit_range = '%s%s%s' % ('a' * 40, COMMIT_RANGE_DELIMITER, 'b' * 40)
+        self.commit_range = '%s..%s' % ('a' * 40, 'b' * 40)
         self.prev_commit = 'a' * 40
 
     def test_simple(self):
@@ -1599,29 +1598,29 @@ class ReleaseHeadCommitSerializerTest(TestCase):
 
     def test_commit_range_does_not_allow_empty_commits(self):
         serializer = ReleaseHeadCommitSerializer(data={
-            'commit': '%s%s%s' % ('', COMMIT_RANGE_DELIMITER, 'b' * MAX_COMMIT_LENGTH),
+            'commit': '%s..%s' % ('', 'b' * MAX_COMMIT_LENGTH),
             'repository': self.repo_name,
         })
         assert not serializer.is_valid()
         serializer = ReleaseHeadCommitSerializer(data={
-            'commit': '%s%s%s' % ('a' * MAX_COMMIT_LENGTH, COMMIT_RANGE_DELIMITER, ''),
+            'commit': '%s..%s' % ('a' * MAX_COMMIT_LENGTH, ''),
             'repository': self.repo_name,
         })
         assert not serializer.is_valid()
 
     def test_commit_range_limited_by_max_commit_length(self):
         serializer = ReleaseHeadCommitSerializer(data={
-            'commit': '%s%s%s' % ('a' * MAX_COMMIT_LENGTH, COMMIT_RANGE_DELIMITER, 'b' * MAX_COMMIT_LENGTH),
+            'commit': '%s..%s' % ('a' * MAX_COMMIT_LENGTH, 'b' * MAX_COMMIT_LENGTH),
             'repository': self.repo_name,
         })
         assert serializer.is_valid()
         serializer = ReleaseHeadCommitSerializer(data={
-            'commit': '%s%s%s' % ('a' * (MAX_COMMIT_LENGTH + 1), COMMIT_RANGE_DELIMITER, 'b' * MAX_COMMIT_LENGTH),
+            'commit': '%s..%s' % ('a' * (MAX_COMMIT_LENGTH + 1), 'b' * MAX_COMMIT_LENGTH),
             'repository': self.repo_name,
         })
         assert not serializer.is_valid()
         serializer = ReleaseHeadCommitSerializer(data={
-            'commit': '%s%s%s' % ('a' * MAX_COMMIT_LENGTH, COMMIT_RANGE_DELIMITER, 'b' * (MAX_COMMIT_LENGTH + 1)),
+            'commit': '%s..%s' % ('a' * MAX_COMMIT_LENGTH, 'b' * (MAX_COMMIT_LENGTH + 1)),
             'repository': self.repo_name,
         })
         assert not serializer.is_valid()

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -10,8 +10,16 @@ from datetime import (
 from django.core.urlresolvers import reverse
 from exam import fixture
 
-from sentry.api.endpoints.organization_releases import ReleaseSerializerWithProjects
-from sentry.constants import BAD_RELEASE_CHARS, MAX_VERSION_LENGTH
+from sentry.api.endpoints.organization_releases import (
+    ReleaseHeadCommitSerializer,
+    ReleaseSerializerWithProjects,
+)
+from sentry.constants import (
+    BAD_RELEASE_CHARS,
+    COMMIT_RANGE_DELIMITER,
+    MAX_COMMIT_LENGTH,
+    MAX_VERSION_LENGTH,
+)
 from sentry.models import (
     Activity,
     ApiKey,
@@ -940,16 +948,16 @@ class OrganizationReleaseCommitRangesTest(SetRefsTestCase):
             {
                 'repository': 'test/repo',
                 'previousCommit': None,
-                'commit': 'previous-commit-id..current-commit-id',
+                'commit': 'previous-commit-id%scurrent-commit-id' % COMMIT_RANGE_DELIMITER,
             },
             {
                 'repository': 'test/repo',
                 'previousCommit': 'previous-commit-will-be-ignored',
-                'commit': 'previous-commit-id-2..current-commit-id-2',
+                'commit': 'previous-commit-id-2%scurrent-commit-id-2' % COMMIT_RANGE_DELIMITER,
             },
             {
                 'repository': 'test/repo',
-                'commit': 'previous-commit-id-3..current-commit-id-3',
+                'commit': 'previous-commit-id-3%scurrent-commit-id-3' % COMMIT_RANGE_DELIMITER,
             },
         ]
 
@@ -1504,5 +1512,116 @@ class ReleaseSerializerWithProjectsTest(TestCase):
         serializer = ReleaseSerializerWithProjects(data={
             'version': 'Latest',
             'projects': self.projects,
+        })
+        assert not serializer.is_valid()
+
+
+class ReleaseHeadCommitSerializerTest(TestCase):
+    def setUp(self):
+        super(ReleaseHeadCommitSerializerTest, self).setUp()
+        self.repo_name = 'repo/name'
+        self.commit = 'b' * 40
+        self.commit_range = '%s%s%s' % ('a' * 40, COMMIT_RANGE_DELIMITER, 'b' * 40)
+        self.prev_commit = 'a' * 40
+
+    def test_simple(self):
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': self.commit,
+            'previousCommit': self.prev_commit,
+            'repository': self.repo_name
+        })
+
+        assert serializer.is_valid()
+        assert sorted(serializer.fields.keys()) == sorted(
+            ['commit', 'previousCommit', 'repository'])
+        result = serializer.object
+        assert result['commit'] == self.commit
+        assert result['previousCommit'] == self.prev_commit
+        assert result['repository'] == self.repo_name
+
+    def test_prev_commit_not_required(self):
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': self.commit,
+            'previousCommit': None,
+            'repository': self.repo_name
+        })
+        assert serializer.is_valid()
+
+    def test_do_not_allow_null_or_empty_commit_or_repo(self):
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': None,
+            'previousCommit': self.prev_commit,
+            'repository': self.repo_name
+        })
+        assert not serializer.is_valid()
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': '',
+            'previousCommit': self.prev_commit,
+            'repository': self.repo_name
+        })
+        assert not serializer.is_valid()
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': self.commit,
+            'previousCommit': self.prev_commit,
+            'repository': None
+        })
+        assert not serializer.is_valid()
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': self.commit,
+            'previousCommit': self.prev_commit,
+            'repository': ''
+        })
+        assert not serializer.is_valid()
+
+    def test_single_commit_limited_by_max_commit_length(self):
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': 'b' * MAX_COMMIT_LENGTH,
+            'repository': self.repo_name,
+        })
+        assert serializer.is_valid()
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': self.commit,
+            'previousCommit': 'a' * MAX_COMMIT_LENGTH,
+            'repository': self.repo_name,
+        })
+        assert serializer.is_valid()
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': 'b' * (MAX_COMMIT_LENGTH + 1),
+            'repository': self.repo_name,
+        })
+        assert not serializer.is_valid()
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': self.commit,
+            'previousCommit': 'a' * (MAX_COMMIT_LENGTH + 1),
+            'repository': self.repo_name,
+        })
+        assert not serializer.is_valid()
+
+    def test_commit_range_does_not_allow_empty_commits(self):
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': '%s%s%s' % ('', COMMIT_RANGE_DELIMITER, 'b' * MAX_COMMIT_LENGTH),
+            'repository': self.repo_name,
+        })
+        assert not serializer.is_valid()
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': '%s%s%s' % ('a' * MAX_COMMIT_LENGTH, COMMIT_RANGE_DELIMITER, ''),
+            'repository': self.repo_name,
+        })
+        assert not serializer.is_valid()
+
+    def test_commit_range_limited_by_max_commit_length(self):
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': '%s%s%s' % ('a' * MAX_COMMIT_LENGTH, COMMIT_RANGE_DELIMITER, 'b' * MAX_COMMIT_LENGTH),
+            'repository': self.repo_name,
+        })
+        assert serializer.is_valid()
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': '%s%s%s' % ('a' * (MAX_COMMIT_LENGTH + 1), COMMIT_RANGE_DELIMITER, 'b' * MAX_COMMIT_LENGTH),
+            'repository': self.repo_name,
+        })
+        assert not serializer.is_valid()
+        serializer = ReleaseHeadCommitSerializer(data={
+            'commit': '%s%s%s' % ('a' * MAX_COMMIT_LENGTH, COMMIT_RANGE_DELIMITER, 'b' * (MAX_COMMIT_LENGTH + 1)),
+            'repository': self.repo_name,
         })
         assert not serializer.is_valid()


### PR DESCRIPTION
We say in the docs that the `commit` parameter can be a range:

![image](https://user-images.githubusercontent.com/14812505/59218022-1e294880-8b74-11e9-8fc0-c2f7e84aeed9.png)

But then we limit its length to one commit's worth of characters:

https://github.com/getsentry/sentry/blob/de71f5796e313100da24312837c32bd8aec35d6b/src/sentry/api/serializers/rest_framework/release.py#L18

This fixes that and adds tests.