### PR TITLE
fix(events-v2): Move org events validation code into endpoint

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -28,8 +28,6 @@ SPECIAL_FIELDS = {
     },
 }
 
-ALLOWED_GROUPINGS = frozenset(('issue.id', 'project.id'))
-
 
 class Direction(Enum):
     NEXT = 0
@@ -84,12 +82,6 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         fields = request.GET.getlist('field')[:]
         aggregations = []
         groupby = request.GET.getlist('groupby')
-
-        if not fields and not groupby:
-            raise OrganizationEventsError('No fields or groupings provided')
-
-        if any(field for field in groupby if field not in ALLOWED_GROUPINGS):
-            raise OrganizationEventsError('Invalid groupby value requested')
 
         if fields:
             # If project.name is requested, get the project.id from Snuba so we

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -53,7 +53,7 @@ class OrganizationEventDetailsEndpointTest(OrganizationEventDetailsTestBase):
                 'organization_slug': self.project.organization.slug,
                 'project_slug': self.project.slug,
                 'event_id': 'a' * 32,
-            }
+            },
         )
 
         with self.feature('organizations:events-v2'):


### PR DESCRIPTION
We reuse the `get_snuba_query_args_v2` function in other places where
these validations don't apply.