### PR TITLE
feat(ui) Improve event modal loader experience

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -51,6 +51,15 @@ class EventDetails extends AsyncComponent {
       </ModalContainer>
     );
   }
+
+  renderLoading() {
+    return (
+      <ModalContainer>
+        <CloseButton onClick={this.handleClose} size={30} />
+        {super.renderLoading()}
+      </ModalContainer>
+    );
+  }
 }
 
 const ModalContainer = styled('div')`


### PR DESCRIPTION
Show the modal loader *inside* the modal instead of underneath the table.

![event-modal-loader](https://user-images.githubusercontent.com/24086/59226035-2a2aff80-8ba0-11e9-9b1b-7c7593fae67a.gif)


Refs SEN-732