### PR TITLE
feat(events-v2): Support ordering by a list of fields

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -123,7 +123,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         if groupby:
             snuba_args['groupby'] = groupby
 
-        orderby = request.GET.get('orderby')
+        orderby = request.GET.getlist('orderby')
         if orderby:
             snuba_args['orderby'] = orderby
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -264,7 +264,7 @@ def zerofill(data, start, end, rollup, orderby):
         else:
             rv.append({'time': key})
 
-    if len(orderby) > 0 and orderby[0].startswith('-'):
+    if '-time' in orderby:
         return list(reversed(rv))
 
     return rv

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -264,7 +264,7 @@ def zerofill(data, start, end, rollup, orderby):
         else:
             rv.append({'time': key})
 
-    if orderby.startswith('-'):
+    if len(orderby) > 0 and orderby[0].startswith('-'):
         return list(reversed(rv))
 
     return rv
@@ -456,12 +456,19 @@ def transform_aliases_and_query(skip_conditions=False, **kwargs):
         kwargs['having'] = having
 
     if orderby:
-        order_by_column = orderby.lstrip('-')
-        kwargs['orderby'] = u'{}{}'.format(
-            '-' if orderby.startswith('-') else '',
-            order_by_column if order_by_column in derived_columns else get_snuba_column_name(
-                order_by_column)
-        ) or None
+        if orderby is None:
+            orderby = []
+        orderby = orderby if isinstance(orderby, (list, tuple)) else [orderby]
+        translated_orderby = []
+
+        for field_with_order in orderby:
+            field = field_with_order.lstrip('-')
+            translated_orderby.append(u'{}{}'.format(
+                '-' if field_with_order.startswith('-') else '',
+                field if field in derived_columns else get_snuba_column_name(field)
+            ))
+
+        kwargs['orderby'] = translated_orderby
 
     kwargs['arrayjoin'] = arrayjoin_map.get(arrayjoin, arrayjoin)
 

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -203,6 +203,44 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[1]['project.id'] == project.id
         assert response.data[1]['issue.id'] == groups[1].id
 
+    def test_orderby(self):
+        self.login_as(user=self.user)
+        project = self.create_project()
+        self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'timestamp': self.two_min_ago,
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'b' * 32,
+                'timestamp': self.min_ago,
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'c' * 32,
+                'timestamp': self.min_ago,
+            },
+            project_id=project.id,
+        )
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'field': ['id'],
+                    'orderby': ['-timestamp', '-id']
+                },
+            )
+
+        assert response.data[0]['id'] == 'c' * 32
+        assert response.data[1]['id'] == 'b' * 32
+        assert response.data[2]['id'] == 'a' * 32
+
     def test_special_fields(self):
         self.login_as(user=self.user)
         project = self.create_project()


### PR DESCRIPTION
We want to be able to sort events by multiple fields e.g. `["-timestamp", "-id"]`