### PR TITLE
feat(ui): Add Incident start date to list [SEN-690]

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
@@ -40,10 +40,9 @@ class OrganizationIncidentsList extends AsyncComponent {
 
   renderListItem(incident) {
     const {orgId} = this.props.params;
+    const started = moment(incident.dateStarted);
     const duration = moment
-      .duration(
-        moment(incident.dateClosed || new Date()).diff(moment(incident.dateStarted))
-      )
+      .duration(moment(incident.dateClosed || new Date()).diff(started))
       .as('seconds');
 
     return (
@@ -53,9 +52,11 @@ class OrganizationIncidentsList extends AsyncComponent {
             {incident.title}
           </Link>
           <Status incident={incident} />
+          <div>{started.format('LL')}</div>
           <div>
             <Duration seconds={getDynamicText({value: duration, fixed: 1200})} />
           </div>
+
           <div>
             <Count value={incident.uniqueUsers} />
           </div>
@@ -85,6 +86,7 @@ class OrganizationIncidentsList extends AsyncComponent {
             <TableLayout>
               <div>{t('Incident')}</div>
               <div>{t('Status')}</div>
+              <div>{t('Started')}</div>
               <div>{t('Duration')}</div>
               <div>{t('Users affected')}</div>
               <div>{t('Total events')}</div>
@@ -166,9 +168,10 @@ class OrganizationIncidentsListContainer extends React.Component {
 
 const TableLayout = styled('div')`
   display: grid;
-  grid-template-columns: 4fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: 4fr 1fr 1fr 1fr 1fr 1fr;
   grid-column-gap: ${space(1.5)};
   width: 100%;
+  align-items: center;
 `;
 
 export default OrganizationIncidentsListContainer;

--- a/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
@@ -52,9 +52,9 @@ class OrganizationIncidentsList extends AsyncComponent {
             {incident.title}
           </Link>
           <Status incident={incident} />
-          <div>{started.format('LL')}</div>
           <div>
-            <Duration seconds={getDynamicText({value: duration, fixed: 1200})} />
+            {started.format('LL')}
+            <LightDuration seconds={getDynamicText({value: duration, fixed: 1200})} />
           </div>
 
           <div>
@@ -87,7 +87,6 @@ class OrganizationIncidentsList extends AsyncComponent {
               <div>{t('Incident')}</div>
               <div>{t('Status')}</div>
               <div>{t('Started')}</div>
-              <div>{t('Duration')}</div>
               <div>{t('Users affected')}</div>
               <div>{t('Total events')}</div>
             </TableLayout>
@@ -168,10 +167,16 @@ class OrganizationIncidentsListContainer extends React.Component {
 
 const TableLayout = styled('div')`
   display: grid;
-  grid-template-columns: 4fr 1fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: 4fr 1fr 2fr 1fr 1fr;
   grid-column-gap: ${space(1.5)};
   width: 100%;
   align-items: center;
+`;
+
+const LightDuration = styled(Duration)`
+  color: ${p => p.theme.gray1};
+  font-size: 0.9em;
+  margin-left: ${space(1)};
 `;
 
 export default OrganizationIncidentsListContainer;


### PR DESCRIPTION
Add a new column for incident start date in incidents table

![image](https://user-images.githubusercontent.com/79684/59279918-5e4b0280-8c2a-11e9-93d0-51ae69d12371.png)


Fixes SEN-690