### PR TITLE
fix(events-v2) Improve scroll handling for event modal

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -105,11 +105,13 @@ class EventDetails extends AsyncComponent {
   }
 
   componentDidMount() {
+    this.restoreOverflow = document.body.style.overflow;
+
     document.body.style.overflow = 'hidden';
   }
 
   componentWillUnmount() {
-    document.body.style.overflow = 'auto';
+    document.body.style.overflow = this.restoreOverflow;
   }
 
   renderBody() {

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -104,6 +104,14 @@ class EventDetails extends AsyncComponent {
     throw new Error('Could not determine projectId');
   }
 
+  componentDidMount() {
+    document.body.style.overflow = 'hidden';
+  }
+
+  componentWillUnmount() {
+    document.body.style.overflow = 'auto';
+  }
+
   renderBody() {
     const {organization, view, location} = this.props;
     const {event, activeTab} = this.state;
@@ -135,14 +143,16 @@ class EventDetails extends AsyncComponent {
 }
 
 const ModalContainer = styled('div')`
-  position: absolute;
+  position: fixed;
   top: 0px;
   left: 0px;
   right: 0px;
+  bottom: 0px;
   background: #fff;
 
   margin: ${space(3)};
   padding: ${space(3)};
+
   border: 1px solid ${p => p.theme.borderLight};
   border-radius: ${p => p.theme.borderRadius};
   box-shadow: ${p => p.theme.dropShadowHeavy};

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
@@ -216,6 +216,9 @@ const MetadataContainer = styled('div')`
 
 const ColumnGrid = styled('div')`
   display: grid;
+  max-height: 100%;
+  overflow: auto;
+
   grid-template-columns: 70% 28%;
   grid-template-rows: auto;
   grid-column-gap: 2%;


### PR DESCRIPTION
Make the modal take up the entire viewport and have scrollable content. The style modifications to `document.body` are a bit hacky but I don't know of an alternate way to do this.

![event-modal-scroll](https://user-images.githubusercontent.com/24086/59285843-a6732080-8c3c-11e9-800f-23f7638a71ea.gif)


Refs SEN-718