### PR TITLE
style(stylelint): Remove `no-duplicate-selectors` inline rule

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.jsx
@@ -145,7 +145,6 @@ const HelpDescription = styled('div')`
 `;
 
 const AlertWrapper = styled('div')`
-  /* stylelint-disable-next-line no-duplicate-selectors */
   ${HelpButton} {
     color: #6d6319;
     &:hover {

--- a/src/sentry/static/sentry/app/components/activity/note/index.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/index.jsx
@@ -179,7 +179,6 @@ const StyledActivityItem = styled(ActivityItem)`
 
 const ActivityItemWithEditing = styled(StyledActivityItem)`
   &:hover {
-    /* stylelint-disable-next-line no-duplicate-selectors */
     ${EditorTools} {
       display: inline-block;
     }

--- a/src/sentry/static/sentry/app/components/assigneeSelector.jsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.jsx
@@ -342,7 +342,6 @@ const AssigneeSelector = styled(AssigneeSelectorComponent)`
   justify-content: flex-end;
 
   /* manually align menu underneath dropdown caret */
-  /* stylelint-disable-next-line no-duplicate-selectors */
   ${DropdownBubble} {
     right: -14px;
   }

--- a/src/sentry/static/sentry/app/components/charts/percentageTableChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/percentageTableChart.jsx
@@ -258,7 +258,6 @@ const TableChartWrapper = styled('div')`
   display: flex;
   flex-direction: column;
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
   ${PanelItem} {
     padding: ${space(1)};
   }

--- a/src/sentry/static/sentry/app/components/emptyStateWarning.jsx
+++ b/src/sentry/static/sentry/app/components/emptyStateWarning.jsx
@@ -49,7 +49,6 @@ const EmptyStreamWrapper = styled('div')`
     }
   }
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
   ${HeroIcon} {
     margin-bottom: 20px;
   }

--- a/src/sentry/static/sentry/app/components/globalSelectionHeaderRow.jsx
+++ b/src/sentry/static/sentry/app/components/globalSelectionHeaderRow.jsx
@@ -51,7 +51,6 @@ const Container = styled('div')`
   height: ${p => p.theme.headerSelectorRowHeight}px;
   flex-shrink: 0;
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
   ${CheckboxFancy} {
     opacity: ${p => (p.isChecked ? 1 : 0.33)};
   }

--- a/src/sentry/static/sentry/app/components/organizations/headerItemPosition.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItemPosition.jsx
@@ -9,7 +9,6 @@ const HeaderItemPosition = styled('div')`
   height: 100%;
   min-width: 0;
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
   ${AutoCompleteRoot}, ${TimeRangeRoot} {
     flex: 1;
     min-width: 0;

--- a/src/sentry/static/sentry/app/components/search/searchResult.jsx
+++ b/src/sentry/static/sentry/app/components/search/searchResult.jsx
@@ -180,7 +180,6 @@ const ResultTypeIcon = styled(InlineSvg)`
   font-size: 1.2em;
   flex-shrink: 0;
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
   ${SettingsSearch} & {
     color: inherit;
   }

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -220,11 +220,9 @@ const SidebarDropdownActor = styled('button')`
   width: 100%;
 
   &:hover {
-    /* stylelint-disable-next-line no-duplicate-selectors */
     ${OrgOrUserName} {
       text-shadow: 0 0 6px rgba(255, 255, 255, 0.1);
     }
-    /* stylelint-disable-next-line no-duplicate-selectors */
     ${UserNameOrEmail} {
       color: ${p => p.theme.gray1};
     }

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarMenuItem.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarMenuItem.jsx
@@ -67,7 +67,6 @@ const getMenuItemStyles = p => css`
     outline: none;
   }
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
   ${OrgSummary} {
     padding-left: 0;
     padding-right: 0;

--- a/src/sentry/static/sentry/app/components/text.jsx
+++ b/src/sentry/static/sentry/app/components/text.jsx
@@ -7,7 +7,6 @@ import Panel from 'app/components/panels/panel';
 const Text = styled('div')`
   ${textStyles};
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
   ${Panel} & {
     padding-left: ${space(2)};
     padding-right: ${space(2)};

--- a/src/sentry/static/sentry/app/views/onboarding/onboarding.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/onboarding.jsx
@@ -229,7 +229,6 @@ const Header = styled('header')`
   z-index: 100;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.02);
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
   ${Container} {
     display: grid;
     grid-template-columns: repeat(3, 1fr);

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupMerged/mergedItem.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupMerged/mergedItem.jsx
@@ -171,7 +171,6 @@ const Controls = styled(({expanded: _expanded, ...props}) => (
 const Fingerprint = styled('label')`
   font-family: ${p => p.theme.text.familyMono};
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
   ${Controls} & {
     font-weight: normal;
     margin: 0;

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
@@ -109,7 +109,6 @@ const Sidebar = styled('div')`
   border-left: 1px solid ${p => p.theme.borderLight};
   background-color: ${p => p.theme.white};
 
-  /* stylelint-disable-next-line no-duplicate-selectors */
   ${PageContent} {
     padding-top: ${space(3)};
   }

--- a/src/sentry/static/sentry/app/views/projectsDashboard/teamSection.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/teamSection.jsx
@@ -55,13 +55,11 @@ const ProjectCards = styled(Flex)`
 const TeamSectionWrapper = styled('div')`
   border-bottom: ${p => (p.showBorder ? '1px solid ' + p.theme.borderLight : 0)};
 
-  /* stylelint-disable no-duplicate-selectors */
   &:last-child {
     ${ProjectCards} {
       padding-bottom: 0;
     }
   }
-  /* stylelint-enable */
 `;
 
 const TeamTitleBar = styled(Flex)`


### PR DESCRIPTION
We explicitly set the stylelint syntax to `css-in-js` which correctly
allows using components as selectors.

Depends on https://github.com/getsentry/sentry/pull/13638