### PR TITLE
build(babel): Remove `propTypes` from prod builds

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -15,7 +15,18 @@ module.exports = {
     ['@babel/plugin-proposal-class-properties', {loose: true}],
   ],
   env: {
-    production: {},
+    production: {
+      plugins: [
+        [
+          'transform-react-remove-prop-types',
+          {
+            mode: 'remove', // remove from bundle
+            removeImport: true, // removes `prop-types` import statements
+            // additionalLibraries: [/app\/sentryTypes$/],
+          },
+        ],
+      ],
+    },
     development: {
       plugins: [
         ['emotion', {sourceMap: true, autoLabel: true}],

--- a/babel.config.js
+++ b/babel.config.js
@@ -22,7 +22,7 @@ module.exports = {
           {
             mode: 'remove', // remove from bundle
             removeImport: true, // removes `prop-types` import statements
-            // additionalLibraries: [/app\/sentryTypes$/],
+            additionalLibraries: [/app\/sentryTypes$/],
           },
         ],
       ],

--- a/babel.config.js
+++ b/babel.config.js
@@ -22,6 +22,12 @@ module.exports = {
           {
             mode: 'remove', // remove from bundle
             removeImport: true, // removes `prop-types` import statements
+            classNameMatchers: [
+              'SelectField',
+              'FormField',
+              'AsyncComponent',
+              'AsyncView',
+            ],
             additionalLibraries: [/app\/sentryTypes$/],
           },
         ],

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babel-loader": "^8.0.0",
     "babel-plugin-emotion": "9.2.11",
     "babel-plugin-lodash": "^3.3.4",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "bootstrap": "3.4.0",
     "classnames": "2.2.0",
     "clipboard": "^1.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2878,6 +2878,11 @@ babel-plugin-transform-react-remove-prop-types@0.4.18:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.18.tgz#85ff79d66047b34288c6f7cc986b8854ab384f8c"
   integrity sha512-azed2nHo8vmOy7EY26KH+om5oOcWRs0r1U8wOmhwta+SBMMnmJ4H6yaBZRCcHBtMeWp9AVhvBTL/lpR1kEx+Xw==
 
+babel-plugin-transform-react-remove-prop-types@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz#f2edaf9b4c6a5fbe5c1d678bfb531078c1555f3a"
+  integrity sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==
+
 babel-plugin-transform-regexp-constructors@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz#58b7775b63afcf33328fae9a5f88fbd4fb0b4965"


### PR DESCRIPTION
For some reason I was under the impression this was done with
`@babel/preset-react`, but it is not.

This reduces our bundle size by ~4%

Previous:
![image](https://user-images.githubusercontent.com/79684/59293448-dcb49e00-8c44-11e9-8d89-7eb12acc52dd.png)

New:
![image](https://user-images.githubusercontent.com/79684/59293475-e4744280-8c44-11e9-9869-3fd6bb7ffd2b.png)
