### PR TITLE
feat(events-v2) Add responsive views for events modal

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -9,6 +9,7 @@ import AsyncComponent from 'app/components/asyncComponent';
 import InlineSvg from 'app/components/inlineSvg';
 import withApi from 'app/utils/withApi';
 import space from 'app/styles/space';
+import theme from 'app/utils/theme';
 
 import EventModalContent from './eventModalContent';
 import {getQuery} from './utils';
@@ -160,6 +161,10 @@ const ModalContainer = styled('div')`
   box-shadow: ${p => p.theme.dropShadowHeavy};
 
   z-index: ${p => p.theme.zIndex.modal};
+
+  @media (max-width: ${theme.breakpoints[1]}) {
+    margin: ${space(2)};
+  }
 `;
 
 const CircleButton = styled('button')`

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -9,7 +9,6 @@ import AsyncComponent from 'app/components/asyncComponent';
 import InlineSvg from 'app/components/inlineSvg';
 import withApi from 'app/utils/withApi';
 import space from 'app/styles/space';
-import theme from 'app/utils/theme';
 
 import EventModalContent from './eventModalContent';
 import {getQuery} from './utils';
@@ -162,7 +161,7 @@ const ModalContainer = styled('div')`
 
   z-index: ${p => p.theme.zIndex.modal};
 
-  @media (max-width: ${theme.breakpoints[1]}) {
+  @media (max-width: ${p => p.theme.breakpoints[1]}) {
     margin: ${space(2)};
   }
 `;

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
@@ -19,7 +19,6 @@ import space from 'app/styles/space';
 import {objectIsEmpty, toTitleCase} from 'app/utils';
 import {getMessage, getTitle} from 'app/utils/events';
 import getDynamicText from 'app/utils/getDynamicText';
-import theme from 'app/utils/theme';
 
 import LinkedIssuePreview from './linkedIssuePreview';
 import ModalPagination from './modalPagination';
@@ -229,11 +228,11 @@ const ColumnGrid = styled('div')`
   grid-template-rows: auto;
   grid-column-gap: 2%;
 
-  @media (max-width: ${theme.breakpoints[1]}) {
+  @media (max-width: ${p => p.theme.breakpoints[1]}) {
     grid-template-columns: 60% 38%;
   }
 
-  @media (max-width: ${theme.breakpoints[0]}) {
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
     display: flex;
     flex-direction: column;
   }

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
@@ -3,8 +3,6 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import {INTERFACES} from 'app/components/events/eventEntries';
-import {getMessage, getTitle} from 'app/utils/events';
-import {objectIsEmpty, toTitleCase} from 'app/utils';
 import {t} from 'app/locale';
 import DateTime from 'app/components/dateTime';
 import ErrorBoundary from 'app/components/errorBoundary';
@@ -16,8 +14,12 @@ import ExternalLink from 'app/components/links/externalLink';
 import FileSize from 'app/components/fileSize';
 import NavTabs from 'app/components/navTabs';
 import SentryTypes from 'app/sentryTypes';
-import getDynamicText from 'app/utils/getDynamicText';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
+import {objectIsEmpty, toTitleCase} from 'app/utils';
+import {getMessage, getTitle} from 'app/utils/events';
+import getDynamicText from 'app/utils/getDynamicText';
+import theme from 'app/utils/theme';
 
 import LinkedIssuePreview from './linkedIssuePreview';
 import ModalPagination from './modalPagination';
@@ -172,7 +174,7 @@ const EventHeader = props => {
   const {title} = getTitle(props.event);
   return (
     <div>
-      <h2>{title}</h2>
+      <OverflowHeader>{title}</OverflowHeader>
       <p>{getMessage(props.event)}</p>
     </div>
   );
@@ -206,6 +208,10 @@ EventMetadata.propTypes = {
   eventJsonUrl: PropTypes.string.isRequired,
 };
 
+const OverflowHeader = styled('h2')`
+  ${overflowEllipsis}
+`;
+
 const MetadataContainer = styled('div')`
   display: flex;
   justify-content: space-between;
@@ -222,6 +228,15 @@ const ColumnGrid = styled('div')`
   grid-template-columns: 70% 28%;
   grid-template-rows: auto;
   grid-column-gap: 2%;
+
+  @media (max-width: ${theme.breakpoints[1]}) {
+    grid-template-columns: 60% 38%;
+  }
+
+  @media (max-width: ${theme.breakpoints[0]}) {
+    display: flex;
+    flex-direction: column;
+  }
 `;
 
 const HeaderBox = styled('div')`

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/modalPagination.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/modalPagination.jsx
@@ -9,6 +9,7 @@ import Link from 'app/components/links/link';
 import SentryTypes from 'app/sentryTypes';
 import InlineSvg from 'app/components/inlineSvg';
 import space from 'app/styles/space';
+import theme from 'app/utils/theme';
 
 const ModalPagination = props => {
   const {location, event} = props;
@@ -75,13 +76,22 @@ ModalPagination.propTypes = {
 const StyledLink = styled(Link, {shouldForwardProp: isPropValid})`
   color: ${p => (p.disabled ? p.theme.disabled : p.theme.gray3)};
   font-size: ${p => p.fontSizeMedium};
+  text-align: center;
   padding: ${space(0.5)} ${space(1.5)};
   ${p => (p.isLast ? '' : `border-right: 1px solid ${p.theme.borderDark};`)}
   ${p => (p.disabled ? 'pointer-events: none;' : '')}
+
+  @media(max-width: ${theme.breakpoints[0]}) {
+    flex-grow: 1;
+  }
 `;
 
 const Wrapper = styled('div')`
   display: flex;
+
+  @media (max-width: ${theme.breakpoints[0]}) {
+    width: 100%;
+  }
 `;
 
 const ShadowBox = styled('div')`
@@ -92,6 +102,10 @@ const ShadowBox = styled('div')`
   margin-bottom: ${space(3)};
   box-shadow: 3px 3px 0 ${p => p.theme.offWhite}, 3px 3px 0 1px ${p => p.theme.borderDark},
     7px 7px ${p => p.theme.offWhite}, 7px 7px 0 1px ${p => p.theme.borderDark};
+
+  @media (max-width: ${theme.breakpoints[0]}) {
+    width: 100%;
+  }
 `;
 
 export default ModalPagination;

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/modalPagination.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/modalPagination.jsx
@@ -9,7 +9,6 @@ import Link from 'app/components/links/link';
 import SentryTypes from 'app/sentryTypes';
 import InlineSvg from 'app/components/inlineSvg';
 import space from 'app/styles/space';
-import theme from 'app/utils/theme';
 
 const ModalPagination = props => {
   const {location, event} = props;
@@ -81,7 +80,7 @@ const StyledLink = styled(Link, {shouldForwardProp: isPropValid})`
   ${p => (p.isLast ? '' : `border-right: 1px solid ${p.theme.borderDark};`)}
   ${p => (p.disabled ? 'pointer-events: none;' : '')}
 
-  @media(max-width: ${theme.breakpoints[0]}) {
+  @media(max-width: ${p => p.theme.breakpoints[0]}) {
     flex-grow: 1;
   }
 `;
@@ -89,7 +88,7 @@ const StyledLink = styled(Link, {shouldForwardProp: isPropValid})`
 const Wrapper = styled('div')`
   display: flex;
 
-  @media (max-width: ${theme.breakpoints[0]}) {
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
     width: 100%;
   }
 `;
@@ -103,7 +102,7 @@ const ShadowBox = styled('div')`
   box-shadow: 3px 3px 0 ${p => p.theme.offWhite}, 3px 3px 0 1px ${p => p.theme.borderDark},
     7px 7px ${p => p.theme.offWhite}, 7px 7px 0 1px ${p => p.theme.borderDark};
 
-  @media (max-width: ${theme.breakpoints[0]}) {
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
     width: 100%;
   }
 `;

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/tagsTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/tagsTable.jsx
@@ -65,4 +65,8 @@ const TagValue = styled(TagKey)`
   ${overflowEllipsis};
 `;
 
+const StyledTable = styled('table')`
+  width: 100%;
+`;
+
 export default withRouter(TagsTable);

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/tagsTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/tagsTable.jsx
@@ -65,8 +65,4 @@ const TagValue = styled(TagKey)`
   ${overflowEllipsis};
 `;
 
-const StyledTable = styled('table')`
-  width: 100%;
-`;
-
 export default withRouter(TagsTable);


### PR DESCRIPTION
Adjust layout at our breakpoints so that the modal is readable in each layout mode. 

#### Tablet Size

![Screen Shot 2019-06-11 at 1 03 48 PM](https://user-images.githubusercontent.com/24086/59294153-be53a000-8c4e-11e9-9767-14e8437bda3e.png)

### Mobile portrait

![Screen Shot 2019-06-11 at 1 31 42 PM](https://user-images.githubusercontent.com/24086/59294177-cb708f00-8c4e-11e9-8fdc-34b8ae1fc224.png)

Refs SEN-729