### PR TITLE
perf(snuba): Limit SnubaEvent.get_event to return the first result only.

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -457,6 +457,7 @@ class SnubaEvent(EventCommon):
                 'project_id': [project_id],
             },
             referrer='SnubaEvent.get_event',
+            limit=1,
         )
         if 'error' not in result and len(result['data']) == 1:
             return SnubaEvent(result['data'][0])


### PR DESCRIPTION
We currently search all of history for a result even when we have the single result in hand.

Let's not.