### PR TITLE
ref(ui): Remove OrganizationState from a bunch of places

### DIFF
--- a/src/sentry/static/sentry/app/components/group/pluginActions.jsx
+++ b/src/sentry/static/sentry/app/components/group/pluginActions.jsx
@@ -1,48 +1,42 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import Modal from 'react-bootstrap/lib/Modal';
 import withApi from 'app/utils/withApi';
 import {addSuccessMessage, addErrorMessage} from 'app/actionCreators/indicator';
-import OrganizationState from 'app/mixins/organizationState';
 import NavTabs from 'app/components/navTabs';
 import plugins from 'app/plugins';
 import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
 import IssueSyncListElement from 'app/components/issueSyncListElement';
+import withOrganization from 'app/utils/withOrganization';
 
-const PluginActions = createReactClass({
-  displayName: 'PluginActions',
-
-  propTypes: {
+class PluginActions extends React.Component {
+  static propTypes = {
     api: PropTypes.object,
     group: SentryTypes.Group.isRequired,
+    organization: SentryTypes.Organization.isRequired,
     project: SentryTypes.Project.isRequired,
     plugin: PropTypes.object.isRequired,
-  },
+  };
 
-  mixins: [OrganizationState],
-
-  getInitialState() {
-    return {
-      showModal: false,
-      actionType: null,
-      issue: null,
-      pluginLoading: false,
-    };
-  },
+  state = {
+    showModal: false,
+    actionType: null,
+    issue: null,
+    pluginLoading: false,
+  };
 
   componentDidMount() {
     this.loadPlugin(this.props.plugin);
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     if (this.props.plugin.id !== nextProps.plugin.id) {
       this.loadPlugin(nextProps.plugin);
     }
-  },
+  }
 
-  deleteIssue() {
+  deleteIssue = () => {
     const plugin = {
       ...this.props.plugin,
       issue: null,
@@ -59,9 +53,9 @@ const PluginActions = createReactClass({
         addErrorMessage(t('Unable to unlink issue'));
       },
     });
-  },
+  };
 
-  loadPlugin(data) {
+  loadPlugin = data => {
     this.setState(
       {
         pluginLoading: true,
@@ -73,16 +67,16 @@ const PluginActions = createReactClass({
         });
       }
     );
-  },
+  };
 
-  openModal() {
+  openModal = () => {
     this.setState({
       showModal: true,
       actionType: 'create',
     });
-  },
+  };
 
-  closeModal(data) {
+  closeModal = data => {
     this.setState({
       issue:
         data && data.id && data.link
@@ -90,11 +84,11 @@ const PluginActions = createReactClass({
           : null,
       showModal: false,
     });
-  },
+  };
 
-  handleClick(actionType) {
+  handleClick = actionType => {
     this.setState({actionType});
-  },
+  };
 
   render() {
     const {actionType, issue} = this.state;
@@ -135,7 +129,7 @@ const PluginActions = createReactClass({
                 plugin,
                 group: this.props.group,
                 project: this.props.project,
-                organization: this.getOrganization(),
+                organization: this.props.organization,
                 actionType,
                 onSuccess: this.closeModal,
               })}
@@ -144,9 +138,9 @@ const PluginActions = createReactClass({
         </Modal>
       </React.Fragment>
     );
-  },
-});
+  }
+}
 
 export {PluginActions};
 
-export default withApi(PluginActions);
+export default withApi(withOrganization(PluginActions));

--- a/src/sentry/static/sentry/app/components/organizations/homeContainer.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/homeContainer.jsx
@@ -1,16 +1,10 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
-import OrganizationState from 'app/mixins/organizationState';
 import ProjectNav from 'app/views/organizationProjectsDashboard/projectNav';
 import space from 'app/styles/space';
 
-const HomeContainer = createReactClass({
-  displayName: 'HomeContainer',
-
-  mixins: [OrganizationState],
-
+export default class HomeContainer extends React.Component {
   render() {
     return (
       <div className={`${this.props.className || ''} organization-home`}>
@@ -20,11 +14,9 @@ const HomeContainer = createReactClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 const Content = styled('div')`
   padding-top: ${space(3)};
 `;
-
-export default HomeContainer;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEvents.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEvents.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import {browserHistory} from 'react-router';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import {pick} from 'lodash';
 
 import SentryTypes from 'app/sentryTypes';
@@ -10,40 +9,34 @@ import {t} from 'app/locale';
 import withApi from 'app/utils/withApi';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import EventsTable from 'app/components/eventsTable/eventsTable';
-import OrganizationState from 'app/mixins/organizationState';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
 import SearchBar from 'app/components/searchBar';
 import parseApiError from 'app/utils/parseApiError';
 
-const GroupEvents = createReactClass({
-  displayName: 'GroupEvents',
-
-  propTypes: {
+class GroupEvents extends React.Component {
+  static propTypes = {
     api: PropTypes.object,
     group: SentryTypes.Group.isRequired,
-  },
+  };
 
-  mixins: [OrganizationState],
+  constructor(props) {
+    super(props);
 
-  getInitialState() {
     const queryParams = this.props.location.query;
-
-    const initialState = {
+    this.state = {
       eventList: [],
       loading: true,
       error: false,
       pageLinks: '',
       query: queryParams.query || '',
     };
-
-    return initialState;
-  },
+  }
 
   componentWillMount() {
     this.fetchData();
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     if (this.props.location.search !== nextProps.location.search) {
@@ -56,9 +49,9 @@ const GroupEvents = createReactClass({
         this.fetchData
       );
     }
-  },
+  }
 
-  handleSearch(query) {
+  handleSearch = query => {
     const targetQueryParams = {...this.props.location.query};
     targetQueryParams.query = query;
     const {groupId, orgId} = this.props.params;
@@ -67,9 +60,9 @@ const GroupEvents = createReactClass({
       pathname: `/organizations/${orgId}/issues/${groupId}/events/`,
       query: targetQueryParams,
     });
-  },
+  };
 
-  fetchData() {
+  fetchData = () => {
     this.setState({
       loading: true,
       error: false,
@@ -99,7 +92,7 @@ const GroupEvents = createReactClass({
         });
       },
     });
-  },
+  };
 
   renderNoQueryResults() {
     return (
@@ -107,7 +100,7 @@ const GroupEvents = createReactClass({
         <p>{t('Sorry, no events match your search query.')}</p>
       </EmptyStateWarning>
     );
-  },
+  }
 
   renderEmpty() {
     return (
@@ -115,7 +108,7 @@ const GroupEvents = createReactClass({
         <p>{t("There don't seem to be any events yet.")}</p>
       </EmptyStateWarning>
     );
-  },
+  }
 
   renderResults() {
     const {group, params} = this.props;
@@ -130,7 +123,7 @@ const GroupEvents = createReactClass({
         groupId={params.groupId}
       />
     );
-  },
+  }
 
   renderBody() {
     let body;
@@ -148,7 +141,7 @@ const GroupEvents = createReactClass({
     }
 
     return body;
-  },
+  }
 
   render() {
     return (
@@ -167,8 +160,8 @@ const GroupEvents = createReactClass({
         <Pagination pageLinks={this.state.pageLinks} />
       </div>
     );
-  },
-});
+  }
+}
 
 export {GroupEvents};
 

--- a/src/sentry/static/sentry/app/views/organizationStats/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/index.jsx
@@ -1,27 +1,26 @@
 import $ from 'jquery';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import DocumentTitle from 'react-document-title';
 
 import withApi from 'app/utils/withApi';
-import OrganizationState from 'app/mixins/organizationState';
-
 import LazyLoad from 'app/components/lazyLoad';
+import withOrganization from 'app/utils/withOrganization';
+import SentryTypes from 'app/sentryTypes';
 
-const OrganizationStatsContainer = createReactClass({
-  displayName: 'OrganizationStatsContainer ',
-  propTypes: {
-    api: PropTypes.object,
-    routes: PropTypes.array,
-  },
-  mixins: [OrganizationState],
+class OrganizationStatsContainer extends React.Component {
+  static propTypes = {
+    api: PropTypes.object.isRequired,
+    routes: PropTypes.array.isRequired,
+    organization: SentryTypes.Organization.isRequired,
+  };
 
-  getInitialState() {
+  constructor(props) {
+    super(props);
     const until = Math.floor(new Date().getTime() / 1000);
     const since = until - 3600 * 24 * 7;
 
-    return {
+    this.state = {
       projectsError: false,
       projectsLoading: false,
       projectsRequestsPending: 0,
@@ -37,11 +36,11 @@ const OrganizationStatsContainer = createReactClass({
       querySince: since,
       queryUntil: until,
     };
-  },
+  }
 
   componentWillMount() {
     this.fetchData();
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     // If query string changes, it will be due to pagination.
@@ -54,7 +53,7 @@ const OrganizationStatsContainer = createReactClass({
         projectsLoading: true,
       });
     }
-  },
+  }
 
   componentDidUpdate(prevProps) {
     const prevParams = prevProps.params,
@@ -80,7 +79,7 @@ const OrganizationStatsContainer = createReactClass({
     if (state.projectsLoading && !state.projectsRequestsPending) {
       this.processProjectData();
     }
-  },
+  }
 
   fetchProjectData() {
     this.props.api.request(this.getOrganizationProjectsEndpoint(), {
@@ -105,7 +104,7 @@ const OrganizationStatsContainer = createReactClass({
         });
       },
     });
-  },
+  }
 
   fetchData() {
     this.setState({
@@ -174,17 +173,17 @@ const OrganizationStatsContainer = createReactClass({
     });
 
     this.fetchProjectData();
-  },
+  }
 
   getOrganizationStatsEndpoint() {
     const params = this.props.params;
     return '/organizations/' + params.orgId + '/stats/';
-  },
+  }
 
   getOrganizationProjectsEndpoint() {
     const params = this.props.params;
     return '/organizations/' + params.orgId + '/projects/';
-  },
+  }
 
   processOrgData() {
     let oReceived = 0;
@@ -221,7 +220,7 @@ const OrganizationStatsContainer = createReactClass({
       },
       statsLoading: false,
     });
-  },
+  }
 
   processProjectData() {
     const rawProjectData = this.state.rawProjectData;
@@ -247,10 +246,10 @@ const OrganizationStatsContainer = createReactClass({
       projectTotals,
       projectsLoading: false,
     });
-  },
+  }
 
   render() {
-    const organization = this.getOrganization();
+    const organization = this.props.organization;
 
     return (
       <DocumentTitle title={`Stats - ${organization.slug} - Sentry`}>
@@ -265,9 +264,9 @@ const OrganizationStatsContainer = createReactClass({
         />
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
 export {OrganizationStatsContainer};
 
-export default withApi(OrganizationStatsContainer);
+export default withApi(withOrganization(OrganizationStatsContainer));

--- a/src/sentry/static/sentry/app/views/projectChooser.jsx
+++ b/src/sentry/static/sentry/app/views/projectChooser.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
 import {browserHistory} from 'react-router';
 import $ from 'jquery';
 import {Box} from 'grid-emotion';
@@ -7,7 +6,6 @@ import styled from 'react-emotion';
 
 import {t} from 'app/locale';
 import Link from 'app/components/links/link';
-import OrganizationState from 'app/mixins/organizationState';
 import {sortProjects} from 'app/utils';
 import theme from 'app/utils/theme';
 import {TASKS} from 'app/components/onboardingWizard/todos';
@@ -15,41 +13,38 @@ import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import ProjectLabel from 'app/components/projectLabel';
 import SentryTypes from 'app/sentryTypes';
+import withOrganization from 'app/utils/withOrganization';
 
-const ProjectChooser = createReactClass({
-  displayName: 'ProjectChooser',
-
-  propTypes: {
-    organization: SentryTypes.Organization,
-  },
-
-  mixins: [OrganizationState],
+class ProjectChooser extends React.Component {
+  static propTypes = {
+    organization: SentryTypes.Organization.isRequired,
+  };
 
   componentWillMount() {
     this.redirectNoMultipleProjects();
-  },
+  }
 
   componentWillUnmount() {
     $(document.body).removeClass('narrow');
-  },
+  }
 
   redirectNoMultipleProjects() {
-    const org = this.getOrganization();
-    const projects = org.projects;
+    const {organization} = this.props;
+    const projects = organization.projects;
     const tasks = TASKS.filter(
       task_inst => task_inst.task === this.props.location.query.task
     );
 
     if (projects.length === 0) {
-      browserHistory.push(`/organizations/${org.slug}/projects/new/`);
+      browserHistory.push(`/organizations/${organization.slug}/projects/new/`);
     } else if (projects.length === 1 && tasks && tasks.length === 1) {
       const project = projects[0];
-      browserHistory.push(`/${org.slug}/${project.slug}/${tasks[0].location}`);
+      browserHistory.push(`/${organization.slug}/${project.slug}/${tasks[0].location}`);
     }
-  },
+  }
 
   render() {
-    const org = this.getOrganization();
+    const {organization} = this.props;
     const task = TASKS.filter(
       task_inst => task_inst.task === parseInt(this.props.location.query.task, 10)
     )[0];
@@ -65,11 +60,11 @@ const ProjectChooser = createReactClass({
         <Panel>
           <PanelHeader hasButtons>{t('Projects')}</PanelHeader>
           <PanelBody css={{width: '100%'}}>
-            {sortProjects(org.projects).map((project, i) => (
+            {sortProjects(organization.projects).map((project, i) => (
               <PanelItem p={0} key={project.slug} align="center">
                 <Box p={2} flex="1">
                   <Link
-                    to={`/${org.slug}/${project.slug}/${task.location}`}
+                    to={`/${organization.slug}/${project.slug}/${task.location}`}
                     css={{color: theme.gray3}}
                   >
                     <StyledProjectLabel
@@ -84,11 +79,11 @@ const ProjectChooser = createReactClass({
         </Panel>
       </div>
     );
-  },
-});
+  }
+}
 
 const StyledProjectLabel = styled(ProjectLabel)`
   color: ${p => p.theme.blue};
 `;
 
-export default ProjectChooser;
+export default withOrganization(ProjectChooser);

--- a/src/sentry/static/sentry/app/views/projectSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectSettings/index.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
 import {t} from 'app/locale';
 import withApi from 'app/utils/withApi';
@@ -8,39 +7,30 @@ import Badge from 'app/components/badge';
 import ListLink from 'app/components/links/listLink';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import OrganizationState from 'app/mixins/organizationState';
 import PluginNavigation from 'app/views/projectSettings/pluginNavigation';
 import ExternalLink from 'app/components/links/externalLink';
+import withOrganization from 'app/utils/withOrganization';
+import SentryTypes from 'app/sentryTypes';
 
-const ProjectSettings = createReactClass({
-  displayName: 'ProjectSettings',
-
-  propTypes: {
+class ProjectSettings extends React.Component {
+  static propTypes = {
     api: PropTypes.object,
+    organization: SentryTypes.Organization.isRequired,
     setProjectNavSection: PropTypes.func,
-  },
+  };
 
-  contextTypes: {
-    location: PropTypes.object,
-    organization: PropTypes.object,
-  },
-
-  mixins: [OrganizationState],
-
-  getInitialState() {
-    return {
-      loading: true,
-      error: false,
-      project: null,
-    };
-  },
+  state = {
+    loading: true,
+    error: false,
+    project: null,
+  };
 
   componentWillMount() {
     const {setProjectNavSection} = this.props;
 
     setProjectNavSection('settings');
     this.fetchData();
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     const params = this.props.params;
@@ -56,9 +46,9 @@ const ProjectSettings = createReactClass({
         this.fetchData
       );
     }
-  },
+  }
 
-  fetchData() {
+  fetchData = () => {
     const params = this.props.params;
 
     this.props.api.request(`/projects/${params.orgId}/${params.projectId}/`, {
@@ -76,7 +66,7 @@ const ProjectSettings = createReactClass({
         });
       },
     });
-  },
+  };
 
   render() {
     // TODO(dcramer): move sidebar into component
@@ -86,7 +76,7 @@ const ProjectSettings = createReactClass({
       return <LoadingError onRetry={this.fetchData} />;
     }
 
-    const access = this.getAccess();
+    const access = new Set(this.props.organization.access);
     const {orgId, projectId} = this.props.params;
     const pathPrefix = `/settings/${orgId}/projects/${projectId}`;
     const settingsUrlRoot = pathPrefix;
@@ -94,7 +84,7 @@ const ProjectSettings = createReactClass({
     const rootInstallPath = `${pathPrefix}/install/`;
     const path = this.props.location.pathname;
     const processingIssues = this.state.project.processingIssues;
-    const organization = this.context.organization;
+    const organization = this.props.organization;
 
     return (
       <div className="row">
@@ -185,9 +175,9 @@ const ProjectSettings = createReactClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 export {ProjectSettings};
 
-export default withApi(ProjectSettings);
+export default withApi(withOrganization(ProjectSettings));

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -14,10 +14,10 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import MemberListStore from 'app/stores/memberListStore';
 import MissingProjectMembership from 'app/components/missingProjectMembership';
-import OrganizationState from 'app/mixins/organizationState';
 import ProjectsStore from 'app/stores/projectsStore';
 import SentryTypes from 'app/sentryTypes';
 import withProjects from 'app/utils/withProjects';
+import withOrganization from 'app/utils/withOrganization';
 
 const ERROR_TYPES = {
   MISSING_MEMBERSHIP: 'MISSING_MEMBERSHIP',
@@ -42,7 +42,7 @@ const ProjectContext = createReactClass({
      * If true, this will not change `state.loading` during `fetchData` phase
      */
     skipReload: PropTypes.bool,
-
+    organization: SentryTypes.Organization,
     projects: PropTypes.arrayOf(SentryTypes.Project),
     projectId: PropTypes.string,
     orgId: PropTypes.string,
@@ -56,7 +56,6 @@ const ProjectContext = createReactClass({
   mixins: [
     Reflux.connect(MemberListStore, 'memberList'),
     Reflux.listenTo(ProjectsStore, 'onProjectChange'),
-    OrganizationState,
   ],
 
   getInitialState() {
@@ -267,7 +266,7 @@ const ProjectContext = createReactClass({
           // out into a reusable missing access error component
           return (
             <MissingProjectMembership
-              organization={this.getOrganization()}
+              organization={this.props.organization}
               projectId={this.state.project.slug}
             />
           );
@@ -290,4 +289,4 @@ const ProjectContext = createReactClass({
 
 export {ProjectContext};
 
-export default withApi(withProjects(withRouter(ProjectContext)));
+export default withApi(withOrganization(withProjects(withRouter(ProjectContext))));

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
@@ -2,16 +2,16 @@ import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import createReactClass from 'create-react-class';
 import * as Sentry from '@sentry/browser';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {t, tct} from 'app/locale';
 import withApi from 'app/utils/withApi';
+import withOrganization from 'app/utils/withOrganization';
+import SentryTypes from 'app/sentryTypes';
 import Button from 'app/components/button';
 import ConfigStore from 'app/stores/configStore';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import OrganizationState from 'app/mixins/organizationState';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import TextField from 'app/components/forms/textField';
@@ -48,21 +48,20 @@ const STATIC_ROLE_LIST = [
   },
 ];
 
-const InviteMember = createReactClass({
-  displayName: 'InviteMember',
-  propTypes: {
+class InviteMember extends React.Component {
+  static propTypes = {
     api: PropTypes.object,
+    organization: SentryTypes.Organization.isRequired,
     router: PropTypes.object,
-  },
-  mixins: [OrganizationState],
+  };
 
-  getInitialState() {
-    const {teams} = this.getOrganization();
-
+  constructor(props) {
+    super(props);
+    const {teams} = props.organization;
     //select team if there's only one
     const initialTeamSelection = teams.length === 1 ? [teams[0].slug] : [];
 
-    return {
+    this.state = {
       selectedTeams: new Set(initialTeamSelection),
       roleList: [],
       selectedRole: 'member',
@@ -71,10 +70,10 @@ const InviteMember = createReactClass({
       busy: false,
       error: undefined,
     };
-  },
+  }
 
   componentDidMount() {
-    const {slug} = this.getOrganization();
+    const {slug} = this.props.organization;
     const {isSuperuser} = ConfigStore.get('user');
 
     this.props.api.request(`/organizations/${slug}/members/me/`, {
@@ -119,9 +118,9 @@ const InviteMember = createReactClass({
         addErrorMessage(t('Error with request, please reload'));
       },
     });
-  },
+  }
 
-  redirectToMemberPage() {
+  redirectToMemberPage = () => {
     // Get path to parent route (`/organizations/${slug}/members/`)
     // `recreateRoute` fucks up because of getsentry hooks
     const {params, router} = this.props;
@@ -130,17 +129,17 @@ const InviteMember = createReactClass({
       ? '/settings/:orgId/members/'
       : '/organizations/:orgId/members/';
     router.push(replaceRouterParams(pathToParentRoute, params));
-  },
+  };
 
-  splitEmails(text) {
+  splitEmails = text => {
     return text
       .split(',')
       .map(e => e.trim())
       .filter(e => e);
-  },
+  };
 
-  inviteUser(email) {
-    const {slug} = this.getOrganization();
+  inviteUser = email => {
+    const {slug} = this.props.organization;
     const {selectedTeams, selectedRole} = this.state;
 
     return new Promise((resolve, reject) => {
@@ -175,9 +174,9 @@ const InviteMember = createReactClass({
         },
       });
     });
-  },
+  };
 
-  submit() {
+  submit = () => {
     const {email} = this.state;
     const emails = this.splitEmails(email);
     if (!emails.length) {
@@ -196,26 +195,26 @@ const InviteMember = createReactClass({
         }
         this.setState({error, busy: false});
       });
-  },
+  };
 
-  handleAddTeam(team) {
+  handleAddTeam = team => {
     const {selectedTeams} = this.state;
     if (!selectedTeams.has(team.slug)) {
       selectedTeams.add(team.slug);
     }
     this.setState({selectedTeams});
-  },
+  };
 
-  handleRemoveTeam(teamSlug) {
+  handleRemoveTeam = teamSlug => {
     const {selectedTeams} = this.state;
     selectedTeams.delete(teamSlug);
 
     this.setState({selectedTeams});
-  },
+  };
 
   render() {
     const {error, loading, roleList, selectedRole, selectedTeams} = this.state;
-    const organization = this.getOrganization();
+    const {organization} = this.props;
     const {invitesEnabled} = ConfigStore.getConfig();
     const {isSuperuser} = ConfigStore.get('user');
 
@@ -270,8 +269,8 @@ const InviteMember = createReactClass({
         )}
       </div>
     );
-  },
-});
+  }
+}
 
 export {InviteMember};
-export default withApi(withRouter(InviteMember));
+export default withApi(withRouter(withOrganization(InviteMember)));

--- a/src/sentry/static/sentry/app/views/settings/organizationRateLimits/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRateLimits/index.jsx
@@ -1,27 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import createReactClass from 'create-react-class';
 
-import OrganizationState from 'app/mixins/organizationState';
+import SentryTypes from 'app/sentryTypes';
+import withOrganization from 'app/utils/withOrganization';
 
 import OrganizationRateLimits from './organizationRateLimits';
 
-const OrganizationRateLimitsContainer = createReactClass({
-  displayName: 'OrganizationRateLimits',
-  propTypes: {
+class OrganizationRateLimitsContainer extends React.Component {
+  static propTypes = {
+    organization: SentryTypes.Organization,
     routes: PropTypes.array,
-  },
-  mixins: [OrganizationState],
+  };
 
   render() {
-    if (!this.context.organization) {
+    if (!this.props.organization) {
       return null;
     }
 
-    return (
-      <OrganizationRateLimits {...this.props} organization={this.context.organization} />
-    );
-  },
-});
+    return <OrganizationRateLimits {...this.props} />;
+  }
+}
 
-export default OrganizationRateLimitsContainer;
+export default withOrganization(OrganizationRateLimitsContainer);

--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
@@ -1,23 +1,23 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
 import {Panel} from 'app/components/panels';
 import {addLoadingMessage, removeIndicator} from 'app/actionCreators/indicator';
 import {t, tn} from 'app/locale';
 import Access from 'app/components/acl/access';
 import withApi from 'app/utils/withApi';
+import withOrganization from 'app/utils/withOrganization';
 import Button from 'app/components/button';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import OrganizationState from 'app/mixins/organizationState';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import TimeSince from 'app/components/timeSince';
 import formGroups from 'app/data/forms/processingIssues';
+import SentryTypes from 'app/sentryTypes';
 
 const MESSAGES = {
   native_no_crashed_thread: t('No crashed thread found in crash report'),
@@ -44,29 +44,26 @@ const HELP_LINKS = {
   native_missing_symbol: 'https://docs.sentry.io/server/dsym/',
 };
 
-const ProjectProcessingIssues = createReactClass({
-  displayName: 'ProjectProcessingIssues',
-  propTypes: {
-    api: PropTypes.object,
-  },
-  mixins: [OrganizationState],
+class ProjectProcessingIssues extends React.Component {
+  static propTypes = {
+    api: PropTypes.object.isRequired,
+    organization: SentryTypes.Organization.isRequired,
+  };
 
-  getInitialState() {
-    return {
-      formData: {},
-      loading: true,
-      reprocessing: false,
-      expected: 0,
-      error: false,
-      processingIssues: null,
-    };
-  },
+  state = {
+    formData: {},
+    loading: true,
+    reprocessing: false,
+    expected: 0,
+    error: false,
+    processingIssues: null,
+  };
 
   componentDidMount() {
     this.fetchData();
-  },
+  }
 
-  fetchData() {
+  fetchData = () => {
     const {orgId, projectId} = this.props.params;
     this.setState({
       expected: this.state.expected + 2,
@@ -113,9 +110,9 @@ const ProjectProcessingIssues = createReactClass({
         },
       }
     );
-  },
+  };
 
-  sendReprocessing() {
+  sendReprocessing = () => {
     this.setState({
       reprocessing: true,
     });
@@ -138,9 +135,9 @@ const ProjectProcessingIssues = createReactClass({
         removeIndicator(loadingIndicator);
       },
     });
-  },
+  };
 
-  discardEvents() {
+  discardEvents = () => {
     const {orgId, projectId} = this.props.params;
     this.setState({
       expected: this.state.expected + 1,
@@ -167,9 +164,9 @@ const ProjectProcessingIssues = createReactClass({
         });
       },
     });
-  },
+  };
 
-  deleteProcessingIssues() {
+  deleteProcessingIssues = () => {
     const {orgId, projectId} = this.props.params;
     this.setState({
       expected: this.state.expected + 1,
@@ -196,9 +193,9 @@ const ProjectProcessingIssues = createReactClass({
         });
       },
     });
-  },
+  };
 
-  renderDebugTable() {
+  renderDebugTable = () => {
     let body;
     if (this.state.loading) {
       body = this.renderLoading();
@@ -215,17 +212,17 @@ const ProjectProcessingIssues = createReactClass({
     }
 
     return body;
-  },
+  };
 
-  renderLoading() {
+  renderLoading = () => {
     return (
       <div className="box">
         <LoadingIndicator />
       </div>
     );
-  },
+  };
 
-  renderEmpty() {
+  renderEmpty = () => {
     return (
       <Panel>
         <EmptyStateWarning>
@@ -233,19 +230,19 @@ const ProjectProcessingIssues = createReactClass({
         </EmptyStateWarning>
       </Panel>
     );
-  },
+  };
 
-  getProblemDescription(item) {
+  getProblemDescription = item => {
     const msg = MESSAGES[item.type];
     return msg || item.message || 'Unknown Error';
-  },
+  };
 
-  getImageName(path) {
+  getImageName = path => {
     const pathSegments = path.split(/^([a-z]:\\|\\\\)/i.test(path) ? '\\' : '/');
     return pathSegments[pathSegments.length - 1];
-  },
+  };
 
-  renderProblem(item) {
+  renderProblem = item => {
     const description = this.getProblemDescription(item);
     const helpLink = HELP_LINKS[item.type];
     return (
@@ -258,9 +255,9 @@ const ProjectProcessingIssues = createReactClass({
         )}
       </div>
     );
-  },
+  };
 
-  renderDetails(item) {
+  renderDetails = item => {
     let dsymUUID = null;
     let dsymName = null;
     let dsymArch = null;
@@ -284,9 +281,9 @@ const ProjectProcessingIssues = createReactClass({
         {dsymName && <span> (for {dsymName})</span>}
       </span>
     );
-  },
+  };
 
-  renderResolveButton() {
+  renderResolveButton = () => {
     const issues = this.state.processingIssues;
     if (issues === null || this.state.reprocessing) {
       return null;
@@ -304,9 +301,9 @@ const ProjectProcessingIssues = createReactClass({
         Pro Tip: <a onClick={this.sendReprocessing}>{fixButton}</a>
       </div>
     );
-  },
+  };
 
-  renderResults() {
+  renderResults = () => {
     const fixLink = this.state.processingIssues
       ? this.state.processingIssues.signedLink
       : false;
@@ -404,10 +401,10 @@ const ProjectProcessingIssues = createReactClass({
         </div>
       </div>
     );
-  },
+  };
 
-  renderReprocessingSettings() {
-    const access = this.getAccess();
+  renderReprocessingSettings = () => {
+    const access = new Set(this.props.organization.access);
     if (this.state.loading) {
       return this.renderLoading();
     }
@@ -425,7 +422,7 @@ const ProjectProcessingIssues = createReactClass({
         <JsonForm access={access} forms={formGroups} />
       </Form>
     );
-  },
+  };
 
   render() {
     return (
@@ -447,9 +444,9 @@ const ProjectProcessingIssues = createReactClass({
         {this.renderReprocessingSettings()}
       </div>
     );
-  },
-});
+  }
+}
 
 export {ProjectProcessingIssues};
 
-export default withApi(ProjectProcessingIssues);
+export default withApi(withOrganization(ProjectProcessingIssues));

--- a/tests/js/spec/views/__snapshots__/projectChooser.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectChooser.spec.jsx.snap
@@ -1,106 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProjectChooser renders 1`] = `
-<div
-  className="css-arqurf container"
->
-  <SettingsPageHeading
-    noTitleStyles={false}
-    title="Projects"
-  />
-  <Panel>
-    <PanelHeader
-      hasButtons={true}
-    >
-      Projects
-    </PanelHeader>
-    <PanelBody
-      className="css-8atqhb"
-      direction="column"
-      disablePadding={true}
-      flex={false}
-    >
-      <PanelItem
-        align="center"
-        key="another-project"
-        p={0}
-      >
-        <Box
-          flex="1"
-          p={2}
-        >
-          <Link
-            className="css-5kvhca"
-            to="/org/another-project/settings/install/"
-          >
-            <StyledProjectLabel
-              project={
-                Object {
-                  "isMember": true,
-                  "name": "Another Project",
-                  "slug": "another-project",
-                  "team": Object {
-                    "isMember": true,
-                    "name": "Test Team",
-                    "projects": Array [
-                      Object {
-                        "name": "Test Project",
-                        "slug": "test-project",
-                      },
-                      Object {
-                        "name": "Another Project",
-                        "slug": "another-project",
-                      },
-                    ],
-                    "slug": "test-team",
-                  },
-                }
-              }
-            />
-          </Link>
-        </Box>
-      </PanelItem>
-      <PanelItem
-        align="center"
-        key="test-project"
-        p={0}
-      >
-        <Box
-          flex="1"
-          p={2}
-        >
-          <Link
-            className="css-5kvhca"
-            to="/org/test-project/settings/install/"
-          >
-            <StyledProjectLabel
-              project={
-                Object {
-                  "isMember": true,
-                  "name": "Test Project",
-                  "slug": "test-project",
-                  "team": Object {
-                    "isMember": true,
-                    "name": "Test Team",
-                    "projects": Array [
-                      Object {
-                        "name": "Test Project",
-                        "slug": "test-project",
-                      },
-                      Object {
-                        "name": "Another Project",
-                        "slug": "another-project",
-                      },
-                    ],
-                    "slug": "test-team",
-                  },
-                }
-              }
-            />
-          </Link>
-        </Box>
-      </PanelItem>
-    </PanelBody>
-  </Panel>
-</div>
+<ProjectChooser
+  location={
+    Object {
+      "pathname": "https://sentry.io/organizations/tester1/projects/choose/",
+      "query": Object {
+        "onboarding": "1",
+        "task": "2",
+      },
+      "search": "?onboarding=1&task=2",
+    }
+  }
+  organization={
+    Object {
+      "access": Array [],
+      "id": "org",
+      "projects": Array [
+        Object {
+          "isMember": true,
+          "name": "Test Project",
+          "slug": "test-project",
+          "team": Object {
+            "isMember": true,
+            "name": "Test Team",
+            "projects": Array [
+              Object {
+                "name": "Test Project",
+                "slug": "test-project",
+              },
+              Object {
+                "name": "Another Project",
+                "slug": "another-project",
+              },
+            ],
+            "slug": "test-team",
+          },
+        },
+        Object {
+          "isMember": true,
+          "name": "Another Project",
+          "slug": "another-project",
+          "team": Object {
+            "isMember": true,
+            "name": "Test Team",
+            "projects": Array [
+              Object {
+                "name": "Test Project",
+                "slug": "test-project",
+              },
+              Object {
+                "name": "Another Project",
+                "slug": "another-project",
+              },
+            ],
+            "slug": "test-team",
+          },
+        },
+      ],
+      "slug": "org",
+      "teams": Array [
+        Object {
+          "isMember": true,
+          "name": "Test Team",
+          "projects": Array [
+            Object {
+              "name": "Test Project",
+              "slug": "test-project",
+            },
+            Object {
+              "name": "Another Project",
+              "slug": "another-project",
+            },
+          ],
+          "slug": "test-team",
+        },
+      ],
+    }
+  }
+/>
 `;

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -21,6 +21,47 @@ exports[`InviteMember should render roles when available and allowed, and handle
       "query": Object {},
     }
   }
+  organization={
+    Object {
+      "access": Array [
+        "org:read",
+        "org:write",
+        "org:admin",
+        "org:integrations",
+        "project:read",
+        "project:write",
+        "project:admin",
+        "team:read",
+        "team:write",
+        "team:admin",
+      ],
+      "features": Array [],
+      "id": "1",
+      "name": "Organization Name",
+      "onboardingTasks": Array [],
+      "projects": Array [],
+      "scrapeJavaScript": true,
+      "slug": "testOrg",
+      "status": Object {
+        "id": "active",
+        "name": "active",
+      },
+      "teams": Array [
+        Object {
+          "hasAccess": true,
+          "id": "1",
+          "name": "bar",
+          "slug": "bar",
+        },
+        Object {
+          "hasAccess": false,
+          "id": "2",
+          "name": "foo",
+          "slug": "foo",
+        },
+      ],
+    }
+  }
   params={
     Object {
       "orgId": "testOrg",
@@ -351,8 +392,29 @@ exports[`InviteMember should render roles when available and allowed, and handle
         onRemoveTeam={[Function]}
         organization={
           Object {
+            "access": Array [
+              "org:read",
+              "org:write",
+              "org:admin",
+              "org:integrations",
+              "project:read",
+              "project:write",
+              "project:admin",
+              "team:read",
+              "team:write",
+              "team:admin",
+            ],
+            "features": Array [],
             "id": "1",
+            "name": "Organization Name",
+            "onboardingTasks": Array [],
+            "projects": Array [],
+            "scrapeJavaScript": true,
             "slug": "testOrg",
+            "status": Object {
+              "id": "active",
+              "name": "active",
+            },
             "teams": Array [
               Object {
                 "hasAccess": true,
@@ -377,8 +439,29 @@ exports[`InviteMember should render roles when available and allowed, and handle
           onRemoveTeam={[Function]}
           organization={
             Object {
+              "access": Array [
+                "org:read",
+                "org:write",
+                "org:admin",
+                "org:integrations",
+                "project:read",
+                "project:write",
+                "project:admin",
+                "team:read",
+                "team:write",
+                "team:admin",
+              ],
+              "features": Array [],
               "id": "1",
+              "name": "Organization Name",
+              "onboardingTasks": Array [],
+              "projects": Array [],
+              "scrapeJavaScript": true,
               "slug": "testOrg",
+              "status": Object {
+                "id": "active",
+                "name": "active",
+              },
               "teams": Array [
                 Object {
                   "hasAccess": true,

--- a/tests/js/spec/views/inviteMember/inviteMember.spec.jsx
+++ b/tests/js/spec/views/inviteMember/inviteMember.spec.jsx
@@ -8,34 +8,39 @@ jest.mock('app/api');
 jest.mock('jquery');
 
 describe('InviteMember', function() {
-  const baseProps = {
-    api: new MockApiClient(),
-    params: {
-      orgId: 'testOrg',
-    },
-    location: {query: {}},
-  };
-
-  const teams = [
-    {slug: 'bar', id: '1', name: 'bar', hasAccess: true},
-    {slug: 'foo', id: '2', name: 'foo', hasAccess: false},
-  ];
-
-  const baseContext = TestStubs.routerContext([
-    {
-      organization: {
-        id: '1',
-        slug: 'testOrg',
-        teams: [
-          {slug: 'bar', id: '1', name: 'bar', hasAccess: true},
-          {slug: 'foo', id: '2', name: 'foo', hasAccess: false},
-        ],
-      },
-      location: {query: {}},
-    },
-  ]);
+  let organization, baseProps, teams, baseContext;
 
   beforeEach(function() {
+    organization = TestStubs.Organization({
+      id: '1',
+      slug: 'testOrg',
+      teams: [
+        {slug: 'bar', id: '1', name: 'bar', hasAccess: true},
+        {slug: 'foo', id: '2', name: 'foo', hasAccess: false},
+      ],
+    });
+
+    baseProps = {
+      api: new MockApiClient(),
+      params: {
+        orgId: 'testOrg',
+      },
+      organization,
+      location: {query: {}},
+    };
+
+    teams = [
+      {slug: 'bar', id: '1', name: 'bar', hasAccess: true},
+      {slug: 'foo', id: '2', name: 'foo', hasAccess: false},
+    ];
+
+    baseContext = TestStubs.routerContext([
+      {
+        organization,
+        location: {query: {}},
+      },
+    ]);
+
     jest.spyOn(ConfigStore, 'getConfig').mockImplementation(() => ({
       id: 1,
       invitesEnabled: true,
@@ -70,8 +75,8 @@ describe('InviteMember', function() {
 
     const context = _.cloneDeep(baseContext);
 
-    const team = context.context.organization.teams.slice(0, 1);
-    context.context.organization.teams = team;
+    const team = organization.teams.slice(0, 1);
+    organization.teams = team;
 
     const wrapper = mount(<InviteMember {...baseProps} />, context);
 

--- a/tests/js/spec/views/onboarding/__snapshots__/configure.spec.jsx.snap
+++ b/tests/js/spec/views/onboarding/__snapshots__/configure.spec.jsx.snap
@@ -220,7 +220,7 @@ exports[`Configure should render correctly render() should render platform docs 
             </withApi(WithOrganizationMockWrapper)>
           </div>
         </h2>
-        <withApi(withProjects(withRouter(ProjectContext)))
+        <withApi(WithOrganizationMockWrapper)
           orgId="testOrg"
           projectId="project-slug"
           style={
@@ -229,7 +229,7 @@ exports[`Configure should render correctly render() should render platform docs 
             }
           }
         >
-          <withProjects(withRouter(ProjectContext))
+          <WithOrganizationMockWrapper
             api={Client {}}
             orgId="testOrg"
             projectId="project-slug"
@@ -239,43 +239,93 @@ exports[`Configure should render correctly render() should render platform docs 
               }
             }
           >
-            <withRouter(ProjectContext)
+            <withProjects(withRouter(ProjectContext))
               api={Client {}}
               orgId="testOrg"
-              projectId="project-slug"
-              projects={
-                Array [
-                  Object {
-                    "hasAccess": true,
-                    "id": "testProject",
-                    "isBookmarked": false,
-                    "isMember": true,
-                    "name": "Test Project",
-                    "slug": "project-slug",
-                    "teams": Array [
-                      Object {
-                        "hasAccess": true,
-                        "id": "coolid",
-                        "slug": "coolteam",
-                      },
-                    ],
-                  },
-                ]
+              organization={
+                Object {
+                  "id": "1337",
+                  "projects": Array [
+                    Object {
+                      "hasAccess": true,
+                      "id": "testProject",
+                      "isBookmarked": false,
+                      "isMember": true,
+                      "name": "Test Project",
+                      "slug": "project-slug",
+                      "teams": Array [
+                        Object {
+                          "hasAccess": true,
+                          "id": "coolteam",
+                          "slug": "coolteam",
+                        },
+                      ],
+                    },
+                  ],
+                  "slug": "testOrg",
+                  "teams": Array [
+                    Object {
+                      "hasAccess": true,
+                      "id": "coolteam",
+                      "projects": Array [
+                        Object {
+                          "id": "testProject",
+                          "name": "Test Project",
+                          "slug": "project-slug",
+                        },
+                      ],
+                      "slug": "coolteam",
+                    },
+                  ],
+                }
               }
+              projectId="project-slug"
               style={
                 Object {
                   "marginBottom": 30,
                 }
               }
             >
-              <ProjectContext
+              <withRouter(ProjectContext)
                 api={Client {}}
-                location={
+                orgId="testOrg"
+                organization={
                   Object {
-                    "query": Object {},
+                    "id": "1337",
+                    "projects": Array [
+                      Object {
+                        "hasAccess": true,
+                        "id": "testProject",
+                        "isBookmarked": false,
+                        "isMember": true,
+                        "name": "Test Project",
+                        "slug": "project-slug",
+                        "teams": Array [
+                          Object {
+                            "hasAccess": true,
+                            "id": "coolteam",
+                            "slug": "coolteam",
+                          },
+                        ],
+                      },
+                    ],
+                    "slug": "testOrg",
+                    "teams": Array [
+                      Object {
+                        "hasAccess": true,
+                        "id": "coolteam",
+                        "projects": Array [
+                          Object {
+                            "id": "testProject",
+                            "name": "Test Project",
+                            "slug": "project-slug",
+                          },
+                        ],
+                        "slug": "coolteam",
+                      },
+                    ],
                   }
                 }
-                orgId="testOrg"
                 projectId="project-slug"
                 projects={
                   Array [
@@ -296,45 +346,106 @@ exports[`Configure should render correctly render() should render platform docs 
                     },
                   ]
                 }
-                router={
-                  Object {
-                    "createHref": [MockFunction],
-                    "go": [MockFunction],
-                    "goBack": [MockFunction],
-                    "goForward": [MockFunction],
-                    "isActive": [MockFunction],
-                    "listen": [MockFunction],
-                    "location": Object {
-                      "query": Object {},
-                    },
-                    "push": [MockFunction],
-                    "replace": [MockFunction],
-                    "setRouteLeaveHook": [MockFunction],
-                  }
-                }
                 style={
                   Object {
                     "marginBottom": 30,
                   }
                 }
               >
-                <SideEffect(DocumentTitle)
-                  title="project-slug"
+                <ProjectContext
+                  api={Client {}}
+                  location={
+                    Object {
+                      "query": Object {},
+                    }
+                  }
+                  orgId="testOrg"
+                  organization={
+                    Object {
+                      "id": "1337",
+                      "projects": Array [
+                        Object {
+                          "hasAccess": true,
+                          "id": "testProject",
+                          "isBookmarked": false,
+                          "isMember": true,
+                          "name": "Test Project",
+                          "slug": "project-slug",
+                          "teams": Array [
+                            Object {
+                              "hasAccess": true,
+                              "id": "coolteam",
+                              "slug": "coolteam",
+                            },
+                          ],
+                        },
+                      ],
+                      "slug": "testOrg",
+                      "teams": Array [
+                        Object {
+                          "hasAccess": true,
+                          "id": "coolteam",
+                          "projects": Array [
+                            Object {
+                              "id": "testProject",
+                              "name": "Test Project",
+                              "slug": "project-slug",
+                            },
+                          ],
+                          "slug": "coolteam",
+                        },
+                      ],
+                    }
+                  }
+                  projectId="project-slug"
+                  projects={
+                    Array [
+                      Object {
+                        "hasAccess": true,
+                        "id": "testProject",
+                        "isBookmarked": false,
+                        "isMember": true,
+                        "name": "Test Project",
+                        "slug": "project-slug",
+                        "teams": Array [
+                          Object {
+                            "hasAccess": true,
+                            "id": "coolid",
+                            "slug": "coolteam",
+                          },
+                        ],
+                      },
+                    ]
+                  }
+                  router={
+                    Object {
+                      "createHref": [MockFunction],
+                      "go": [MockFunction],
+                      "goBack": [MockFunction],
+                      "goForward": [MockFunction],
+                      "isActive": [MockFunction],
+                      "listen": [MockFunction],
+                      "location": Object {
+                        "query": Object {},
+                      },
+                      "push": [MockFunction],
+                      "replace": [MockFunction],
+                      "setRouteLeaveHook": [MockFunction],
+                    }
+                  }
+                  style={
+                    Object {
+                      "marginBottom": 30,
+                    }
+                  }
                 >
-                  <DocumentTitle
+                  <SideEffect(DocumentTitle)
                     title="project-slug"
                   >
-                    <withApi(WithOrganizationMockWrapper)
-                      params={
-                        Object {
-                          "orgId": "testOrg",
-                          "platform": "node",
-                          "projectId": "project-slug",
-                        }
-                      }
+                    <DocumentTitle
+                      title="project-slug"
                     >
-                      <WithOrganizationMockWrapper
-                        api={Client {}}
+                      <withApi(WithOrganizationMockWrapper)
                         params={
                           Object {
                             "orgId": "testOrg",
@@ -343,45 +454,8 @@ exports[`Configure should render correctly render() should render platform docs 
                           }
                         }
                       >
-                        <withProject(ProjectInstallPlatform)
+                        <WithOrganizationMockWrapper
                           api={Client {}}
-                          organization={
-                            Object {
-                              "id": "1337",
-                              "projects": Array [
-                                Object {
-                                  "hasAccess": true,
-                                  "id": "testProject",
-                                  "isBookmarked": false,
-                                  "isMember": true,
-                                  "name": "Test Project",
-                                  "slug": "project-slug",
-                                  "teams": Array [
-                                    Object {
-                                      "hasAccess": true,
-                                      "id": "coolteam",
-                                      "slug": "coolteam",
-                                    },
-                                  ],
-                                },
-                              ],
-                              "slug": "testOrg",
-                              "teams": Array [
-                                Object {
-                                  "hasAccess": true,
-                                  "id": "coolteam",
-                                  "projects": Array [
-                                    Object {
-                                      "id": "testProject",
-                                      "name": "Test Project",
-                                      "slug": "project-slug",
-                                    },
-                                  ],
-                                  "slug": "coolteam",
-                                },
-                              ],
-                            }
-                          }
                           params={
                             Object {
                               "orgId": "testOrg",
@@ -390,7 +464,7 @@ exports[`Configure should render correctly render() should render platform docs 
                             }
                           }
                         >
-                          <ProjectInstallPlatform
+                          <withProject(ProjectInstallPlatform)
                             api={Client {}}
                             organization={
                               Object {
@@ -436,180 +510,146 @@ exports[`Configure should render correctly render() should render platform docs 
                                 "projectId": "project-slug",
                               }
                             }
-                            project={
-                              Object {
-                                "environments": Array [],
-                                "hasAccess": true,
-                                "id": "2",
-                                "isBookmarked": false,
-                                "isMember": true,
-                                "name": "Project Name",
-                                "slug": "project-slug",
-                                "teams": Array [],
-                              }
-                            }
                           >
-                            <Panel>
-                              <Component
-                                className="css-10qfvek-Panel e1laxa7d0"
-                              >
-                                <div
+                            <ProjectInstallPlatform
+                              api={Client {}}
+                              organization={
+                                Object {
+                                  "id": "1337",
+                                  "projects": Array [
+                                    Object {
+                                      "hasAccess": true,
+                                      "id": "testProject",
+                                      "isBookmarked": false,
+                                      "isMember": true,
+                                      "name": "Test Project",
+                                      "slug": "project-slug",
+                                      "teams": Array [
+                                        Object {
+                                          "hasAccess": true,
+                                          "id": "coolteam",
+                                          "slug": "coolteam",
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                  "slug": "testOrg",
+                                  "teams": Array [
+                                    Object {
+                                      "hasAccess": true,
+                                      "id": "coolteam",
+                                      "projects": Array [
+                                        Object {
+                                          "id": "testProject",
+                                          "name": "Test Project",
+                                          "slug": "project-slug",
+                                        },
+                                      ],
+                                      "slug": "coolteam",
+                                    },
+                                  ],
+                                }
+                              }
+                              params={
+                                Object {
+                                  "orgId": "testOrg",
+                                  "platform": "node",
+                                  "projectId": "project-slug",
+                                }
+                              }
+                              project={
+                                Object {
+                                  "environments": Array [],
+                                  "hasAccess": true,
+                                  "id": "2",
+                                  "isBookmarked": false,
+                                  "isMember": true,
+                                  "name": "Project Name",
+                                  "slug": "project-slug",
+                                  "teams": Array [],
+                                }
+                              }
+                            >
+                              <Panel>
+                                <Component
                                   className="css-10qfvek-Panel e1laxa7d0"
                                 >
-                                  <PanelHeader
-                                    hasButtons={true}
+                                  <div
+                                    className="css-10qfvek-Panel e1laxa7d0"
                                   >
-                                    <Component
-                                      className="css-1m2bast-PanelHeader-getPadding e1p8v8nv0"
+                                    <PanelHeader
                                       hasButtons={true}
                                     >
-                                      <Flex
-                                        align="center"
+                                      <Component
                                         className="css-1m2bast-PanelHeader-getPadding e1p8v8nv0"
-                                        justify="space-between"
+                                        hasButtons={true}
                                       >
-                                        <Base
+                                        <Flex
                                           align="center"
-                                          className="e1p8v8nv0 css-yowjp-PanelHeader-getPadding"
+                                          className="css-1m2bast-PanelHeader-getPadding e1p8v8nv0"
                                           justify="space-between"
                                         >
-                                          <div
+                                          <Base
+                                            align="center"
                                             className="e1p8v8nv0 css-yowjp-PanelHeader-getPadding"
-                                            is={null}
+                                            justify="space-between"
                                           >
-                                            Configure Node.js
-                                            <Flex>
-                                              <Base
-                                                className="css-sncxrr"
-                                              >
-                                                <div
+                                            <div
+                                              className="e1p8v8nv0 css-yowjp-PanelHeader-getPadding"
+                                              is={null}
+                                            >
+                                              Configure Node.js
+                                              <Flex>
+                                                <Base
                                                   className="css-sncxrr"
-                                                  is={null}
                                                 >
-                                                  <Box
-                                                    ml={1}
+                                                  <div
+                                                    className="css-sncxrr"
+                                                    is={null}
                                                   >
-                                                    <Base
-                                                      className="css-re0chm"
+                                                    <Box
                                                       ml={1}
                                                     >
-                                                      <div
+                                                      <Base
                                                         className="css-re0chm"
-                                                        is={null}
+                                                        ml={1}
                                                       >
-                                                        <Button
-                                                          disabled={false}
-                                                          href="/organizations/testOrg/projects/project-slug/getting-started/"
-                                                          size="small"
+                                                        <div
+                                                          className="css-re0chm"
+                                                          is={null}
                                                         >
-                                                          <StyledButton
-                                                            aria-disabled={false}
-                                                            aria-label="< Back"
+                                                          <Button
                                                             disabled={false}
                                                             href="/organizations/testOrg/projects/project-slug/getting-started/"
-                                                            onClick={[Function]}
-                                                            role="button"
                                                             size="small"
                                                           >
-                                                            <ForwardRef
+                                                            <StyledButton
                                                               aria-disabled={false}
                                                               aria-label="< Back"
-                                                              className="css-1uhlusb-StyledButton-getColors e12ma6z0"
                                                               disabled={false}
                                                               href="/organizations/testOrg/projects/project-slug/getting-started/"
                                                               onClick={[Function]}
                                                               role="button"
                                                               size="small"
                                                             >
-                                                              <a
+                                                              <ForwardRef
                                                                 aria-disabled={false}
                                                                 aria-label="< Back"
                                                                 className="css-1uhlusb-StyledButton-getColors e12ma6z0"
+                                                                disabled={false}
                                                                 href="/organizations/testOrg/projects/project-slug/getting-started/"
                                                                 onClick={[Function]}
                                                                 role="button"
                                                                 size="small"
                                                               >
-                                                                <ButtonLabel
-                                                                  size="small"
-                                                                >
-                                                                  <Component
-                                                                    className="css-7ui8bl-ButtonLabel e12ma6z1"
-                                                                    size="small"
-                                                                  >
-                                                                    <span
-                                                                      className="css-7ui8bl-ButtonLabel e12ma6z1"
-                                                                    >
-                                                                      &lt; Back
-                                                                    </span>
-                                                                  </Component>
-                                                                </ButtonLabel>
-                                                              </a>
-                                                            </ForwardRef>
-                                                          </StyledButton>
-                                                        </Button>
-                                                      </div>
-                                                    </Base>
-                                                  </Box>
-                                                  <Box
-                                                    ml={1}
-                                                  >
-                                                    <Base
-                                                      className="css-re0chm"
-                                                      ml={1}
-                                                    >
-                                                      <div
-                                                        className="css-re0chm"
-                                                        is={null}
-                                                      >
-                                                        <Button
-                                                          disabled={false}
-                                                          external={true}
-                                                          href="https://docs.getsentry.com/hosted/clients/node/"
-                                                          size="small"
-                                                        >
-                                                          <StyledButton
-                                                            aria-disabled={false}
-                                                            aria-label="Full Documentation"
-                                                            disabled={false}
-                                                            external={true}
-                                                            href="https://docs.getsentry.com/hosted/clients/node/"
-                                                            onClick={[Function]}
-                                                            role="button"
-                                                            size="small"
-                                                          >
-                                                            <ForwardRef
-                                                              aria-disabled={false}
-                                                              aria-label="Full Documentation"
-                                                              className="css-1uhlusb-StyledButton-getColors e12ma6z0"
-                                                              disabled={false}
-                                                              external={true}
-                                                              href="https://docs.getsentry.com/hosted/clients/node/"
-                                                              onClick={[Function]}
-                                                              role="button"
-                                                              size="small"
-                                                            >
-                                                              <ForwardRef
-                                                                aria-disabled={false}
-                                                                aria-label="Full Documentation"
-                                                                className="css-1uhlusb-StyledButton-getColors e12ma6z0"
-                                                                href="https://docs.getsentry.com/hosted/clients/node/"
-                                                                onClick={[Function]}
-                                                                rel="noreferrer noopener"
-                                                                role="button"
-                                                                size="small"
-                                                                target="_blank"
-                                                              >
                                                                 <a
                                                                   aria-disabled={false}
-                                                                  aria-label="Full Documentation"
+                                                                  aria-label="< Back"
                                                                   className="css-1uhlusb-StyledButton-getColors e12ma6z0"
-                                                                  href="https://docs.getsentry.com/hosted/clients/node/"
+                                                                  href="/organizations/testOrg/projects/project-slug/getting-started/"
                                                                   onClick={[Function]}
-                                                                  rel="noreferrer noopener"
                                                                   role="button"
                                                                   size="small"
-                                                                  target="_blank"
                                                                 >
                                                                   <ButtonLabel
                                                                     size="small"
@@ -621,170 +661,252 @@ exports[`Configure should render correctly render() should render platform docs 
                                                                       <span
                                                                         className="css-7ui8bl-ButtonLabel e12ma6z1"
                                                                       >
-                                                                        Full Documentation
+                                                                        &lt; Back
                                                                       </span>
                                                                     </Component>
                                                                   </ButtonLabel>
                                                                 </a>
                                                               </ForwardRef>
-                                                            </ForwardRef>
-                                                          </StyledButton>
-                                                        </Button>
-                                                      </div>
-                                                    </Base>
-                                                  </Box>
-                                                </div>
-                                              </Base>
-                                            </Flex>
-                                          </div>
-                                        </Base>
-                                      </Flex>
-                                    </Component>
-                                  </PanelHeader>
-                                  <PanelAlert
-                                    type="info"
-                                  >
-                                    <Component
-                                      className="css-e1otmf-PanelAlert e1wrupv90"
+                                                            </StyledButton>
+                                                          </Button>
+                                                        </div>
+                                                      </Base>
+                                                    </Box>
+                                                    <Box
+                                                      ml={1}
+                                                    >
+                                                      <Base
+                                                        className="css-re0chm"
+                                                        ml={1}
+                                                      >
+                                                        <div
+                                                          className="css-re0chm"
+                                                          is={null}
+                                                        >
+                                                          <Button
+                                                            disabled={false}
+                                                            external={true}
+                                                            href="https://docs.getsentry.com/hosted/clients/node/"
+                                                            size="small"
+                                                          >
+                                                            <StyledButton
+                                                              aria-disabled={false}
+                                                              aria-label="Full Documentation"
+                                                              disabled={false}
+                                                              external={true}
+                                                              href="https://docs.getsentry.com/hosted/clients/node/"
+                                                              onClick={[Function]}
+                                                              role="button"
+                                                              size="small"
+                                                            >
+                                                              <ForwardRef
+                                                                aria-disabled={false}
+                                                                aria-label="Full Documentation"
+                                                                className="css-1uhlusb-StyledButton-getColors e12ma6z0"
+                                                                disabled={false}
+                                                                external={true}
+                                                                href="https://docs.getsentry.com/hosted/clients/node/"
+                                                                onClick={[Function]}
+                                                                role="button"
+                                                                size="small"
+                                                              >
+                                                                <ForwardRef
+                                                                  aria-disabled={false}
+                                                                  aria-label="Full Documentation"
+                                                                  className="css-1uhlusb-StyledButton-getColors e12ma6z0"
+                                                                  href="https://docs.getsentry.com/hosted/clients/node/"
+                                                                  onClick={[Function]}
+                                                                  rel="noreferrer noopener"
+                                                                  role="button"
+                                                                  size="small"
+                                                                  target="_blank"
+                                                                >
+                                                                  <a
+                                                                    aria-disabled={false}
+                                                                    aria-label="Full Documentation"
+                                                                    className="css-1uhlusb-StyledButton-getColors e12ma6z0"
+                                                                    href="https://docs.getsentry.com/hosted/clients/node/"
+                                                                    onClick={[Function]}
+                                                                    rel="noreferrer noopener"
+                                                                    role="button"
+                                                                    size="small"
+                                                                    target="_blank"
+                                                                  >
+                                                                    <ButtonLabel
+                                                                      size="small"
+                                                                    >
+                                                                      <Component
+                                                                        className="css-7ui8bl-ButtonLabel e12ma6z1"
+                                                                        size="small"
+                                                                      >
+                                                                        <span
+                                                                          className="css-7ui8bl-ButtonLabel e12ma6z1"
+                                                                        >
+                                                                          Full Documentation
+                                                                        </span>
+                                                                      </Component>
+                                                                    </ButtonLabel>
+                                                                  </a>
+                                                                </ForwardRef>
+                                                              </ForwardRef>
+                                                            </StyledButton>
+                                                          </Button>
+                                                        </div>
+                                                      </Base>
+                                                    </Box>
+                                                  </div>
+                                                </Base>
+                                              </Flex>
+                                            </div>
+                                          </Base>
+                                        </Flex>
+                                      </Component>
+                                    </PanelHeader>
+                                    <PanelAlert
                                       type="info"
                                     >
-                                      <Alert
+                                      <Component
                                         className="css-e1otmf-PanelAlert e1wrupv90"
-                                        icon="icon-circle-info"
-                                        iconSize="24px"
-                                        system={true}
                                         type="info"
                                       >
-                                        <AlertWrapper
-                                          className="ref-info css-e1otmf-PanelAlert e1wrupv90"
+                                        <Alert
+                                          className="css-e1otmf-PanelAlert e1wrupv90"
+                                          icon="icon-circle-info"
+                                          iconSize="24px"
                                           system={true}
                                           type="info"
                                         >
-                                          <div
-                                            className="ref-info e1wrupv90 css-1yek4dg-AlertWrapper-alertStyles-PanelAlert e1xb5l7j1"
+                                          <AlertWrapper
+                                            className="ref-info css-e1otmf-PanelAlert e1wrupv90"
+                                            system={true}
                                             type="info"
                                           >
-                                            <StyledInlineSvg
-                                              size="24px"
-                                              src="icon-circle-info"
+                                            <div
+                                              className="ref-info e1wrupv90 css-1yek4dg-AlertWrapper-alertStyles-PanelAlert e1xb5l7j1"
+                                              type="info"
                                             >
-                                              <InlineSvg
-                                                className="css-1e3iblq-StyledInlineSvg e1xb5l7j0"
+                                              <StyledInlineSvg
                                                 size="24px"
                                                 src="icon-circle-info"
                                               >
-                                                <StyledSvg
+                                                <InlineSvg
                                                   className="css-1e3iblq-StyledInlineSvg e1xb5l7j0"
-                                                  height="24px"
-                                                  viewBox={Object {}}
-                                                  width="24px"
+                                                  size="24px"
+                                                  src="icon-circle-info"
                                                 >
-                                                  <svg
-                                                    className="e1xb5l7j0 css-lbx2sj-StyledSvg-StyledInlineSvg e2idor0"
+                                                  <StyledSvg
+                                                    className="css-1e3iblq-StyledInlineSvg e1xb5l7j0"
                                                     height="24px"
                                                     viewBox={Object {}}
                                                     width="24px"
                                                   >
-                                                    <use
-                                                      href="#test"
-                                                      xlinkHref="#test"
-                                                    />
-                                                  </svg>
-                                                </StyledSvg>
-                                              </InlineSvg>
-                                            </StyledInlineSvg>
-                                            <StyledTextBlock>
-                                              <Component
-                                                className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
-                                              >
-                                                <div
+                                                    <svg
+                                                      className="e1xb5l7j0 css-lbx2sj-StyledSvg-StyledInlineSvg e2idor0"
+                                                      height="24px"
+                                                      viewBox={Object {}}
+                                                      width="24px"
+                                                    >
+                                                      <use
+                                                        href="#test"
+                                                        xlinkHref="#test"
+                                                      />
+                                                    </svg>
+                                                  </StyledSvg>
+                                                </InlineSvg>
+                                              </StyledInlineSvg>
+                                              <StyledTextBlock>
+                                                <Component
                                                   className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
                                                 >
-                                                  <span
-                                                    key="8"
+                                                  <div
+                                                    className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
                                                   >
                                                     <span
-                                                      key="0"
-                                                    >
-                                                      
-             This is a quick getting started guide. For in-depth instructions
-             on integrating Sentry with 
-                                                    </span>
-                                                    <span
-                                                      key="2"
-                                                    >
-                                                      Node.js
-                                                    </span>
-                                                    <span
-                                                      key="3"
-                                                    >
-                                                      , view
-             
-                                                    </span>
-                                                    <a
-                                                      href="https://docs.getsentry.com/hosted/clients/node/"
-                                                      key="5"
+                                                      key="8"
                                                     >
                                                       <span
-                                                        key="4"
+                                                        key="0"
                                                       >
-                                                        our complete documentation
+                                                        
+             This is a quick getting started guide. For in-depth instructions
+             on integrating Sentry with 
                                                       </span>
-                                                    </a>
-                                                    <span
-                                                      key="6"
-                                                    >
-                                                      .
+                                                      <span
+                                                        key="2"
+                                                      >
+                                                        Node.js
+                                                      </span>
+                                                      <span
+                                                        key="3"
+                                                      >
+                                                        , view
+             
+                                                      </span>
+                                                      <a
+                                                        href="https://docs.getsentry.com/hosted/clients/node/"
+                                                        key="5"
+                                                      >
+                                                        <span
+                                                          key="4"
+                                                        >
+                                                          our complete documentation
+                                                        </span>
+                                                      </a>
+                                                      <span
+                                                        key="6"
+                                                      >
+                                                        .
             
+                                                      </span>
                                                     </span>
-                                                  </span>
-                                                </div>
-                                              </Component>
-                                            </StyledTextBlock>
-                                          </div>
-                                        </AlertWrapper>
-                                      </Alert>
-                                    </Component>
-                                  </PanelAlert>
-                                  <PanelBody
-                                    direction="column"
-                                    disablePadding={false}
-                                    flex={false}
-                                  >
-                                    <div
-                                      className="css-8qprok-padding-textStyles"
+                                                  </div>
+                                                </Component>
+                                              </StyledTextBlock>
+                                            </div>
+                                          </AlertWrapper>
+                                        </Alert>
+                                      </Component>
+                                    </PanelAlert>
+                                    <PanelBody
+                                      direction="column"
+                                      disablePadding={false}
+                                      flex={false}
                                     >
-                                      <DocumentationWrapper
-                                        dangerouslySetInnerHTML={
-                                          Object {
-                                            "__html": undefined,
-                                          }
-                                        }
+                                      <div
+                                        className="css-8qprok-padding-textStyles"
                                       >
-                                        <div
-                                          className="css-1y7l4t-DocumentationWrapper e1w9lqpk0"
+                                        <DocumentationWrapper
                                           dangerouslySetInnerHTML={
                                             Object {
                                               "__html": undefined,
                                             }
                                           }
-                                        />
-                                      </DocumentationWrapper>
-                                    </div>
-                                  </PanelBody>
-                                </div>
-                              </Component>
-                            </Panel>
-                          </ProjectInstallPlatform>
-                        </withProject(ProjectInstallPlatform)>
-                      </WithOrganizationMockWrapper>
-                    </withApi(WithOrganizationMockWrapper)>
-                  </DocumentTitle>
-                </SideEffect(DocumentTitle)>
-              </ProjectContext>
-            </withRouter(ProjectContext)>
-          </withProjects(withRouter(ProjectContext))>
-        </withApi(withProjects(withRouter(ProjectContext)))>
+                                        >
+                                          <div
+                                            className="css-1y7l4t-DocumentationWrapper e1w9lqpk0"
+                                            dangerouslySetInnerHTML={
+                                              Object {
+                                                "__html": undefined,
+                                              }
+                                            }
+                                          />
+                                        </DocumentationWrapper>
+                                      </div>
+                                    </PanelBody>
+                                  </div>
+                                </Component>
+                              </Panel>
+                            </ProjectInstallPlatform>
+                          </withProject(ProjectInstallPlatform)>
+                        </WithOrganizationMockWrapper>
+                      </withApi(WithOrganizationMockWrapper)>
+                    </DocumentTitle>
+                  </SideEffect(DocumentTitle)>
+                </ProjectContext>
+              </withRouter(ProjectContext)>
+            </withProjects(withRouter(ProjectContext))>
+          </WithOrganizationMockWrapper>
+        </withApi(WithOrganizationMockWrapper)>
         <DoneButton>
           <div
             className="css-5mss3k-DoneButton e1f5fl7e0"

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/actions.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/actions.spec.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`GroupActions render() renders correctly 1`] = `
-<GroupDetailsActions
+<WithOrganizationMockWrapper
   api={Client {}}
   group={
     Object {
@@ -70,6 +70,34 @@ exports[`GroupActions render() renders correctly 1`] = `
       "type": "error",
       "userCount": 35097,
       "userReportCount": 0,
+    }
+  }
+  organization={
+    Object {
+      "access": Array [
+        "org:read",
+        "org:write",
+        "org:admin",
+        "org:integrations",
+        "project:read",
+        "project:write",
+        "project:admin",
+        "team:read",
+        "team:write",
+        "team:admin",
+      ],
+      "features": Array [],
+      "id": "4660",
+      "name": "Organization Name",
+      "onboardingTasks": Array [],
+      "projects": Array [],
+      "scrapeJavaScript": true,
+      "slug": "org",
+      "status": Object {
+        "id": "active",
+        "name": "active",
+      },
+      "teams": Array [],
     }
   }
   project={

--- a/tests/js/spec/views/organizationGroupDetails/actions.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/actions.spec.jsx
@@ -25,15 +25,11 @@ describe('GroupActions', function() {
             name: 'project name',
             slug: 'project',
           })}
-        />,
-        {
-          context: {
-            organization: TestStubs.Organization({
-              id: '4660',
-              slug: 'org',
-            }),
-          },
-        }
+          organization={TestStubs.Organization({
+            id: '4660',
+            slug: 'org',
+          })}
+        />
       );
       expect(wrapper).toMatchSnapshot();
     });

--- a/tests/js/spec/views/projects/projectContext.spec.jsx
+++ b/tests/js/spec/views/projects/projectContext.spec.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {mount} from 'enzyme';
 
 import {ProjectContext} from 'app/views/projects/projectContext';
-import SentryTypes from 'app/sentryTypes';
 
 jest.unmock('app/utils/recreateRoute');
 jest.mock('app/actionCreators/modal', () => ({
@@ -58,10 +57,7 @@ describe('projectContext component', function() {
       />
     );
 
-    const wrapper = mount(projectContext, {
-      context: {organization: org},
-      childContextTypes: {organization: SentryTypes.Organization},
-    });
+    const wrapper = mount(projectContext);
 
     await tick();
     wrapper.update();
@@ -93,10 +89,7 @@ describe('projectContext component', function() {
       />
     );
 
-    const wrapper = mount(projectContext, {
-      context: {organization: org},
-      childContextTypes: {organization: SentryTypes.Organization},
-    });
+    const wrapper = mount(projectContext);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
@@ -141,10 +134,7 @@ describe('projectContext component', function() {
       />
     );
 
-    const wrapper = mount(projectContext, {
-      context: {organization: org},
-      childContextTypes: {organization: SentryTypes.Organization},
-    });
+    const wrapper = mount(projectContext);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
We'll want to remove the OrganizationState mixin completely in favor of
the withOrganization higher order component. This PR removes usage from
a handful of components as well as converts those components from
using `createReactClass` to ES6 style class where possible.