### PR TITLE
fix: Re-export createReactClass to window as django templates rely on this variable

### DIFF
--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -13,6 +13,7 @@ import Reflux from 'reflux';
 import * as Router from 'react-router';
 import * as Sentry from '@sentry/browser';
 import {ExtraErrorData, Tracing} from '@sentry/integrations';
+import createReactClass from 'create-react-class';
 import jQuery from 'jquery';
 import moment from 'moment';
 
@@ -114,6 +115,9 @@ const globals = {
   // makes use of it.
   $: jQuery,
   jQuery,
+
+  // django templates make use of these globals
+  createReactClass,
 };
 
 // The SentryApp global contains exported app modules for use in javascript


### PR DESCRIPTION
The `createReactClass` re-export to `window` was removed in https://github.com/getsentry/sentry/pull/13578


Django templates rely on this `createReactClass` variable. Specifically, https://github.com/getsentry/sentry/blob/c32193e29afacad21b2c776009910a67e0a4a43c/src/sentry/templates/sentry/layout.html#L72-L85

------

Some users were experiencing these errors (i.e. `createReactClass is not defined`) through this template: https://github.com/getsentry/sentry/blob/c32193e29afacad21b2c776009910a67e0a4a43c/src/sentry/templates/sentry/account/email_unsubscribe_project.html