### PR TITLE
fix(app-platform): Only build internal slug once

### DIFF
--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -5,6 +5,7 @@ import uuid
 import hmac
 import itertools
 import hashlib
+import re
 
 from django.db import models
 from django.utils import timezone
@@ -171,11 +172,14 @@ class SentryApp(ParanoidModel, HasApiScopes):
         if not self.slug:
             self.slug = slugify(self.name)
 
-        if self.is_internal:
+        if self.is_internal and not self._has_internal_slug():
             self.slug = u'{}-{}'.format(
                 self.slug,
                 hashlib.sha1(self.owner.slug).hexdigest()[0:6],
             )
+
+    def _has_internal_slug(self):
+        return re.match(r'\w+-[0-9a-zA-Z]+', self.slug)
 
     def build_signature(self, body):
         secret = self.application.client_secret

--- a/tests/sentry/models/test_sentryapp.py
+++ b/tests/sentry/models/test_sentryapp.py
@@ -35,6 +35,15 @@ class SentryAppTest(TestCase):
             hashlib.sha1(self.org.slug).hexdigest()[0:6]
         )
 
+    def test_internal_slug_on_update(self):
+        self.sentry_app.status = SentryAppStatus.INTERNAL
+        self.sentry_app.save()
+        self.sentry_app.save()
+
+        assert self.sentry_app.slug == u'nulldb-{}'.format(
+            hashlib.sha1(self.org.slug).hexdigest()[0:6]
+        )
+
     def test_paranoid(self):
         self.sentry_app.save()
         self.sentry_app.delete()


### PR DESCRIPTION
Previously, every time you saved a `SentryApp`, it'd append the Org's
hashed slug to end of the SentryApp's slug.

We only actually want to do this once, when creating the SentryApp the
first time. This change does that. cc @untitaker

FIXES SENTRY-B1A