### PR TITLE
feat(events-v2) Display the current event indicator 

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -48,7 +48,7 @@ class EventDetails extends AsyncComponent {
       let url = `/organizations/${organization.slug}/events/`;
       // latest / oldest have dedicated endpoints
       if (['latest', 'oldest'].includes(eventId)) {
-        url += 'latest/';
+        url += `${eventId}/`;
       } else {
         url += `${projectId}:${eventId}/`;
       }

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
@@ -94,7 +94,7 @@ const EventModalContent = props => {
             value: (
               <ModalLineGraph
                 organization={organization}
-                groupId={event.groupID}
+                currentEvent={event}
                 location={location}
               />
             ),


### PR DESCRIPTION
Add the line mark for the current event to the grouped event chart. The custom icon still needs to be added in a subsequent pull request.

<img width="1214" alt="Screen Shot 2019-06-12 at 6 46 07 PM" src="https://user-images.githubusercontent.com/24086/59391554-a0676780-8d42-11e9-9c6d-4c2b538cf891.png">


Refs SEN-733