### PR TITLE
ref(ui): Handle portal clicks in DropdownMenu

### DIFF
--- a/src/sentry/static/sentry/app/components/autoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/autoComplete.jsx
@@ -147,13 +147,19 @@ class AutoComplete extends React.Component {
   };
 
   // Dropdown detected click outside, we should close
-  handleClickOutside = () => {
+  handleClickOutside = async () => {
     // Otherwise, it's possible that this gets fired multiple times
     // e.g. click outside triggers closeMenu and at the same time input gets blurred, so
     // a timer is set to close the menu
     if (this.blurTimer) {
       clearTimeout(this.blurTimer);
     }
+
+    // Wait until the current macrotask completes, in the case that the click
+    // happened on a hovercard or some other element rendered outside of the
+    // autocomplete, but controlled by the existance of the autocomplete, we
+    // need to ensure any click handlers are run.
+    await new Promise(resolve => setTimeout(resolve));
 
     this.closeMenu();
   };

--- a/src/sentry/static/sentry/app/components/dropdownMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownMenu.jsx
@@ -69,7 +69,7 @@ class DropdownMenu extends React.Component {
 
   // Checks if click happens inside of dropdown menu (or its button)
   // Closes dropdownmenu if it is "outside"
-  checkClickOutside = e => {
+  checkClickOutside = async e => {
     const {onClickOutside, shouldIgnoreClickOutside} = this.props;
 
     if (!this.dropdownMenu) {
@@ -101,7 +101,13 @@ class DropdownMenu extends React.Component {
       onClickOutside(e);
     }
 
-    this.handleClose(e);
+    // Wait until the current macrotask completes, in the case that the click
+    // happened on a hovercard or some other element rendered outside of the
+    // dropdown, but controlled by the existance of the dropdown, we need to
+    // ensure any click handlers are run.
+    await new Promise(resolve => setTimeout(resolve));
+
+    this.handleClose();
   };
 
   // Callback function from <DropdownMenu> to see if we should close menu

--- a/tests/js/spec/components/autoComplete.spec.jsx
+++ b/tests/js/spec/components/autoComplete.spec.jsx
@@ -114,7 +114,7 @@ describe('AutoComplete', function() {
       expect(wrapper.find('li')).toHaveLength(3);
     });
 
-    it('only tries to close once if input is blurred and click outside occurs', function() {
+    it('only tries to close once if input is blurred and click outside occurs', async function() {
       jest.useFakeTimers();
       input.simulate('focus');
       input.simulate('blur');
@@ -122,6 +122,7 @@ describe('AutoComplete', function() {
       expect(wrapper.find('li')).toHaveLength(3);
       wrapper.find('DropdownMenu').prop('onClickOutside')();
       jest.runAllTimers();
+      await Promise.resolve();
       wrapper.update();
 
       expect(mocks.onClose).toHaveBeenCalledTimes(1);

--- a/tests/js/spec/components/dropdownLink.spec.jsx
+++ b/tests/js/spec/components/dropdownLink.spec.jsx
@@ -72,10 +72,12 @@ describe('DropdownLink', function() {
         wrapper.find('a').simulate('click');
       });
 
-      it('closes when clicked outside', function() {
+      it('closes when clicked outside', async function() {
         const evt = document.createEvent('HTMLEvents');
         evt.initEvent('click', false, true);
         document.body.dispatchEvent(evt);
+        jest.runAllTimers();
+        await Promise.resolve();
         wrapper.update();
         expect(wrapper.find('li')).toHaveLength(0);
       });

--- a/tests/js/spec/components/dropdownMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownMenu.spec.jsx
@@ -46,12 +46,14 @@ describe('DropdownMenu', function() {
     expect(wrapper.find('ul')).toHaveLength(0);
   });
 
-  it('closes dropdown when clicking outside of menu', function() {
+  it('closes dropdown when clicking outside of menu', async function() {
     wrapper.find('button').simulate('click');
     // Simulate click on document
     const evt = document.createEvent('HTMLEvents');
     evt.initEvent('click', false, true);
     document.body.dispatchEvent(evt);
+    jest.runAllTimers();
+    await Promise.resolve();
     wrapper.update();
 
     expect(wrapper.find('ul')).toHaveLength(0);


### PR DESCRIPTION
Currently, when a react portal (e.g. `Hovercard`) is clicked within a dropdown, the dropdown closes immediately before the onClick of the portal can be triggered. Adding a timeout here so the click will go through.