### PR TITLE
feat(global-header): Adds DisabledFeature to mutli selectors

### DIFF
--- a/src/sentry/static/sentry/app/components/globalSelectionHeaderRow.jsx
+++ b/src/sentry/static/sentry/app/components/globalSelectionHeaderRow.jsx
@@ -11,21 +11,31 @@ class GlobalSelectionHeaderRow extends React.Component {
     multi: PropTypes.bool,
     onCheckClick: PropTypes.func.isRequired,
     children: PropTypes.node.isRequired,
+
+    /**
+     * This is a render prop which may be used to augment the checkbox rendered
+     * to the right of the row. It will receive the default `checkbox` as a
+     * prop anlong with the `checked` boolean.
+     */
+    renderCheckbox: PropTypes.func,
   };
 
   static defaultProps = {
+    renderCheckbox: ({checkbox}) => checkbox,
     multi: true,
   };
 
   render() {
-    const {checked, onCheckClick, multi, children, ...props} = this.props;
+    const {checked, onCheckClick, multi, renderCheckbox, children, ...props} = this.props;
+
+    const checkbox = <CheckboxFancy disabled={!multi} checked={multi && checked} />;
 
     return (
       <Container isMulti={multi} isChecked={checked} {...props}>
         <Content multi={multi}>{children}</Content>
-        <CheckboxWrapper onClick={multi ? onCheckClick : null} checked={checked}>
-          <CheckboxFancy disabled={!multi} checked={multi && checked} />
-        </CheckboxWrapper>
+        <CheckboxHitbox onClick={multi ? onCheckClick : null} checked={checked}>
+          {renderCheckbox({checkbox, checked})}
+        </CheckboxHitbox>
       </Container>
     );
   }
@@ -66,7 +76,7 @@ const Content = styled('div')`
   }
 `;
 
-const CheckboxWrapper = styled('div')`
+const CheckboxHitbox = styled('div')`
   margin: 0 -${space(1)} 0 0; /* pushes the click box to be flush with the edge of the menu */
   padding: 0 ${space(1.5)} 0 ${space(1.25)};
   height: 100%;

--- a/src/sentry/static/sentry/app/components/projectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/projectSelector.jsx
@@ -13,13 +13,31 @@ import ConfigStore from 'app/stores/configStore';
 import InlineSvg from 'app/components/inlineSvg';
 import BookmarkStar from 'app/components/projects/bookmarkStar';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
+import Feature from 'app/components/acl/feature';
+import FeatureDisabled from 'app/components/acl/featureDisabled';
 import GlobalSelectionHeaderRow from 'app/components/globalSelectionHeaderRow';
 import Highlight from 'app/components/highlight';
+import Hovercard from 'app/components/hovercard';
 import IdBadge from 'app/components/idBadge';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import withProjects from 'app/utils/withProjects';
+
+const renderDisabledCheckbox = p => (
+  <Hovercard
+    body={
+      <FeatureDisabled
+        features={p.features}
+        hideHelpToggle
+        message={t('Multiple project selection disabled')}
+        featureName={t('Multiple Project Selection')}
+      />
+    }
+  >
+    {p.children}
+  </Hovercard>
+);
 
 class ProjectSelector extends React.Component {
   static propTypes = {
@@ -370,6 +388,15 @@ class ProjectSelectorItem extends React.PureComponent {
           onCheckClick={this.handleClick}
           multi={multi}
           priority="secondary"
+          renderCheckbox={({checkbox}) => (
+            <Feature
+              features={['organizations:global-views']}
+              hookName="project-selector-checkbox"
+              renderDisabled={renderDisabledCheckbox}
+            >
+              {checkbox}
+            </Feature>
+          )}
         >
           <BadgeWrapper multi={multi}>
             <IdBadge

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -60,6 +60,7 @@ const validHookNames = new Set([
   'feature-disabled:events-sidebar-item',
   'feature-disabled:discover-page',
   'feature-disabled:discover-sidebar-item',
+  'feature-disabled:project-selector-checkbox',
 ]);
 
 /**

--- a/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
@@ -52,7 +52,7 @@ describe('MultipleEnvironmentSelector', function() {
       wrapper
         .find('EnvironmentSelectorItem')
         .at(i)
-        .find('CheckboxWrapper')
+        .find('CheckboxHitbox')
         .simulate('click', {});
     });
     expect(onChange).toHaveBeenCalledTimes(3);
@@ -72,7 +72,7 @@ describe('MultipleEnvironmentSelector', function() {
 
     // Select 'production'
     await wrapper
-      .find('MultipleEnvironmentSelector AutoCompleteItem CheckboxWrapper')
+      .find('MultipleEnvironmentSelector AutoCompleteItem CheckboxHitbox')
       .at(0)
       .simulate('click');
     await wrapper.update();
@@ -90,14 +90,14 @@ describe('MultipleEnvironmentSelector', function() {
     await wrapper.find('MultipleEnvironmentSelector HeaderItem').simulate('click');
 
     await wrapper
-      .find('MultipleEnvironmentSelector AutoCompleteItem CheckboxWrapper')
+      .find('MultipleEnvironmentSelector AutoCompleteItem CheckboxHitbox')
       .at(0)
       .simulate('click');
 
     expect(onChange).toHaveBeenLastCalledWith(['production'], expect.anything());
 
     wrapper
-      .find('MultipleEnvironmentSelector AutoCompleteItem CheckboxWrapper')
+      .find('MultipleEnvironmentSelector AutoCompleteItem CheckboxHitbox')
       .at(1)
       .simulate('click');
     expect(onChange).toHaveBeenLastCalledWith(

--- a/tests/js/spec/components/projectSelector.spec.jsx
+++ b/tests/js/spec/components/projectSelector.spec.jsx
@@ -172,7 +172,7 @@ describe('ProjectSelector', function() {
 
     // Select first project
     wrapper
-      .find('CheckboxWrapper')
+      .find('CheckboxHitbox')
       .first()
       .simulate('click');
 
@@ -190,7 +190,7 @@ describe('ProjectSelector', function() {
 
     // Select first project
     wrapper
-      .find('CheckboxWrapper')
+      .find('CheckboxHitbox')
       .at(0)
       .simulate('click', {target: {checked: true}});
 
@@ -220,7 +220,7 @@ describe('ProjectSelector', function() {
 
     // second project
     wrapper
-      .find('CheckboxWrapper')
+      .find('CheckboxHitbox')
       .at(1)
       .simulate('click', {target: {checked: true}});
 
@@ -254,7 +254,7 @@ describe('ProjectSelector', function() {
 
     // Can unselect item
     wrapper
-      .find('CheckboxWrapper')
+      .find('CheckboxHitbox')
       .at(1)
       .simulate('click', {target: {checked: false}});
 

--- a/tests/js/spec/views/organizationEvents/index.spec.jsx
+++ b/tests/js/spec/views/organizationEvents/index.spec.jsx
@@ -97,7 +97,7 @@ describe('OrganizationEvents', function() {
       wrapper
         .find('EnvironmentSelectorItem')
         .at(1)
-        .find('CheckboxWrapper')
+        .find('CheckboxHitbox')
         .simulate('click');
 
       expect(wrapper.find('MultipleEnvironmentSelector').prop('value')).toEqual([
@@ -173,14 +173,14 @@ describe('OrganizationEvents', function() {
       wrapper.find('MultipleProjectSelector HeaderItem').simulate('click');
 
       wrapper
-        .find('MultipleProjectSelector AutoCompleteItem CheckboxWrapper')
+        .find('MultipleProjectSelector AutoCompleteItem CheckboxHitbox')
         .at(0)
         .simulate('click');
 
       expect(wrapper.find('MultipleProjectSelector').prop('value')).toEqual([2]);
 
       wrapper
-        .find('MultipleProjectSelector AutoCompleteItem CheckboxWrapper')
+        .find('MultipleProjectSelector AutoCompleteItem CheckboxHitbox')
         .at(1)
         .simulate('click');
 


### PR DESCRIPTION
Uses the `DisabledFeature` component to render a hovercard when the `global-veiws` feature is disabled and the project selector cannot be used to select multiple projects.

![image](https://user-images.githubusercontent.com/1421724/59392583-f9c49c00-8d2c-11e9-8cdf-0bfe90605de4.png)

