### PR TITLE
ref(app-platform): Instrument webhooks

### DIFF
--- a/src/sentry/testutils/helpers/faux.py
+++ b/src/sentry/testutils/helpers/faux.py
@@ -180,6 +180,31 @@ class Mock(object):
             setattr(self, k, v)
 
 
+class DictContaining(object):
+    def __init__(self, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], dict):
+            self.args = []
+            self.kwargs = args[0]
+        else:
+            self.args = args
+            self.kwargs = kwargs
+
+    def __eq__(self, other):
+        return self._args_match(other) and self._kwargs_match(other)
+
+    def _args_match(self, other):
+        for key in self.args:
+            if key not in other.keys():
+                return False
+        return True
+
+    def _kwargs_match(self, other):
+        for key, value in six.iteritems(self.kwargs):
+            if self.kwargs[key] != other[key]:
+                return False
+        return True
+
+
 def faux(mock, call=None):
     if call is not None:
         return Faux(mock.mock_calls[call])

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -7,12 +7,12 @@ from collections import namedtuple
 from datetime import timedelta
 from django.core.urlresolvers import reverse
 from django.utils import timezone
-from mock import patch
+from mock import patch, call
 
 from sentry.models import Rule, SentryApp, SentryAppInstallation
 from sentry.testutils import TestCase
-from sentry.testutils.helpers import with_feature
-from sentry.testutils.helpers.faux import faux
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.faux import faux, Mock, DictContaining
 from sentry.utils.http import absolute_uri
 from sentry.receivers.sentry_apps import *  # NOQA
 from sentry.utils import json
@@ -27,31 +27,6 @@ from sentry.tasks.sentry_apps import (
 )
 
 RuleFuture = namedtuple('RuleFuture', ['rule', 'kwargs'])
-
-
-class DictContaining(object):
-    def __init__(self, *args, **kwargs):
-        if len(args) == 1 and isinstance(args[0], dict):
-            self.args = []
-            self.kwargs = args[0]
-        else:
-            self.args = args
-            self.kwargs = kwargs
-
-    def __eq__(self, other):
-        return self._args_match(other) and self._kwargs_match(other)
-
-    def _args_match(self, other):
-        for key in self.args:
-            if key not in other.keys():
-                return False
-        return True
-
-    def _kwargs_match(self, other):
-        for key, value in six.iteritems(self.kwargs):
-            if self.kwargs[key] != other[key]:
-                return False
-        return True
 
 
 class TestSendAlertEvent(TestCase):
@@ -117,7 +92,7 @@ class TestSendAlertEvent(TestCase):
         with self.tasks():
             notify_sentry_app(event, [rule_future])
 
-        data = json.loads(faux(safe_urlopen).kwargs['data'])
+        data = json.loads(faux(safe_urlopen, 0).kwargs['data'])
 
         assert data == {
             'action': 'triggered',
@@ -150,7 +125,7 @@ class TestSendAlertEvent(TestCase):
             }
         }
 
-        assert faux(safe_urlopen).kwarg_equals('headers', DictContaining(
+        assert faux(safe_urlopen, 0).kwarg_equals('headers', DictContaining(
             'Content-Type',
             'Request-ID',
             'Sentry-Hook-Resource',
@@ -158,8 +133,42 @@ class TestSendAlertEvent(TestCase):
             'Sentry-Hook-Signature',
         ))
 
+    @patch('sentry.net.http.SafeSession.request')
+    @patch('sentry.utils.metrics.incr')
+    def test_records_request_metrics(self, incr, request):
+        request.return_value = Mock(status_code=200)
 
-@patch('sentry.tasks.sentry_apps.safe_urlopen')
+        group = self.create_group(project=self.project)
+        event = self.create_event(group=group)
+
+        send_alert_event(event, self.rule.label, self.sentry_app.id)
+
+        incr.assert_has_calls([
+            call(
+                'webhook.sent',
+                instance='sentry.tasks.sentry_apps.send_alert_event',
+                tags={
+                    'integration_platform': True,
+                    'event': 'event_alert.triggered',
+                    'sentry_app': self.sentry_app.slug,
+                },
+                skip_internal=False,
+            ),
+            call(
+                'webhook.delivered',
+                instance='sentry.tasks.sentry_apps.send_alert_event',
+                tags={
+                    'integration_platform': True,
+                    'event': 'event_alert.triggered',
+                    'sentry_app': self.sentry_app.slug,
+                    'status_code': 200,
+                },
+                skip_internal=False,
+            ),
+        ], any_order=True)
+
+
+@patch('sentry.net.http.SafeSession.request')
 class TestProcessResourceChange(TestCase):
     def setUp(self):
         self.project = self.create_project()
@@ -174,7 +183,7 @@ class TestProcessResourceChange(TestCase):
             slug=self.sentry_app.slug,
         )
 
-    def test_group_created_sends_webhook(self, safe_urlopen):
+    def test_group_created_sends_webhook(self, request):
         issue = self.create_group(project=self.project)
         event = self.create_event(group=issue)
 
@@ -187,22 +196,22 @@ class TestProcessResourceChange(TestCase):
                 is_new_group_environment=False,
             )
 
-        data = json.loads(faux(safe_urlopen).kwargs['data'])
+        data = json.loads(faux(request, 0).kwargs['data'])
 
         assert data['action'] == 'created'
         assert data['installation']['uuid'] == self.install.uuid
         assert data['data']['issue']['id'] == six.text_type(issue.id)
-        assert faux(safe_urlopen).kwargs_contain('headers.Content-Type')
-        assert faux(safe_urlopen).kwargs_contain('headers.Request-ID')
-        assert faux(safe_urlopen).kwargs_contain('headers.Sentry-Hook-Resource')
-        assert faux(safe_urlopen).kwargs_contain('headers.Sentry-Hook-Timestamp')
-        assert faux(safe_urlopen).kwargs_contain('headers.Sentry-Hook-Signature')
+        assert faux(request, 0).kwargs_contain('headers.Content-Type')
+        assert faux(request, 0).kwargs_contain('headers.Request-ID')
+        assert faux(request, 0).kwargs_contain('headers.Sentry-Hook-Resource')
+        assert faux(request, 0).kwargs_contain('headers.Sentry-Hook-Timestamp')
+        assert faux(request, 0).kwargs_contain('headers.Sentry-Hook-Signature')
 
-    def test_does_not_process_disallowed_event(self, safe_urlopen):
+    def test_does_not_process_disallowed_event(self, request):
         process_resource_change('delete', 'Group', self.create_group().id)
-        assert len(safe_urlopen.mock_calls) == 0
+        assert len(request.mock_calls) == 0
 
-    def test_does_not_process_sentry_apps_without_issue_webhooks(self, safe_urlopen):
+    def test_does_not_process_sentry_apps_without_issue_webhooks(self, request):
         SentryAppInstallation.objects.all().delete()
         SentryApp.objects.all().delete()
 
@@ -211,10 +220,10 @@ class TestProcessResourceChange(TestCase):
 
         process_resource_change('created', 'Group', self.create_group().id)
 
-        assert len(safe_urlopen.mock_calls) == 0
+        assert len(request.mock_calls) == 0
 
     @patch('sentry.tasks.sentry_apps._process_resource_change')
-    def test_process_resource_change_bound_passes_retry_object(self, process, safe_urlopen):
+    def test_process_resource_change_bound_passes_retry_object(self, process, request):
         group = self.create_group(project=self.project)
 
         process_resource_change_bound('created', 'Group', group.id)
@@ -223,7 +232,7 @@ class TestProcessResourceChange(TestCase):
         assert isinstance(task, Task)
 
     @with_feature('organizations:integrations-event-hooks')
-    def test_error_created_sends_webhook(self, safe_urlopen):
+    def test_error_created_sends_webhook(self, request):
         sentry_app = self.create_sentry_app(
             organization=self.project.organization,
             events=['error.created'],
@@ -254,16 +263,50 @@ class TestProcessResourceChange(TestCase):
                 is_new_group_environment=False,
             )
 
-        data = json.loads(faux(safe_urlopen).kwargs['data'])
+        data = json.loads(faux(request, 0).kwargs['data'])
 
         assert data['action'] == 'created'
         assert data['installation']['uuid'] == install.uuid
         assert data['data']['error']['event_id'] == event.event_id
-        assert faux(safe_urlopen).kwargs_contain('headers.Content-Type')
-        assert faux(safe_urlopen).kwargs_contain('headers.Request-ID')
-        assert faux(safe_urlopen).kwargs_contain('headers.Sentry-Hook-Resource')
-        assert faux(safe_urlopen).kwargs_contain('headers.Sentry-Hook-Timestamp')
-        assert faux(safe_urlopen).kwargs_contain('headers.Sentry-Hook-Signature')
+        assert faux(request, 0).kwargs_contain('headers.Content-Type')
+        assert faux(request, 0).kwargs_contain('headers.Request-ID')
+        assert faux(request, 0).kwargs_contain('headers.Sentry-Hook-Resource')
+        assert faux(request, 0).kwargs_contain('headers.Sentry-Hook-Timestamp')
+        assert faux(request, 0).kwargs_contain('headers.Sentry-Hook-Signature')
+
+    @patch('sentry.utils.metrics.incr')
+    def test_records_request_metrics(self, incr, request):
+        request.return_value = Mock(status_code=200)
+
+        process_resource_change_bound(
+            'created',
+            'Group',
+            self.create_group().id,
+        )
+
+        incr.assert_has_calls([
+            call(
+                'webhook.sent',
+                instance='sentry.tasks.sentry_apps.process_resource_change',
+                tags={
+                    'integration_platform': True,
+                    'event': 'issue.created',
+                    'sentry_app': self.sentry_app.slug,
+                },
+                skip_internal=False,
+            ),
+            call(
+                'webhook.delivered',
+                instance='sentry.tasks.sentry_apps.process_resource_change',
+                tags={
+                    'integration_platform': True,
+                    'event': 'issue.created',
+                    'sentry_app': self.sentry_app.slug,
+                    'status_code': 200,
+                },
+                skip_internal=False,
+            )
+        ], any_order=True)
 
 
 @patch('sentry.mediators.sentry_app_installations.InstallationNotifier.run')
@@ -299,7 +342,7 @@ class TestInstallationWebhook(TestCase):
         assert len(run.mock_calls) == 0
 
 
-@patch('sentry.tasks.sentry_apps.safe_urlopen')
+@patch('sentry.net.http.SafeSession.request')
 class TestWorkflowNotification(TestCase):
     def setUp(self):
         self.project = self.create_project()
@@ -317,24 +360,24 @@ class TestWorkflowNotification(TestCase):
 
         self.issue = self.create_group(project=self.project)
 
-    def test_sends_resolved_webhook(self, safe_urlopen):
+    def test_sends_resolved_webhook(self, request):
         workflow_notification(self.install.id, self.issue.id, 'resolved', self.user.id)
 
-        assert faux(safe_urlopen).kwarg_equals('url', self.sentry_app.webhook_url)
-        assert faux(safe_urlopen).kwarg_equals('data.action', 'resolved', format='json')
-        assert faux(safe_urlopen).kwarg_equals('headers.Sentry-Hook-Resource', 'issue')
-        assert faux(safe_urlopen).kwarg_equals(
+        assert faux(request, 0).kwarg_equals('url', self.sentry_app.webhook_url)
+        assert faux(request, 0).kwarg_equals('data.action', 'resolved', format='json')
+        assert faux(request, 0).kwarg_equals('headers.Sentry-Hook-Resource', 'issue')
+        assert faux(request, 0).kwarg_equals(
             'data.data.issue.id', six.binary_type(
                 self.issue.id), format='json')
 
-    def test_sends_resolved_webhook_as_Sentry_without_user(self, safe_urlopen):
+    def test_sends_resolved_webhook_as_Sentry_without_user(self, request):
         workflow_notification(self.install.id, self.issue.id, 'resolved', None)
 
-        assert faux(safe_urlopen).kwarg_equals('data.actor.type', 'application', format='json')
-        assert faux(safe_urlopen).kwarg_equals('data.actor.id', 'sentry', format='json')
-        assert faux(safe_urlopen).kwarg_equals('data.actor.name', 'Sentry', format='json')
+        assert faux(request, 0).kwarg_equals('data.actor.type', 'application', format='json')
+        assert faux(request, 0).kwarg_equals('data.actor.id', 'sentry', format='json')
+        assert faux(request, 0).kwarg_equals('data.actor.name', 'Sentry', format='json')
 
-    def test_does_not_send_if_no_service_hook_exists(self, safe_urlopen):
+    def test_does_not_send_if_no_service_hook_exists(self, request):
         sentry_app = self.create_sentry_app(
             name='Another App',
             organization=self.project.organization,
@@ -345,9 +388,9 @@ class TestWorkflowNotification(TestCase):
             slug=sentry_app.slug,
         )
         workflow_notification(install.id, self.issue.id, 'assigned', self.user.id)
-        assert not safe_urlopen.called
+        assert not request.called
 
-    def test_does_not_send_if_event_not_in_app_events(self, safe_urlopen):
+    def test_does_not_send_if_event_not_in_app_events(self, request):
         sentry_app = self.create_sentry_app(
             name='Another App',
             organization=self.project.organization,
@@ -358,4 +401,34 @@ class TestWorkflowNotification(TestCase):
             slug=sentry_app.slug,
         )
         workflow_notification(install.id, self.issue.id, 'assigned', self.user.id)
-        assert not safe_urlopen.called
+        assert not request.called
+
+    @patch('sentry.utils.metrics.incr')
+    def test_records_request_metrics(self, incr, request):
+        request.return_value = Mock(status_code=200)
+
+        workflow_notification(self.install.id, self.issue.id, 'resolved', self.user.id)
+
+        incr.assert_has_calls([
+            call(
+                'webhook.sent',
+                instance='sentry.tasks.sentry_apps.workflow_notification',
+                tags={
+                    'integration_platform': True,
+                    'event': 'issue.resolved',
+                    'sentry_app': self.sentry_app.slug,
+                },
+                skip_internal=False,
+            ),
+            call(
+                'webhook.delivered',
+                instance='sentry.tasks.sentry_apps.workflow_notification',
+                tags={
+                    'integration_platform': True,
+                    'event': 'issue.resolved',
+                    'sentry_app': self.sentry_app.slug,
+                    'status_code': 200,
+                },
+                skip_internal=False,
+            )
+        ], any_order=True)


### PR DESCRIPTION
Adds metric instrumentation to ~all Integration Platform webhooks~ requests.

### UPDATE
I changed how this is written. Now, if you pass a `metrics` key to `safe_urlopen`, specifying some info about how you want it logged, it'll collect data about the request and response for you. Without the `metrics` kwargs, it'll keep functioning as it always did.