### PR TITLE
ref(global-header): CheckboxFancy styling take two

### DIFF
--- a/src/sentry/static/sentry/app/components/checkboxFancy.jsx
+++ b/src/sentry/static/sentry/app/components/checkboxFancy.jsx
@@ -4,10 +4,9 @@ import PropTypes from 'prop-types';
 import InlineSvg from 'app/components/inlineSvg';
 
 const getDisabledStyles = p =>
-  !p.checked &&
   p.disabled &&
   css`
-    background: ${p.theme.gray1};
+    background: ${p.checked ? p.theme.gray1 : p.theme.offWhite};
     border-color: ${p.theme.gray1};
   `;
 
@@ -19,7 +18,7 @@ const getHoverStyles = p =>
 
 const CheckboxFancy = styled(({checked, disabled, ...props}) => (
   <div role="checkbox" aria-disabled={disabled} aria-checked={checked} {...props}>
-    {(checked || disabled) && <Check src="icon-checkmark-sm" />}
+    {checked && <Check src="icon-checkmark-sm" />}
   </div>
 ))`
   width: ${p => p.size};

--- a/src/sentry/static/sentry/app/components/globalSelectionHeaderRow.jsx
+++ b/src/sentry/static/sentry/app/components/globalSelectionHeaderRow.jsx
@@ -28,12 +28,12 @@ class GlobalSelectionHeaderRow extends React.Component {
   render() {
     const {checked, onCheckClick, multi, renderCheckbox, children, ...props} = this.props;
 
-    const checkbox = <CheckboxFancy disabled={!multi} checked={multi && checked} />;
+    const checkbox = <CheckboxFancy disabled={!multi} checked={checked} />;
 
     return (
-      <Container isMulti={multi} isChecked={checked} {...props}>
+      <Container isChecked={checked} {...props}>
         <Content multi={multi}>{children}</Content>
-        <CheckboxHitbox onClick={multi ? onCheckClick : null} checked={checked}>
+        <CheckboxHitbox onClick={multi ? onCheckClick : null}>
           {renderCheckbox({checkbox, checked})}
         </CheckboxHitbox>
       </Container>
@@ -53,7 +53,7 @@ const Container = styled('div')`
 
   /* stylelint-disable-next-line no-duplicate-selectors */
   ${CheckboxFancy} {
-    opacity: ${p => (p.isMulti && p.isChecked ? 1 : 0.33)};
+    opacity: ${p => (p.isChecked ? 1 : 0.33)};
   }
 
   &:hover ${CheckboxFancy} {


### PR DESCRIPTION
Gives the disabled checkboxes a better look and feel to differentiate checked and unchecked read only checkboxes.

![image](https://user-images.githubusercontent.com/1421724/59394616-28467500-8d35-11e9-8c9d-89f585a49db2.png)
