### PR TITLE
fix(environments): Fix project environment data not being loaded

### DIFF
--- a/src/sentry/static/sentry/app/utils/environment.jsx
+++ b/src/sentry/static/sentry/app/utils/environment.jsx
@@ -1,0 +1,12 @@
+import {toTitleCase} from 'app/utils';
+
+const DEFAULT_EMPTY_ROUTING_NAME = 'none';
+const DEFAULT_EMPTY_ENV_NAME = '(No Environment)';
+
+export function getUrlRoutingName(env) {
+  return encodeURIComponent(env.name) || DEFAULT_EMPTY_ROUTING_NAME;
+}
+
+export function getDisplayName(env) {
+  return toTitleCase(env.name) || DEFAULT_EMPTY_ENV_NAME;
+}

--- a/src/sentry/static/sentry/app/views/settings/project/projectEnvironments.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectEnvironments.jsx
@@ -20,8 +20,7 @@ import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import recreateRoute from 'app/utils/recreateRoute';
 import space from 'app/styles/space';
-
-const DEFAULT_EMPTY_ROUTING_NAME = 'none';
+import {getUrlRoutingName, getDisplayName} from 'app/utils/environment';
 
 const ProjectEnvironments = createReactClass({
   propTypes: {
@@ -93,14 +92,14 @@ const ProjectEnvironments = createReactClass({
         success: e => {
           addSuccessMessage(
             tct('Updated [environment]', {
-              environment: env.displayName,
+              environment: getDisplayName(env),
             })
           );
         },
         error: err => {
           addErrorMessage(
             tct('Unable to update [environment]', {
-              environment: env.displayName,
+              environment: getDisplayName(env),
             })
           );
         },
@@ -123,7 +122,7 @@ const ProjectEnvironments = createReactClass({
    * - "No Environment"
    *
    */
-  renderSystemRows() {
+  renderAllEnvironmentsSystemRow() {
     // Not available in "Hidden" tab
     const isHidden = this.props.location.pathname.endsWith('hidden/');
     if (isHidden) {
@@ -134,7 +133,6 @@ const ProjectEnvironments = createReactClass({
         name={ALL_ENVIRONMENTS_KEY}
         environment={{
           id: ALL_ENVIRONMENTS_KEY,
-          displayName: t('All Environments'),
           name: ALL_ENVIRONMENTS_KEY,
         }}
         isSystemRow
@@ -148,7 +146,7 @@ const ProjectEnvironments = createReactClass({
 
     return (
       <React.Fragment>
-        {this.renderSystemRows()}
+        {this.renderAllEnvironmentsSystemRow()}
         {envs.map(env => {
           return (
             <EnvironmentRow
@@ -229,7 +227,7 @@ class EnvironmentRow extends React.Component {
     return (
       <PanelItem align="center" justify="space-between">
         <Flex align="center">
-          {isSystemRow ? environment.displayName : environment.name}
+          {isSystemRow ? t('All Environments') : environment.name}
         </Flex>
         <Access access={['project:write']}>
           {({hasAccess}) => (
@@ -256,7 +254,3 @@ const EnvironmentButton = styled(Button)`
 
 export {ProjectEnvironments};
 export default withApi(ProjectEnvironments);
-
-function getUrlRoutingName(env) {
-  return encodeURIComponent(env.name) || DEFAULT_EMPTY_ROUTING_NAME;
-}

--- a/src/sentry/static/sentry/app/views/settings/project/projectEnvironments.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectEnvironments.jsx
@@ -54,7 +54,9 @@ const ProjectEnvironments = createReactClass({
   fetchData() {
     const isHidden = this.props.location.pathname.endsWith('hidden/');
 
-    this.setState({isLoading: true});
+    if (!this.state.isLoading) {
+      this.setState({isLoading: true});
+    }
 
     const {orgId, projectId} = this.props.params;
     this.props.api.request(`/projects/${orgId}/${projectId}/environments/`, {

--- a/tests/js/spec/views/settings/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -1167,10 +1167,9 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                 actionText="Show"
                 environment={
                   Object {
-                    "displayName": "Zzz",
                     "id": "1",
+                    "isHidden": true,
                     "name": "zzz",
-                    "urlRoutingName": "zzz",
                   }
                 }
                 isHidden={true}

--- a/tests/js/spec/views/settings/projectEnvironments.spec.jsx
+++ b/tests/js/spec/views/settings/projectEnvironments.spec.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {mount} from 'enzyme';
 
-import EnvironmentStore from 'app/stores/environmentStore';
 import ProjectEnvironments from 'app/views/settings/project/projectEnvironments';
 import recreateRoute from 'app/utils/recreateRoute';
 import {ALL_ENVIRONMENTS_KEY} from 'app/constants';
@@ -45,7 +44,11 @@ describe('ProjectEnvironments', function() {
 
   describe('render active', function() {
     it('renders empty message', function() {
-      EnvironmentStore.loadInitialData([]);
+      MockApiClient.addMockResponse({
+        url: '/projects/org-slug/project-slug/environments/',
+        body: [],
+      });
+
       const wrapper = mountComponent(false);
       const errorMessage = wrapper.find('div').first();
 
@@ -54,7 +57,10 @@ describe('ProjectEnvironments', function() {
     });
 
     it('renders environment list', async function() {
-      EnvironmentStore.loadInitialData(TestStubs.Environments(false));
+      MockApiClient.addMockResponse({
+        url: '/projects/org-slug/project-slug/environments/',
+        body: TestStubs.Environments(false),
+      });
       const wrapper = mountComponent(false);
 
       const productionRow = wrapper.find('EnvironmentRow[name="production"]');
@@ -65,7 +71,10 @@ describe('ProjectEnvironments', function() {
 
   describe('render hidden', function() {
     it('renders empty message', function() {
-      EnvironmentStore.loadHiddenData([]);
+      MockApiClient.addMockResponse({
+        url: '/projects/org-slug/project-slug/environments/',
+        body: [],
+      });
 
       const wrapper = mountComponent(true);
       const errorMessage = wrapper.find('div').first();
@@ -76,7 +85,10 @@ describe('ProjectEnvironments', function() {
     });
 
     it('renders environment list', function() {
-      EnvironmentStore.loadHiddenData(TestStubs.Environments(true));
+      MockApiClient.addMockResponse({
+        url: '/projects/org-slug/project-slug/environments/',
+        body: TestStubs.Environments(true),
+      });
       const wrapper = mountComponent(true);
 
       // Hidden buttons should not have "Set as default"
@@ -103,7 +115,11 @@ describe('ProjectEnvironments', function() {
       });
     });
     it('hides', function() {
-      EnvironmentStore.loadInitialData(TestStubs.Environments(false));
+      MockApiClient.addMockResponse({
+        url: baseUrl,
+        body: TestStubs.Environments(false),
+      });
+
       const wrapper = mountComponent(false);
       wrapper.find('EnvironmentRow[name="production"] Button').simulate('click');
       expect(hideMock).toHaveBeenCalledWith(
@@ -115,15 +131,18 @@ describe('ProjectEnvironments', function() {
     });
 
     it('hides names requiring encoding', function() {
+      MockApiClient.addMockResponse({
+        url: baseUrl,
+        body: [{id: '1', name: '%app_env%', isHidden: false}],
+      });
+
       hideMock = MockApiClient.addMockResponse({
         url: `${baseUrl}%25app_env%25/`,
         method: 'PUT',
       });
 
-      const environments = [{id: '1', name: '%app_env%', isHidden: false}];
-      EnvironmentStore.loadInitialData(environments);
-
       const wrapper = mountComponent(false);
+
       wrapper
         .find('EnvironmentRow[name="%app_env%"] button[aria-label="Hide"]')
         .simulate('click');
@@ -136,7 +155,11 @@ describe('ProjectEnvironments', function() {
     });
 
     it('shows', function() {
-      EnvironmentStore.loadHiddenData(TestStubs.Environments(true));
+      MockApiClient.addMockResponse({
+        url: baseUrl,
+        body: TestStubs.Environments(true),
+      });
+
       const wrapper = mountComponent(true);
       wrapper.find('EnvironmentRow[name="zzz"] Button').simulate('click');
       expect(showMock).toHaveBeenCalledWith(
@@ -148,7 +171,11 @@ describe('ProjectEnvironments', function() {
     });
 
     it('does not have "All Enviroments" rows', function() {
-      EnvironmentStore.loadHiddenData(TestStubs.Environments(true));
+      MockApiClient.addMockResponse({
+        url: baseUrl,
+        body: TestStubs.Environments(true),
+      });
+
       const wrapper = mountComponent(true);
       expect(wrapper.find(`EnvironmentRow[name="${ALL_ENVIRONMENTS_KEY}"]`)).toHaveLength(
         0


### PR DESCRIPTION
The project environments component is now disconnected from the
EnvironmentStore. Since we no longer need to load environments when we
bootstrap the app, this component is now responsible for fetching its
own data. This PR fixes a bug that caused the environment list to
sometimes display as empty.