### PR TITLE
feat(api): Add analytics tracking for incidents (SEN-567)

### DIFF
--- a/src/sentry/incidents/__init__.py
+++ b/src/sentry/incidents/__init__.py
@@ -1,1 +1,2 @@
 from __future__ import absolute_import
+from . import events  # NOQA

--- a/src/sentry/incidents/events.py
+++ b/src/sentry/incidents/events.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class BaseIncidentEvent(analytics.Event):
+    attributes = (
+        analytics.Attribute('incident_id'),
+        analytics.Attribute('organization_id'),
+        analytics.Attribute('incident_type'),
+    )
+
+
+class IncidentCreatedEvent(BaseIncidentEvent):
+    type = 'incident.created'
+
+
+class IncidentStatusUpdatedEvent(BaseIncidentEvent):
+    type = 'incident.status_change'
+    attributes = BaseIncidentEvent.attributes + (
+        analytics.Attribute('prev_status'),
+        analytics.Attribute('status'),
+    )
+
+
+class IncidentCommentCreatedEvent(BaseIncidentEvent):
+    type = 'incident.comment'
+    attributes = BaseIncidentEvent.attributes + (
+        analytics.Attribute('user_id', required=False),
+        analytics.Attribute('activity_id', required=False),
+    )
+
+
+analytics.register(IncidentCreatedEvent)
+analytics.register(IncidentStatusUpdatedEvent)
+analytics.register(IncidentCommentCreatedEvent)

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
+from six.moves.urllib.parse import urlencode
 
 from sentry.auth.access import from_user
 from sentry.incidents.models import (
@@ -86,7 +87,7 @@ def build_activity_context(activity, user):
                 'organization_slug': incident.organization.slug,
                 'incident_id': incident.identifier,
             },
-        )),
+        )) + '?' + urlencode({'referrer': 'incident_activity_email'}),
         'comment': activity.comment,
         'unsubscribe_link': generate_signed_link(
             user,

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -113,7 +113,7 @@ class TestBuildActivityContext(BaseIncidentActivityTest, TestCase):
                 'organization_slug': incident.organization.slug,
                 'incident_id': incident.identifier,
             },
-        ))
+        )) + '?referrer=incident_activity_email'
         assert context['comment'] == expected_comment
         assert context['unsubscribe_link'] == generate_signed_link(
             expected_recipient,


### PR DESCRIPTION
This adds tracking to:
Incident creation
Incident status changes
Incident comments

Also adds `referrer=incident_activity_email` to the incident link in activity emails for clicktracking purposes.