### PR TITLE
fix(ui) Add spacing between button groups in crash header

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/crashHeader.jsx
@@ -1,14 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
 
-const CrashHeader = createReactClass({
-  displayName: 'CrashHeader',
-
-  propTypes: {
+class CrashHeader extends React.Component {
+  static propTypes = {
     title: PropTypes.string,
     beforeTitle: PropTypes.any,
     platform: PropTypes.string,
@@ -19,7 +16,7 @@ const CrashHeader = createReactClass({
     newestFirst: PropTypes.bool.isRequired,
     stackType: PropTypes.string, // 'original', 'minified', or falsy (none)
     onChange: PropTypes.func,
-  },
+  };
 
   hasSystemFrames() {
     const {stacktrace, thread, exception} = this.props;
@@ -29,7 +26,7 @@ const CrashHeader = createReactClass({
       (exception &&
         exception.values.find(x => !!(x.stacktrace && x.stacktrace.hasSystemFrames)))
     );
-  },
+  }
 
   hasMinified() {
     if (!this.props.stackType) {
@@ -40,7 +37,7 @@ const CrashHeader = createReactClass({
       (exception && !!exception.values.find(x => x.rawStacktrace)) ||
       (thread && !!thread.rawStacktrace)
     );
-  },
+  }
 
   getOriginalButtonLabel() {
     if (this.props.platform === 'javascript' || this.props.platform === 'node') {
@@ -48,7 +45,7 @@ const CrashHeader = createReactClass({
     } else {
       return t('Symbolicated');
     }
-  },
+  }
 
   getMinifiedButtonLabel() {
     if (this.props.platform === 'javascript' || this.props.platform === 'node') {
@@ -56,31 +53,31 @@ const CrashHeader = createReactClass({
     } else {
       return t('Unsymbolicated');
     }
-  },
+  }
 
-  toggleOrder() {
+  handleToggleOrder = () => {
     this.notify({
       newestFirst: !this.props.newestFirst,
     });
-  },
+  };
 
   setStackType(type) {
     this.notify({
       stackType: type,
     });
-  },
+  }
 
   setStackView(view) {
     this.notify({
       stackView: view,
     });
-  },
+  }
 
   notify(obj) {
     if (this.props.onChange) {
       this.props.onChange(obj);
     }
-  },
+  }
 
   render() {
     const {stackView, stackType, newestFirst} = this.props;
@@ -94,7 +91,10 @@ const CrashHeader = createReactClass({
           <small style={{marginLeft: 5}}>
             (
             <Tooltip title={t('Toggle stacktrace order')}>
-              <a onClick={this.toggleOrder} style={{borderBottom: '1px dotted #aaa'}}>
+              <a
+                onClick={this.handleToggleOrder}
+                style={{borderBottom: '1px dotted #aaa'}}
+              >
                 {newestFirst ? t('most recent call first') : t('most recent call last')}
               </a>
             </Tooltip>
@@ -107,20 +107,20 @@ const CrashHeader = createReactClass({
               className={
                 (stackView === 'app' ? 'active' : '') + ' btn btn-default btn-sm'
               }
-              onClick={this.setStackView.bind(this, 'app')}
+              onClick={() => this.setStackView('app')}
             >
               {t('App Only')}
             </a>
           )}
           <a
             className={(stackView === 'full' ? 'active' : '') + ' btn btn-default btn-sm'}
-            onClick={this.setStackView.bind(this, 'full')}
+            onClick={() => this.setStackView('full')}
           >
             {t('Full')}
           </a>
           <a
             className={(stackView === 'raw' ? 'active' : '') + ' btn btn-default btn-sm'}
-            onClick={this.setStackView.bind(this, 'raw')}
+            onClick={() => this.setStackView('raw')}
           >
             {t('Raw')}
           </a>
@@ -149,7 +149,7 @@ const CrashHeader = createReactClass({
         </div>
       </div>
     );
-  },
-});
+  }
+}
 
 export default CrashHeader;

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1088,6 +1088,7 @@ ul.faces {
     .btn-group {
       float: right;
       position: relative;
+      margin-bottom: 8px;
     }
 
     .nav-tabs {


### PR DESCRIPTION
Without this space the buttons are vertically adjacent and look bad.

### Before
![Screen Shot 2019-06-14 at 11 38 58 AM](https://user-images.githubusercontent.com/24086/59520921-0d8d1100-8e99-11e9-9c53-da85cd08d494.png)

### After
![Screen Shot 2019-06-14 at 11 38 39 AM](https://user-images.githubusercontent.com/24086/59520935-154cb580-8e99-11e9-9dd3-7cf7b0af5125.png)
