### PR TITLE
feat(ui): Do not load Global Selection values from local storage in Issue Details

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -208,7 +208,7 @@ class GlobalSelectionHeader extends React.Component {
     }
 
     // Update if `forceUrlSync` changes
-    if (this.props.forceUrlSync !== nextProps.forceUrlSync && !this.props.forceUrlSync) {
+    if (!this.props.forceUrlSync && nextProps.forceUrlSync) {
       return true;
     }
 
@@ -223,7 +223,7 @@ class GlobalSelectionHeader extends React.Component {
     }
 
     // Kind of gross
-    if (forceUrlSync !== prevProps.forceUrlSync && !prevProps.forceUrlSync) {
+    if (forceUrlSync && !prevProps.forceUrlSync) {
       const {project, environment} = getStateFromQuery(location.query);
 
       if (
@@ -250,10 +250,9 @@ class GlobalSelectionHeader extends React.Component {
   };
 
   /**
-   * Identifies if query string has changed (with query params that this component cares about)
+   * Identifies the query params (that are relevant to this component) that have changed
    *
-   *
-   * @return {String[]} Returns `false` if did not change, otherwise return an array of params that have changed
+   * @return {String[]} Returns an array of param keys that have changed
    */
   changedQueryKeys = (prevProps, nextProps) => {
     const urlParamKeys = Object.values(URL_PARAM);

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -954,6 +954,8 @@ function routes() {
             }
             component={errorHandler(LazyLoad)}
           >
+            {/* XXX: if we change the path for group details, we *must* update `OrganizationContext`.
+            There is behavior that depends on this path and unfortunately no great way to test for this contract */}
             <IndexRoute
               componentPromise={() =>
                 import(/* webpackChunkName: "OrganizationGroupEventDetails" */ './views/organizationGroupDetails/groupEventDetails')

--- a/src/sentry/static/sentry/app/utils/withGlobalSelection.jsx
+++ b/src/sentry/static/sentry/app/utils/withGlobalSelection.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 
-import getDisplayName from 'app/utils/getDisplayName';
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';
+import getDisplayName from 'app/utils/getDisplayName';
 
 /**
  * Higher order component that uses GlobalSelectionStore and provides the
@@ -19,13 +19,33 @@ const withGlobalSelection = WrappedComponent =>
       };
     },
 
-    onUpdate() {
-      this.setState({
-        selection: GlobalSelectionStore.get(),
-      });
+    componentDidMount() {
+      this.updateSelection();
     },
+
+    onUpdate() {
+      this.updateSelection();
+    },
+
+    updateSelection() {
+      const selection = GlobalSelectionStore.get();
+
+      if (this.state.selection !== selection) {
+        this.setState({
+          selection,
+        });
+      }
+    },
+
     render() {
-      return <WrappedComponent selection={this.state.selection} {...this.props} />;
+      const {forceUrlSync, ...selection} = this.state.selection;
+      return (
+        <WrappedComponent
+          forceUrlSync={forceUrlSync}
+          selection={selection}
+          {...this.props}
+        />
+      );
     },
   });
 

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -34,6 +34,7 @@ const OrganizationContext = createReactClass({
 
   propTypes: {
     api: PropTypes.object,
+    routes: PropTypes.arrayOf(PropTypes.object),
     includeSidebar: PropTypes.bool,
     useLastOrganization: PropTypes.bool,
     organizationsLoading: PropTypes.bool,
@@ -136,7 +137,17 @@ const OrganizationContext = createReactClass({
 
         TeamStore.loadInitialData(data.teams);
         ProjectsStore.loadInitialData(data.projects);
-        GlobalSelectionStore.loadInitialData(data, this.props.location.query);
+
+        // Make an exception for issue details in the case where it is accessed directly (e.g. from email)
+        // We do not want to load the user's last used env/project in this case, otherwise will
+        // lead to very confusing behavior.
+        if (
+          !this.props.routes.find(
+            ({path}) => path && path.includes('/organizations/:orgId/issues/:groupId/')
+          )
+        ) {
+          GlobalSelectionStore.loadInitialData(data, this.props.location.query);
+        }
         OrganizationEnvironmentsStore.loadInitialData(environments);
 
         this.setState({

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/index.jsx
@@ -21,14 +21,13 @@ class OrganizationGroupDetails extends React.Component {
   }
 
   render() {
-    // eslint-disable-next-line no-unused-vars
     const {selection, ...props} = this.props;
 
     return (
       <GroupDetails
         environments={selection.environments}
-        enableSnuba={true}
-        showGlobalHeader={true}
+        enableSnuba
+        showGlobalHeader
         {...props}
       />
     );

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -30,6 +30,7 @@ describe('OrganizationContext', function() {
         api={new MockApiClient()}
         params={{orgId: 'org-slug'}}
         location={{query: {}}}
+        routes={[]}
         {...props}
       >
         <div />
@@ -55,6 +56,7 @@ describe('OrganizationContext', function() {
     TeamStore.loadInitialData.mockRestore();
     ProjectsStore.loadInitialData.mockRestore();
     ConfigStore.get.mockRestore();
+    GlobalSelectionStore.loadInitialData.mockRestore();
   });
 
   it('renders and fetches org', async function() {
@@ -219,5 +221,18 @@ describe('OrganizationContext', function() {
     });
 
     expect(getOrgMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call `GlobalSelectionStore.loadInitialData` on group details route', async function() {
+    wrapper = createWrapper({
+      routes: [{path: '/organizations/:orgId/issues/:groupId/'}],
+    });
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.state('loading')).toBe(false);
+    expect(wrapper.state('error')).toBe(false);
+
+    expect(GlobalSelectionStore.loadInitialData).not.toHaveBeenCalled();
   });
 });

--- a/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
@@ -30,7 +30,7 @@ describe('OrganizationDetails', function() {
           }),
         });
         const tree = mount(
-          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} />,
+          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />,
           TestStubs.routerContext()
         );
         await tick();
@@ -56,7 +56,7 @@ describe('OrganizationDetails', function() {
           }),
         });
         const tree = mount(
-          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} />,
+          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />,
           TestStubs.routerContext()
         );
         await tick();
@@ -88,7 +88,7 @@ describe('OrganizationDetails', function() {
 
       it('should render a deletion in progress prompt', async function() {
         const tree = mount(
-          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} />
+          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />
         );
         await tick();
         await tick();


### PR DESCRIPTION
This is for the case where an Issue is accessed from a direct URL.
Previously it would load the last accessed project/env from local storage.
This is not desired behavior when accessing an Issue directly. This will
look for a route to Issue details and avoid loading the store.

However we also want to initialize the store if we leave the issue details
page. Otherwise (this is exacerbated in the single project case), you could
have last accessed project `Foo`, open url to issue in `Bar`, and then
navigating from Issue to Issues list could result in a project that is
neither `Foo` nor `Bar`.

Fixes SEN-709
Fixes SEN-658