### PR TITLE
fix(gitlab) When gitlab requests fail respond with a 400

### DIFF
--- a/tests/sentry/integrations/gitlab/test_search.py
+++ b/tests/sentry/integrations/gitlab/test_search.py
@@ -255,7 +255,7 @@ class GitlabSearchTest(GitLabTestCase):
                 'project': '5',
             }
         )
-        assert resp.status_code == 503
+        assert resp.status_code == 400
 
     def test_projects_request_fails(self):
         responses.add(
@@ -269,4 +269,4 @@ class GitlabSearchTest(GitLabTestCase):
                 'query': 'GetSentry',
             }
         )
-        assert resp.status_code == 503
+        assert resp.status_code == 400


### PR DESCRIPTION
Don't fail and create sentry issues when GitLab instances cannot be reached, timeout or otherwise behave poorly.

Fixes SENTRY-B2C