### PR TITLE
fix(events-v2): Add error/csp conditions to tabs

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -40,6 +40,7 @@ export const ALL_VIEWS = deepFreeze([
       fields: ['error', 'event_count', 'user_count', 'project', 'last_seen'],
       groupby: ['issue.id', 'project.id'],
       orderby: ['-last_seen', '-issue.id'],
+      query: 'event.type:error',
     },
     tags: ['error.type', 'project.name'],
   },
@@ -50,6 +51,7 @@ export const ALL_VIEWS = deepFreeze([
       fields: ['csp', 'event_count', 'user_count', 'project', 'last_seen'],
       groupby: ['issue.id', 'project.id'],
       orderby: ['-last_seen', '-issue.id'],
+      query: 'event.type:csp',
     },
     tags: [
       'project.name',

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
@@ -55,6 +55,14 @@ export function getQuery(view, location) {
   data.groupby = groupby;
   data.orderby = view.data.orderby;
   data.per_page = DEFAULT_PER_PAGE;
+
+  if (view.data.query) {
+    if (data.query) {
+      data.query = `${data.query} ${view.data.query}`;
+    } else {
+      data.query = view.data.query;
+    }
+  }
   return data;
 }
 

--- a/tests/js/spec/views/organizationEventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/utils.spec.jsx
@@ -40,6 +40,18 @@ describe('getQuery()', function() {
       'issue.id',
     ]);
   });
+
+  it('appends any additional conditions defined for view', function() {
+    const view = {
+      id: 'test',
+      name: 'test view',
+      data: {fields: ['id'], query: 'event.type:csp'},
+      tags: [],
+    };
+
+    expect(getQuery(view, {}).query).toEqual('event.type:csp');
+    expect(getQuery(view, {query: {query: 'test'}}).query).toEqual('test event.type:csp');
+  });
 });
 
 describe('eventTagSearchUrl()', function() {


### PR DESCRIPTION
This adds the error/csp filtering to those tabs. Previously the data on
these two tabs was exactly the same.