### PR TITLE
feat(ui): Fix layout issues with long release names in Releases List

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationReleases/list/layout.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/list/layout.jsx
@@ -16,21 +16,21 @@ const Layout = styled('div')`
   }
 `;
 
-const ReleaseName = styled('div')`
+const VersionColumn = styled('div')`
   grid-area: release-name;
   overflow: hidden;
 `;
-const Stats = styled('div')`
+const StatsColumn = styled('div')`
   grid-area: stats;
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     display: none;
   }
 `;
-const NewCount = styled('div')`
+const CountColumn = styled('div')`
   grid-area: new-count;
 `;
-const LastEvent = styled('div')`
+const LastEventColumn = styled('div')`
   grid-area: last-event;
 `;
-export {Layout, ReleaseName, Stats, NewCount, LastEvent};
+export {Layout, VersionColumn, StatsColumn, CountColumn, LastEventColumn};

--- a/src/sentry/static/sentry/app/views/organizationReleases/list/layout.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/list/layout.jsx
@@ -4,14 +4,14 @@ import space from 'app/styles/space';
 
 const Layout = styled('div')`
   display: grid;
-  grid-template-columns: 4fr 1fr 1fr 1fr;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
   grid-column-gap: ${space(1.5)};
   width: 100%;
   align-items: center;
   grid-template-areas: 'release-name stats new-count last-event';
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    grid-template-columns: 4fr 1fr 1fr;
+    grid-template-columns: 3fr 1fr 1fr;
     grid-template-areas: 'release-name new-count last-event';
   }
 `;

--- a/src/sentry/static/sentry/app/views/organizationReleases/list/layout.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/list/layout.jsx
@@ -1,0 +1,36 @@
+import styled from 'react-emotion';
+
+import space from 'app/styles/space';
+
+const Layout = styled('div')`
+  display: grid;
+  grid-template-columns: 4fr 1fr 1fr 1fr;
+  grid-column-gap: ${space(1.5)};
+  width: 100%;
+  align-items: center;
+  grid-template-areas: 'release-name stats new-count last-event';
+
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: 4fr 1fr 1fr;
+    grid-template-areas: 'release-name new-count last-event';
+  }
+`;
+
+const ReleaseName = styled('div')`
+  grid-area: release-name;
+  overflow: hidden;
+`;
+const Stats = styled('div')`
+  grid-area: stats;
+
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    display: none;
+  }
+`;
+const NewCount = styled('div')`
+  grid-area: new-count;
+`;
+const LastEvent = styled('div')`
+  grid-area: last-event;
+`;
+export {Layout, ReleaseName, Stats, NewCount, LastEvent};

--- a/src/sentry/static/sentry/app/views/organizationReleases/list/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/list/releaseList.jsx
@@ -65,7 +65,7 @@ export default ReleaseList;
 
 const ReleasePanelItem = styled(PanelItem)`
   align-items: center;
-  padding: ${space(2)} ${space(1)};
+  padding: ${space(1)} ${space(2)};
 `;
 
 const VersionWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/views/organizationReleases/list/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/list/releaseList.jsx
@@ -1,13 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Box} from 'grid-emotion';
+import styled from 'react-emotion';
 
 import {PanelItem} from 'app/components/panels';
-import ReleaseStats from 'app/components/releaseStats';
 import Count from 'app/components/count';
+import ReleaseStats from 'app/components/releaseStats';
 import TimeSince from 'app/components/timeSince';
 import Version from 'app/components/version';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
+import space from 'app/styles/space';
 
+import {LastEvent, Layout, NewCount, ReleaseName, Stats} from './layout';
 import LatestDeployOrReleaseTime from './latestDeployOrReleaseTime';
 
 class ReleaseList extends React.Component {
@@ -24,33 +27,33 @@ class ReleaseList extends React.Component {
       <div>
         {this.props.releaseList.map(release => {
           return (
-            <PanelItem key={release.version} align="center" px={2} py={1}>
-              <Box flex="1">
-                <div>
-                  <div style={{fontWeight: 'bold', marginBottom: 2}}>
+            <ReleasePanelItem key={release.version}>
+              <Layout>
+                <ReleaseName>
+                  <VersionWrapper>
                     <Version
                       orgId={orgId}
                       projectId={projectId}
                       version={release.version}
                     />
-                  </div>
+                  </VersionWrapper>
                   <LatestDeployOrReleaseTime orgId={orgId} release={release} />
-                </div>
-              </Box>
-              <Box w={4 / 12} pl={2} className="hidden-xs">
-                <ReleaseStats release={release} />
-              </Box>
-              <Box w={2 / 12} pl={2}>
-                <Count className="release-count" value={release.newGroups || 0} />
-              </Box>
-              <Box w={2 / 12} pl={2}>
-                {release.lastEvent ? (
-                  <TimeSince date={release.lastEvent} style={{fontSize: 13}} />
-                ) : (
-                  <span>—</span>
-                )}
-              </Box>
-            </PanelItem>
+                </ReleaseName>
+                <Stats>
+                  <ReleaseStats release={release} />
+                </Stats>
+                <NewCount>
+                  <Count className="release-count" value={release.newGroups || 0} />
+                </NewCount>
+                <LastEvent>
+                  {release.lastEvent ? (
+                    <SmallTimeSince date={release.lastEvent} />
+                  ) : (
+                    <span>—</span>
+                  )}
+                </LastEvent>
+              </Layout>
+            </ReleasePanelItem>
           );
         })}
       </div>
@@ -59,3 +62,18 @@ class ReleaseList extends React.Component {
 }
 
 export default ReleaseList;
+
+const ReleasePanelItem = styled(PanelItem)`
+  align-items: center;
+  padding: ${space(2)} ${space(1)};
+`;
+
+const VersionWrapper = styled('div')`
+  font-weight: bold;
+  margin-bottom: ${space(0.25)};
+  ${overflowEllipsis};
+`;
+
+const SmallTimeSince = styled(TimeSince)`
+  font-size: ${p => p.theme.fontSizeSmall};
+`;

--- a/src/sentry/static/sentry/app/views/organizationReleases/list/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/list/releaseList.jsx
@@ -10,7 +10,7 @@ import Version from 'app/components/version';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 
-import {LastEvent, Layout, NewCount, ReleaseName, Stats} from './layout';
+import {LastEventColumn, Layout, CountColumn, VersionColumn, StatsColumn} from './layout';
 import LatestDeployOrReleaseTime from './latestDeployOrReleaseTime';
 
 class ReleaseList extends React.Component {
@@ -29,7 +29,7 @@ class ReleaseList extends React.Component {
           return (
             <ReleasePanelItem key={release.version}>
               <Layout>
-                <ReleaseName>
+                <VersionColumn>
                   <VersionWrapper>
                     <Version
                       orgId={orgId}
@@ -38,20 +38,20 @@ class ReleaseList extends React.Component {
                     />
                   </VersionWrapper>
                   <LatestDeployOrReleaseTime orgId={orgId} release={release} />
-                </ReleaseName>
-                <Stats>
+                </VersionColumn>
+                <StatsColumn>
                   <ReleaseStats release={release} />
-                </Stats>
-                <NewCount>
+                </StatsColumn>
+                <CountColumn>
                   <Count className="release-count" value={release.newGroups || 0} />
-                </NewCount>
-                <LastEvent>
+                </CountColumn>
+                <LastEventColumn>
                   {release.lastEvent ? (
                     <SmallTimeSince date={release.lastEvent} />
                   ) : (
                     <span>—</span>
                   )}
-                </LastEvent>
+                </LastEventColumn>
               </Layout>
             </ReleasePanelItem>
           );

--- a/src/sentry/static/sentry/app/views/organizationReleases/list/releaseListHeader.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/list/releaseListHeader.jsx
@@ -3,17 +3,17 @@ import React from 'react';
 import {PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
 
-import {LastEvent, Layout, NewCount, ReleaseName, Stats} from './layout';
+import {LastEventColumn, Layout, CountColumn, VersionColumn, StatsColumn} from './layout';
 
 export default class ReleaseListHeader extends React.Component {
   render() {
     return (
       <PanelHeader>
         <Layout>
-          <ReleaseName>{t('Version')}</ReleaseName>
-          <Stats />
-          <NewCount>{t('New Issues')}</NewCount>
-          <LastEvent>{t('Last Event')}</LastEvent>
+          <VersionColumn>{t('Version')}</VersionColumn>
+          <StatsColumn />
+          <CountColumn>{t('New Issues')}</CountColumn>
+          <LastEventColumn>{t('Last Event')}</LastEventColumn>
         </Layout>
       </PanelHeader>
     );

--- a/src/sentry/static/sentry/app/views/organizationReleases/list/releaseListHeader.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/list/releaseListHeader.jsx
@@ -1,21 +1,20 @@
 import React from 'react';
-import {Box} from 'grid-emotion';
-import {PanelHeader} from 'app/components/panels';
 
+import {PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
+
+import {LastEvent, Layout, NewCount, ReleaseName, Stats} from './layout';
 
 export default class ReleaseListHeader extends React.Component {
   render() {
     return (
       <PanelHeader>
-        <Box flex="1">{t('Version')}</Box>
-        <Box w={4 / 12} pl={2} className="hidden-xs" />
-        <Box w={2 / 12} pl={2}>
-          {t('New Issues')}
-        </Box>
-        <Box w={2 / 12} pl={2}>
-          {t('Last Event')}
-        </Box>
+        <Layout>
+          <ReleaseName>{t('Version')}</ReleaseName>
+          <Stats />
+          <NewCount>{t('New Issues')}</NewCount>
+          <LastEvent>{t('Last Event')}</LastEvent>
+        </Layout>
       </PanelHeader>
     );
   }


### PR DESCRIPTION
Layout was messed up with long release names (and if the committers were missing). 

Also refactors to use CSS grid.


New:
![image](https://user-images.githubusercontent.com/79684/59541365-bfd2d180-8eb5-11e9-84d7-2feff64abd9d.png)


Old:
![image](https://user-images.githubusercontent.com/79684/59541272-666aa280-8eb5-11e9-8558-212603f31e67.png)
