### PR TITLE
featu(search) Use snuba to fetch events by default

### DIFF
--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -53,7 +53,6 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
             return Response({'detail': 'Event not found'}, status=404)
 
         data = serialize(snuba_event)
-
         requested_environments = set(request.GET.getlist('environment'))
 
         next_event_id = snuba_event.next_event_id(environments=requested_environments)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -159,7 +159,7 @@ register('snuba.search.chunk-growth-rate', default=1.5)
 register('snuba.search.max-chunk-size', default=2000)
 register('snuba.search.max-total-chunk-time-seconds', default=30.0)
 register('snuba.search.hits-sample-size', default=100)
-register('snuba.events-queries.enabled', type=Bool, default=False)
+register('snuba.events-queries.enabled', type=Bool, default=True)
 register('snuba.track-outcomes-sample-rate', default=0.0)
 
 # Kafka Publisher

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -36,19 +36,18 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         # Only set these properties if we were given a time.
         # event processing will mark old time values as processing errors.
         if time:
-            event_data['timestamp'] = time.isoformat()
             event_data['received'] = time.isoformat()
 
         # We need a fallback datetime for the event
         if time is None:
-            time = datetime(2017, 9, 6, 0, 0)
+            time = (now - timedelta(days=1))
+
+        event_data['timestamp'] = time.isoformat()
         event = self.store_event(
             data=event_data,
             project_id=self.project.id,
             assert_no_errors=False,
         )
-        event.datetime = time
-        event.save()
         event.group.update(
             first_seen=datetime(2015, 8, 13, 3, 8, 25, tzinfo=timezone.utc),
             last_seen=time

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -21,9 +21,11 @@ class AuthenticationTest(AuthProviderTestCase):
             user=user, organization=organization, teams=[team])
         setattr(member.flags, 'sso:linked', True)
         member.save()
-        group = self.create_group(project=project)
-        self.create_event(group=group)
-
+        event = self.store_event(
+            data={},
+            project_id=project.id,
+        )
+        group_id = event.group_id
         auth_provider = AuthProvider.objects.create(
             organization=organization,
             provider='dummy',
@@ -41,9 +43,9 @@ class AuthenticationTest(AuthProviderTestCase):
             u'/api/0/organizations/{}/'.format(organization.slug),
             u'/api/0/projects/{}/{}/'.format(organization.slug, project.slug),
             u'/api/0/teams/{}/{}/'.format(organization.slug, team.slug),
-            u'/api/0/issues/{}/'.format(group.id),
+            u'/api/0/issues/{}/'.format(group_id),
             # this uses the internal API, which once upon a time was broken
-            u'/api/0/issues/{}/events/latest/'.format(group.id),
+            u'/api/0/issues/{}/events/latest/'.format(group_id),
         )
 
         for path in paths:
@@ -78,8 +80,11 @@ class AuthenticationTest(AuthProviderTestCase):
             user=user, organization=organization, teams=[team])
         setattr(member.flags, 'sso:linked', True)
         member.save()
-        group = self.create_group(project=project)
-        self.create_event(group=group)
+
+        self.store_event(
+            data={},
+            project_id=project.id,
+        )
 
         auth_provider = AuthProvider.objects.create(
             organization=organization,

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -17,7 +17,6 @@ class CreateAttachmentMixin(object):
         min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
         self.event = self.store_event(
             data={
-                # 'event_id': 'a' * 32,
                 'fingerprint': ['group1'],
                 'timestamp': min_ago,
                 'tags': {'sentry:release': self.release.version},

--- a/tests/sentry/api/endpoints/test_event_attachments.py
+++ b/tests/sentry/api/endpoints/test_event_attachments.py
@@ -16,19 +16,15 @@ class EventAttachmentsTest(APITestCase):
         min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
         event1 = self.store_event(
             data={
-                # 'event_id': 'a' * 32,
                 'fingerprint': ['group1'],
                 'timestamp': min_ago,
-                # 'tags': {'sentry:release': release.version},
             },
             project_id=self.project.id,
         )
         event2 = self.store_event(
             data={
-                # 'event_id': 'b' * 32,
                 'fingerprint': ['group1'],
                 'timestamp': min_ago,
-                # 'tags': {'sentry:release': release.version},
             },
             project_id=self.project.id,
         )

--- a/tests/sentry/api/endpoints/test_event_attachments.py
+++ b/tests/sentry/api/endpoints/test_event_attachments.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 
 import six
 
-from datetime import datetime
+from datetime import timedelta
+from django.utils import timezone
 
 from sentry.models import EventAttachment, File
 from sentry.testutils import APITestCase
@@ -12,23 +13,24 @@ class EventAttachmentsTest(APITestCase):
     def test_simple(self):
         self.login_as(user=self.user)
 
-        project = self.create_project()
-
-        release = self.create_release(project, self.user)
-
-        group = self.create_group(project=project, first_release=release)
-
-        event1 = self.create_event(
-            event_id='a',
-            group=group,
-            datetime=datetime(2016, 8, 13, 3, 8, 25),
-            tags={'sentry:release': release.version}
+        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        event1 = self.store_event(
+            data={
+                # 'event_id': 'a' * 32,
+                'fingerprint': ['group1'],
+                'timestamp': min_ago,
+                # 'tags': {'sentry:release': release.version},
+            },
+            project_id=self.project.id,
         )
-        event2 = self.create_event(
-            event_id='b',
-            group=group,
-            datetime=datetime(2016, 8, 13, 3, 8, 25),
-            tags={'sentry:release': release.version}
+        event2 = self.store_event(
+            data={
+                # 'event_id': 'b' * 32,
+                'fingerprint': ['group1'],
+                'timestamp': min_ago,
+                # 'tags': {'sentry:release': release.version},
+            },
+            project_id=self.project.id,
         )
 
         attachment1 = EventAttachment.objects.create(
@@ -56,7 +58,7 @@ class EventAttachmentsTest(APITestCase):
         path = u'/api/0/projects/{}/{}/events/{}/attachments/'.format(
             event1.project.organization.slug,
             event1.project.slug,
-            event1.id,
+            event1.event_id,
         )
 
         with self.feature('organizations:event-attachments'):

--- a/tests/sentry/api/endpoints/test_group_events.py
+++ b/tests/sentry/api/endpoints/test_group_events.py
@@ -18,6 +18,9 @@ class GroupEventsTest(APITestCase):
         super(GroupEventsTest, self).setUp()
         options.set('snuba.events-queries.enabled', False)
 
+    def tearDown(self):
+        options.set('snuba.events-queries.enabled', True)
+
     def test_simple(self):
         self.login_as(user=self.user)
 

--- a/tests/sentry/api/endpoints/test_group_events_latest.py
+++ b/tests/sentry/api/endpoints/test_group_events_latest.py
@@ -20,7 +20,6 @@ class GroupEventsLatestTest(APITestCase):
 
         self.event1 = self.store_event(
             data={
-                'event_id': 'a' * 32,
                 'environment': 'staging',
                 'fingerprint': ['group_1'],
                 'timestamp': two_min_ago
@@ -30,7 +29,6 @@ class GroupEventsLatestTest(APITestCase):
 
         self.event2 = self.store_event(
             data={
-                'event_id': 'b' * 32,
                 'environment': 'production',
                 'fingerprint': ['group_1'],
                 'timestamp': min_ago
@@ -43,6 +41,5 @@ class GroupEventsLatestTest(APITestCase):
     def test_simple(self):
         url = u'/api/0/issues/{}/events/latest/'.format(self.group.id)
         response = self.client.get(url, format='json')
-
         assert response.status_code == 200
-        assert response.data['id'] == six.text_type(self.event2.id)
+        assert response.data['eventID'] == six.text_type(self.event2.event_id)

--- a/tests/sentry/api/endpoints/test_group_events_oldest.py
+++ b/tests/sentry/api/endpoints/test_group_events_oldest.py
@@ -20,7 +20,6 @@ class GroupEventsOldestTest(APITestCase):
 
         self.event1 = self.store_event(
             data={
-                'event_id': 'a' * 32,
                 'environment': 'staging',
                 'fingerprint': ['group_1'],
                 'timestamp': two_min_ago
@@ -30,7 +29,6 @@ class GroupEventsOldestTest(APITestCase):
 
         self.event2 = self.store_event(
             data={
-                'event_id': 'b' * 32,
                 'environment': 'production',
                 'fingerprint': ['group_1'],
                 'timestamp': min_ago
@@ -45,4 +43,4 @@ class GroupEventsOldestTest(APITestCase):
         response = self.client.get(url, format='json')
 
         assert response.status_code == 200
-        assert response.data['id'] == six.text_type(self.event1.id)
+        assert response.data['id'] == six.text_type(self.event1.event_id)

--- a/tests/sentry/api/endpoints/test_project_event_details.py
+++ b/tests/sentry/api/endpoints/test_project_event_details.py
@@ -20,7 +20,7 @@ class ProjectEventDetailsTest(APITestCase):
 
         self.prev_event = self.store_event(
             data={
-                'event_id': 'a' * 32,
+                # 'event_id': 'a' * 32,
                 'timestamp': three_min_ago,
                 'fingerprint': ['group-1']
             },
@@ -28,7 +28,7 @@ class ProjectEventDetailsTest(APITestCase):
         )
         self.cur_event = self.store_event(
             data={
-                'event_id': 'b' * 32,
+                # 'event_id': 'b' * 32,
                 'timestamp': two_min_ago,
                 'fingerprint': ['group-1']
             },
@@ -36,7 +36,7 @@ class ProjectEventDetailsTest(APITestCase):
         )
         self.next_event = self.store_event(
             data={
-                'event_id': 'c' * 32,
+                # 'event_id': 'c' * 32,
                 'timestamp': one_min_ago,
                 'fingerprint': ['group-1'],
                 'environment': 'production',
@@ -55,9 +55,8 @@ class ProjectEventDetailsTest(APITestCase):
             }
         )
         response = self.client.get(url, format='json')
-
         assert response.status_code == 200, response.content
-        assert response.data['id'] == six.text_type(self.cur_event.id)
+        assert response.data['id'] == six.text_type(self.cur_event.event_id)
         assert response.data['nextEventID'] == six.text_type(self.next_event.event_id)
         assert response.data['previousEventID'] == six.text_type(self.prev_event.event_id)
         assert response.data['groupID'] == six.text_type(self.cur_event.group.id)
@@ -66,7 +65,7 @@ class ProjectEventDetailsTest(APITestCase):
         url = reverse(
             'sentry-api-0-project-event-details',
             kwargs={
-                'event_id': self.cur_event.id,
+                'event_id': self.cur_event.event_id,
                 'project_slug': self.cur_event.project.slug,
                 'organization_slug': self.cur_event.project.organization.slug,
             }
@@ -74,7 +73,7 @@ class ProjectEventDetailsTest(APITestCase):
         response = self.client.get(url, format='json')
 
         assert response.status_code == 200, response.content
-        assert response.data['id'] == six.text_type(self.cur_event.id)
+        assert response.data['id'] == six.text_type(self.cur_event.event_id)
         assert response.data['nextEventID'] == six.text_type(self.next_event.event_id)
         assert response.data['previousEventID'] == six.text_type(self.prev_event.event_id)
         assert response.data['groupID'] == six.text_type(self.cur_event.group.id)
@@ -95,7 +94,7 @@ class ProjectEventDetailsTest(APITestCase):
         response = self.client.get(url, format='json')
 
         assert response.status_code == 200, response.content
-        assert response.data['id'] == six.text_type(self.prev_event.id)
+        assert response.data['id'] == six.text_type(self.prev_event.event_id)
         assert response.data['previousEventID'] is None
         assert response.data['nextEventID'] == self.cur_event.event_id
         assert response.data['groupID'] == six.text_type(self.prev_event.group.id)

--- a/tests/sentry/api/endpoints/test_project_event_details.py
+++ b/tests/sentry/api/endpoints/test_project_event_details.py
@@ -20,7 +20,6 @@ class ProjectEventDetailsTest(APITestCase):
 
         self.prev_event = self.store_event(
             data={
-                # 'event_id': 'a' * 32,
                 'timestamp': three_min_ago,
                 'fingerprint': ['group-1']
             },
@@ -28,7 +27,6 @@ class ProjectEventDetailsTest(APITestCase):
         )
         self.cur_event = self.store_event(
             data={
-                # 'event_id': 'b' * 32,
                 'timestamp': two_min_ago,
                 'fingerprint': ['group-1']
             },
@@ -36,7 +34,6 @@ class ProjectEventDetailsTest(APITestCase):
         )
         self.next_event = self.store_event(
             data={
-                # 'event_id': 'c' * 32,
                 'timestamp': one_min_ago,
                 'fingerprint': ['group-1'],
                 'environment': 'production',

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
+from datetime import timedelta
 from exam import patcher
 from freezegun import freeze_time
 
-from datetime import timedelta
 from uuid import uuid4
 
 import six
@@ -494,6 +494,7 @@ class GetIncidentSuspectCommitsTest(TestCase, BaseIncidentsTest):
         included_commits = set([letter * 40 for letter in ('a', 'b', 'c', 'd')])
         commit_iter = iter(included_commits)
 
+        one_min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
         event = self.store_event(
             data={
                 'fingerprint': ['group-1'],
@@ -506,6 +507,7 @@ class GetIncidentSuspectCommitsTest(TestCase, BaseIncidentsTest):
                     ]
                 },
                 'release': release.version,
+                'timestamp': one_min_ago,
             },
             project_id=self.project.id,
         )
@@ -553,6 +555,7 @@ class GetIncidentSuspectCommitsTest(TestCase, BaseIncidentsTest):
                     ],
                 },
                 'release': release_2.version,
+                'timestamp': one_min_ago,
             },
             project_id=self.project.id,
         )

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -4,7 +4,9 @@ import six
 
 from celery import Task
 from collections import namedtuple
+from datetime import timedelta
 from django.core.urlresolvers import reverse
+from django.utils import timezone
 from mock import patch
 
 from sentry.models import Rule, SentryApp, SentryAppInstallation
@@ -231,11 +233,13 @@ class TestProcessResourceChange(TestCase):
             slug=sentry_app.slug,
         )
 
+        one_min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
         event = self.store_event(
             data={
                 'message': 'Foo bar',
                 'exception': {"type": "Foo", "value": "shits on fiah yo"},
                 'level': 'error',
+                'timestamp': one_min_ago,
             },
             project_id=self.project.id,
             assert_no_errors=False

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
+from datetime import timedelta
 from django.core.urlresolvers import reverse
+from django.utils import timezone
 from sentry.testutils import TestCase
 from sentry import options
 
@@ -19,8 +21,14 @@ class ProjectEventTest(TestCase):
             teams=[self.team],
         )
         self.project = self.create_project(organization=self.org, teams=[self.team])
-        self.group = self.create_group(project=self.project)
-        self.event = self.create_event(event_id='a' * 32, group=self.group)
+        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        self.event = self.store_event(
+            data={
+                'fingerprint': ['group1'],
+                'timestamp': min_ago,
+            },
+            project_id=self.project.id,
+        )
 
     def test_redirect_to_event(self):
         resp = self.client.get(
@@ -29,13 +37,13 @@ class ProjectEventTest(TestCase):
                 args=[
                     self.org.slug,
                     self.project.slug,
-                    'a' * 32]))
+                    self.event.event_id]))
         assert resp.status_code == 302
         assert resp['Location'] == '{}/organizations/{}/issues/{}/events/{}/'.format(
             options.get('system.url-prefix'),
             self.org.slug,
-            self.group.id,
-            self.event.id,
+            self.event.group_id,
+            self.event.event_id,
         )
 
     def test_event_not_found(self):


### PR DESCRIPTION
snuba.events-queries.enabled option is supposed to be already active in production. This commit activates it by default and fixes the tests that did not support it.
This step is needed in order to remove our dependency on PG events which is useful for issueless
events.
