### PR TITLE
fix(releases): Fix resolve in release

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationStream/actions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/actions.jsx
@@ -23,6 +23,7 @@ import SentryTypes from 'app/sentryTypes';
 import ToolbarHeader from 'app/components/toolbarHeader';
 import Tooltip from 'app/components/tooltip';
 import withApi from 'app/utils/withApi';
+import GroupStore from 'app/stores/groupStore';
 
 const BULK_LIMIT = 1000;
 const BULK_LIMIT_STR = BULK_LIMIT.toLocaleString();
@@ -223,13 +224,22 @@ const StreamActions = createReactClass({
     const {selection} = this.props;
     this.actionSelectedGroups(itemIds => {
       const loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+
+      let projectId;
+
+      try {
+        projectId = GroupStore.get(itemIds[0]).project.slug;
+      } catch (err) {
+        // nothing
+      }
+
       this.props.api.bulkUpdate(
         {
           orgId: this.props.orgId,
           itemIds,
           data,
           query: this.props.query,
-          project: selection.projects,
+          projectId,
           environment: selection.environments,
           ...selection.datetime,
         },


### PR DESCRIPTION
This is a quick fix for the resolve in release feature. This feature is
currently not working (since Sentry 10) when "all projects" or more
than one project is selected in the top bar.

The proposed longer term solution for this for the API to allow resolving
without needing to pass a specific project ID, outlined in SEN-771