### PR TITLE
feat: Add system for suggesting SDK integrations to enable

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -17,6 +17,7 @@ from sentry.models import (
 )
 from sentry.search.utils import convert_user_tag_to_query
 from sentry.utils.safe import get_path
+from sentry.sdk_updates import get_suggested_updates, SdkSetupState
 
 
 CRASH_FILE_TYPES = set(['event.minidump'])
@@ -292,10 +293,14 @@ class DetailedEventSerializer(EventSerializer):
     Adds release and user report info to the serialized event.
     """
 
+    def _get_sdk_updates(self, obj):
+        return list(get_suggested_updates(SdkSetupState.from_event_json(obj.data)))
+
     def serialize(self, obj, attrs, user):
         result = super(DetailedEventSerializer, self).serialize(obj, attrs, user)
         result['release'] = self._get_release_info(user, obj)
         result['userReport'] = self._get_user_report(user, obj)
+        result['sdkUpdates'] = self._get_sdk_updates(obj)
         return result
 
 

--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -1,88 +1,8 @@
 from __future__ import absolute_import
 
-import logging
-
 __all__ = ('Sdk', )
 
-from distutils.version import LooseVersion
-from django.conf import settings
-
 from sentry.interfaces.base import Interface, prune_empty_keys
-from sentry.net.http import Session
-from sentry.cache import default_cache
-
-
-logger = logging.getLogger(__name__)
-
-
-SDK_INDEX_CACHE_KEY = u'sentry:sdk-versions'
-
-
-def get_sdk_index():
-    value = default_cache.get(SDK_INDEX_CACHE_KEY)
-    if value is not None:
-        return value
-
-    base_url = settings.SENTRY_RELEASE_REGISTRY_BASEURL
-    if not base_url:
-        return {}
-
-    url = '%s/sdks' % (base_url,)
-
-    try:
-        with Session() as session:
-            response = session.get(url, timeout=1)
-            response.raise_for_status()
-            json = response.json()
-    except Exception:
-        logger.exception("Failed to fetch version index from release registry")
-        json = {}
-
-    default_cache.set(SDK_INDEX_CACHE_KEY, json, 3600)
-    return json
-
-
-def get_sdk_versions():
-    try:
-        rv = dict(settings.SDK_VERSIONS)
-        rv.update((key, info['version']) for (key, info) in get_sdk_index().items())
-        return rv
-    except Exception:
-        logger.exception("sentry-release-registry.sdk-versions")
-        return {}
-
-
-def get_sdk_urls():
-    try:
-        rv = dict(settings.SDK_URLS)
-        rv.update((key, info['main_docs_url']) for (key, info) in get_sdk_index().items())
-        return rv
-    except Exception:
-        logger.exception("sentry-release-registry.sdk-urls")
-        return {}
-
-
-def get_with_prefix(d, k, default=None, delimiter=":"):
-    """\
-    Retrieve a value from the dictionary, falling back to using its
-    prefix, denoted by a delimiter (default ':'). Useful for cases
-    such as looking up `raven-java:logback` in a dict like
-    {"raven-java": "7.0.0"}.
-    """
-
-    if k is None:
-        return default
-
-    prefix = k.split(delimiter, 1)[0]
-    for key in [k, prefix]:
-        if key in d:
-            return d[key]
-
-        key = key.lower()
-        if key in d:
-            return d[key]
-
-    return default
 
 
 class Sdk(Interface):
@@ -123,30 +43,9 @@ class Sdk(Interface):
         })
 
     def get_api_context(self, is_public=False, platform=None):
-        newest_version = get_with_prefix(get_sdk_versions(), self.name)
-        newest_name = get_with_prefix(settings.DEPRECATED_SDKS, self.name, self.name)
-
-        if newest_version is not None:
-            try:
-                is_newer = (
-                    newest_name != self.name or
-                    LooseVersion(newest_version) > LooseVersion(self.version)
-                )
-            except ValueError:
-                is_newer = False
-        else:
-            is_newer = newest_name != self.name
-
         return {
             'name': self.name,
             'version': self.version,
-            'upstream': {
-                'name': newest_name,
-                # when this is correct we can make it available
-                # 'version': newest_version,
-                'isNewer': is_newer,
-                'url': get_with_prefix(get_sdk_urls(), newest_name),
-            },
         }
 
     def get_api_meta(self, meta, is_public=False, platform=None):

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -293,7 +293,7 @@ def get_sdk_urls():
     try:
         rv = dict(settings.SDK_URLS)
         rv.update(
-            (key, info.get('package_url') or info['main_docs_url']) for (
+            (key, info['main_docs_url']) for (
                 key, info) in get_sdk_index().items())
         return rv
     except Exception:

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -1,0 +1,282 @@
+from __future__ import absolute_import
+
+import logging
+from distutils.version import LooseVersion
+from django.conf import settings
+
+from sentry.net.http import Session
+from sentry.cache import default_cache
+from sentry.utils.safe import get_path
+
+logger = logging.getLogger(__name__)
+
+SDK_INDEX_CACHE_KEY = u'sentry:sdk-versions'
+
+
+class SdkSetupState(object):
+    def __init__(self, sdk_name, sdk_version, modules, integrations):
+        self.sdk_name = sdk_name
+        self.sdk_version = sdk_version
+        self.modules = dict(modules or ())
+        self.integrations = list(integrations or ())
+
+    def copy(self):
+        return type(self)(
+            sdk_name=self.sdk_name,
+            sdk_version=self.sdk_version,
+            modules=self.modules,
+            integrations=self.integrations
+        )
+
+    @classmethod
+    def from_event_json(cls, event_data):
+        sdk_name = get_path(event_data, 'sdk', 'name')
+        if sdk_name:
+            sdk_name = sdk_name.lower().rsplit(':', 1)[0]
+
+        if sdk_name == 'sentry-python':
+            sdk_name = 'sentry.python'
+
+        return cls(
+            sdk_name=sdk_name,
+            sdk_version=get_path(event_data, 'sdk', 'version'),
+            modules=get_path(event_data, 'modules'),
+            integrations=get_path(event_data, 'sdk', 'integrations'),
+        )
+
+
+class SdkIndexState(object):
+    def __init__(self, sdk_versions=None, deprecated_sdks=None, sdk_supported_modules=None):
+        self.sdk_versions = sdk_versions or get_sdk_versions()
+        self.deprecated_sdks = deprecated_sdks or settings.DEPRECATED_SDKS
+        self.sdk_supported_modules = sdk_supported_modules or SDK_SUPPORTED_MODULES
+
+
+class Suggestion(object):
+    def to_json(self):
+        raise NotImplementedError()
+
+    def __eq__(self, other):
+        return self.to_json() == other.to_json()
+
+
+class EnableIntegrationSuggestion(Suggestion):
+    def __init__(self, integration_name, integration_url):
+        self.integration_name = integration_name
+        self.integration_url = integration_url
+
+    def to_json(self):
+        return {
+            "type": "enableIntegration",
+            "integrationName": self.integration_name,
+            "integrationUrl": self.integration_url
+        }
+
+    def get_new_state(self, old_state):
+        if self.integration_name in old_state.integrations:
+            return old_state
+
+        new_state = old_state.copy()
+        new_state.integrations.append(self.integration_name)
+        return new_state
+
+
+class UpdateSDKSuggestion(Suggestion):
+    def __init__(self, sdk_name, new_sdk_version):
+        self.sdk_name = sdk_name
+        self.new_sdk_version = new_sdk_version
+
+    def to_json(self):
+        return {
+            "type": "updateSdk",
+            "sdkName": self.sdk_name,
+            "newSdkVersion": self.new_sdk_version,
+            "sdkUrl": get_sdk_urls().get(self.sdk_name)
+        }
+
+    def get_new_state(self, old_state):
+        if self.new_sdk_version is None:
+            return old_state
+
+        try:
+            has_newer_version = (
+                LooseVersion(old_state.sdk_version)
+                < LooseVersion(self.new_sdk_version)
+            )
+        except Exception:
+            has_newer_version = False
+
+        if not has_newer_version:
+            return old_state
+
+        new_state = old_state.copy()
+        new_state.sdk_version = self.new_sdk_version
+        return new_state
+
+
+class ChangeSDKSuggestion(Suggestion):
+    def __init__(self, new_sdk_name):
+        self.new_sdk_name = new_sdk_name
+
+    def to_json(self):
+        return {
+            "type": "changeSdk",
+            "newSdkName": self.new_sdk_name,
+            "sdkUrl": get_sdk_urls().get(self.new_sdk_name)
+        }
+
+    def get_new_state(self, old_state):
+        if old_state.sdk_name == self.new_sdk_name:
+            return old_state
+
+        new_state = old_state.copy()
+        new_state.sdk_name = self.new_sdk_name
+        return new_state
+
+
+SDK_SUPPORTED_MODULES = [
+    {
+        'sdk_name': 'sentry.python',
+        'sdk_version_added': '0.3.2',
+        'module_name': 'django',
+        'module_version_min': '1.6.0',
+        'suggestion': EnableIntegrationSuggestion('django', 'https://docs.sentry.io/platforms/python/django/')
+    },
+    {
+        'sdk_name': 'sentry.python',
+        'sdk_version_added': '0.3.2',
+        'module_name': 'flask',
+        'module_version_min': '0.11.0',
+        'suggestion': EnableIntegrationSuggestion('flask', 'https://docs.sentry.io/platforms/python/flask/')
+    },
+]
+
+
+def get_sdk_index():
+    value = default_cache.get(SDK_INDEX_CACHE_KEY)
+    if value is not None:
+        return value
+
+    base_url = settings.SENTRY_RELEASE_REGISTRY_BASEURL
+    if not base_url:
+        return {}
+
+    url = '%s/sdks' % (base_url,)
+
+    try:
+        with Session() as session:
+            response = session.get(url, timeout=1)
+            response.raise_for_status()
+            json = response.json()
+    except Exception:
+        logger.exception("Failed to fetch version index from release registry")
+        json = {}
+
+    default_cache.set(SDK_INDEX_CACHE_KEY, json, 3600)
+    return json
+
+
+def get_sdk_versions():
+    try:
+        rv = settings.SDK_VERSIONS
+        rv.update((key, info['value']) for (key, info) in get_sdk_index().items())
+        return rv
+    except Exception:
+        logger.exception("sentry-release-registry.sdk-versions")
+        return {}
+
+
+def get_sdk_urls():
+    try:
+        rv = dict(settings.SDK_URLS)
+        rv.update(
+            (key, info.get('package_url') or info['main_docs_url']) for (
+                key, info) in get_sdk_index().items())
+        return rv
+    except Exception:
+        logger.exception("sentry-release-registry.sdk-urls")
+        return {}
+
+
+def _get_suggested_updates_step(
+    setup_state,
+    index_state
+):
+    if not setup_state.sdk_name or not setup_state.sdk_version:
+        return
+
+    yield UpdateSDKSuggestion(setup_state.sdk_name, index_state.sdk_versions.get(setup_state.sdk_name))
+
+    # If an SDK is both outdated and entirely deprecated, we want to inform
+    # the user of both. It's unclear if they would want to upgrade the SDK
+    # or migrate to the new one.
+    newest_name = settings.DEPRECATED_SDKS.get(setup_state.sdk_name, setup_state.sdk_name)
+    yield ChangeSDKSuggestion(newest_name)
+
+    for support_info in SDK_SUPPORTED_MODULES:
+        if support_info['sdk_name'] != setup_state.sdk_name:
+            continue
+
+        if support_info['module_name'] not in setup_state.modules:
+            continue
+
+        try:
+            if LooseVersion(support_info['sdk_version_added']
+                            ) > LooseVersion(setup_state.sdk_version):
+                continue
+        except Exception:
+            continue
+
+        try:
+            if LooseVersion(support_info['module_version_min']) > LooseVersion(
+                    setup_state.modules[support_info['module_name']]):
+                # TODO(markus): Maybe we want to suggest people to upgrade their module?
+                #
+                # E.g. "please upgrade Django so you can get the
+                # Django integration"
+                continue
+        except Exception:
+            continue
+
+        yield support_info['suggestion']
+
+
+def get_suggested_updates(
+    setup_state,
+    index_state=None,
+    parent_suggestions=None
+):
+    if index_state is None:
+        index_state = SdkIndexState()
+
+    if parent_suggestions is None:
+        parent_suggestions = []
+
+    suggestions = list(_get_suggested_updates_step(
+        setup_state,
+        index_state,
+    ))
+
+    rv = []
+    new_setup_states = []
+
+    for suggestion in suggestions:
+        if suggestion in parent_suggestions:
+            continue
+
+        new_setup_state = suggestion.get_new_state(setup_state)
+        if new_setup_state == setup_state:
+            continue
+
+        rv.append(suggestion)
+        new_setup_states.append(new_setup_state)
+
+    for new_setup_state, suggestion in zip(new_setup_states, rv):
+        json = suggestion.to_json()
+        json['enables'] = list(get_suggested_updates(
+            new_setup_state,
+            parent_suggestions=parent_suggestions + rv,
+            index_state=index_state
+        ))
+
+        yield json

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -278,8 +278,10 @@ def _get_suggested_updates_step(
             continue
 
         try:
-            if LooseVersion(support_info['sdk_version_added']
-                            ) > LooseVersion(setup_state.sdk_version):
+            if (
+                LooseVersion(support_info['sdk_version_added'])
+                > LooseVersion(setup_state.sdk_version)
+            ):
                 continue
         except Exception:
             continue

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -149,6 +149,63 @@ SDK_SUPPORTED_MODULES = [
         'module_version_min': '0.11.0',
         'suggestion': EnableIntegrationSuggestion('flask', 'https://docs.sentry.io/platforms/python/flask/')
     },
+    {
+        'sdk_name': 'sentry.python',
+        'sdk_version_added': '0.7.9',
+        'module_name': 'bottle',
+        'module_version_min': '0.12.0',
+        'suggestion': EnableIntegrationSuggestion('bottle', 'https://docs.sentry.io/platforms/python/bottle/')
+    },
+    {
+        'sdk_name': 'sentry.python',
+        'sdk_version_added': '0.7.11',
+        'module_name': 'falcon',
+        'module_version_min': '1.4.0',
+        'suggestion': EnableIntegrationSuggestion('falcon', 'https://docs.sentry.io/platforms/python/falcon/')
+    },
+    {
+        'sdk_name': 'sentry.python',
+        'sdk_version_added': '0.3.6',
+        'module_name': 'sanic',
+        'module_version_min': '0.8.0',
+        'suggestion': EnableIntegrationSuggestion('sanic', 'https://docs.sentry.io/platforms/python/sanic/')
+    },
+    {
+        'sdk_name': 'sentry.python',
+        'sdk_version_added': '0.3.2',
+        'module_name': 'celery',
+        'module_version_min': '3.0.0',
+        'suggestion': EnableIntegrationSuggestion('celery', 'https://docs.sentry.io/platforms/python/celery/')
+    },
+    # TODO: Detect AWS Lambda for Python
+    {
+        'sdk_name': 'sentry.python',
+        'sdk_version_added': '0.5.0',
+        'module_name': 'pyramid',
+        'module_version_min': '1.3.0',
+        'suggestion': EnableIntegrationSuggestion('pyramid', 'https://docs.sentry.io/platforms/python/pyramid/')
+    },
+    {
+        'sdk_name': 'sentry.python',
+        'sdk_version_added': '0.5.1',
+        'module_name': 'rq',
+        'module_version_min': '0.6',
+        'suggestion': EnableIntegrationSuggestion('rq', 'https://docs.sentry.io/platforms/python/rq/')
+    },
+    {
+        'sdk_name': 'sentry.python',
+        'sdk_version_added': '0.6.1',
+        'module_name': 'aiohttp',
+        'module_version_min': '3.4.0',
+        'suggestion': EnableIntegrationSuggestion('aiohttp', 'https://docs.sentry.io/platforms/python/aiohttp/')
+    },
+    {
+        'sdk_name': 'sentry.python',
+        'sdk_version_added': '0.6.3',
+        'module_name': 'tornado',
+        'module_version_min': '5.0.0',
+        'suggestion': EnableIntegrationSuggestion('tornado', 'https://docs.sentry.io/platforms/python/tornado/')
+    },
 ]
 
 

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -236,7 +236,7 @@ def get_sdk_index():
 def get_sdk_versions():
     try:
         rv = settings.SDK_VERSIONS
-        rv.update((key, info['value']) for (key, info) in get_sdk_index().items())
+        rv.update((key, info['version']) for (key, info) in get_sdk_index().items())
         return rv
     except Exception:
         logger.exception("sentry-release-registry.sdk-versions")

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -20,6 +20,7 @@ import EventExtraData from 'app/components/events/extraData';
 import EventGroupingInfo from 'app/components/events/groupingInfo';
 import EventPackageData from 'app/components/events/packageData';
 import EventSdk from 'app/components/events/sdk';
+import EventSdkUpdates from 'app/components/events/sdkUpdates';
 import EventTags from 'app/components/events/eventTags';
 import EventUserFeedback from 'app/components/events/userFeedback';
 import ExceptionInterface from 'app/components/events/interfaces/exception';
@@ -181,20 +182,9 @@ class EventEntries extends React.Component {
           <EventAttachments event={event} orgId={orgId} projectId={project.slug} />
         )}
         {!objectIsEmpty(event.sdk) && <EventSdk event={event} />}
-        {!objectIsEmpty(event.sdk) && event.sdk.upstream.isNewer && (
-          <div className="alert-block alert-info box">
-            <span className="icon-exclamation" />
-            {t(
-              'This event was reported with an old version of the %s SDK.',
-              event.platform
-            )}
-            {event.sdk.upstream.url && (
-              <a href={event.sdk.upstream.url} className="btn btn-sm btn-default">
-                {t('Learn More')}
-              </a>
-            )}
-          </div>
-        )}{' '}
+        {!isShare && event.sdkUpdates && event.sdkUpdates.length > 0 && (
+          <EventSdkUpdates event={event} />
+        )}
         {!isShare && features.has('grouping-info') && (
           <EventGroupingInfo projectId={project.slug} event={event} />
         )}

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -80,7 +80,7 @@ class EventSdkUpdateSuggestion extends React.Component {
     }
 
     return (
-      <div>
+      <span>
         {title}
         {t(' so you can: ')}
         <ul>
@@ -92,7 +92,7 @@ class EventSdkUpdateSuggestion extends React.Component {
             );
           })}
         </ul>
-      </div>
+      </span>
     );
   }
 }

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -1,10 +1,16 @@
 import React from 'react';
+import styled from 'react-emotion';
 import PropTypes from 'prop-types';
+
 import SentryTypes from 'app/sentryTypes';
 import Alert from 'app/components/alert';
 import ExternalLink from 'app/components/links/externalLink';
+import {t, tct} from 'app/locale';
+import space from 'app/styles/space';
 
-import {t} from 'app/locale';
+const StyledAlert = styled(Alert)`
+  margin: 0 ${space(2)};
+`;
 
 export const EnableIntegrationSuggestion = PropTypes.shape({
   type: PropTypes.string,
@@ -56,8 +62,8 @@ class EventSdkUpdateSuggestion extends React.Component {
         break;
       case 'changeSdk':
         href = suggestion.sdkUrl;
-        content = tct("migrate to the [sdkName] SDK", {
-          sdkName: <code>{suggestion.newSdkName}</code>
+        content = tct('migrate to the [sdkName] SDK', {
+          sdkName: <code>{suggestion.newSdkName}</code>,
         });
         break;
       case 'enableIntegration':
@@ -114,14 +120,14 @@ class EventSdkUpdates extends React.Component {
       <div>
         {data.map(suggestion => {
           return (
-            <Alert
+            <StyledAlert
               type="info"
               icon="icon-upgrade"
               key={getSuggestionComponentKey(suggestion)}
             >
               {t('We recommend you')}
               <EventSdkUpdateSuggestion event={event} suggestion={suggestion} />
-            </Alert>
+            </StyledAlert>
           );
         })}
       </div>

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -43,36 +43,38 @@ class EventSdkUpdateSuggestion extends React.Component {
 
   getSuggestionTitle() {
     const {event, suggestion} = this.props;
+    let href;
+    let content;
     switch (suggestion.type) {
       case 'updateSdk':
-        return (
-          <ExternalLink href={suggestion.sdkUrl}>
-            {t(
-              'Update your SDK from version %s to version %s',
-              event.sdk.version,
-              suggestion.newSdkVersion
-            )}
-          </ExternalLink>
+        href = suggestion.sdkUrl;
+        content = t(
+          'Update your SDK from version %s to version %s',
+          event.sdk.version,
+          suggestion.newSdkVersion
         );
+        break;
       case 'changeSdk':
-        return (
-          <ExternalLink href={suggestion.sdkUrl}>
-            {t("Migrate to the '%s' SDK", suggestion.newSdkName)}
-          </ExternalLink>
-        );
+        href = suggestion.sdkUrl;
+        content = t("Migrate to the '%s' SDK", suggestion.newSdkName);
+        break;
       case 'enableIntegration':
-        return (
-          <ExternalLink href={suggestion.integrationUrl}>
-            {t("Enable the '%s' integration", suggestion.integrationName)}
-          </ExternalLink>
-        );
+        href = suggestion.integrationUrl;
+        content = t("Enable the '%s' integration", suggestion.integrationName);
+        break;
       default:
         return null;
     }
+
+    if (!href) {
+      return content;
+    }
+
+    return <ExternalLink href={href}>{content}</ExternalLink>;
   }
 
   render() {
-    const {suggestion} = this.props;
+    const {event, suggestion} = this.props;
     const title = this.getSuggestionTitle();
 
     if (suggestion.enables.length == 0) {

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -56,7 +56,9 @@ class EventSdkUpdateSuggestion extends React.Component {
         break;
       case 'changeSdk':
         href = suggestion.sdkUrl;
-        content = t("Migrate to the '%s' SDK", suggestion.newSdkName);
+        content = tct("migrate to the [sdkName] SDK", {
+          sdkName: <code>{suggestion.newSdkName}</code>
+        });
         break;
       case 'enableIntegration':
         href = suggestion.integrationUrl;

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -125,7 +125,7 @@ class EventSdkUpdates extends React.Component {
               icon="icon-upgrade"
               key={getSuggestionComponentKey(suggestion)}
             >
-              {t('We recommend you')}
+              {t('We recommend you ')}
               <EventSdkUpdateSuggestion event={event} suggestion={suggestion} />
             </StyledAlert>
           );

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -86,7 +86,7 @@ class EventSdkUpdateSuggestion extends React.Component {
     return (
       <span>
         {title}
-        {t(' so you can: ')}
+        {t(' so you can')}
         <ul>
           {suggestion.enables.map((suggestion2, i) => {
             return (

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import SentryTypes from 'app/sentryTypes';
+
+import {t} from 'app/locale';
+
+class EventSdkUpdateSuggestion extends React.Component {
+  static propTypes = {
+    suggestion: PropTypes.object.isRequired,
+  };
+
+  getSuggestionTitle() {
+    const {suggestion} = this.props;
+    switch (suggestion.type) {
+      case 'updateSdk':
+        return <a href={suggestion.sdkUrl}>{t('update your SDK')}</a>;
+      case 'changeSdk':
+        return (
+          <a href={suggestion.sdkUrl}>
+            {t("migrate to the '%s' SDK", suggestion.newSdkName)}
+          </a>
+        );
+      case 'enableIntegration':
+        return (
+          <a href={suggestion.integrationUrl}>
+            {t("enable the '%s' integration", suggestion.integrationName)}
+          </a>
+        );
+      default:
+        return null;
+    }
+  }
+
+  render() {
+    const {suggestion} = this.props;
+    const title = this.getSuggestionTitle();
+
+    if (suggestion.enables.length == 0) {
+      return title;
+    }
+
+    return (
+      <span>
+        {title}
+        {t(' so you can: ')}
+        <ul>
+          {suggestion.enables.map((suggestion2, i) => {
+            return (
+              <li key={suggestion2}>
+                <EventSdkUpdateSuggestion suggestion={suggestion2} />
+              </li>
+            );
+          })}
+        </ul>
+      </span>
+    );
+  }
+}
+
+class EventSdkUpdates extends React.Component {
+  static propTypes = {
+    event: SentryTypes.Event.isRequired,
+  };
+
+  render() {
+    const {event} = this.props;
+    const data = event.sdkUpdates;
+
+    return (
+      <div>
+        {data.map(suggestion => {
+          return (
+            <div className="alert-block alert-info box row" key={suggestion}>
+              We recommend to <EventSdkUpdateSuggestion suggestion={suggestion} />
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+}
+
+export default EventSdkUpdates;

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -40,7 +40,7 @@ class EventSdkUpdateSuggestion extends React.Component {
     }
 
     return (
-      <span>
+      <div>
         {title}
         {t(' so you can: ')}
         <ul>
@@ -52,7 +52,7 @@ class EventSdkUpdateSuggestion extends React.Component {
             );
           })}
         </ul>
-      </span>
+      </div>
     );
   }
 }
@@ -71,7 +71,8 @@ class EventSdkUpdates extends React.Component {
         {data.map(suggestion => {
           return (
             <div className="alert-block alert-info box row" key={suggestion}>
-              {t('We recommend to ')}<EventSdkUpdateSuggestion suggestion={suggestion} />
+              {t('We recommend to ')}
+              <EventSdkUpdateSuggestion suggestion={suggestion} />
             </div>
           );
         })}

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -71,7 +71,7 @@ class EventSdkUpdates extends React.Component {
         {data.map(suggestion => {
           return (
             <div className="alert-block alert-info box row" key={suggestion}>
-              We recommend to <EventSdkUpdateSuggestion suggestion={suggestion} />
+              {t('We recommend to ')}<EventSdkUpdateSuggestion suggestion={suggestion} />
             </div>
           );
         })}

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'react-emotion';
+
 import SentryTypes from 'app/sentryTypes';
 import Alert from 'app/components/alert';
 import ExternalLink from 'app/components/links/externalLink';
-
 import {t, tct} from 'app/locale';
+import space from 'app/styles/space';
+
+const AlertUl = styled('ul')`
+  margin-top: ${space(1)};
+  margin-bottom: ${space(1)};
+`;
 
 export const EnableIntegrationSuggestion = PropTypes.shape({
   type: PropTypes.string,
@@ -87,7 +94,7 @@ class EventSdkUpdateSuggestion extends React.Component {
       <span>
         {title}
         {t(' so you can')}
-        <ul>
+        <AlertUl>
           {suggestion.enables.map((suggestion2, i) => {
             return (
               <li key={getSuggestionComponentKey(suggestion2)}>
@@ -95,7 +102,7 @@ class EventSdkUpdateSuggestion extends React.Component {
               </li>
             );
           })}
-        </ul>
+        </AlertUl>
       </span>
     );
   }

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -55,7 +55,7 @@ class EventSdkUpdateSuggestion extends React.Component {
       case 'updateSdk':
         href = suggestion.sdkUrl;
         content = t(
-          'Update your SDK from version %s to version %s',
+          'update your SDK from version %s to version %s',
           event.sdk.version,
           suggestion.newSdkVersion
         );
@@ -68,7 +68,7 @@ class EventSdkUpdateSuggestion extends React.Component {
         break;
       case 'enableIntegration':
         href = suggestion.integrationUrl;
-        content = t("Enable the '%s' integration", suggestion.integrationName);
+        content = t("enable the '%s' integration", suggestion.integrationName);
         break;
       default:
         return null;

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -117,7 +117,7 @@ class EventSdkUpdates extends React.Component {
               icon="icon-upgrade"
               key={getSuggestionComponentKey(suggestion)}
             >
-              {t('We recommend to ')}
+              {t('We recommend you')}
               <EventSdkUpdateSuggestion event={event} suggestion={suggestion} />
             </Alert>
           );

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -1,30 +1,70 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SentryTypes from 'app/sentryTypes';
+import Alert from 'app/components/alert';
+import ExternalLink from 'app/components/links/externalLink';
 
 import {t} from 'app/locale';
 
+export const EnableIntegrationSuggestion = PropTypes.shape({
+  type: PropTypes.string,
+  integrationName: PropTypes.string,
+  integrationUrl: PropTypes.string,
+});
+
+export const UpdateSdkSuggestion = PropTypes.shape({
+  type: PropTypes.string,
+  sdkName: PropTypes.string,
+  newSdkVersion: PropTypes.string,
+  sdkUrl: PropTypes.string,
+});
+
+export const ChangeSdkSuggestion = PropTypes.shape({
+  type: PropTypes.string,
+  newSdkName: PropTypes.string,
+  sdkUrl: PropTypes.string,
+});
+
+export const Suggestion = PropTypes.oneOfType([
+  EnableIntegrationSuggestion,
+  UpdateSdkSuggestion,
+  ChangeSdkSuggestion,
+]);
+
+function getSuggestionComponentKey(suggestion) {
+  return JSON.stringify(suggestion, Object.keys(suggestion).sort());
+}
+
 class EventSdkUpdateSuggestion extends React.Component {
   static propTypes = {
-    suggestion: PropTypes.object.isRequired,
+    event: SentryTypes.Event.isRequired,
+    suggestion: Suggestion.isRequired,
   };
 
   getSuggestionTitle() {
-    const {suggestion} = this.props;
+    const {event, suggestion} = this.props;
     switch (suggestion.type) {
       case 'updateSdk':
-        return <a href={suggestion.sdkUrl}>{t('update your SDK')}</a>;
+        return (
+          <ExternalLink href={suggestion.sdkUrl}>
+            {t(
+              'Update your SDK from version %s to version %s',
+              event.sdk.version,
+              suggestion.newSdkVersion
+            )}
+          </ExternalLink>
+        );
       case 'changeSdk':
         return (
-          <a href={suggestion.sdkUrl}>
-            {t("migrate to the '%s' SDK", suggestion.newSdkName)}
-          </a>
+          <ExternalLink href={suggestion.sdkUrl}>
+            {t("Migrate to the '%s' SDK", suggestion.newSdkName)}
+          </ExternalLink>
         );
       case 'enableIntegration':
         return (
-          <a href={suggestion.integrationUrl}>
-            {t("enable the '%s' integration", suggestion.integrationName)}
-          </a>
+          <ExternalLink href={suggestion.integrationUrl}>
+            {t("Enable the '%s' integration", suggestion.integrationName)}
+          </ExternalLink>
         );
       default:
         return null;
@@ -46,8 +86,8 @@ class EventSdkUpdateSuggestion extends React.Component {
         <ul>
           {suggestion.enables.map((suggestion2, i) => {
             return (
-              <li key={suggestion2}>
-                <EventSdkUpdateSuggestion suggestion={suggestion2} />
+              <li key={getSuggestionComponentKey(suggestion2)}>
+                <EventSdkUpdateSuggestion event={event} suggestion={suggestion2} />
               </li>
             );
           })}
@@ -70,10 +110,14 @@ class EventSdkUpdates extends React.Component {
       <div>
         {data.map(suggestion => {
           return (
-            <div className="alert-block alert-info box row" key={suggestion}>
+            <Alert
+              type="info"
+              icon="icon-upgrade"
+              key={getSuggestionComponentKey(suggestion)}
+            >
               {t('We recommend to ')}
-              <EventSdkUpdateSuggestion suggestion={suggestion} />
-            </div>
+              <EventSdkUpdateSuggestion event={event} suggestion={suggestion} />
+            </Alert>
           );
         })}
       </div>

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates.jsx
@@ -1,16 +1,10 @@
 import React from 'react';
-import styled from 'react-emotion';
 import PropTypes from 'prop-types';
-
 import SentryTypes from 'app/sentryTypes';
 import Alert from 'app/components/alert';
 import ExternalLink from 'app/components/links/externalLink';
-import {t, tct} from 'app/locale';
-import space from 'app/styles/space';
 
-const StyledAlert = styled(Alert)`
-  margin: 0 ${space(2)};
-`;
+import {t, tct} from 'app/locale';
 
 export const EnableIntegrationSuggestion = PropTypes.shape({
   type: PropTypes.string,
@@ -117,17 +111,17 @@ class EventSdkUpdates extends React.Component {
     const data = event.sdkUpdates;
 
     return (
-      <div>
+      <div className="box">
         {data.map(suggestion => {
           return (
-            <StyledAlert
+            <Alert
               type="info"
               icon="icon-upgrade"
               key={getSuggestionComponentKey(suggestion)}
             >
               {t('We recommend you ')}
               <EventSdkUpdateSuggestion event={event} suggestion={suggestion} />
-            </StyledAlert>
+            </Alert>
           );
         })}
       </div>

--- a/tests/js/fixtures/updateSdkAndEnableIntegrationSuggestion.jsx
+++ b/tests/js/fixtures/updateSdkAndEnableIntegrationSuggestion.jsx
@@ -1,0 +1,25 @@
+export function UpdateSdkAndEnableIntegrationSuggestion(params) {
+  return {
+    id: '123',
+    sdk: {
+      name: 'sentry.python',
+      version: '0.1.0',
+    },
+    sdkUpdates: [
+      {
+        enables: [
+          {
+            type: 'enableIntegration',
+            enables: [],
+            integrationName: 'django',
+            integrationUrl: 'https://docs.sentry.io/platforms/python/django/',
+          },
+        ],
+        newSdkVersion: '0.9.0',
+        sdkName: 'sentry.python',
+        sdkUrl: null,
+        type: 'updateSdk',
+      },
+    ],
+  };
+}

--- a/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
@@ -1,0 +1,194 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EventSdkUpdates renders a suggestion to update the sdk and then enable an integration 1`] = `
+<EventSdkUpdates
+  event={
+    Object {
+      "id": "123",
+      "sdk": Object {
+        "name": "sentry.python",
+        "version": "0.1.0",
+      },
+      "sdkUpdates": Array [
+        Object {
+          "enables": Array [
+            Object {
+              "enables": Array [],
+              "integrationName": "django",
+              "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+              "type": "enableIntegration",
+            },
+          ],
+          "newSdkVersion": "0.9.0",
+          "sdkName": "sentry.python",
+          "sdkUrl": null,
+          "type": "updateSdk",
+        },
+      ],
+    }
+  }
+>
+  <div>
+    <Alert
+      icon="icon-upgrade"
+      iconSize="24px"
+      key="{\\"enables\\":[{\\"enables\\":[],\\"type\\":\\"enableIntegration\\"}],\\"newSdkVersion\\":\\"0.9.0\\",\\"sdkName\\":\\"sentry.python\\",\\"sdkUrl\\":null,\\"type\\":\\"updateSdk\\"}"
+      type="info"
+    >
+      <AlertWrapper
+        className="ref-info"
+        type="info"
+      >
+        <div
+          className="ref-info css-1ngonsm-AlertWrapper-alertStyles e1xb5l7j1"
+          type="info"
+        >
+          <StyledInlineSvg
+            size="24px"
+            src="icon-upgrade"
+          >
+            <InlineSvg
+              className="css-1e3iblq-StyledInlineSvg e1xb5l7j0"
+              size="24px"
+              src="icon-upgrade"
+            >
+              <StyledSvg
+                className="css-1e3iblq-StyledInlineSvg e1xb5l7j0"
+                height="24px"
+                viewBox={Object {}}
+                width="24px"
+              >
+                <svg
+                  className="e1xb5l7j0 css-lbx2sj-StyledSvg-StyledInlineSvg e2idor0"
+                  height="24px"
+                  viewBox={Object {}}
+                  width="24px"
+                >
+                  <use
+                    href="#test"
+                    xlinkHref="#test"
+                  />
+                </svg>
+              </StyledSvg>
+            </InlineSvg>
+          </StyledInlineSvg>
+          <StyledTextBlock>
+            <Component
+              className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
+            >
+              <div
+                className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
+              >
+                We recommend to 
+                <EventSdkUpdateSuggestion
+                  event={
+                    Object {
+                      "id": "123",
+                      "sdk": Object {
+                        "name": "sentry.python",
+                        "version": "0.1.0",
+                      },
+                      "sdkUpdates": Array [
+                        Object {
+                          "enables": Array [
+                            Object {
+                              "enables": Array [],
+                              "integrationName": "django",
+                              "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                              "type": "enableIntegration",
+                            },
+                          ],
+                          "newSdkVersion": "0.9.0",
+                          "sdkName": "sentry.python",
+                          "sdkUrl": null,
+                          "type": "updateSdk",
+                        },
+                      ],
+                    }
+                  }
+                  suggestion={
+                    Object {
+                      "enables": Array [
+                        Object {
+                          "enables": Array [],
+                          "integrationName": "django",
+                          "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                          "type": "enableIntegration",
+                        },
+                      ],
+                      "newSdkVersion": "0.9.0",
+                      "sdkName": "sentry.python",
+                      "sdkUrl": null,
+                      "type": "updateSdk",
+                    }
+                  }
+                >
+                  <span>
+                    Update your SDK from version 0.1.0 to version 0.9.0
+                     so you can: 
+                    <ul>
+                      <li
+                        key="{\\"enables\\":[],\\"integrationName\\":\\"django\\",\\"integrationUrl\\":\\"https://docs.sentry.io/platforms/python/django/\\",\\"type\\":\\"enableIntegration\\"}"
+                      >
+                        <EventSdkUpdateSuggestion
+                          event={
+                            Object {
+                              "id": "123",
+                              "sdk": Object {
+                                "name": "sentry.python",
+                                "version": "0.1.0",
+                              },
+                              "sdkUpdates": Array [
+                                Object {
+                                  "enables": Array [
+                                    Object {
+                                      "enables": Array [],
+                                      "integrationName": "django",
+                                      "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                                      "type": "enableIntegration",
+                                    },
+                                  ],
+                                  "newSdkVersion": "0.9.0",
+                                  "sdkName": "sentry.python",
+                                  "sdkUrl": null,
+                                  "type": "updateSdk",
+                                },
+                              ],
+                            }
+                          }
+                          suggestion={
+                            Object {
+                              "enables": Array [],
+                              "integrationName": "django",
+                              "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                              "type": "enableIntegration",
+                            }
+                          }
+                        >
+                          <ForwardRef
+                            href="https://docs.sentry.io/platforms/python/django/"
+                            rel="noreferrer noopener"
+                            target="_blank"
+                          >
+                            <a
+                              href="https://docs.sentry.io/platforms/python/django/"
+                              rel="noreferrer noopener"
+                              target="_blank"
+                            >
+                              Enable the 'django' integration
+                            </a>
+                          </ForwardRef>
+                        </EventSdkUpdateSuggestion>
+                      </li>
+                    </ul>
+                  </span>
+                </EventSdkUpdateSuggestion>
+              </div>
+            </Component>
+          </StyledTextBlock>
+        </div>
+      </AlertWrapper>
+    </Alert>
+  </div>
+</EventSdkUpdates>
+`;

--- a/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
@@ -128,61 +128,65 @@ exports[`EventSdkUpdates renders a suggestion to update the sdk and then enable 
                   <span>
                     update your SDK from version 0.1.0 to version 0.9.0
                      so you can
-                    <ul>
-                      <li
-                        key="{\\"enables\\":[],\\"integrationName\\":\\"django\\",\\"integrationUrl\\":\\"https://docs.sentry.io/platforms/python/django/\\",\\"type\\":\\"enableIntegration\\"}"
+                    <AlertUl>
+                      <ul
+                        className="css-j5zjp6-AlertUl emcdiy70"
                       >
-                        <EventSdkUpdateSuggestion
-                          event={
-                            Object {
-                              "id": "123",
-                              "sdk": Object {
-                                "name": "sentry.python",
-                                "version": "0.1.0",
-                              },
-                              "sdkUpdates": Array [
-                                Object {
-                                  "enables": Array [
-                                    Object {
-                                      "enables": Array [],
-                                      "integrationName": "django",
-                                      "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
-                                      "type": "enableIntegration",
-                                    },
-                                  ],
-                                  "newSdkVersion": "0.9.0",
-                                  "sdkName": "sentry.python",
-                                  "sdkUrl": null,
-                                  "type": "updateSdk",
-                                },
-                              ],
-                            }
-                          }
-                          suggestion={
-                            Object {
-                              "enables": Array [],
-                              "integrationName": "django",
-                              "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
-                              "type": "enableIntegration",
-                            }
-                          }
+                        <li
+                          key="{\\"enables\\":[],\\"integrationName\\":\\"django\\",\\"integrationUrl\\":\\"https://docs.sentry.io/platforms/python/django/\\",\\"type\\":\\"enableIntegration\\"}"
                         >
-                          <ForwardRef
-                            href="https://docs.sentry.io/platforms/python/django/"
-                            rel="noreferrer noopener"
-                            target="_blank"
+                          <EventSdkUpdateSuggestion
+                            event={
+                              Object {
+                                "id": "123",
+                                "sdk": Object {
+                                  "name": "sentry.python",
+                                  "version": "0.1.0",
+                                },
+                                "sdkUpdates": Array [
+                                  Object {
+                                    "enables": Array [
+                                      Object {
+                                        "enables": Array [],
+                                        "integrationName": "django",
+                                        "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                                        "type": "enableIntegration",
+                                      },
+                                    ],
+                                    "newSdkVersion": "0.9.0",
+                                    "sdkName": "sentry.python",
+                                    "sdkUrl": null,
+                                    "type": "updateSdk",
+                                  },
+                                ],
+                              }
+                            }
+                            suggestion={
+                              Object {
+                                "enables": Array [],
+                                "integrationName": "django",
+                                "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                                "type": "enableIntegration",
+                              }
+                            }
                           >
-                            <a
+                            <ForwardRef
                               href="https://docs.sentry.io/platforms/python/django/"
                               rel="noreferrer noopener"
                               target="_blank"
                             >
-                              enable the 'django' integration
-                            </a>
-                          </ForwardRef>
-                        </EventSdkUpdateSuggestion>
-                      </li>
-                    </ul>
+                              <a
+                                href="https://docs.sentry.io/platforms/python/django/"
+                                rel="noreferrer noopener"
+                                target="_blank"
+                              >
+                                enable the 'django' integration
+                              </a>
+                            </ForwardRef>
+                          </EventSdkUpdateSuggestion>
+                        </li>
+                      </ul>
+                    </AlertUl>
                   </span>
                 </EventSdkUpdateSuggestion>
               </div>

--- a/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
@@ -130,7 +130,7 @@ exports[`EventSdkUpdates renders a suggestion to update the sdk and then enable 
                     }
                   >
                     <span>
-                      Update your SDK from version 0.1.0 to version 0.9.0
+                      update your SDK from version 0.1.0 to version 0.9.0
                        so you can
                       <ul>
                         <li
@@ -181,7 +181,7 @@ exports[`EventSdkUpdates renders a suggestion to update the sdk and then enable 
                                 rel="noreferrer noopener"
                                 target="_blank"
                               >
-                                Enable the 'django' integration
+                                enable the 'django' integration
                               </a>
                             </ForwardRef>
                           </EventSdkUpdateSuggestion>

--- a/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
@@ -29,166 +29,173 @@ exports[`EventSdkUpdates renders a suggestion to update the sdk and then enable 
   }
 >
   <div>
-    <Alert
+    <StyledAlert
       icon="icon-upgrade"
       iconSize="24px"
       key="{\\"enables\\":[{\\"enables\\":[],\\"type\\":\\"enableIntegration\\"}],\\"newSdkVersion\\":\\"0.9.0\\",\\"sdkName\\":\\"sentry.python\\",\\"sdkUrl\\":null,\\"type\\":\\"updateSdk\\"}"
       type="info"
     >
-      <AlertWrapper
-        className="ref-info"
+      <Alert
+        className="css-4xdpr6-StyledAlert emcdiy70"
+        icon="icon-upgrade"
+        iconSize="24px"
         type="info"
       >
-        <div
-          className="ref-info css-1ngonsm-AlertWrapper-alertStyles e1xb5l7j1"
+        <AlertWrapper
+          className="ref-info css-4xdpr6-StyledAlert emcdiy70"
           type="info"
         >
-          <StyledInlineSvg
-            size="24px"
-            src="icon-upgrade"
+          <div
+            className="ref-info emcdiy70 css-a48bmr-AlertWrapper-alertStyles-StyledAlert e1xb5l7j1"
+            type="info"
           >
-            <InlineSvg
-              className="css-1e3iblq-StyledInlineSvg e1xb5l7j0"
+            <StyledInlineSvg
               size="24px"
               src="icon-upgrade"
             >
-              <StyledSvg
+              <InlineSvg
                 className="css-1e3iblq-StyledInlineSvg e1xb5l7j0"
-                height="24px"
-                viewBox={Object {}}
-                width="24px"
+                size="24px"
+                src="icon-upgrade"
               >
-                <svg
-                  className="e1xb5l7j0 css-lbx2sj-StyledSvg-StyledInlineSvg e2idor0"
+                <StyledSvg
+                  className="css-1e3iblq-StyledInlineSvg e1xb5l7j0"
                   height="24px"
                   viewBox={Object {}}
                   width="24px"
                 >
-                  <use
-                    href="#test"
-                    xlinkHref="#test"
-                  />
-                </svg>
-              </StyledSvg>
-            </InlineSvg>
-          </StyledInlineSvg>
-          <StyledTextBlock>
-            <Component
-              className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
-            >
-              <div
+                  <svg
+                    className="e1xb5l7j0 css-lbx2sj-StyledSvg-StyledInlineSvg e2idor0"
+                    height="24px"
+                    viewBox={Object {}}
+                    width="24px"
+                  >
+                    <use
+                      href="#test"
+                      xlinkHref="#test"
+                    />
+                  </svg>
+                </StyledSvg>
+              </InlineSvg>
+            </StyledInlineSvg>
+            <StyledTextBlock>
+              <Component
                 className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
               >
-                We recommend to 
-                <EventSdkUpdateSuggestion
-                  event={
-                    Object {
-                      "id": "123",
-                      "sdk": Object {
-                        "name": "sentry.python",
-                        "version": "0.1.0",
-                      },
-                      "sdkUpdates": Array [
-                        Object {
-                          "enables": Array [
-                            Object {
-                              "enables": Array [],
-                              "integrationName": "django",
-                              "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
-                              "type": "enableIntegration",
-                            },
-                          ],
-                          "newSdkVersion": "0.9.0",
-                          "sdkName": "sentry.python",
-                          "sdkUrl": null,
-                          "type": "updateSdk",
-                        },
-                      ],
-                    }
-                  }
-                  suggestion={
-                    Object {
-                      "enables": Array [
-                        Object {
-                          "enables": Array [],
-                          "integrationName": "django",
-                          "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
-                          "type": "enableIntegration",
-                        },
-                      ],
-                      "newSdkVersion": "0.9.0",
-                      "sdkName": "sentry.python",
-                      "sdkUrl": null,
-                      "type": "updateSdk",
-                    }
-                  }
+                <div
+                  className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
                 >
-                  <span>
-                    Update your SDK from version 0.1.0 to version 0.9.0
-                     so you can: 
-                    <ul>
-                      <li
-                        key="{\\"enables\\":[],\\"integrationName\\":\\"django\\",\\"integrationUrl\\":\\"https://docs.sentry.io/platforms/python/django/\\",\\"type\\":\\"enableIntegration\\"}"
-                      >
-                        <EventSdkUpdateSuggestion
-                          event={
-                            Object {
-                              "id": "123",
-                              "sdk": Object {
-                                "name": "sentry.python",
-                                "version": "0.1.0",
+                  We recommend you
+                  <EventSdkUpdateSuggestion
+                    event={
+                      Object {
+                        "id": "123",
+                        "sdk": Object {
+                          "name": "sentry.python",
+                          "version": "0.1.0",
+                        },
+                        "sdkUpdates": Array [
+                          Object {
+                            "enables": Array [
+                              Object {
+                                "enables": Array [],
+                                "integrationName": "django",
+                                "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                                "type": "enableIntegration",
                               },
-                              "sdkUpdates": Array [
-                                Object {
-                                  "enables": Array [
-                                    Object {
-                                      "enables": Array [],
-                                      "integrationName": "django",
-                                      "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
-                                      "type": "enableIntegration",
-                                    },
-                                  ],
-                                  "newSdkVersion": "0.9.0",
-                                  "sdkName": "sentry.python",
-                                  "sdkUrl": null,
-                                  "type": "updateSdk",
-                                },
-                              ],
-                            }
-                          }
-                          suggestion={
-                            Object {
-                              "enables": Array [],
-                              "integrationName": "django",
-                              "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
-                              "type": "enableIntegration",
-                            }
-                          }
+                            ],
+                            "newSdkVersion": "0.9.0",
+                            "sdkName": "sentry.python",
+                            "sdkUrl": null,
+                            "type": "updateSdk",
+                          },
+                        ],
+                      }
+                    }
+                    suggestion={
+                      Object {
+                        "enables": Array [
+                          Object {
+                            "enables": Array [],
+                            "integrationName": "django",
+                            "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                            "type": "enableIntegration",
+                          },
+                        ],
+                        "newSdkVersion": "0.9.0",
+                        "sdkName": "sentry.python",
+                        "sdkUrl": null,
+                        "type": "updateSdk",
+                      }
+                    }
+                  >
+                    <span>
+                      Update your SDK from version 0.1.0 to version 0.9.0
+                       so you can
+                      <ul>
+                        <li
+                          key="{\\"enables\\":[],\\"integrationName\\":\\"django\\",\\"integrationUrl\\":\\"https://docs.sentry.io/platforms/python/django/\\",\\"type\\":\\"enableIntegration\\"}"
                         >
-                          <ForwardRef
-                            href="https://docs.sentry.io/platforms/python/django/"
-                            rel="noreferrer noopener"
-                            target="_blank"
+                          <EventSdkUpdateSuggestion
+                            event={
+                              Object {
+                                "id": "123",
+                                "sdk": Object {
+                                  "name": "sentry.python",
+                                  "version": "0.1.0",
+                                },
+                                "sdkUpdates": Array [
+                                  Object {
+                                    "enables": Array [
+                                      Object {
+                                        "enables": Array [],
+                                        "integrationName": "django",
+                                        "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                                        "type": "enableIntegration",
+                                      },
+                                    ],
+                                    "newSdkVersion": "0.9.0",
+                                    "sdkName": "sentry.python",
+                                    "sdkUrl": null,
+                                    "type": "updateSdk",
+                                  },
+                                ],
+                              }
+                            }
+                            suggestion={
+                              Object {
+                                "enables": Array [],
+                                "integrationName": "django",
+                                "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                                "type": "enableIntegration",
+                              }
+                            }
                           >
-                            <a
+                            <ForwardRef
                               href="https://docs.sentry.io/platforms/python/django/"
                               rel="noreferrer noopener"
                               target="_blank"
                             >
-                              Enable the 'django' integration
-                            </a>
-                          </ForwardRef>
-                        </EventSdkUpdateSuggestion>
-                      </li>
-                    </ul>
-                  </span>
-                </EventSdkUpdateSuggestion>
-              </div>
-            </Component>
-          </StyledTextBlock>
-        </div>
-      </AlertWrapper>
-    </Alert>
+                              <a
+                                href="https://docs.sentry.io/platforms/python/django/"
+                                rel="noreferrer noopener"
+                                target="_blank"
+                              >
+                                Enable the 'django' integration
+                              </a>
+                            </ForwardRef>
+                          </EventSdkUpdateSuggestion>
+                        </li>
+                      </ul>
+                    </span>
+                  </EventSdkUpdateSuggestion>
+                </div>
+              </Component>
+            </StyledTextBlock>
+          </div>
+        </AlertWrapper>
+      </Alert>
+    </StyledAlert>
   </div>
 </EventSdkUpdates>
 `;

--- a/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/sdkUpdates.spec.jsx.snap
@@ -28,174 +28,169 @@ exports[`EventSdkUpdates renders a suggestion to update the sdk and then enable 
     }
   }
 >
-  <div>
-    <StyledAlert
+  <div
+    className="box"
+  >
+    <Alert
       icon="icon-upgrade"
       iconSize="24px"
       key="{\\"enables\\":[{\\"enables\\":[],\\"type\\":\\"enableIntegration\\"}],\\"newSdkVersion\\":\\"0.9.0\\",\\"sdkName\\":\\"sentry.python\\",\\"sdkUrl\\":null,\\"type\\":\\"updateSdk\\"}"
       type="info"
     >
-      <Alert
-        className="css-4xdpr6-StyledAlert emcdiy70"
-        icon="icon-upgrade"
-        iconSize="24px"
+      <AlertWrapper
+        className="ref-info"
         type="info"
       >
-        <AlertWrapper
-          className="ref-info css-4xdpr6-StyledAlert emcdiy70"
+        <div
+          className="ref-info css-1ngonsm-AlertWrapper-alertStyles e1xb5l7j1"
           type="info"
         >
-          <div
-            className="ref-info emcdiy70 css-a48bmr-AlertWrapper-alertStyles-StyledAlert e1xb5l7j1"
-            type="info"
+          <StyledInlineSvg
+            size="24px"
+            src="icon-upgrade"
           >
-            <StyledInlineSvg
+            <InlineSvg
+              className="css-1e3iblq-StyledInlineSvg e1xb5l7j0"
               size="24px"
               src="icon-upgrade"
             >
-              <InlineSvg
+              <StyledSvg
                 className="css-1e3iblq-StyledInlineSvg e1xb5l7j0"
-                size="24px"
-                src="icon-upgrade"
+                height="24px"
+                viewBox={Object {}}
+                width="24px"
               >
-                <StyledSvg
-                  className="css-1e3iblq-StyledInlineSvg e1xb5l7j0"
+                <svg
+                  className="e1xb5l7j0 css-lbx2sj-StyledSvg-StyledInlineSvg e2idor0"
                   height="24px"
                   viewBox={Object {}}
                   width="24px"
                 >
-                  <svg
-                    className="e1xb5l7j0 css-lbx2sj-StyledSvg-StyledInlineSvg e2idor0"
-                    height="24px"
-                    viewBox={Object {}}
-                    width="24px"
-                  >
-                    <use
-                      href="#test"
-                      xlinkHref="#test"
-                    />
-                  </svg>
-                </StyledSvg>
-              </InlineSvg>
-            </StyledInlineSvg>
-            <StyledTextBlock>
-              <Component
+                  <use
+                    href="#test"
+                    xlinkHref="#test"
+                  />
+                </svg>
+              </StyledSvg>
+            </InlineSvg>
+          </StyledInlineSvg>
+          <StyledTextBlock>
+            <Component
+              className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
+            >
+              <div
                 className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
               >
-                <div
-                  className="css-1h3n7tg-TextBlock-StyledTextBlock e1xb5l7j2"
-                >
-                  We recommend you
-                  <EventSdkUpdateSuggestion
-                    event={
-                      Object {
-                        "id": "123",
-                        "sdk": Object {
-                          "name": "sentry.python",
-                          "version": "0.1.0",
+                We recommend you 
+                <EventSdkUpdateSuggestion
+                  event={
+                    Object {
+                      "id": "123",
+                      "sdk": Object {
+                        "name": "sentry.python",
+                        "version": "0.1.0",
+                      },
+                      "sdkUpdates": Array [
+                        Object {
+                          "enables": Array [
+                            Object {
+                              "enables": Array [],
+                              "integrationName": "django",
+                              "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                              "type": "enableIntegration",
+                            },
+                          ],
+                          "newSdkVersion": "0.9.0",
+                          "sdkName": "sentry.python",
+                          "sdkUrl": null,
+                          "type": "updateSdk",
                         },
-                        "sdkUpdates": Array [
-                          Object {
-                            "enables": Array [
-                              Object {
-                                "enables": Array [],
-                                "integrationName": "django",
-                                "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
-                                "type": "enableIntegration",
+                      ],
+                    }
+                  }
+                  suggestion={
+                    Object {
+                      "enables": Array [
+                        Object {
+                          "enables": Array [],
+                          "integrationName": "django",
+                          "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                          "type": "enableIntegration",
+                        },
+                      ],
+                      "newSdkVersion": "0.9.0",
+                      "sdkName": "sentry.python",
+                      "sdkUrl": null,
+                      "type": "updateSdk",
+                    }
+                  }
+                >
+                  <span>
+                    update your SDK from version 0.1.0 to version 0.9.0
+                     so you can
+                    <ul>
+                      <li
+                        key="{\\"enables\\":[],\\"integrationName\\":\\"django\\",\\"integrationUrl\\":\\"https://docs.sentry.io/platforms/python/django/\\",\\"type\\":\\"enableIntegration\\"}"
+                      >
+                        <EventSdkUpdateSuggestion
+                          event={
+                            Object {
+                              "id": "123",
+                              "sdk": Object {
+                                "name": "sentry.python",
+                                "version": "0.1.0",
                               },
-                            ],
-                            "newSdkVersion": "0.9.0",
-                            "sdkName": "sentry.python",
-                            "sdkUrl": null,
-                            "type": "updateSdk",
-                          },
-                        ],
-                      }
-                    }
-                    suggestion={
-                      Object {
-                        "enables": Array [
-                          Object {
-                            "enables": Array [],
-                            "integrationName": "django",
-                            "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
-                            "type": "enableIntegration",
-                          },
-                        ],
-                        "newSdkVersion": "0.9.0",
-                        "sdkName": "sentry.python",
-                        "sdkUrl": null,
-                        "type": "updateSdk",
-                      }
-                    }
-                  >
-                    <span>
-                      update your SDK from version 0.1.0 to version 0.9.0
-                       so you can
-                      <ul>
-                        <li
-                          key="{\\"enables\\":[],\\"integrationName\\":\\"django\\",\\"integrationUrl\\":\\"https://docs.sentry.io/platforms/python/django/\\",\\"type\\":\\"enableIntegration\\"}"
-                        >
-                          <EventSdkUpdateSuggestion
-                            event={
-                              Object {
-                                "id": "123",
-                                "sdk": Object {
-                                  "name": "sentry.python",
-                                  "version": "0.1.0",
+                              "sdkUpdates": Array [
+                                Object {
+                                  "enables": Array [
+                                    Object {
+                                      "enables": Array [],
+                                      "integrationName": "django",
+                                      "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                                      "type": "enableIntegration",
+                                    },
+                                  ],
+                                  "newSdkVersion": "0.9.0",
+                                  "sdkName": "sentry.python",
+                                  "sdkUrl": null,
+                                  "type": "updateSdk",
                                 },
-                                "sdkUpdates": Array [
-                                  Object {
-                                    "enables": Array [
-                                      Object {
-                                        "enables": Array [],
-                                        "integrationName": "django",
-                                        "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
-                                        "type": "enableIntegration",
-                                      },
-                                    ],
-                                    "newSdkVersion": "0.9.0",
-                                    "sdkName": "sentry.python",
-                                    "sdkUrl": null,
-                                    "type": "updateSdk",
-                                  },
-                                ],
-                              }
+                              ],
                             }
-                            suggestion={
-                              Object {
-                                "enables": Array [],
-                                "integrationName": "django",
-                                "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
-                                "type": "enableIntegration",
-                              }
+                          }
+                          suggestion={
+                            Object {
+                              "enables": Array [],
+                              "integrationName": "django",
+                              "integrationUrl": "https://docs.sentry.io/platforms/python/django/",
+                              "type": "enableIntegration",
                             }
+                          }
+                        >
+                          <ForwardRef
+                            href="https://docs.sentry.io/platforms/python/django/"
+                            rel="noreferrer noopener"
+                            target="_blank"
                           >
-                            <ForwardRef
+                            <a
                               href="https://docs.sentry.io/platforms/python/django/"
                               rel="noreferrer noopener"
                               target="_blank"
                             >
-                              <a
-                                href="https://docs.sentry.io/platforms/python/django/"
-                                rel="noreferrer noopener"
-                                target="_blank"
-                              >
-                                enable the 'django' integration
-                              </a>
-                            </ForwardRef>
-                          </EventSdkUpdateSuggestion>
-                        </li>
-                      </ul>
-                    </span>
-                  </EventSdkUpdateSuggestion>
-                </div>
-              </Component>
-            </StyledTextBlock>
-          </div>
-        </AlertWrapper>
-      </Alert>
-    </StyledAlert>
+                              enable the 'django' integration
+                            </a>
+                          </ForwardRef>
+                        </EventSdkUpdateSuggestion>
+                      </li>
+                    </ul>
+                  </span>
+                </EventSdkUpdateSuggestion>
+              </div>
+            </Component>
+          </StyledTextBlock>
+        </div>
+      </AlertWrapper>
+    </Alert>
   </div>
 </EventSdkUpdates>
 `;

--- a/tests/js/spec/components/events/sdkUpdates.spec.jsx
+++ b/tests/js/spec/components/events/sdkUpdates.spec.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {initializeOrg} from 'app-test/helpers/initializeOrg';
+import EventSdkUpdates from 'app/components/events/sdkUpdates';
+
+describe('EventSdkUpdates', function() {
+  const {routerContext} = initializeOrg();
+
+  it('renders a suggestion to update the sdk and then enable an integration', function() {
+    const props = {
+      event: TestStubs.UpdateSdkAndEnableIntegrationSuggestion(),
+    };
+
+    const wrapper = mount(<EventSdkUpdates {...props} />, routerContext);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/sharedGroupDetails/__snapshots__/index.spec.jsx.snap
@@ -898,7 +898,6 @@ exports[`SharedGroupDetails renders 1`] = `
                                   </div>
                                 </EventDataSection>
                               </MessageInterface>
-                               
                             </div>
                           </EventEntries>
                         </withApi(EventEntries)>

--- a/tests/sentry/test_sdk_updates.py
+++ b/tests/sentry/test_sdk_updates.py
@@ -1,0 +1,108 @@
+from __future__ import absolute_import
+
+from sentry.sdk_updates import SdkSetupState, SdkIndexState, get_suggested_updates
+
+
+PYTHON_INDEX_STATE = SdkIndexState(
+    sdk_versions={"sentry.python": "0.9.0"},
+)
+
+
+def test_too_old_django():
+    setup = SdkSetupState(
+        sdk_name='sentry.python',
+        sdk_version='0.9.0',
+        integrations=[],
+        modules={
+            'django': '1.3'})
+    assert list(get_suggested_updates(setup, PYTHON_INDEX_STATE)) == []
+
+
+def test_too_old_sdk():
+    setup = SdkSetupState(
+        sdk_name='sentry.python',
+        sdk_version='0.1.0',
+        integrations=[],
+        modules={
+            'django': '1.8'})
+    assert list(get_suggested_updates(setup, PYTHON_INDEX_STATE)) == [
+        {
+            'enables': [
+                {
+                    'type': 'enableIntegration',
+                    'enables': [],
+                    'integrationName': 'django',
+                    'integrationUrl': 'https://docs.sentry.io/platforms/python/django/',
+                }
+            ],
+            'newSdkVersion': '0.9.0',
+            'sdkName': 'sentry.python',
+            'sdkUrl': None,
+            'type': 'updateSdk'
+        }
+    ]
+
+
+def test_enable_django_integration():
+    setup = SdkSetupState(
+        sdk_name='sentry.python',
+        sdk_version='0.9.0',
+        integrations=[],
+        modules={
+            'django': '1.8'})
+    assert list(get_suggested_updates(setup, PYTHON_INDEX_STATE)) == [
+        {
+            'type': 'enableIntegration',
+            'enables': [],
+            'integrationName': 'django',
+            'integrationUrl': 'https://docs.sentry.io/platforms/python/django/',
+        }
+    ]
+
+
+def test_update_sdk():
+    setup = SdkSetupState(
+        sdk_name='sentry.python',
+        sdk_version='0.1.0',
+        integrations=[],
+        modules={})
+    assert list(get_suggested_updates(setup, PYTHON_INDEX_STATE)) == [
+        {
+            'enables': [],
+            'newSdkVersion': '0.9.0',
+            'sdkName': 'sentry.python',
+            'sdkUrl': None,
+            'type': 'updateSdk'
+        }
+    ]
+
+
+def test_enable_two_integrations():
+    setup = SdkSetupState(
+        sdk_name='sentry.python',
+        sdk_version='0.1.0',
+        integrations=[],
+        modules={"django": "1.8.0", "flask": "1.0.0"})
+
+    assert list(get_suggested_updates(setup, PYTHON_INDEX_STATE)) == [
+        {
+            'enables': [
+                {
+                    'type': 'enableIntegration',
+                    'enables': [],
+                    'integrationName': 'django',
+                    'integrationUrl': 'https://docs.sentry.io/platforms/python/django/',
+                },
+                {
+                    'type': 'enableIntegration',
+                    'enables': [],
+                    'integrationName': 'flask',
+                    'integrationUrl': 'https://docs.sentry.io/platforms/python/flask/',
+                }
+            ],
+            'newSdkVersion': '0.9.0',
+            'sdkName': 'sentry.python',
+            'sdkUrl': None,
+            'type': 'updateSdk'
+        }
+    ]

--- a/tests/sentry/test_sdk_updates.py
+++ b/tests/sentry/test_sdk_updates.py
@@ -1,10 +1,16 @@
 from __future__ import absolute_import
 
+import pytest
+
 from sentry.sdk_updates import SdkSetupState, SdkIndexState, get_suggested_updates
 
 
 PYTHON_INDEX_STATE = SdkIndexState(
     sdk_versions={"sentry.python": "0.9.0"},
+)
+
+DOTNET_INDEX_STATE = SdkIndexState(
+    sdk_versions={"sentry.dotnet": "1.2.0"},
 )
 
 
@@ -106,3 +112,73 @@ def test_enable_two_integrations():
             'type': 'updateSdk'
         }
     ]
+
+
+@pytest.fixture(params=['sentry.dotnet.serilog', 'sentry.dotnet.aspnetcore',
+                        'sentry.dotnet.foobar', 'sentry.dotnet'])
+def some_dotnet_sdk(request):
+    return request.param
+
+
+def test_add_aspnetcore_sdk(some_dotnet_sdk):
+    setup = SdkSetupState(
+        sdk_name=some_dotnet_sdk,
+        sdk_version='1.2.0',
+        integrations=[],
+        modules={
+            "Sentry.Serilog": "1.2.0",
+            "Microsoft.AspNetCore.Hosting": "2.2.0",
+            "Serilog": "2.7.1"}
+    )
+
+    suggestions = list(get_suggested_updates(setup, DOTNET_INDEX_STATE))
+
+    if some_dotnet_sdk == 'sentry.dotnet.aspnetcore':
+        assert not suggestions
+    else:
+        assert suggestions == [
+            {
+                'enables': [],
+                'newSdkName': 'sentry.dotnet.aspnetcore',
+                'sdkUrl': None,
+                'type': 'changeSdk'
+            }
+        ]
+
+
+def test_add_serilog_sdk(some_dotnet_sdk):
+    setup = SdkSetupState(
+        sdk_name=some_dotnet_sdk,
+        sdk_version='1.2.0',
+        integrations=[],
+        modules={"Sentry.AspNetCore": "1.2.0", "Microsoft.AspNetCore": "2.2.0", "Serilog": "2.7.1"}
+    )
+
+    suggestions = list(get_suggested_updates(setup, DOTNET_INDEX_STATE))
+    if some_dotnet_sdk == 'sentry.dotnet.serilog':
+        assert not suggestions
+    else:
+        assert suggestions == [
+            {
+                'enables': [],
+                'newSdkName': 'sentry.dotnet.serilog',
+                'sdkUrl': None,
+                'type': 'changeSdk'
+            }
+        ]
+
+
+def test_add_no_dotnet_sdk(some_dotnet_sdk):
+    setup = SdkSetupState(
+        sdk_name=some_dotnet_sdk,
+        sdk_version='1.2.0',
+        integrations=[],
+        modules={
+            "Sentry.AspNetCore": "1.2.0",
+            "Sentry.Serilog": "1.2.0",
+            "Microsoft.AspNetCore": "2.2.0",
+            "Serilog": "2.7.1"}
+    )
+
+    suggestions = list(get_suggested_updates(setup, DOTNET_INDEX_STATE))
+    assert suggestions == []


### PR DESCRIPTION
Example for Python:

<img width="584" alt="Screenshot 2019-06-16 at 15 34 48" src="https://user-images.githubusercontent.com/837573/59565183-60f58f80-9050-11e9-858e-a7df2807af49.png">

Or if the SDK is already up-to-date:

<img width="481" alt="Screenshot 2019-06-16 at 16 09 44" src="https://user-images.githubusercontent.com/837573/59565256-322be900-9051-11e9-912a-da65c3659230.png">



- [x] Add data for dotnet (requires "schema" changes)