### PR TITLE
fix(build): Add `grouping` directory to pip sdist packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ recursive-include ./ requirements*.txt
 recursive-include src/sentry/templates *
 recursive-include src/sentry/locale *
 recursive-include src/sentry/data *
+recursive-include src/sentry/grouping *
 recursive-include src/sentry/static/sentry *
 recursive-include src/sentry/scripts *.lua
 recursive-include src/sentry/integration-docs *.json


### PR DESCRIPTION
Right now this is breaking docker-sentry git builds. Guessing it will
cause more issues in the future and was reported here on the forums:

https://forum.sentry.io/t/enhancement-configs-not-found-on-latest-branches/6800?u=byk