### PR TITLE
fix: Fix tooltip if either release commits has no author, or if an author's name/email of a commit contains just whitespace.

### DIFF
--- a/src/sentry/static/sentry/app/components/avatar/userAvatar.jsx
+++ b/src/sentry/static/sentry/app/components/avatar/userAvatar.jsx
@@ -53,6 +53,8 @@ class UserAvatar extends React.Component {
         tooltip={
           typeof renderTooltip === 'function'
             ? renderTooltip(user)
+            : props.tooltip
+            ? props.tooltip
             : userDisplayName(user)
         }
         title={user.name || user.email || user.username || ''}

--- a/src/sentry/static/sentry/app/utils/formatters.jsx
+++ b/src/sentry/static/sentry/app/utils/formatters.jsx
@@ -1,6 +1,17 @@
+import {get} from 'lodash';
+
+import {t} from 'app/locale';
+
 export function userDisplayName(user) {
-  let displayName = user.name;
-  if (user.email && user.email !== user.name) {
+  let displayName = String(get(user, 'name', t('Unknown author'))).trim();
+
+  if (displayName.length <= 0) {
+    displayName = t('Unknown author');
+  }
+
+  const email = String(get(user, 'email', '')).trim();
+
+  if (email.length > 0 && email !== displayName) {
     displayName += ' (' + user.email + ')';
   }
   return displayName;

--- a/src/sentry/static/sentry/app/views/organizationReleases/detail/commitAuthorStats.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/detail/commitAuthorStats.jsx
@@ -117,12 +117,7 @@ class CommitAuthorStats extends React.Component {
               return (
                 <PanelItem key={i} p={1} align="center">
                   <Flex>
-                    <Avatar
-                      user={author}
-                      size={20}
-                      hasTooltip
-                      tooltip={`${author.name} ${author.email}`}
-                    />
+                    <Avatar user={author} size={20} hasTooltip />
                   </Flex>
                   <Flex flex="1" px={1}>
                     <CommitBar

--- a/tests/js/spec/helpers/formatters.spec.jsx
+++ b/tests/js/spec/helpers/formatters.spec.jsx
@@ -19,5 +19,34 @@ describe('formatters', function() {
         })
       ).toEqual('user (foo@bar.com)');
     });
+
+    it('should show unknown author with email, if email is only provided', function() {
+      expect(
+        userDisplayName({
+          email: 'foo@bar.com',
+        })
+      ).toEqual('Unknown author (foo@bar.com)');
+    });
+
+    it('should show unknown author, if author or email is just whitespace', function() {
+      expect(
+        userDisplayName({
+          // eslint-disable-next-line quotes
+          name: `\t\n `,
+        })
+      ).toEqual('Unknown author');
+
+      expect(
+        userDisplayName({
+          // eslint-disable-next-line quotes
+          email: `\t\n `,
+        })
+      ).toEqual('Unknown author');
+    });
+
+    it('should show unknown author, if user object is either not an object or incomplete', function() {
+      expect(userDisplayName()).toEqual('Unknown author');
+      expect(userDisplayName({})).toEqual('Unknown author');
+    });
   });
 });


### PR DESCRIPTION

- Commits may contain no author, and thus the author tooltip will be empty. This PR indicates those commits has having been authored by "Unknown author".

- Commit authors that are just whitespace are indicated as either "Unknown author", or "Unknown author (email)" (if an email was provided).

------

Before:

![Screen Shot 2019-06-16 at 9 16 15 PM](https://user-images.githubusercontent.com/139499/59603990-e02ea600-90d8-11e9-9969-7a88f58b7675.png)

After:

![Screen Shot 2019-06-16 at 9 15 11 PM](https://user-images.githubusercontent.com/139499/59604002-e7ee4a80-90d8-11e9-80e8-c134c4e2d1bc.png)
