### PR TITLE
fix(audit): Log correct state for filter changes

### DIFF
--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -56,7 +56,7 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
             returned_state = filter.id
             removed = current_state - new_state
 
-            if removed == -1:
+            if removed == 1:
                 audit_log_state = AuditLogEntryEvent.PROJECT_DISABLE
 
         self.create_audit_entry(


### PR DESCRIPTION
Logic for the audit entry is wrong for boolean filters:

Re: pull request #12932 

removed = current_state - new_state
Enable: new_state=True, current_state=False => False-True => -1
Disable: new_state=False, current_state=True => True-False => 1