### PR TITLE
ci(yarn): Fix TravisCI not using the checked-in yarn binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ base_acceptance: &acceptance_default
     - docker run -d --network host --name snuba --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=localhost:9000 getsentry/snuba
     - docker ps -a
   install:
-    - yarn install --pure-lockfile
+    - ./bin yarn install --pure-lockfile
     - python setup.py install_egg_info
     - pip install -e ".[dev,tests,optional]"
     - wget -N "https://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_74)/chromedriver_linux64.zip" -P ~/
@@ -118,7 +118,7 @@ matrix:
         - SENTRY_LIGHT_BUILD=1 pip install -e ".[dev,tests,optional]"
         - find "$NODE_DIR" -type d -empty -delete
         - nvm install
-        - yarn install --pure-lockfile
+        - ./bin/yarn install --pure-lockfile
 
     - <<: *postgres_default
       name: 'Backend [Postgres] (1/2)'
@@ -156,7 +156,7 @@ matrix:
         - find "$NODE_DIR" -type d -empty -delete
         - nvm install
       install:
-        - yarn install --pure-lockfile
+        - ./bin/yarn install --pure-lockfile
 
     - python: 2.7
       name: 'Command Line'
@@ -221,7 +221,7 @@ matrix:
         # Use the decrypted service account credentials to authenticate the command line tool
         - gcloud auth activate-service-account --key-file client-secret.json
       install:
-        - yarn install --pure-lockfile
+        - ./bin/yarn install --pure-lockfile
         - gcloud version
       script: bash .travis/deploy-storybook.sh
       after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ base_acceptance: &acceptance_default
     - docker run -d --network host --name snuba --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=localhost:9000 getsentry/snuba
     - docker ps -a
   install:
-    - ./bin yarn install --pure-lockfile
+    - ./bin/yarn install --pure-lockfile
     - python setup.py install_egg_info
     - pip install -e ".[dev,tests,optional]"
     - wget -N "https://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_74)/chromedriver_linux64.zip" -P ~/


### PR DESCRIPTION
Follow up to #13569. Normally, any recent Yarn version (>1.0.0) should
read the `yarn-path` value from the `.yarnrc` file but some TravisCI
machines seem to be using an ancient version (`0.27.0`) that doesn't
support this and causing build failures.

This diff will ensure the correct binary is being used.