### PR TITLE
fix(ui) Fix proptype warning when modal is a loading state

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -129,7 +129,11 @@ class EventDetails extends AsyncComponent {
   }
 
   renderLoading() {
-    return <ModalDialog className={modalStyles}>{super.renderLoading()}</ModalDialog>;
+    return (
+      <ModalDialog onDismiss={this.onDismiss} className={modalStyles}>
+        {super.renderLoading()}
+      </ModalDialog>
+    );
   }
 }
 


### PR DESCRIPTION
Forgot to set the onDismiss prop after I made it required.