### PR TITLE
fix(ui) Fix graph navigation in event modal

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/modalLineGraph.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/modalLineGraph.jsx
@@ -74,12 +74,19 @@ const handleClick = async function(
   // Get the timestamp that was clicked.
   const value = series.value[0];
 
+  // Apply the issue.id condition to the request.
+  let search = location.query.query;
+  if (search && search.length) {
+    search += ` issue.id:${groupId}`;
+  } else {
+    search = `issue.id:${groupId}`;
+  }
+
   // Get events that match the clicked timestamp
   // taking into account the group and current environment & query
   const query = {
     environment: selection.environments,
-    query: location.query.query,
-    group: groupId,
+    query: search,
     start: getUtcDateString(value),
     end: getUtcDateString(value + intervalToMilliseconds(interval)),
   };


### PR DESCRIPTION
The event details latest/oldest endpoints don't support a `group` query parameter. Instead the `issue.id` condition must be sent in the query text. I was using `group` because I made it work in an earlier prototype and then removed it when I saw tests for `issue.id` condition.

Refs SEN-774