### PR TITLE
fix(ui): Use GlobalSelectionLink in Issue Details, Events Table

### DIFF
--- a/src/sentry/static/sentry/app/components/eventsTable/eventsTableRow.jsx
+++ b/src/sentry/static/sentry/app/components/eventsTable/eventsTableRow.jsx
@@ -1,14 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Link} from 'react-router';
 
-import SentryTypes from 'app/sentryTypes';
+import AttachmentUrl from 'app/utils/attachmentUrl';
 import Avatar from 'app/components/avatar';
 import DateTime from 'app/components/dateTime';
 import DeviceName from 'app/components/deviceName';
 import FileSize from 'app/components/fileSize';
+import GlobalSelectionLink from 'app/components/globalSelectionLink';
+import SentryTypes from 'app/sentryTypes';
 import withOrganization from 'app/utils/withOrganization';
-import AttachmentUrl from 'app/utils/attachmentUrl';
 
 class EventsTableRow extends React.Component {
   static propTypes = {
@@ -67,16 +67,15 @@ class EventsTableRow extends React.Component {
     event.tags.forEach(tag => {
       tagMap[tag.key] = tag.value;
     });
-
-    const basePath = `/organizations/${orgId}/issues/`;
+    const link = `/organizations/${orgId}/issues/${groupId}/events/${event.id}/`;
 
     return (
       <tr key={event.id} className={className}>
         <td>
           <h5>
-            <Link to={`${basePath}${groupId}/events/${event.id}/`}>
+            <GlobalSelectionLink to={link}>
               <DateTime date={event.dateCreated} />
-            </Link>
+            </GlobalSelectionLink>
             <small>{(this.getEventTitle(event) || '').substr(0, 100)}</small>
             {this.renderCrashFileLink()}
           </h5>

--- a/tests/js/spec/components/eventsTable/__snapshots__/eventsTableRow.spec.jsx.snap
+++ b/tests/js/spec/components/eventsTable/__snapshots__/eventsTableRow.spec.jsx.snap
@@ -6,16 +6,14 @@ exports[`EventsTableRow renders 1`] = `
 >
   <td>
     <h5>
-      <Link
-        onlyActiveOnIndex={false}
-        style={Object {}}
+      <GlobalSelectionLink
         to="/organizations/orgId/issues/groupId/events/904/"
       >
         <DateTime
           date="2017-07-26T00:34:20Z"
           seconds={true}
         />
-      </Link>
+      </GlobalSelectionLink>
       <small>
         TypeError: Cannot read property 'assignedTo' of undefined
       </small>

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/organizationGroupEvents.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/organizationGroupEvents.spec.jsx.snap
@@ -12,25 +12,29 @@ Array [
   >
     <td>
       <h5>
-        <Link
-          onlyActiveOnIndex={false}
-          style={Object {}}
+        <GlobalSelectionLink
           to="/organizations/orgId/issues/1/events/1/"
         >
-          <a
-            onClick={[Function]}
+          <Link
+            onlyActiveOnIndex={false}
             style={Object {}}
+            to="/organizations/orgId/issues/1/events/1/"
           >
-            <DateTime
-              date="2019-05-21T18:01:48.762Z"
-              seconds={true}
+            <a
+              onClick={[Function]}
+              style={Object {}}
             >
-              <time>
-                May 21, 2019 6:01:48 PM UTC
-              </time>
-            </DateTime>
-          </a>
-        </Link>
+              <DateTime
+                date="2019-05-21T18:01:48.762Z"
+                seconds={true}
+              >
+                <time>
+                  May 21, 2019 6:01:48 PM UTC
+                </time>
+              </DateTime>
+            </a>
+          </Link>
+        </GlobalSelectionLink>
         <small>
           ApiException
         </small>
@@ -42,25 +46,29 @@ Array [
   >
     <td>
       <h5>
-        <Link
-          onlyActiveOnIndex={false}
-          style={Object {}}
+        <GlobalSelectionLink
           to="/organizations/orgId/issues/1/events/98654/"
         >
-          <a
-            onClick={[Function]}
+          <Link
+            onlyActiveOnIndex={false}
             style={Object {}}
+            to="/organizations/orgId/issues/1/events/98654/"
           >
-            <DateTime
-              date="2019-05-21T18:00:23Z"
-              seconds={true}
+            <a
+              onClick={[Function]}
+              style={Object {}}
             >
-              <time>
-                May 21, 2019 6:00:23 PM UTC
-              </time>
-            </DateTime>
-          </a>
-        </Link>
+              <DateTime
+                date="2019-05-21T18:00:23Z"
+                seconds={true}
+              >
+                <time>
+                  May 21, 2019 6:00:23 PM UTC
+                </time>
+              </DateTime>
+            </a>
+          </Link>
+        </GlobalSelectionLink>
         <small>
           TestException
         </small>


### PR DESCRIPTION
This preserves global selection header URL values when possible inside of
the events table (in Issue Details)