### PR TITLE
feat(upload): Implement PDB and PE upload

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -28,6 +28,7 @@ HASH_ALGORITHM = 'sha1'
 CHUNK_UPLOAD_ACCEPT = (
     'debug_files',  # DIF assemble
     'release_files',  # Artifacts assemble
+    'pdbs',  # PDB upload and debug id override
 )
 
 

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -251,6 +251,7 @@ class DifAssembleEndpoint(ProjectEndpoint):
                     "required": ["name", "chunks"],
                     "properties": {
                         "name": {"type": "string"},
+                        "debug_id": {"type": "string"},
                         "chunks": {
                             "type": "array",
                             "items": {
@@ -259,7 +260,7 @@ class DifAssembleEndpoint(ProjectEndpoint):
                             }
                         }
                     },
-                    "additionalProperties": False
+                    "additionalProperties": True
                 }
             },
             "additionalProperties": False
@@ -279,6 +280,7 @@ class DifAssembleEndpoint(ProjectEndpoint):
 
         for checksum, file_to_assemble in six.iteritems(files):
             name = file_to_assemble.get('name', None)
+            debug_id = file_to_assemble.get('debug_id', None)
             chunks = file_to_assemble.get('chunks', [])
 
             # First, check the cached assemble status. During assembling, a
@@ -348,6 +350,7 @@ class DifAssembleEndpoint(ProjectEndpoint):
                 kwargs={
                     'project_id': project.id,
                     'name': name,
+                    'debug_id': debug_id,
                     'checksum': checksum,
                     'chunks': chunks,
                 }

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -229,6 +229,8 @@ KNOWN_DIF_FORMATS = {
     'text/x-breakpad': 'breakpad',
     'application/x-mach-binary': 'macho',
     'application/x-elf-binary': 'elf',
+    'application/x-dosexec': 'pe',
+    'application/x-ms-pdb': 'pdb',
     'text/x-proguard+plain': 'proguard',
 }
 

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -140,15 +140,24 @@ class ProjectDebugFile(Model):
         return KNOWN_DIF_FORMATS.get(ct, 'unknown')
 
     @property
+    def file_type(self):
+        if self.data:
+            return self.data.get('type')
+
+    @property
     def file_extension(self):
         if self.file_format == 'breakpad':
             return '.sym'
         if self.file_format == 'macho':
-            return '.dSYM'
+            return '' if self.file_type == 'exe' else '.dSYM'
         if self.file_format == 'proguard':
             return '.txt'
         if self.file_format == 'elf':
-            return '.debug'
+            return '' if self.file_type == 'exe' else '.debug'
+        if self.file_format == 'pe':
+            return '.exe' if self.file_type == 'exe' else '.dll'
+        if self.file_format == 'pdb':
+            return '.pdb'
 
         return ''
 
@@ -189,7 +198,7 @@ def create_dif_from_id(project, meta, fileobj=None, file=None):
     """
     if meta.file_format == 'proguard':
         object_name = 'proguard-mapping'
-    elif meta.file_format in ('macho', 'elf'):
+    elif meta.file_format in ('macho', 'elf', 'pdb', 'pe'):
         object_name = meta.name
     elif meta.file_format == 'breakpad':
         object_name = meta.name[:-4] if meta.name.endswith('.sym') else meta.name

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -79,7 +79,7 @@ def set_assemble_status(task, scope, checksum, state, detail=None):
 
 
 @instrumented_task(name='sentry.tasks.assemble.assemble_dif', queue='assemble')
-def assemble_dif(project_id, name, checksum, chunks, **kwargs):
+def assemble_dif(project_id, name, debug_id, checksum, chunks, **kwargs):
     """
     Assembles uploaded chunks into a ``ProjectDebugFile``.
     """
@@ -109,7 +109,11 @@ def assemble_dif(project_id, name, checksum, chunks, **kwargs):
             # We only permit split difs to hit this endpoint.  The
             # client is required to split them up first or we error.
             try:
-                result = debugfile.detect_dif_from_path(temp_file.name, name=name)
+                result = debugfile.detect_dif_from_path(
+                    temp_file.name,
+                    name=name,
+                    debug_id=debug_id,
+                )
             except BadDif as e:
                 set_assemble_status(AssembleTask.DIF, project.id, checksum,
                                     ChunkFileState.ERROR, detail=e.args[0])

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -79,7 +79,7 @@ def set_assemble_status(task, scope, checksum, state, detail=None):
 
 
 @instrumented_task(name='sentry.tasks.assemble.assemble_dif', queue='assemble')
-def assemble_dif(project_id, name, debug_id, checksum, chunks, **kwargs):
+def assemble_dif(project_id, name, checksum, chunks, debug_id=None, **kwargs):
     """
     Assembles uploaded chunks into a ``ProjectDebugFile``.
     """

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -252,6 +252,7 @@ class DifAssembleEndpoint(APITestCase):
                 'name': 'test',
                 'chunks': chunks,
                 'checksum': total_checksum,
+                'debug_id': None,
             }
         )
 


### PR DESCRIPTION
Allow to upload (native) PDBs and PE files via the chunk upload and store them as debug files. Additionally, this PR allows to override debug identifiers in the chunk upload.

For now, the override is only applied if the UUID portion of the id matches. This is used to fix the age of PDB files. All other overrides are discarded by the server.

There is a new chunk upload capability flag `pdbs`, which indicates the following:
 - The server accepts PDBs.
 - The server accepts debug_id overrides.
 - The server will ignore unknown properties in the chunk upload request.