### PR TITLE
fix(bitbucket) Handle users with no username.

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -173,7 +173,7 @@ class BitbucketIntegrationProvider(IntegrationProvider):
             return {
                 'provider': self.key,
                 'external_id': state['clientKey'],
-                'name': principal_data['username'],
+                'name': principal_data.get('display_name', 'Unnamed User'),
                 'metadata': {
                     'public_key': state['publicKey'],
                     'shared_secret': state['sharedSecret'],

--- a/tests/sentry/integrations/bitbucket/test_installed.py
+++ b/tests/sentry/integrations/bitbucket/test_installed.py
@@ -18,7 +18,6 @@ class BitbucketInstalledEndpointTest(APITestCase):
         self.provider = 'bitbucket'
         self.path = '/extensions/bitbucket/installed/'
 
-        self.username = u'sentryuser'
         self.client_key = u'connection:123'
         self.public_key = u'123abcDEFg'
         self.shared_secret = u'G12332434SDfsjkdfgsd'
@@ -28,7 +27,6 @@ class BitbucketInstalledEndpointTest(APITestCase):
         self.icon = u'https://bitbucket.org/account/sentryuser/avatar/32/'
 
         self.user_data = {
-            u'username': self.username,
             u'display_name': self.display_name,
             u'account_id': u'123456t256371u',
             u'links': {
@@ -91,7 +89,7 @@ class BitbucketInstalledEndpointTest(APITestCase):
             provider=self.provider,
             external_id=self.client_key
         )
-        assert integration.name == self.username
+        assert integration.name == self.display_name
         assert integration.metadata == self.metadata
 
     @responses.activate
@@ -206,7 +204,7 @@ class BitbucketInstalledEndpointTest(APITestCase):
             provider=self.provider,
             external_id=self.client_key,
             defaults={
-                'name': self.username,
+                'name': self.display_name,
                 'metadata': self.metadata,
             }
         )[0]


### PR DESCRIPTION
Recent privacy related changes in bitbucket mean that we can't see usernames anymore. Instead we can use the display_name of a user.

See https://confluence.atlassian.com/bbkb/changes-to-usernames-in-bitbucket-cloud-969521174.html

Fixes SENTRY-AXP