### PR TITLE
ref(ui): incidents design pass

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownControl.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownControl.jsx
@@ -104,7 +104,6 @@ const StyledDropdownButton = styled(
 )`
   z-index: ${p => p.theme.zIndex.dropdownAutocomplete.actor};
   white-space: nowrap;
-  font-weight: normal;
 `;
 
 const MenuContainer = styled(DropdownBubble.withComponent('ul'))`

--- a/src/sentry/static/sentry/app/components/seenByList.jsx
+++ b/src/sentry/static/sentry/app/components/seenByList.jsx
@@ -72,7 +72,7 @@ export default class SeenByList extends React.Component {
         />
         <IconWrapper>
           <Tooltip title={iconTooltip}>
-            <EyeIcon className="icon-eye" />
+            <EyeIcon className="icon-eye" iconPosition={iconPosition} />
           </Tooltip>
         </IconWrapper>
       </SeenByWrapper>
@@ -94,7 +94,7 @@ const IconWrapper = styled('div')`
   width: 28px;
   line-height: 26px;
   text-align: center;
-  margin-right: 10px;
+  ${p => (p.iconPosition === 'left' ? 'margin-right: 10px' : '')};
 `;
 
 const EyeIcon = styled('span')`

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
@@ -29,7 +29,6 @@ export default class DetailsBody extends React.Component {
 
     // Considered loading when there is no incident object
     const loading = !incident;
-
     return (
       <StyledPageContent>
         <Main>
@@ -108,6 +107,12 @@ const Sidebar = styled('div')`
   width: 40%;
   border-left: 1px solid ${p => p.theme.borderLight};
   background-color: ${p => p.theme.white};
+
+  /* stylelint-disable-next-line no-duplicate-selectors */
+  ${PageContent} {
+    padding-top: ${space(3)};
+  }
+
   @media (max-width: ${theme.breakpoints[0]}) {
     width: 100%;
     border: 0;
@@ -125,9 +130,11 @@ const StyledPageContent = styled(PageContent)`
 const StyledNavTabs = styled(NavTabs)`
   display: flex;
 `;
+
 const SeenByTab = styled('li')`
   flex: 1;
   margin-left: ${space(2)};
+  margin-right: 0;
 
   .nav-tabs > & {
     margin-right: 0;

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
@@ -9,6 +9,7 @@ import {t} from 'app/locale';
 import Access from 'app/components/acl/access';
 import Count from 'app/components/count';
 import DropdownControl from 'app/components/dropdownControl';
+import Duration from 'app/components/duration';
 import InlineSvg from 'app/components/inlineSvg';
 import LoadingError from 'app/components/loadingError';
 import MenuItem from 'app/components/menuItem';
@@ -16,6 +17,7 @@ import PageHeading from 'app/components/pageHeading';
 import SentryTypes from 'app/sentryTypes';
 import SubscribeButton from 'app/components/subscribeButton';
 import space from 'app/styles/space';
+import getDynamicText from 'app/utils/getDynamicText';
 
 import {isOpen} from '../utils';
 import Status from '../status';
@@ -44,7 +46,7 @@ export default class DetailsHeader extends React.Component {
           label={incident && <Status incident={incident} />}
           menuWidth="160px"
           alignRight
-          buttonProps={!incident ? {disabled: true} : null}
+          buttonProps={!incident ? {disabled: true, size: 'small'} : {size: 'small'}}
         >
           <StyledMenuItem onSelect={onStatusChange}>
             {isIncidentOpen ? t('Close this incident') : t('Reopen this incident')}
@@ -67,6 +69,13 @@ export default class DetailsHeader extends React.Component {
       },
     };
     const dateStarted = incident && moment(incident.dateStarted).format('LL');
+    const duration =
+      incident &&
+      moment
+        .duration(
+          moment(incident.dateClosed || new Date()).diff(moment(incident.dateStarted))
+        )
+        .as('seconds');
 
     return (
       <Header>
@@ -97,13 +106,10 @@ export default class DetailsHeader extends React.Component {
               <ItemValue>{this.renderStatus()}</ItemValue>
             </HeaderItem>
             <HeaderItem>
-              <ItemTitle>{t('Event count')}</ItemTitle>
+              <ItemTitle>{t('Duration')}</ItemTitle>
               {isIncidentReady && (
                 <ItemValue>
-                  <Count value={incident.totalEvents} />
-                  <OpenLink to={eventLink}>
-                    <InlineSvg src="icon-open" />
-                  </OpenLink>
+                  <Duration seconds={getDynamicText({value: duration, fixed: 1200})} />
                 </ItemValue>
               )}
             </HeaderItem>
@@ -116,12 +122,24 @@ export default class DetailsHeader extends React.Component {
               )}
             </HeaderItem>
             <HeaderItem>
+              <ItemTitle>{t('Total events')}</ItemTitle>
+              {isIncidentReady && (
+                <ItemValue>
+                  <Count value={incident.totalEvents} />
+                  <OpenLink to={eventLink}>
+                    <InlineSvg src="icon-open" size="14" />
+                  </OpenLink>
+                </ItemValue>
+              )}
+            </HeaderItem>
+            <HeaderItem>
               <ItemTitle>{t('Notifications')}</ItemTitle>
               <ItemValue>
                 <SubscribeButton
                   disabled={!isIncidentReady}
                   isSubscribed={incident && !!incident.isSubscribed}
                   onClick={onSubscriptionChange}
+                  size="small"
                 />
               </ItemValue>
             </HeaderItem>
@@ -153,7 +171,8 @@ const GroupedHeaderItems = styled('div')`
 `;
 
 const HeaderItem = styled('div')`
-  padding: 0 ${space(3)};
+  padding: 0 ${space(4)};
+  min-width: 0; /* Prevent text from horizontally stretching flexbox */
 `;
 
 const ItemTitle = styled('h6')`
@@ -168,13 +187,14 @@ const ItemValue = styled('div')`
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  font-size: ${p => p.theme.headerFontSize};
+  font-size: ${p => p.theme.fontSizeExtraLarge};
   height: 40px; /* This is the height of the Status dropdown */
 `;
 
 const Breadcrumb = styled('div')`
   display: flex;
   align-items: center;
+  font-size: ${p => p.theme.fontSizeLarge};
   margin-bottom: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/header.jsx
@@ -46,7 +46,7 @@ export default class DetailsHeader extends React.Component {
           label={incident && <Status incident={incident} />}
           menuWidth="160px"
           alignRight
-          buttonProps={!incident ? {disabled: true, size: 'small'} : {size: 'small'}}
+          buttonProps={{size: 'small', disabled: !incident}}
         >
           <StyledMenuItem onSelect={onStatusChange}>
             {isIncidentOpen ? t('Close this incident') : t('Reopen this incident')}

--- a/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
@@ -61,12 +61,12 @@ class OrganizationIncidentsList extends AsyncComponent {
             {started.format('LL')}
             <LightDuration seconds={getDynamicText({value: duration, fixed: 1200})} />
           </div>
-          <AlignRight>
+          <NumericColumn>
             <Count value={incident.uniqueUsers} />
-          </AlignRight>
-          <AlignRight>
+          </NumericColumn>
+          <NumericColumn>
             <Count value={incident.totalEvents} />
-          </AlignRight>
+          </NumericColumn>
         </TableLayout>
       </IncidentPanelItem>
     );
@@ -94,9 +94,9 @@ class OrganizationIncidentsList extends AsyncComponent {
             <TableLayout>
               <div>{t('Incident')}</div>
               <div>{t('Status')}</div>
-              <div>{t('Duration')}</div>
-              <AlignRight>{t('Users affected')}</AlignRight>
-              <AlignRight>{t('Total events')}</AlignRight>
+              <div>{t('Started')}</div>
+              <NumericColumn>{t('Users affected')}</NumericColumn>
+              <NumericColumn>{t('Total events')}</NumericColumn>
             </TableLayout>
           </PanelHeader>
 
@@ -197,13 +197,14 @@ const TitleAndSparkLine = styled('div')`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  padding-right: ${space(2)};
 `;
 
 const IncidentPanelItem = styled(PanelItem)`
   padding: ${space(1)} ${space(2)};
 `;
 
-const AlignRight = styled('div')`
+const NumericColumn = styled('div')`
   text-align: right;
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
@@ -56,12 +56,12 @@ class OrganizationIncidentsList extends AsyncComponent {
           <div>
             <Duration seconds={getDynamicText({value: duration, fixed: 1200})} />
           </div>
-          <div>
+          <AlignRight>
             <Count value={incident.uniqueUsers} />
-          </div>
-          <div>
+          </AlignRight>
+          <AlignRight>
             <Count value={incident.totalEvents} />
-          </div>
+          </AlignRight>
         </TableLayout>
       </PanelItem>
     );
@@ -86,8 +86,8 @@ class OrganizationIncidentsList extends AsyncComponent {
               <div>{t('Incident')}</div>
               <div>{t('Status')}</div>
               <div>{t('Duration')}</div>
-              <div>{t('Users affected')}</div>
-              <div>{t('Total events')}</div>
+              <AlignRight>{t('Users affected')}</AlignRight>
+              <AlignRight>{t('Total events')}</AlignRight>
             </TableLayout>
           </PanelHeader>
           <PanelBody>
@@ -169,6 +169,10 @@ const TableLayout = styled('div')`
   grid-template-columns: 4fr 1fr 1fr 1fr 1fr;
   grid-column-gap: ${space(1.5)};
   width: 100%;
+`;
+
+const AlignRight = styled('div')`
+  text-align: right;
 `;
 
 export default OrganizationIncidentsListContainer;

--- a/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
@@ -70,7 +70,7 @@ class OrganizationIncidentsList extends AsyncComponent {
   renderEmpty() {
     return (
       <EmptyStateWarning>
-        <p>{t("You don't have any incidents yet")}</p>
+        <p>{t("You don't have any Incidents yet")}</p>
       </EmptyStateWarning>
     );
   }
@@ -117,7 +117,7 @@ class OrganizationIncidentsListContainer extends React.Component {
       <DocumentTitle title={`Incidents - ${orgId} - Sentry`}>
         <PageContent>
           <PageHeader>
-            <PageHeading withMargins>
+            <PageHeading>
               {t('Incidents')} <BetaTag />
             </PageHeading>
 
@@ -152,7 +152,7 @@ class OrganizationIncidentsListContainer extends React.Component {
             icon="icon-circle-info"
           >
             {tct(
-              'To create a new incident, select one or more issues from the Issues view. Then, click the [create:Create Incident] button.',
+              'To create a new Incident, select one or more issues from the Issues view. Then, click the [create:Create Incident] button.',
               {create: <em />}
             )}
           </AlertLink>

--- a/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
@@ -64,7 +64,7 @@ describe('IncidentDetails', function() {
     expect(
       wrapper
         .find('ItemValue')
-        .at(1)
+        .at(3)
         .text()
     ).toBe('100');
     expect(

--- a/tests/js/spec/views/organizationIncidents/list/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/list/index.spec.jsx
@@ -46,7 +46,7 @@ describe('OrganizationIncidentsList', function() {
       routerContext
     );
     expect(wrapper.find('PanelItem')).toHaveLength(0);
-    expect(wrapper.text()).toContain("You don't have any incidents yet");
+    expect(wrapper.text()).toContain("You don't have any Incidents yet");
   });
 
   it('toggles all/open', function() {


### PR DESCRIPTION
There's more i'd like to do here, but here's a quick initial pass:

<img width="1512" alt="Screen Shot 2019-06-18 at 2 12 12 PM" src="https://user-images.githubusercontent.com/30713/59720214-26683000-91d3-11e9-9647-baeeed5aa0dd.png">

and

<img width="1512" alt="Screen Shot 2019-06-18 at 2 10 46 PM" src="https://user-images.githubusercontent.com/30713/59720235-2d8f3e00-91d3-11e9-929e-44b1cac64b8d.png">

#### Overall

- [x] Treat Incident as a proper noun in the app

#### Incidents Index

- [x] h1: kill vertical margin so it will center properly
- [x]  right align numerical cells

#### Incidents Detail

- Header
    - [x] Reorder header items to match order on index
    - [x] Make breadcrumb compete less with title
    - [x] 30px horizontal padding
    - [x] Make buttons smaller
        - [x] Bold Status button text
    - [x] Add a “Duration” metric?