### PR TITLE
fix(jira) Fix jira users not having emails

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -693,7 +693,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 try:
                     jira_user = [
                         r for r in res
-                        if 'emailAddress' in r and r['emailAddress'].lower() == ue.email.lower()
+                        if r.get('emailAddress') and r['emailAddress'].lower() == ue.email.lower()
                     ][0]
                 except IndexError:
                     pass

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -692,7 +692,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                     continue
                 try:
                     jira_user = [
-                        r for r in res if r['emailAddress'] and r['emailAddress'].lower() == ue.email.lower()
+                        r for r in res
+                        if 'emailAddress' in r and r['emailAddress'].lower() == ue.email.lower()
                     ][0]
                 except IndexError:
                     pass


### PR DESCRIPTION
Recent atlassian privacy changes mean we don't always get `emailAddress` field for user objects in jira. Sync tasks should silently fail when this happens instead of alerting us.

Fixes SENTRY-AVP