### PR TITLE
fix(i18n): Use correct langauge session key

### DIFF
--- a/src/sentry/middleware/locale.py
+++ b/src/sentry/middleware/locale.py
@@ -12,7 +12,7 @@ import pytz
 
 from django.conf import settings
 from django.middleware.locale import LocaleMiddleware
-from django.utils.translation import _trans
+from django.utils.translation import _trans, LANGUAGE_SESSION_KEY
 
 from sentry.models import UserOption
 from sentry.utils.safe import safe_execute
@@ -49,7 +49,7 @@ class SentryLocaleMiddleware(LocaleMiddleware):
 
         language = UserOption.objects.get_value(user=request.user, key='language')
         if language:
-            request.session['django_language'] = language
+            request.session[LANGUAGE_SESSION_KEY] = language
 
         timezone = UserOption.objects.get_value(user=request.user, key='timezone')
         if timezone:


### PR DESCRIPTION
Taken from the 1.8 documentation:

> In previous versions, the key was named django_language, and the LANGUAGE_SESSION_KEY constant did not exist.

and from the 1.8 changelog
 
> The session key django_language is no longer read for backwards compatibility.

Ideally we should add some test coverage for using different languages as well

Fixes: JAVASCRIPT-4Y3