### PR TITLE
fix(releases): Allow release to be deleted if all associated groups are pending deletion

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -236,7 +236,7 @@ class GroupManager(BaseManager):
         )
 
 
-def filter_out_groups_pending_deletion(group_queryset):
+def exclude_groups_pending_deletion(group_queryset):
     """
     Given a queryset of Group objects, filter them to only include ones NOT
     queued for deletion. Returns another queryset.


### PR DESCRIPTION
Currently, a release cannot be deleted until all `Group` objects listing the release in question as their `first_release` have finished being deleted. This leads to the following scenario for users:

1) User tries to delete a release, gets an error message that there are still issues pointing to it.
2) User goes and deletes all related issues. To them, the issues are gone, because they disappear from the UI. Under the hood, the issues have been queued for deletion but have not yet been deleted.
3) User again tries to delete the release, and gets the same error message, even though as far as they're concerned, they've fixed the problem.
4) User gets frustrated and contacts support, who tells them to cool their jets for a while.
5) A day or so later, the issues finish being deleted and they're able to delete the release.

Now, on the one hand, there are worse problems than having to wait to delete a release. On the other, why wait, given that once an issue is queued for deletion, it's effectively gone? (This last bit - the fact that an issue can't change state from `PENDING_DELETION` or `DELETION_IN_PROGRESS` back to some live state - has been confirmed by the ops team.)

This fixes the problem by doing two things:

1) It changes the check on the release details `DELETE` endpoint to only return an error message if there are live (not queued for deletion) issues pointing to that release, as opposed to checking if there are _any_ issues pointing to the release.

2) It changes the `on_delete` property of the foreign key `first_release` in the `Group` table to act conditionally, based on the status of a release's associated groups. None of the [standard](https://docs.djangoproject.com/en/1.8/ref/models/fields/#django.db.models.ForeignKey.on_delete) `on_delete` options can do this, so this PR includes a new one, `conditional_protect`, patterned after [the originals](https://docs.djangoproject.com/en/1.8/_modules/django/db/models/deletion/).

Refs #5701