### PR TITLE
fix(ui) Don't give links to add redundant filters

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/tagsTable.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/tagsTable.jsx
@@ -4,27 +4,39 @@ import PropTypes from 'prop-types';
 import {withRouter} from 'react-router';
 
 import Link from 'app/components/links/link';
+import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import {getEventTagSearchUrl} from './utils';
 
 const TagsTable = props => {
+  const {location, tags} = props;
   return (
     <div>
       <TagHeading>{t('Tags')}</TagHeading>
       <StyledTable>
         <tbody>
-          {props.tags.map(tag => (
-            <StyledTr key={tag.key}>
-              <TagKey>{tag.key}</TagKey>
-              <TagValue>
-                <Link to={getEventTagSearchUrl(tag.key, tag.value, props.location)}>
-                  {tag.value}
-                </Link>
-              </TagValue>
-            </StyledTr>
-          ))}
+          {tags.map(tag => {
+            const tagInQuery =
+              location.query.query && location.query.query.indexOf(`${tag.key}:`) !== -1;
+            return (
+              <StyledTr key={tag.key}>
+                <TagKey>{tag.key}</TagKey>
+                <TagValue>
+                  {tagInQuery ? (
+                    <Tooltip title={t('This tag is in the current filter conditions')}>
+                      <span>{tag.value}</span>
+                    </Tooltip>
+                  ) : (
+                    <Link to={getEventTagSearchUrl(tag.key, tag.value, location)}>
+                      {tag.value}
+                    </Link>
+                  )}
+                </TagValue>
+              </StyledTr>
+            );
+          })}
         </tbody>
       </StyledTable>
     </div>


### PR DESCRIPTION
If a tag is already being used in the current filter query offering a link to re-add that condition seems redundant. Instead we can display disabled text with a tooltip.

![Screen Shot 2019-06-19 at 11 21 13 AM](https://user-images.githubusercontent.com/24086/59778388-64715c80-9284-11e9-981c-28ad6a7f7432.png)
