### PR TITLE
ref(ui): Fix font size on releases list -- refactor "repo label"

### DIFF
--- a/docs-ui/components/repoLabel.stories.js
+++ b/docs-ui/components/repoLabel.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+import {withInfo} from '@storybook/addon-info';
+
+import RepoLabel from 'app/components/repoLabel';
+
+storiesOf('RepoLabel', module).add(
+  'default',
+  withInfo('A badge to use for repo names')(() => {
+    return <RepoLabel>prod</RepoLabel>;
+  })
+);

--- a/src/sentry/static/sentry/app/components/repoLabel.jsx
+++ b/src/sentry/static/sentry/app/components/repoLabel.jsx
@@ -1,0 +1,25 @@
+import styled from 'react-emotion';
+
+import overflowEllipsis from 'app/styles/overflowEllipsis';
+
+const RepoLabel = styled('span')`
+  /* label mixin from bootstrap */
+  font-weight: 700;
+  color: ${p => p.theme.white};
+  text-align: center;
+  white-space: nowrap;
+  border-radius: 0.25em;
+  /* end of label mixin from bootstrap */
+
+  ${overflowEllipsis};
+
+  display: inline-block;
+  vertical-align: text-bottom;
+  line-height: 1;
+  background: ${p => p.theme.gray1};
+  padding: 3px;
+  max-width: 86px;
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+export default RepoLabel;

--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -1,21 +1,20 @@
+import {Box} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import _ from 'lodash';
-
-import AvatarList from 'app/components/avatar/avatarList';
-
-import {Box} from 'grid-emotion';
-import Button from 'app/components/button';
-import LastCommit from 'app/components/lastCommit';
-import LoadingIndicator from 'app/components/loadingIndicator';
-import LoadingError from 'app/components/loadingError';
-import TimeSince from 'app/components/timeSince';
-import Hovercard from 'app/components/hovercard';
+import createReactClass from 'create-react-class';
+import styled from 'react-emotion';
 
 import {getShortVersion} from 'app/utils';
 import {t, tct} from 'app/locale';
-
+import AvatarList from 'app/components/avatar/avatarList';
+import Button from 'app/components/button';
+import Hovercard from 'app/components/hovercard';
+import LastCommit from 'app/components/lastCommit';
+import LoadingError from 'app/components/loadingError';
+import LoadingIndicator from 'app/components/loadingIndicator';
+import RepoLabel from 'app/components/repoLabel';
+import TimeSince from 'app/components/timeSince';
 import withApi from 'app/utils/withApi';
 
 const VersionHoverCard = createReactClass({
@@ -187,19 +186,7 @@ const VersionHoverCard = createReactClass({
                 return (
                   <div className="deploy" key={idx}>
                     <div className="deploy-meta" style={{position: 'relative'}}>
-                      <strong
-                        className="repo-label truncate"
-                        style={{
-                          padding: 3,
-                          display: 'inline-block',
-                          width: 86,
-                          maxWidth: 86,
-                          textAlign: 'center',
-                          fontSize: 12,
-                        }}
-                      >
-                        {env}
-                      </strong>
+                      <VersionRepoLabel>{env}</VersionRepoLabel>
                       {dateFinished && (
                         <span
                           className="text-light"
@@ -250,3 +237,7 @@ const VersionHoverCard = createReactClass({
 export {VersionHoverCard};
 
 export default withApi(VersionHoverCard);
+
+const VersionRepoLabel = styled(RepoLabel)`
+  width: 86px;
+`;

--- a/src/sentry/static/sentry/app/views/organizationReleases/detail/releaseDeploys.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/detail/releaseDeploys.jsx
@@ -1,10 +1,12 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'react-emotion';
 
-import InlineSvg from 'app/components/inlineSvg';
-import TimeSince from 'app/components/timeSince';
-import Link from 'app/components/links/link';
 import {t} from 'app/locale';
+import InlineSvg from 'app/components/inlineSvg';
+import Link from 'app/components/links/link';
+import RepoLabel from 'app/components/repoLabel';
+import TimeSince from 'app/components/timeSince';
 
 export default class ReleaseDeploys extends React.Component {
   static propTypes = {
@@ -35,10 +37,10 @@ export default class ReleaseDeploys extends React.Component {
                     <Link to={path} title={t('View in stream')}>
                       <div className="row row-flex row-center-vertically">
                         <div className="col-xs-6">
-                          <span className="repo-label" style={{verticalAlign: 'bottom'}}>
+                          <ReleaseRepoLabel>
                             {deploy.environment}
                             <InlineSvg src="icon-open" style={{marginLeft: 6}} />
-                          </span>
+                          </ReleaseRepoLabel>
                         </div>
                         <div className="col-xs-6 align-right">
                           <small>
@@ -55,3 +57,8 @@ export default class ReleaseDeploys extends React.Component {
     );
   }
 }
+
+const ReleaseRepoLabel = styled(RepoLabel)`
+  padding: 5px 8px;
+  vertical-align: bottom;
+`;

--- a/src/sentry/static/sentry/app/views/organizationReleases/list/latestDeployOrReleaseTime.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/list/latestDeployOrReleaseTime.jsx
@@ -1,9 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import Tooltip from 'app/components/tooltip';
-import TimeSince from 'app/components/timeSince';
+import styled from 'react-emotion';
+
 import {t} from 'app/locale';
+import RepoLabel from 'app/components/repoLabel';
+import TimeSince from 'app/components/timeSince';
+import Tooltip from 'app/components/tooltip';
+import space from 'app/styles/space';
 
 const LatestDeployOrReleaseTime = createReactClass({
   displayName: 'LatestDeployOrReleaseTime',
@@ -24,21 +28,17 @@ const LatestDeployOrReleaseTime = createReactClass({
         {latestDeploy && latestDeploy.dateFinished ? (
           <div className="deploy">
             <p className="m-b-0 text-light">
-              <span
-                className="repo-label"
+              <ReleaseRepoLabel
                 style={{
                   padding: 3,
-                  display: 'inline-block',
                   width: 70,
                   maxWidth: 86,
-                  textAlign: 'center',
                   fontSize: 12,
                 }}
               >
                 {latestDeploy.environment + ' '}
-              </span>{' '}
-              <span className="icon icon-clock" />{' '}
-              <TimeSince date={latestDeploy.dateFinished} />
+              </ReleaseRepoLabel>{' '}
+              <TimeWithIcon date={latestDeploy.dateFinished} />
               {earlierDeploysNum > 0 && (
                 <Tooltip title={t('%s earlier deploys', earlierDeploysNum)}>
                   <span className="badge">{earlierDeploysNum}</span>
@@ -47,9 +47,7 @@ const LatestDeployOrReleaseTime = createReactClass({
             </p>
           </div>
         ) : (
-          <p className="m-b-0 text-light">
-            <span className="icon icon-clock" /> <TimeSince date={release.dateCreated} />
-          </p>
+          <TimeWithIcon date={release.dateCreated} />
         )}
       </div>
     );
@@ -57,3 +55,23 @@ const LatestDeployOrReleaseTime = createReactClass({
 });
 
 export default LatestDeployOrReleaseTime;
+
+const ReleaseRepoLabel = styled(RepoLabel)`
+  width: 70px;
+`;
+
+const TimeWithIcon = styled(({date, ...props}) => (
+  <span {...props}>
+    <ClockIcon className="icon icon-clock" />
+    <TimeSince date={date} />
+  </span>
+))`
+  display: inline-flex;
+  align-items: center;
+  color: ${p => p.theme.gray2};
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const ClockIcon = styled('span')`
+  margin-right: ${space(0.25)};
+`;

--- a/src/sentry/static/sentry/app/views/organizationReleases/list/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/list/releaseList.jsx
@@ -47,7 +47,7 @@ class ReleaseList extends React.Component {
                 </CountColumn>
                 <LastEventColumn>
                   {release.lastEvent ? (
-                    <SmallTimeSince date={release.lastEvent} />
+                    <TimeSince date={release.lastEvent} />
                   ) : (
                     <span>—</span>
                   )}
@@ -72,8 +72,4 @@ const VersionWrapper = styled('div')`
   font-weight: bold;
   margin-bottom: ${space(0.25)};
   ${overflowEllipsis};
-`;
-
-const SmallTimeSince = styled(TimeSince)`
-  font-size: ${p => p.theme.fontSizeSmall};
 `;

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1762,15 +1762,6 @@ header + .alert {
 * ============================================================================
 */
 
-.repo-label {
-  .label;
-  display: inline-block;
-  vertical-align: text-bottom;
-  padding: 5px 8px;
-  line-height: 1;
-  background: @40;
-}
-
 /**
 * Project nav
 * ============================================================================


### PR DESCRIPTION
This fixes the font size on Releases list and refactors "repo label" to be a component.

Old:
![image](https://user-images.githubusercontent.com/79684/59787960-7d2b4380-927f-11e9-9ee4-2497a0b87b58.png)


New:

![image](https://user-images.githubusercontent.com/79684/59787833-35a4b780-927f-11e9-8b83-e76f3a64b5ed.png)
![image](https://user-images.githubusercontent.com/79684/59787846-3b9a9880-927f-11e9-8102-e2179d671a31.png)
