### PR TITLE
fix(packaging): Include all of `src/sentry`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include setup.py src/sentry/assets.json README.rst MANIFEST.in LICENSE AUTHORS
+include setup.py README.rst MANIFEST.in LICENSE AUTHORS
 recursive-include ./ requirements*.txt
 graft src/sentry
 global-exclude *~

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,11 +1,4 @@
 include setup.py src/sentry/assets.json README.rst MANIFEST.in LICENSE AUTHORS
-include src/sentry/loader/_registry.json
 recursive-include ./ requirements*.txt
-recursive-include src/sentry/templates *
-recursive-include src/sentry/locale *
-recursive-include src/sentry/data *
-recursive-include src/sentry/grouping *
-recursive-include src/sentry/static/sentry *
-recursive-include src/sentry/scripts *.lua
-recursive-include src/sentry/integration-docs *.json
+graft src/sentry
 global-exclude *~


### PR DESCRIPTION
Resolves the issue reported here:
https://forum.sentry.io/t/unable-to-configure-google-oauth-provider/6872

Will also prevent any similar issues in the future, such as
https://forum.sentry.io/t/enhancement-configs-not-found-on-latest-branches/6800

Fixes #13565.