### PR TITLE
ref(onboarding): Fix project picker mobile category

### DIFF
--- a/src/sentry/static/sentry/app/data/platformCategories.jsx
+++ b/src/sentry/static/sentry/app/data/platformCategories.jsx
@@ -16,7 +16,7 @@ const popular = [
   'php',
   'ruby',
   'node',
-  'cocoa',
+  'react-native',
   'javascript-angular',
 ];
 
@@ -30,7 +30,7 @@ const frontend = [
   'javascript-vue',
 ];
 
-const mobile = ['objc', 'swift', 'java-android', 'cocoa', 'cordova'];
+const mobile = ['cocoa-objc', 'cocoa-swift', 'java-android', 'cordova', 'react-native'];
 
 const backend = [
   'go',

--- a/tests/fixtures/integration-docs/_platforms.json
+++ b/tests/fixtures/integration-docs/_platforms.json
@@ -15,6 +15,24 @@
     {
       "integrations": [
         {
+          "link": "https://docs.getsentry.com/hosted/clients/cocoa/",
+          "type": "language",
+          "id": "cocoa-swift",
+          "name": "Swift"
+        },
+        {
+          "link": "https://docs.getsentry.com/hosted/clients/cocoa/",
+          "type": "language",
+          "id": "cocoa-objc",
+          "name": "Objective-C"
+        }
+      ],
+      "id": "cocoa",
+      "name": "Objective-C"
+    },
+    {
+      "integrations": [
+        {
           "link": "https://docs.getsentry.com/hosted/clients/cordova/",
           "type": "language",
           "id": "cordova",
@@ -207,18 +225,6 @@
     {
       "integrations": [
         {
-          "link": "https://docs.getsentry.com/hosted/clients/cocoa/",
-          "type": "language",
-          "id": "objc",
-          "name": "Objective-C"
-        }
-      ],
-      "id": "objc",
-      "name": "Objective-C"
-    },
-    {
-      "integrations": [
-        {
           "link": "https://docs.getsentry.com/hosted/clients/php/integrations/laravel/",
           "type": "framework",
           "id": "php-laravel",
@@ -311,11 +317,11 @@
         {
           "link": "https://docs.getsentry.com/hosted/clients/react-native/",
           "type": "language",
-          "id": "cocoa",
+          "id": "react-native",
           "name": "React-Native"
         }
       ],
-      "id": "cocoa",
+      "id": "react-native",
       "name": "React-Native"
     },
     {
@@ -353,18 +359,6 @@
       ],
       "id": "rust",
       "name": "Rust"
-    },
-    {
-      "integrations": [
-        {
-          "link": "https://docs.getsentry.com/hosted/clients/cocoa/",
-          "type": "language",
-          "id": "swift",
-          "name": "Swift"
-        }
-      ],
-      "id": "swift",
-      "name": "Swift"
     },
     {
       "integrations": [

--- a/tests/js/spec/components/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/createProject.spec.jsx.snap
@@ -1070,14 +1070,14 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
             </Component>
           </PlatformCard>
           <PlatformCard
-            data-test-id="platform-cocoa"
-            key="cocoa"
+            data-test-id="platform-react-native"
+            key="react-native"
             onClear={[Function]}
             onClick={[Function]}
             platform={
               Object {
-                "id": "cocoa",
-                "language": "cocoa",
+                "id": "react-native",
+                "language": "react-native",
                 "link": "https://docs.getsentry.com/hosted/clients/react-native/",
                 "name": "React-Native",
                 "type": "language",
@@ -1087,13 +1087,13 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
           >
             <Component
               className="css-1y7hwtx-PlatformCard exv4dm86"
-              data-test-id="platform-cocoa"
+              data-test-id="platform-react-native"
               onClear={[Function]}
               onClick={[Function]}
               platform={
                 Object {
-                  "id": "cocoa",
-                  "language": "cocoa",
+                  "id": "react-native",
+                  "language": "react-native",
                   "link": "https://docs.getsentry.com/hosted/clients/react-native/",
                   "name": "React-Native",
                   "type": "language",
@@ -1103,14 +1103,14 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
             >
               <div
                 className="css-1y7hwtx-PlatformCard exv4dm86"
-                data-test-id="platform-cocoa"
+                data-test-id="platform-react-native"
                 onClick={[Function]}
               >
                 <StyledPlatformIconTile
-                  platform="cocoa"
+                  platform="react-native"
                 >
                   <div
-                    className="css-10i69ba-PlatformIconTile-getColorStyles-StyledPlatformIconTile exv4dm84"
+                    className="css-79er81-PlatformIconTile-getColorStyles-StyledPlatformIconTile exv4dm84"
                   />
                 </StyledPlatformIconTile>
                 <h3>
@@ -3732,14 +3732,14 @@ exports[`CreateProject should fill in project name if its empty when platform is
             </Component>
           </PlatformCard>
           <PlatformCard
-            data-test-id="platform-cocoa"
-            key="cocoa"
+            data-test-id="platform-react-native"
+            key="react-native"
             onClear={[Function]}
             onClick={[Function]}
             platform={
               Object {
-                "id": "cocoa",
-                "language": "cocoa",
+                "id": "react-native",
+                "language": "react-native",
                 "link": "https://docs.getsentry.com/hosted/clients/react-native/",
                 "name": "React-Native",
                 "type": "language",
@@ -3749,13 +3749,13 @@ exports[`CreateProject should fill in project name if its empty when platform is
           >
             <Component
               className="css-1y7hwtx-PlatformCard exv4dm86"
-              data-test-id="platform-cocoa"
+              data-test-id="platform-react-native"
               onClear={[Function]}
               onClick={[Function]}
               platform={
                 Object {
-                  "id": "cocoa",
-                  "language": "cocoa",
+                  "id": "react-native",
+                  "language": "react-native",
                   "link": "https://docs.getsentry.com/hosted/clients/react-native/",
                   "name": "React-Native",
                   "type": "language",
@@ -3765,14 +3765,14 @@ exports[`CreateProject should fill in project name if its empty when platform is
             >
               <div
                 className="css-1y7hwtx-PlatformCard exv4dm86"
-                data-test-id="platform-cocoa"
+                data-test-id="platform-react-native"
                 onClick={[Function]}
               >
                 <StyledPlatformIconTile
-                  platform="cocoa"
+                  platform="react-native"
                 >
                   <div
-                    className="css-10i69ba-PlatformIconTile-getColorStyles-StyledPlatformIconTile exv4dm84"
+                    className="css-79er81-PlatformIconTile-getColorStyles-StyledPlatformIconTile exv4dm84"
                   />
                 </StyledPlatformIconTile>
                 <h3>

--- a/tests/js/spec/components/platformPicker.spec.jsx
+++ b/tests/js/spec/components/platformPicker.spec.jsx
@@ -32,7 +32,11 @@ describe('PlatformPicker', function() {
         .map(node => node.prop('platform').id);
 
       expect(filteredPlatforms).not.toContain('java');
-      expect(filteredPlatforms).toContain('swift');
+      expect(filteredPlatforms).toContain('cocoa-swift');
+      expect(filteredPlatforms).toContain('react-native');
+      expect(filteredPlatforms).toContain('cocoa-objc');
+      expect(filteredPlatforms).toContain('java-android');
+      expect(filteredPlatforms).toContain('cordova');
     });
 
     it('should render renderPlatformList with Python when filtered with py', function() {


### PR DESCRIPTION
Swift and react native weren't showing up in the mobile category, since their id changed

<img width="624" alt="Screen Shot 2019-06-19 at 4 44 51 PM" src="https://user-images.githubusercontent.com/16394317/59808566-a9f84e80-92b1-11e9-8bf7-722e7caaa8e5.png">
