### PR TITLE
fix: Show userreport and release info on project event details

### DIFF
--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -52,7 +52,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         if snuba_event is None:
             return Response({'detail': 'Event not found'}, status=404)
 
-        data = serialize(snuba_event)
+        data = serialize(snuba_event, request.user, DetailedEventSerializer())
         requested_environments = set(request.GET.getlist('environment'))
 
         next_event_id = snuba_event.next_event_id(environments=requested_environments)


### PR DESCRIPTION
Use `DetailedEventSerializer` like the endpoint did before using `SnubaEvent`. Right now this uses the regular event serializer, which causes user feedback, some release info (?) and the stuff introduced in #13703 (this is how I noticed in the first place) to be missing from the event view on the issue details page.

This adds a few database queries, so I wonder what the best approach here really is. Just putting this PR out there so I don't loose track of this bug.

cc @lynnagara @fpacifici 