### PR TITLE
fix(event-search): Added fix for special fields in all events.

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -184,8 +184,11 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         conditions = []
         for condition in snuba_args['conditions']:
             field = condition[0]
-            if not isinstance(field, (list, tuple)
-                              ) and field in SPECIAL_FIELDS and field not in special_fields:
+            if (
+                not isinstance(field, (list, tuple))
+                and field in SPECIAL_FIELDS
+                and field not in special_fields
+            ):
                 # skip over special field.
                 continue
             conditions.append(condition)

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -83,7 +83,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
         try:
             params = self.get_filter_params(request, organization)
             snuba_args = self.get_snuba_query_args_v2(request, organization, params)
-
             fields = snuba_args.get('selected_columns')
             groupby = snuba_args.get('groupby', [])
 


### PR DESCRIPTION
Realized I was doing the opposite of what we wanted. Instead of adding an aggregation if we do not specify it in fields, removed it from conditions if it was not included as a field as it will not have the information necessary.