### PR TITLE
fix(ui): Fix closed/re-opened activities in Incidents [SEN-780]

### DIFF
--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -469,6 +469,8 @@ export const IncidentActivity = PropTypes.shape({
     .isRequired,
   user: User,
   comment: PropTypes.string,
+  value: PropTypes.string,
+  previousValue: PropTypes.string,
 });
 
 export const GlobalSelection = PropTypes.shape({

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/statusItem.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/statusItem.jsx
@@ -34,11 +34,11 @@ class StatusItem extends React.Component {
     const isDetected = activity.type === INCIDENT_ACTIVITY_TYPE.DETECTED;
     const isClosed =
       activity.type === INCIDENT_ACTIVITY_TYPE.STATUS_CHANGE &&
-      activity.value === INCIDENT_STATUS.CLOSED;
+      activity.value === `${INCIDENT_STATUS.CLOSED}`;
     const isReopened =
       activity.type === INCIDENT_ACTIVITY_TYPE.STATUS_CHANGE &&
-      activity.value === INCIDENT_STATUS.CREATED &&
-      activity.previousValue === INCIDENT_STATUS.CLOSED;
+      activity.value === `${INCIDENT_STATUS.CREATED}` &&
+      activity.previousValue === `${INCIDENT_STATUS.CLOSED}`;
 
     // Unknown activity, don't render anything
     if (!isCreated && !isDetected && !isClosed && !isReopened) {

--- a/tests/js/spec/views/organizationIncidents/list/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/list/index.spec.jsx
@@ -8,6 +8,21 @@ import OrganizationIncidentsList from 'app/views/organizationIncidents/list';
 describe('OrganizationIncidentsList', function() {
   const {routerContext} = initializeOrg();
   let mock;
+  let wrapper;
+
+  const createWrapper = async props => {
+    wrapper = mount(
+      <OrganizationIncidentsList
+        params={{orgId: 'org-slug'}}
+        location={{query: {}, search: ''}}
+      />,
+      routerContext
+    );
+    // Wait for sparklines library
+    await tick();
+    wrapper.update();
+    return wrapper;
+  };
 
   beforeEach(function() {
     mock = MockApiClient.addMockResponse({
@@ -23,11 +38,8 @@ describe('OrganizationIncidentsList', function() {
     MockApiClient.clearMockResponses();
   });
 
-  it('displays list', function() {
-    const wrapper = mount(
-      <OrganizationIncidentsList params={{orgId: 'org-slug'}} location={{query: {}}} />,
-      TestStubs.routerContext()
-    );
+  it('displays list', async function() {
+    wrapper = await createWrapper();
 
     const items = wrapper.find('IncidentPanelItem');
 
@@ -36,27 +48,19 @@ describe('OrganizationIncidentsList', function() {
     expect(items.at(1).text()).toContain('Second incident');
   });
 
-  it('displays empty state', function() {
+  it('displays empty state', async function() {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/incidents/',
       body: [],
     });
-    const wrapper = mount(
-      <OrganizationIncidentsList params={{orgId: 'org-slug'}} location={{query: {}}} />,
-      routerContext
-    );
+
+    wrapper = await createWrapper();
     expect(wrapper.find('PanelItem')).toHaveLength(0);
     expect(wrapper.text()).toContain("You don't have any Incidents yet");
   });
 
-  it('toggles all/open', function() {
-    const wrapper = mount(
-      <OrganizationIncidentsList
-        params={{orgId: 'org-slug'}}
-        location={{query: {}, search: ''}}
-      />,
-      routerContext
-    );
+  it('toggles all/open', async function() {
+    wrapper = await createWrapper();
 
     expect(
       wrapper


### PR DESCRIPTION
These were not displaying because `value` is a string (and UI was expecting
an int).

Fixes SEN-780