### PR TITLE
feat(ui): Use markdown to show app detail overview

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.jsx
@@ -9,6 +9,7 @@ import PluginIcon from 'app/plugins/components/pluginIcon';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {t} from 'app/locale';
+import marked from 'app/utils/marked';
 
 export default class SentryAppDetailsModal extends React.Component {
   static propTypes = {
@@ -32,7 +33,7 @@ export default class SentryAppDetailsModal extends React.Component {
           </Flex>
         </Flex>
 
-        <Description>{sentryApp.overview}</Description>
+        <Description dangerouslySetInnerHTML={{__html: marked(sentryApp.overview)}} />
 
         <Metadata>
           <Author flex={1}>{t('By %s', sentryApp.author)}</Author>

--- a/tests/js/spec/components/modals/sentryAppDetailsModal.spec.jsx
+++ b/tests/js/spec/components/modals/sentryAppDetailsModal.spec.jsx
@@ -38,7 +38,7 @@ describe('SentryAppDetailsModal', function() {
   });
 
   it('displays the Integrations description', () => {
-    expect(wrapper.find('Description').text()).toBe(sentryApp.overview);
+    expect(wrapper.find('Description').text()).toContain(sentryApp.overview);
   });
 
   it('closes when Cancel is clicked', () => {


### PR DESCRIPTION
This PR enables the use of markdown text in the app detail overview. Example:

![Screen Shot 2019-06-20 at 1 46 32 PM](https://user-images.githubusercontent.com/8533851/59880462-f00ceb00-9361-11e9-9002-e8777ba3cee3.png)
