### PR TITLE
Fix the first timestamp on breadcrumbs in acceptance tests

### DIFF
--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -41,6 +41,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         # We need a fallback datetime for the event
         if time is None:
             time = (now - timedelta(days=1))
+            time = time.replace(hour=0, minute=0, second=0, microsecond=0)
 
         event_data['timestamp'] = time.isoformat()
         event = self.store_event(


### PR DESCRIPTION
#13700 changed the way test events are generated. The result is that, in acceptance tests, the time the event is created is not normalized to the day thus the screenshot of the details page is different at every execution breaking the snapshot tests on percy.
This normalizes the creation timestamp thus should make the snapshot consistent.