### PR TITLE
feat(ui): Add @mentions to Incidents [SEN-781]

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/incident.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/incident.jsx
@@ -60,6 +60,7 @@ export async function createIncidentNote(api, orgId, incidentId, note) {
       {
         method: 'POST',
         data: {
+          mentions: note.mentions,
           comment: note.text,
         },
       }
@@ -101,6 +102,7 @@ export async function updateIncidentNote(api, orgId, incidentId, noteId, note) {
       {
         method: 'PUT',
         data: {
+          mentions: note.mentions,
           comment: note.text,
         },
       }

--- a/src/sentry/static/sentry/app/components/activity/note/index.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/index.jsx
@@ -28,9 +28,6 @@ class Note extends React.Component {
 
     dateCreated: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
 
-    memberList: PropTypes.array.isRequired,
-    teams: PropTypes.arrayOf(SentryTypes.Team).isRequired,
-
     // pass through to ActivityItem
     // shows absolute time instead of a relative string
     showTime: PropTypes.bool,
@@ -41,6 +38,9 @@ class Note extends React.Component {
 
     // min-height for NoteInput textarea
     minHeight: PropTypes.number,
+
+    // If used, will fetch list of teams/members that can be mentioned for projects
+    projectSlugs: PropTypes.arrayOf(PropTypes.string),
 
     onDelete: PropTypes.func,
     onCreate: PropTypes.func,
@@ -85,11 +85,10 @@ class Note extends React.Component {
       dateCreated,
       text,
       authorName,
-      teams,
-      memberList,
       hideDate,
       minHeight,
       showTime,
+      projectSlugs,
     } = this.props;
 
     const activityItemProps = {
@@ -130,8 +129,7 @@ class Note extends React.Component {
             onEditFinish={this.handleEditFinish}
             onUpdate={this.handleUpdate}
             onCreate={this.handleCreate}
-            memberList={memberList}
-            teams={teams}
+            projectSlugs={projectSlugs}
           />
         )}
       </StyledActivityItem>

--- a/src/sentry/static/sentry/app/components/activity/note/input.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/input.jsx
@@ -8,7 +8,6 @@ import {t} from 'app/locale';
 import Button from 'app/components/button';
 import ConfigStore from 'app/stores/configStore';
 import NavTabs from 'app/components/navTabs';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import textStyles from 'app/styles/text';
 import withApi from 'app/utils/withApi';
@@ -16,10 +15,16 @@ import withApi from 'app/utils/withApi';
 import Mentionables from './mentionables';
 import mentionStyle from './mentionStyle';
 
+const mentionShape = PropTypes.shape({
+  display: PropTypes.string,
+  email: PropTypes.string,
+  id: PropTypes.string,
+});
+
 class NoteInput extends React.Component {
   static propTypes = {
-    teams: PropTypes.arrayOf(SentryTypes.Team).isRequired,
-    memberList: PropTypes.array.isRequired,
+    teams: PropTypes.arrayOf(mentionShape).isRequired,
+    memberList: PropTypes.arrayOf(mentionShape).isRequired,
 
     // This is the id of the note object from the server
     // This is to indicate you are editing an existing item

--- a/src/sentry/static/sentry/app/components/activity/note/input.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/input.jsx
@@ -10,7 +10,6 @@ import ConfigStore from 'app/stores/configStore';
 import NavTabs from 'app/components/navTabs';
 import space from 'app/styles/space';
 import textStyles from 'app/styles/text';
-import withApi from 'app/utils/withApi';
 
 import Mentionables from './mentionables';
 import mentionStyle from './mentionStyle';
@@ -295,7 +294,7 @@ class NoteInputContainer extends React.Component {
   }
 }
 
-export default withApi(NoteInputContainer);
+export default NoteInputContainer;
 
 // This styles both the note preview and the note editor input
 const getNotePreviewCss = p => {

--- a/src/sentry/static/sentry/app/components/activity/note/mentionables.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/mentionables.jsx
@@ -1,0 +1,102 @@
+import {uniqBy} from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Reflux from 'reflux';
+
+import MemberListStore from 'app/stores/memberListStore';
+import Projects from 'app/utils/projects';
+import SentryTypes from 'app/sentryTypes';
+import withOrganization from 'app/utils/withOrganization';
+
+const buildUserId = id => `user:${id}`;
+const buildTeamId = id => `team:${id}`;
+
+/**
+ * Make sure the actionCreator, `fetchOrgMembers`, has been called somewhere
+ * higher up the component chain.
+ *
+ * Will provide a list of users and teams that can be used for @-mentions
+ * */
+class Mentionables extends React.PureComponent {
+  static propTypes = {
+    me: SentryTypes.User,
+    organization: SentryTypes.Organization.isRequired,
+    projectSlugs: PropTypes.arrayOf(PropTypes.string),
+  };
+
+  state = {
+    members: MemberListStore.getAll(),
+  };
+
+  componentDidMount() {
+    this.membersStoreMixin = Reflux.listenTo(
+      MemberListStore,
+      this.handleMemberListUpdate
+    );
+    this.membersStoreMixin.componentDidMount();
+  }
+
+  componentWillUnmount() {
+    this.membersStoreMixin.componentWillUnmount();
+  }
+
+  handleMemberListUpdate = members => {
+    if (members === this.state.members) {
+      return;
+    }
+
+    this.setState({
+      members,
+    });
+  };
+
+  getMemberList = (memberList, sessionUser) => {
+    const members = uniqBy(memberList, ({id}) => id).filter(
+      ({id}) => !sessionUser || sessionUser.id !== id
+    );
+    return members.map(member => ({
+      id: buildUserId(member.id),
+      display: member.name,
+      email: member.email,
+    }));
+  };
+
+  getTeams = projects => {
+    const uniqueTeams = uniqBy(
+      projects
+        .map(({teams}) => teams)
+        .reduce((acc, teams) => acc.concat(teams || []), []),
+      'id'
+    );
+
+    return uniqueTeams.map(team => ({
+      id: buildTeamId(team.id),
+      display: `#${team.slug}`,
+      email: team.id,
+    }));
+  };
+
+  renderChildren = ({projects}) => {
+    const {children, me} = this.props;
+    return children({
+      members: this.getMemberList(this.state.members, me),
+      teams: this.getTeams(projects),
+    });
+  };
+
+  render() {
+    const {organization, projectSlugs} = this.props;
+
+    if (!projectSlugs || !projectSlugs.length) {
+      return this.renderChildren({projects: []});
+    }
+
+    return (
+      <Projects slugs={projectSlugs} orgId={organization.slug}>
+        {this.renderChildren}
+      </Projects>
+    );
+  }
+}
+
+export default withOrganization(Mentionables);

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupActivity.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupActivity.jsx
@@ -14,10 +14,8 @@ import ActivityAuthor from 'app/components/activity/author';
 import ActivityItem from 'app/components/activity/item';
 import ConfigStore from 'app/stores/configStore';
 import ErrorBoundary from 'app/components/errorBoundary';
-import MemberListStore from 'app/stores/memberListStore';
 import Note from 'app/components/activity/note';
 import NoteInputWithStorage from 'app/components/activity/note/inputWithStorage';
-import ProjectsStore from 'app/stores/projectsStore';
 import SentryTypes from 'app/sentryTypes';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
@@ -41,9 +39,6 @@ class GroupActivity extends React.Component {
     error: false,
     inputId: uniqueId(),
   };
-
-  getMemberList = (memberList, sessionUser) =>
-    _.uniqBy(memberList, ({id}) => id).filter(({id}) => sessionUser.id !== id);
 
   handleNoteDelete = async ({modelId, text: oldText}) => {
     const {api, group} = this.props;
@@ -116,23 +111,13 @@ class GroupActivity extends React.Component {
     }
   };
 
-  getMentionableTeams = projectSlug => {
-    return (
-      ProjectsStore.getBySlug(projectSlug) || {
-        teams: [],
-      }
-    ).teams;
-  };
-
   render() {
     const {organization, group} = this.props;
     const me = ConfigStore.get('user');
-    const memberList = this.getMemberList(MemberListStore.getAll(), me);
-    const teams = this.getMentionableTeams(group && group.project && group.project.slug);
+    const projectSlugs = group && group.project ? [group.project.slug] : [];
     const noteProps = {
       group,
-      memberList,
-      teams,
+      projectSlugs,
       placeholder: t(
         'Add details or updates to this event. \nTag users with @, or teams with #'
       ),

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/activity.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/activity.jsx
@@ -70,9 +70,8 @@ class Activity extends React.Component {
     } = this.props;
 
     const noteProps = {
-      memberList: [],
-      teams: [],
       minHeight: 80,
+      projectSlugs: (incident && incident.projects) || [],
       ...this.props.noteInputProps,
     };
     const activitiesByDate = groupBy(activities, ({dateCreated}) =>
@@ -95,7 +94,6 @@ class Activity extends React.Component {
               placeholder={t(
                 'Leave a comment, paste a tweet, or link any other relevant information about this Incident...'
               )}
-              sessionUser={me}
               {...noteProps}
             />
           )}

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/body.jsx
@@ -7,8 +7,8 @@ import Chart from 'app/views/organizationIncidents/details/chart';
 import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
 import NavTabs from 'app/components/navTabs';
-import Projects from 'app/utils/projects';
 import Placeholder from 'app/components/placeholder';
+import Projects from 'app/utils/projects';
 import SeenByList from 'app/components/seenByList';
 import SentryTypes from 'app/sentryTypes';
 import SideHeader from 'app/views/organizationIncidents/details/sideHeader';
@@ -50,6 +50,7 @@ export default class DetailsBody extends React.Component {
             </StyledNavTabs>
             <Activity
               params={params}
+              incident={incident}
               incidentStatus={!loading ? incident.status : null}
             />
           </PageContent>

--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/index.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
+import {fetchOrgMembers} from 'app/actionCreators/members';
 import {markIncidentAsSeen} from 'app/actionCreators/incident';
 import {t} from 'app/locale';
 import withApi from 'app/utils/withApi';
@@ -27,6 +28,8 @@ class OrganizationIncidentDetails extends React.Component {
   }
 
   componentDidMount() {
+    const {api, params} = this.props;
+    fetchOrgMembers(api, params.orgId);
     this.fetchData();
   }
 

--- a/tests/js/spec/components/activity/note/input.spec.jsx
+++ b/tests/js/spec/components/activity/note/input.spec.jsx
@@ -99,7 +99,7 @@ describe('NoteInput', function() {
 
       wrapper.find('textarea').simulate('keyDown', {key: 'Enter', ctrlKey: true});
 
-      expect(onUpdate).toHaveBeenCalledWith({text: 'new item'});
+      expect(onUpdate).toHaveBeenCalledWith({text: 'new item', mentions: []});
     });
 
     it('canels editing and moves to preview mode', async function() {

--- a/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupActivity.spec.jsx
@@ -1,24 +1,28 @@
 import React from 'react';
-import {mount} from 'enzyme';
 
-import {initializeOrg} from 'app-test/helpers/initializeOrg';
 import {GroupActivity} from 'app/views/organizationGroupDetails/groupActivity';
-import NoteInput from 'app/components/activity/note/input';
+import {initializeOrg} from 'app-test/helpers/initializeOrg';
+import {mount} from 'enzyme';
 import ConfigStore from 'app/stores/configStore';
 import GroupStore from 'app/stores/groupStore';
+import NoteInput from 'app/components/activity/note/input';
+import ProjectsStore from 'app/stores/projectsStore';
 
 describe('GroupActivity', function() {
+  const project = TestStubs.Project();
   const group = TestStubs.Group({
     id: '1337',
     activity: [
       {type: 'note', id: 'note-1', data: {text: 'Test Note'}, user: TestStubs.User()},
     ],
-    project: TestStubs.Project(),
+    project,
   });
   const {organization, routerContext} = initializeOrg({
     group,
   });
+
   beforeEach(function() {
+    ProjectsStore.loadInitialData([project]);
     jest.spyOn(ConfigStore, 'get').mockImplementation(key => {
       if (key === 'user') {
         return {

--- a/tests/js/spec/views/organizationIncidents/details/activity.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/details/activity.spec.jsx
@@ -73,7 +73,7 @@ describe('IncidentDetails -> Activity', function() {
     await tick();
     expect(createComment).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/incidents/${incident.identifier}/comments/`,
-      expect.objectContaining({data: {comment: 'new incident comment'}})
+      expect.objectContaining({data: {comment: 'new incident comment', mentions: []}})
     );
   });
 

--- a/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
@@ -24,6 +24,13 @@ describe('IncidentDetails', function() {
       url: '/organizations/org-slug/incidents/123/',
       body: mockIncident,
     });
+
+    // For @mentions
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [],
+    });
+
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/incidents/123/suspects/',
       body: [TestStubs.IncidentSuspectCommit()],


### PR DESCRIPTION
This refactors members/teams list out of Group activity and moves it into a new component. By giving a list of project slugs to `<Note>` or `<NoteInput>` it will handle fetching users + teams for those projects

Fixes SEN-781