### PR TITLE
fix(ui) Fix flashing as event tags load

### DIFF
--- a/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
+++ b/src/sentry/static/sentry/app/components/group/tagDistributionMeter.jsx
@@ -1,34 +1,29 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
 import {deviceNameMapper, loadDeviceListModule} from 'app/components/deviceName';
 import SentryTypes from 'app/sentryTypes';
 
 import TagDistributionMeter from 'app/components/tagDistributionMeter';
 
-const GroupTagDistributionMeter = createReactClass({
-  displayName: 'TagDistributionMeter',
-
-  propTypes: {
+class GroupTagDistributionMeter extends React.Component {
+  static propTypes = {
     group: SentryTypes.Group.isRequired,
     tag: PropTypes.string.isRequired,
     name: PropTypes.string,
     organization: SentryTypes.Organization.isRequired,
     totalValues: PropTypes.number,
     topValues: PropTypes.array,
-  },
+  };
 
-  getInitialState() {
-    return {
-      loading: true,
-      error: false,
-    };
-  },
+  state = {
+    loading: true,
+    error: false,
+  };
 
   componentWillMount() {
     this.fetchData();
-  },
+  }
 
   shouldComponentUpdate(nextProps, nextState) {
     return (
@@ -39,7 +34,7 @@ const GroupTagDistributionMeter = createReactClass({
       this.props.totalValues !== nextProps.totalValues ||
       this.props.topValues !== nextProps.topValues
     );
-  },
+  }
 
   fetchData() {
     this.setState({
@@ -61,7 +56,7 @@ const GroupTagDistributionMeter = createReactClass({
           loading: false,
         });
       });
-  },
+  }
 
   render() {
     const {organization, group, tag, totalValues, topValues} = this.props;
@@ -93,7 +88,7 @@ const GroupTagDistributionMeter = createReactClass({
         segments={segments}
       />
     );
-  },
-});
+  }
+}
 
 export default GroupTagDistributionMeter;

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/tags.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/tags.jsx
@@ -5,6 +5,7 @@ import {isEqual, omit} from 'lodash';
 import * as Sentry from '@sentry/browser';
 
 import SentryTypes from 'app/sentryTypes';
+import Placeholder from 'app/components/placeholder';
 import TagDistributionMeter from 'app/components/tagDistributionMeter';
 import withApi from 'app/utils/withApi';
 import {fetchTagDistribution, fetchTotalCount, getEventTagSearchUrl} from './utils';
@@ -88,7 +89,7 @@ class Tags extends React.Component {
         segments={segments}
         totalValues={totalValues}
         isLoading={isLoading}
-        renderLoading={() => <Placeholder />}
+        renderLoading={() => <StyledPlaceholder height="16px" />}
       />
     );
   }
@@ -98,12 +99,8 @@ class Tags extends React.Component {
   }
 }
 
-const Placeholder = styled('div')`
-  height: 16px;
-  width: 100%;
-  display: inline-block;
+const StyledPlaceholder = styled(Placeholder)`
   border-radius: ${p => p.theme.borderRadius};
-  background-color: #dad9ed;
 `;
 
 export {Tags};

--- a/tests/js/spec/components/group/sidebar.spec.jsx
+++ b/tests/js/spec/components/group/sidebar.spec.jsx
@@ -72,9 +72,9 @@ describe('GroupSidebar', function() {
       expect(wrapper.find('SuggestedOwners')).toHaveLength(1);
       expect(wrapper.find('GroupReleaseStats')).toHaveLength(1);
       expect(wrapper.find('ExternalIssueList')).toHaveLength(1);
-      expect(wrapper.find('TagDistributionMeter[data-test-id="group-tag"]')).toHaveLength(
-        5
-      );
+      expect(
+        wrapper.find('GroupTagDistributionMeter[data-test-id="group-tag"]')
+      ).toHaveLength(5);
     });
   });
 

--- a/tests/js/spec/views/organizationEventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/tags.spec.jsx
@@ -47,9 +47,9 @@ describe('Tags', function() {
       />
     );
 
-    expect(wrapper.find('Placeholder')).toHaveLength(2);
+    expect(wrapper.find('StyledPlaceholder')).toHaveLength(2);
     await tick();
     wrapper.update();
-    expect(wrapper.find('Placeholder')).toHaveLength(0);
+    expect(wrapper.find('StyledPlaceholder')).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Make the placeholder elements the same height as the actual bars. This fixes flashing and jumping as tag bars incrementally load in.

![event-tags](https://user-images.githubusercontent.com/24086/59947329-ec00cc00-943a-11e9-8dee-e1b0107fa9cc.gif)
