### PR TITLE
fix(bitbucket) Fix errors when username is missing in bitbucket data

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -173,7 +173,7 @@ class BitbucketIntegrationProvider(IntegrationProvider):
             return {
                 'provider': self.key,
                 'external_id': state['clientKey'],
-                'name': principal_data['username'],
+                'name': principal_data.get('username', principal_data['uuid']),
                 'metadata': {
                     'public_key': state['publicKey'],
                     'shared_secret': state['sharedSecret'],

--- a/tests/sentry/integrations/bitbucket/test_installed.py
+++ b/tests/sentry/integrations/bitbucket/test_installed.py
@@ -94,6 +94,22 @@ class BitbucketInstalledEndpointTest(APITestCase):
         assert integration.name == self.username
         assert integration.metadata == self.metadata
 
+    def test_installed_without_username(self):
+        # Remove username to simulate privacy mode.
+        del self.data_from_bitbucket['principal']['username']
+
+        response = self.client.post(
+            self.path,
+            data=self.data_from_bitbucket
+        )
+        assert response.status_code == 200
+        integration = Integration.objects.get(
+            provider=self.provider,
+            external_id=self.client_key
+        )
+        assert integration.name == self.user_data['uuid']
+        assert integration.metadata == self.metadata
+
     @responses.activate
     def test_plugin_migration(self):
         accessible_repo = Repository.objects.create(


### PR DESCRIPTION
My previous attempt to fix this problem was incorrect. The replacement for `username` is `uuid` when privacy modes are enabled. This change will allow users who have hidden their username to complete the bitbucket setup process.

Fixes SENTRY-AXP