### PR TITLE
fix(ui): Do not display the dropdown clear button for the dropdown list of environments if it is empty

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -258,7 +258,7 @@ class MultipleEnvironmentSelector extends React.PureComponent {
           <StyledHeaderItem
             icon={<StyledInlineSvg src="icon-window" />}
             isOpen={isOpen}
-            hasSelected={value && !!value.length}
+            hasSelected={value && !!value.length && environments.length > 0}
             onClear={this.handleClear}
             {...getActorProps({
               isStyled: true,


### PR DESCRIPTION
Before:
![Screen Shot 2019-06-21 at 4 14 14 PM](https://user-images.githubusercontent.com/139499/59949235-857eac80-9440-11e9-8106-1d3cb6f05055.png)

After:

![Screen Shot 2019-06-21 at 4 14 37 PM](https://user-images.githubusercontent.com/139499/59949255-93ccc880-9440-11e9-9b1b-3ad51e8a03bc.png)

