### PR TITLE
ref: (Django 1.9) Replace `pre_syncdb` with `pre_migrate`

### DIFF
--- a/src/sentry/db/models/fields/citext.py
+++ b/src/sentry/db/models/fields/citext.py
@@ -12,7 +12,7 @@ import six
 
 from django.conf import settings
 from django.db import connections, models
-from django.db.models.signals import pre_syncdb
+from django.db.models.signals import pre_migrate
 
 
 __all__ = ('CITextField', 'CICharField', 'CIEmailField')
@@ -51,18 +51,18 @@ if 'south' in settings.INSTALLED_APPS:
     add_introspection_rules([], ["^sentry\.db\.models\.fields\.citext\.CIEmailField"])
 
 
-def create_citext_extension(db, **kwargs):
+def create_citext_extension(using, **kwargs):
     from sentry.utils.db import is_postgres
 
     # We always need the citext extension installed for Postgres,
     # and for tests, it's not always guaranteed that we will have
     # run full migrations which installed it.
-    if is_postgres(db):
-        cursor = connections[db].cursor()
+    if is_postgres(using):
+        cursor = connections[using].cursor()
         try:
             cursor.execute('CREATE EXTENSION IF NOT EXISTS citext')
         except Exception:
             pass
 
 
-pre_syncdb.connect(create_citext_extension)
+pre_migrate.connect(create_citext_extension)


### PR DESCRIPTION
`pre_syncdb` was deprecated in 1.7, and is now removed in 1.9.
https://docs.djangoproject.com/en/2.2/releases/1.7/#schema-migrations