### PR TITLE
ref: (Django 1.9) Stop using django's version of `import_module`

### DIFF
--- a/src/debug_toolbar/compat.py
+++ b/src/debug_toolbar/compat.py
@@ -23,10 +23,7 @@ except ImportError:  # Django < 1.8
     from django.template.context import get_standard_processors  # NOQA
     from django.template.loader import find_template_loader  # NOQA
 
-try:
-    from importlib import import_module
-except ImportError:  # python = 2.6
-    from django.utils.importlib import import_module  # NOQA
+from importlib import import_module  # NOQA
 
 try:
     from collections import OrderedDict

--- a/src/sentry/relay/change_set.py
+++ b/src/sentry/relay/change_set.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+from importlib import import_module
 
 from sentry.relay.utils import type_to_class_name
 from sentry.relay.changesets.base import ChangesetError
@@ -9,8 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 def execute_changesets(relay, changesets):
-    from django.utils.importlib import import_module
-
     for changeset in changesets:
         try:
             relay_changeset = import_module(

--- a/src/sentry/relay/query.py
+++ b/src/sentry/relay/query.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from importlib import import_module
+
 import six
 
 from sentry.relay.queries.base import InvalidQuery
@@ -7,8 +9,6 @@ from sentry.relay.utils import type_to_class_name
 
 
 def execute_queries(relay, queries):
-    from django.utils.importlib import import_module
-
     query_results = {}
     for query_id, query in six.iteritems(queries):
         try:

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from django.conf import settings
-from django.utils.importlib import import_module
 
 import copy
 import io
@@ -11,6 +10,7 @@ import petname
 import random
 import six
 import warnings
+from importlib import import_module
 
 from django.utils import timezone
 from django.utils.text import slugify

--- a/src/social_auth/utils.py
+++ b/src/social_auth/utils.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import random
 import logging
+from importlib import import_module
 
 from cgi import parse_qsl
 from collections import defaultdict
@@ -9,7 +10,6 @@ from django.conf import settings
 from django.db.models import Model
 from django.contrib.contenttypes.models import ContentType
 from django.utils.functional import empty, SimpleLazyObject
-from django.utils.importlib import import_module
 from six.moves.urllib.parse import urlencode, urlparse, urlunparse
 from six.moves.urllib.request import urlopen
 

--- a/src/south/management/commands/south_migrate.py
+++ b/src/south/management/commands/south_migrate.py
@@ -8,11 +8,11 @@ import os.path
 import re
 import sys
 from functools import reduce
+from importlib import import_module
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
-from django.utils.importlib import import_module
 
 from south import migration
 from south.migration import Migrations


### PR DESCRIPTION
This was only used to support python 2.6. Support for this has ended, and we haven't supported 2.6
for a long while anyway.