### PR TITLE
ref: (Django 1.9) Various fixes for debug_toolbar

### DIFF
--- a/src/debug_toolbar/templatetags/compat.py
+++ b/src/debug_toolbar/templatetags/compat.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.template.base import Library
+from django.template import Library
 
 from ..compat import url as url_compat
 

--- a/src/debug_toolbar/utils.py
+++ b/src/debug_toolbar/utils.py
@@ -16,10 +16,13 @@ from django.utils.encoding import force_text
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils import six
-from django.views.debug import linebreak_iter
 
 from .settings import CONFIG
 from debug_toolbar.compat import import_module
+try:
+    from django.template.base import linebreak_iter  # NOQA
+except ImportError:  # Django < 1.9
+    from django.views.debug import linebreak_iter  # NOQA
 
 # Figure out some paths
 django_path = os.path.realpath(os.path.dirname(django.__file__))


### PR DESCRIPTION
import `linebreak_iter` correctly
Import `from django.template import Library` correctly