### PR TITLE
fix(events-v2): Fix tag distribution meter proptypes

### DIFF
--- a/src/sentry/static/sentry/app/components/tagDistributionMeter/index.jsx
+++ b/src/sentry/static/sentry/app/components/tagDistributionMeter/index.jsx
@@ -17,8 +17,10 @@ export default class TagDistributionMeter extends React.Component {
     segments: PropTypes.arrayOf(
       PropTypes.shape({
         count: PropTypes.number.isRequired,
-        name: PropTypes.string.isRequired,
-        value: PropTypes.string.isRequired,
+        name: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array])
+          .isRequired,
+        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array])
+          .isRequired,
         url: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
       })
     ).isRequired,


### PR DESCRIPTION
We use this component to render other event properties now that may
not be strings. Updated to allow numbers as well as arrays
(e.g. for stack trace properties) as these are valid Snuba column types.