### PR TITLE
ref: (Django 1.9) Remove the `django-templatetag-sugar` library

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -11,7 +11,6 @@ django-crispy-forms>=1.4.0,<1.5.0
 django-jsonfield>=0.9.13,<0.9.14
 django-picklefield>=0.3.0,<1.1.0
 django-sudo>=2.1.0,<3.0.0
-django-templatetag-sugar>=0.1.0
 Django>=1.8,<1.9
 djangorestframework>=2.4.8,<2.5.0
 email-reply-parser>=0.2.0,<0.3.0

--- a/src/sentry/templates/sentry/auth-confirm-identity.html
+++ b/src/sentry/templates/sentry/auth-confirm-identity.html
@@ -18,7 +18,7 @@
         {% letter_avatar_svg identity_display_name identity_identifier %}
       </span>
       <span class="avatar">
-        <img src="{% gravatar_url identity.email size 36 default 'blank' %}" class="avatar">
+        <img src="{% gravatar_url identity.email 36 'blank' %}" class="avatar">
       </span>
     </div>
 
@@ -50,7 +50,7 @@
           {% letter_avatar_svg identity_display_name identity_identifier %}
         </span>
         <span class="avatar">
-          <img src="{% gravatar_url identity.email size 36 default 'blank' %}" class="avatar">
+          <img src="{% gravatar_url identity.email 36 'blank' %}" class="avatar">
         </span>
       </div>
 

--- a/src/sentry/templates/sentry/auth-confirm-link.html
+++ b/src/sentry/templates/sentry/auth-confirm-link.html
@@ -20,7 +20,7 @@
         {% letter_avatar_svg identity_display_name identity_identifier %}
       </span>
       <span class="avatar">
-        <img src="{% gravatar_url identity.email size 36 default 'blank' %}">
+        <img src="{% gravatar_url identity.email 36 'blank' %}">
       </span>
     </div>
 

--- a/src/sentry/templates/sentry/emails/activity/new-user-feedback.html
+++ b/src/sentry/templates/sentry/emails/activity/new-user-feedback.html
@@ -17,7 +17,7 @@
     <table class="note">
       <tr>
         <td class="avatar-column">
-          {% email_avatar report.name report.email size 48 %}
+          {% email_avatar report.name report.email 48 %}
         </td>
         <td class="notch-column">
           <img width="7" height="48" src="{% absolute_asset_url 'sentry' 'images/email/avatar-notch.png' %}">

--- a/src/sentry/templates/sentry/emails/activity/note.html
+++ b/src/sentry/templates/sentry/emails/activity/note.html
@@ -16,11 +16,11 @@
     <tr>
       <td class="avatar-column">
         {% if author.get_avatar_type == 'upload' %}
-          <img class="avatar" src="{% profile_photo_url author.id size 48 %}">
+          <img class="avatar" src="{% profile_photo_url author.id 48 %}">
         {% elif author.get_avatar_type == 'letter_avatar' %}
-          {% email_avatar author.get_display_name author.get_label size 48 try_gravatar False %}
+          {% email_avatar author.get_display_name author.get_label 48 False %}
         {% else %}
-          {% email_avatar author.get_display_name author.get_label size 48 %}
+          {% email_avatar author.get_display_name author.get_label 48 %}
         {% endif %}
       </td>
       <td class="notch-column">

--- a/src/sentry/templates/sentry/emails/activity/release.html
+++ b/src/sentry/templates/sentry/emails/activity/release.html
@@ -58,14 +58,14 @@
               <td class="avatar-column">
                 {% if user %}
                   {% if user.get_avatar_type == 'upload' %}
-                    <img class="avatar" src="{% profile_photo_url user.id size 36 %}">
+                    <img class="avatar" src="{% profile_photo_url user.id 36 %}">
                   {% elif user.get_avatar_type == 'letter_avatar' %}
-                    {% email_avatar user.get_display_name user.get_label size 36 try_gravatar False %}
+                    {% email_avatar user.get_display_name user.get_label 36 False %}
                   {% else %}
-                    {% email_avatar user.get_display_name user.get_label size 36 %}
+                    {% email_avatar user.get_display_name user.get_label 36 %}
                   {% endif %}
                 {% elif commit.author %}
-                  {% email_avatar commit.author.name commit.author.get_label size 36 %}
+                  {% email_avatar commit.author.name commit.author.get_label 36 %}
                 {% else %}
                     <div class="placeholder-avatar">?</div>
                 {% endif %}

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -96,7 +96,7 @@
         <table class="table commit-table">
         {% for commit in commits %}
           <tr>
-            <td style="padding:0;width:32px;">{% email_avatar commits.author.name commits.author.email size 32 %}</td>
+            <td style="padding:0;width:32px;">{% email_avatar commits.author.name commits.author.email 32 %}</td>
             <td>
               <h5 class="truncate">{{ commit.subject }}</h5>
               <div><small>{{ commit.shortId }}&nbsp;&mdash;&nbsp;

--- a/src/sentry/templates/sentry/emails/incidents/activity.html
+++ b/src/sentry/templates/sentry/emails/incidents/activity.html
@@ -18,7 +18,7 @@
       <table class="note">
         <tr>
           <td class="avatar-column">
-            {% email_avatar user_name user_email size 48 %}
+            {% email_avatar user_name user_email 48 %}
           </td>
           <td class="notch-column">
             <img width="7" height="48" src="{% absolute_asset_url 'sentry' 'images/email/avatar-notch.png' %}">

--- a/src/sentry/templates/sentry/partial/avatar.html
+++ b/src/sentry/templates/sentry/partial/avatar.html
@@ -1,18 +1,18 @@
 {% load sentry_avatars %}
 <span class="avatar">
   {% if avatar_type == 'upload' %}
-    <img src="{% profile_photo_url user_id size size %}">
+    <img src="{% profile_photo_url user_id size %}">
   {% else %}
     {% if for_email %}
       {% if avatar_type == 'letter_avatar' %}
-        {% email_avatar display_name label size size try_gravatar False %}
+        {% email_avatar display_name label size False %}
       {% else %}
-        {% email_avatar display_name label size size try_gravatar True %}
+        {% email_avatar display_name label size True %}
       {% endif %}
     {% else %}
-      {% letter_avatar_svg display_name label size size %}
+      {% letter_avatar_svg display_name label size %}
       {% if avatar_type == 'gravatar' %}
-        <img src="{% gravatar_url email size size default 'blank' %}">
+        <img src="{% gravatar_url email size 'blank' %}">
       {% endif %}
     {% endif %}
   {% endif %}

--- a/src/sentry/templates/sentry/partial/interfaces/user_email.html
+++ b/src/sentry/templates/sentry/partial/interfaces/user_email.html
@@ -47,7 +47,7 @@
     {% if user_email %}
       <td style="padding-top:5px; width:64px; vertical-align:top; text-align: right;">
         <span class="avatar-container" style="width: inherit;">
-          {% email_avatar user.get_display_name user.get_label size 64 %}
+          {% email_avatar user.get_display_name user.get_label 64 %}
         </span>
       </td>
     {% endif %}

--- a/src/sentry/templatetags/sentry_avatars.py
+++ b/src/sentry/templatetags/sentry_avatars.py
@@ -4,8 +4,6 @@ from django import template
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from six.moves.urllib.parse import urlencode
-from templatetag_sugar.parser import Constant, Optional, Variable
-from templatetag_sugar.register import tag
 
 from sentry.models import User, UserAvatar
 from sentry.utils.avatar import (get_email_avatar, get_gravatar_url, get_letter_avatar)
@@ -16,29 +14,17 @@ register = template.Library()
 # Adapted from http://en.gravatar.com/site/implement/images/django/
 # The "mm" default is for the grey, "mystery man" icon. See:
 #   http://en.gravatar.com/site/implement/images/
-@tag(
-    register, [
-        Variable('email'),
-        Optional([Constant('size'), Variable('size')]),
-        Optional([Constant('default'), Variable('default')])
-    ]
-)
-def gravatar_url(context, email, size=None, default='mm'):
+@register.simple_tag(takes_context=True)
+def gravatar_url(context, email, size, default='mm'):
     return get_gravatar_url(email, size, default)
 
 
-@tag(
-    register, [
-        Variable('display_name'),
-        Variable('identifier'),
-        Optional([Constant('size'), Variable('size')])
-    ]
-)
+@register.simple_tag(takes_context=True)
 def letter_avatar_svg(context, display_name, identifier, size=None):
     return get_letter_avatar(display_name, identifier, size=size)
 
 
-@tag(register, [Variable('user_id'), Optional([Constant('size'), Variable('size')])])
+@register.simple_tag(takes_context=True)
 def profile_photo_url(context, user_id, size=None):
     try:
         avatar = UserAvatar.objects.get_from_cache(user=user_id)
@@ -52,14 +38,7 @@ def profile_photo_url(context, user_id, size=None):
 
 # Don't use this in any situations where you're rendering more
 # than 1-2 avatars. It will make a request for every user!
-@tag(
-    register, [
-        Variable('display_name'),
-        Variable('identifier'),
-        Optional([Constant('size'), Variable('size')]),
-        Optional([Constant('try_gravatar'), Variable('try_gravatar')])
-    ]
-)
+@register.simple_tag(takes_context=True)
 def email_avatar(context, display_name, identifier, size=None, try_gravatar=True):
     return get_email_avatar(display_name, identifier, size, try_gravatar)
 


### PR DESCRIPTION
This library isn't maintained and doesn't currently support Django 1.9. It's only used in a small
number of places, so just remove.