### PR TITLE
fix(events-v2): Prevent tabs crashing on toggle

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -194,12 +194,20 @@ export const SPECIAL_FIELDS = {
   event_count: {
     title: 'events',
     fields: ['event_count'],
-    renderFunc: data => <Container>{data.event_count.toLocaleString()}</Container>,
+    renderFunc: data => (
+      <Container>
+        {typeof data.event_count === 'number' ? data.event_count.toLocaleString() : null}
+      </Container>
+    ),
   },
   user_count: {
     title: 'users',
     fields: ['user_count'],
-    renderFunc: data => <Container>{data.user_count.toLocaleString()}</Container>,
+    renderFunc: data => (
+      <Container>
+        {typeof data.user_count === 'number' ? data.user_count.toLocaleString() : null}
+      </Container>
+    ),
   },
   last_seen: {
     title: 'last seen',


### PR DESCRIPTION
Fixes a bug that causes this component to crash on toggle if counts are
not yet loaded