### PR TITLE
fix(logging): Fix 'github.missing-integration' repository object to the full_name like other statements.

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -54,7 +54,7 @@ class Webhook(object):
                 'github.missing-integration',
                 extra={
                     'action': event.get('action'),
-                    'repository': event.get('repository'),
+                    'repository': event.get('repository')['full_name'],
                     'external_id': external_id,
                 }
             )


### PR DESCRIPTION
This creates a type mismatch in Elasticsearch and results in anything using `full_name` to fail to log.