### PR TITLE
ref: (Django 1.9) Bump djangorestframework to 3.1.3 as an intermediate step to get to 3.3.x

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -13,7 +13,7 @@ django-picklefield>=0.3.0,<1.1.0
 django-sudo>=2.1.0,<3.0.0
 django-templatetag-sugar>=0.1.0
 Django>=1.8,<1.9
-djangorestframework>=2.4.8,<2.5.0
+djangorestframework==3.1.3
 email-reply-parser>=0.2.0,<0.3.0
 enum34>=1.1.6,<1.2.0
 exam>=0.5.1


### PR DESCRIPTION
See if less tests fail, so that I can break my transition diff up.