### PR TITLE
feat:issueless events. Prepare data structures for issueless events

### DIFF
--- a/src/sentry/api/bases/event.py
+++ b/src/sentry/api/bases/event.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+from sentry.api.bases.project import ProjectPermission
+
+
+class EventPermission(ProjectPermission):
+    scope_map = {
+        'GET': ['event:read', 'event:write', 'event:admin'],
+        'POST': ['event:write', 'event:admin'],
+        'PUT': ['event:write', 'event:admin'],
+        'DELETE': ['event:admin'],
+    }
+
+    def has_object_permission(self, request, view, event):
+        return super(EventPermission, self).has_object_permission(
+            request, view, event.project)

--- a/src/sentry/api/endpoints/event_details.py
+++ b/src/sentry/api/endpoints/event_details.py
@@ -3,14 +3,14 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
-from sentry.api.bases.group import GroupPermission
+from sentry.api.bases.event import EventPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import DetailedEventSerializer, serialize
 from sentry.models import Event
 
 
 class EventDetailsEndpoint(Endpoint):
-    permission_classes = (GroupPermission, )
+    permission_classes = (EventPermission, )
 
     def get(self, request, event_id):
         """
@@ -27,7 +27,7 @@ class EventDetailsEndpoint(Endpoint):
         if event is None:
             raise ResourceDoesNotExist
 
-        self.check_object_permissions(request, event.group)
+        self.check_object_permissions(request, event)
 
         Event.objects.bind_nodes([event], 'data')
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -247,7 +247,7 @@ class EventSerializer(Serializer):
 
         d = {
             'id': six.text_type(obj.id),
-            'groupID': six.text_type(obj.group_id),
+            'groupID': six.text_type(obj.group_id) if obj.group_id else None,
             'eventID': six.text_type(obj.event_id),
             'projectID': six.text_type(obj.project_id),
             'size': obj.size,
@@ -359,7 +359,7 @@ class SimpleEventSerializer(EventSerializer):
         return {
             'id': six.text_type(obj.id),
             'event.type': six.text_type(obj.type),
-            'groupID': six.text_type(obj.group_id),
+            'groupID': six.text_type(obj.group_id) if obj.group_id else None,
             'eventID': six.text_type(obj.event_id),
             'projectID': six.text_type(obj.project_id),
             # XXX for 'message' this doesn't do the proper resolution of logentry

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -886,7 +886,7 @@ class EventManager(object):
             if not project.first_event:
                 project.update(first_event=date)
                 first_event_received.send_robust(
-                    project=project, group=group, event=event, sender=Project)
+                    project=project, event=event, sender=Project)
 
         eventstream.insert(
             group=group,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -725,7 +725,7 @@ class EventManager(object):
                     extra={
                         'event_uuid': event_id,
                         'project_id': project.id,
-                        'group_id': group.id,
+                        'group_id': group.id if group else None,
                         'model': EventMapping.__name__,
                     }
                 )
@@ -833,7 +833,7 @@ class EventManager(object):
                     extra={
                         'event_uuid': event_id,
                         'project_id': project.id,
-                        'group_id': group.id,
+                        'group_id': group.id if group else None,
                         'model': Event.__name__,
                     }
                 )
@@ -842,7 +842,7 @@ class EventManager(object):
             tagstore.delay_index_event_tags(
                 organization_id=project.organization_id,
                 project_id=project.id,
-                group_id=group.id,
+                group_id=group.id if group else None,
                 environment_id=environment.id,
                 event_id=event.id,
                 tags=event.tags,
@@ -885,7 +885,8 @@ class EventManager(object):
         if not raw:
             if not project.first_event:
                 project.update(first_event=date)
-                first_event_received.send_robust(project=project, group=group, sender=Project)
+                first_event_received.send_robust(
+                    project=project, group=group, event=event, sender=Project)
 
         eventstream.insert(
             group=group,

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -57,12 +57,12 @@ def record_first_event(project, **kwargs):
 
 
 @event_processed.connect(weak=False)
-def record_event_processed(project, event, **kwargs):
+def record_event_processed(project, group, event, **kwargs):
     feature_slugs = []
 
     # Platform
-    if event.platform in manager.location_slugs('language'):
-        feature_slugs.append(event.platform)
+    if group.platform in manager.location_slugs('language'):
+        feature_slugs.append(group.platform)
 
     # Release Tracking
     if event.get_tag('sentry:release'):

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -50,19 +50,19 @@ DEFAULT_TAGS = frozenset(
 
 # First Event
 @first_event_received.connect(weak=False)
-def record_first_event(project, group, **kwargs):
+def record_first_event(project, **kwargs):
     FeatureAdoption.objects.record(
         organization_id=project.organization_id, feature_slug="first_event", complete=True
     )
 
 
 @event_processed.connect(weak=False)
-def record_event_processed(project, group, event, **kwargs):
+def record_event_processed(project, event, **kwargs):
     feature_slugs = []
 
     # Platform
-    if group.platform in manager.location_slugs('language'):
-        feature_slugs.append(group.platform)
+    if event.platform in manager.location_slugs('language'):
+        feature_slugs.append(event.platform)
 
     # Release Tracking
     if event.get_tag('sentry:release'):

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -93,7 +93,7 @@ def record_raven_installed(project, user, **kwargs):
 
 
 @first_event_received.connect(weak=False)
-def record_first_event(project, group, **kwargs):
+def record_first_event(project, event, **kwargs):
     """
     Requires up to 2 database calls, but should only run with the first event in
     any project, so performance should not be a huge bottleneck.
@@ -111,7 +111,7 @@ def record_first_event(project, group, **kwargs):
             'project_id': project.id,
             'date_completed': project.first_event,
             'data': {
-                'platform': group.platform
+                'platform': event.platform
             },
         }
     )
@@ -124,7 +124,7 @@ def record_first_event(project, group, **kwargs):
             user_id=user.id,
             organization_id=project.organization_id,
             project_id=project.id,
-            platform=group.platform,
+            platform=event.platform,
         )
         return
 
@@ -138,8 +138,8 @@ def record_first_event(project, group, **kwargs):
 
     # Only counts if it's a new project and platform
     if oot.project_id != project.id and oot.data.get(
-        'platform', group.platform
-    ) != group.platform:
+        'platform', event.platform
+    ) != event.platform:
         rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
             organization_id=project.organization_id,
             task=OnboardingTask.SECOND_PLATFORM,
@@ -149,7 +149,7 @@ def record_first_event(project, group, **kwargs):
                 'project_id': project.id,
                 'date_completed': project.first_event,
                 'data': {
-                    'platform': group.platform
+                    'platform': event.platform
                 },
             }
         )
@@ -159,7 +159,7 @@ def record_first_event(project, group, **kwargs):
                 user_id=user.id,
                 organization_id=project.organization_id,
                 project_id=project.id,
-                platform=group.platform,
+                platform=event.platform,
             )
 
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -66,7 +66,7 @@ event_saved = BetterSignal(providing_args=["project"])
 # Organization Onboarding Signals
 project_created = BetterSignal(providing_args=["project", "user"])
 first_event_pending = BetterSignal(providing_args=["project", "user"])
-first_event_received = BetterSignal(providing_args=["project", "group"])
+first_event_received = BetterSignal(providing_args=["project", "event", "group"])
 member_invited = BetterSignal(providing_args=["member", "user"])
 member_joined = BetterSignal(providing_args=["member", "organization"])
 issue_tracker_used = BetterSignal(providing_args=["plugin", "project", "user"])

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -66,7 +66,7 @@ event_saved = BetterSignal(providing_args=["project"])
 # Organization Onboarding Signals
 project_created = BetterSignal(providing_args=["project", "user"])
 first_event_pending = BetterSignal(providing_args=["project", "user"])
-first_event_received = BetterSignal(providing_args=["project", "event", "group"])
+first_event_received = BetterSignal(providing_args=["project", "event"])
 member_invited = BetterSignal(providing_args=["member", "user"])
 member_joined = BetterSignal(providing_args=["member", "organization"])
 issue_tracker_used = BetterSignal(providing_args=["plugin", "project", "user"])

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -102,6 +102,9 @@ class FeatureSet(object):
 
         items = []
         for event in events:
+            # TODO: how we index events?
+            if not event.group:
+                continue
             for label, features in self.extract(event).items():
                 if scope is None:
                     scope = self.__get_scope(event.project)

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -103,7 +103,7 @@ class FeatureSet(object):
         items = []
         for event in events:
             # TODO: how we index events?
-            if not event.group:
+            if not event.group_id:
                 continue
             for label, features in self.extract(event).items():
                 if scope is None:

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -449,10 +449,6 @@ class Factories(object):
     @staticmethod
     def create_event(group=None, project=None, event_id=None, normalize=True, **kwargs):
         # XXX: Do not use this method for new tests! Prefer `store_event`.
-        if group is None and project is not None:
-            group = Factories.create_group(project=project)
-        elif group is None:
-            raise ValueError('Missing `group` or `project` argument')
         if event_id is None:
             event_id = uuid4().hex
         kwargs.setdefault('project', group.project)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -451,7 +451,7 @@ class Factories(object):
         # XXX: Do not use this method for new tests! Prefer `store_event`.
         if event_id is None:
             event_id = uuid4().hex
-        kwargs.setdefault('project', group.project)
+        kwargs.setdefault('project', project if project else group.project)
         kwargs.setdefault('data', copy.deepcopy(DEFAULT_EVENT_DATA))
         kwargs.setdefault('platform', kwargs['data'].get('platform', 'python'))
         kwargs.setdefault('message', kwargs['data'].get('message', 'message'))
@@ -497,11 +497,12 @@ class Factories(object):
         )
 
         event = Event(event_id=event_id, group=group, **kwargs)
-        EventMapping.objects.create(
-            project_id=event.project.id,
-            event_id=event_id,
-            group=group,
-        )
+        if group:
+            EventMapping.objects.create(
+                project_id=event.project.id,
+                event_id=event_id,
+                group=group,
+            )
         # emulate EventManager refs
         event.data.bind_ref(event)
         event.save()

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -447,8 +447,12 @@ class Factories(object):
         return useremail
 
     @staticmethod
-    def create_event(group, event_id=None, normalize=True, **kwargs):
+    def create_event(group=None, project=None, event_id=None, normalize=True, **kwargs):
         # XXX: Do not use this method for new tests! Prefer `store_event`.
+        if group is None and project is not None:
+            group = Factories.create_group(project=project)
+        elif group is None:
+            raise ValueError('Missing `group` or `project` argument')
         if event_id is None:
             event_id = uuid4().hex
         kwargs.setdefault('project', group.project)

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -247,3 +247,29 @@ class SnubaEventSerializerTest(TestCase):
             'value': 'email:test@test.com',
             'query': 'user.email:test@test.com',
         }]
+
+    def test_no_group(self):
+        """
+        Use the SimpleEventSerializer to serialize an event without group
+        """
+
+        event = SnubaEvent({
+            'event_id': 'a',
+            'project_id': 1,
+            'message': 'hello there',
+            'title': 'hi',
+            'type': 'default',
+            'location': 'somewhere',
+            'culprit': 'foo',
+            'timestamp': '2011-01-01T00:00:00Z',
+            'user_id': '123',
+            'email': 'test@test.com',
+            'username': 'test',
+            'ip_address': '192.168.0.1',
+            'platform': 'asdf',
+            'group_id': None,
+            'tags.key': ['sentry:user'],
+            'tags.value': ['email:test@test.com'],
+        })
+        result = serialize(event, None, SimpleEventSerializer())
+        assert result['groupID'] is None

--- a/tests/sentry/models/test_event.py
+++ b/tests/sentry/models/test_event.py
@@ -7,6 +7,7 @@ from sentry.models import Environment
 from sentry.db.models.fields.node import NodeData
 from sentry.event_manager import EventManager
 from sentry.testutils import TestCase
+from sentry.testutils.factories import Factories
 
 
 class EventTest(TestCase):
@@ -161,6 +162,22 @@ class EventTest(TestCase):
 
         event = self.create_event()
         assert event.ip_address is None
+
+    def test_issueless_event(self):
+        event = Factories.create_event(
+            group=None,
+            project=self.project,
+            event_id='a' * 32,
+            tags={'level': 'info'},
+            message='Foo bar',
+            data={
+                'culprit': 'app/components/events/eventEntries in map',
+            },
+        )
+        assert event.group is None
+        assert event.culprit == 'app/components/events/eventEntries in map'
+        assert event.level is None
+        assert event.get_level_display() is None
 
 
 @pytest.mark.django_db

--- a/tests/sentry/receivers/test_featureadoption.py
+++ b/tests/sentry/receivers/test_featureadoption.py
@@ -63,10 +63,14 @@ class FeatureAdoptionTest(TestCase):
         assert feature_complete.complete
 
     def test_first_event(self):
-        group = self.create_group(
+        event = self.create_event(
             project=self.project, platform='javascript', message='javascript error message'
         )
-        first_event_received.send(project=self.project, group=group, sender=type(self.project))
+        first_event_received.send(
+            project=self.project,
+            event=event,
+            sender=type(self.project),
+        )
 
         first_event = FeatureAdoption.objects.get_by_slug(
             organization=self.organization, slug="first_event"
@@ -563,10 +567,15 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform='javascript', message='javascript error message'
         )
-        simple_event = self.create_event()
-        first_event_received.send(project=self.project, group=group, sender=type(self.project))
+        simple_event = self.create_event(group=group, platform='javascript')
+        first_event_received.send(
+            project=self.project,
+            event=simple_event,
+            sender=type(self.project),
+        )
         event_processed.send(
-            project=self.project, group=group, event=simple_event, sender=type(self.project)
+            project=self.project, group=simple_event.group, event=simple_event, sender=type(
+                self.project)
         )
 
         first_event = FeatureAdoption.objects.get_by_slug(
@@ -580,7 +589,8 @@ class FeatureAdoptionTest(TestCase):
 
         full_event = self.create_full_event()
         event_processed.send(
-            project=self.project, group=group, event=full_event, sender=type(self.project)
+            project=self.project, group=full_event.group, event=full_event, sender=type(
+                self.project)
         )
 
         release_tracking = FeatureAdoption.objects.get_by_slug(

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -284,13 +284,11 @@ class OrganizationOnboardingTaskTest(TestCase):
         first_event_received.send(
             project=project,
             event=event,
-            group=event.group,
             sender=type(project),
         )
         first_event_received.send(
             project=second_project,
             event=second_event,
-            group=second_event.group,
             sender=type(second_project),
         )
         member_joined.send(member=member, organization=self.organization, sender=type(member))

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -25,7 +25,6 @@ class OrganizationOnboardingTaskTest(TestCase):
         project = self.create_project(first_event=now)
         first_event_received.send(
             project=project,
-            group=self.event.group,
             event=self.event,
             sender=type(project),
         )
@@ -53,7 +52,6 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         first_event_received.send(
             project=project,
-            group=self.event.group,
             event=self.event,
             sender=type(project),
         )
@@ -78,7 +76,6 @@ class OrganizationOnboardingTaskTest(TestCase):
 
         first_event_received.send(
             project=project,
-            group=self.event.group,
             event=self.event,
             sender=type(project),
         )
@@ -148,7 +145,6 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
         first_event_received.send(
             project=project,
-            group=event.group,
             event=event,
             sender=type(project),
         )
@@ -177,7 +173,6 @@ class OrganizationOnboardingTaskTest(TestCase):
         first_event_received.send(
             project=second_project,
             event=second_event,
-            group=second_event.group,
             sender=type(second_project),
         )
         second_task = OrganizationOnboardingTask.objects.get(


### PR DESCRIPTION
This PR prepares the ground for skipping issue creation if the event has no fingerprint by removing some assumption that the group should always exists.