### PR TITLE
ref(api): Remove uneeded mediaUrl from client config

### DIFF
--- a/src/sentry/templatetags/sentry_react.py
+++ b/src/sentry/templatetags/sentry_react.py
@@ -117,7 +117,6 @@ def get_react_config(context):
         'urlPrefix': options.get('system.url-prefix'),
         'version': version_info,
         'features': enabled_features,
-        'mediaUrl': get_asset_url('sentry', ''),
         'distPrefix': get_asset_url('sentry', 'dist/'),
         'needsUpgrade': needs_upgrade,
         'dsn': get_public_dsn(),


### PR DESCRIPTION
Missed this in https://github.com/getsentry/sentry/pull/13827