### PR TITLE
fix(build): Fixes build fail when integration-docs is missing

### DIFF
--- a/build-utils/integration-docs-fetch-plugin.js
+++ b/build-utils/integration-docs-fetch-plugin.js
@@ -34,6 +34,10 @@ const transformPlatformsToList = ({platforms}) =>
 class IntegrationDocsFetchPlugin {
   constructor({basePath}) {
     this.modulePath = path.join(basePath, DOCS_INDEX_PATH);
+    const moduleDir = path.dirname(this.modulePath);
+    if (!fs.existsSync(moduleDir)) {
+      fs.mkdirSync(moduleDir, {recursive: true});
+    }
   }
 
   apply(compiler) {


### PR DESCRIPTION
Follow up to #13813.