### PR TITLE
fix: Add deep property path support for methods like _.get, _.has, & _.set for lodash-webpack-plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -225,6 +225,7 @@ const appConfig = {
       currying: true, // these are enabled to support lodash/fp/ features
       flattening: true, // used by a dependency of react-mentions
       shorthands: true,
+      paths: true,
     }),
     /**
      * jQuery must be provided in the global scope specifically and only for


### PR DESCRIPTION
This is something I noticed during a hackweek project. 

This change is necessary to enable deep path support as used in https://github.com/getsentry/sentry/pull/13800 .

-----

Probably fixes some sentry issues that may have propped up over a few days ago. 