### PR TITLE
ref: (Django 1.9) Convert request.DATA to request.data

### DIFF
--- a/src/sentry/api/bases/avatar.py
+++ b/src/sentry/api/bases/avatar.py
@@ -53,7 +53,7 @@ class AvatarMixin(object):
     def put(self, request, **kwargs):
         obj = kwargs[self.object_type]
         serializer = AvatarSerializer(
-            data=request.DATA,
+            data=request.data,
             context=self.get_serializer_context(obj),
         )
         if not serializer.is_valid():

--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -82,7 +82,7 @@ class AcceptProjectTransferEndpoint(Endpoint):
     @sudo_required
     def post(self, request):
         try:
-            data = request.DATA['data']
+            data = request.data['data']
         except KeyError:
             raise Http404
 
@@ -93,8 +93,8 @@ class AcceptProjectTransferEndpoint(Endpoint):
 
         transaction_id = data['transaction_id']
 
-        org_slug = request.DATA.get('organization')
-        team_id = request.DATA.get('team')
+        org_slug = request.data.get('organization')
+        team_id = request.data.get('team')
 
         if org_slug is not None and team_id is not None:
             return Response({

--- a/src/sentry/api/endpoints/api_application_details.py
+++ b/src/sentry/api/endpoints/api_application_details.py
@@ -74,7 +74,7 @@ class ApiApplicationDetailsEndpoint(Endpoint):
         except ApiApplication.DoesNotExist:
             raise ResourceDoesNotExist
 
-        serializer = ApiApplicationSerializer(data=request.DATA, partial=True)
+        serializer = ApiApplicationSerializer(data=request.data, partial=True)
 
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/api/endpoints/api_authorizations.py
+++ b/src/sentry/api/endpoints/api_authorizations.py
@@ -30,7 +30,7 @@ class ApiAuthorizationsEndpoint(Endpoint):
         )
 
     def delete(self, request):
-        authorization = request.DATA.get('authorization')
+        authorization = request.data.get('authorization')
         if not authorization:
             return Response({'authorization': ''}, status=400)
 

--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -34,7 +34,7 @@ class ApiTokensEndpoint(Endpoint):
         return Response(serialize(token_list, request.user))
 
     def post(self, request):
-        serializer = ApiTokenSerializer(data=request.DATA)
+        serializer = ApiTokenSerializer(data=request.data)
 
         if serializer.is_valid():
             result = serializer.validated_data
@@ -59,7 +59,7 @@ class ApiTokensEndpoint(Endpoint):
         return Response(serializer.errors, status=400)
 
     def delete(self, request):
-        token = request.DATA.get('token')
+        token = request.data.get('token')
         if not token:
             return Response({'token': ''}, status=400)
 

--- a/src/sentry/api/endpoints/assistant.py
+++ b/src/sentry/api/endpoints/assistant.py
@@ -56,13 +56,13 @@ class AssistantEndpoint(Endpoint):
             'useful' (optional): true / false,
         }
         """
-        serializer = AssistantSerializer(data=request.DATA, partial=True)
+        serializer = AssistantSerializer(data=request.data, partial=True)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        guide_id = request.DATA['guide_id']
-        status = request.DATA['status']
-        useful = request.DATA.get('useful')
+        guide_id = request.data['guide_id']
+        status = request.data['status']
+        useful = request.data.get('useful')
 
         fields = {}
         if useful is not None:

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -99,7 +99,7 @@ class AuthIndexEndpoint(Endpoint):
         if not request.user.is_authenticated():
             return Response(status=status.HTTP_401_UNAUTHORIZED)
 
-        validator = AuthVerifyValidator(data=request.DATA)
+        validator = AuthVerifyValidator(data=request.data)
         if not validator.is_valid():
             return self.respond(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -152,7 +152,7 @@ class AuthIndexEndpoint(Endpoint):
         Deauthenticate the currently active session. Can also deactivate
         all sessions for a user if the ``all`` parameter is sent.
         """
-        if request.DATA.get('all'):
+        if request.data.get('all'):
             # Rotate the session nonce to invalidate all other sessions.
             request.user.refresh_session_nonce()
             request.user.save()

--- a/src/sentry/api/endpoints/broadcast_details.py
+++ b/src/sentry/api/endpoints/broadcast_details.py
@@ -54,7 +54,7 @@ class BroadcastDetailsEndpoint(Endpoint):
 
     def put(self, request, broadcast_id):
         broadcast = self._get_broadcast(request, broadcast_id)
-        validator = self._get_validator(request)(data=request.DATA, partial=True)
+        validator = self._get_validator(request)(data=request.data, partial=True)
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)
 

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -112,7 +112,7 @@ class BroadcastIndexEndpoint(OrganizationEndpoint):
         )
 
     def put(self, request):
-        validator = BroadcastValidator(data=request.DATA, partial=True)
+        validator = BroadcastValidator(data=request.data, partial=True)
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)
 
@@ -157,7 +157,7 @@ class BroadcastIndexEndpoint(OrganizationEndpoint):
         if not (is_active_superuser(request) and request.access.has_permission('broadcasts.admin')):
             return self.respond(status=401)
 
-        validator = AdminBroadcastValidator(data=request.DATA)
+        validator = AdminBroadcastValidator(data=request.data)
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)
 

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -338,7 +338,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         :param boolean isPublic: sets the issue to public or private.
         :auth: required
         """
-        discard = request.DATA.get('discard')
+        discard = request.data.get('discard')
 
         # TODO(dcramer): we need to implement assignedTo in the bulk mutation
         # endpoint
@@ -351,7 +351,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 params={
                     'id': group.id,
                 },
-                data=request.DATA,
+                data=request.data,
                 request=request,
             )
         except client.ApiError as e:

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -87,7 +87,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             return Response(
                 {'detail': MISSING_FEATURE_MESSAGE}, status=400)
 
-        external_issue_id = request.DATA.get('externalIssue')
+        external_issue_id = request.data.get('externalIssue')
         if not external_issue_id:
             return Response({'externalIssue': ['Issue ID is required']}, status=400)
 
@@ -107,7 +107,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
 
         installation = integration.get_installation(organization_id)
         try:
-            data = installation.get_issue(external_issue_id, data=request.DATA)
+            data = installation.get_issue(external_issue_id, data=request.data)
         except IntegrationFormError as exc:
             return Response(exc.field_errors, status=400)
         except IntegrationError as exc:
@@ -137,9 +137,9 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         else:
             external_issue.update(**defaults)
 
-        installation.store_issue_last_defaults(group.project_id, request.DATA)
+        installation.store_issue_last_defaults(group.project_id, request.data)
         try:
-            installation.after_link_issue(external_issue, data=request.DATA)
+            installation.after_link_issue(external_issue, data=request.data)
         except IntegrationFormError as exc:
             return Response(exc.field_errors, status=400)
         except IntegrationError as exc:
@@ -192,7 +192,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
 
         installation = integration.get_installation(organization_id)
         try:
-            data = installation.create_issue(request.DATA)
+            data = installation.create_issue(request.data)
         except IntegrationFormError as exc:
             return Response(exc.field_errors, status=400)
         except IntegrationError as exc:
@@ -229,7 +229,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
                 user=request.user,
                 sender=self.__class__,
             )
-        installation.store_issue_last_defaults(group.project_id, request.DATA)
+        installation.store_issue_last_defaults(group.project_id, request.data)
 
         self.create_issue_activity(request, group, installation, external_issue)
 

--- a/src/sentry/api/endpoints/group_notes.py
+++ b/src/sentry/api/endpoints/group_notes.py
@@ -37,7 +37,7 @@ class GroupNotesEndpoint(GroupEndpoint):
 
     def post(self, request, group):
         serializer = NoteSerializer(
-            data=request.DATA,
+            data=request.data,
             context={
                 'organization_id': group.organization.id,
                 'projects': [group.project],

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -48,7 +48,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
         except Activity.DoesNotExist:
             raise ResourceDoesNotExist
 
-        serializer = NoteSerializer(data=request.DATA)
+        serializer = NoteSerializer(data=request.data)
 
         if serializer.is_valid():
             # Would be nice to have a last_modified timestamp we could bump here

--- a/src/sentry/api/endpoints/monitor_checkin_details.py
+++ b/src/sentry/api/endpoints/monitor_checkin_details.py
@@ -102,7 +102,7 @@ class MonitorCheckInDetailsEndpoint(Endpoint):
             return self.respond(status=400)
 
         serializer = CheckInSerializer(
-            data=request.DATA,
+            data=request.data,
             partial=True,
             context={
                 'project': project,

--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -61,7 +61,7 @@ class MonitorCheckInsEndpoint(MonitorEndpoint):
             return self.respond(status=404)
 
         serializer = CheckInSerializer(
-            data=request.DATA,
+            data=request.data,
             context={
                 'project': project,
                 'request': request,

--- a/src/sentry/api/endpoints/monitor_details.py
+++ b/src/sentry/api/endpoints/monitor_details.py
@@ -34,7 +34,7 @@ class MonitorDetailsEndpoint(MonitorEndpoint):
         :auth: required
         """
         validator = MonitorValidator(
-            data=request.DATA,
+            data=request.data,
             partial=True,
             instance={
                 'name': monitor.name,

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -104,7 +104,7 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
         if not self._can_access(request, access_request):
             return Response(status=403)
 
-        serializer = AccessRequestSerializer(data=request.DATA, partial=True)
+        serializer = AccessRequestSerializer(data=request.data, partial=True)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 

--- a/src/sentry/api/endpoints/organization_api_key_details.py
+++ b/src/sentry/api/endpoints/organization_api_key_details.py
@@ -60,7 +60,7 @@ class OrganizationApiKeyDetailsEndpoint(OrganizationEndpoint):
         except ApiKey.DoesNotExist:
             raise ResourceDoesNotExist
 
-        serializer = ApiKeySerializer(api_key, data=request.DATA, partial=True)
+        serializer = ApiKeySerializer(api_key, data=request.data, partial=True)
 
         if serializer.is_valid():
             api_key = serializer.save()

--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -134,7 +134,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardEndpoint):
         :auth: required
         """
         serializer = DashboardWithWidgetsSerializer(
-            data=request.DATA,
+            data=request.data,
             context={'dashboard_id': dashboard.id}
         )
 

--- a/src/sentry/api/endpoints/organization_dashboard_widget_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_widget_details.py
@@ -54,7 +54,7 @@ class OrganizationDashboardWidgetDetailsEndpoint(OrganizationDashboardWidgetEndp
         :auth: required
         """
         # TODO(lb): better document displayType, displayOptions, and dataSources.
-        serializer = WidgetSerializer(data=request.DATA, context={'organization': organization})
+        serializer = WidgetSerializer(data=request.data, context={'organization': organization})
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 

--- a/src/sentry/api/endpoints/organization_dashboard_widgets.py
+++ b/src/sentry/api/endpoints/organization_dashboard_widgets.py
@@ -32,7 +32,7 @@ class OrganizationDashboardWidgetsEndpoint(OrganizationDashboardEndpoint):
         :auth: required
         """
 
-        serializer = WidgetSerializer(data=request.DATA, context={'organization': organization})
+        serializer = WidgetSerializer(data=request.data, context={'organization': organization})
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -54,7 +54,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                                           dashboards belongs to.
         :param string title: the title of the dashboard.
         """
-        serializer = DashboardSerializer(data=request.DATA)
+        serializer = DashboardSerializer(data=request.data)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -352,7 +352,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         was_pending_deletion = organization.status in DELETION_STATUSES
 
         serializer = serializer_cls(
-            data=request.DATA,
+            data=request.data,
             partial=True,
             context={
                 'organization': organization,

--- a/src/sentry/api/endpoints/organization_discover_saved_queries.py
+++ b/src/sentry/api/endpoints/organization_discover_saved_queries.py
@@ -33,7 +33,7 @@ class OrganizationDiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         if not features.has('organizations:discover', organization, actor=request.user):
             return self.respond(status=404)
 
-        serializer = DiscoverSavedQuerySerializer(data=request.DATA, context={
+        serializer = DiscoverSavedQuerySerializer(data=request.data, context={
             'organization': organization,
         })
 

--- a/src/sentry/api/endpoints/organization_discover_saved_query_detail.py
+++ b/src/sentry/api/endpoints/organization_discover_saved_query_detail.py
@@ -39,7 +39,7 @@ class OrganizationDiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
         except DiscoverSavedQuery.DoesNotExist:
             raise ResourceDoesNotExist
 
-        serializer = DiscoverSavedQuerySerializer(data=request.DATA, context={
+        serializer = DiscoverSavedQuerySerializer(data=request.data, context={
             'organization': organization,
         })
 

--- a/src/sentry/api/endpoints/organization_incident_comment_details.py
+++ b/src/sentry/api/endpoints/organization_incident_comment_details.py
@@ -75,7 +75,7 @@ class OrganizationIncidentCommentDetailsEndpoint(CommentDetailsEndpoint):
         :auth: required
         """
 
-        serializer = CommentSerializer(data=request.DATA)
+        serializer = CommentSerializer(data=request.data)
         if serializer.is_valid():
             result = serializer.validated_data
 

--- a/src/sentry/api/endpoints/organization_incident_comment_index.py
+++ b/src/sentry/api/endpoints/organization_incident_comment_index.py
@@ -26,7 +26,7 @@ class OrganizationIncidentCommentIndexEndpoint(IncidentEndpoint):
 
     def post(self, request, organization, incident):
         serializer = CommentSerializer(
-            data=request.DATA,
+            data=request.data,
             context={'projects': incident.projects.all(), 'organization_id': organization.id},
         )
         if serializer.is_valid():

--- a/src/sentry/api/endpoints/organization_incident_details.py
+++ b/src/sentry/api/endpoints/organization_incident_details.py
@@ -46,7 +46,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
         return Response(data)
 
     def put(self, request, organization, incident):
-        serializer = IncidentSerializer(data=request.DATA)
+        serializer = IncidentSerializer(data=request.data)
         if serializer.is_valid():
             result = serializer.validated_data
 

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -212,7 +212,7 @@ class OrganizationIndexEndpoint(Endpoint):
                 status=429
             )
 
-        serializer = OrganizationSerializer(data=request.DATA)
+        serializer = OrganizationSerializer(data=request.data)
 
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -66,7 +66,7 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationEndpoint):
 
         installation = integration.get_installation(organization.id)
         try:
-            installation.update_organization_config(request.DATA)
+            installation.update_organization_config(request.data)
         except IntegrationError as e:
             return self.respond({'detail': e.message}, status=400)
 

--- a/src/sentry/api/endpoints/organization_member_details.py
+++ b/src/sentry/api/endpoints/organization_member_details.py
@@ -138,7 +138,7 @@ class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
             raise ResourceDoesNotExist
 
         serializer = OrganizationMemberSerializer(
-            data=request.DATA, partial=True)
+            data=request.data, partial=True)
 
         if not serializer.is_valid():
             return Response(status=400)

--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -111,7 +111,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
             return Response(
                 {'organization': 'Your organization is not allowed to invite members'}, status=403)
 
-        serializer = OrganizationMemberSerializer(data=request.DATA)
+        serializer = OrganizationMemberSerializer(data=request.data)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
@@ -169,7 +169,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
         if settings.SENTRY_ENABLE_INVITES and result.get('sendInvite'):
             om.send_invite_email()
             member_invited.send_robust(member=om, user=request.user, sender=self,
-                                       referrer=request.DATA.get('referrer'))
+                                       referrer=request.data.get('referrer'))
         self.create_audit_entry(
             request=request,
             organization_id=organization.id,

--- a/src/sentry/api/endpoints/organization_monitors.py
+++ b/src/sentry/api/endpoints/organization_monitors.py
@@ -109,7 +109,7 @@ class OrganizationMonitorsEndpoint(OrganizationEndpoint):
         :auth: required
         """
         validator = MonitorValidator(
-            data=request.DATA,
+            data=request.data,
             context={
                 'organization': organization,
                 'access': request.access,

--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -11,11 +11,11 @@ from sentry.receivers import check_for_onboarding_complete
 class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
     def post(self, request, organization):
         try:
-            task_id = int(request.DATA['task'])
+            task_id = int(request.data['task'])
         except (TypeError, ValueError):
             return Response(status=500)
 
-        if request.DATA['status'] == 'skipped' and task_id in (
+        if request.data['status'] == 'skipped' and task_id in (
             OnboardingTask.INVITE_MEMBER, OnboardingTask.SECOND_PLATFORM,
             OnboardingTask.USER_CONTEXT, OnboardingTask.RELEASE_TRACKING, OnboardingTask.SOURCEMAPS,
             OnboardingTask.USER_REPORTS, OnboardingTask.ISSUE_TRACKER,
@@ -24,7 +24,7 @@ class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
             rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
                 organization=organization,
                 user=request.user,
-                task=request.DATA['task'],
+                task=request.data['task'],
                 values={
                     'status': OnboardingTaskStatus.SKIPPED,
                     'date_completed': timezone.now(),

--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -33,7 +33,7 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationPinnedSearchPermission, )
 
     def put(self, request, organization):
-        serializer = OrganizationSearchSerializer(data=request.DATA)
+        serializer = OrganizationSearchSerializer(data=request.data)
 
         if serializer.is_valid():
             result = serializer.validated_data
@@ -68,7 +68,7 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
 
     def delete(self, request, organization):
         try:
-            search_type = SearchType(int(request.DATA.get('type', 0)))
+            search_type = SearchType(int(request.data.get('type', 0)))
         except ValueError as e:
             return Response(
                 {'detail': 'Invalid input for `type`. Error: %s' % six.text_type(e)},

--- a/src/sentry/api/endpoints/organization_recent_searches.py
+++ b/src/sentry/api/endpoints/organization_recent_searches.py
@@ -75,7 +75,7 @@ class OrganizationRecentSearchesEndpoint(OrganizationEndpoint):
         return Response(serialize(recent_searches, request.user))
 
     def post(self, request, organization):
-        serializer = RecentSearchSerializer(data=request.DATA)
+        serializer = RecentSearchSerializer(data=request.data)
 
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -120,7 +120,7 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        serializer = OrganizationReleaseSerializer(data=request.DATA)
+        serializer = OrganizationReleaseSerializer(data=request.data)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/organization_release_file_details.py
+++ b/src/sentry/api/endpoints/organization_release_file_details.py
@@ -111,7 +111,7 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         except ReleaseFile.DoesNotExist:
             raise ResourceDoesNotExist
 
-        serializer = ReleaseFileSerializer(data=request.DATA)
+        serializer = ReleaseFileSerializer(data=request.data)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -124,7 +124,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
 
         fileobj = request.FILES['file']
 
-        full_name = request.DATA.get('name', fileobj.name)
+        full_name = request.data.get('name', fileobj.name)
         if not full_name or full_name == 'file':
             return Response({'detail': 'File name must be specified'}, status=400)
 
@@ -137,7 +137,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
                 }, status=400
             )
 
-        dist_name = request.DATA.get('dist')
+        dist_name = request.data.get('dist')
         dist = None
         if dist_name:
             dist = release.add_dist(dist_name)
@@ -145,7 +145,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
         headers = {
             'Content-Type': fileobj.content_type,
         }
-        for headerval in request.DATA.getlist('header') or ():
+        for headerval in request.data.getlist('header') or ():
             try:
                 k, v = headerval.split(':', 1)
             except ValueError:

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -177,7 +177,7 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
                            ``commit`` may contain a range in the form of ``previousCommit..commit``
         :auth: required
         """
-        serializer = ReleaseSerializerWithProjects(data=request.DATA)
+        serializer = ReleaseSerializerWithProjects(data=request.data)
 
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/api/endpoints/organization_repositories.py
+++ b/src/sentry/api/endpoints/organization_repositories.py
@@ -80,7 +80,7 @@ class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
     def post(self, request, organization):
         if not request.user.is_authenticated():
             return Response(status=401)
-        provider_id = request.DATA.get('provider')
+        provider_id = request.data.get('provider')
 
         if provider_id is not None and provider_id.startswith('integrations:'):
             try:

--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -53,7 +53,7 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
         if repo.status == ObjectStatus.DELETION_IN_PROGRESS:
             return Response(status=400)
 
-        serializer = RepositorySerializer(data=request.DATA, partial=True)
+        serializer = RepositorySerializer(data=request.data, partial=True)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/organization_searches.py
+++ b/src/sentry/api/endpoints/organization_searches.py
@@ -89,7 +89,7 @@ class OrganizationSearchesEndpoint(OrganizationEndpoint):
         return Response(serialize(results, request.user))
 
     def post(self, request, organization):
-        serializer = OrganizationSearchSerializer(data=request.DATA)
+        serializer = OrganizationSearchSerializer(data=request.data)
 
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/api/endpoints/organization_slugs.py
+++ b/src/sentry/api/endpoints/organization_slugs.py
@@ -23,7 +23,7 @@ class SlugsUpdateEndpoint(OrganizationEndpoint):
         :param slugs: a dictionary of project IDs to their intended slugs.
         :auth: required
         """
-        slugs = request.DATA.get('slugs', {})
+        slugs = request.data.get('slugs', {})
         for project_id, slug in six.iteritems(slugs):
             slug = slug.lower()
             try:

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -134,7 +134,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                             name.
         :auth: required
         """
-        serializer = TeamSerializer(data=request.DATA)
+        serializer = TeamSerializer(data=request.data)
 
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -354,7 +354,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             serializer_cls = ProjectMemberSerializer
 
         serializer = serializer_cls(
-            data=request.DATA,
+            data=request.data,
             partial=True,
             context={
                 'project': project,
@@ -369,7 +369,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         if not has_project_write:
             # options isn't part of the serializer, but should not be editable by members
             for key in chain(six.iterkeys(ProjectAdminSerializer().fields), ['options']):
-                if request.DATA.get(key) and not result.get(key):
+                if request.data.get(key) and not result.get(key):
                     return Response(
                         {
                             'detail': ['You do not have permission to perform this action.']
@@ -526,7 +526,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
 
         # TODO(dcramer): rewrite options to use standard API config
         if has_project_write:
-            options = request.DATA.get('options', {})
+            options = request.data.get('options', {})
             if 'sentry:origins' in options:
                 project.update_option(
                     'sentry:origins', clean_newline_inputs(

--- a/src/sentry/api/endpoints/project_environment_details.py
+++ b/src/sentry/api/endpoints/project_environment_details.py
@@ -34,7 +34,7 @@ class ProjectEnvironmentDetailsEndpoint(ProjectEndpoint):
         except EnvironmentProject.DoesNotExist:
             raise ResourceDoesNotExist
 
-        serializer = ProjectEnvironmentSerializer(data=request.DATA, partial=True)
+        serializer = ProjectEnvironmentSerializer(data=request.data, partial=True)
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 

--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -27,7 +27,7 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
         else:
             raise ResourceDoesNotExist  # could not find filter with the requested id
 
-        serializer = current_filter.spec.serializer_cls(data=request.DATA, partial=True)
+        serializer = current_filter.spec.serializer_cls(data=request.data, partial=True)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/project_key_details.py
+++ b/src/sentry/api/endpoints/project_key_details.py
@@ -92,7 +92,7 @@ class ProjectKeyDetailsEndpoint(ProjectEndpoint):
         except ProjectKey.DoesNotExist:
             raise ResourceDoesNotExist
 
-        serializer = KeySerializer(data=request.DATA, partial=True)
+        serializer = KeySerializer(data=request.data, partial=True)
         default_version = get_default_sdk_version_for_project(project)
 
         if serializer.is_valid():

--- a/src/sentry/api/endpoints/project_keys.py
+++ b/src/sentry/api/endpoints/project_keys.py
@@ -87,7 +87,7 @@ class ProjectKeysEndpoint(ProjectEndpoint):
                                      belong to.
         :param string name: the name for the new key.
         """
-        serializer = KeySerializer(data=request.DATA)
+        serializer = KeySerializer(data=request.data)
 
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -133,7 +133,7 @@ class ProjectOwnershipEndpoint(ProjectEndpoint):
         :auth: required
         """
         serializer = ProjectOwnershipSerializer(
-            data=request.DATA,
+            data=request.data,
             partial=True,
             context={'ownership': self.get_ownership(project)}
         )

--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -51,7 +51,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
         """
         plugin = self._get_plugin(plugin_id)
 
-        if request.DATA.get('test') and plugin.is_testable():
+        if request.data.get('test') and plugin.is_testable():
             try:
                 test_results = plugin.test_configuration(project)
             except Exception as exc:
@@ -67,7 +67,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
                 test_results = 'No errors returned'
             return Response({'detail': test_results}, status=200)
 
-        if request.DATA.get('reset'):
+        if request.data.get('reset'):
             plugin = self._get_plugin(plugin_id)
             plugin.reset_options(project=project)
             context = serialize(plugin, request.user, PluginWithConfigSerializer(project))
@@ -126,7 +126,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
             for c in plugin.get_config(
                 project=project,
                 user=request.user,
-                initial=request.DATA,
+                initial=request.data,
             )
         ]
 
@@ -134,7 +134,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
         errors = {}
         for field in config:
             key = field['name']
-            value = request.DATA.get(key)
+            value = request.data.get(key)
 
             if field.get('required') and not value:
                 errors[key] = ERR_FIELD_REQUIRED

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -74,7 +74,7 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint):
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 
-        serializer = ReleaseSerializer(data=request.DATA, partial=True)
+        serializer = ReleaseSerializer(data=request.data, partial=True)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/project_release_file_details.py
+++ b/src/sentry/api/endpoints/project_release_file_details.py
@@ -160,7 +160,7 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint):
         except ReleaseFile.DoesNotExist:
             raise ResourceDoesNotExist
 
-        serializer = ReleaseFileSerializer(data=request.DATA)
+        serializer = ReleaseFileSerializer(data=request.data)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -140,7 +140,7 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
 
         fileobj = request.FILES['file']
 
-        full_name = request.DATA.get('name', fileobj.name)
+        full_name = request.data.get('name', fileobj.name)
         if not full_name or full_name == 'file':
             return Response({'detail': 'File name must be specified'}, status=400)
 
@@ -153,7 +153,7 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
                 }, status=400
             )
 
-        dist_name = request.DATA.get('dist')
+        dist_name = request.data.get('dist')
         dist = None
         if dist_name:
             dist = release.add_dist(dist_name)
@@ -161,7 +161,7 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
         headers = {
             'Content-Type': fileobj.content_type,
         }
-        for headerval in request.DATA.getlist('header') or ():
+        for headerval in request.data.getlist('header') or ():
             try:
                 k, v = headerval.split(':', 1)
             except ValueError:

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -104,7 +104,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
                                       the current time is assumed.
         :auth: required
         """
-        serializer = ReleaseWithVersionSerializer(data=request.DATA)
+        serializer = ReleaseWithVersionSerializer(data=request.data)
 
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -50,7 +50,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
 
         serializer = RuleSerializer(
             context={'project': project},
-            data=request.DATA,
+            data=request.data,
             partial=True
         )
 

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -49,7 +49,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         """
         serializer = RuleSerializer(
             context={'project': project},
-            data=request.DATA,
+            data=request.data,
         )
 
         if serializer.is_valid():

--- a/src/sentry/api/endpoints/project_search_details.py
+++ b/src/sentry/api/endpoints/project_search_details.py
@@ -68,9 +68,9 @@ class ProjectSearchDetailsEndpoint(ProjectEndpoint):
             request.access.has_team_scope(team, 'project:write') for team in project.teams.all()
         )
         if has_team_scope:
-            serializer = SavedSearchSerializer(data=request.DATA, partial=True)
+            serializer = SavedSearchSerializer(data=request.data, partial=True)
         else:
-            serializer = LimitedSavedSearchSerializer(data=request.DATA, partial=True)
+            serializer = LimitedSavedSearchSerializer(data=request.data, partial=True)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/project_searches.py
+++ b/src/sentry/api/endpoints/project_searches.py
@@ -51,7 +51,7 @@ class ProjectSearchesEndpoint(ProjectEndpoint):
             }}
 
         """
-        serializer = SavedSearchSerializer(data=request.DATA)
+        serializer = SavedSearchSerializer(data=request.data)
 
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/api/endpoints/project_servicehook_details.py
+++ b/src/sentry/api/endpoints/project_servicehook_details.py
@@ -63,7 +63,7 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
         except ServiceHook.DoesNotExist:
             raise ResourceDoesNotExist
 
-        validator = ServiceHookValidator(data=request.DATA, partial=True)
+        validator = ServiceHookValidator(data=request.data, partial=True)
         if not validator.is_valid():
             return self.respond(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/sentry/api/endpoints/project_servicehooks.py
+++ b/src/sentry/api/endpoints/project_servicehooks.py
@@ -117,7 +117,7 @@ class ProjectServiceHooksEndpoint(ProjectEndpoint):
                 'detail': ['You do not have that feature enabled']
             }, status=403)
 
-        validator = ServiceHookValidator(data=request.DATA)
+        validator = ServiceHookValidator(data=request.data)
         if not validator.is_valid():
             return self.respond(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/sentry/api/endpoints/project_transfer.py
+++ b/src/sentry/api/endpoints/project_transfer.py
@@ -50,7 +50,7 @@ class ProjectTransferEndpoint(ProjectEndpoint):
                 status=status.HTTP_403_FORBIDDEN
             )
 
-        email = request.DATA.get('email')
+        email = request.data.get('email')
 
         if email is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -130,7 +130,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
         if hasattr(request.auth, 'project_id') and project.id != request.auth.project_id:
             return self.respond(status=400)
 
-        serializer = UserReportSerializer(data=request.DATA)
+        serializer = UserReportSerializer(data=request.data)
         if not serializer.is_valid():
             return self.respond(serializer.errors, status=400)
 

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -64,7 +64,7 @@ class PromptsActivityEndpoint(Endpoint):
 
     def put(self, request):
         serializer = PromptsActivitySerializer(
-            data=request.DATA,
+            data=request.data,
         )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
@@ -74,7 +74,7 @@ class PromptsActivityEndpoint(Endpoint):
         status = serialized['status']
 
         required_fields = PROMPTS[feature]['required_fields']
-        fields = {k: request.DATA.get(k) for k in required_fields}
+        fields = {k: request.data.get(k) for k in required_fields}
 
         if any(elem is None for elem in fields.values()):
             return Response({'detail': 'Missing required field'}, status=400)

--- a/src/sentry/api/endpoints/release_deploys.py
+++ b/src/sentry/api/endpoints/release_deploys.py
@@ -94,7 +94,7 @@ class ReleaseDeploysEndpoint(OrganizationReleasesBaseEndpoint):
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        serializer = DeploySerializer(data=request.DATA)
+        serializer = DeploySerializer(data=request.data)
 
         if serializer.is_valid():
             projects = list(release.projects.all())

--- a/src/sentry/api/endpoints/sentry_app_installation_external_issues.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_external_issues.py
@@ -10,7 +10,7 @@ from sentry.models import Group, Project
 
 class SentryAppInstallationExternalIssuesEndpoint(SentryAppInstallationBaseEndpoint):
     def post(self, request, installation):
-        data = request.DATA.copy()
+        data = request.data.copy()
 
         if not set(['groupId', 'action', 'uri']).issubset(data.keys()):
             return Response(status=400)

--- a/src/sentry/api/endpoints/sentry_app_installations.py
+++ b/src/sentry/api/endpoints/sentry_app_installations.py
@@ -44,7 +44,7 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
         )
 
     def post(self, request, organization):
-        serializer = SentryAppInstallationsSerializer(data=request.DATA)
+        serializer = SentryAppInstallationsSerializer(data=request.data)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -56,7 +56,7 @@ class SystemOptionsEndpoint(Endpoint):
 
     def put(self, request):
         # TODO(dcramer): this should validate options before saving them
-        for k, v in six.iteritems(request.DATA):
+        for k, v in six.iteritems(request.data):
             if v and isinstance(v, six.string_types):
                 v = v.strip()
             try:

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -88,7 +88,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
                             and available.
         :auth: required
         """
-        serializer = TeamSerializer(team, data=request.DATA, partial=True)
+        serializer = TeamSerializer(team, data=request.data, partial=True)
         if serializer.is_valid():
             team = serializer.save()
 

--- a/src/sentry/api/endpoints/team_projects.py
+++ b/src/sentry/api/endpoints/team_projects.py
@@ -128,7 +128,7 @@ class TeamProjectsEndpoint(TeamEndpoint, EnvironmentMixin):
                             not provided a slug is generated from the name.
         :auth: required
         """
-        serializer = ProjectSerializer(data=request.DATA)
+        serializer = ProjectSerializer(data=request.data)
 
         if serializer.is_valid():
             result = serializer.validated_data

--- a/src/sentry/api/endpoints/user_appearance.py
+++ b/src/sentry/api/endpoints/user_appearance.py
@@ -74,7 +74,7 @@ class UserAppearanceEndpoint(UserEndpoint):
         :param clock_24_hours boolean: use 24 hour clock
         :auth: required
         """
-        serializer = UserAppearanceSerializer(data=request.DATA, partial=True)
+        serializer = UserAppearanceSerializer(data=request.data, partial=True)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -174,7 +174,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
         if serializer_cls is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-        serializer = serializer_cls(data=request.DATA)
+        serializer = serializer_cls(data=request.data)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -189,18 +189,18 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
             return Response(ALREADY_ENROLLED_ERR, status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            interface.secret = request.DATA['secret']
+            interface.secret = request.data['secret']
         except KeyError:
             pass
 
         context = {}
         # Need to update interface with phone number before validating OTP
-        if 'phone' in request.DATA:
+        if 'phone' in request.data:
             interface.phone_number = serializer.data['phone']
 
             # Disregarding value of 'otp', if no OTP was provided,
             # send text message to phone number with OTP
-            if 'otp' not in request.DATA:
+            if 'otp' not in request.data:
                 if interface.send_text(for_enrollment=True, request=request._request):
                     return Response(status=status.HTTP_204_NO_CONTENT)
                 else:
@@ -208,7 +208,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
                     return Response(SEND_SMS_ERR, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
         # Attempt to validate OTP
-        if 'otp' in request.DATA and not interface.validate_otp(serializer.data['otp']):
+        if 'otp' in request.data and not interface.validate_otp(serializer.data['otp']):
             return Response(INVALID_OTP_ERR, status=status.HTTP_400_BAD_REQUEST)
 
         # Try u2f enrollment

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -133,10 +133,9 @@ class UserDetailsEndpoint(UserEndpoint):
             serializer_cls = AdminUserSerializer
         else:
             serializer_cls = UserSerializer
-        serializer = serializer_cls(user, data=request.DATA, partial=True)
+        serializer = serializer_cls(user, data=request.data, partial=True)
 
-        serializer_options = UserOptionsSerializer(
-            data=request.DATA.get('options', {}), partial=True)
+        serializer_options = UserOptionsSerializer(data=request.data.get('options', {}), partial=True)
 
         # This serializer should NOT include privileged fields e.g. password
         if not serializer.is_valid() or not serializer_options.is_valid():
@@ -175,7 +174,7 @@ class UserDetailsEndpoint(UserEndpoint):
         :auth required:
         """
 
-        serializer = OrganizationsSerializer(data=request.DATA)
+        serializer = OrganizationsSerializer(data=request.data)
 
         if not serializer.is_valid():
             return Response(status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/user_emails.py
+++ b/src/sentry/api/endpoints/user_emails.py
@@ -77,7 +77,7 @@ class UserEmailsEndpoint(UserEndpoint):
         :auth required:
         """
 
-        validator = EmailValidator(data=request.DATA)
+        validator = EmailValidator(data=request.data)
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)
 
@@ -115,7 +115,7 @@ class UserEmailsEndpoint(UserEndpoint):
         :auth required:
         """
 
-        validator = EmailValidator(data=request.DATA)
+        validator = EmailValidator(data=request.data)
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)
 
@@ -205,7 +205,7 @@ class UserEmailsEndpoint(UserEndpoint):
         :param string email: email to remove
         :auth required:
         """
-        validator = EmailValidator(data=request.DATA)
+        validator = EmailValidator(data=request.data)
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)
 

--- a/src/sentry/api/endpoints/user_emails_confirm.py
+++ b/src/sentry/api/endpoints/user_emails_confirm.py
@@ -53,7 +53,7 @@ class UserEmailsConfirmEndpoint(UserEndpoint):
             return self.respond({'detail': 'You have made too many email confirmation requests. Please try again later.', },
                                 status=status.HTTP_429_TOO_MANY_REQUESTS)
 
-        serializer = EmailSerializer(data=request.DATA)
+        serializer = EmailSerializer(data=request.data)
 
         if not serializer.is_valid():
             return InvalidEmailResponse()

--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -99,7 +99,7 @@ class UserNotificationDetailsEndpoint(UserEndpoint):
         return Response(serialized)
 
     def put(self, request, user):
-        serializer = UserNotificationDetailsSerializer(data=request.DATA)
+        serializer = UserNotificationDetailsSerializer(data=request.data)
 
         if serializer.is_valid():
             for key in serializer.validated_data:

--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -94,7 +94,7 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
 
             # set of org ids that user is a member of
             org_ids = self.get_org_ids(user)
-            for org_id, enabled in request.DATA.items():
+            for org_id, enabled in request.data.items():
                 org_id = int(org_id)
                 # We want "0" to be falsey
                 enabled = int(enabled)
@@ -122,7 +122,7 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
             parent_ids = set(self.get_org_ids(user))
 
         try:
-            ids_to_update = set([int(i) for i in request.DATA.keys()])
+            ids_to_update = set([int(i) for i in request.data.keys()])
         except ValueError:
             return Response({
                 'detail': 'Invalid id value provided. Id values should be integers.'
@@ -135,7 +135,7 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
 
         if notification_type == 'email':
             # make sure target emails exist and are verified
-            emails_to_check = set(request.DATA.values())
+            emails_to_check = set(request.data.values())
             emails = UserEmail.objects.filter(
                 user=user,
                 email__in=emails_to_check,
@@ -147,8 +147,8 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
                 return Response(status=status.HTTP_400_BAD_REQUEST)
 
         with transaction.atomic():
-            for id in request.DATA:
-                val = request.DATA[id]
+            for id in request.data:
+                val = request.data[id]
                 int_val = int(val) if notification_type != 'email' else None
 
                 filter_args['%s_id' % update_key] = id

--- a/src/sentry/api/endpoints/user_subscriptions.py
+++ b/src/sentry/api/endpoints/user_subscriptions.py
@@ -56,7 +56,7 @@ class UserSubscriptionsEndpoint(UserEndpoint):
         :param boolean subscribed: should be subscribed to newsletter
         :auth: required
         """
-        validator = NewsletterValidator(data=request.DATA)
+        validator = NewsletterValidator(data=request.data)
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)
 
@@ -86,7 +86,7 @@ class UserSubscriptionsEndpoint(UserEndpoint):
         :param boolean subscribed: should be subscribed to newsletter
         :auth: required
         """
-        validator = DefaultNewsletterValidator(data=request.DATA)
+        validator = DefaultNewsletterValidator(data=request.data)
         if not validator.is_valid():
             return self.respond(validator.errors, status=400)
 

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -462,7 +462,7 @@ def update_groups(request, projects, organization_id, search_fn):
     # because of the assignee validation. Punting on this for now.
     for project in projects:
         serializer = GroupValidator(
-            data=request.DATA,
+            data=request.data,
             partial=True,
             context={'project': project},
         )

--- a/src/sentry/integrations/bitbucket/installed.py
+++ b/src/sentry/integrations/bitbucket/installed.py
@@ -18,7 +18,7 @@ class BitbucketInstalledEndpoint(Endpoint):
         return super(BitbucketInstalledEndpoint, self).dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
-        state = request.DATA
+        state = request.data
         data = BitbucketIntegrationProvider().build_integration(state)
         ensure_integration('bitbucket', data)
 

--- a/src/sentry/integrations/cloudflare/webhook.py
+++ b/src/sentry/integrations/cloudflare/webhook.py
@@ -37,7 +37,7 @@ class CloudflareTokenAuthentication(TokenAuthentication):
         # are ok with it.
         request.body = six.text_type(request.body)
         try:
-            token = request.DATA['authentications']['account']['token']['token']
+            token = request.data['authentications']['account']['token']['token']
         except KeyError:
             return None
         return self.authenticate_credentials(request, token)
@@ -229,7 +229,7 @@ class CloudflareWebhookEndpoint(Endpoint):
 
         payload = request.body
         try:
-            data = request.DATA
+            data = request.data
         except (ValueError, TypeError):
             logger.error('cloudflare.webhook.invalid-json', extra=logging_data)
             return Response(status=400)

--- a/src/sentry/integrations/jira/installed.py
+++ b/src/sentry/integrations/jira/installed.py
@@ -19,7 +19,7 @@ class JiraInstalledEndpoint(Endpoint):
         return super(JiraInstalledEndpoint, self).dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
-        state = request.DATA
+        state = request.data
         data = JiraIntegrationProvider().build_integration(state)
         integration = ensure_integration('jira', data)
 

--- a/src/sentry/integrations/jira/webhooks.py
+++ b/src/sentry/integrations/jira/webhooks.py
@@ -96,7 +96,7 @@ class JiraIssueUpdatedWebhook(Endpoint):
         except AtlassianConnectValidationError:
             return self.respond(status=400)
 
-        data = request.DATA
+        data = request.data
 
         if not data.get('changelog'):
             logger.info(

--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -64,7 +64,7 @@ class JiraIssueUpdatedWebhook(Endpoint):
             })
             return self.respond(status=400)
 
-        data = request.DATA
+        data = request.data
 
         if not data.get('changelog'):
             logger.info('missing-changelog', extra={'integration_id': integration.id})

--- a/src/sentry/integrations/slack/requests.py
+++ b/src/sentry/integrations/slack/requests.py
@@ -87,7 +87,7 @@ class SlackRequest(object):
 
     def _validate_data(self):
         try:
-            self._data = self.request.DATA
+            self._data = self.request.data
         except (ValueError, TypeError):
             raise SlackRequestError(status=400)
 
@@ -202,7 +202,7 @@ class SlackActionRequest(SlackRequest):
         """
         super(SlackActionRequest, self)._validate_data()
 
-        if 'payload' not in self.request.DATA:
+        if 'payload' not in self.request.data:
             raise SlackRequestError(status=400)
 
         try:

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -31,7 +31,7 @@ class WorkItemWebhook(Endpoint):
         return super(WorkItemWebhook, self).dispatch(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
-        data = request.DATA
+        data = request.data
         try:
             event_type = data['eventType']
             external_id = data['resourceContainers']['collection']['id']

--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -513,7 +513,7 @@ class IPlugin(local, PluggableViewMixin, PluginConfigMixin, PluginStatusMixin):
                     **kwargs
                 )
             )
-        self.configure(project, request.DATA)
+        self.configure(project, request.data)
         return Response({'message': 'Successfully updated configuration.'})
 
     def handle_signal(self, name, payload, **kwargs):

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -257,14 +257,14 @@ class IssueTrackingPlugin2(Plugin):
         if request.method == 'GET':
             return Response(fields)
 
-        errors = self.validate_form(fields, request.DATA)
+        errors = self.validate_form(fields, request.data)
         if errors:
             return Response({'error_type': 'validation', 'errors': errors}, status=400)
 
         try:
             issue = self.create_issue(
                 group=group,
-                form_data=request.DATA,
+                form_data=request.data,
                 request=request,
             )
         except Exception as e:
@@ -281,7 +281,7 @@ class IssueTrackingPlugin2(Plugin):
                 GroupMeta.objects.unset_value(group, meta_name)
 
         issue_information = {
-            'title': issue.get('title') or request.DATA.get('title') or self._get_issue_label_compat(group, issue),
+            'title': issue.get('title') or request.data.get('title') or self._get_issue_label_compat(group, issue),
             'provider': self.get_title(),
             'location': self._get_issue_url_compat(group, issue),
             'label': self._get_issue_label_compat(group, issue),
@@ -323,22 +323,22 @@ class IssueTrackingPlugin2(Plugin):
             return self.handle_api_error(e)
         if request.method == 'GET':
             return Response(fields)
-        errors = self.validate_form(fields, request.DATA)
+        errors = self.validate_form(fields, request.data)
         if errors:
             return Response({'error_type': 'validation', 'errors': errors}, status=400)
 
         try:
             issue = self.link_issue(
                 group=group,
-                form_data=request.DATA,
+                form_data=request.data,
                 request=request,
             ) or {}
         except Exception as e:
             return self.handle_api_error(e)
 
         # HACK(dcramer): maintain data for legacy issues
-        if 'id' not in issue and 'issue_id' in request.DATA:
-            issue['id'] = request.DATA['issue_id']
+        if 'id' not in issue and 'issue_id' in request.data:
+            issue['id'] = request.data['issue_id']
 
         issue_field_map = self.get_issue_field_map()
         for key, meta_name in six.iteritems(issue_field_map):

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -27,7 +27,7 @@ class IntegrationRepositoryProvider(object):
 
     def dispatch(self, request, organization, **kwargs):
         try:
-            config = self.get_repository_data(organization, request.DATA)
+            config = self.get_repository_data(organization, request.data)
             result = self.build_repository_config(
                 organization=organization,
                 data=config,

--- a/src/sentry/plugins/providers/repository.py
+++ b/src/sentry/plugins/providers/repository.py
@@ -49,7 +49,7 @@ class RepositoryProvider(ProviderMixin):
         if request.method == 'GET':
             return Response(fields)
 
-        validator = ConfigValidator(fields, request.DATA)
+        validator = ConfigValidator(fields, request.data)
         if not validator.is_valid():
             return Response(
                 {

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -19,7 +19,7 @@ class SlackRequestTest(TestCase):
         super(SlackRequestTest, self).setUp()
 
         self.request = mock.Mock()
-        self.request.DATA = {
+        self.request.data = {
             'type': 'foo',
             'team_id': 'T001',
             'channel': {'id': '1'},
@@ -46,7 +46,7 @@ class SlackRequestTest(TestCase):
         }
 
     def test_disregards_None_logging_values(self):
-        self.request.DATA['api_app_id'] = None
+        self.request.data['api_app_id'] = None
 
         assert self.slack_request.logging_data == {
             'slack_team_id': 'T001',
@@ -68,13 +68,13 @@ class SlackRequestTest(TestCase):
             assert e.status == 400
 
     def test_validates_token(self):
-        self.request.DATA['token'] = 'notthetoken'
+        self.request.data['token'] = 'notthetoken'
 
         with self.assertRaises(SlackRequestError):
             self.slack_request.validate()
 
     def test_returns_401_on_invalid_token(self):
-        self.request.DATA['token'] = 'notthetoken'
+        self.request.data['token'] = 'notthetoken'
 
         with self.assertRaises(SlackRequestError) as e:
             self.slack_request.validate()
@@ -91,7 +91,7 @@ class SlackEventRequestTest(TestCase):
         super(SlackEventRequestTest, self).setUp()
 
         self.request = mock.Mock()
-        self.request.DATA = {
+        self.request.data = {
             'type': 'foo',
             'team_id': 'T001',
             'event_id': 'E1',
@@ -106,7 +106,7 @@ class SlackEventRequestTest(TestCase):
         return SlackEventRequest(self.request)
 
     def test_ignores_event_validation_on_challenge_request(self):
-        self.request.DATA = {
+        self.request.data = {
             'token': options.get('slack.verification-token'),
             'challenge': 'abc123',
             'type': 'url_verification',
@@ -117,7 +117,7 @@ class SlackEventRequestTest(TestCase):
         self.slack_request.validate()
 
     def test_is_challenge(self):
-        self.request.DATA = {
+        self.request.data = {
             'token': options.get('slack.verification-token'),
             'challenge': 'abc123',
             'type': 'url_verification',
@@ -126,13 +126,13 @@ class SlackEventRequestTest(TestCase):
         assert self.slack_request.is_challenge()
 
     def test_validate_missing_event(self):
-        self.request.DATA.pop('event')
+        self.request.data.pop('event')
 
         with self.assertRaises(SlackRequestError):
             self.slack_request.validate()
 
     def test_validate_missing_event_type(self):
-        self.request.DATA['event'] = {}
+        self.request.data['event'] = {}
 
         with self.assertRaises(SlackRequestError):
             self.slack_request.validate()
@@ -146,7 +146,7 @@ class SlackActionRequestTest(TestCase):
         super(SlackActionRequestTest, self).setUp()
 
         self.request = mock.Mock()
-        self.request.DATA = {
+        self.request.data = {
             'payload': json.dumps({
                 'type': 'foo',
                 'team': {'id': 'T001'},
@@ -168,13 +168,13 @@ class SlackActionRequestTest(TestCase):
         assert self.slack_request.callback_data == {'issue': 'I1'}
 
     def test_validates_existence_of_payload(self):
-        self.request.DATA.pop('payload')
+        self.request.data.pop('payload')
 
         with self.assertRaises(SlackRequestError):
             self.slack_request.validate()
 
     def test_validates_payload_json(self):
-        self.request.DATA['payload'] = 'notjson'
+        self.request.data['payload'] = 'notjson'
 
         with self.assertRaises(SlackRequestError):
             self.slack_request.validate()


### PR DESCRIPTION
This very interesting pr converts uses of request.DATA to request.data. Just a change required by
DRF 3.x:
https://www.django-rest-framework.org/community/3.0-announcement/#the-data-and-query_params-properties

I'll do the changes to `FILES` separately. Note that this isn't required to get to 3.0.5, but is required to get to 3.3.x.