### PR TITLE
ref: (Django 1.9) Convert request.FILES to request.data

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -86,8 +86,8 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         logger = logging.getLogger('sentry.files')
         logger.info('chunkupload.start')
 
-        files = request.FILES.getlist('file')
-        files += [GzipChunk(chunk) for chunk in request.FILES.getlist('file_gzip')]
+        files = request.data.getlist('file')
+        files += [GzipChunk(chunk) for chunk in request.data.getlist('file_gzip')]
         if len(files) == 0:
             # No files uploaded is ok
             logger.info('chunkupload.end', extra={'status': status.HTTP_200_OK})

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -35,9 +35,9 @@ ERR_FILE_EXISTS = 'A file matching this debug identifier already exists'
 
 
 def upload_from_request(request, project):
-    if 'file' not in request.FILES:
+    if 'file' not in request.data:
         return Response({'detail': 'Missing uploaded file'}, status=400)
-    fileobj = request.FILES['file']
+    fileobj = request.data['file']
     files = create_files_from_dif_zip(fileobj, project=project)
     return Response(serialize(files, request.user), status=201)
 

--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -119,10 +119,10 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        if 'file' not in request.FILES:
+        if 'file' not in request.data:
             return Response({'detail': 'Missing uploaded file'}, status=400)
 
-        fileobj = request.FILES['file']
+        fileobj = request.data['file']
 
         full_name = request.data.get('name', fileobj.name)
         if not full_name or full_name == 'file':

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -135,10 +135,10 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
         logger = logging.getLogger('sentry.files')
         logger.info('projectreleasefile.start')
 
-        if 'file' not in request.FILES:
+        if 'file' not in request.data:
             return Response({'detail': 'Missing uploaded file'}, status=400)
 
-        fileobj = request.FILES['file']
+        fileobj = request.data['file']
 
         full_name = request.data.get('name', fileobj.name)
         if not full_name or full_name == 'file':


### PR DESCRIPTION
This very interesting pr converts uses of request.FILES to request.data. Just a change required by
DRF 3.x:
https://www.django-rest-framework.org/community/3.0-announcement/#the-data-and-query_params-properties