### PR TITLE
feat(search) Add search options for linked_ticket

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -32,6 +32,7 @@ class IssueSearchVisitor(SearchVisitor):
         # on date_from and date_to explicitly
         'date': ['event.timestamp'],
         'times_seen': ['timesSeen'],
+        'linked_ticket': ['linkedTicket'],
         'sentry:dist': ['dist'],
     }
     numeric_keys = SearchVisitor.numeric_keys.union(['times_seen'])
@@ -98,12 +99,25 @@ def convert_release_value(value, projects, user, environments):
     return parse_release(value, projects, environments)
 
 
+def convert_linked_ticket_value(value, *args):
+    if value in ('true', '1'):
+        return True
+    if value in ('false', '0'):
+        return False
+    raise InvalidSearchQuery(
+        u"Invalid value '{}' for linked_ticket filter. Use one of 'true', 'false'".format(
+            value
+        )
+    )
+
+
 value_converters = {
     'assigned_to': convert_actor_value,
     'bookmarked_by': convert_user_value,
     'subscribed_by': convert_user_value,
     'first_release': convert_release_value,
     'release': convert_release_value,
+    'linked_ticket': convert_linked_ticket_value
 }
 
 

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -438,6 +438,13 @@ def parse_query(projects, query, user, environments):
                 results.update(get_date_params(value, 'date_from', 'date_to'))
             elif key == 'timesSeen':
                 results.update(get_numeric_field_value('times_seen', value))
+            elif key == 'linked_ticket':
+                if value == 'true':
+                    results['linked_ticket'] = True
+                elif value == 'false':
+                    results['linked_ticket'] = False
+                else:
+                    raise InvalidQuery(u"'linked_ticket:' had unknown value '{}'.".format(value))
             else:
                 results['tags'][key] = value
 

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -1126,6 +1126,8 @@ function getIconForTypeAndTag(type, tagName) {
     case 'lastSeen':
     case 'event.timestamp':
       return 'icon-av_timer';
+    case 'linked_ticket':
+      return 'icon-toggle';
     default:
       return 'icon-tag';
   }

--- a/src/sentry/static/sentry/app/stores/tagStore.jsx
+++ b/src/sentry/static/sentry/app/stores/tagStore.jsx
@@ -89,6 +89,12 @@ const TagStore = Reflux.createStore({
         values: [],
         predefined: true,
       },
+      linkedTicket: {
+        key: 'linkedTicket',
+        name: 'Linked Ticket',
+        values: ['true', 'false'],
+        predefined: true,
+      },
     };
 
     this.trigger(this.tags);

--- a/src/sentry/static/sentry/app/views/organizationStream/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/organizationStream/searchBar.jsx
@@ -40,6 +40,12 @@ const SEARCH_ITEMS = [
     value: 'bookmarks:',
     type: 'default',
   },
+  {
+    title: t('Has Linked Ticket'),
+    desc: 'linked_ticket:[true|false]',
+    value: 'linked_ticket:',
+    type: 'default',
+  },
 ];
 
 class SearchBar extends React.Component {

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
-from sentry.models import Activity, OrganizationMember, OrganizationMemberTeam
+from sentry.models import Activity, GroupLink, Integration, ExternalIssue, OrganizationMember, OrganizationMemberTeam
 from sentry.incidents.models import IncidentActivityType
 
 import pytest
@@ -242,3 +242,30 @@ class Fixtures(object):
     @pytest.fixture(autouse=True)
     def _init_insta_snapshot(self, insta_snapshot):
         self.insta_snapshot = insta_snapshot
+
+    def create_integration(self, org, user, **kwargs):
+        kwargs.setdefault('provider', 'example')
+        kwargs.setdefault('name', 'Example')
+        if not user:
+            user = self.user
+        if not org:
+            org = self.organization
+        integration = Integration.objects.create(**kwargs)
+        integration.add_organization(org, user)
+        return integration
+
+    def create_external_issue(self, org, integration, **kwargs):
+        kwargs.setdefault('key', 'APP-123')
+        return ExternalIssue.objects.create(
+            organization_id=org.id,
+            integration_id=integration.id,
+            **kwargs
+        )
+
+    def create_group_link(self, group, external_issue, **kwargs):
+        return GroupLink.objects.create(
+            group_id=group.id,
+            project_id=group.project.id,
+            linked_id=external_issue.id,
+            **kwargs
+        )

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -12,7 +12,7 @@ from mock import patch, Mock
 from sentry.models import (
     Activity, ApiToken, EventMapping, Group, GroupAssignee, GroupBookmark, GroupHash,
     GroupLink, GroupResolution, GroupSeen, GroupShare, GroupSnooze, GroupStatus, GroupSubscription,
-    GroupTombstone, ExternalIssue, Integration, Release, OrganizationIntegration, UserOption
+    GroupTombstone, Release, OrganizationIntegration, UserOption
 )
 from sentry.models.event import Event
 from sentry.testutils import APITestCase, SnubaTestCase
@@ -365,6 +365,41 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 0
 
+    def test_lookup_by_linked_ticket_present(self):
+        self.login_as(self.user)
+        project = self.project
+        integration = self.create_integration(self.organization, self.user)
+        group = self.create_group(checksum='a' * 32, project=project)
+        group2 = self.create_group(checksum='b' * 32, project=project)
+
+        external_issue = self.create_external_issue(group, integration)
+        self.create_group_link(
+            group,
+            external_issue,
+            linked_type=GroupLink.LinkedType.issue,
+            relationship=GroupLink.Relationship.references)
+
+        url = '%s?query=%s' % (self.path, quote('linked_ticket:true'))
+        response = self.client.get(url, format='json')
+        issues = json.loads(response.content)
+        assert response.status_code == 200
+        assert len(issues) == 1
+        assert int(issues[0]['id']) == group.id
+
+        url = '%s?query=%s' % (self.path, quote('linked_ticket:false'))
+        response = self.client.get(url, format='json')
+        issues = json.loads(response.content)
+        assert response.status_code == 200
+        assert len(issues) == 1
+        assert int(issues[0]['id']) == group2.id
+
+    def test_lookup_by_linked_ticket_invalid(self):
+        self.login_as(self.user)
+
+        url = '%s?query=%s' % (self.path, quote('linked_ticket:poop'))
+        response = self.client.get(url, format='json')
+        assert response.status_code == 400
+
     def test_token_auth(self):
         token = ApiToken.objects.create(user=self.user, scopes=256)
         response = self.client.get(
@@ -494,12 +529,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         org = self.organization
-
-        integration = Integration.objects.create(
-            provider='example',
-            name='Example',
-        )
-        integration.add_organization(org, self.user)
+        integration = self.create_integration(org, self.user)
         group = self.create_group(status=GroupStatus.UNRESOLVED, organization=org)
 
         OrganizationIntegration.objects.filter(
@@ -514,19 +544,12 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
                 'sync_assignee_inbound': True,
             }
         )
-        external_issue = ExternalIssue.objects.get_or_create(
-            organization_id=org.id,
-            integration_id=integration.id,
-            key='APP-%s' % group.id,
-        )[0]
-
-        GroupLink.objects.get_or_create(
-            group_id=group.id,
-            project_id=group.project_id,
+        external_issue = self.create_external_issue(org, integration)
+        self.create_group_link(
+            group,
+            external_issue,
             linked_type=GroupLink.LinkedType.issue,
-            linked_id=external_issue.id,
-            relationship=GroupLink.Relationship.references,
-        )[0]
+            relationship=GroupLink.Relationship.references)
 
         response = self.client.get(
             u'{}?sort_by=date&query=is:unresolved'.format(self.path),
@@ -570,11 +593,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         release = self.create_release(project=self.project, version='abc')
         group = self.create_group(checksum='a' * 32, status=GroupStatus.RESOLVED)
         org = self.organization
-        integration = Integration.objects.create(
-            provider='example',
-            name='Example',
-        )
-        integration.add_organization(org, self.user)
+        integration = self.create_integration(org, self.user)
+
         OrganizationIntegration.objects.filter(
             integration_id=integration.id,
             organization_id=group.organization.id,
@@ -591,19 +611,12 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             group=group,
             release=release,
         )
-        external_issue = ExternalIssue.objects.get_or_create(
-            organization_id=org.id,
-            integration_id=integration.id,
-            key='APP-%s' % group.id,
-        )[0]
-
-        GroupLink.objects.get_or_create(
-            group_id=group.id,
-            project_id=group.project_id,
+        external_issue = self.create_external_issue(org, integration)
+        self.create_group_link(
+            group,
+            external_issue,
             linked_type=GroupLink.LinkedType.issue,
-            linked_id=external_issue.id,
-            relationship=GroupLink.Relationship.references,
-        )[0]
+            relationship=GroupLink.Relationship.references)
 
         self.login_as(user=self.user)
 


### PR DESCRIPTION
Add linked_ticket as a search filter for both the django based search
and as a pre-filter for snuba based search.

A request we've heard from customers is the need to find which issues in sentry have not been triaged into their external bug tracker. This new filter makes it possible to find groups that have or don't have integration based issues attached to them. Plugin based issue trackers are not covered by these changes as the `GroupMeta` data is stored in a way that makes searching it slow.

Refs APP-894