### PR TITLE
fix(events-v2): Fix pagination

### DIFF
--- a/src/sentry/static/sentry/app/components/pagination.jsx
+++ b/src/sentry/static/sentry/app/components/pagination.jsx
@@ -29,10 +29,9 @@ export default class Pagination extends React.Component {
 
   static defaultProps = {
     onCursor: (cursor, path, query) => {
-      query.cursor = cursor;
       browserHistory.push({
         pathname: path,
-        query,
+        query: {...query, cursor},
       });
     },
     className: streamCss,


### PR DESCRIPTION
Updates the pagination component to not mutate previous query so that
cursor changes get correctly picked up by `componentDidUpdate`
functions.