### PR TITLE
fix(events-v2): Drop cursor value when switching views

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
@@ -35,7 +35,7 @@ export default class OrganizationEventsV2 extends React.Component {
             key={view.id}
             to={{
               pathname: `/organizations/${organization.slug}/events/`,
-              query: {...this.props.location.query, view: view.id},
+              query: {...this.props.location.query, view: view.id, cursor: undefined},
             }}
             isActive={() => view.id === currentView.id}
           >


### PR DESCRIPTION
Ensures that changing tabs always navigates to the first page