### PR TITLE
ref: Move cache things to memcache that don't need redis

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -13,6 +13,7 @@ import six
 
 from datetime import datetime, timedelta
 from django.conf import settings
+from django.core.cache import cache
 from django.db import connection, IntegrityError, router, transaction
 from django.db.models import Func
 from django.utils import timezone
@@ -49,7 +50,6 @@ from sentry.plugins import plugins
 from sentry.signals import event_discarded, event_saved, first_event_received
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.utils import metrics
-from sentry.utils.cache import default_cache
 from sentry.utils.canonical import CanonicalKeyDict
 from sentry.utils.contexts_normalization import normalize_user_agent
 from sentry.utils.data_filters import (
@@ -943,7 +943,7 @@ class EventManager(object):
             project.id,
             euser.hash,
         )
-        euser_id = default_cache.get(cache_key)
+        euser_id = cache.get(cache_key)
         if euser_id is None:
             try:
                 with transaction.atomic(using=router.db_for_write(EventUser)):
@@ -963,7 +963,7 @@ class EventManager(object):
                             name=user_data['name'],
                         )
                     e_userid = euser.id
-                default_cache.set(cache_key, e_userid, 3600)
+                cache.set(cache_key, e_userid, 3600)
         return euser
 
     def _find_hashes(self, project, hash_list):

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -10,10 +10,10 @@ from __future__ import absolute_import
 import six
 
 from django.conf import settings
+from django.core.cache import cache
 
 from sentry import options
 from sentry.utils.services import Service
-from sentry.utils.cache import default_cache
 
 
 class RateLimit(object):
@@ -92,10 +92,10 @@ class Quota(Service):
         # This happens on /store.
         cache_key = u'project:{}:features:rate-limits'.format(key.project.id)
 
-        has_rate_limits = default_cache.get(cache_key)
+        has_rate_limits = cache.get(cache_key)
         if has_rate_limits is None:
             has_rate_limits = features.has('projects:rate-limits', key.project)
-            default_cache.set(cache_key, has_rate_limits, 600)
+            cache.set(cache_key, has_rate_limits, 600)
 
         return key.rate_limit if has_rate_limits else (0, 0)
 

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import
 import logging
 from distutils.version import LooseVersion
 from django.conf import settings
+from django.core.cache import cache
 
 from sentry.net.http import Session
-from sentry.cache import default_cache
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)
@@ -256,7 +256,7 @@ SDK_SUPPORTED_MODULES = [
 
 
 def get_sdk_index():
-    value = default_cache.get(SDK_INDEX_CACHE_KEY)
+    value = cache.get(SDK_INDEX_CACHE_KEY)
     if value is not None:
         return value
 
@@ -275,7 +275,7 @@ def get_sdk_index():
         logger.exception("Failed to fetch version index from release registry")
         json = {}
 
-    default_cache.set(SDK_INDEX_CACHE_KEY, json, 3600)
+    cache.set(SDK_INDEX_CACHE_KEY, json, 3600)
     return json
 
 


### PR DESCRIPTION
This removes more reliance on a non-HA redis cluster for things that are
truly caches.

See also: #13860