### PR TITLE
ref(app-platform): Add error.created UI

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -26,21 +26,6 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
 
             return Response(status=404)
 
-        data = {
-            'user': request.user,
-            'sentry_app': sentry_app,
-            'name': request.json_body.get('name'),
-            'status': request.json_body.get('status'),
-            'author': request.json_body.get('author'),
-            'webhookUrl': request.json_body.get('webhookUrl'),
-            'redirectUrl': request.json_body.get('redirectUrl'),
-            'isAlertable': request.json_body.get('isAlertable'),
-            'scopes': request.json_body.get('scopes'),
-            'events': request.json_body.get('events'),
-            'schema': request.json_body.get('schema'),
-            'overview': request.json_body.get('overview'),
-        }
-
         if self._has_hook_events(request) and not features.has('organizations:integrations-event-hooks',
                                                                sentry_app.owner,
                                                                actor=request.user):

--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -41,14 +41,13 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
             'overview': request.json_body.get('overview'),
         }
 
-        if data.get('events'):
-            if ('error' in data['events']) and not features.has('organizations:integrations-event-hooks',
-                                                                sentry_app.owner,
-                                                                actor=request.user):
+        if self._has_hook_events(request) and not features.has('organizations:integrations-event-hooks',
+                                                               sentry_app.owner,
+                                                               actor=request.user):
 
-                return Response({"non_field_errors": [
-                    "Your organization does not have access to the 'error' resource subscription.",
-                ]}, status=403)
+            return Response({"non_field_errors": [
+                "Your organization does not have access to the 'error' resource subscription.",
+            ]}, status=403)
 
         serializer = SentryAppSerializer(
             sentry_app,
@@ -97,3 +96,9 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
             },
             status=403
         )
+
+    def _has_hook_events(self, request):
+        if not request.json_body.get('events'):
+            return False
+
+        return 'error' in request.json_body['events']

--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -26,6 +26,30 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
 
             return Response(status=404)
 
+        data = {
+            'user': request.user,
+            'sentry_app': sentry_app,
+            'name': request.json_body.get('name'),
+            'status': request.json_body.get('status'),
+            'author': request.json_body.get('author'),
+            'webhookUrl': request.json_body.get('webhookUrl'),
+            'redirectUrl': request.json_body.get('redirectUrl'),
+            'isAlertable': request.json_body.get('isAlertable'),
+            'scopes': request.json_body.get('scopes'),
+            'events': request.json_body.get('events'),
+            'schema': request.json_body.get('schema'),
+            'overview': request.json_body.get('overview'),
+        }
+
+        if data.get('events'):
+            if ('error' in data['events']) and not features.has('organizations:integrations-event-hooks',
+                                                                sentry_app.owner,
+                                                                actor=request.user):
+
+                return Response({"non_field_errors": [
+                    "Your organization does not have access to the 'error' resource subscription.",
+                ]}, status=403)
+
         serializer = SentryAppSerializer(
             sentry_app,
             data=request.data,

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -68,14 +68,13 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             'overview': request.json_body.get('overview'),
         }
 
-        if data.get('events'):
-            if ('error' in data['events']) and not features.has('organizations:integrations-event-hooks',
-                                                                organization,
-                                                                actor=request.user):
+        if self._has_hook_events(request) and not features.has('organizations:integrations-event-hooks',
+                                                               organization,
+                                                               actor=request.user):
 
-                return Response({"non_field_errors": [
-                    "Your organization does not have access to the 'error' resource subscription.",
-                ]}, status=403)
+            return Response({"non_field_errors": [
+                "Your organization does not have access to the 'error' resource subscription.",
+            ]}, status=403)
 
         serializer = SentryAppSerializer(data=data)
 
@@ -98,3 +97,9 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             ),
             None,
         )
+
+    def _has_hook_events(self, request):
+        if not request.json_body.get('events'):
+            return False
+
+        return 'error' in request.json_body['events']

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.auth.superuser import is_active_superuser
 from sentry.api.bases import SentryAppsBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
@@ -66,6 +67,15 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             'schema': request.json_body.get('schema', {}),
             'overview': request.json_body.get('overview'),
         }
+
+        if data.get('events'):
+            if ('error' in data['events']) and not features.has('organizations:integrations-event-hooks',
+                                                                organization,
+                                                                actor=request.user):
+
+                return Response({"non_field_errors": [
+                    "Your organization does not have access to the 'error' resource subscription.",
+                ]}, status=403)
 
         serializer = SentryAppSerializer(data=data)
 

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/constants.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/constants.jsx
@@ -1,9 +1,11 @@
-export const EVENT_CHOICES = ['issue'];
+export const EVENT_CHOICES = ['issue', 'error'];
 
 export const DESCRIPTIONS = {
   issue: 'created, resolved, assigned',
+  error: 'created',
 };
 
 export const PERMISSIONS_MAP = {
   issue: 'Event',
+  error: 'Event',
 };

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/subscriptionBox.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/subscriptionBox.jsx
@@ -36,9 +36,10 @@ class SubscriptionBox extends React.Component {
   render() {
     const {resource, organization} = this.props;
     const features = new Set(organization.features);
+    const {checked} = this.state;
+
     let disabled = this.props.disabled;
     let message = `Must have at least 'Read' permissions enabled for ${resource}`;
-    const {checked} = this.state;
     if (resource === 'error' && !features.has('integrations-event-hooks')) {
       disabled = true;
       message =

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/subscriptionBox.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/subscriptionBox.jsx
@@ -7,13 +7,16 @@ import styled from 'react-emotion';
 import Checkbox from 'app/components/checkbox';
 import Tooltip from 'app/components/tooltip';
 import {Flex} from 'grid-emotion';
+import withOrganization from 'app/utils/withOrganization';
+import SentryTypes from 'app/sentryTypes';
 
-export default class SubscriptionBox extends React.Component {
+class SubscriptionBox extends React.Component {
   static propTypes = {
     resource: PropTypes.string.isRequired,
     disabled: PropTypes.bool.isRequired,
     checked: PropTypes.bool.isRequired,
     onChange: PropTypes.func.isRequired,
+    organization: SentryTypes.Organization,
   };
 
   constructor(...args) {
@@ -31,9 +34,16 @@ export default class SubscriptionBox extends React.Component {
   };
 
   render() {
-    const {resource, disabled} = this.props;
+    const {resource, organization} = this.props;
+    const features = new Set(organization.features);
+    let disabled = this.props.disabled;
+    let message = `Must have at least 'Read' permissions enabled for ${resource}`;
     const {checked} = this.state;
-    const message = `Must have at least 'Read' permissions enabled for ${resource}`;
+    if (resource === 'error' && !features.has('integrations-event-hooks')) {
+      disabled = true;
+      message =
+        'Your organization does not have access to the error subscription resource.';
+    }
     return (
       <React.Fragment>
         <SubscriptionGridItemWrapper key={resource}>
@@ -60,6 +70,9 @@ export default class SubscriptionBox extends React.Component {
     );
   }
 }
+
+export {SubscriptionBox};
+export default withOrganization(SubscriptionBox);
 
 const SubscriptionInfo = styled(Flex)`
   flex-direction: column;

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/subscriptionBox.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/subscriptionBox.spec.jsx.snap
@@ -5,6 +5,34 @@ exports[`SubscriptionBox renders resource checkbox 1`] = `
   checked={false}
   disabled={false}
   onChange={[MockFunction]}
+  organization={
+    Object {
+      "access": Array [
+        "org:read",
+        "org:write",
+        "org:admin",
+        "org:integrations",
+        "project:read",
+        "project:write",
+        "project:admin",
+        "team:read",
+        "team:write",
+        "team:admin",
+      ],
+      "features": Array [],
+      "id": "3",
+      "name": "Organization Name",
+      "onboardingTasks": Array [],
+      "projects": Array [],
+      "scrapeJavaScript": true,
+      "slug": "org-slug",
+      "status": Object {
+        "id": "active",
+        "name": "active",
+      },
+      "teams": Array [],
+    }
+  }
   resource="issue"
 >
   <SubscriptionGridItemWrapper

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.jsx
@@ -33,7 +33,12 @@ describe('Resource Subscriptions', () => {
     });
 
     it('renders disabled checkbox with no issue permission', () => {
-      expect(wrapper.find('SubscriptionBox').prop('disabled')).toBe(true);
+      expect(
+        wrapper
+          .find('SubscriptionBox')
+          .first()
+          .prop('disabled')
+      ).toBe(true);
     });
 
     it('updates events state when new permissions props is passed', () => {
@@ -46,7 +51,12 @@ describe('Resource Subscriptions', () => {
       };
 
       wrapper.setProps({permissions});
-      expect(wrapper.find('SubscriptionBox').prop('disabled')).toBe(false);
+      expect(
+        wrapper
+          .find('SubscriptionBox')
+          .first()
+          .prop('disabled')
+      ).toBe(false);
     });
   });
 
@@ -75,7 +85,12 @@ describe('Resource Subscriptions', () => {
     });
 
     it('renders nondisabled checkbox with correct permissions', () => {
-      expect(wrapper.find('SubscriptionBox').prop('disabled')).toBe(false);
+      expect(
+        wrapper
+          .find('SubscriptionBox')
+          .first()
+          .prop('disabled')
+      ).toBe(false);
     });
 
     it('revoked permissions also revokes access to corresponding subscriptions', () => {
@@ -89,7 +104,12 @@ describe('Resource Subscriptions', () => {
 
       wrapper.setProps({permissions});
       expect(wrapper.state('events')).toEqual([]);
-      expect(wrapper.find('SubscriptionBox').prop('disabled')).toBe(true);
+      expect(
+        wrapper
+          .find('SubscriptionBox')
+          .first()
+          .prop('disabled')
+      ).toBe(true);
     });
   });
 });

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/subscriptionBox.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/subscriptionBox.spec.jsx
@@ -53,10 +53,29 @@ describe('SubscriptionBox', () => {
     });
 
     it('checkbox disabled without integrations-event-hooks flag', () => {
+      expect(wrapper.find('Checkbox').prop('disabled')).toBe(true);
+    });
+
+    it('tooltip enabled without integrations-event-hooks flag', () => {
       expect(wrapper.find('Tooltip').prop('disabled')).toBe(false);
     });
 
     it('checkbox visible with integrations-event-hooks flag', () => {
+      org = TestStubs.Organization({features: ['integrations-event-hooks']});
+      wrapper = mount(
+        <SubscriptionBox
+          resource="error"
+          checked={false}
+          disabled={false}
+          onChange={onChange}
+          organization={org}
+        />,
+        TestStubs.routerContext()
+      );
+      expect(wrapper.find('Checkbox').prop('disabled')).toBe(false);
+    });
+
+    it('Tooltip disabled with integrations-event-hooks flag', () => {
       org = TestStubs.Organization({features: ['integrations-event-hooks']});
       wrapper = mount(
         <SubscriptionBox

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/subscriptionBox.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/subscriptionBox.spec.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
 import {mount} from 'enzyme';
-import SubscriptionBox from 'app/views/settings/organizationDeveloperSettings/subscriptionBox';
+import {SubscriptionBox} from 'app/views/settings/organizationDeveloperSettings/subscriptionBox';
 
 describe('SubscriptionBox', () => {
   let wrapper;
   let onChange;
+  let org = TestStubs.Organization();
 
   beforeEach(() => {
     onChange = jest.fn();
@@ -15,6 +16,7 @@ describe('SubscriptionBox', () => {
         checked={false}
         disabled={false}
         onChange={onChange}
+        organization={org}
       />,
       TestStubs.routerContext()
     );
@@ -33,5 +35,40 @@ describe('SubscriptionBox', () => {
   it('renders tooltip when checkbox is disabled', () => {
     wrapper.setProps({disabled: true});
     expect(wrapper.find('Tooltip').prop('disabled')).toBe(false);
+  });
+
+  describe('error.created resource subscription', () => {
+    beforeEach(() => {
+      onChange = jest.fn();
+      wrapper = mount(
+        <SubscriptionBox
+          resource="error"
+          checked={false}
+          disabled={false}
+          onChange={onChange}
+          organization={org}
+        />,
+        TestStubs.routerContext()
+      );
+    });
+
+    it('checkbox disabled without integrations-event-hooks flag', () => {
+      expect(wrapper.find('Tooltip').prop('disabled')).toBe(false);
+    });
+
+    it('checkbox visible with integrations-event-hooks flag', () => {
+      org = TestStubs.Organization({features: ['integrations-event-hooks']});
+      wrapper = mount(
+        <SubscriptionBox
+          resource="error"
+          checked={false}
+          disabled={false}
+          onChange={onChange}
+          organization={org}
+        />,
+        TestStubs.routerContext()
+      );
+      expect(wrapper.find('Tooltip').prop('disabled')).toBe(true);
+    });
   });
 });

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -294,6 +294,41 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.status_code == 200
         assert SentryApp.objects.get(id=app.id).status == SentryAppStatus.UNPUBLISHED
 
+    @with_feature('organizations:sentry-apps')
+    def test_cannot_add_error_created_hook_without_flag(self):
+        self.login_as(user=self.user)
+        app = self.create_sentry_app(
+            name='SampleApp',
+            organization=self.org,
+        )
+        url = reverse('sentry-api-0-sentry-app-details', args=[app.slug])
+        response = self.client.put(
+            url,
+            data={
+                'events': ('error',),
+            },
+            format='json',
+        )
+        assert response.status_code == 403
+
+    @with_feature(['organizations:sentry-apps', 'organizations:integrations-event-hooks'])
+    def test_can_add_error_created_hook_with_flag(self):
+        self.login_as(user=self.user)
+        app = self.create_sentry_app(
+            name='SampleApp',
+            organization=self.org,
+        )
+        url = reverse('sentry-api-0-sentry-app-details', args=[app.slug])
+        response = self.client.put(
+            url,
+            data={
+                'events': ('error',),
+                'scopes': ('event:read',)
+            },
+            format='json',
+        )
+        assert response.status_code == 200
+
 
 class DeleteSentryAppDetailsTest(SentryAppDetailsTest):
     @with_feature('organizations:sentry-apps')

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -375,7 +375,7 @@ class PostSentryAppsTest(SentryAppsTest):
         response = self._post(**kwargs)
 
         assert response.status_code == 403, response.content
-        assert response.content == '{"non_field_errors": ["Your organization does not have access to the \'error\' resource subscription."]}'
+        assert response.content == '{"non_field_errors":["Your organization does not have access to the \'error\' resource subscription."]}'
 
     @with_feature('organizations:sentry-apps')
     def test_allows_empty_schema(self):

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -351,6 +351,32 @@ class PostSentryAppsTest(SentryAppsTest):
         assert response.data == \
             {'schema': ["['#general'] is too short"]}
 
+    @with_feature(['organizations:sentry-apps', 'organizations:integrations-event-hooks'])
+    def test_can_create_with_error_created_hook_with_flag(self):
+        self.login_as(user=self.user)
+
+        kwargs = {'events': ('error',)}
+        response = self._post(**kwargs)
+        expected = {
+            'name': 'MyApp',
+            'scopes': ['project:read', 'event:read'],
+            'events': ['error'],
+            'webhookUrl': 'https://example.com',
+        }
+
+        assert response.status_code == 201, response.content
+        assert six.viewitems(expected) <= six.viewitems(json.loads(response.content))
+
+    @with_feature('organizations:sentry-apps')
+    def test_cannot_create_with_error_created_hook_without_flag(self):
+        self.login_as(user=self.user)
+
+        kwargs = {'events': ('error',)}
+        response = self._post(**kwargs)
+
+        assert response.status_code == 403, response.content
+        assert response.content == '{"non_field_errors": ["Your organization does not have access to the \'error\' resource subscription."]}'
+
     @with_feature('organizations:sentry-apps')
     def test_allows_empty_schema(self):
         self.login_as(self.user)


### PR DESCRIPTION
* Adds `error.created` to the UI
* Adds feature flag checks in sentry app endpoints
> ![Screen Shot 2019-07-01 at 2 20 27 PM](https://user-images.githubusercontent.com/15368179/60467402-671c6c00-9c0b-11e9-9193-aaaa1780300e.png)

@mnoble I know we talked about `error.created` being visible for unpublished apps if we have a note explaining that installs will not get that feature unless on the correct plan, but for now am just disabling it. 
