### PR TITLE
Error when app overview is undefined

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.jsx
@@ -23,7 +23,7 @@ export default class SentryAppDetailsModal extends React.Component {
   render() {
     const {sentryApp, closeModal, onInstall, isInstalled, organization} = this.props;
 
-    const overviewHtml = sentryApp.overview || '';
+    const overview = sentryApp.overview || '';
 
     return (
       <React.Fragment>
@@ -35,7 +35,7 @@ export default class SentryAppDetailsModal extends React.Component {
           </Flex>
         </Flex>
 
-        <Description dangerouslySetInnerHTML={{__html: marked(overviewHtml)}} />
+        <Description dangerouslySetInnerHTML={{__html: marked(overview)}} />
 
         <Metadata>
           <Author flex={1}>{t('By %s', sentryApp.author)}</Author>

--- a/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.jsx
@@ -23,6 +23,8 @@ export default class SentryAppDetailsModal extends React.Component {
   render() {
     const {sentryApp, closeModal, onInstall, isInstalled, organization} = this.props;
 
+    const overviewHtml = sentryApp.overview || '';
+
     return (
       <React.Fragment>
         <Flex align="center" mb={2}>
@@ -33,7 +35,7 @@ export default class SentryAppDetailsModal extends React.Component {
           </Flex>
         </Flex>
 
-        <Description dangerouslySetInnerHTML={{__html: marked(sentryApp.overview)}} />
+        <Description dangerouslySetInnerHTML={{__html: marked(overviewHtml)}} />
 
         <Metadata>
           <Author flex={1}>{t('By %s', sentryApp.author)}</Author>


### PR DESCRIPTION
This fixes a bug when the app overview is `undefined`:

<img width="705" alt="Screen Shot 2019-07-01 at 3 47 48 PM" src="https://user-images.githubusercontent.com/8533851/60471025-98029e00-9c17-11e9-8b36-f8d8ce671bc9.png">
