### PR TITLE
feat(ui): Add project id to URL when visiting Issue Details directly

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -25,6 +25,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     onChange: PropTypes.func,
     onUpdate: PropTypes.func,
     multi: PropTypes.bool,
+    shouldForceProject: PropTypes.bool,
     forceProject: SentryTypes.Project,
   };
 
@@ -135,6 +136,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
       nonMemberProjects,
       multi,
       organization,
+      shouldForceProject,
       forceProject,
     } = this.props;
     const selectedProjectIds = new Set(value);
@@ -145,14 +147,23 @@ export default class MultipleProjectSelector extends React.PureComponent {
       selectedProjectIds.has(parseInt(project.id, 10))
     );
 
-    return forceProject ? (
+    // `forceProject` can be undefined if it is loading the project
+    // We are intentionally using an empty string as its "loading" state
+
+    return shouldForceProject ? (
       <StyledHeaderItem
         icon={<StyledInlineSvg src="icon-project" />}
         locked={true}
-        lockedMessage={t(`This issue is unique to the ${forceProject.slug} project`)}
-        settingsLink={`/settings/${organization.slug}/projects/${forceProject.slug}/`}
+        lockedMessage={
+          forceProject
+            ? t(`This issue is unique to the ${forceProject.slug} project`)
+            : t('This issue is unique to a project')
+        }
+        settingsLink={
+          forceProject && `/settings/${organization.slug}/projects/${forceProject.slug}/`
+        }
       >
-        {forceProject.slug}
+        {forceProject ? forceProject.slug : ''}
       </StyledHeaderItem>
     ) : (
       <StyledProjectSelector

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -254,6 +254,7 @@ const GroupDetails = createReactClass({
             organization={organization}
             forceProject={project}
             showDateSelector={false}
+            shouldForceProject
           />
         )}
         {isLoading ? (

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -482,6 +482,7 @@ describe('GlobalSelectionHeader', function() {
     const wrapper = mount(
       <GlobalSelectionHeader
         organization={initialData.organization}
+        shouldForceProject
         forceProject={initialData.organization.projects[0]}
       />,
       initialData.routerContext


### PR DESCRIPTION
There is still a problem when visiting an issue details page with a direct URL and when a user does not have access to multiple projects. When this happens the global selection header tries to select a seemingly random project.

This PR makes a few changes -- if there is no existing `project` URL param and you visit an issue details page, it will add the issues project id to the URL. This way when you go back to the issues stream it will have the proper project in context (instead of selecting a random project).

This also fixes the project selector on issue details: there is an async loading state that we are not handling well. The project selector flashes from "All Projects" (and unlocked) to a locked state with project slug. This will make the project selector aware of its "loading" state and show an empty string until we have the project slug.

Header change: https://cl.ly/44b3bfd218fb