### PR TITLE
fix(jira) Add validation around consumer key

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -103,9 +103,8 @@ class InstallationForm(forms.Form):
     consumer_key = forms.CharField(
         label=_('Jira Consumer Key'),
         widget=forms.TextInput(
-            attrs={'placeholder': _(
-                'sentry-consumer-key')}
-        )
+            attrs={'placeholder': _('sentry-consumer-key')}
+        ),
     )
     private_key = forms.CharField(
         label=_('Jira Consumer Private Key'),
@@ -127,6 +126,12 @@ class InstallationForm(forms.Form):
         except Exception:
             raise forms.ValidationError(
                 'Private key must be a valid SSH private key encoded in a PEM format.')
+        return data
+
+    def clean_consumer_key(self):
+        data = self.cleaned_data['consumer_key']
+        if len(data) > 200:
+            raise forms.ValidationError('Consumer key is limited to 200 characters.')
         return data
 
 

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -67,6 +67,22 @@ class JiraServerIntegrationTest(IntegrationTestCase):
             resp, 'Private key must be a valid SSH private key encoded in a PEM format.')
 
     @responses.activate
+    def test_validate_consumer_key_length(self):
+        # Start pipeline and go to setup page.
+        self.client.get(self.setup_path)
+
+        # Submit credentials
+        data = {
+            'url': 'jira.example.com/',
+            'verify_ssl': False,
+            'consumer_key': 'x' * 201,
+            'private_key': EXAMPLE_PRIVATE_KEY
+        }
+        resp = self.client.post(self.setup_path, data=data)
+        assert resp.status_code == 200
+        self.assertContains(resp, 'Consumer key is limited to 200')
+
+    @responses.activate
     def test_authentication_request_token_timeout(self):
         timeout = ReadTimeout('Read timed out. (read timeout=30)')
         responses.add(


### PR DESCRIPTION
Some customers are putting long hash-like data into the consumer-key and hitting errors. I've opted to use validation instead of setting the `max_length` on the field as `maxlength` will truncate data to fit which will result in the integration connection failing later during setup.

Fixes SENTRY-B7B