### PR TITLE
chore: Remove un-used route for saved-searches/

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1320,10 +1320,6 @@ function routes() {
             to="/settings/:orgId/projects/:projectId/data-forwarding/"
           />
           <Redirect
-            from="saved-searches/"
-            to="/settings/:orgId/projects/:projectId/saved-searches/"
-          />
-          <Redirect
             from="debug-symbols/"
             to="/settings/:orgId/projects/:projectId/debug-symbols/"
           />


### PR DESCRIPTION
Removing this redirect since there's no route handler for `/settings/:orgId/projects/:projectId/saved-searches/` 