### PR TITLE
fix: Always show long release name in list and detail page

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/resolve.jsx
+++ b/src/sentry/static/sentry/app/components/actions/resolve.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import {getShortVersion} from 'app/utils';
 import {t} from 'app/locale';
 import CustomResolutionModal from 'app/components/customResolutionModal';
 import MenuItem from 'app/components/menuItem';
@@ -182,10 +181,7 @@ export default class ResolveActions extends React.Component {
                     }}
                   >
                     {latestRelease
-                      ? t(
-                          'The current release (%s)',
-                          getShortVersion(latestRelease.version)
-                        )
+                      ? t('The current release (%s)', latestRelease.version)
                       : t('The current release')}
                   </ActionLink>
                 </Tooltip>

--- a/src/sentry/static/sentry/app/components/commitLink.jsx
+++ b/src/sentry/static/sentry/app/components/commitLink.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import {t} from 'app/locale';
-import {getShortVersion} from 'app/utils';
+import {getShortCommitHash} from 'app/utils';
 import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
 import InlineSvg from 'app/components/inlineSvg';
@@ -37,7 +37,7 @@ function CommitLink({inline, commitId, repository}) {
     return <span>{t('Unknown Commit')}</span>;
   }
 
-  const shortId = getShortVersion(commitId);
+  const shortId = getShortCommitHash(commitId);
 
   const providerData = SUPPORTED_PROVIDERS.find(provider => {
     if (!repository.provider) {

--- a/src/sentry/static/sentry/app/components/version.jsx
+++ b/src/sentry/static/sentry/app/components/version.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {getShortVersion} from 'app/utils';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
 import Link from 'app/components/links/link';
 import withOrganization from 'app/utils/withOrganization';
@@ -11,7 +10,6 @@ class Version extends React.Component {
     anchor: PropTypes.bool,
     version: PropTypes.string.isRequired,
     orgId: PropTypes.string,
-    showShortVersion: PropTypes.bool,
 
     /**
      * Should link to Release preserve user's global selection values
@@ -21,20 +19,11 @@ class Version extends React.Component {
 
   static defaultProps = {
     anchor: true,
-    showShortVersion: false,
   };
 
   render() {
-    const {
-      orgId,
-      showShortVersion,
-      version,
-      anchor,
-      className,
-      preserveGlobalSelection,
-    } = this.props;
+    const {orgId, version, anchor, className, preserveGlobalSelection} = this.props;
 
-    const versionTitle = showShortVersion ? getShortVersion(version) : version;
     const LinkComponent = preserveGlobalSelection ? GlobalSelectionLink : Link;
 
     if (anchor && orgId) {
@@ -43,14 +32,14 @@ class Version extends React.Component {
           to={`/organizations/${orgId}/releases/${encodeURIComponent(version)}/`}
           className={className}
         >
-          <span title={version}>{versionTitle}</span>
+          <span title={version}>{version}</span>
         </LinkComponent>
       );
     }
 
     return (
       <span title={version} className={className}>
-        {versionTitle}
+        {version}
       </span>
     );
   }

--- a/src/sentry/static/sentry/app/components/version.jsx
+++ b/src/sentry/static/sentry/app/components/version.jsx
@@ -21,7 +21,7 @@ class Version extends React.Component {
 
   static defaultProps = {
     anchor: true,
-    showShortVersion: true,
+    showShortVersion: false,
   };
 
   render() {
@@ -48,7 +48,11 @@ class Version extends React.Component {
       );
     }
 
-    return <span title={version}>{versionTitle}</span>;
+    return (
+      <span title={version} className={className}>
+        {versionTitle}
+      </span>
+    );
   }
 }
 

--- a/src/sentry/static/sentry/app/components/versionHoverCard.jsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-import {getShortVersion} from 'app/utils';
 import {t, tct} from 'app/locale';
 import AvatarList from 'app/components/avatar/avatarList';
 import Button from 'app/components/button';
@@ -106,7 +105,6 @@ class VersionHoverCard extends React.Component {
     const {release, deploys} = this.state;
     const {version} = this.props;
     const lastCommit = release.lastCommit;
-    const shortVersion = getShortVersion(version);
 
     const recentDeploysByEnviroment = deploys.reduce(function(dbe, deploy) {
       const {dateFinished, environment} = deploy;
@@ -121,11 +119,7 @@ class VersionHoverCard extends React.Component {
       mostRecentDeploySlice = Object.keys(recentDeploysByEnviroment).slice(0, 3);
     }
     return {
-      header: (
-        <span className="truncate">
-          {tct('Release [version]', {version: shortVersion})}
-        </span>
-      ),
+      header: <span className="truncate">{tct('Release [version]', {version})}</span>,
       body: (
         <div>
           <div className="row row-flex">

--- a/src/sentry/static/sentry/app/utils.tsx
+++ b/src/sentry/static/sentry/app/utils.tsx
@@ -158,21 +158,11 @@ export function formatBytes(bytes: number): string {
   return bytes.toFixed(1) + ' ' + units[u];
 }
 
-export function getShortVersion(version: string): string {
-  if (version.length < 12) {
-    return version;
+export function getShortCommitHash(hash: string): string {
+  if (hash.match(/^[a-f0-9]{40}$/)) {
+    hash = hash.substr(0, 7);
   }
-
-  const match = version.match(
-    /^(?:[a-zA-Z][a-zA-Z0-9-]+)(?:\.[a-zA-Z][a-zA-Z0-9-]+)+-(.*)$/
-  );
-  if (match) {
-    version = match[1];
-  }
-  if (version.match(/^[a-f0-9]{40}$/)) {
-    version = version.substr(0, 7);
-  }
-  return version;
+  return hash;
 }
 
 export function parseRepo<T>(repo: T): T {

--- a/src/sentry/static/sentry/app/views/projectsDashboard/deploys.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/deploys.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import moment from 'moment-timezone';
 import styled from 'react-emotion';
 
-import {getShortVersion} from 'app/utils';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 import Link from 'app/components/links/link';
@@ -70,7 +69,7 @@ class Deploy extends React.Component {
               deploy.version
             }/?project=${project.id}`}
           >
-            {getShortVersion(deploy.version)}
+            {deploy.version}
           </StyledLink>
         </Version>
         <Flex w={90} justify="flex-end">

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 
 import {t} from 'app/locale';
 
@@ -7,6 +8,7 @@ import Count from 'app/components/count';
 import ExternalLink from 'app/components/links/externalLink';
 import ListLink from 'app/components/links/listLink';
 import NavTabs from 'app/components/navTabs';
+import PageHeading from 'app/components/pageHeading';
 import ReleaseStats from 'app/components/releaseStats';
 import TextOverflow from 'app/components/textOverflow';
 import TimeSince from 'app/components/timeSince';
@@ -43,12 +45,13 @@ export default class ReleaseHeader extends React.Component {
       <div className="release-details">
         <div className="row">
           <div className="col-sm-4 col-xs-12">
-            <h3>
-              {t('Release')}{' '}
-              <strong>
-                <Version orgId={orgId} version={release.version} anchor={false} />
-              </strong>
-            </h3>
+            <PageHeading>{t('Release')} </PageHeading>
+            <StyledVersion
+              orgId={orgId}
+              version={release.version}
+              showShortVersion={false}
+              anchor={false}
+            />
             {!!release.url && (
               <div>
                 <ExternalLink href={release.url}>
@@ -113,3 +116,11 @@ export default class ReleaseHeader extends React.Component {
     );
   }
 }
+
+const StyledVersion = styled(Version)`
+  font-weight: 600;
+  word-break: break-all;
+  line-height: 1.2;
+  display: block;
+  margin: 6px 0;
+`;

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.jsx
@@ -46,12 +46,7 @@ export default class ReleaseHeader extends React.Component {
         <div className="row">
           <div className="col-sm-4 col-xs-12">
             <PageHeading>{t('Release')} </PageHeading>
-            <StyledVersion
-              orgId={orgId}
-              version={release.version}
-              showShortVersion={false}
-              anchor={false}
-            />
+            <StyledVersion orgId={orgId} version={release.version} anchor={false} />
             {!!release.url && (
               <div>
                 <ExternalLink href={release.url}>

--- a/src/sentry/static/sentry/app/views/releases/list/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseList.jsx
@@ -27,7 +27,6 @@ const ReleaseList = props => {
                   <Version
                     orgId={orgId}
                     version={release.version}
-                    showShortVersion={false}
                     preserveGlobalSelection
                   />
                 </VersionWrapper>

--- a/src/sentry/static/sentry/app/views/releases/list/releaseList.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseList.jsx
@@ -27,6 +27,7 @@ const ReleaseList = props => {
                   <Version
                     orgId={orgId}
                     version={release.version}
+                    showShortVersion={false}
                     preserveGlobalSelection
                   />
                 </VersionWrapper>


### PR DESCRIPTION
We currently often have confusion around release names, especially when it comes to mobile / react-native apps.

So here is how to list would look like:

![Screenshot 2019-07-03 14 25 53](https://user-images.githubusercontent.com/363802/60591380-a6c78d00-9d9e-11e9-9405-88113bc1a7be.png)

As you can see, there are two `1.0` releases in their even tho they are different releases.
We have some "smart" logic trimming release names depending on how their format is.
Let's take React Native for example, one could be Android, the other iOS.
The releases are named different but you only see the full name when hovering the title or looking at the URL in the detail page.

This PR changes this so on the list and detail view the whole release name will be shown.

![Screenshot 2019-07-03 14 24 51](https://user-images.githubusercontent.com/363802/60591523-f0b07300-9d9e-11e9-891f-167e7f0b5dda.png)

Detail:

![Screenshot 2019-07-03 14 20 31](https://user-images.githubusercontent.com/363802/60591607-19386d00-9d9f-11e9-85b7-90eba26e0a80.png)
![Screenshot 2019-07-03 14 19 28](https://user-images.githubusercontent.com/363802/60591613-1ccbf400-9d9f-11e9-95a6-b38b3fd4ba03.png)
