### PR TITLE
ci(travis): Limit cross docker-sentry builds to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ after_script:
   - zeus upload -t "application/webpack-stats+json" .artifacts/*webpack-stats.json
   # Trigger a build for the `git` image on docker-sentry
   - >
+      if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
       curl -s -X POST
       -H "Content-Type: application/json"
       -H "Accept: application/json"


### PR DESCRIPTION
These cross-builds seem to be getting triggered too frequently, causing rate limit enforcement. This PR limits them to only landed master commits.