### PR TITLE
feat(issueless events) Skip group specific phases in post_process for issueless events

### DIFF
--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -57,12 +57,12 @@ def record_first_event(project, **kwargs):
 
 
 @event_processed.connect(weak=False)
-def record_event_processed(project, group, event, **kwargs):
+def record_event_processed(project, event, **kwargs):
     feature_slugs = []
 
     # Platform
-    if group.platform in manager.location_slugs('language'):
-        feature_slugs.append(group.platform)
+    if event.platform in manager.location_slugs('language'):
+        feature_slugs.append(event.platform)
 
     # Release Tracking
     if event.get_tag('sentry:release'):

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -60,9 +60,11 @@ def record_first_event(project, **kwargs):
 def record_event_processed(project, event, **kwargs):
     feature_slugs = []
 
+    platform = event.group.platform if event.group else event.platform
+
     # Platform
-    if event.platform in manager.location_slugs('language'):
-        feature_slugs.append(event.platform)
+    if platform in manager.location_slugs('language'):
+        feature_slugs.append(platform)
 
     # Release Tracking
     if event.get_tag('sentry:release'):

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -199,7 +199,7 @@ def record_member_joined(member, organization, **kwargs):
 
 
 @event_processed.connect(weak=False)
-def record_release_received(project, group, event, **kwargs):
+def record_release_received(project, event, **kwargs):
     if not event.get_tag('sentry:release'):
         return
 
@@ -221,7 +221,7 @@ def record_release_received(project, group, event, **kwargs):
 
 
 @event_processed.connect(weak=False)
-def record_user_context_received(project, group, event, **kwargs):
+def record_user_context_received(project, event, **kwargs):
     user_context = event.data.get('user')
     if not user_context:
         return
@@ -247,7 +247,7 @@ def record_user_context_received(project, group, event, **kwargs):
 
 
 @event_processed.connect(weak=False)
-def record_sourcemaps_received(project, group, event, **kwargs):
+def record_sourcemaps_received(project, event, **kwargs):
     if not has_sourcemap(event):
         return
 

--- a/src/sentry/receivers/similarity.py
+++ b/src/sentry/receivers/similarity.py
@@ -6,7 +6,7 @@ from sentry.similarity import features as similarity_features
 
 
 @event_processed.connect(weak=False)
-def record(project, group, event, **kwargs):
+def record(project, event, **kwargs):
     if not feature_flags.has('projects:similarity-indexing', project):
         return
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -60,7 +60,7 @@ event_dropped = BetterSignal(providing_args=["ip", "data", "project", "reason_co
 event_filtered = BetterSignal(providing_args=["ip", "data", "project"])
 event_received = BetterSignal(providing_args=["ip", "project"])
 pending_delete = BetterSignal(providing_args=['instance', 'actor'])
-event_processed = BetterSignal(providing_args=['project', 'group', 'event'])
+event_processed = BetterSignal(providing_args=['project', 'event'])
 event_saved = BetterSignal(providing_args=["project"])
 
 # Organization Onboarding Signals

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -102,7 +102,6 @@ class FeatureSet(object):
 
         items = []
         for event in events:
-            # TODO: how we index events?
             if not event.group_id:
                 continue
             for label, features in self.extract(event).items():

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -87,7 +87,7 @@ def _should_send_error_created_hooks(project):
 
 def _capture_stats(event, is_new):
     # TODO(dcramer): limit platforms to... something?
-    platform = event.platform
+    platform = event.group.platform if event.group else event.platform
     if not platform:
         return
     platform = platform.split('-', 1)[0].split('_', 1)[0]

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -102,6 +102,16 @@ def _capture_stats(event, is_new):
     metrics.incr(u'events.processed.{platform}'.format(platform=platform), skip_internal=False)
     metrics.timing('events.size.data', event.size, tags=tags)
 
+    # This is an experiment to understand whether we have, in production,
+    # mismatches between event and group before we permanently rely on events
+    # for project and platform. before adding some more verbose logging ont this
+    # case, using a stats will give us a sense of the magnitude of the problem.
+    if event.group:
+        if event.group.platform != event.platform:
+            metrics.incr('events.platform_mismatch', tags=tags)
+        if event.group.project_id != event.project_id:
+            metrics.incr('events.project_mismatch')
+
 
 def check_event_already_post_processed(event):
     cluster_key = getattr(settings, 'SENTRY_POST_PROCESSING_LOCK_REDIS_CLUSTER', None)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -159,13 +159,10 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
 
         # Re-bind Group since we're pickling the whole Event object
         # which may contain a stale Group.
-        if event.group_id:
-            event.group, _ = get_group_with_redirect(event.group_id)
-            event.group_id = event.group.id
-            project_id = event.group.project_id
-        else:
-            project_id = event.project_id
+        event.group, _ = get_group_with_redirect(event.group_id)
+        event.group_id = event.group.id
 
+        project_id = event.group.project_id
         with configure_scope() as scope:
             scope.set_tag("project", project_id)
 
@@ -178,60 +175,59 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
         # we process snoozes before rules as it might create a regression
         has_reappeared = process_snoozes(event.group)
 
-        if event.group_id:
-            handle_owner_assignment(event.project, event.group, event)
+        handle_owner_assignment(event.project, event.group, event)
 
-            rp = RuleProcessor(
-                event,
-                is_new,
-                is_regression,
-                is_new_group_environment,
-                has_reappeared)
-            has_alert = False
-            # TODO(dcramer): ideally this would fanout, but serializing giant
-            # objects back and forth isn't super efficient
-            for callback, futures in rp.apply():
-                has_alert = True
-                safe_execute(callback, event, futures)
+        rp = RuleProcessor(
+            event,
+            is_new,
+            is_regression,
+            is_new_group_environment,
+            has_reappeared)
+        has_alert = False
+        # TODO(dcramer): ideally this would fanout, but serializing giant
+        # objects back and forth isn't super efficient
+        for callback, futures in rp.apply():
+            has_alert = True
+            safe_execute(callback, event, futures)
 
-            if features.has(
-                'projects:servicehooks',
-                project=event.project,
-            ):
-                allowed_events = set(['event.created'])
-                if has_alert:
-                    allowed_events.add('event.alert')
+        if features.has(
+            'projects:servicehooks',
+            project=event.project,
+        ):
+            allowed_events = set(['event.created'])
+            if has_alert:
+                allowed_events.add('event.alert')
 
-                if allowed_events:
-                    for servicehook_id, events in _get_service_hooks(project_id=event.project_id):
-                        if any(e in allowed_events for e in events):
-                            process_service_hook.delay(
-                                servicehook_id=servicehook_id,
-                                event=event,
-                            )
+            if allowed_events:
+                for servicehook_id, events in _get_service_hooks(project_id=event.project_id):
+                    if any(e in allowed_events for e in events):
+                        process_service_hook.delay(
+                            servicehook_id=servicehook_id,
+                            event=event,
+                        )
 
-            if event.get_event_type() == 'error' and _should_send_error_created_hooks(event.project):
-                process_resource_change_bound.delay(
-                    action='created',
-                    sender='Error',
-                    instance_id=event.event_id,
-                    instance=event,
-                )
-            if is_new:
-                process_resource_change_bound.delay(
-                    action='created',
-                    sender='Group',
-                    instance_id=event.group_id,
-                )
+        if event.get_event_type() == 'error' and _should_send_error_created_hooks(event.project):
+            process_resource_change_bound.delay(
+                action='created',
+                sender='Error',
+                instance_id=event.event_id,
+                instance=event,
+            )
+        if is_new:
+            process_resource_change_bound.delay(
+                action='created',
+                sender='Group',
+                instance_id=event.group_id,
+            )
 
-            for plugin in plugins.for_project(event.project):
-                plugin_post_process_group(
-                    plugin_slug=plugin.slug,
-                    event=event,
-                    is_new=is_new,
-                    is_regresion=is_regression,
-                    is_sample=is_sample,
-                )
+        for plugin in plugins.for_project(event.project):
+            plugin_post_process_group(
+                plugin_slug=plugin.slug,
+                event=event,
+                is_new=is_new,
+                is_regresion=is_regression,
+                is_sample=is_sample,
+            )
 
         event_processed.send_robust(
             sender=post_process_group,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -150,6 +150,8 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
         # in the database due to sampling.
         from sentry.models import Project
         from sentry.models.group import get_group_with_redirect
+        from sentry.rules.processor import RuleProcessor
+        from sentry.tasks.servicehooks import process_service_hook
 
         # Re-bind node data to avoid renormalization. We only want to
         # renormalize when loading old data from the database.
@@ -173,127 +175,69 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
 
         _capture_stats(event, is_new)
 
-<<<<<<< HEAD
         # we process snoozes before rules as it might create a regression
         has_reappeared = process_snoozes(event.group)
 
-        handle_owner_assignment(event.project, event.group, event)
+        if event.group_id:
+            handle_owner_assignment(event.project, event.group, event)
 
-        rp = RuleProcessor(event, is_new, is_regression, is_new_group_environment, has_reappeared)
-        has_alert = False
-        # TODO(dcramer): ideally this would fanout, but serializing giant
-        # objects back and forth isn't super efficient
-        for callback, futures in rp.apply():
-            has_alert = True
-            safe_execute(callback, event, futures)
+            rp = RuleProcessor(
+                event,
+                is_new,
+                is_regression,
+                is_new_group_environment,
+                has_reappeared)
+            has_alert = False
+            # TODO(dcramer): ideally this would fanout, but serializing giant
+            # objects back and forth isn't super efficient
+            for callback, futures in rp.apply():
+                has_alert = True
+                safe_execute(callback, event, futures)
 
-        if features.has(
-            'projects:servicehooks',
-            project=event.project,
-        ):
-            allowed_events = set(['event.created'])
-            if has_alert:
-                allowed_events.add('event.alert')
+            if features.has(
+                'projects:servicehooks',
+                project=event.project,
+            ):
+                allowed_events = set(['event.created'])
+                if has_alert:
+                    allowed_events.add('event.alert')
 
-            if allowed_events:
-                for servicehook_id, events in _get_service_hooks(project_id=event.project_id):
-                    if any(e in allowed_events for e in events):
-                        process_service_hook.delay(
-                            servicehook_id=servicehook_id,
-                            event=event,
-                        )
+                if allowed_events:
+                    for servicehook_id, events in _get_service_hooks(project_id=event.project_id):
+                        if any(e in allowed_events for e in events):
+                            process_service_hook.delay(
+                                servicehook_id=servicehook_id,
+                                event=event,
+                            )
 
-        if event.get_event_type() == 'error' and _should_send_error_created_hooks(event.project):
-            process_resource_change_bound.delay(
-                action='created',
-                sender='Error',
-                instance_id=event.event_id,
-                instance=event,
-            )
-        if is_new:
-            process_resource_change_bound.delay(
-                action='created',
-                sender='Group',
-                instance_id=event.group_id,
-            )
+            if event.get_event_type() == 'error' and _should_send_error_created_hooks(event.project):
+                process_resource_change_bound.delay(
+                    action='created',
+                    sender='Error',
+                    instance_id=event.event_id,
+                    instance=event,
+                )
+            if is_new:
+                process_resource_change_bound.delay(
+                    action='created',
+                    sender='Group',
+                    instance_id=event.group_id,
+                )
 
-        for plugin in plugins.for_project(event.project):
-            plugin_post_process_group(
-                plugin_slug=plugin.slug,
-=======
-        if event.group:
-            process_group(
->>>>>>> Split postprocess
-                event=event,
-                is_new=is_new,
-                is_regression=is_regression,
-                is_sample=is_sample,
-                is_new_group_environment=is_new_group_environment,
-            )
+            for plugin in plugins.for_project(event.project):
+                plugin_post_process_group(
+                    plugin_slug=plugin.slug,
+                    event=event,
+                    is_new=is_new,
+                    is_regresion=is_regression,
+                    is_sample=is_sample,
+                )
 
         event_processed.send_robust(
             sender=post_process_group,
             project=event.project,
             event=event,
             primary_hash=kwargs.get('primary_hash'),
-        )
-
-
-def process_group(event, is_new, is_regression, is_sample, is_new_group_environment):
-    # we process snoozes before rules as it might create a regression
-    has_reappeared = process_snoozes(event.group)
-
-    handle_owner_assignment(event.project, event.group, event)
-
-    from sentry.rules.processor import RuleProcessor
-    from sentry.tasks.servicehooks import process_service_hook
-
-    rp = RuleProcessor(event, is_new, is_regression, is_new_group_environment, has_reappeared)
-    has_alert = False
-    # TODO(dcramer): ideally this would fanout, but serializing giant
-    # objects back and forth isn't super efficient
-    for callback, futures in rp.apply():
-        has_alert = True
-        safe_execute(callback, event, futures)
-
-    if features.has(
-        'projects:servicehooks',
-        project=event.project,
-    ):
-        allowed_events = set(['event.created'])
-        if has_alert:
-            allowed_events.add('event.alert')
-
-        if allowed_events:
-            for servicehook_id, events in _get_service_hooks(project_id=event.project_id):
-                if any(e in allowed_events for e in events):
-                    process_service_hook.delay(
-                        servicehook_id=servicehook_id,
-                        event=event,
-                    )
-
-    if event.get_event_type() == 'error' and _should_send_error_created_hooks(event.project):
-        process_resource_change_bound.delay(
-            action='created',
-            sender='Error',
-            instance_id=event.event_id,
-            project_id=event.project_id,
-            group_id=event.group_id,
-        )
-    if is_new:
-        process_resource_change_bound.delay(
-            action='created',
-            sender='Group',
-            instance_id=event.group_id,
-        )
-
-    for plugin in plugins.for_project(event.project):
-        plugin_post_process_group(
-            plugin_slug=plugin.slug,
-            event=event,
-            is_new=is_new,
-            is_regresion=is_regression,
-            is_sample=is_sample,
         )
 
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -131,10 +131,6 @@ def handle_owner_assignment(project, group, event):
         GroupAssignee.objects.assign(group, owner)
 
 
-def post_process_issue(event):
-    pass
-
-
 @instrumented_task(name='sentry.tasks.post_process.post_process_group')
 def post_process_group(event, is_new, is_regression, is_sample, is_new_group_environment, **kwargs):
     """
@@ -164,8 +160,10 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
         if event.group_id:
             event.group, _ = get_group_with_redirect(event.group_id)
             event.group_id = event.group.id
+            project_id = event.group.project_id
+        else:
+            project_id = event.project_id
 
-        project_id = event.project_id
         with configure_scope() as scope:
             scope.set_tag("project", project_id)
 

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -156,6 +156,9 @@ class Fixtures(object):
             group = self.group
         return Factories.create_event(event_id=event_id, group=group, *args, **kwargs)
 
+    def create_issueless_event(self, event_id=None, *args, **kwargs):
+        return Factories.create_event(event_id=event_id, group=None, *args, **kwargs)
+
     def store_event(self, *args, **kwargs):
         return Factories.store_event(*args, **kwargs)
 

--- a/tests/sentry/receivers/test_featureadoption.py
+++ b/tests/sentry/receivers/test_featureadoption.py
@@ -42,19 +42,13 @@ class FeatureAdoptionTest(TestCase):
         assert feature_complete is None
 
     def test_all_passed_feature_slugs_are_complete(self):
-        group1 = self.create_group(
-            project=self.project, platform='javascript', message='javascript error message'
-        )
         event1 = self.create_full_event()
-        group2 = self.create_group(
-            project=self.project, platform='javascript', message='javascript error message'
-        )
         event2 = self.create_full_event(event_id='b')
         event_processed.send(
-            project=self.project, group=group1, event=event1, sender=type(self.project)
+            project=self.project, event=event1, sender=type(self.project)
         )
         event_processed.send(
-            project=self.project, group=group2, event=event2, sender=type(self.project)
+            project=self.project, event=event2, sender=type(self.project)
         )
 
         feature_complete = FeatureAdoption.objects.get_by_slug(
@@ -78,182 +72,144 @@ class FeatureAdoptionTest(TestCase):
         assert first_event.complete
 
     def test_javascript(self):
-        group = self.create_group(
-            project=self.project, platform='javascript', message='javascript error message'
-        )
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'javascript'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         js = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="javascript")
         assert js.complete
 
     def test_python(self):
-        group = self.create_group(
-            project=self.project, platform='python', message='python error message'
-        )
         event = self.create_event()
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         python = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="python")
         assert python.complete
 
     def test_node(self):
-        group = self.create_group(
-            project=self.project, platform='node', message='node error message'
-        )
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'node'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         node = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="node")
         assert node.complete
 
     def test_ruby(self):
-        group = self.create_group(
-            project=self.project, platform='ruby', message='ruby error message'
-        )
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'ruby'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         ruby = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="ruby")
         assert ruby.complete
 
     def test_java(self):
-        group = self.create_group(
-            project=self.project, platform='java', message='java error message'
-        )
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'java'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         java = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="java")
         assert java.complete
 
     def test_cocoa(self):
-        group = self.create_group(
-            project=self.project, platform='cocoa', message='cocoa error message'
-        )
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'cocoa'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         cocoa = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="cocoa")
         assert cocoa.complete
 
     def test_objc(self):
-        group = self.create_group(
-            project=self.project, platform='objc', message='objc error message'
-        )
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'objc'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         objc = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="objc")
         assert objc.complete
 
     def test_php(self):
-        group = self.create_group(project=self.project, platform='php', message='php error message')
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'php'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         php = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="php")
         assert php.complete
 
     def test_go(self):
-        group = self.create_group(project=self.project, platform='go', message='go error message')
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'go'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         go = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="go")
         assert go.complete
 
     def test_csharp(self):
-        group = self.create_group(
-            project=self.project, platform='csharp', message='C# error message'
-        )
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'csharp'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         csharp = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="csharp")
         assert csharp.complete
 
     def test_perl(self):
-        group = self.create_group(project=self.project, platform='perl', message='C# error message')
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'perl'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         perl = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="perl")
         assert perl.complete
 
     def test_elixir(self):
-        group = self.create_group(
-            project=self.project, platform='elixir', message='C# error message'
-        )
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'elixir'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         elixir = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="elixir")
         assert elixir.complete
 
     def test_cfml(self):
-        group = self.create_group(project=self.project, platform='cfml', message='C# error message')
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'cfml'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         cfml = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="cfml")
         assert cfml.complete
 
     def test_groovy(self):
-        group = self.create_group(
-            project=self.project, platform='groovy', message='C# error message'
-        )
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'groovy'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         groovy = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="groovy")
         assert groovy.complete
 
     def test_csp(self):
-        group = self.create_group(project=self.project, platform='csp', message='C# error message')
-        event = self.create_event()
+        event = self.create_event(data={'platform': 'csp'})
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         csp = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="csp")
         assert csp.complete
 
     def test_release_tracking(self):
-        group = self.create_group(
-            project=self.project, platform='javascript', message='javascript error message'
-        )
         event = self.create_full_event()
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         release_tracking = FeatureAdoption.objects.get_by_slug(
@@ -262,12 +218,9 @@ class FeatureAdoptionTest(TestCase):
         assert release_tracking
 
     def test_environment_tracking(self):
-        group = self.create_group(
-            project=self.project, platform='javascript', message='javascript error message'
-        )
         event = self.create_full_event()
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         environment_tracking = FeatureAdoption.objects.get_by_slug(
@@ -276,12 +229,9 @@ class FeatureAdoptionTest(TestCase):
         assert environment_tracking
 
     def test_bulk_create(self):
-        group = self.create_group(
-            project=self.project, platform='javascript', message='javascript error message'
-        )
         event = self.create_full_event()
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         javascript = FeatureAdoption.objects.get_by_slug(
@@ -305,12 +255,9 @@ class FeatureAdoptionTest(TestCase):
         assert feature_complete
 
     def test_user_tracking(self):
-        group = self.create_group(
-            project=self.project, platform='javascript', message='javascript error message'
-        )
         event = self.create_full_event()
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         feature_complete = FeatureAdoption.objects.get_by_slug(
@@ -404,14 +351,11 @@ class FeatureAdoptionTest(TestCase):
                     ]
                 }
             }"""
-        group = self.create_group(
-            project=self.project, platform='javascript', message='javascript error message'
-        )
         userless_event = self.create_event(
             event_id='a', platform='javascript', data=json.loads(userless_payload)
         )
         event_processed.send(
-            project=self.project, group=group, event=userless_event, sender=type(self.project)
+            project=self.project, event=userless_event, sender=type(self.project)
         )
 
         feature_complete = FeatureAdoption.objects.get_by_slug(
@@ -504,14 +448,11 @@ class FeatureAdoptionTest(TestCase):
                     ]
                 }
             }"""
-        group = self.create_group(
-            project=self.project, platform='javascript', message='javascript error message'
-        )
         envless_event = self.create_event(
             event_id='a', platform='javascript', data=json.loads(envless_payload)
         )
         event_processed.send(
-            project=self.project, group=group, event=envless_event, sender=type(self.project)
+            project=self.project, event=envless_event, sender=type(self.project)
         )
 
         feature_complete = FeatureAdoption.objects.get_by_slug(
@@ -520,14 +461,11 @@ class FeatureAdoptionTest(TestCase):
         assert feature_complete is None
 
     def test_custom_tags(self):
-        group = self.create_group(
-            project=self.project, platform='javascript', message='javascript error message'
-        )
         event = self.create_full_event()
         event.data['tags'].append(('foo', 'bar'))
         assert event.get_tag('foo') == 'bar'
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         custom_tags = FeatureAdoption.objects.get_by_slug(
@@ -536,12 +474,9 @@ class FeatureAdoptionTest(TestCase):
         assert custom_tags
 
     def test_source_maps(self):
-        group = self.create_group(
-            project=self.project, platform='javascript', message='javascript error message'
-        )
         event = self.create_full_event()
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         source_maps = FeatureAdoption.objects.get_by_slug(
@@ -550,12 +485,9 @@ class FeatureAdoptionTest(TestCase):
         assert source_maps
 
     def test_breadcrumbs(self):
-        group = self.create_group(
-            project=self.project, platform='javascript', message='javascript error message'
-        )
         event = self.create_full_event()
         event_processed.send(
-            project=self.project, group=group, event=event, sender=type(self.project)
+            project=self.project, event=event, sender=type(self.project)
         )
 
         breadcrumbs = FeatureAdoption.objects.get_by_slug(
@@ -574,7 +506,7 @@ class FeatureAdoptionTest(TestCase):
             sender=type(self.project),
         )
         event_processed.send(
-            project=self.project, group=simple_event.group, event=simple_event, sender=type(
+            project=self.project, event=simple_event, sender=type(
                 self.project)
         )
 
@@ -589,7 +521,7 @@ class FeatureAdoptionTest(TestCase):
 
         full_event = self.create_full_event()
         event_processed.send(
-            project=self.project, group=full_event.group, event=full_event, sender=type(
+            project=self.project, event=full_event, sender=type(
                 self.project)
         )
 

--- a/tests/sentry/receivers/test_featureadoption.py
+++ b/tests/sentry/receivers/test_featureadoption.py
@@ -72,7 +72,10 @@ class FeatureAdoptionTest(TestCase):
         assert first_event.complete
 
     def test_javascript(self):
-        event = self.create_event(data={'platform': 'javascript'})
+        group = self.create_group(
+            project=self.project, platform='javascript', message='javascript error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'javascript'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -81,7 +84,10 @@ class FeatureAdoptionTest(TestCase):
         assert js.complete
 
     def test_python(self):
-        event = self.create_event()
+        group = self.create_group(
+            project=self.project, platform='python', message='python error message'
+        )
+        event = self.create_event(group=group)
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -90,7 +96,10 @@ class FeatureAdoptionTest(TestCase):
         assert python.complete
 
     def test_node(self):
-        event = self.create_event(data={'platform': 'node'})
+        group = self.create_group(
+            project=self.project, platform='node', message='node error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'node'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -99,7 +108,10 @@ class FeatureAdoptionTest(TestCase):
         assert node.complete
 
     def test_ruby(self):
-        event = self.create_event(data={'platform': 'ruby'})
+        group = self.create_group(
+            project=self.project, platform='ruby', message='ruby error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'ruby'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -108,7 +120,10 @@ class FeatureAdoptionTest(TestCase):
         assert ruby.complete
 
     def test_java(self):
-        event = self.create_event(data={'platform': 'java'})
+        group = self.create_group(
+            project=self.project, platform='java', message='java error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'java'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -117,7 +132,10 @@ class FeatureAdoptionTest(TestCase):
         assert java.complete
 
     def test_cocoa(self):
-        event = self.create_event(data={'platform': 'cocoa'})
+        group = self.create_group(
+            project=self.project, platform='cocoa', message='cocoa error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'cocoa'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -126,7 +144,10 @@ class FeatureAdoptionTest(TestCase):
         assert cocoa.complete
 
     def test_objc(self):
-        event = self.create_event(data={'platform': 'objc'})
+        group = self.create_group(
+            project=self.project, platform='objc', message='objc error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'objc'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -135,7 +156,10 @@ class FeatureAdoptionTest(TestCase):
         assert objc.complete
 
     def test_php(self):
-        event = self.create_event(data={'platform': 'php'})
+        group = self.create_group(
+            project=self.project, platform='php', message='php error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'php'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -144,7 +168,10 @@ class FeatureAdoptionTest(TestCase):
         assert php.complete
 
     def test_go(self):
-        event = self.create_event(data={'platform': 'go'})
+        group = self.create_group(
+            project=self.project, platform='go', message='go error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'go'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -153,7 +180,10 @@ class FeatureAdoptionTest(TestCase):
         assert go.complete
 
     def test_csharp(self):
-        event = self.create_event(data={'platform': 'csharp'})
+        group = self.create_group(
+            project=self.project, platform='csharp', message='csharp error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'csharp'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -162,7 +192,10 @@ class FeatureAdoptionTest(TestCase):
         assert csharp.complete
 
     def test_perl(self):
-        event = self.create_event(data={'platform': 'perl'})
+        group = self.create_group(
+            project=self.project, platform='perl', message='perl error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'perl'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -171,7 +204,10 @@ class FeatureAdoptionTest(TestCase):
         assert perl.complete
 
     def test_elixir(self):
-        event = self.create_event(data={'platform': 'elixir'})
+        group = self.create_group(
+            project=self.project, platform='elixir', message='elixir error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'elixir'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -180,7 +216,10 @@ class FeatureAdoptionTest(TestCase):
         assert elixir.complete
 
     def test_cfml(self):
-        event = self.create_event(data={'platform': 'cfml'})
+        group = self.create_group(
+            project=self.project, platform='cfml', message='cfml error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'cfml'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -189,7 +228,10 @@ class FeatureAdoptionTest(TestCase):
         assert cfml.complete
 
     def test_groovy(self):
-        event = self.create_event(data={'platform': 'groovy'})
+        group = self.create_group(
+            project=self.project, platform='groovy', message='groovy error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'groovy'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -198,7 +240,10 @@ class FeatureAdoptionTest(TestCase):
         assert groovy.complete
 
     def test_csp(self):
-        event = self.create_event(data={'platform': 'csp'})
+        group = self.create_group(
+            project=self.project, platform='csp', message='csp error message'
+        )
+        event = self.create_event(group=group, data={'platform': 'csp'})
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )
@@ -229,7 +274,10 @@ class FeatureAdoptionTest(TestCase):
         assert environment_tracking
 
     def test_bulk_create(self):
-        event = self.create_full_event()
+        group = self.create_group(
+            project=self.project, platform='javascript', message='javascript error message'
+        )
+        event = self.create_full_event(group=group)
         event_processed.send(
             project=self.project, event=event, sender=type(self.project)
         )

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -89,7 +89,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         now = timezone.now()
         project = self.create_project(first_event=now)
         event = self.create_full_event()
-        event_processed.send(project=project, group=self.group, event=event, sender=type(project))
+        event_processed.send(project=project, event=event, sender=type(project))
 
         task = OrganizationOnboardingTask.objects.get(
             organization=project.organization,
@@ -272,7 +272,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         event = self.create_full_event(project=project)
         member = self.create_member(organization=self.organization, teams=[self.team], user=user)
 
-        event_processed.send(project=project, group=event.group, event=event, sender=type(project))
+        event_processed.send(project=project, event=event, sender=type(project))
         project_created.send(project=project, user=user, sender=type(project))
         project_created.send(project=second_project, user=user, sender=type(second_project))
 

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from datetime import timedelta
 from django.utils import timezone
-from mock import Mock, patch
+from mock import Mock, patch, ANY
 
 from sentry import tagstore
 from sentry import options
@@ -17,6 +17,32 @@ from sentry.tasks.post_process import index_event_tags, post_process_group
 
 
 class PostProcessGroupTest(TestCase):
+    @patch('sentry.rules.processor.RuleProcessor')
+    @patch('sentry.tasks.servicehooks.process_service_hook')
+    @patch('sentry.tasks.sentry_apps.process_resource_change_bound.delay')
+    @patch('sentry.signals.event_processed.send_robust')
+    def test_issueless(self, mock_signal, mock_process_resource_change_bound,
+                       mock_process_service_hook, mock_processor):
+        event = self.create_issueless_event(project=self.project)
+        post_process_group(
+            event=event,
+            is_new=True,
+            is_regression=False,
+            is_sample=False,
+            is_new_group_environment=True,
+        )
+
+        mock_processor.assert_not_called()  # NOQA
+        mock_process_service_hook.assert_not_called()  # NOQA
+        mock_process_resource_change_bound.assert_not_called()  # NOQA
+
+        mock_signal.assert_called_once_with(
+            sender=ANY,
+            project=self.project,
+            event=event,
+            primary_hash=None,
+        )
+
     @patch('sentry.rules.processor.RuleProcessor')
     def test_rule_processor(self, mock_processor):
         group = self.create_group(project=self.project)

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from datetime import timedelta
 from django.utils import timezone
-from mock import Mock, patch, ANY
+from mock import Mock, patch
 
 from sentry import tagstore
 from sentry import options
@@ -17,32 +17,6 @@ from sentry.tasks.post_process import index_event_tags, post_process_group
 
 
 class PostProcessGroupTest(TestCase):
-    @patch('sentry.rules.processor.RuleProcessor')
-    @patch('sentry.tasks.servicehooks.process_service_hook')
-    @patch('sentry.tasks.sentry_apps.process_resource_change_bound.delay')
-    @patch('sentry.signals.event_processed.send_robust')
-    def test_issueless(self, mock_signal, mock_process_resource_change_bound,
-                       mock_process_service_hook, mock_processor):
-        event = self.create_issueless_event(project=self.project)
-        post_process_group(
-            event=event,
-            is_new=True,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=True,
-        )
-
-        mock_processor.assert_not_called()  # NOQA
-        mock_process_service_hook.assert_not_called()  # NOQA
-        mock_process_resource_change_bound.assert_not_called()  # NOQA
-
-        mock_signal.assert_called_once_with(
-            sender=ANY,
-            project=self.project,
-            event=event,
-            primary_hash=None,
-        )
-
     @patch('sentry.rules.processor.RuleProcessor')
     def test_rule_processor(self, mock_processor):
         group = self.create_group(project=self.project)


### PR DESCRIPTION
We cannot skip all post process for issueless events. Event_process signal should be send anyway.
If the event has no group this skips:
- group assignment
- the whole rule processor phase
- service hooks (for now at least)
- plugins