### PR TITLE
ref(app-platform): Enable error.created testing for all orgs

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -63,12 +63,7 @@ def _should_send_error_created_hooks(project):
         if random.random() >= options.get('post-process.error-hook-sample-rate'):
             return False
 
-        org = Organization.objects.get_from_cache(id=project.organization_id)
-        result = ServiceHook.objects.filter(
-            organization_id=org.id,
-        ).extra(where=["events @> '{error.created}'"]).exists()
-
-        return result
+        return True
 
     cache_key = u'servicehooks-error-created:1:{}'.format(project.id)
     result = cache.get(cache_key)


### PR DESCRIPTION
This makes it so that all orgs can be used for the sample testing.

All org except ours should make it to [here](https://github.com/getsentry/sentry/blob/master/src/sentry/tasks/sentry_apps.py#L185).