### PR TITLE
ref: Refactor user reports to not use Postgres Event

### DIFF
--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -37,6 +37,10 @@ class UserReportSerializer(Serializer):
             'comments': obj.comments,
             'dateCreated': obj.date_added,
             'user': attrs['event_user'],
+            'event': {
+                'id': obj.event_id,
+                'eventID': obj.event_id,
+            }
         }
 
 

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 from sentry.api.serializers import register, serialize, Serializer
-from sentry.models import EventUser, UserReport, Event
+from sentry.models import EventUser, UserReport
 
 
 @register(UserReport)
@@ -15,20 +15,10 @@ class UserReportSerializer(Serializer):
 
         event_users = {e.id: d for e, d in zip(queryset, serialize(queryset, user))}
 
-        # If a event list with multiple project IDs is passed to this and event IDs are not unique
-        # this could return the wrong eventIDs
-        events_dict = dict(Event.objects.filter(
-            project_id__in={i.project_id for i in item_list},
-            event_id__in=[i.event_id for i in item_list]
-        ).values_list('id', 'event_id'))
-
         attrs = {}
         for item in item_list:
             attrs[item] = {
                 'event_user': event_users.get(item.event_user_id),
-                'event': {
-                    'id': events_dict.get(item.event_id)
-                }
             }
 
         return attrs
@@ -38,7 +28,6 @@ class UserReportSerializer(Serializer):
         # context == user / http / extra interfaces
         return {
             'id': six.text_type(obj.id),
-            # TODO(lyn): Verify this isn't being used and eventually remove this from API
             'eventID': obj.event_id,
             'name': (
                 obj.name or obj.email or
@@ -48,11 +37,6 @@ class UserReportSerializer(Serializer):
             'comments': obj.comments,
             'dateCreated': obj.date_added,
             'user': attrs['event_user'],
-            'event': {
-                'id': six.text_type(attrs['event']['id']) if attrs['event']['id'] else None,
-                'eventID': obj.event_id
-            }
-
         }
 
 

--- a/src/sentry/static/sentry/app/components/events/userFeedback.jsx
+++ b/src/sentry/static/sentry/app/components/events/userFeedback.jsx
@@ -21,7 +21,7 @@ class EventUserFeedback extends React.Component {
   getUrl() {
     const {report, orgId, issueId} = this.props;
 
-    return `/organizations/${orgId}/issues/${issueId}/events/${report.event.eventID}/`;
+    return `/organizations/${orgId}/issues/${issueId}/events/${report.eventID}/`;
   }
 
   render() {
@@ -41,8 +41,7 @@ class EventUserFeedback extends React.Component {
                   <CopyIcon src="icon-copy" />
                 </Email>
               </Clipboard>
-              {/* event.eventID might be undefined for legacy accounts */}
-              {report.event.eventID && (
+              {report.eventID && (
                 <ViewEventLink to={this.getUrl()}>{t('View event')}</ViewEventLink>
               )}
             </div>

--- a/src/sentry/static/sentry/app/views/userFeedback/organizationUserFeedback.jsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/organizationUserFeedback.jsx
@@ -51,12 +51,7 @@ class OrganizationUserFeedback extends AsyncView {
         {this.state.reportList.map(item => {
           const issue = item.issue;
           return (
-            <CompactIssue
-              key={item.id}
-              id={issue.id}
-              data={issue}
-              eventId={item.event.eventID}
-            >
+            <CompactIssue key={item.id} id={issue.id} data={issue} eventId={item.eventID}>
               <StyledEventUserFeedback report={item} orgId={orgId} issueId={issue.id} />
             </CompactIssue>
           );


### PR DESCRIPTION
Previously we queried Events in order to fetch the PG event ID, this is
no longer needed.