### PR TITLE
feat: Use Snuba events in group model

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -377,12 +377,6 @@ class Group(Model):
         return self.get_latest_event_for_environments()
 
     def get_latest_event_for_environments(self, environments=()):
-        use_snuba = options.get('snuba.events-queries.enabled')
-
-        # Fetch without environment if Snuba is not enabled
-        if not use_snuba:
-            return self.get_latest_event()
-
         return get_oldest_or_latest_event_for_environments(
             EventOrdering.LATEST,
             environments=environments,
@@ -390,12 +384,6 @@ class Group(Model):
             project_id=self.project_id)
 
     def get_oldest_event_for_environments(self, environments=()):
-        use_snuba = options.get('snuba.events-queries.enabled')
-
-        # Fetch without environment if Snuba is not enabled
-        if not use_snuba:
-            return self.get_oldest_event()
-
         return get_oldest_or_latest_event_for_environments(
             EventOrdering.OLDEST,
             environments=environments,

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -374,7 +374,10 @@ class Group(Model):
         return type(self).calculate_score(self.times_seen, self.last_seen)
 
     def get_latest_event(self):
-        return self.get_latest_event_for_environments()
+        if not hasattr(self, '_latest_event'):
+            self._latest_event = self.get_latest_event_for_environments()
+
+        return self._latest_event
 
     def get_latest_event_for_environments(self, environments=()):
         return get_oldest_or_latest_event_for_environments(

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -20,7 +20,7 @@ from django.utils import timezone
 from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
 
-from sentry import eventtypes, tagstore, options
+from sentry import eventtypes, tagstore
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS, MAX_CULPRIT_LENGTH
 from sentry.db.models import (
     BaseManager, BoundedBigIntegerField, BoundedIntegerField, BoundedPositiveIntegerField,

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -175,8 +175,6 @@ class GroupManager(BaseManager):
     def filter_by_event_id(self, project_ids, event_id):
         from sentry.utils import snuba
 
-        group_ids = set()
-
         group_ids = set([evt['issue'] for evt in snuba.raw_query(
             start=datetime.utcfromtimestamp(0),
             end=datetime.utcnow(),
@@ -186,7 +184,7 @@ class GroupManager(BaseManager):
                 'event_id': [event_id],
                 'project_id': project_ids,
             },
-            limit=1,
+            limit=1000,
             referrer="Group.filter_by_event_id",
         )['data']])
 

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -150,9 +150,7 @@ class RavenIntegrationTest(TransactionTestCase):
         assert request.call_count is 1
         assert Group.objects.count() == 1
         group = Group.objects.get()
-        assert group.event_set.count() == 1
-        instance = group.event_set.get()
-        assert instance.data['logentry']['formatted'] == 'foo'
+        assert group.data['title'] == 'foo'
 
 
 class SentryRemoteTest(TestCase):

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import
 
 import six
 import mock
+from datetime import timedelta
+from django.utils import timezone
 
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.integrations.exceptions import IntegrationError
@@ -11,6 +13,10 @@ from sentry.utils.http import absolute_uri
 
 
 class GroupIntegrationDetailsTest(APITestCase):
+    def setUp(self):
+        super(GroupIntegrationDetailsTest, self).setUp()
+        self.min_ago = timezone.now() - timedelta(minutes=1)
+
     def test_simple_get_link(self):
         self.login_as(user=self.user)
         org = self.organization
@@ -367,8 +373,14 @@ class GroupIntegrationDetailsTest(APITestCase):
 
         self.login_as(user=self.user)
         org = self.organization
-        group = self.create_group()
-        self.create_event(group=group)
+        event = self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'timestamp': self.min_ago.isoformat()[:19],
+            },
+            project_id=self.project.id
+        )
+        group = event.group
         integration = Integration.objects.create(
             provider='example',
             name='Example',

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -4,30 +4,42 @@ import six
 import mock
 from datetime import timedelta
 from django.utils import timezone
+import copy
 
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.integrations.exceptions import IntegrationError
 from sentry.models import Activity, ExternalIssue, GroupLink, Integration
 from sentry.testutils import APITestCase
 from sentry.utils.http import absolute_uri
+from sentry.testutils.factories import DEFAULT_EVENT_DATA
 
 
 class GroupIntegrationDetailsTest(APITestCase):
     def setUp(self):
         super(GroupIntegrationDetailsTest, self).setUp()
         self.min_ago = timezone.now() - timedelta(minutes=1)
+        self.event = self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'timestamp': self.min_ago.isoformat()[:19],
+                'message': 'message',
+                'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
+            },
+            project_id=self.project.id
+        )
+        self.group = self.event.group
 
     def test_simple_get_link(self):
         self.login_as(user=self.user)
         org = self.organization
-        group = self.create_group()
         integration = Integration.objects.create(
             provider='example',
             name='Example',
         )
         integration.add_organization(org, self.user)
 
-        path = u'/api/0/issues/{}/integrations/{}/?action=link'.format(group.id, integration.id)
+        path = u'/api/0/issues/{}/integrations/{}/?action=link'.format(
+            self.group.id, integration.id)
 
         with self.feature('organizations:integrations-issue-basic'):
             response = self.client.get(path)
@@ -67,13 +79,12 @@ class GroupIntegrationDetailsTest(APITestCase):
     def test_simple_get_create(self):
         self.login_as(user=self.user)
         org = self.organization
-        group = self.create_group()
-        self.create_event(group=group)
         integration = Integration.objects.create(
             provider='example',
             name='Example',
         )
         integration.add_organization(org, self.user)
+        group = self.group
 
         path = u'/api/0/issues/{}/integrations/{}/?action=create'.format(group.id, integration.id)
 
@@ -105,7 +116,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                         'required': True,
                     }, {
                         'default': ('Sentry Issue: [%s](%s)\n\n```\n'
-                                    'Stacktrace (most recent call last):\n\n  '
+                                    'Stacktrace (most recent call first):\n\n  '
                                     'File "sentry/models/foo.py", line 29, in build_msg\n    '
                                     'string_max_length=self.string_max_length)\n\nmessage\n```'
                                     ) % (group.qualified_short_id, absolute_uri(group.get_absolute_url(params={'referrer': 'example_integration'}))),
@@ -127,15 +138,14 @@ class GroupIntegrationDetailsTest(APITestCase):
     def test_get_create_with_error(self):
         self.login_as(user=self.user)
         org = self.organization
-        group = self.create_group()
-        self.create_event(group=group)
         integration = Integration.objects.create(
             provider='example',
             name='Example',
         )
         integration.add_organization(org, self.user)
 
-        path = u'/api/0/issues/{}/integrations/{}/?action=create'.format(group.id, integration.id)
+        path = u'/api/0/issues/{}/integrations/{}/?action=create'.format(
+            self.group.id, integration.id)
 
         with self.feature('organizations:integrations-issue-basic'):
             with mock.patch.object(ExampleIntegration, 'get_create_issue_config', side_effect=IntegrationError('oops')):
@@ -147,15 +157,14 @@ class GroupIntegrationDetailsTest(APITestCase):
     def test_get_feature_disabled(self):
         self.login_as(user=self.user)
         org = self.organization
-        group = self.create_group()
-        self.create_event(group=group)
         integration = Integration.objects.create(
             provider='example',
             name='Example',
         )
         integration.add_organization(org, self.user)
 
-        path = u'/api/0/issues/{}/integrations/{}/?action=create'.format(group.id, integration.id)
+        path = u'/api/0/issues/{}/integrations/{}/?action=create'.format(
+            self.group.id, integration.id)
 
         with self.feature({'organizations:integrations-issue-basic': False}):
             response = self.client.get(path)
@@ -173,7 +182,6 @@ class GroupIntegrationDetailsTest(APITestCase):
         integration.add_organization(org, self.user)
 
         path = u'/api/0/issues/{}/integrations/{}/'.format(group.id, integration.id)
-
         with self.feature('organizations:integrations-issue-basic'):
             response = self.client.put(path, data={
                 'externalIssue': 'APP-123'

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -2,10 +2,12 @@ from __future__ import absolute_import
 
 import responses
 import six
+from datetime import timedelta
 
 from mock import patch
 from exam import fixture
 from django.test import RequestFactory
+from django.utils import timezone
 
 from sentry.integrations.github.integration import GitHubIntegration
 from sentry.models import Integration, ExternalIssue
@@ -28,6 +30,7 @@ class GitHubIssueBasicTest(TestCase):
         )
         self.model.add_organization(self.organization, self.user)
         self.integration = GitHubIntegration(self.model, self.organization.id)
+        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
 
     @responses.activate
     @patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
@@ -158,6 +161,7 @@ class GitHubIssueBasicTest(TestCase):
         event = self.store_event(
             data={
                 'event_id': 'a' * 32,
+                'timestamp': self.min_ago,
             },
             project_id=self.project.id,
         )
@@ -247,6 +251,7 @@ class GitHubIssueBasicTest(TestCase):
         event = self.store_event(
             data={
                 'event_id': 'a' * 32,
+                'timestamp': self.min_ago,
             },
             project_id=self.project.id,
         )
@@ -291,6 +296,7 @@ class GitHubIssueBasicTest(TestCase):
         event = self.store_event(
             data={
                 'event_id': 'a' * 32,
+                'timestamp': self.min_ago,
             },
             project_id=self.project.id,
         )
@@ -322,6 +328,7 @@ class GitHubIssueBasicTest(TestCase):
         event = self.store_event(
             data={
                 'event_id': 'a' * 32,
+                'timestamp': self.min_ago,
             },
             project_id=self.project.id,
         )
@@ -348,6 +355,7 @@ class GitHubIssueBasicTest(TestCase):
         event = self.store_event(
             data={
                 'event_id': 'a' * 32,
+                'timestamp': self.min_ago,
             },
             project_id=self.project.id,
         )

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -155,8 +155,12 @@ class GitHubIssueBasicTest(TestCase):
     @responses.activate
     @patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
     def test_repo_dropdown_choices(self, mock_get_jwt):
-        group = self.create_group()
-        self.create_event(group)
+        event = self.store_event(
+            data={
+                'event_id': 'a' * 32,
+            },
+            project_id=self.project.id,
+        )
 
         responses.add(
             responses.POST,
@@ -176,7 +180,7 @@ class GitHubIssueBasicTest(TestCase):
             json={'repositories': [{'full_name': 'getsentry/sentry', 'name': 'sentry'}]}
         )
 
-        resp = self.integration.get_create_issue_config(group=self.group)
+        resp = self.integration.get_create_issue_config(group=event.group)
         assert resp[0]['choices'] == [(u'getsentry/sentry', u'sentry')]
 
         responses.add(
@@ -187,12 +191,12 @@ class GitHubIssueBasicTest(TestCase):
 
         # create an issue
         data = {'params': {'repo': 'getsentry/hello'}}
-        resp = self.integration.get_create_issue_config(group=self.group, **data)
+        resp = self.integration.get_create_issue_config(group=event.group, **data)
         assert resp[0]['choices'] == [(u'getsentry/hello', u'hello'),
                                       (u'getsentry/sentry', u'sentry')]
         # link an issue
         data = {'params': {'repo': 'getsentry/hello'}}
-        resp = self.integration.get_link_issue_config(group=self.group, **data)
+        resp = self.integration.get_link_issue_config(group=event.group, **data)
         assert resp[0]['choices'] == [(u'getsentry/hello', u'hello'),
                                       (u'getsentry/sentry', u'sentry')]
 
@@ -240,8 +244,14 @@ class GitHubIssueBasicTest(TestCase):
                 ]
             },
         )
-        group = self.create_group()
-        self.create_event(group=group)
+        event = self.store_event(
+            data={
+                'event_id': 'a' * 32,
+            },
+            project_id=self.project.id,
+        )
+        group = event.group
+
         org_integration = self.integration.org_integration
         org_integration.config = {
             'project_issue_defaults': {
@@ -278,8 +288,13 @@ class GitHubIssueBasicTest(TestCase):
             'https://api.github.com/installations/github_external_id/access_tokens',
             json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
         )
-        group = self.create_group()
-        self.create_event(group=group)
+        event = self.store_event(
+            data={
+                'event_id': 'a' * 32,
+            },
+            project_id=self.project.id,
+        )
+        group = event.group
         org_integration = self.integration.org_integration
         org_integration.config = {
             'project_issue_defaults': {
@@ -304,10 +319,13 @@ class GitHubIssueBasicTest(TestCase):
                 'repositories': []
             },
         )
-        group = self.create_group()
-        self.create_event(group=group)
-
-        fields = self.integration.get_link_issue_config(group)
+        event = self.store_event(
+            data={
+                'event_id': 'a' * 32,
+            },
+            project_id=self.project.id,
+        )
+        fields = self.integration.get_link_issue_config(event.group)
         repo_field = [field for field in fields if field['name'] == 'repo'][0]
         assert repo_field['default'] is ''
         assert repo_field['choices'] == []
@@ -327,11 +345,13 @@ class GitHubIssueBasicTest(TestCase):
             'https://api.github.com/installations/github_external_id/access_tokens',
             json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
         )
-
-        group = self.create_group()
-        self.create_event(group=group)
-
-        fields = self.integration.get_create_issue_config(group)
+        event = self.store_event(
+            data={
+                'event_id': 'a' * 32,
+            },
+            project_id=self.project.id,
+        )
+        fields = self.integration.get_create_issue_config(event.group)
         repo_field = [field for field in fields if field['name'] == 'repo'][0]
         assignee_field = [field for field in fields if field['name'] == 'assignee'][0]
 

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -6,6 +6,7 @@ import responses
 import six
 import pytest
 import copy
+from datetime import timedelta
 
 from django.core.urlresolvers import reverse
 from django.utils import timezone
@@ -437,6 +438,10 @@ class JiraIntegrationTest(APITestCase):
             self.user)
         return integration
 
+    def setUp(self):
+        super(JiraIntegrationTest, self).setUp()
+        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+
     def test_get_create_issue_config(self):
         org = self.organization
         self.login_as(self.user)
@@ -444,7 +449,7 @@ class JiraIntegrationTest(APITestCase):
             data={
                 'event_id': 'a' * 32,
                 'message': 'message',
-                'timestamp': timezone.now().isoformat(),
+                'timestamp': self.min_ago,
                 'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
             },
             project_id=self.project.id,
@@ -524,7 +529,7 @@ class JiraIntegrationTest(APITestCase):
             data={
                 'event_id': 'a' * 32,
                 'message': 'message',
-                'timestamp': timezone.now().isoformat(),
+                'timestamp': self.min_ago,
                 'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
             },
             project_id=self.project.id,
@@ -561,7 +566,7 @@ class JiraIntegrationTest(APITestCase):
             data={
                 'event_id': 'a' * 32,
                 'message': 'message',
-                'timestamp': timezone.now().isoformat(),
+                'timestamp': self.min_ago,
                 'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
             },
             project_id=self.project.id,
@@ -598,7 +603,7 @@ class JiraIntegrationTest(APITestCase):
             data={
                 'event_id': 'a' * 32,
                 'message': 'message',
-                'timestamp': timezone.now().isoformat(),
+                'timestamp': self.min_ago,
                 'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
             },
             project_id=self.project.id,
@@ -637,7 +642,7 @@ class JiraIntegrationTest(APITestCase):
         event = self.store_event(
             data={
                 'message': 'oh no',
-                'timestamp': timezone.now().isoformat()
+                'timestamp': self.min_ago,
             },
             project_id=self.project.id
         )
@@ -663,7 +668,7 @@ class JiraIntegrationTest(APITestCase):
         event = self.store_event(
             data={
                 'message': 'oh no',
-                'timestamp': timezone.now().isoformat()
+                'timestamp': self.min_ago,
             },
             project_id=self.project.id
         )

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -444,6 +444,7 @@ class JiraIntegrationTest(APITestCase):
             data={
                 'event_id': 'a' * 32,
                 'message': 'message',
+                'timestamp': timezone.now().isoformat(),
                 'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
             },
             project_id=self.project.id,
@@ -523,6 +524,7 @@ class JiraIntegrationTest(APITestCase):
             data={
                 'event_id': 'a' * 32,
                 'message': 'message',
+                'timestamp': timezone.now().isoformat(),
                 'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
             },
             project_id=self.project.id,
@@ -559,6 +561,7 @@ class JiraIntegrationTest(APITestCase):
             data={
                 'event_id': 'a' * 32,
                 'message': 'message',
+                'timestamp': timezone.now().isoformat(),
                 'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
             },
             project_id=self.project.id,
@@ -595,6 +598,7 @@ class JiraIntegrationTest(APITestCase):
             data={
                 'event_id': 'a' * 32,
                 'message': 'message',
+                'timestamp': timezone.now().isoformat(),
                 'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
             },
             project_id=self.project.id,

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -5,6 +5,7 @@ import mock
 import responses
 import six
 import pytest
+import copy
 
 from django.core.urlresolvers import reverse
 from django.utils import timezone
@@ -17,6 +18,7 @@ from sentry.models import (
 )
 from sentry.testutils import APITestCase
 from sentry.utils.http import absolute_uri
+from sentry.testutils.factories import DEFAULT_EVENT_DATA
 
 
 SAMPLE_CREATE_META_RESPONSE = """
@@ -438,8 +440,15 @@ class JiraIntegrationTest(APITestCase):
     def test_get_create_issue_config(self):
         org = self.organization
         self.login_as(self.user)
-        group = self.create_group()
-        self.create_event(group=group)
+        event = self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'message': 'message',
+                'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
+            },
+            project_id=self.project.id,
+        )
+        group = event.group
 
         installation = self.integration.get_installation(org.id)
 
@@ -462,7 +471,7 @@ class JiraIntegrationTest(APITestCase):
                 'required': True,
             }, {
                 'default': ('Sentry Issue: [%s|%s]\n\n{code}\n'
-                            'Stacktrace (most recent call last):\n\n  '
+                            'Stacktrace (most recent call first):\n\n  '
                             'File "sentry/models/foo.py", line 29, in build_msg\n    '
                             'string_max_length=self.string_max_length)\n\nmessage\n{code}'
                             ) % (
@@ -510,9 +519,15 @@ class JiraIntegrationTest(APITestCase):
     def test_get_create_issue_config_with_default_and_param(self):
         org = self.organization
         self.login_as(self.user)
-        group = self.create_group()
-        self.create_event(group=group)
-
+        event = self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'message': 'message',
+                'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
+            },
+            project_id=self.project.id,
+        )
+        group = event.group
         installation = self.integration.get_installation(org.id)
         installation.org_integration.config = {
             'project_issue_defaults': {
@@ -540,9 +555,15 @@ class JiraIntegrationTest(APITestCase):
     def test_get_create_issue_config_with_default(self):
         org = self.organization
         self.login_as(self.user)
-        group = self.create_group()
-        self.create_event(group=group)
-
+        event = self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'message': 'message',
+                'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
+            },
+            project_id=self.project.id,
+        )
+        group = event.group
         installation = self.integration.get_installation(org.id)
         installation.org_integration.config = {
             'project_issue_defaults': {
@@ -570,9 +591,15 @@ class JiraIntegrationTest(APITestCase):
     def test_get_create_issue_config_with_label_default(self):
         org = self.organization
         self.login_as(self.user)
-        group = self.create_group()
-        self.create_event(group=group)
-
+        event = self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'message': 'message',
+                'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
+            },
+            project_id=self.project.id,
+        )
+        group = event.group
         label_default = 'hi'
 
         installation = self.integration.get_installation(org.id)

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -7,6 +7,8 @@ import six
 from exam import fixture
 from django.test import RequestFactory
 from time import time
+from datetime import timedelta
+from django.utils import timezone
 
 from sentry.integrations.exceptions import IntegrationError
 from sentry.integrations.vsts.integration import VstsIntegration
@@ -349,8 +351,15 @@ class VstsIssueFormTest(VstsIssueBase):
                 ]
             },
         )
-        self.group = self.create_group()
-        self.create_event(group=self.group)
+        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        event = self.store_event(
+            data={
+                'fingerprint': ['group1'],
+                'timestamp': min_ago,
+            },
+            project_id=self.project.id,
+        )
+        self.group = event.group
 
     def tearDown(self):
         responses.reset()

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 
-import six
-
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pytest
 from django.db.models import ProtectedError
@@ -16,6 +14,14 @@ from sentry.testutils import TestCase
 
 
 class GroupTest(TestCase):
+
+    def setUp(self):
+        super(GroupTest, self).setUp()
+        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        self.two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
+        self.sec_ago = (timezone.now() - timedelta(seconds=1)).isoformat()[:19]
+        self.two_sec_ago = (timezone.now() - timedelta(seconds=1)).isoformat()[:19]
+
     def test_is_resolved(self):
         group = self.create_group(status=GroupStatus.RESOLVED)
         assert group.is_resolved()
@@ -36,56 +42,68 @@ class GroupTest(TestCase):
 
         assert group.is_resolved()
 
-    def test_get_oldest_latest_event_no_events(self):
-        group = self.create_group()
+    def test_get_latest_event_no_events(self):
+        project = self.create_project()
+        group = self.create_group(project=project)
         assert group.get_latest_event() is None
-        assert group.get_oldest_event() is None
 
-    def test_get_oldest_latest_events(self):
-        group = self.create_group()
-        for i in range(0, 3):
-            self.create_event(
-                event_id=six.text_type(i),
-                group=group,
-                datetime=datetime(2013, 8, 13, 3, 8, i),
-            )
-
-        assert group.get_latest_event().event_id == '2'
-        assert group.get_oldest_event().event_id == '0'
-
-    def test_get_oldest_latest_identical_timestamps(self):
-        group = self.create_group()
-        for i in range(0, 3):
-            self.create_event(
-                event_id=six.text_type(i),
-                group=group,
-                datetime=datetime(2013, 8, 13, 3, 8, 50),
-            )
-
-        assert group.get_latest_event().event_id == '2'
-        assert group.get_oldest_event().event_id == '0'
-
-    def test_get_oldest_latest_almost_identical_timestamps(self):
-        group = self.create_group()
-        self.create_event(
-            event_id='0',
-            group=group,
-            datetime=datetime(2013, 8, 13, 3, 8, 0),  # earliest
+    def test_get_latest_event(self):
+        self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'fingerprint': ['group-1'],
+                'timestamp': self.two_min_ago,
+            },
+            project_id=self.project.id,
         )
-        for i in range(1, 3):
-            self.create_event(
-                event_id=six.text_type(i),
-                group=group,
-                datetime=datetime(2013, 8, 13, 3, 8, 30),  # all in the middle
-            )
-        self.create_event(
-            event_id='3',
-            group=group,
-            datetime=datetime(2013, 8, 13, 3, 8, 59),  # latest
+        self.store_event(
+            data={
+                'event_id': 'b' * 32,
+                'fingerprint': ['group-1'],
+                'timestamp': self.min_ago,
+            },
+            project_id=self.project.id,
         )
 
-        assert group.get_latest_event().event_id == '3'
-        assert group.get_oldest_event().event_id == '0'
+        group = Group.objects.first()
+
+        assert group.get_latest_event().event_id == 'b' * 32
+
+    def test_get_latest_identical_timestamps(self):
+        events = []
+        for i in 'abc':
+            event = self.store_event(
+                data={
+                    'event_id': i * 32,
+                    'fingerprint': ['group-1'],
+                    'timestamp': self.min_ago,
+                },
+                project_id=self.project.id,
+            )
+            events.append(event)
+
+        assert events[0].group.get_latest_event().event_id == 'c' * 32
+
+    def test_get_latest_almost_identical_timestamps(self):
+        self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'fingerprint': ['group-1'],
+                'timestamp': self.two_sec_ago,
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'b' * 32,
+                'fingerprint': ['group-1'],
+                'timestamp': self.sec_ago,
+            },
+            project_id=self.project.id,
+        )
+        group = Group.objects.first()
+
+        assert group.get_latest_event().event_id == 'b' * 32
 
     def test_is_ignored_with_expired_snooze(self):
         group = self.create_group(

--- a/tests/sentry/plugins/bases/test_issue2.py
+++ b/tests/sentry/plugins/bases/test_issue2.py
@@ -4,7 +4,9 @@ from __future__ import absolute_import
 
 import json
 import mock
+from datetime import timedelta
 
+from django.utils import timezone
 from social_auth.models import UserSocialAuth
 
 from sentry.models import GroupMeta, User
@@ -80,12 +82,16 @@ class IssuePlugin2GroupActionTest(TestCase):
     def setUp(self):
         super(IssuePlugin2GroupActionTest, self).setUp()
         self.project = self.create_project()
-        self.group = self.create_group(project=self.project)
         self.plugin_instance = plugins.get(slug='issuetrackingplugin2')
-        self.event = self.create_event(
-            event_id='a',
-            group=self.group,
+        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        self.event = self.store_event(
+            data={
+                'timestamp': min_ago,
+                'fingerprint': ['group-1']
+            },
+            project_id=self.project.id
         )
+        self.group = self.event.group
 
     @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
     def test_get_create(self, *args):

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -435,8 +435,6 @@ class UnmergeTestCase(TestCase):
             events.values()[0],
         )
 
-        assert source.event_set.count() == 10
-
         assert set(
             EventMapping.objects.filter(
                 group_id=source.id,
@@ -496,8 +494,6 @@ class UnmergeTestCase(TestCase):
             lambda event: event.event_id,
             events.values()[1],
         )
-
-        assert destination.event_set.count() == 7
 
         assert set(
             EventMapping.objects.filter(

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -10,11 +10,10 @@ from exam import fixture
 from mock import patch, Mock
 
 from sentry.models import (
-    Activity, ApiToken, EventMapping, Group, GroupAssignee, GroupBookmark, GroupHash,
-    GroupLink, GroupResolution, GroupSeen, GroupShare, GroupSnooze, GroupStatus, GroupSubscription,
+    Activity, ApiToken, Group, GroupAssignee, GroupBookmark, GroupHash, GroupLink,
+    GroupResolution, GroupSeen, GroupShare, GroupSnooze, GroupStatus, GroupSubscription,
     GroupTombstone, ExternalIssue, Integration, Release, OrganizationIntegration, UserOption
 )
-from sentry.models.event import Event
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from six.moves.urllib.parse import quote
@@ -192,31 +191,31 @@ class GroupListTest(APITestCase, SnubaTestCase):
     def test_lookup_by_event_id(self):
         project = self.project
         project.update_option('sentry:resolve_age', 1)
-        group = self.create_group(checksum='a' * 32)
-        self.create_group(checksum='b' * 32)
         event_id = 'c' * 32
-        event = Event.objects.create(project_id=self.project.id, event_id=event_id)
-        EventMapping.objects.create(
-            event_id=event_id,
-            project=group.project,
-            group=group,
+        event = self.store_event(
+            data={
+                'event_id': event_id,
+                'timestamp': self.min_ago.isoformat()[:19],
+            },
+            project_id=self.project.id
         )
-
         self.login_as(user=self.user)
 
         response = self.client.get(u'{}?query={}'.format(self.path, 'c' * 32), format='json')
         assert response.status_code == 200
         assert len(response.data) == 1
-        assert response.data[0]['id'] == six.text_type(group.id)
+        assert response.data[0]['id'] == six.text_type(event.group.id)
         assert response.data[0]['matchingEventId'] == event.id
 
     def test_lookup_by_event_with_matching_environment(self):
         project = self.project
         project.update_option('sentry:resolve_age', 1)
         self.create_environment(name="test", project=project)
+
         event = self.store_event(
             data={
                 'environment': 'test',
+                'timestamp': self.min_ago.isoformat()[:19],
             },
             project_id=self.project.id,
         )
@@ -235,21 +234,20 @@ class GroupListTest(APITestCase, SnubaTestCase):
     def test_lookup_by_event_id_with_whitespace(self):
         project = self.project
         project.update_option('sentry:resolve_age', 1)
-        group = self.create_group(checksum='a' * 32)
-        self.create_group(checksum='b' * 32)
-        EventMapping.objects.create(
-            event_id='c' * 32,
-            project=group.project,
-            group=group,
+        event = self.store_event(
+            data={
+                'event_id': 'c' * 32,
+                'timestamp': self.min_ago.isoformat()[:19],
+            },
+            project_id=self.project.id
         )
-
         self.login_as(user=self.user)
         response = self.client.get(
             u'{}?query=%20%20{}%20%20'.format(self.path, 'c' * 32), format='json'
         )
         assert response.status_code == 200
         assert len(response.data) == 1
-        assert response.data[0]['id'] == six.text_type(group.id)
+        assert response.data[0]['id'] == six.text_type(event.group.id)
 
     def test_lookup_by_unknown_event_id(self):
         project = self.project


### PR DESCRIPTION
Refactor group model to always use events from Snuba instead of Postgres.
Rewrite a bunch of tests to use `store_event` instead of `create_event` as
this writes the events into Snuba.