### PR TITLE
feat(auth): Add react versions of login / register forms (no routes)

### DIFF
--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -42,6 +42,14 @@ export const User = PropTypes.shape({
   username: PropTypes.string,
 });
 
+export const AuthConfig = PropTypes.shape({
+  canRegister: PropTypes.bool,
+  serverHostname: PropTypes.string,
+  hasNewsletter: PropTypes.bool,
+  githubLoginLink: PropTypes.string,
+  vstsLoginLink: PropTypes.string,
+});
+
 export const Config = PropTypes.shape({
   dsn: PropTypes.string,
   features: PropTypes.instanceOf(Set),
@@ -990,6 +998,7 @@ const SentryTypes = {
     id: PropTypes.string.isRequired,
   }),
   Actor,
+  AuthConfig,
   Activity,
   AuthProvider,
   Config,

--- a/src/sentry/static/sentry/app/views/auth/layout.jsx
+++ b/src/sentry/static/sentry/app/views/auth/layout.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import styled from 'react-emotion';
+
+import InlineSvg from 'app/components/inlineSvg';
+import Link from 'app/components/links/link';
+import Panel from 'app/components/panels/panel';
+import space from 'app/styles/space';
+
+const BODY_CLASSES = ['narrow'];
+
+class Layout extends React.Component {
+  componentDidMount() {
+    document.body.classList.add(...BODY_CLASSES);
+  }
+
+  componentWillUnmount() {
+    document.body.classList.remove(...BODY_CLASSES);
+  }
+
+  render() {
+    const {children} = this.props;
+    return (
+      <div className="app">
+        <AuthContainer>
+          <div className="pattern-bg" />
+          <AuthPanel>
+            <AuthSidebar>
+              <SentryButton />
+            </AuthSidebar>
+            <div>{children}</div>
+          </AuthPanel>
+        </AuthContainer>
+      </div>
+    );
+  }
+}
+
+const AuthContainer = styled('div')`
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 5vh;
+`;
+
+const AuthPanel = styled(Panel)`
+  min-width: 550px;
+  display: inline-grid;
+  grid-template-columns: 60px 1fr;
+`;
+
+const AuthSidebar = styled('div')`
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: ${space(3)};
+  border-radius: ${p => p.theme.borderRadius} 0 0 ${p => p.theme.borderRadius};
+  margin: -1px;
+  margin-right: 0;
+  background: #564f64;
+  background-image: linear-gradient(
+    -180deg,
+    rgba(52, 44, 62, 0) 0%,
+    rgba(52, 44, 62, 0.5) 100%
+  );
+`;
+
+const SentryButton = styled(p => (
+  <Link to="/" {...p}>
+    <InlineSvg size="24px" src="icon-sentry" />
+  </Link>
+))`
+  color: #fff;
+
+  &:hover,
+  &:focus {
+    color: #fff;
+  }
+`;
+
+export default Layout;

--- a/src/sentry/static/sentry/app/views/auth/login.jsx
+++ b/src/sentry/static/sentry/app/views/auth/login.jsx
@@ -1,0 +1,144 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled, {css} from 'react-emotion';
+
+import {t} from 'app/locale';
+import LoadingError from 'app/components/loadingError';
+import LoadingIndicator from 'app/components/loadingIndicator';
+import NavTabs from 'app/components/navTabs';
+import space from 'app/styles/space';
+import withApi from 'app/utils/withApi';
+
+import LoginForm from './loginForm';
+import RegisterForm from './registerForm';
+import SsoForm from './ssoForm';
+
+const FORM_COMPONENTS = {
+  login: LoginForm,
+  register: RegisterForm,
+  sso: SsoForm,
+};
+
+class Login extends React.Component {
+  static propTypes = {
+    api: PropTypes.object,
+  };
+
+  state = {
+    loading: true,
+    error: null,
+    activeTab: 'login',
+    authConfig: {},
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  handleSetTab = (activeTab, event) => {
+    this.setState({activeTab});
+    event.preventDefault();
+  };
+
+  fetchData = async () => {
+    const {api} = this.props;
+    try {
+      const response = await api.requestPromise('/auth/login/');
+
+      const {vsts_login_link, github_login_link, ...config} = response;
+      const authConfig = {
+        ...config,
+        vstsLoginLink: vsts_login_link,
+        githubLoginLink: github_login_link,
+      };
+
+      this.setState({authConfig});
+    } catch (e) {
+      this.setState({error: true});
+    }
+
+    this.setState({loading: false});
+  };
+
+  get hasAuthProviders() {
+    const {githubLoginLink, vstsLoginLink} = this.state.authConfig;
+    return githubLoginLink || vstsLoginLink;
+  }
+
+  render() {
+    const {api} = this.props;
+    const {loading, error, activeTab, authConfig} = this.state;
+
+    const FormComponent = FORM_COMPONENTS[activeTab];
+
+    const tabs = [
+      ['login', t('Login')],
+      ['sso', t('Single Sign-On')],
+      ['register', t('Register'), !authConfig.canRegister],
+    ];
+
+    const renderTab = ([key, label, disabled]) =>
+      !disabled && (
+        <li key={key} className={activeTab === key ? 'active' : ''}>
+          <a href="#" onClick={e => this.handleSetTab(key, e)}>
+            {label}
+          </a>
+        </li>
+      );
+
+    return (
+      <React.Fragment>
+        <Header>
+          <Heading>{t('Sign in to continue')}</Heading>
+          <AuthNavTabs>{tabs.map(renderTab)}</AuthNavTabs>
+        </Header>
+        {loading && <LoadingIndicator />}
+        {error && (
+          <LoadingError
+            message={t('Unable to load authentication configuration')}
+            onRetry={this.fetchData}
+          />
+        )}
+        {!loading && !error && (
+          <FormWrapper hasAuthProviders={this.hasAuthProviders}>
+            <FormComponent {...{api, authConfig}} />
+          </FormWrapper>
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+const Header = styled('div')`
+  border-bottom: 1px solid ${p => p.theme.borderLight};
+  padding: 20px 40px 0;
+`;
+
+const Heading = styled('h3')`
+  font-size: 24px;
+  margin: 0 0 20px 0;
+`;
+
+const AuthNavTabs = styled(NavTabs)`
+  margin: 0;
+`;
+
+const FormWrapper = styled('div')`
+  padding: 35px;
+  width: ${p => (p.hasAuthProviders ? '600px' : '490px')};
+`;
+
+const formFooterClass = css`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  grid-gap: ${space(1)};
+  align-items: center;
+  justify-items: end;
+  border-top: none;
+  margin-bottom: 0;
+  padding: 0;
+`;
+
+export {formFooterClass};
+
+export default withApi(Login);

--- a/src/sentry/static/sentry/app/views/auth/loginForm.jsx
+++ b/src/sentry/static/sentry/app/views/auth/loginForm.jsx
@@ -1,0 +1,165 @@
+import {browserHistory} from 'react-router';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'react-emotion';
+
+import {formFooterClass} from 'app/views/auth/login';
+import {t} from 'app/locale';
+import Button from 'app/components/button';
+import ConfigStore from 'app/stores/configStore';
+import Form from 'app/components/forms/form';
+import Link from 'app/components/links/link';
+import PasswordField from 'app/components/forms/passwordField';
+import SentryTypes from 'app/sentryTypes';
+import TextField from 'app/components/forms/textField';
+import space from 'app/styles/space';
+
+// TODO(epurkhiser): The abstraction here would be much nicer if we just
+// exposed a configuration object telling us what auth providers there are.
+const LoginProviders = ({vstsLoginLink, githubLoginLink}) => (
+  <ProviderWrapper>
+    <ProviderHeading>{t('External Account Login')}</ProviderHeading>
+    {githubLoginLink && (
+      <Button align="left" size="small" icon="icon-github" href={githubLoginLink}>
+        {t('Sign in with GitHub')}
+      </Button>
+    )}
+    {vstsLoginLink && (
+      <Button align="left" size="small" icon="icon-vsts" href={vstsLoginLink}>
+        {t('Sign in with Azure DevOps')}
+      </Button>
+    )}
+  </ProviderWrapper>
+);
+
+LoginProviders.propTypes = {
+  githubLoginLink: PropTypes.string,
+  vstsLoginLink: PropTypes.string,
+};
+
+class LoginForm extends React.Component {
+  static propTypes = {
+    api: PropTypes.object,
+    authConfig: SentryTypes.AuthConfig,
+  };
+
+  state = {
+    errorMessage: null,
+    errors: {},
+  };
+
+  handleSubmit = async (data, onSuccess, onError) => {
+    try {
+      const response = await this.props.api.requestPromise('/auth/login/', {
+        method: 'POST',
+        data,
+      });
+      onSuccess(data);
+
+      // TODO(epurkhiser): There is likely more that needs to happen to update
+      // the application state after user login.
+
+      ConfigStore.set('user', response.user);
+
+      // TODO(epurkhiser): Reconfigure sentry SDK identity
+
+      browserHistory.push({pathname: response.nextUri});
+    } catch (e) {
+      if (!e.responseJSON || !e.responseJSON.errors) {
+        onError(e);
+        return;
+      }
+
+      let message = e.responseJSON.detail;
+      if (e.responseJSON.errors.__all__) {
+        message = e.responseJSON.errors.__all__;
+      }
+
+      this.setState({
+        errorMessage: message,
+        errors: e.responseJSON.errors || {},
+      });
+
+      onError(e);
+    }
+  };
+
+  render() {
+    const {errorMessage, errors} = this.state;
+    const {githubLoginLink, vstsLoginLink} = this.props.authConfig;
+
+    const hasLoginProvider = githubLoginLink || vstsLoginLink;
+
+    return (
+      <FormWrapper hasLoginProvider={hasLoginProvider}>
+        <Form
+          submitLabel={t('Continue')}
+          onSubmit={this.handleSubmit}
+          footerClass={formFooterClass}
+          errorMessage={errorMessage}
+          extraButton={
+            <LostPasswordLink to="/account/recover/">
+              {t('Lost your password?')}
+            </LostPasswordLink>
+          }
+        >
+          <TextField
+            name="username"
+            placeholder={t('username or email')}
+            label={t('Account')}
+            error={errors.username}
+            required
+          />
+          <PasswordField
+            name="password"
+            placeholder={t('password')}
+            label={t('Password')}
+            error={errors.password}
+            required
+          />
+        </Form>
+        {hasLoginProvider && <LoginProviders {...{vstsLoginLink, githubLoginLink}} />}
+      </FormWrapper>
+    );
+  }
+}
+
+const FormWrapper = styled('div')`
+  display: grid;
+  grid-gap: 60px;
+  grid-template-columns: ${p => (p.hasLoginProvider ? '1fr 0.8fr' : '1fr')};
+`;
+
+const ProviderHeading = styled('div')`
+  margin: 0;
+  font-size: 15px;
+  font-weight: bold;
+  line-height: 24px;
+`;
+
+const ProviderWrapper = styled('div')`
+  position: relative;
+  display: grid;
+  grid-auto-rows: max-content;
+  grid-gap: ${space(1.5)};
+
+  &:before {
+    position: absolute;
+    display: block;
+    content: '';
+    top: 0;
+    bottom: 0;
+    left: -30px;
+    border-left: 1px solid ${p => p.theme.borderLight};
+  }
+`;
+
+const LostPasswordLink = styled(Link)`
+  color: ${p => p.theme.gray2};
+
+  &:hover {
+    color: ${p => p.theme.gray5};
+  }
+`;
+
+export default LoginForm;

--- a/src/sentry/static/sentry/app/views/auth/registerForm.jsx
+++ b/src/sentry/static/sentry/app/views/auth/registerForm.jsx
@@ -1,0 +1,133 @@
+import {browserHistory} from 'react-router';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'react-emotion';
+
+import {formFooterClass} from 'app/views/auth/login';
+import {t, tct} from 'app/locale';
+import ConfigStore from 'app/stores/configStore';
+import ExternalLink from 'app/components/links/externalLink';
+import Form from 'app/components/forms/form';
+import PasswordField from 'app/components/forms/passwordField';
+import RadioBooleanField from 'app/components/forms/radioBooleanField';
+import SentryTypes from 'app/sentryTypes';
+import TextField from 'app/components/forms/textField';
+
+const SubscribeField = () => (
+  <RadioBooleanField
+    name="subscribe"
+    yesLabel={t('Yes, I would like to receive updates via email')}
+    noLabel={t("No, I'd prefer not to receive these updates")}
+    help={tct(
+      `We'd love to keep you updated via email with product and feature
+           announcements, promotions, educational materials, and events. Our
+           updates focus on relevant information, and we'll never sell your data
+           to third parties. See our [link] for more details.`,
+      {
+        link: <a href="https://sentry.io/privacy/">Privacy Policy</a>,
+      }
+    )}
+  />
+);
+
+class RegisterForm extends React.Component {
+  static propTypes = {
+    api: PropTypes.object,
+    authConfig: SentryTypes.AuthConfig,
+  };
+
+  state = {
+    errorMessage: null,
+    errors: {},
+  };
+
+  handleSubmit = async (data, onSuccess, onError) => {
+    const {api} = this.props;
+
+    try {
+      const response = await api.requestPromise('/auth/register/', {
+        method: 'POST',
+        data,
+      });
+      onSuccess(data);
+
+      // TODO(epurkhiser): There is more we need to do to setup the user. but
+      // definitely primarily we need to init our user.
+      ConfigStore.set('user', response.user);
+
+      browserHistory.push({pathname: response.nextUri});
+    } catch (e) {
+      if (!e.responseJSON || !e.responseJSON.errors) {
+        onError(e);
+        return;
+      }
+
+      let message = e.responseJSON.detail;
+      if (e.responseJSON.errors.__all__) {
+        message = e.responseJSON.errors.__all__;
+      }
+
+      this.setState({
+        errorMessage: message,
+        errors: e.responseJSON.errors || {},
+      });
+
+      onError(e);
+    }
+  };
+
+  render() {
+    const {hasNewsletter} = this.props.authConfig;
+    const {errorMessage, errors} = this.state;
+
+    return (
+      <Form
+        initialData={{subscribe: true}}
+        submitLabel={t('Continue')}
+        onSubmit={this.handleSubmit}
+        footerClass={formFooterClass}
+        errorMessage={errorMessage}
+        extraButton={
+          <PrivacyPolicyLink href="https://sentry.io/privacy/">
+            {t('Privacy Policy')}
+          </PrivacyPolicyLink>
+        }
+      >
+        <TextField
+          name="name"
+          placeholder={t('Jane Doe')}
+          maxlength={30}
+          label={t('Name')}
+          error={errors.name}
+          required
+        />
+        <TextField
+          name="username"
+          placeholder={t('you@example.com')}
+          maxlength={128}
+          label={t('Email')}
+          error={errors.username}
+          required
+        />
+        <PasswordField
+          name="password"
+          placeholder={t('something super secret')}
+          label={t('Password')}
+          error={errors.password}
+          required
+        />
+        {hasNewsletter && <SubscribeField />}
+      </Form>
+    );
+  }
+}
+
+const PrivacyPolicyLink = styled(ExternalLink)`
+  color: ${p => p.theme.gray2};
+
+  &:hover {
+    color: ${p => p.theme.gray5};
+  }
+`;
+
+export default RegisterForm;

--- a/src/sentry/static/sentry/app/views/auth/ssoForm.jsx
+++ b/src/sentry/static/sentry/app/views/auth/ssoForm.jsx
@@ -1,0 +1,73 @@
+import {browserHistory} from 'react-router';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {t, tct} from 'app/locale';
+import Form from 'app/components/forms/form';
+import SentryTypes from 'app/sentryTypes';
+import TextField from 'app/components/forms/textField';
+
+const SlugExample = p => (
+  <code>
+    {p.hostname}/<strong>{p.slug}</strong>
+  </code>
+);
+
+class SsoForm extends React.Component {
+  static propTypes = {
+    api: PropTypes.object,
+    authConfig: SentryTypes.AuthConfig,
+  };
+
+  state = {
+    errorMessage: null,
+  };
+
+  handleSubmit = async (data, onSuccess, onError) => {
+    const {api} = this.props;
+    try {
+      const response = await api.requestPromise('/auth/sso-locate/', {
+        method: 'POST',
+        data,
+      });
+      onSuccess(data);
+      browserHistory.push({pathname: response.nextUri});
+    } catch (e) {
+      if (!e.responseJSON) {
+        onError(e);
+        return;
+      }
+      const message = e.responseJSON.detail;
+      this.setState({errorMessage: message});
+      onError(e);
+    }
+  };
+
+  render() {
+    const {serverHostname} = this.props.authConfig;
+    const {errorMessage} = this.state;
+
+    return (
+      <Form
+        className="form-stacked"
+        submitLabel={t('Continue')}
+        onSubmit={this.handleSubmit}
+        footerClass="auth-footer"
+        errorMessage={errorMessage}
+      >
+        <TextField
+          name="organization"
+          placeholder="acme"
+          label={t('Organization ID')}
+          required
+          help={tct('Your ID is the slug after the hostname. e.g. [example] is [slug].', {
+            slug: <strong>acme</strong>,
+            example: <SlugExample slug="acme" hostname={serverHostname} />,
+          })}
+        />
+      </Form>
+    );
+  }
+}
+
+export default SsoForm;

--- a/tests/js/spec/views/auth/login.spec.jsx
+++ b/tests/js/spec/views/auth/login.spec.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import Login from 'app/views/auth/login';
+
+describe('Login', function() {
+  it('renders a loading indicator', function() {
+    const wrapper = mount(<Login />);
+
+    expect(wrapper.find('LoadingIndicator').exists()).toBe(true);
+  });
+
+  it('renders an error if auth config cannot be loaded', async function() {
+    MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      statusCode: 500,
+    });
+
+    const wrapper = mount(<Login />);
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('LoadingError').exists()).toBe(true);
+    expect(wrapper.find('LoginForm').exists()).toBe(false);
+  });
+
+  it('does not show register when disabled', function() {
+    MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      body: {canRegister: false},
+    });
+
+    const wrapper = mount(<Login />);
+
+    expect(
+      wrapper
+        .find('AuthNavTabs a')
+        .filter({children: 'Register'})
+        .exists()
+    ).toBe(false);
+  });
+
+  it('shows register when canRegister is enabled', async function() {
+    MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      body: {canRegister: true},
+    });
+
+    const wrapper = mount(<Login />);
+
+    await tick();
+    wrapper.update();
+
+    expect(
+      wrapper
+        .find('AuthNavTabs a')
+        .filter({children: 'Register'})
+        .exists()
+    ).toBe(true);
+  });
+
+  it('toggles between tabs', async function() {
+    MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      body: {canRegister: true},
+    });
+
+    const wrapper = mount(<Login />);
+
+    await tick();
+    wrapper.update();
+
+    const tabs = wrapper.find('AuthNavTabs a');
+
+    // Default tab is login
+    expect(wrapper.find('LoginForm').exists()).toBe(true);
+
+    tabs.filter({children: 'Single Sign-On'}).simulate('click');
+    expect(wrapper.find('SsoForm').exists()).toBe(true);
+
+    tabs.filter({children: 'Register'}).simulate('click');
+    expect(wrapper.find('RegisterForm').exists()).toBe(true);
+  });
+});

--- a/tests/js/spec/views/auth/loginForm.spec.jsx
+++ b/tests/js/spec/views/auth/loginForm.spec.jsx
@@ -1,0 +1,86 @@
+import {browserHistory} from 'react-router';
+import React from 'react';
+
+import {mount} from 'enzyme';
+import ConfigStore from 'app/stores/configStore';
+import LoginForm from 'app/views/auth/loginForm';
+
+function doLogin(wrapper, apiRequest) {
+  wrapper.find('#id-username').simulate('change', {target: {value: 'test@test.com'}});
+  wrapper.find('#id-password').simulate('change', {target: {value: '12345pass'}});
+
+  wrapper.find('form').simulate('submit');
+
+  expect(apiRequest).toHaveBeenCalledWith(
+    '/auth/login/',
+    expect.objectContaining({
+      data: {username: 'test@test.com', password: '12345pass'},
+    })
+  );
+}
+
+describe('LoginForm', function() {
+  const routerContext = TestStubs.routerContext();
+  const api = new MockApiClient();
+
+  it('handles errors', async function() {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      statusCode: 400,
+      body: {
+        detail: 'Bad username password',
+      },
+    });
+
+    const authConfig = {};
+
+    const wrapper = mount(<LoginForm api={api} authConfig={authConfig} />, routerContext);
+    doLogin(wrapper, mockRequest);
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('.alert').exists()).toBe(true);
+  });
+
+  it('handles success', async function() {
+    const userObject = {
+      id: 1,
+      name: 'Joe',
+    };
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      statusCode: 200,
+      body: {
+        user: userObject,
+        nextUri: '/next/',
+      },
+    });
+
+    const authConfig = {};
+    const wrapper = mount(<LoginForm api={api} authConfig={authConfig} />, routerContext);
+
+    doLogin(wrapper, mockRequest);
+
+    await tick();
+
+    expect(ConfigStore.get('user')).toEqual(userObject);
+    expect(browserHistory.push).toHaveBeenCalledWith({pathname: '/next/'});
+  });
+
+  it('renders login provider buttons', function() {
+    const authConfig = {
+      vstsLoginLink: '/vstsLogin',
+      githubLoginLink: '/githubLogin',
+    };
+
+    const wrapper = mount(<LoginForm api={api} authConfig={authConfig} />, routerContext);
+
+    expect(wrapper.find('ProviderWrapper Button').map(b => b.props().href)).toEqual(
+      expect.arrayContaining(['/vstsLogin', '/githubLogin'])
+    );
+  });
+});

--- a/tests/js/spec/views/auth/registerForm.spec.jsx
+++ b/tests/js/spec/views/auth/registerForm.spec.jsx
@@ -1,0 +1,85 @@
+import {browserHistory} from 'react-router';
+import React from 'react';
+
+import {mount} from 'enzyme';
+import ConfigStore from 'app/stores/configStore';
+import RegisterForm from 'app/views/auth/registerForm';
+
+function doLogin(wrapper, apiRequest) {
+  wrapper.find('#id-name').simulate('change', {target: {value: 'joe'}});
+  wrapper.find('#id-username').simulate('change', {target: {value: 'test@test.com'}});
+  wrapper.find('#id-password').simulate('change', {target: {value: '12345pass'}});
+
+  wrapper.find('form').simulate('submit');
+
+  expect(apiRequest).toHaveBeenCalledWith(
+    '/auth/register/',
+    expect.objectContaining({
+      data: {
+        name: 'joe',
+        username: 'test@test.com',
+        password: '12345pass',
+        subscribe: true,
+      },
+    })
+  );
+}
+
+describe('Register', function() {
+  const routerContext = TestStubs.routerContext();
+  const api = new MockApiClient();
+
+  it('handles errors', async function() {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/auth/register/',
+      method: 'POST',
+      statusCode: 400,
+      body: {
+        detail: 'Registration failed',
+      },
+    });
+
+    const authConfig = {};
+
+    const wrapper = mount(
+      <RegisterForm api={api} authConfig={authConfig} />,
+      routerContext
+    );
+    doLogin(wrapper, mockRequest);
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('.alert').exists()).toBe(true);
+  });
+
+  it('handles success', async function() {
+    const userObject = {
+      id: 1,
+      name: 'Joe',
+    };
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/auth/register/',
+      method: 'POST',
+      statusCode: 200,
+      body: {
+        user: userObject,
+        nextUri: '/next/',
+      },
+    });
+
+    const authConfig = {};
+    const wrapper = mount(
+      <RegisterForm api={api} authConfig={authConfig} />,
+      routerContext
+    );
+
+    doLogin(wrapper, mockRequest);
+
+    await tick();
+
+    expect(ConfigStore.get('user')).toEqual(userObject);
+    expect(browserHistory.push).toHaveBeenCalledWith({pathname: '/next/'});
+  });
+});

--- a/tests/js/spec/views/auth/ssoForm.spec.jsx
+++ b/tests/js/spec/views/auth/ssoForm.spec.jsx
@@ -1,0 +1,74 @@
+import {browserHistory} from 'react-router';
+import React from 'react';
+
+import {mount} from 'enzyme';
+import SsoForm from 'app/views/auth/ssoForm';
+
+function doSso(wrapper, apiRequest) {
+  wrapper.find('#id-organization').simulate('change', {target: {value: 'org123'}});
+
+  wrapper.find('form').simulate('submit');
+
+  expect(apiRequest).toHaveBeenCalledWith(
+    '/auth/sso-locate/',
+    expect.objectContaining({data: {organization: 'org123'}})
+  );
+}
+
+describe('SsoForm', function() {
+  const routerContext = TestStubs.routerContext();
+  const api = new MockApiClient();
+
+  it('renders', function() {
+    const authConfig = {
+      serverHostname: 'testserver',
+    };
+
+    const wrapper = mount(<SsoForm api={api} authConfig={authConfig} />, routerContext);
+
+    expect(wrapper.find('.help-block').text()).toBe(
+      'Your ID is the slug after the hostname. e.g. testserver/acme is acme.'
+    );
+  });
+
+  it('handles errors', async function() {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/auth/sso-locate/',
+      method: 'POST',
+      statusCode: 400,
+      body: {
+        detail: 'Invalid org name',
+      },
+    });
+
+    const authConfig = {};
+
+    const wrapper = mount(<SsoForm api={api} authConfig={authConfig} />, routerContext);
+    doSso(wrapper, mockRequest);
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('.alert').exists()).toBe(true);
+  });
+
+  it('handles success', async function() {
+    const mockRequest = MockApiClient.addMockResponse({
+      url: '/auth/sso-locate/',
+      method: 'POST',
+      statusCode: 200,
+      body: {
+        nextUri: '/next/',
+      },
+    });
+
+    const authConfig = {};
+    const wrapper = mount(<SsoForm api={api} authConfig={authConfig} />, routerContext);
+
+    doSso(wrapper, mockRequest);
+
+    await tick();
+
+    expect(browserHistory.push).toHaveBeenCalledWith({pathname: '/next/'});
+  });
+});


### PR DESCRIPTION
This adds an initial version of the auth / register views.

These components will not yet be rendered anywhere as they have not yet been included in the route tree.

Pretty much matches the current login pages
![image](https://user-images.githubusercontent.com/1421724/60745897-3309b980-9f31-11e9-9873-b8a250d5d62c.png)

Sentry w/ registration:
![image](https://user-images.githubusercontent.com/1421724/60745983-79f7af00-9f31-11e9-881e-7e5925206fea.png)
