### PR TITLE
feat(ui) Add micro button size

### DIFF
--- a/docs-ui/components/button.stories.js
+++ b/docs-ui/components/button.stories.js
@@ -51,7 +51,7 @@ storiesOf('UI|Buttons', module)
           </Item>
 
           <Item>
-            <Button to={''} disabled onClick={action('click disabled')}>
+            <Button to="" disabled onClick={action('click disabled')}>
               Disabled Button
             </Button>
           </Item>
@@ -59,6 +59,14 @@ storiesOf('UI|Buttons', module)
 
         <Section>
           <h2>Sizes</h2>
+          <Item>
+            <Button size="micro">Micro</Button>
+          </Item>
+
+          <Item>
+            <Button size="zero">Zero</Button>
+          </Item>
+
           <Item>
             <Button size="xsmall">Extra Small</Button>
           </Item>
@@ -86,6 +94,9 @@ storiesOf('UI|Buttons', module)
               <Button size="small" icon="icon-github">
                 View on GitHub
               </Button>
+            </Item>
+            <Item>
+              <Button size="micro" icon="icon-trash" />
             </Item>
           </div>
         </Section>

--- a/src/sentry/static/sentry/app/components/button.jsx
+++ b/src/sentry/static/sentry/app/components/button.jsx
@@ -12,7 +12,7 @@ import Tooltip from 'app/components/tooltip';
 class Button extends React.Component {
   static propTypes = {
     priority: PropTypes.oneOf(['default', 'primary', 'danger', 'link', 'success']),
-    size: PropTypes.oneOf(['zero', 'small', 'xsmall', 'large']),
+    size: PropTypes.oneOf(['zero', 'micro', 'small', 'xsmall', 'large']),
     disabled: PropTypes.bool,
     busy: PropTypes.bool,
     /**
@@ -126,7 +126,9 @@ class Button extends React.Component {
             <Icon size={size} hasChildren={!!children}>
               <StyledInlineSvg
                 src={icon}
-                size={size && size.endsWith('small') ? '12px' : '16px'}
+                size={
+                  (size && size.endsWith('small')) || size === 'micro' ? '12px' : '16px'
+                }
               />
             </Icon>
           )}
@@ -152,6 +154,7 @@ export default Button;
 
 const getFontSize = ({size, theme}) => {
   switch (size) {
+    case 'micro':
     case 'xsmall':
     case 'small':
       return theme.fontSizeSmall;
@@ -263,6 +266,7 @@ const getLabelPadding = ({size, priority, borderless}) => {
   }
 
   switch (size) {
+    case 'micro':
     case 'zero':
       return '0';
     case 'xsmall':


### PR DESCRIPTION
Add an even smaller button size to allow buttons inside buttons size pill elements to use standard components. This button size is needed by the changes in #13898.

![Screen Shot 2019-07-08 at 11 19 17 AM](https://user-images.githubusercontent.com/24086/60821853-5ec7b200-a172-11e9-8b2b-e9b5d136cb90.png)
