### PR TITLE
plugins(ui): Hide plugins from Legacy Integrations page v1

### DIFF
--- a/src/sentry/static/sentry/app/views/projectPluginDetails.jsx
+++ b/src/sentry/static/sentry/app/views/projectPluginDetails.jsx
@@ -10,6 +10,8 @@ import PluginConfig from 'app/components/pluginConfig';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import withPlugins from 'app/utils/withPlugins';
 
+import {DEPRECATED_PLUGINS} from 'app/views/projectPlugins/constants';
+
 /**
  * There are currently two sources of truths for plugin details:
  *
@@ -79,9 +81,19 @@ class ProjectPluginDetails extends AsyncView {
   renderActions() {
     const {pluginDetails} = this.state;
     const enabled = this.getEnabled();
+    const {pluginId} = this.props.params;
 
+    let disabled = false;
+    if (DEPRECATED_PLUGINS.includes(pluginId)) {
+      disabled = true;
+    }
     const enable = (
-      <Button size="small" onClick={this.handleEnable} style={{marginRight: '6px'}}>
+      <Button
+        disabled={disabled}
+        size="small"
+        onClick={this.handleEnable}
+        style={{marginRight: '6px'}}
+      >
         {t('Enable Plugin')}
       </Button>
     );

--- a/src/sentry/static/sentry/app/views/projectPluginDetails.jsx
+++ b/src/sentry/static/sentry/app/views/projectPluginDetails.jsx
@@ -83,10 +83,8 @@ class ProjectPluginDetails extends AsyncView {
     const enabled = this.getEnabled();
     const {pluginId} = this.props.params;
 
-    let disabled = false;
-    if (DEPRECATED_PLUGINS.includes(pluginId)) {
-      disabled = true;
-    }
+    const disabled = DEPRECATED_PLUGINS.includes(pluginId);
+
     const enable = (
       <Button
         disabled={disabled}

--- a/src/sentry/static/sentry/app/views/projectPlugins/constants.jsx
+++ b/src/sentry/static/sentry/app/views/projectPlugins/constants.jsx
@@ -1,0 +1,1 @@
+export const DEPRECATED_PLUGINS = ['taiga', 'lighthouse', 'grove-io'];

--- a/src/sentry/static/sentry/app/views/projectPlugins/projectPlugins.jsx
+++ b/src/sentry/static/sentry/app/views/projectPlugins/projectPlugins.jsx
@@ -16,6 +16,8 @@ import ProjectPluginRow from 'app/views/projectPlugins/projectPluginRow';
 import RouteError from 'app/views/routeError';
 import SentryTypes from 'app/sentryTypes';
 
+import {DEPRECATED_PLUGINS} from './constants';
+
 class ProjectPlugins extends Component {
   static propTypes = {
     plugins: PropTypes.arrayOf(SentryTypes.PluginShape),
@@ -65,7 +67,12 @@ class ProjectPlugins extends Component {
           </PanelAlert>
 
           {plugins
-            .filter(p => !p.isHidden)
+            .filter(p => {
+              if (DEPRECATED_PLUGINS.includes(p.id) && !p.enabled) {
+                return false;
+              }
+              return !p.isHidden;
+            })
             .map(plugin => (
               <PanelItem key={plugin.id}>
                 <ProjectPluginRow


### PR DESCRIPTION
This hides a select few to be hidden from the Legacy Integrations page if they are 
1. Listed in DEPRECATED_PLUGINS
2. Not currently enabled for that project

This also hides the enable button in case someone tries to hard code the url i.e. `.../plugins/taiga/`
![Screen Shot 2019-07-08 at 12 02 20 PM](https://user-images.githubusercontent.com/15368179/60845772-3a7bcd80-a192-11e9-8ea6-470ff1fc8d3e.png)
