### PR TITLE
fix: Pass the correct query to the /organizations/:org-slug/events-meta/ endpoint

### DIFF
--- a/src/sentry/static/sentry/app/__mocks__/api.jsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.jsx
@@ -20,7 +20,7 @@ class Client {
   }
 
   // Returns a jest mock that represents Client.request calls
-  static addMockResponse(response) {
+  static addMockResponse(response, predicate = () => true) {
     const mock = jest.fn();
     Client.mockResponses.unshift([
       {
@@ -32,14 +32,19 @@ class Client {
         headers: response.headers || {},
       },
       mock,
+      predicate,
     ]);
 
     return mock;
   }
 
   static findMockResponse(url, options) {
-    return Client.mockResponses.find(([response]) => {
-      return url === response.url && (options.method || 'GET') === response.method;
+    return Client.mockResponses.find(([response, mock, predicate]) => {
+      const matchesURL = url === response.url;
+      const matchesMethod = (options.method || 'GET') === response.method;
+      const matchesPredicate = predicate(url, options);
+
+      return matchesURL && matchesMethod && matchesPredicate;
     });
   }
 

--- a/src/sentry/static/sentry/app/__mocks__/api.jsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.jsx
@@ -12,6 +12,10 @@ const respond = (isAsync, fn, ...args) => {
   }
 };
 
+const DEFAULT_MOCK_RESPONSE_OPTIONS = {
+  predicate: () => true,
+};
+
 class Client {
   static mockResponses = [];
 
@@ -20,7 +24,7 @@ class Client {
   }
 
   // Returns a jest mock that represents Client.request calls
-  static addMockResponse(response, predicate = () => true) {
+  static addMockResponse(response, options = DEFAULT_MOCK_RESPONSE_OPTIONS) {
     const mock = jest.fn();
     Client.mockResponses.unshift([
       {
@@ -32,7 +36,7 @@ class Client {
         headers: response.headers || {},
       },
       mock,
-      predicate,
+      options.predicate,
     ]);
 
     return mock;

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/tags.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/tags.jsx
@@ -8,7 +8,12 @@ import SentryTypes from 'app/sentryTypes';
 import Placeholder from 'app/components/placeholder';
 import TagDistributionMeter from 'app/components/tagDistributionMeter';
 import withApi from 'app/utils/withApi';
-import {fetchTagDistribution, fetchTotalCount, getEventTagSearchUrl} from './utils';
+import {
+  fetchTagDistribution,
+  fetchTotalCount,
+  getEventTagSearchUrl,
+  getQuery,
+} from './utils';
 import {MODAL_QUERY_KEYS} from './data';
 
 class Tags extends React.Component {
@@ -61,7 +66,11 @@ class Tags extends React.Component {
     });
 
     try {
-      const totalValues = await fetchTotalCount(api, organization.slug, location.query);
+      const totalValues = await fetchTotalCount(
+        api,
+        organization.slug,
+        getQuery(view, location)
+      );
       this.setState({totalValues});
     } catch (err) {
       Sentry.captureException(err);

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
@@ -1,4 +1,4 @@
-import {pick} from 'lodash';
+import {pick, get} from 'lodash';
 
 import {DEFAULT_PER_PAGE} from 'app/constants';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
@@ -25,7 +25,9 @@ export function getQuery(view, location) {
   const fields = [];
   const groupby = view.data.groupby ? [...view.data.groupby] : [];
 
-  view.data.fields.forEach(field => {
+  const viewFields = get(view, 'data.fields', []);
+
+  viewFields.forEach(field => {
     if (SPECIAL_FIELDS.hasOwnProperty(field)) {
       const specialField = SPECIAL_FIELDS[field];
 

--- a/tests/js/spec/views/organizationEventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/tags.spec.jsx
@@ -7,15 +7,35 @@ import {Tags} from 'app/views/organizationEventsV2/tags';
 describe('Tags', function() {
   const org = TestStubs.Organization();
   beforeEach(function() {
-    Client.addMockResponse({
-      url: `/organizations/${org.slug}/events-distribution/`,
-      body: {
-        key: 'release',
-        name: 'Release',
-        totalValues: 2,
-        topValues: [{count: 2, value: 'abcd123', name: 'abcd123'}],
+    Client.addMockResponse(
+      {
+        url: `/organizations/${org.slug}/events-distribution/`,
+        body: {
+          key: 'release',
+          name: 'Release',
+          totalValues: 2,
+          topValues: [{count: 2, value: 'abcd123', name: 'abcd123'}],
+        },
       },
-    });
+      function predicate(url, options) {
+        return options.query.key === 'release';
+      }
+    );
+
+    Client.addMockResponse(
+      {
+        url: `/organizations/${org.slug}/events-distribution/`,
+        body: {
+          key: 'environment',
+          name: 'Environment',
+          totalValues: 2,
+          topValues: [{count: 2, value: 'abcd123', name: 'abcd123'}],
+        },
+      },
+      function predicate(url, options) {
+        return options.query.key === 'environment';
+      }
+    );
 
     Client.addMockResponse({
       url: `/organizations/${org.slug}/events-meta/`,
@@ -47,9 +67,13 @@ describe('Tags', function() {
       />
     );
 
+    // component is in loading state
     expect(wrapper.find('StyledPlaceholder')).toHaveLength(2);
+
     await tick();
     wrapper.update();
+
+    // component has loaded
     expect(wrapper.find('StyledPlaceholder')).toHaveLength(0);
   });
 });

--- a/tests/js/spec/views/organizationEventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/tags.spec.jsx
@@ -17,8 +17,10 @@ describe('Tags', function() {
           topValues: [{count: 2, value: 'abcd123', name: 'abcd123'}],
         },
       },
-      function predicate(url, options) {
-        return options.query.key === 'release';
+      {
+        predicate: (url, options) => {
+          return options.query.key === 'release';
+        },
       }
     );
 
@@ -32,8 +34,10 @@ describe('Tags', function() {
           topValues: [{count: 2, value: 'abcd123', name: 'abcd123'}],
         },
       },
-      function predicate(url, options) {
-        return options.query.key === 'environment';
+      {
+        predicate: (url, options) => {
+          return options.query.key === 'environment';
+        },
       }
     );
 


### PR DESCRIPTION
This ensures tags correctly reflect the active view/tab (e.g. CSP or Errors).

See screenshots below.

-----

Before:

![Screen Shot 2019-07-08 at 4 48 26 PM](https://user-images.githubusercontent.com/139499/60842051-3b682b80-a1a1-11e9-889e-f21813f7eed9.png)

After:

![Screen Shot 2019-07-08 at 4 48 36 PM](https://user-images.githubusercontent.com/139499/60842068-4753ed80-a1a1-11e9-88f5-6c5b79e99c6a.png)
