### PR TITLE
build: Remove browser-reload flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "test-staged": "yarn test --findRelatedTests $(git diff --name-only --cached)",
     "lint": "node_modules/.bin/eslint tests/js src/sentry/static/sentry/app --ext .js,.jsx,.ts,.tsx",
     "lint:css": "stylelint 'src/sentry/static/sentry/app/**/*.jsx'",
-    "dev": "(yarn check --verify-tree || yarn install --check-files) && sentry devserver --browser-reload",
+    "dev": "(yarn check --verify-tree || yarn install --check-files) && sentry devserver",
     "dev-server": "webpack-dev-server",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "storybook-build": "build-storybook -c .storybook -o .storybook-out && sed -i -e 's/\\/sb_dll/sb_dll/g' .storybook-out/index.html",

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -21,11 +21,6 @@ from sentry.runner.decorators import configuration, log_options
 )
 @click.option('--workers/--no-workers', default=False, help='Run asynchronous workers.')
 @click.option(
-    '--browser-reload/--no-browser-reload',
-    default=False,
-    help='Automatic browser refreshing on webpack builds'
-)
-@click.option(
     '--prefix/--no-prefix',
     default=True,
     help='Show the service name prefix and timestamp'
@@ -44,7 +39,7 @@ from sentry.runner.decorators import configuration, log_options
 )
 @log_options()
 @configuration
-def devserver(reload, watchers, workers, browser_reload, styleguide, prefix, environment, bind):
+def devserver(reload, watchers, workers, styleguide, prefix, environment, bind):
     "Starts a lightweight web server for development."
     if ':' in bind:
         host, port = bind.split(':', 1)
@@ -107,13 +102,12 @@ def devserver(reload, watchers, workers, browser_reload, styleguide, prefix, env
 
     daemons = []
 
+    # We proxy all requests through webpacks devserver on the configured port.
+    # The backend is served on port+1 and is proxied via the webpack
+    # configuration.
     if watchers:
         daemons += settings.SENTRY_WATCHERS
 
-    # When using browser_reload we proxy all requests through webpacks
-    # devserver on the configured port. The backend is served on port+1 and is
-    # proxied via the webpack configuration.
-    if watchers and browser_reload:
         proxy_port = port
         port = port + 1
 


### PR DESCRIPTION
Without using this flag the watchers rebuild files on disk and django servers the assets. Instead it is much faster to just always use webpack as a proxy server.

For frontend development this will always be faster to recompile and server assets from memory. For backend development this will very minimally affect any response times, and you can always just run without --watchers and run webpack once to build assets.

Will write an email once this goes out.