### PR TITLE
Add quotes around fix missing symbols URL

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
@@ -324,7 +324,7 @@ class ProjectProcessingIssues extends React.Component {
                 )}
               </label>
               <AutoSelectText className="form-control disabled" style={{marginBottom: 6}}>
-                curl -sL {fixLink} | bash
+                curl -sL "{fixLink}" | bash
               </AutoSelectText>
             </div>
           </div>


### PR DESCRIPTION
When copy/pasting this command in [fish](https://fishshell.com/) (untested in other shells) the shell will try to expand the URL due to the `?` in the URL (``No matches for wildcard 'https://sentry.io/api/0/projects/[...]/processingissues/fix?_=[...]'. See `help expand`.``)

This was raised in support request 22916. Colleen was kind enough to point me to this line of code.

I am not totally familiar with JSX syntax so I hope that simply adding quotes works and does not need any escaping.