### PR TITLE
feat(api): Add option to fetch Organization details without Projects and Teams

### DIFF
--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -11,7 +11,7 @@ from sentry import roles
 from sentry.api.base import Endpoint, SessionAuthentication
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.organization import DetailedOrganizationSerializer
+from sentry.api.serializers.models.organization import DetailedOrganizationSerializerWithProjectsAndTeams
 from sentry.utils.signing import unsign
 from sentry.models import (
     AuditLogEntryEvent, OrganizationMember, Organization, OrganizationStatus, Team, Project
@@ -70,7 +70,7 @@ class AcceptProjectTransferEndpoint(Endpoint):
             'organizations': serialize(
                 list(organizations),
                 request.user,
-                DetailedOrganizationSerializer(),
+                DetailedOrganizationSerializerWithProjectsAndTeams(),
                 access=request.access
             ),
             'project': {

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -317,8 +317,8 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                                           team should be created for.
         :auth: required
         """
-        is_light = request.GET.get('light') == '1'
-        serializer = org_serializers.LightDetailedOrganizationSerializer if is_light else org_serializers.DetailedOrganizationSerializer
+        is_detailed = request.GET.get('detailed', '1') != '0'
+        serializer = org_serializers.DetailedOrganizationProjectsAndTeamsSerializer if is_detailed else org_serializers.DetailedOrganizationSerializerWithProjectsAndTeams
         context = serialize(
             organization,
             request.user,
@@ -390,7 +390,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                 serialize(
                     organization,
                     request.user,
-                    org_serializers.DetailedOrganizationSerializer(),
+                    org_serializers.DetailedOrganizationSerializerWithProjectsAndTeams(),
                     access=request.access,
                 )
             )
@@ -461,7 +461,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         context = serialize(
             organization,
             request.user,
-            org_serializers.DetailedOrganizationSerializer(),
+            org_serializers.DetailedOrganizationSerializerWithProjectsAndTeams(),
             access=request.access,
         )
         return self.respond(context, status=202)

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -315,6 +315,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
 
         :pparam string organization_slug: the slug of the organization the
                                           team should be created for.
+        :param string detailed: Specify '0' to retrieve details without projects and teams.
         :auth: required
         """
         is_detailed = request.GET.get('detailed', '1') != '0'

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -317,8 +317,8 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                                           team should be created for.
         :auth: required
         """
-        is_skinny = request.GET.get('skinny') == '1'
-        serializer = org_serializers.SkinnyDetailedOrganizationSerializer if is_skinny else org_serializers.DetailedOrganizationSerializer
+        is_light = request.GET.get('light') == '1'
+        serializer = org_serializers.LightDetailedOrganizationSerializer if is_light else org_serializers.DetailedOrganizationSerializer
         context = serialize(
             organization,
             request.user,

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -317,10 +317,12 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
                                           team should be created for.
         :auth: required
         """
+        is_skinny = request.GET.get('skinny') == '1'
+        serializer = org_serializers.SkinnyDetailedOrganizationSerializer if is_skinny else org_serializers.DetailedOrganizationSerializer
         context = serialize(
             organization,
             request.user,
-            org_serializers.DetailedOrganizationSerializer(),
+            serializer(),
             access=request.access,
         )
         return self.respond(context)

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -319,7 +319,7 @@ class OrganizationDetailsEndpoint(OrganizationEndpoint):
         :auth: required
         """
         is_detailed = request.GET.get('detailed', '1') != '0'
-        serializer = org_serializers.DetailedOrganizationProjectsAndTeamsSerializer if is_detailed else org_serializers.DetailedOrganizationSerializerWithProjectsAndTeams
+        serializer = org_serializers.DetailedOrganizationSerializerWithProjectsAndTeams if is_detailed else org_serializers.DetailedOrganizationSerializer
         context = serialize(
             organization,
             request.user,

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -117,9 +117,9 @@ class OnboardingTasksSerializer(Serializer):
 
 
 # Does not include project/teams list
-class SkinnyDetailedOrganizationSerializer(OrganizationSerializer):
+class LightDetailedOrganizationSerializer(OrganizationSerializer):
     def get_attrs(self, item_list, user, **kwargs):
-        return super(SkinnyDetailedOrganizationSerializer, self).get_attrs(item_list, user)
+        return super(LightDetailedOrganizationSerializer, self).get_attrs(item_list, user)
 
     def serialize(self, obj, attrs, user, access):
         from sentry import experiments
@@ -132,7 +132,7 @@ class SkinnyDetailedOrganizationSerializer(OrganizationSerializer):
 
         experiment_assignments = experiments.all(org=obj, actor=user)
 
-        context = super(SkinnyDetailedOrganizationSerializer, self).serialize(obj, attrs, user)
+        context = super(LightDetailedOrganizationSerializer, self).serialize(obj, attrs, user)
         max_rate = quotas.get_maximum_quota(obj)
         context['experiments'] = experiment_assignments
         context['quota'] = {
@@ -183,7 +183,7 @@ class SkinnyDetailedOrganizationSerializer(OrganizationSerializer):
         return context
 
 
-class DetailedOrganizationSerializer(SkinnyDetailedOrganizationSerializer):
+class DetailedOrganizationSerializer(LightDetailedOrganizationSerializer):
     def get_attrs(self, item_list, user, **kwargs):
         return super(DetailedOrganizationSerializer, self).get_attrs(item_list, user)
 

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -117,9 +117,9 @@ class OnboardingTasksSerializer(Serializer):
 
 
 # Does not include project/teams list
-class LightDetailedOrganizationSerializer(OrganizationSerializer):
+class DetailedOrganizationSerializer(OrganizationSerializer):
     def get_attrs(self, item_list, user, **kwargs):
-        return super(LightDetailedOrganizationSerializer, self).get_attrs(item_list, user)
+        return super(DetailedOrganizationSerializer, self).get_attrs(item_list, user)
 
     def serialize(self, obj, attrs, user, access):
         from sentry import experiments
@@ -132,7 +132,7 @@ class LightDetailedOrganizationSerializer(OrganizationSerializer):
 
         experiment_assignments = experiments.all(org=obj, actor=user)
 
-        context = super(LightDetailedOrganizationSerializer, self).serialize(obj, attrs, user)
+        context = super(DetailedOrganizationSerializer, self).serialize(obj, attrs, user)
         max_rate = quotas.get_maximum_quota(obj)
         context['experiments'] = experiment_assignments
         context['quota'] = {
@@ -183,9 +183,10 @@ class LightDetailedOrganizationSerializer(OrganizationSerializer):
         return context
 
 
-class DetailedOrganizationSerializer(LightDetailedOrganizationSerializer):
+class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSerializer):
     def get_attrs(self, item_list, user, **kwargs):
-        return super(DetailedOrganizationSerializer, self).get_attrs(item_list, user)
+        return super(DetailedOrganizationSerializerWithProjectsAndTeams,
+                     self).get_attrs(item_list, user)
 
     def _project_list(self, organization, access):
         member_projects = list(access.projects)
@@ -217,7 +218,13 @@ class DetailedOrganizationSerializer(LightDetailedOrganizationSerializer):
         from sentry.api.serializers.models.project import ProjectSummarySerializer
         from sentry.api.serializers.models.team import TeamSerializer
 
-        context = super(DetailedOrganizationSerializer, self).serialize(obj, attrs, user, access)
+        context = super(
+            DetailedOrganizationSerializerWithProjectsAndTeams,
+            self).serialize(
+            obj,
+            attrs,
+            user,
+            access)
 
         team_list = self._team_list(obj, access)
         project_list = self._project_list(obj, access)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -116,7 +116,6 @@ class OnboardingTasksSerializer(Serializer):
         }
 
 
-# Does not include project/teams list
 class DetailedOrganizationSerializer(OrganizationSerializer):
     def get_attrs(self, item_list, user, **kwargs):
         return super(DetailedOrganizationSerializer, self).get_attrs(item_list, user)

--- a/src/sentry/templatetags/sentry_api.py
+++ b/src/sentry/templatetags/sentry_api.py
@@ -5,7 +5,8 @@ from django.http import HttpRequest
 
 from sentry.auth.access import from_user, NoAccess
 from sentry.api.serializers.base import serialize as serialize_func
-from sentry.api.serializers.models.organization import (DetailedOrganizationSerializer)
+from sentry.api.serializers.models.organization import (
+    DetailedOrganizationSerializerWithProjectsAndTeams)
 from sentry.utils import json
 
 register = template.Library()
@@ -38,7 +39,7 @@ def serialize_detailed_org(context, obj):
     context = serialize_func(
         obj,
         user,
-        DetailedOrganizationSerializer(),
+        DetailedOrganizationSerializerWithProjectsAndTeams(),
         access=access
     )
 

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -96,7 +96,7 @@ class OrganizationDetailsTest(APITestCase):
         assert len(team_slugs) == 2
         assert 'deleted' not in team_slugs
 
-    def test_light_details_no_projects_or_teams(self):
+    def test_details_no_projects_or_teams(self):
         user = self.create_user('owner@example.org')
         org = self.create_organization(owner=user)
         team = self.create_team(
@@ -116,7 +116,7 @@ class OrganizationDetailsTest(APITestCase):
         )
         self.login_as(user=user)
 
-        response = self.client.get(u'{}?light=1'.format(url), format='json')
+        response = self.client.get(u'{}?detailed=0'.format(url), format='json')
 
         assert 'projects' not in response.data
         assert 'teams' not in response.data

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -96,7 +96,7 @@ class OrganizationDetailsTest(APITestCase):
         assert len(team_slugs) == 2
         assert 'deleted' not in team_slugs
 
-    def test_skinny_details_no_projects_or_teams(self):
+    def test_light_details_no_projects_or_teams(self):
         user = self.create_user('owner@example.org')
         org = self.create_organization(owner=user)
         team = self.create_team(
@@ -116,7 +116,7 @@ class OrganizationDetailsTest(APITestCase):
         )
         self.login_as(user=user)
 
-        response = self.client.get(u'{}?skinny=1'.format(url), format='json')
+        response = self.client.get(u'{}?light=1'.format(url), format='json')
 
         assert 'projects' not in response.data
         assert 'teams' not in response.data


### PR DESCRIPTION
This adds an option to fetch Organization details without projects and teams. This is direction we want to move towards, but we do not want to break the existing details endpoint

Fixes SEN-389