### PR TITLE
feat(apm) Add first draft of trace details API

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_details.py
+++ b/src/sentry/api/endpoints/organization_trace_details.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+
+from django.utils import timezone
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.bases import OrganizationEndpoint, OrganizationPermission
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.event_search import get_snuba_query_args
+from sentry.models import SnubaEvent
+from sentry.api.utils import MAX_STATS_PERIOD
+from sentry.tracing.logic import transform_to_spans
+from sentry.utils import snuba
+
+
+class OrganizationTracePermission(OrganizationPermission):
+    scope_map = {
+        'GET': ['event:read', 'event:write', 'event:admin'],
+    }
+
+
+class OrganizationTraceDetailsEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationTracePermission, )
+
+    def get(self, request, organization, trace_id):
+        """
+        Fetch all the events in a trace by trace_id
+
+        :pparam string trace_id: The trace id to get transactions/events for.
+        :auth: required
+        """
+        if not features.has('organizations:events-v2', organization, actor=request.user):
+            raise ResourceDoesNotExist()
+
+        projects = self.get_projects(request, organization)
+        current_time = timezone.now()
+        trace_query = {
+            'trace': trace_id,
+            'project_id': [p.id for p in projects],
+        }
+        snuba_query = get_snuba_query_args(params=trace_query)
+        results = snuba.raw_query(
+            selected_columns=SnubaEvent.selected_columns,
+            start=current_time - MAX_STATS_PERIOD,
+            end=current_time,
+            orderby='-timestamp',
+            referrer='api.organization-trace-details',
+            **snuba_query
+        )
+        if not len(results['data']):
+            raise ResourceDoesNotExist(detail='No trace with the provided id could be found')
+
+        # We don't use a typical serializer here because we need
+        # to flatten the event -> spans tree and the serializer apis
+        # are not built for that kind of transformation.
+        spans = transform_to_spans([SnubaEvent(row) for row in results['data']])
+        return Response(spans)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -86,6 +86,7 @@ from .endpoints.organization_dashboard_widget_details import OrganizationDashboa
 from .endpoints.organization_dashboard_widgets import OrganizationDashboardWidgetsEndpoint
 from .endpoints.organization_health import OrganizationHealthTopEndpoint, OrganizationHealthGraphEndpoint
 from .endpoints.organization_shortid import ShortIdLookupEndpoint
+from .endpoints.organization_trace_details import OrganizationTraceDetailsEndpoint
 from .endpoints.organization_environments import OrganizationEnvironmentsEndpoint
 from .endpoints.organization_eventid import EventIdLookupEndpoint
 from .endpoints.organization_slugs import SlugsUpdateEndpoint
@@ -693,6 +694,11 @@ urlpatterns = patterns(
         r'^organizations/(?P<organization_slug>[^\/]+)/searches/$',
         OrganizationSearchesEndpoint.as_view(),
         name='sentry-api-0-organization-searches'
+    ),
+    url(
+        r'^organizations/(?P<organization_slug>[^\/]+)/traces/(?P<trace_id>[^\/]+)/$',
+        OrganizationTraceDetailsEndpoint.as_view(),
+        name='sentry-api-0-organization-trace-details'
     ),
     url(
         r'^organizations/(?P<organization_slug>[^\/]+)/users/issues/$',

--- a/src/sentry/data/samples/transaction.json
+++ b/src/sentry/data/samples/transaction.json
@@ -1,0 +1,182 @@
+{
+   "platform": "python",
+   "message": "",
+   "tags": [
+      [
+         "application",
+         "countries"
+      ],
+      [
+         "browser",
+         "Python Requests 2.22"
+      ],
+      [
+         "browser.name",
+         "Python Requests"
+      ],
+      [
+         "environment",
+         "dev"
+      ],
+      [
+         "level",
+         "error"
+      ],
+      [
+         "runtime",
+         "CPython 3.7.3"
+      ],
+      [
+         "runtime.name",
+         "CPython"
+      ],
+      [
+         "release",
+         "v0.1"
+      ],
+      [
+         "user",
+         "ip:127.0.0.1"
+      ],
+      [
+         "server_name",
+         "a90286977562"
+      ],
+      [
+         "trace",
+         "a7d67cf796774551a95be6543cacd459"
+      ],
+      [
+         "trace.ctx",
+         "a7d67cf796774551a95be6543cacd459-babaae0d4b7512d9"
+      ],
+      [
+         "trace.span",
+         "babaae0d4b7512d9"
+      ],
+      [
+         "transaction",
+         "/country_by_code/"
+      ],
+      [
+         "url",
+         "http://countries:8010/country_by_code/"
+      ]
+   ],
+   "breadcrumbs": {
+      "values": [
+         {
+            "category": "query",
+            "timestamp":1562681591.0,
+            "message": "SELECT \"countries\".\"id\", \"countries\".\"name\", \"countries\".\"continent\", \"countries\".\"region\", \"countries\".\"surface_area\", \"coun...'CAN'",
+            "type": "default",
+            "level": "info"
+         }
+      ]
+   },
+   "contexts": {
+      "runtime": {
+         "version": "3.7.3",
+         "type": "runtime",
+         "name": "CPython",
+         "build": "3.7.3 (default, Jun 27 2019, 22:53:21) \n[GCC 8.3.0]"
+      },
+      "trace": {
+         "parent_span_id": "8988cec7cc0779c1",
+         "type": "trace",
+         "trace_id": "a7d67cf796774551a95be6543cacd459",
+         "span_id": "babaae0d4b7512d9"
+      },
+      "browser": {
+         "version": "2.22",
+         "type": "browser",
+         "name": "Python Requests"
+      }
+   },
+   "culprit": "/country_by_code/",
+   "environment": "dev",
+   "extra": {
+      "sys.argv": [
+         "manage.py",
+         "runserver",
+         "0.0.0.0:8010"
+      ]
+   },
+   "logger": "",
+   "metadata": {
+      "location": "/country_by_code/",
+      "title": "/country_by_code/"
+   },
+   "request": {
+      "url": "http://countries:8010/country_by_code/",
+      "headers": [
+         [
+            "Accept",
+            "*/*"
+         ],
+         [
+            "Accept-Encoding",
+            "gzip, deflate"
+         ],
+         [
+            "Connection",
+            "keep-alive"
+         ],
+         [
+            "Content-Length",
+            ""
+         ],
+         [
+            "Content-Type",
+            "text/plain"
+         ],
+         [
+            "Host",
+            "countries:8010"
+         ],
+         [
+            "Sentry-Trace",
+            "a7d67cf796774551a95be6543cacd459-8988cec7cc0779c1-1"
+         ],
+         [
+            "User-Agent",
+            "python-requests/2.22.0"
+         ]
+      ],
+      "env": {
+         "SERVER_PORT": "8010",
+         "SERVER_NAME": "a90286977562"
+      },
+      "query_string": [
+         [
+            "code",
+            "CAN"
+         ]
+      ],
+      "method": "GET",
+      "inferred_content_type": "text/plain"
+   },
+   "spans": [
+      {
+         "start_timestamp": 1562681591.0,
+         "same_process_as_parent":true,
+         "description": "Django: SELECT \"countries\".\"id\", \"countries\".\"name\", \"countries\".\"continent\", \"countries\".\"region\", \"countries\".\"surface_area\", \"coun...'CAN'",
+         "tags": {
+            "error":false
+         },
+         "timestamp":1562681591.0,
+         "parent_span_id": "babaae0d4b7512d9",
+         "trace_id": "a7d67cf796774551a95be6543cacd459",
+         "op": "db",
+         "data": {},
+         "span_id": "b048b4c8fdc5168c"
+      }
+   ],
+   "start_timestamp": 1562681591.0,
+   "timestamp": 1562681591.0,
+   "transaction": "/country_by_code/",
+   "type": "transaction",
+   "user": {
+      "ip_address": "127.0.0.1"
+   }
+}

--- a/src/sentry/tracing/__init__.py
+++ b/src/sentry/tracing/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry/tracing/logic.py
+++ b/src/sentry/tracing/logic.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+
+from sentry.models import Event
+
+
+def transform_to_spans(events):
+    """
+    Transform events into their span equivalent
+
+    While we currently store spans inside 'transaction'
+    type events that may not always be the case. Our tracing
+    APIs should only emit the span shaped data from our events
+    """
+    Event.objects.bind_nodes(events, 'data')
+    spans = []
+    for event in events:
+        spans.extend(_transform_to_spans(event))
+    return spans
+
+
+def _transform_to_spans(event):
+    """
+    Each event contains a bit of tracing data that we have to
+    extract out of the context and interfaces, as well as 0-N
+    child spans
+    """
+    contexts = event.get_interface('contexts')
+    context_data = contexts.get_api_context().get('trace', {})
+
+    root_span = {
+        'traceId': context_data.get('trace_id'),
+        'spanId': context_data.get('span_id'),
+        'parentSpanId': context_data.get('parent_span_id', None),
+        'description': event.title,
+        'op': 'transaction',
+        'startTimestamp': event.data['start_timestamp'],
+        'endTimestamp': event.data['timestamp'],
+        'tags': event.tags,
+        'data': {}
+    }
+    spans = [root_span]
+    for span in event.data['spans']:
+        spans.append(_transform_span(span))
+
+    return spans
+
+
+def _transform_span(span):
+    return {
+        'traceId': span.get('trace_id'),
+        'spanId': span.get('span_id'),
+        'parentSpanId': span.get('parent_span_id', None),
+        'description': span.get('description', ''),
+        'op': span.get('op', ''),
+        'startTimestamp': span.get('start_timestamp'),
+        'endTimestamp': span.get('timestamp'),
+        'tags': span.get('tags', {}),
+        'data': span.get('data', {}),
+    }

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -139,7 +139,7 @@ def load_data(platform, default=None, sample_name=None):
         return
 
     data = CanonicalKeyDict(data)
-    if platform in ('csp', 'hkpk', 'expectct', 'expectstaple'):
+    if platform in ('transaction', 'csp', 'hkpk', 'expectct', 'expectstaple'):
         return data
 
     data['platform'] = platform

--- a/tests/snuba/api/endpoints/test_organization_trace_details.py
+++ b/tests/snuba/api/endpoints/test_organization_trace_details.py
@@ -1,0 +1,76 @@
+from __future__ import absolute_import
+
+import pytz
+from datetime import datetime, timedelta
+
+from django.core.urlresolvers import reverse
+from django.utils import timezone
+from mock import patch
+
+from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.utils.samples import load_data
+
+
+class GetOrganizationTraceDetailsTest(APITestCase, SnubaTestCase):
+    endpoint = 'sentry-api-0-organization-trace-details'
+    trace_id = 'a7d67cf796774551a95be6543cacd459'
+
+    def setUp(self):
+        super(GetOrganizationTraceDetailsTest, self).setUp()
+        self.url = reverse(self.endpoint, args=[self.organization.slug, self.trace_id])
+
+    def test_requires_login(self):
+        res = self.client.get(self.url)
+        assert res.status_code == 401
+
+    def test_no_access(self):
+        self.login_as(self.user)
+        res = self.client.get(self.url)
+        assert res.status_code == 404
+
+    def test_no_matching_trace(self):
+        self.login_as(self.user)
+        # Access project fixture to ensure it exists.
+        self.project
+        with self.feature('organizations:events-v2'):
+            res = self.client.get(self.url)
+        assert res.status_code == 404
+        assert 'No trace' in res.content
+
+    @patch('django.utils.timezone.now')
+    def test_success(self, mock_now):
+        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+
+        data = load_data('transaction')
+        data.update({
+            'timestamp': min_ago,
+            'received': min_ago,
+            'event_id': 'a' * 32
+        })
+        self.store_event(
+            data=data,
+            project_id=self.project.id
+        )
+
+        self.login_as(self.user)
+        with self.feature('organizations:events-v2'):
+            res = self.client.get(self.url)
+        assert res.status_code == 200
+        assert len(res.data) == 2
+
+        parent_span = res.data[0]
+        required_keys = set([
+            'traceId', 'spanId', 'parentSpanId', 'description',
+            'op', 'startTimestamp', 'endTimestamp', 'tags', 'data'
+        ])
+        assert required_keys.issuperset(set(parent_span.keys()))
+        assert parent_span['op'] == 'transaction'
+        assert parent_span['description'] == '/country_by_code/'
+
+        child_span = res.data[1]
+        assert required_keys.issuperset(set(child_span.keys()))
+        assert child_span['op'] == 'db'
+        assert child_span['parentSpanId'] == parent_span['spanId']
+
+        assert child_span['traceId'] == parent_span['traceId']


### PR DESCRIPTION
Add an endpoint that allows all the tracing spans for a single trace to be fetched. Because our events contain some tracing data at the root event and some in the `spans` interface, I've had to take a more bespoke approach to serializing the response. This is likely not the final shape of the API but will help unblock UI development in the short term.

Refs SEN-797