### PR TITLE
feat(api): Allow fetching team details without projects

### DIFF
--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -81,7 +81,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
 
         :pparam string organization_slug: the slug of the organization for
                                           which the teams should be listed.
-        :param string light: if this is "1", then do not include projects
+        :param string detailed: Specify "0" to return team details that do not include projects
         :auth: required
         """
         # TODO(dcramer): this should be system-wide default for organization
@@ -105,8 +105,8 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                 else:
                     queryset = queryset.none()
 
-        serializer = team_serializers.TeamSerializer if request.GET.get(
-            'light') == '1' else team_serializers.TeamWithProjectsSerializer
+        is_detailed = request.GET.get('detailed', '1') != '0'
+        serializer = team_serializers.TeamWithProjectsSerializer if is_detailed else team_serializers.TeamSerializer
 
         return self.paginate(
             request=request,

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -36,6 +36,30 @@ class OrganizationTeamsListTest(APITestCase):
         assert response.data[1]['id'] == six.text_type(team1.id)
         assert response.data[1]['isMember']
 
+    def test_simple_light_results(self):
+        user = self.create_user()
+        org = self.create_organization(owner=self.user)
+        team1 = self.create_team(organization=org, name='foo')
+        self.create_team(organization=org, name='bar')
+
+        self.create_member(
+            organization=org,
+            user=user,
+            has_global_access=False,
+            teams=[team1],
+        )
+
+        path = u'/api/0/organizations/{}/teams/?light=1'.format(org.slug)
+
+        self.login_as(user=user)
+
+        response = self.client.get(path)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        assert 'projects' not in response.data[0]
+        assert 'projects' not in response.data[1]
+
     def test_search(self):
         user = self.create_user()
         org = self.create_organization(owner=self.user)

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -36,7 +36,7 @@ class OrganizationTeamsListTest(APITestCase):
         assert response.data[1]['id'] == six.text_type(team1.id)
         assert response.data[1]['isMember']
 
-    def test_simple_light_results(self):
+    def test_simple_results_no_projects(self):
         user = self.create_user()
         org = self.create_organization(owner=self.user)
         team1 = self.create_team(organization=org, name='foo')
@@ -49,7 +49,7 @@ class OrganizationTeamsListTest(APITestCase):
             teams=[team1],
         )
 
-        path = u'/api/0/organizations/{}/teams/?light=1'.format(org.slug)
+        path = u'/api/0/organizations/{}/teams/?detailed=0'.format(org.slug)
 
         self.login_as(user=user)
 


### PR DESCRIPTION
This allows you to fetch team details that do not include projects, which
improves performance.