### PR TITLE
feat(ui) Linked issue box should link to the specific event

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
@@ -49,7 +49,9 @@ const EventModalContent = props => {
         <EventInterfaces event={event} projectId={projectId} />
       </ContentColumn>
       <SidebarColumn>
-        {event.groupID && <LinkedIssuePreview groupId={event.groupID} />}
+        {event.groupID && (
+          <LinkedIssuePreview groupId={event.groupID} eventId={event.eventID} />
+        )}
         <EventMetadata event={event} eventJsonUrl={eventJsonUrl} />
         <SidebarBlock>
           <TagsTable tags={event.tags} />

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/linkedIssuePreview.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/linkedIssuePreview.jsx
@@ -17,6 +17,7 @@ import space from 'app/styles/space';
 class LinkedIssuePreview extends AsyncComponent {
   static propTypes = {
     groupId: PropTypes.string.isRequired,
+    eventId: PropTypes.string.isRequired,
   };
 
   getEndpoints() {
@@ -31,7 +32,9 @@ class LinkedIssuePreview extends AsyncComponent {
   }
 
   renderBody() {
+    const {eventId} = this.props;
     const {group} = this.state;
+    const issueUrl = `${group.permalink}events/${eventId}/`;
 
     return (
       <Container>
@@ -39,7 +42,7 @@ class LinkedIssuePreview extends AsyncComponent {
           <InlineSvg src="icon-link" size="12px" /> {t('Linked Issue')}
         </Title>
         <Section>
-          <Link to={group.permalink}>
+          <Link to={issueUrl} data-test-id="linked-issue">
             <StyledShortId
               shortId={group.shortId}
               avatar={<ProjectBadge project={group.project} avatarSize={16} hideName />}

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -115,7 +115,7 @@ class OrganizationEventsTest(AcceptanceTestCase, SnubaTestCase):
             'received': min_ago,
             'fingerprint': ['group-1']
         })
-        self.store_event(
+        event = self.store_event(
             data=event_data,
             project_id=self.project.id,
             assert_no_errors=False
@@ -132,6 +132,10 @@ class OrganizationEventsTest(AcceptanceTestCase, SnubaTestCase):
 
             header = self.browser.element('[data-test-id="modal-dialog"] h2')
             assert event_data['message'] in header.text
+
+            issue_link = self.browser.element('[data-test-id="linked-issue"]')
+            issue_event_url_fragment = '/issues/%s/events/%s/' % (event.group_id, event.event_id)
+            assert issue_event_url_fragment in issue_link.get_attribute('href')
 
             self.browser.snapshot('events-v2 - single error modal')
 


### PR DESCRIPTION
When going from an event modal view to the event in context of the group we should preserve the current event selection so that the user doesn't lose track of what they were looking at before.

Fixes SEN-801