### PR TITLE
ref(app-platform): Pass through event for error.created

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,7 +61,7 @@
   "python.pythonPath": "${workspaceFolder}/.venv/bin/python",
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
-  "python.testing.pytestEnabled": false,
+  "python.testing.pyTestEnabled": false,
   "python.testing.unittestEnabled": false,
   "python.testing.nosetestsEnabled": false,
   "editor.tabSize": 4,
@@ -69,5 +69,5 @@
   "python.linting.enabled": true,
   "python.linting.flake8Path": "${workspaceFolder}/.venv/bin/flake8",
   "python.linting.pep8Path": "${workspaceFolder}/.venv/bin/pep8",
-  "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest"
+  "python.testing.pyTestPath": "${workspaceFolder}/.venv/bin/pytest"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,7 +61,7 @@
   "python.pythonPath": "${workspaceFolder}/.venv/bin/python",
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
-  "python.testing.pyTestEnabled": false,
+  "python.testing.pytestEnabled": false,
   "python.testing.unittestEnabled": false,
   "python.testing.nosetestsEnabled": false,
   "editor.tabSize": 4,
@@ -69,5 +69,5 @@
   "python.linting.enabled": true,
   "python.linting.flake8Path": "${workspaceFolder}/.venv/bin/flake8",
   "python.linting.pep8Path": "${workspaceFolder}/.venv/bin/pep8",
-  "python.testing.pyTestPath": "${workspaceFolder}/.venv/bin/pytest"
+  "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest"
 }

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -207,8 +207,7 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
                 action='created',
                 sender='Error',
                 instance_id=event.event_id,
-                project_id=event.project_id,
-                group_id=event.group_id,
+                instance=event,
             )
         if is_new:
             process_resource_change_bound.delay(

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -148,8 +148,10 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
     # transaction that creates the Group has committed.
     try:
         if issubclass(model, EventCommon):
-            # 'from_event_id' is supported for both Event and SnubaEvent
-            # instance_id is the event.event_id NOT the event.id
+            # XXX:(Meredith): Passing through the entire event was an intentional choice
+            # to avoid having to query NodeStore again for data we had previously in
+            # post_process. While this is not ideal, changing this will most likely involve
+            # an overhaul of how we do things in post_process, not just this task alone.
             instance = kwargs.get('instance')
         else:
             instance = model.objects.get(id=instance_id)

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -122,7 +122,7 @@ def send_alert_event(event, rule, sentry_app_id):
 def _process_resource_change(action, sender, instance_id, retryer=None, *args, **kwargs):
     # The class is serialized as a string when enqueueing the class.
     model = TYPES[sender]
-    # The Event model has different hooks for the differenct types. The sender
+    # The Event model has different hooks for the different event types. The sender
     # determines which type eg. Error and therefore the 'name' eg. error
     if issubclass(model, EventCommon):
         if not kwargs.get('instance'):

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -429,8 +429,7 @@ class PostProcessGroupTest(TestCase):
         )
 
         kwargs = {
-            'project_id': self.project.id,
-            'group_id': event.group.id,
+            'instance': event,
         }
         delay.assert_called_once_with(
             action='created',
@@ -546,8 +545,7 @@ class PostProcessGroupTest(TestCase):
         )
 
         kwargs = {
-            'project_id': self.project.id,
-            'group_id': event.group.id,
+            'instance': event,
         }
 
         delay.assert_called_once_with(


### PR DESCRIPTION
**Current Problem:**
Passing through the `event_id` to the `process_resource_change` task (even with the `group_id` and `project_id`), we still end up querying Snuba. A possible solution would be to figure out how to only query NodeStore but that requires some overhead and doesn't really address the full scope of the problem - we want to use the event data we have already have to begin with. 

**Temporarily Solution:**
Since we are already passing through the Event object in other tasks, we are going to at least keep that consistent. We want to move away from pickle in general, so this isn't ideal and why this is a  _temporary_ solution. 

**Long Term Solution:**
TBD. We'd like to re-evaluate this piece of the event pipeline to see how we can improve it for other processes, not just the `error.created` hook. 