### PR TITLE
fix(api): Fix sms otp validation error when passing a null/blank otp value.

### DIFF
--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -379,6 +379,8 @@ class OtpMixin(object):
             cache.set(cache_key, '1', timeout=120)
 
     def validate_otp(self, otp):
+        if not otp:
+            return False
         otp = otp.strip().replace('-', '').replace(' ', '')
         used_counter = self.make_otp().verify(
             otp, return_counter=True, check_counter_func=self.check_otp_counter


### PR DESCRIPTION
This was caused by the DRF upgrade. No actual bug here, just an error where we should have a
validation error.

Fixes SENTRY-BGA