### PR TITLE
feat(grouping): Improve single frame grouping and add min-frames

### DIFF
--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -473,15 +473,10 @@ def stacktrace_legacy(stacktrace, config, variant, **meta):
         frames_for_filtering.append(frame.get_raw_data())
         prev_frame = frame
 
-    config.enhancements.update_frame_components_contributions(
+    rv = config.enhancements.assemble_stacktrace_component(
         values, frames_for_filtering, meta['event'].platform)
-
-    return GroupingComponent(
-        id='stacktrace',
-        values=values,
-        contributes=contributes,
-        hint=hint,
-    )
+    rv.update(contributes=contributes, hint=hint)
+    return rv
 
 
 @strategy(

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -395,8 +395,16 @@ def get_frame_component(frame, event, meta, legacy_function_logic=False,
     score=1800,
 )
 def stacktrace_v1(stacktrace, config, variant, **meta):
+    return get_stacktrace_component(stacktrace, config, variant, meta)
+
+
+@stacktrace_v1.variant_processor
+def stacktrace_v1_variant_processor(variants, config, **meta):
+    return remove_non_stacktrace_variants(variants)
+
+
+def get_stacktrace_component(stacktrace, config, variant, meta):
     frames = stacktrace.frames
-    hint = None
     all_frames_considered_in_app = False
 
     values = []
@@ -422,19 +430,8 @@ def stacktrace_v1(stacktrace, config, variant, **meta):
         frames_for_filtering.append(frame.get_raw_data())
         prev_frame = frame
 
-    config.enhancements.update_frame_components_contributions(
+    return config.enhancements.assemble_stacktrace_component(
         values, frames_for_filtering, meta['event'].platform)
-
-    return GroupingComponent(
-        id='stacktrace',
-        values=values,
-        hint=hint,
-    )
-
-
-@stacktrace_v1.variant_processor
-def stacktrace_v1_variant_processor(variants, config, **meta):
-    return remove_non_stacktrace_variants(variants)
 
 
 def single_exception_common(exception, config, meta, with_value):

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -430,6 +430,17 @@ def get_stacktrace_component(stacktrace, config, variant, meta):
         frames_for_filtering.append(frame.get_raw_data())
         prev_frame = frame
 
+    # Special case for JavaScript where we want to ignore single frame
+    # stacktraces in certain cases where those would be of too low quality
+    # for grouping.
+    if len(frames) == 1 and values[0].contributes and \
+       get_behavior_family_for_platform(frames[0].platform or meta['event'].platform) == 'javascript' and \
+       not frames[0].function and frames[0].is_url():
+        values[0].update(
+            contributes=False,
+            hint='ignored single non-URL JavaScript frame'
+        )
+
     return config.enhancements.assemble_stacktrace_component(
         values, frames_for_filtering, meta['event'].platform)
 

--- a/tests/sentry/grouping/grouping_inputs/stacktrace-enforce-min-frames.json
+++ b/tests/sentry/grouping/grouping_inputs/stacktrace-enforce-min-frames.json
@@ -1,0 +1,52 @@
+{
+  "_grouping": {
+    "enhancement_base": "common:2019-03-23",
+    "enhancements": "function:log_demo::* +app\nfamily:native min-frames=2"
+  },
+  "exception": {
+    "values": [
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_main",
+              "instruction_addr": "0x10d6dd338"
+            },
+            {
+              "function": "std::rt::lang_start_internal",
+              "package": "std",
+              "instruction_addr": "0x10d98ea2c"
+            },
+            {
+              "function": "___rust_maybe_catch_panic",
+              "instruction_addr": "0x10d99175e"
+            },
+            {
+              "function": "std::panicking::try::do_call",
+              "package": "std",
+              "instruction_addr": "0x10d98df37"
+            },
+            {
+              "function": "std::rt::lang_start::{{closure}}",
+              "package": "std",
+              "instruction_addr": "0x10d6d93b5"
+            },
+            {
+              "function": "log_demo::main",
+              "package": "log_demo",
+              "instruction_addr": "0x10d6dd251"
+            },
+            {
+              "function": "log::__private_api_log",
+              "package": "log",
+              "instruction_addr": "0x10d97fdbb"
+            }
+          ]
+        },
+        "type": "log_demo",
+        "value": "Holy shit everything is on fire!"
+      }
+    ]
+  },
+  "platform": "native"
+}

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/stacktrace_enforce_min_frames.pysnap
@@ -1,0 +1,64 @@
+---
+created: '2019-07-09T13:22:06.178503Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: None
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace (discarded because stacktrace only contains 1 frame which is under the configured threshold by grouping enhancement rule (family:native min-frames=2))
+          frame (non app frame)
+            function*
+              u'_main'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start_internal'
+          frame (non app frame)
+            function*
+              u'___rust_maybe_catch_panic'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::panicking::try::do_call'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start::{{closure}}'
+          frame* (marked in-app by grouping enhancement rule (function:log_demo::* +app))
+            function*
+              u'log_demo::main'
+          frame (non app frame)
+            function*
+              u'log::__private_api_log'
+        type*
+          u'log_demo'
+--------------------------------------------------------------------------
+system:
+  hash: 'e0b4eea234ff891472cb927c00153bbe'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              u'_main'
+          frame* (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start_internal'
+          frame*
+            function*
+              u'___rust_maybe_catch_panic'
+          frame* (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::panicking::try::do_call'
+          frame* (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start::{{closure}}'
+          frame* (marked in-app by grouping enhancement rule (function:log_demo::* +app))
+            function*
+              u'log_demo::main'
+          frame*
+            function*
+              u'log::__private_api_log'
+        type*
+          u'log_demo'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_enforce_min_frames.pysnap
@@ -1,0 +1,68 @@
+---
+created: '2019-07-09T12:12:23.637309Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: None
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because hash matches system variant)
+        stacktrace
+          frame (non app frame)
+            function (function name is used only if module or filename are available)
+              u'_main'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function (function name is used only if module or filename are available)
+              u'std::rt::lang_start_internal'
+          frame (non app frame)
+            function (function name is used only if module or filename are available)
+              u'___rust_maybe_catch_panic'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function (function name is used only if module or filename are available)
+              u'std::panicking::try::do_call'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function (function name is used only if module or filename are available)
+              u'std::rt::lang_start::{{closure}}'
+          frame (marked in-app by grouping enhancement rule (function:log_demo::* +app))
+            function (function name is used only if module or filename are available)
+              u'log_demo::main'
+          frame (non app frame)
+            function (function name is used only if module or filename are available)
+              u'log::__private_api_log'
+        type*
+          u'log_demo'
+        value*
+          u'Holy shit everything is on fire!'
+--------------------------------------------------------------------------
+system:
+  hash: '3e0ae2ce25cce2fca3390f3416e6a82a'
+  component:
+    system*
+      exception*
+        stacktrace
+          frame
+            function (function name is used only if module or filename are available)
+              u'_main'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function (function name is used only if module or filename are available)
+              u'std::rt::lang_start_internal'
+          frame
+            function (function name is used only if module or filename are available)
+              u'___rust_maybe_catch_panic'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function (function name is used only if module or filename are available)
+              u'std::panicking::try::do_call'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function (function name is used only if module or filename are available)
+              u'std::rt::lang_start::{{closure}}'
+          frame (marked in-app by grouping enhancement rule (function:log_demo::* +app))
+            function (function name is used only if module or filename are available)
+              u'log_demo::main'
+          frame
+            function (function name is used only if module or filename are available)
+              u'log::__private_api_log'
+        type*
+          u'log_demo'
+        value*
+          u'Holy shit everything is on fire!'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/frame_ignores_module_if_page_url.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2019-03-16T15:38:20.740059Z'
+created: '2019-07-10T12:18:43.528621Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: None
   component:
-    app (stacktrace of system takes precedence)
+    app
       stacktrace
         frame (non app frame)
           module*
@@ -14,12 +14,15 @@ app:
           filename (ignored because frame points to a URL)
             u'foo.py'
 --------------------------------------------------------------------------
+fallback:
+  hash: 'd41d8cd98f00b204e9800998ecf8427e'
+--------------------------------------------------------------------------
 system:
-  hash: 'a7a536723f7289f3ab7cbb444b7058ac'
+  hash: None
   component:
-    system*
-      stacktrace*
-        frame*
+    system
+      stacktrace
+        frame (ignored single non-URL JavaScript frame)
           module*
             u'foo/bar/baz'
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/stacktrace_enforce_min_frames.pysnap
@@ -1,0 +1,64 @@
+---
+created: '2019-07-09T13:22:08.877627Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: None
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace (discarded because stacktrace only contains 1 frame which is under the configured threshold by grouping enhancement rule (family:native min-frames=2))
+          frame (non app frame)
+            function*
+              u'_main'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start_internal'
+          frame (non app frame)
+            function*
+              u'___rust_maybe_catch_panic'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::panicking::try::do_call'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start::{{closure}}'
+          frame* (marked in-app by grouping enhancement rule (function:log_demo::* +app))
+            function*
+              u'log_demo::main'
+          frame (non app frame)
+            function*
+              u'log::__private_api_log'
+        type*
+          u'log_demo'
+--------------------------------------------------------------------------
+system:
+  hash: 'e0b4eea234ff891472cb927c00153bbe'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              u'_main'
+          frame* (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start_internal'
+          frame*
+            function*
+              u'___rust_maybe_catch_panic'
+          frame* (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::panicking::try::do_call'
+          frame* (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start::{{closure}}'
+          frame* (marked in-app by grouping enhancement rule (function:log_demo::* +app))
+            function*
+              u'log_demo::main'
+          frame*
+            function*
+              u'log::__private_api_log'
+        type*
+          u'log_demo'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/frame_ignores_module_if_page_url.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2019-04-17T20:07:50.372035Z'
+created: '2019-07-10T12:18:44.713927Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: None
   component:
-    app (stacktrace of system takes precedence)
+    app
       stacktrace
         frame (non app frame)
           module*
@@ -14,12 +14,15 @@ app:
           filename (ignored because frame points to a URL)
             u'foo.py'
 --------------------------------------------------------------------------
+fallback:
+  hash: 'd41d8cd98f00b204e9800998ecf8427e'
+--------------------------------------------------------------------------
 system:
-  hash: 'a7a536723f7289f3ab7cbb444b7058ac'
+  hash: None
   component:
-    system*
-      stacktrace*
-        frame*
+    system
+      stacktrace
+        frame (ignored single non-URL JavaScript frame)
           module*
             u'foo/bar/baz'
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/stacktrace_enforce_min_frames.pysnap
@@ -1,0 +1,68 @@
+---
+created: '2019-07-09T13:22:10.137941Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: None
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace (discarded because stacktrace only contains 1 frame which is under the configured threshold by grouping enhancement rule (family:native min-frames=2))
+          frame (non app frame)
+            function*
+              u'_main'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start_internal'
+          frame (non app frame)
+            function*
+              u'___rust_maybe_catch_panic'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::panicking::try::do_call'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start::{{closure}}'
+          frame* (marked in-app by grouping enhancement rule (function:log_demo::* +app))
+            function*
+              u'log_demo::main'
+          frame (non app frame)
+            function*
+              u'log::__private_api_log'
+        type*
+          u'log_demo'
+        value*
+          u'Holy shit everything is on fire!'
+--------------------------------------------------------------------------
+system:
+  hash: 'e0b4eea234ff891472cb927c00153bbe'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              u'_main'
+          frame* (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start_internal'
+          frame*
+            function*
+              u'___rust_maybe_catch_panic'
+          frame* (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::panicking::try::do_call'
+          frame* (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start::{{closure}}'
+          frame* (marked in-app by grouping enhancement rule (function:log_demo::* +app))
+            function*
+              u'log_demo::main'
+          frame*
+            function*
+              u'log::__private_api_log'
+        type*
+          u'log_demo'
+        value (ignored because stacktrace takes precedence)
+          u'Holy shit everything is on fire!'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_ignores_module_if_page_url.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2019-05-10T12:45:55.344044Z'
+created: '2019-07-10T12:18:45.903717Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: None
   component:
-    app (stacktrace of system takes precedence)
+    app
       stacktrace
         frame (non app frame)
           module*
@@ -15,12 +15,15 @@ app:
             u'foo.py'
           function (ignored unknown function name)
 --------------------------------------------------------------------------
+fallback:
+  hash: 'd41d8cd98f00b204e9800998ecf8427e'
+--------------------------------------------------------------------------
 system:
-  hash: 'a7a536723f7289f3ab7cbb444b7058ac'
+  hash: None
   component:
-    system*
-      stacktrace*
-        frame*
+    system
+      stacktrace
+        frame (ignored single non-URL JavaScript frame)
           module*
             u'foo/bar/baz'
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/stacktrace_enforce_min_frames.pysnap
@@ -1,0 +1,68 @@
+---
+created: '2019-07-09T13:22:11.421699Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: None
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace (discarded because stacktrace only contains 1 frame which is under the configured threshold by grouping enhancement rule (family:native min-frames=2))
+          frame (non app frame)
+            function*
+              u'_main'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start_internal'
+          frame (non app frame)
+            function*
+              u'___rust_maybe_catch_panic'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::panicking::try::do_call'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start::{{closure}}'
+          frame* (marked in-app by grouping enhancement rule (function:log_demo::* +app))
+            function*
+              u'log_demo::main'
+          frame (non app frame)
+            function*
+              u'log::__private_api_log'
+        type*
+          u'log_demo'
+        value*
+          u'Holy shit everything is on fire!'
+--------------------------------------------------------------------------
+system:
+  hash: 'e0b4eea234ff891472cb927c00153bbe'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              u'_main'
+          frame* (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start_internal'
+          frame*
+            function*
+              u'___rust_maybe_catch_panic'
+          frame* (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::panicking::try::do_call'
+          frame* (marked out of app by grouping enhancement rule (family:native function:std::* -app))
+            function*
+              u'std::rt::lang_start::{{closure}}'
+          frame* (marked in-app by grouping enhancement rule (function:log_demo::* +app))
+            function*
+              u'log_demo::main'
+          frame*
+            function*
+              u'log::__private_api_log'
+        type*
+          u'log_demo'
+        value (ignored because stacktrace takes precedence)
+          u'Holy shit everything is on fire!'


### PR DESCRIPTION
This improves the grouping performance for JavaScript by discarding single
frame stacktraces without URLs again and also adds a configurable min-frames
setting which can be used to enforce a minimum frame limit which if fallen
below will discard a stacktrace entirely.

This lets the system variant win over the app variant in some cases if users
configure an appropriate grouping enhancer.