### PR TITLE
fix: Events v2 graph should reflect the query and the active tab/view

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
@@ -42,7 +42,7 @@ export default class Events extends React.Component {
             value: (
               <EventsChart
                 router={router}
-                query={query}
+                query={getQuery(view, location).query}
                 organization={organization}
                 showLegend
                 yAxisOptions={CHART_AXIS_OPTIONS}


### PR DESCRIPTION
Follow up PR to https://github.com/getsentry/sentry/pull/13917

-------

Some events:

![Screen Shot 2019-07-10 at 1 00 40 PM](https://user-images.githubusercontent.com/139499/60988989-d9c7ce80-a312-11e9-8a8d-226c1fa022e5.png)

No events (implies no spikes in the graph):

![Screen Shot 2019-07-10 at 1 00 43 PM](https://user-images.githubusercontent.com/139499/60988988-d9c7ce80-a312-11e9-927f-f5a7f28110fe.png)
