### PR TITLE
feat(events-v2) Add sorting to events v2 views

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -90,8 +90,14 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         if groupby:
             snuba_args['groupby'] = groupby
 
+        sort = request.GET.getlist('sort')
+        if sort and snuba.valid_orderby(sort, SPECIAL_FIELDS):
+            snuba_args['orderby'] = sort
+
+        # Deprecated. `sort` should be used as it is supported by
+        # more endpoints.
         orderby = request.GET.getlist('orderby')
-        if orderby:
+        if orderby and snuba.valid_orderby(orderby, SPECIAL_FIELDS) and 'orderby' not in snuba_args:
             snuba_args['orderby'] = orderby
 
         # TODO(lb): remove once boolean search is fully functional

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -22,7 +22,7 @@ export const ALL_VIEWS = deepFreeze([
     name: 'All Events',
     data: {
       fields: ['event', 'type', 'project', 'user', 'time'],
-      orderby: ['-timestamp', '-id'],
+      sort: ['-timestamp', '-id'],
     },
     tags: [
       'event.type',
@@ -40,7 +40,7 @@ export const ALL_VIEWS = deepFreeze([
     data: {
       fields: ['error', 'event_count', 'user_count', 'project', 'last_seen'],
       groupby: ['issue.id', 'project.id'],
-      orderby: ['-last_seen', '-issue.id'],
+      sort: ['-last_seen', '-issue.id'],
       query: 'event.type:error',
     },
     tags: ['error.type', 'project.name'],
@@ -52,7 +52,7 @@ export const ALL_VIEWS = deepFreeze([
     data: {
       fields: ['csp', 'event_count', 'user_count', 'project', 'last_seen'],
       groupby: ['issue.id', 'project.id'],
-      orderby: ['-last_seen', '-issue.id'],
+      sort: ['-last_seen', '-issue.id'],
       query: 'event.type:csp',
     },
     tags: [
@@ -74,6 +74,7 @@ export const ALL_VIEWS = deepFreeze([
 export const SPECIAL_FIELDS = {
   event: {
     fields: ['title', 'id', 'project.name'],
+    sortField: 'title',
     renderFunc: (data, {organization, location}) => {
       const target = {
         pathname: `/organizations/${organization.slug}/events/`,
@@ -90,6 +91,7 @@ export const SPECIAL_FIELDS = {
   },
   type: {
     fields: ['event.type'],
+    sortField: 'event.type',
     renderFunc: (data, {location, organization}) => {
       const target = {
         pathname: `/organizations/${organization.slug}/events/`,
@@ -104,6 +106,7 @@ export const SPECIAL_FIELDS = {
   },
   project: {
     fields: ['project.name'],
+    sortField: false,
     renderFunc: (data, {organization}) => {
       const project = organization.projects.find(p => p.slug === data['project.name']);
       return (
@@ -119,6 +122,7 @@ export const SPECIAL_FIELDS = {
   },
   user: {
     fields: ['user', 'user.name', 'user.email', 'user.ip'],
+    sortField: 'user',
     renderFunc: (data, {organization, location}) => {
       const userObj = {
         name: data['user.name'],
@@ -145,6 +149,7 @@ export const SPECIAL_FIELDS = {
   },
   time: {
     fields: ['timestamp'],
+    sortField: 'timestamp',
     renderFunc: data => (
       <Container>
         {data.timestamp ? (
@@ -155,6 +160,7 @@ export const SPECIAL_FIELDS = {
   },
   error: {
     fields: ['issue_title', 'project.name', 'issue.id'],
+    sortField: 'issue_title',
     renderFunc: (data, {organization, location}) => {
       const target = {
         pathname: `/organizations/${organization.slug}/events/`,
@@ -174,6 +180,7 @@ export const SPECIAL_FIELDS = {
   },
   csp: {
     fields: ['issue_title', 'project.name', 'issue.id'],
+    sortField: 'issue_title',
     renderFunc: (data, {organization, location}) => {
       const target = {
         pathname: `/organizations/${organization.slug}/events/`,
@@ -194,6 +201,7 @@ export const SPECIAL_FIELDS = {
   event_count: {
     title: 'events',
     fields: ['event_count'],
+    sortField: 'event_count',
     renderFunc: data => (
       <Container>
         {typeof data.event_count === 'number' ? data.event_count.toLocaleString() : null}
@@ -203,6 +211,7 @@ export const SPECIAL_FIELDS = {
   user_count: {
     title: 'users',
     fields: ['user_count'],
+    sortField: 'user_count',
     renderFunc: data => (
       <Container>
         {typeof data.user_count === 'number' ? data.user_count.toLocaleString() : null}
@@ -212,6 +221,7 @@ export const SPECIAL_FIELDS = {
   last_seen: {
     title: 'last seen',
     fields: ['last_seen'],
+    sortField: 'last_seen',
     renderFunc: data => {
       return (
         <Container>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
@@ -35,7 +35,12 @@ export default class OrganizationEventsV2 extends React.Component {
             key={view.id}
             to={{
               pathname: `/organizations/${organization.slug}/events/`,
-              query: {...this.props.location.query, view: view.id, cursor: undefined},
+              query: {
+                ...this.props.location.query,
+                view: view.id,
+                cursor: undefined,
+                sort: undefined,
+              },
             }}
             isActive={() => view.id === currentView.id}
           >

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/sortLink.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/sortLink.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'react-emotion';
+
+import InlineSvg from 'app/components/inlineSvg';
+import Link from 'app/components/links/link';
+
+class SortLink extends React.Component {
+  static propTypes = {
+    title: PropTypes.string.isRequired,
+    sortKey: PropTypes.string.isRequired,
+    location: PropTypes.object.isRequired,
+  };
+
+  getSort() {
+    const {sortKey, location} = this.props;
+
+    // Page is currently unsorted or is ascending
+    if (!location.query.sort || location.query.sort === `-${sortKey}`) {
+      return sortKey;
+    }
+    // Reverse direction
+    if (location.query.sort === sortKey) {
+      return `-${sortKey}`;
+    }
+    return sortKey;
+  }
+
+  getTarget() {
+    const {location} = this.props;
+    return {
+      pathname: location.pathname,
+      query: {...location.query, sort: this.getSort()},
+    };
+  }
+
+  renderChevron() {
+    const {location, sortKey} = this.props;
+    if (!location.query.sort || location.query.sort.indexOf(sortKey) === -1) {
+      return null;
+    }
+
+    if (location.query.sort[0] === '-') {
+      return <InlineSvg src="icon-chevron-down" />;
+    }
+
+    return <InlineSvg src="icon-chevron-up" />;
+  }
+
+  render() {
+    const {title} = this.props;
+    return (
+      <StyledLink to={this.getTarget()}>
+        {title} {this.renderChevron()}
+      </StyledLink>
+    );
+  }
+}
+
+const StyledLink = styled(Link)`
+  white-space: nowrap;
+`;
+
+export default SortLink;

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/table.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/table.jsx
@@ -11,6 +11,7 @@ import space from 'app/styles/space';
 
 import {SPECIAL_FIELDS} from './data';
 import {QueryLink} from './styles';
+import SortLink from './sortLink';
 
 export default class Table extends React.Component {
   static propTypes = {
@@ -63,19 +64,30 @@ export default class Table extends React.Component {
   }
 
   render() {
-    const {isLoading, view} = this.props;
+    const {isLoading, location, view} = this.props;
     const {fields} = view.data;
 
     return (
       <Panel>
         <TableHeader className={getGridStyle(view)}>
-          {fields.map(field => (
-            <HeaderItem key={field}>
-              {SPECIAL_FIELDS.hasOwnProperty(field)
-                ? SPECIAL_FIELDS[field].title || field
-                : field}
-            </HeaderItem>
-          ))}
+          {fields.map(field => {
+            let title = field;
+            let sortKey = field;
+            if (SPECIAL_FIELDS.hasOwnProperty(field)) {
+              title = SPECIAL_FIELDS[field].title || field;
+              sortKey = SPECIAL_FIELDS[field].sortField;
+            }
+
+            if (sortKey === false) {
+              return <HeaderItem key={field}>{title}</HeaderItem>;
+            }
+
+            return (
+              <HeaderItem key={field}>
+                <SortLink sortKey={sortKey} title={title} location={location} />
+              </HeaderItem>
+            );
+          })}
         </TableHeader>
         <StyledPanelBody isLoading={isLoading}>
           <LoadingContainer isLoading={isLoading}>{this.renderBody()}</LoadingContainer>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
@@ -51,11 +51,14 @@ export function getQuery(view, location) {
     'statsPeriod',
     'cursor',
     'query',
+    'sort',
   ]);
 
   data.field = [...new Set(fields)];
   data.groupby = groupby;
-  data.orderby = view.data.orderby;
+  if (!data.sort) {
+    data.sort = view.data.sort;
+  }
   data.per_page = DEFAULT_PER_PAGE;
 
   if (view.data.query) {

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -379,6 +379,22 @@ def get_arrayjoin(column):
         return match.groups()[0]
 
 
+def valid_orderby(orderby, custom_fields=None):
+    """
+    Check if a field can be used in sorting. We don't allow
+    sorting on fields that would be aliased as tag[foo] because those
+    fields are unlikely to be selected.
+    """
+    if custom_fields is None:
+        custom_fields = []
+    fields = orderby if isinstance(orderby, (list, tuple)) else [orderby]
+    for field in fields:
+        field = field.lstrip('-')
+        if field not in SENTRY_SNUBA_MAP and field not in custom_fields:
+            return False
+    return True
+
+
 def transform_aliases_and_query(skip_conditions=False, **kwargs):
     """
     Convert aliases in selected_columns, groupby, aggregation, conditions,

--- a/tests/sentry/mediators/sentry_apps/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_apps/test_destroyer.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django.db import connection
 from mock import patch
+import responses
 
 from sentry.mediators.sentry_apps import Destroyer
 from sentry.models import AuditLogEntry, AuditLogEntryEvent, ApiApplication, User, SentryApp, SentryAppInstallation
@@ -21,7 +22,9 @@ class TestDestroyer(TestCase):
 
         self.destroyer = Destroyer(sentry_app=self.sentry_app, user=self.user)
 
+    @responses.activate
     def test_deletes_app_installations(self):
+        responses.add(responses.POST, 'https://example.com/webhook', status=200)
         install = self.create_sentry_app_installation(
             organization=self.org,
             slug=self.sentry_app.slug,

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -241,6 +241,68 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
         assert response.data[1]['id'] == 'b' * 32
         assert response.data[2]['id'] == 'a' * 32
 
+    def test_sort_title(self):
+        self.login_as(user=self.user)
+        project = self.create_project()
+        self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'message': 'zlast',
+                'timestamp': self.two_min_ago,
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'b' * 32,
+                'message': 'second',
+                'timestamp': self.min_ago,
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'c' * 32,
+                'message': 'first',
+                'timestamp': self.min_ago,
+            },
+            project_id=project.id,
+        )
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'field': ['id'],
+                    'sort': 'title'
+                },
+            )
+
+        assert response.data[0]['id'] == 'c' * 32
+        assert response.data[1]['id'] == 'b' * 32
+        assert response.data[2]['id'] == 'a' * 32
+
+    def test_sort_ignore_invalid(self):
+        self.login_as(user=self.user)
+        project = self.create_project()
+        self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'timestamp': self.two_min_ago,
+            },
+            project_id=project.id,
+        )
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'field': ['id'],
+                    'sort': 'garbage'
+                },
+            )
+        assert response.status_code == 200
+
     def test_special_fields(self):
         self.login_as(user=self.user)
         project = self.create_project()

--- a/tests/snuba/test_util.py
+++ b/tests/snuba/test_util.py
@@ -69,3 +69,16 @@ class SnubaUtilTest(TestCase, SnubaTestCase):
                 assert snuba.OVERRIDE_OPTIONS == {'foo': 2, 'consistent': False}
             assert snuba.OVERRIDE_OPTIONS == {'foo': 1, 'consistent': False}
         assert snuba.OVERRIDE_OPTIONS == {'consistent': False}
+
+    def test_valid_orderby(self):
+        assert snuba.valid_orderby('event.type')
+        assert snuba.valid_orderby('project.id')
+        assert snuba.valid_orderby(['event.type', '-id'])
+        assert not snuba.valid_orderby('project.name')
+        assert not snuba.valid_orderby('issue_count')
+
+        extra_fields = ['issue_count', 'event_count']
+        assert snuba.valid_orderby(['issue_count', '-timestamp'], extra_fields)
+        assert snuba.valid_orderby('issue_count', extra_fields)
+        assert not snuba.valid_orderby(['invalid', 'issue_count'], extra_fields)
+        assert not snuba.valid_orderby(['issue_count', 'invalid'], extra_fields)


### PR DESCRIPTION
Enable sorting for all the fields that we can. Project name cannot be sorted on as it is not in snuba. I've also added validation for sort column names where invalid values are ignored. I think that is better behavior than the 500 errors that came before.

![Screen Shot 2019-07-10 at 3 31 50 PM](https://user-images.githubusercontent.com/24086/60998903-e571c000-a327-11e9-87b6-c8f8a3f9a627.png)


Fixes SEN-663