### PR TITLE
fix(api): Fix auth via api keys failing when calling an endpoint that senceptions

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -128,14 +128,21 @@ class Endpoint(APIView):
             return
 
     def initialize_request(self, request, *args, **kwargs):
+        # XXX: Since DRF 3.x, when the request is passed into
+        # `initialize_request` it's set as an internal variable on the returned
+        # request. Then when we call `rv.auth` it attempts to authenticate,
+        # fails and sets `user` and `auth` to None on the internal request. We
+        # keep track of these here and reassign them as needed.
+        orig_auth = getattr(request, 'auth', None)
+        orig_user = getattr(request, 'user', None)
         rv = super(Endpoint, self).initialize_request(request, *args, **kwargs)
         # If our request is being made via our internal API client, we need to
         # stitch back on auth and user information
         if getattr(request, '__from_api_client__', False):
             if rv.auth is None:
-                rv.auth = getattr(request, 'auth', None)
+                rv.auth = orig_auth
             if rv.user is None:
-                rv.user = getattr(request, 'user', None)
+                rv.user = orig_user
         return rv
 
     @csrf_exempt

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -2,13 +2,14 @@ from __future__ import absolute_import, print_function
 
 import mock
 import six
+from base64 import b64encode
 
 from datetime import timedelta
 from django.utils import timezone
 
 from sentry import tagstore
 from sentry.models import (
-    Activity, Environment, Group, GroupHash, GroupAssignee, GroupBookmark,
+    Activity, ApiKey, Environment, Group, GroupHash, GroupAssignee, GroupBookmark,
     GroupResolution, GroupSeen, GroupSnooze, GroupSubscription, GroupStatus,
     GroupTombstone, Release
 )
@@ -322,6 +323,27 @@ class GroupUpdateTest(APITestCase):
         assert response.status_code == 200, response.content
 
         assert not GroupAssignee.objects.filter(group=group, user=self.user).exists()
+
+    def test_assign_id_via_api_key(self):
+        # XXX: This test is written to verify that using api keys works when
+        # hitting an endpoint that uses `client.{get,put,post}` to redirect to
+        # another endpoint. This catches a regression that happened when
+        # migrating to DRF 3.x.
+        api_key = ApiKey.objects.create(
+            organization=self.organization,
+            scope_list=['event:write'],
+        )
+        group = self.create_group()
+        url = u'/api/0/issues/{}/'.format(group.id)
+
+        response = self.client.put(
+            url,
+            data={'assignedTo': self.user.id},
+            format='json',
+            HTTP_AUTHORIZATION='Basic ' + b64encode(u'{}:'.format(api_key.key)),
+        )
+        assert response.status_code == 200, response.content
+        assert GroupAssignee.objects.filter(group=group, user=self.user).exists()
 
     def test_assign_team(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
Senceptioning is when an api endpoint uses `sentry.api.client` to make the call to another
endpoint and returns the response. Auth was failing for api keys in these cases after the upgrade to DRF 3.0.5.