### PR TITLE
fix: Previous period of the events v2 graph are persisted when switching between view/tabs

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
@@ -34,13 +34,6 @@ class EventsLineChart extends React.Component {
       return false;
     }
 
-    if (
-      isEqual(this.props.timeseriesData, nextProps.timeseriesData) &&
-      isEqual(this.props.releaseSeries, nextProps.releaseSeries)
-    ) {
-      return false;
-    }
-
     return true;
   }
 

--- a/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEvents/eventsChart.jsx
@@ -34,6 +34,14 @@ class EventsLineChart extends React.Component {
       return false;
     }
 
+    if (
+      isEqual(this.props.timeseriesData, nextProps.timeseriesData) &&
+      isEqual(this.props.releaseSeries, nextProps.releaseSeries) &&
+      isEqual(this.props.previousTimeseriesData, nextProps.previousTimeseriesData)
+    ) {
+      return false;
+    }
+
     return true;
   }
 


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry/pull/13957

When switching events v2 tabs/views, the `timeseriesData` and `releaseSeries` props can be the same, but the `previousTimeseriesData` prop will not be the same. Therefore, the previous period graph will persist, when it shouldn't.

I updated `shouldComponentUpdate()` to consider the `previousTimeseriesData` prop.

-------


This was previously introduced in https://github.com/getsentry/sentry/pull/11977