### PR TITLE
conf: Add a setting to explicitly declare a default organization id

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -923,6 +923,10 @@ SENTRY_LOGIN_URL = None
 SENTRY_PROJECT = 1
 SENTRY_PROJECT_KEY = None
 
+# Default organization to represent the Internal Sentry project.
+# Used as a default when in SINGLE_ORGANIZATION mode.
+SENTRY_ORGANIZATION = 1
+
 # Project ID for recording frontend (javascript) exceptions
 SENTRY_FRONTEND_PROJECT = None
 # DSN for the frontend to use explicitly, which takes priority

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -159,9 +159,11 @@ class Organization(Model):
         """
         Return the organization used in single organization mode.
         """
-        return cls.objects.filter(
+
+        return cls.objects.get(
+            id=settings.SENTRY_ORGANIZATION,
             status=OrganizationStatus.ACTIVE,
-        )[0]
+        )
 
     def __unicode__(self):
         return u'%s (%s)' % (self.name, self.slug)


### PR DESCRIPTION
In single organization mode there's currently an assumption that the
default is the single row being returned from the database. But in cases
where you've explicitly created multiple organizations, and are using
SINGLE_ORGANIZATION as just a way to prevent more from being created and
give a single org experience, we need a way of saying which org to use.

This is similar vein to the SENTRY_PROJECT setting.

And to save investigation, Organization.get_default() is only used in
contexts behind a check for SENTRY_SINGLE_ORGANIZATION.

cc @b1naryth1ef 