### PR TITLE
feat(netlify): Configure netlify for preview builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,25 @@
+# Sentry uses netlify to deploy pull-request previews of the frontend which
+# talk to the production API.
+#
+# This is an EXPERIMENTAL developer experience, there are still various pages
+# that are served through django and have no SPA equivalent views.
+
+[build]
+  publish = "src/sentry/static/sentry/dist"
+  command = "yarn webpack"
+
+[[redirects]]
+  from = "/_assets/*"
+  to = "/:splat"
+  status = 200
+
+[[redirects]]
+  from = "/api/*"
+  to = "https://sentry.io/api/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
We have netlify configured to deploy pull requests. However, in order for the SPA app to work, we must configure netlify to proxy the production API, and direct all other pages to react.

This won't do too much yet until we expose react auth.