### PR TITLE
feat(api): Recalculate incident suspects if related commits are changed (SEN-776)

### DIFF
--- a/src/sentry/incidents/__init__.py
+++ b/src/sentry/incidents/__init__.py
@@ -1,2 +1,3 @@
 from __future__ import absolute_import
 from . import events  # NOQA
+from . import receivers  # NOQA

--- a/src/sentry/incidents/receivers.py
+++ b/src/sentry/incidents/receivers.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from sentry.incidents.models import IncidentSuspectCommit
+from sentry.signals import release_commits_updated
+
+
+@release_commits_updated.connect(weak=False)
+def handle_release_commits_updated(removed_commit_ids, added_commit_ids, **kwargs):
+    from sentry.incidents.tasks import calculate_incident_suspects
+    incident_ids = IncidentSuspectCommit.objects.filter(
+        commit_id__in=removed_commit_ids | added_commit_ids,
+    ).values_list('incident_id', flat=True).distinct()
+    for incident_id in incident_ids:
+        calculate_incident_suspects.apply_async(kwargs={'incident_id': incident_id})

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -96,6 +96,9 @@ data_scrubber_enabled = BetterSignal(providing_args=["organization"])
 alert_rule_created = BetterSignal(providing_args=["project", "rule", "user"])
 repo_linked = BetterSignal(providing_args=["repo", "user"])
 release_created = BetterSignal(providing_args=["release"])
+release_commits_updated = BetterSignal(
+    providing_args=["release", "removed_commit_ids", "added_commit_ids"],
+)
 deploy_created = BetterSignal(providing_args=["deploy"])
 ownership_rule_created = BetterSignal(providing_args=["project"])
 issue_ignored = BetterSignal(providing_args=["project", "user", "group_list", "activity_data"])

--- a/tests/sentry/incidents/test_receivers.py
+++ b/tests/sentry/incidents/test_receivers.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+from sentry.incidents.models import IncidentSuspectCommit
+from sentry.models.commit import Commit
+from sentry.models.release import Release
+from sentry.models.releasecommit import ReleaseCommit
+from sentry.models.repository import Repository
+from sentry.signals import release_commits_updated
+from sentry.testutils import TestCase
+
+
+class HandleReleaseCommitsUpdatedTest(TestCase):
+
+    def test(self):
+        release = self.create_release(project=self.project, version='something')
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name=self.organization.id,
+        )
+        release.set_commits([
+            {
+                'id': 'a' * 40,
+                'repository': self.repo.name,
+                'author_email': 'bob@example.com',
+                'author_name': 'Bob',
+            },
+        ])
+        commit = Commit.objects.get(releasecommit__release=release)
+
+        incident = self.create_incident()
+        ReleaseCommit.objects.filter(release=release).delete()
+        IncidentSuspectCommit.objects.create(
+            incident=incident,
+            commit=commit,
+            order=1,
+        )
+        with self.tasks():
+            release_commits_updated.send_robust(
+                release=release,
+                removed_commit_ids=set([commit.id]),
+                added_commit_ids=set([]),
+                sender=Release,
+            )
+            assert not IncidentSuspectCommit.objects.filter(incident=incident).exists()

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -13,6 +13,7 @@ from sentry.models import (
     ExternalIssue, Integration, OrganizationIntegration, Release, ReleaseCommit, ReleaseEnvironment,
     ReleaseHeadCommit, ReleaseProject, ReleaseProjectEnvironment, Repository
 )
+from sentry.signals import release_commits_updated
 
 from sentry.testutils import TestCase, SetRefsTestCase
 
@@ -565,6 +566,38 @@ class SetCommitsTestCase(TestCase):
         assert resolution.actor_id is None
 
         assert Group.objects.get(id=group.id).status == GroupStatus.RESOLVED
+
+    def test_release_commits_updated(self):
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        release = self.create_release(user=self.user, project=project)
+        repo = Repository.objects.get(organization_id=org.id)
+        removed_commit = ReleaseCommit.objects.get(release=release).commit
+        added_commit = Commit.objects.create(
+            organization_id=org.id,
+            repository_id=repo.id,
+            message='Something',
+            key='alksdflskdfjsldkfajsflkslk',
+        )
+
+        release_result = []
+        added = set()
+        removed = set()
+
+        def dummy_signal_handler(release, added_commit_ids, removed_commit_ids, **kwargs):
+            release_result.append(release)
+            added.update(added_commit_ids)
+            removed.update(removed_commit_ids)
+
+        release_commits_updated.connect(dummy_signal_handler)
+        release.set_commits([{'id': added_commit.key, 'repository': repo.name}])
+        assert ReleaseCommit.objects.filter(commit=added_commit, release=release).exists()
+        assert not ReleaseCommit.objects.filter(commit=removed_commit, release=release).exists()
+        assert release_result[0] == release
+        assert added == set([added_commit.id])
+        assert removed == set([removed_commit.id])
+
+        release_commits_updated.disconnect(dummy_signal_handler)
 
 
 class SetRefsTest(SetRefsTestCase):


### PR DESCRIPTION
We want to recalculate suspects for an incident if the commits for a release are changed.