### PR TITLE
fix (cleanup): silent cleanup honors is_filtered

### DIFF
--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -208,11 +208,13 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
             date_added__lte=timezone.now() - timedelta(hours=48)
         ).delete()
 
-    if is_filtered(models.OrganizationMember) and not silent:
-        click.echo('>> Skipping OrganizationMember')
-    else:
+    if not silent:
+        click.echo('Removing expired values for OrganizationMember')
+
+    if is_filtered(models.OrganizationMember):
         if not silent:
-            click.echo('Removing expired values for OrganizationMember')
+            click.echo('>> Skipping OrganizationMember')
+    else:
         expired_threshold = timezone.now() - timedelta(days=days)
         models.OrganizationMember.delete_expired(expired_threshold)
 


### PR DESCRIPTION
Expired organisation members would be deleted during silent cleanup
even when filtered (not specified on the command line).
@getsentry/infrastructure

Fixes GH-13968