### PR TITLE
Fix typos and grammar mistakes in interfaces.

### DIFF
--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -68,7 +68,7 @@ def prune_empty_keys(obj):
     # but rather deal with them case-by-case before calling `prune_empty_keys`
     # (e.g. in `Interface.to_json`). Rarely, but sometimes, there's a slight
     # semantic difference between empty containers and a missing value. One
-    # example would be `event.logenty.formatted`, where `{}` means "this
+    # example would be `event.logentry.formatted`, where `{}` means "this
     # message has no params" and `None` means "this message is already
     # formatted".
     return dict((k, v) for k, v in six.iteritems(obj) if v is not None)

--- a/src/sentry/interfaces/debug_meta.py
+++ b/src/sentry/interfaces/debug_meta.py
@@ -7,7 +7,7 @@ from sentry.interfaces.base import Interface, prune_empty_keys
 
 class DebugMeta(Interface):
     """
-    Holds debug meta information information for processing stacktraces
+    Holds debug meta information for processing stacktraces
     and similar things.  This information is deleted after event processing.
 
     Currently two attributes exist:


### PR DESCRIPTION
Found these while working on spans.