### PR TITLE
feat(apm) Add spans interface to events

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -978,6 +978,7 @@ SENTRY_INTERFACES = {
     'contexts': 'sentry.interfaces.contexts.Contexts',
     'threads': 'sentry.interfaces.threads.Threads',
     'debug_meta': 'sentry.interfaces.debug_meta.DebugMeta',
+    'spans': 'sentry.interfaces.spans.Spans',
 }
 PREFER_CANONICAL_LEGACY_KEYS = False
 

--- a/src/sentry/interfaces/spans.py
+++ b/src/sentry/interfaces/spans.py
@@ -1,0 +1,67 @@
+from __future__ import absolute_import
+
+__all__ = ('Spans', 'Span')
+
+from sentry.interfaces.base import Interface
+
+SPAN_KEYS = (
+    'trace_id',
+    'parent_span_id',
+    'span_id',
+    'start_timestamp',
+    'same_process_as_parent',
+    'description',
+    'tags',
+    'timestamp',
+    'op',
+    'data'
+)
+
+
+class Span(Interface):
+    """
+    Holds timing spans related to APM and tracing.
+
+    >>> {
+    >>>   'trace_id': 'a0fa8803753e40fd8124b21eeb2986b5',
+    >>>   'parent_span_id': '9c2a6db8c79068a2',
+    >>>   'span_id': '8c931f4740435fb8',
+    >>>   'start_timestamp': '2019-06-14T14:01:41Z',
+    >>>   'same_process_as_parent': true,
+    >>>   'description': 'http://httpbin.org/base64/aGVsbG8gd29ybGQK GET',
+    >>>   'tags': { 'http.status_code': 200, 'error': false },
+    >>>   'timestamp': '2019-06-14T14:01:41Z',
+    >>>   'op': 'http',
+    >>>   'data': {
+    >>>     'url': 'http://httpbin.org/base64/aGVsbG8gd29ybGQK',
+    >>>     'status_code': 200,
+    >>>     'reason': 'OK',
+    >>>     'method': 'GET'
+    >>>   }
+    >>> }
+    """
+    @classmethod
+    def to_python(cls, data):
+        for key in SPAN_KEYS:
+            data.setdefault(key, None)
+        return cls(**data)
+
+
+class Spans(Interface):
+    """
+    Contains a list of Span interfaces
+    """
+    display_score = 1950
+    score = 1950
+    path = 'spans'
+
+    @classmethod
+    def to_python(cls, data):
+        spans = [Span.to_python(span) for span in data]
+        return cls(spans=spans)
+
+    def __iter__(self):
+        return iter(self.spans)
+
+    def to_json(self):
+        return [span.to_json() for span in self]

--- a/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_empty.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_empty.pysnap
@@ -1,0 +1,7 @@
+---
+created: '2019-07-11T17:56:10.526330Z'
+creator: sentry
+source: tests/sentry/event_manager/interfaces/test_spans.py
+---
+errors: null
+to_json: []

--- a/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_multiple_full.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_multiple_full.pysnap
@@ -1,0 +1,27 @@
+---
+created: '2019-07-11T19:30:21.322813Z'
+creator: sentry
+source: tests/sentry/event_manager/interfaces/test_spans.py
+---
+errors: null
+to_json:
+- data:
+    reason: OK
+    status_code: 200
+  description: GET http://example.com
+  op: http
+  span_id: 8c931f4740435fb8
+  start_timestamp: 1562873192.624
+  tags:
+    sentry:user: id:1
+    service: example
+  timestamp: 1562873194.624
+  trace_id: a0fa8803753e40fd8124b21eeb2986b5
+- description: SELECT * FROM users
+  op: db
+  span_id: 6c931f4740666fb6
+  start_timestamp: 1562873192.624
+  tags:
+    service: example
+  timestamp: 1562873194.624
+  trace_id: a0fa8803753e40fd8124b21eeb2986b5

--- a/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_single_full.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_single_full.pysnap
@@ -1,0 +1,19 @@
+---
+created: '2019-07-11T19:26:32.626601Z'
+creator: sentry
+source: tests/sentry/event_manager/interfaces/test_spans.py
+---
+errors: null
+to_json:
+- data:
+    reason: OK
+    status_code: 200
+  description: GET http://example.com
+  op: http
+  span_id: 8c931f4740435fb8
+  start_timestamp: 1562873192.624
+  tags:
+    sentry:user: id:1
+    service: example
+  timestamp: 1562873194.624
+  trace_id: a0fa8803753e40fd8124b21eeb2986b5

--- a/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_single_incomplete.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_single_incomplete.pysnap
@@ -1,0 +1,11 @@
+---
+created: '2019-07-11T19:30:21.308502Z'
+creator: sentry
+source: tests/sentry/event_manager/interfaces/test_spans.py
+---
+errors: null
+to_json:
+- span_id: 8c931f4740435fb8
+  start_timestamp: 1562873192.624
+  timestamp: 1562873194.624
+  trace_id: a0fa8803753e40fd8124b21eeb2986b5

--- a/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_single_invalid.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_spans/test_single_invalid.pysnap
@@ -1,0 +1,17 @@
+---
+created: '2019-07-11T19:30:21.301373Z'
+creator: sentry
+source: tests/sentry/event_manager/interfaces/test_spans.py
+---
+errors:
+- name: spans.0.span_id
+  reason: not a valid span id
+  type: invalid_data
+  value: bad
+- name: spans.0.trace_id
+  reason: not a valid trace id
+  type: invalid_data
+  value: bad
+to_json:
+- start_timestamp: 1562873192.624
+  timestamp: 1562873194.624

--- a/tests/sentry/event_manager/interfaces/test_spans.py
+++ b/tests/sentry/event_manager/interfaces/test_spans.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import pytest
+
+from sentry.models import Event
+from sentry.event_manager import EventManager
+
+START_TIME = 1562873192.624
+END_TIME = 1562873194.624
+
+
+@pytest.fixture
+def make_spans_snapshot(insta_snapshot):
+    def inner(data):
+        mgr = EventManager(data={"spans": data})
+        mgr.normalize()
+        evt = Event(data=mgr.get_data())
+
+        interface = evt.interfaces.get('spans')
+
+        insta_snapshot({
+            'errors': evt.data.get('errors'),
+            'to_json': interface.to_json(),
+        })
+
+    return inner
+
+
+def test_empty(make_spans_snapshot):
+    make_spans_snapshot([])
+
+
+def test_single_invalid(make_spans_snapshot):
+    make_spans_snapshot([
+        {
+            'trace_id': 'bad',
+            'span_id': 'bad',
+            'start_timestamp': START_TIME,
+            'timestamp': END_TIME,
+        }
+    ])
+
+
+def test_single_incomplete(make_spans_snapshot):
+    make_spans_snapshot([
+        {
+            'trace_id': 'a0fa8803753e40fd8124b21eeb2986b5',
+            'span_id': '8c931f4740435fb8',
+            'start_timestamp': START_TIME,
+            'timestamp': END_TIME,
+        }
+    ])
+
+
+def test_single_full(make_spans_snapshot):
+    make_spans_snapshot([
+        {
+            'trace_id': 'a0fa8803753e40fd8124b21eeb2986b5',
+            'span_id': '8c931f4740435fb8',
+            'start_timestamp': START_TIME,
+            'timestamp': END_TIME,
+            'op': 'http',
+            'description': 'GET http://example.com',
+            'data': {
+                'status_code': 200,
+                'reason': 'OK',
+            },
+            'tags': {
+                'service': 'example',
+                'sentry:user': 'id:1',
+            }
+        }
+    ])
+
+
+def test_multiple_full(make_spans_snapshot):
+    make_spans_snapshot([
+        {
+            'trace_id': 'a0fa8803753e40fd8124b21eeb2986b5',
+            'span_id': '8c931f4740435fb8',
+            'start_timestamp': START_TIME,
+            'timestamp': END_TIME,
+            'op': 'http',
+            'description': 'GET http://example.com',
+            'data': {
+                'status_code': 200,
+                'reason': 'OK',
+            },
+            'tags': {
+                'service': 'example',
+                'sentry:user': 'id:1',
+            }
+        },
+        {
+            'trace_id': 'a0fa8803753e40fd8124b21eeb2986b5',
+            'span_id': '6c931f4740666fb6',
+            'start_timestamp': START_TIME,
+            'timestamp': END_TIME,
+            'op': 'db',
+            'description': 'SELECT * FROM users',
+            'tags': {
+                'service': 'example',
+            }
+        }
+    ])


### PR DESCRIPTION
The spans interface will be populated by data from nodestore in the short term. Down the road we'll need to update the load spans from their new storage in snuba.

Refs SEN-799