### PR TITLE
fix(serverless): Add trailing slash to dist prefix

### DIFF
--- a/src/sentry/static/sentry/app/index.js
+++ b/src/sentry/static/sentry/app/index.js
@@ -27,7 +27,7 @@ async function bootWithHydration() {
   // mode, where assets are *currently not versioned*. We hardcode this here
   // for now as a quick workaround for the index.html being aware of versioned
   // asset paths.
-  data.distPrefix = '/_assets';
+  data.distPrefix = '/_assets/';
 
   bootApplication(data);
 


### PR DESCRIPTION
Deploy previews don't have working codesplit loading working atm. This
fixes that