### PR TITLE
feat(issueless): Skip most of post process for issueless events

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -168,7 +168,7 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
         event.data = EventDict(event.data, skip_renormalization=True)
 
         if event.group_id:
-            # Re-bind Project since we're pickling the whole Event object
+            # Re-bind Group since we're pickling the whole Event object
             # which may contain a stale Project.
             event.group, _ = get_group_with_redirect(event.group_id)
             project_id = event.group.project_id
@@ -178,6 +178,8 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
         with configure_scope() as scope:
             scope.set_tag("project", project_id)
 
+        # Re-bind Group since we're pickling the whole Event object
+        # which may contain a stale Project.
         event.project = Project.objects.get_from_cache(id=project_id)
 
         _capture_stats(event, is_new)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -168,7 +168,7 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
         event.data = EventDict(event.data, skip_renormalization=True)
 
         if event.group_id:
-            # Re-bind Project since we're pickling the whole Event object
+            # Re-bind Group since we're pickling the whole Event object
             # which may contain a stale Project.
             event.group, _ = get_group_with_redirect(event.group_id)
             project_id = event.group.project_id
@@ -178,7 +178,7 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
         with configure_scope() as scope:
             scope.set_tag("project", project_id)
 
-        # Re-bind Group since we're pickling the whole Event object
+        # Re-bind Project since we're pickling the whole Event object
         # which may contain a stale Project.
         event.project = Project.objects.get_from_cache(id=project_id)
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -171,6 +171,7 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
             # Re-bind Group since we're pickling the whole Event object
             # which may contain a stale Project.
             event.group, _ = get_group_with_redirect(event.group_id)
+            event.group_id = event.group.id
             project_id = event.group.project_id
         else:
             project_id = event.project_id

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -167,77 +167,78 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
         # renormalize when loading old data from the database.
         event.data = EventDict(event.data, skip_renormalization=True)
 
-        # Re-bind Group since we're pickling the whole Event object
-        # which may contain a stale Group.
-        event.group, _ = get_group_with_redirect(event.group_id)
-        event.group_id = event.group.id
+        if event.group_id:
+            # Re-bind Project since we're pickling the whole Event object
+            # which may contain a stale Project.
+            event.group, _ = get_group_with_redirect(event.group_id)
+            project_id = event.group.project_id
+        else:
+            project_id = event.project_id
 
-        project_id = event.group.project_id
         with configure_scope() as scope:
             scope.set_tag("project", project_id)
 
-        # Re-bind Project since we're pickling the whole Event object
-        # which may contain a stale Project.
         event.project = Project.objects.get_from_cache(id=project_id)
 
         _capture_stats(event, is_new)
 
-        # we process snoozes before rules as it might create a regression
-        has_reappeared = process_snoozes(event.group)
+        if event.group_id:
+            # we process snoozes before rules as it might create a regression
+            has_reappeared = process_snoozes(event.group)
 
-        handle_owner_assignment(event.project, event.group, event)
+            handle_owner_assignment(event.project, event.group, event)
 
-        rp = RuleProcessor(
-            event,
-            is_new,
-            is_regression,
-            is_new_group_environment,
-            has_reappeared)
-        has_alert = False
-        # TODO(dcramer): ideally this would fanout, but serializing giant
-        # objects back and forth isn't super efficient
-        for callback, futures in rp.apply():
-            has_alert = True
-            safe_execute(callback, event, futures)
+            rp = RuleProcessor(
+                event,
+                is_new,
+                is_regression,
+                is_new_group_environment,
+                has_reappeared)
+            has_alert = False
+            # TODO(dcramer): ideally this would fanout, but serializing giant
+            # objects back and forth isn't super efficient
+            for callback, futures in rp.apply():
+                has_alert = True
+                safe_execute(callback, event, futures)
 
-        if features.has(
-            'projects:servicehooks',
-            project=event.project,
-        ):
-            allowed_events = set(['event.created'])
-            if has_alert:
-                allowed_events.add('event.alert')
+            if features.has(
+                'projects:servicehooks',
+                project=event.project,
+            ):
+                allowed_events = set(['event.created'])
+                if has_alert:
+                    allowed_events.add('event.alert')
 
-            if allowed_events:
-                for servicehook_id, events in _get_service_hooks(project_id=event.project_id):
-                    if any(e in allowed_events for e in events):
-                        process_service_hook.delay(
-                            servicehook_id=servicehook_id,
-                            event=event,
-                        )
+                if allowed_events:
+                    for servicehook_id, events in _get_service_hooks(project_id=event.project_id):
+                        if any(e in allowed_events for e in events):
+                            process_service_hook.delay(
+                                servicehook_id=servicehook_id,
+                                event=event,
+                            )
 
-        if event.get_event_type() == 'error' and _should_send_error_created_hooks(event.project):
-            process_resource_change_bound.delay(
-                action='created',
-                sender='Error',
-                instance_id=event.event_id,
-                instance=event,
-            )
-        if is_new:
-            process_resource_change_bound.delay(
-                action='created',
-                sender='Group',
-                instance_id=event.group_id,
-            )
+            if event.get_event_type() == 'error' and _should_send_error_created_hooks(event.project):
+                process_resource_change_bound.delay(
+                    action='created',
+                    sender='Error',
+                    instance_id=event.event_id,
+                    instance=event,
+                )
+            if is_new:
+                process_resource_change_bound.delay(
+                    action='created',
+                    sender='Group',
+                    instance_id=event.group_id,
+                )
 
-        for plugin in plugins.for_project(event.project):
-            plugin_post_process_group(
-                plugin_slug=plugin.slug,
-                event=event,
-                is_new=is_new,
-                is_regresion=is_regression,
-                is_sample=is_sample,
-            )
+            for plugin in plugins.for_project(event.project):
+                plugin_post_process_group(
+                    plugin_slug=plugin.slug,
+                    event=event,
+                    is_new=is_new,
+                    is_regresion=is_regression,
+                    is_sample=is_sample,
+                )
 
         event_processed.send_robust(
             sender=post_process_group,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -168,7 +168,7 @@ def post_process_group(event, is_new, is_regression, is_sample, is_new_group_env
         event.data = EventDict(event.data, skip_renormalization=True)
 
         if event.group_id:
-            # Re-bind Group since we're pickling the whole Event object
+            # Re-bind Project since we're pickling the whole Event object
             # which may contain a stale Project.
             event.group, _ = get_group_with_redirect(event.group_id)
             project_id = event.group.project_id

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from datetime import timedelta
 from django.utils import timezone
-from mock import Mock, patch
+from mock import Mock, patch, ANY
 
 from sentry import tagstore
 from sentry import options
@@ -17,6 +17,32 @@ from sentry.tasks.post_process import index_event_tags, post_process_group
 
 
 class PostProcessGroupTest(TestCase):
+    @patch('sentry.rules.processor.RuleProcessor')
+    @patch('sentry.tasks.servicehooks.process_service_hook')
+    @patch('sentry.tasks.sentry_apps.process_resource_change_bound.delay')
+    @patch('sentry.signals.event_processed.send_robust')
+    def test_issueless(self, mock_signal, mock_process_resource_change_bound,
+                       mock_process_service_hook, mock_processor):
+        event = self.create_issueless_event(project=self.project)
+        post_process_group(
+            event=event,
+            is_new=True,
+            is_regression=False,
+            is_sample=False,
+            is_new_group_environment=True,
+        )
+
+        mock_processor.assert_not_called()  # NOQA
+        mock_process_service_hook.assert_not_called()  # NOQA
+        mock_process_resource_change_bound.assert_not_called()  # NOQA
+
+        mock_signal.assert_called_once_with(
+            sender=ANY,
+            project=self.project,
+            event=event,
+            primary_hash=None,
+        )
+
     @patch('sentry.rules.processor.RuleProcessor')
     def test_rule_processor(self, mock_processor):
         group = self.create_group(project=self.project)


### PR DESCRIPTION
This is the second part of the split of #13899. 
This just skips most of post processing for events that do not have a group.

Test plan:
- test added to post process tests for an event without issue
- all existing test coverage for post process is still valid.
- ingested multiple events and noticed from the worker logs that plugins are executed.