### PR TITLE
ref(ui): Fix scroll gaps when alerts exist in the main-container

### DIFF
--- a/src/sentry/static/sentry/app/views/onboarding/wizardNew.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/wizardNew.jsx
@@ -208,9 +208,9 @@ const Theme = {
 };
 
 const OnboardingWrapper = styled('main')`
+  flex-grow: 1;
   background: ${Theme.colors.gray[0]};
   padding-bottom: 50vh;
-  min-height: 100vh;
 `;
 
 const Container = styled.div`

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -249,7 +249,7 @@ body.auth {
 .app {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  flex-grow: 1;
 }
 
 .container {
@@ -266,6 +266,8 @@ body.auth {
 
 // Container around content in app.jsx
 .main-container {
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
   outline: none;
 }


### PR DESCRIPTION
When there are alerts at the top of the page, it causes the page have a scroll gap