### PR TITLE
fix(ui): Fix Organization/Project Settings breadcrumbs

### DIFF
--- a/src/sentry/static/sentry/app/utils/recreateRoute.jsx
+++ b/src/sentry/static/sentry/app/utils/recreateRoute.jsx
@@ -10,11 +10,14 @@ import replaceRouterParams from 'app/utils/replaceRouterParams';
 // See tests for examples
 export default function recreateRoute(to, {routes, params, location, stepBack}) {
   const paths = routes.map(({path}) => path || '');
-  const lastRootIndex = findLastIndex(paths, path => path[0] === '/');
+  let lastRootIndex;
   let routeIndex;
   const routeToRoute = typeof to !== 'string';
   if (routeToRoute) {
-    routeIndex = routes.indexOf(to) + lastRootIndex;
+    routeIndex = routes.indexOf(to) + 1;
+    lastRootIndex = findLastIndex(paths.slice(0, routeIndex), path => path[0] === '/');
+  } else {
+    lastRootIndex = findLastIndex(paths, path => path[0] === '/');
   }
 
   let baseRoute = paths.slice(lastRootIndex, routeIndex);

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam.jsx
@@ -10,6 +10,7 @@ export default function findFirstRouteWithoutRouteParam(routes, route) {
   const routesToSearch = route && routeIndex > -1 ? routes.slice(routeIndex) : routes;
 
   return (
-    routesToSearch.filter(({path}) => !!path).find(({path}) => path[0] !== ':') || route
+    routesToSearch.filter(({path}) => !!path).find(({path}) => !path.includes(':')) ||
+    route
   );
 }

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam.jsx
@@ -1,0 +1,15 @@
+/**
+ * For all routes with a `path`, find the first route without a route param (e.g. :apiKey)
+ *
+ * @param {Object[]} routes A list of react-router route objects
+ * @param {Object} route If given, will only take into account routes between `route` and end of the routes list
+ * @return Object Returns a react-router route object
+ */
+export default function findFirstRouteWithoutRouteParam(routes, route) {
+  const routeIndex = routes.indexOf(route);
+  const routesToSearch = route && routeIndex > -1 ? routes.slice(routeIndex) : routes;
+
+  return (
+    routesToSearch.filter(({path}) => !!path).find(({path}) => path[0] !== ':') || route
+  );
+}

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/organizationCrumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/organizationCrumb.jsx
@@ -8,6 +8,7 @@ import IdBadge from 'app/components/idBadge';
 import MenuItem from 'app/views/settings/components/settingsBreadcrumb/menuItem';
 import SentryTypes from 'app/sentryTypes';
 import TextLink from 'app/components/links/textLink';
+import findFirstRouteWithoutRouteParam from 'app/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam';
 import recreateRoute from 'app/utils/recreateRoute';
 import withLatestContext from 'app/utils/withLatestContext';
 
@@ -17,6 +18,27 @@ class OrganizationCrumb extends React.Component {
     organization: SentryTypes.Organization,
     routes: PropTypes.array,
     route: PropTypes.object,
+  };
+
+  handleSelect = item => {
+    const {params, routes, route} = this.props;
+    // If we are currently in a project context, and we're attempting to switch organizations,
+    // then we need to default to index route (e.g. `route`)
+    //
+    // Otherwise, find the last route without a router param
+    // e.g. if you are on API details, we want the API listing
+    // This fails if our route tree is not nested
+    const hasProjectParam = !!params.projectId;
+    const destination = hasProjectParam
+      ? route
+      : findFirstRouteWithoutRouteParam(routes.slice(routes.indexOf(route)));
+
+    browserHistory.push(
+      recreateRoute(destination, {
+        routes,
+        params: {...params, orgId: item.value},
+      })
+    );
   };
 
   render() {
@@ -42,20 +64,7 @@ class OrganizationCrumb extends React.Component {
             </Flex>
           </TextLink>
         }
-        onSelect={item => {
-          // If we are currently in a project context, and we're attempting to switch organizations,
-          // then we need to default to index route (e.g. `route`)
-          //
-          // Otherwise, using empty string ('') will keep the current route path but with target org
-          const hasProjectParam = !!params.projectId;
-          const destination = hasProjectParam ? route : '';
-          browserHistory.push(
-            recreateRoute(destination, {
-              routes,
-              params: {...params, orgId: item.value},
-            })
-          );
-        }}
+        onSelect={this.handleSelect}
         hasMenu={hasMenu}
         route={route}
         items={organizations.map(org => ({

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/projectCrumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/projectCrumb.jsx
@@ -9,13 +9,12 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import MenuItem from 'app/views/settings/components/settingsBreadcrumb/menuItem';
 import SentryTypes from 'app/sentryTypes';
 import TextLink from 'app/components/links/textLink';
+import findFirstRouteWithoutRouteParam from 'app/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam';
 import recreateRoute from 'app/utils/recreateRoute';
 import replaceRouterParams from 'app/utils/replaceRouterParams';
+import space from 'app/styles/space';
 import withLatestContext from 'app/utils/withLatestContext';
 import withProjects from 'app/utils/withProjects';
-import space from 'app/styles/space';
-
-const ROUTE_PATH_EXCEPTIONS = new Set([':ruleId/', ':keyId/', ':hookId/', ':pluginId/']);
 
 class ProjectCrumb extends React.Component {
   static propTypes = {
@@ -27,18 +26,21 @@ class ProjectCrumb extends React.Component {
   };
 
   handleSelect = item => {
-    const {routes, params} = this.props;
+    const {routes, route, params} = this.props;
 
-    const lastRoute = routes[routes.length - 1];
     // We have to make exceptions for routes like "Project Alerts Rule Edit" or "Client Key Details"
     // Since these models are project specific, we need to traverse up a route when switching projects
-    const stepBack = ROUTE_PATH_EXCEPTIONS.has(lastRoute.path) ? -1 : undefined;
+    //
+    // we manipulate `routes` so that it doesn't include the current projects route
+    // which, unlike the org version, does not start with a route param
     browserHistory.push(
-      recreateRoute('', {
-        routes,
-        params: {...params, projectId: item.value},
-        stepBack,
-      })
+      recreateRoute(
+        findFirstRouteWithoutRouteParam(routes.slice(routes.indexOf(route) + 1), route),
+        {
+          routes,
+          params: {...params, projectId: item.value},
+        }
+      )
     );
   };
 

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/projectCrumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/projectCrumb.jsx
@@ -31,7 +31,7 @@ class ProjectCrumb extends React.Component {
     // We have to make exceptions for routes like "Project Alerts Rule Edit" or "Client Key Details"
     // Since these models are project specific, we need to traverse up a route when switching projects
     //
-    // we manipulate `routes` so that it doesn't include the current projects route
+    // we manipulate `routes` so that it doesn't include the current project's route
     // which, unlike the org version, does not start with a route param
     browserHistory.push(
       recreateRoute(

--- a/tests/js/spec/utils/recreateRoute.spec.jsx
+++ b/tests/js/spec/utils/recreateRoute.spec.jsx
@@ -4,6 +4,7 @@ jest.unmock('app/utils/recreateRoute');
 
 const routes = [
   {path: '/', childRoutes: []},
+  {childRoutes: []},
   {path: '/settings/', name: 'Settings'},
   {name: 'Organizations', path: ':orgId/', childRoutes: []},
   {childRoutes: []},
@@ -12,6 +13,7 @@ const routes = [
 
 const projectRoutes = [
   {path: '/', childRoutes: []},
+  {childRoutes: []},
   {path: '/settings/', name: 'Settings', indexRoute: {}, childRoutes: []},
   {name: 'Organizations', path: ':orgId/', childRoutes: []},
   {name: 'Projects', path: ':projectId/', childRoutes: []},
@@ -29,13 +31,34 @@ const location = {
 
 describe('recreateRoute', function() {
   it('returns correct path to a route object', function() {
-    expect(recreateRoute(routes[4], {routes, params})).toBe(
+    expect(recreateRoute(routes[0], {routes, params})).toBe('/');
+    expect(recreateRoute(routes[1], {routes, params})).toBe('/');
+    expect(recreateRoute(routes[2], {routes, params})).toBe('/settings/');
+    expect(recreateRoute(routes[3], {routes, params})).toBe('/settings/org-slug/');
+    expect(recreateRoute(routes[4], {routes, params})).toBe('/settings/org-slug/');
+    expect(recreateRoute(routes[5], {routes, params})).toBe(
       '/settings/org-slug/api-keys/'
     );
 
     expect(
-      recreateRoute(projectRoutes[4], {routes: projectRoutes, location, params})
+      recreateRoute(projectRoutes[5], {routes: projectRoutes, location, params})
     ).toBe('/settings/org-slug/project-slug/alerts/');
+  });
+
+  it('has correct path with route object with many roots (starts with "/")', function() {
+    const r = [
+      {path: '/', childRoutes: []},
+      {childRoutes: []},
+      {path: '/foo/', childRoutes: []},
+      {childRoutes: []},
+      {path: 'bar', childRoutes: []},
+      {path: '/settings/', name: 'Settings'},
+      {name: 'Organizations', path: ':orgId/', childRoutes: []},
+      {childRoutes: []},
+      {path: 'api-keys/', name: 'API Key'},
+    ];
+
+    expect(recreateRoute(r[4], {routes: r, params})).toBe('/foo/bar');
   });
 
   it('returns correct path to a string (at the end of the routes)', function() {
@@ -55,7 +78,7 @@ describe('recreateRoute', function() {
   });
 
   it('switches to new org but keeps current route', function() {
-    expect(recreateRoute(routes[4], {routes, location, params: {orgId: 'new-org'}})).toBe(
+    expect(recreateRoute(routes[5], {routes, location, params: {orgId: 'new-org'}})).toBe(
       '/settings/new-org/api-keys/'
     );
   });
@@ -65,7 +88,7 @@ describe('recreateRoute', function() {
       search: '?key1=foo&key2=bar',
     };
 
-    expect(recreateRoute(routes[4], {routes, params, location: withSearch})).toBe(
+    expect(recreateRoute(routes[5], {routes, params, location: withSearch})).toBe(
       '/settings/org-slug/api-keys/?key1=foo&key2=bar'
     );
   });

--- a/tests/js/spec/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam.spec.jsx
@@ -1,0 +1,26 @@
+import findFirstRouteWithoutRouteParam from 'app/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam';
+
+describe('findFirstRouteWithoutRouteParam', function() {
+  const routes = [
+    {path: '/', childRoutes: []},
+    {childRoutes: []},
+    {path: '/foo/', childRoutes: []},
+    {childRoutes: []},
+    {path: ':bar', childRoutes: []},
+    {path: '/settings/', name: 'Settings'},
+    {name: 'Organizations', path: ':orgId/', childRoutes: []},
+    {childRoutes: []},
+    {path: 'api-keys/', name: 'API Key'},
+    {path: ':apiKey/', name: 'API Key Details'},
+  ];
+
+  it('finds the first route', function() {
+    expect(findFirstRouteWithoutRouteParam(routes).path).toBe('/');
+  });
+
+  it('finds the first route after the given route', function() {
+    expect(findFirstRouteWithoutRouteParam(routes, routes[2]).path).toBe('/foo/');
+    expect(findFirstRouteWithoutRouteParam(routes, routes[6]).path).toBe('api-keys/');
+    expect(findFirstRouteWithoutRouteParam(routes, routes[8]).path).toBe('api-keys/');
+  });
+});

--- a/tests/js/spec/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsBreadcrumb/findFirstRouteWithoutRouteParam.spec.jsx
@@ -23,4 +23,14 @@ describe('findFirstRouteWithoutRouteParam', function() {
     expect(findFirstRouteWithoutRouteParam(routes, routes[6]).path).toBe('api-keys/');
     expect(findFirstRouteWithoutRouteParam(routes, routes[8]).path).toBe('api-keys/');
   });
+
+  it('does not include routes that have any url parameters', function() {
+    const r = [
+      {path: '/settings/', name: 'Settings'},
+      {name: 'Organizations', path: ':orgId/', childRoutes: []},
+      {path: 'api-keys/:apiKey/', name: 'API Key Details'},
+    ];
+
+    expect(findFirstRouteWithoutRouteParam(r, r[1]).path).toBe(':orgId/');
+  });
 });


### PR DESCRIPTION
This fixes navigation issues with the breadcrumb inside of settings. Also
fixes the problem when inside of an org specific resource and trying to
switch orgs.

Previously it would keep all of the router params the same and it would 404
since the resource would not exist in the target organization.