### PR TITLE
fix(tests) Make browser.element() less racey

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -64,6 +64,7 @@ class Browser(object):
         return self
 
     def element(self, selector):
+        self.wait_until(selector)
         return self.driver.find_element_by_css_selector(selector)
 
     def element_exists(self, selector):

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -64,17 +64,27 @@ class Browser(object):
         return self
 
     def element(self, selector):
+        """
+        Get an element from the page. This method will wait for the element to show up.
+        """
         self.wait_until(selector)
         return self.driver.find_element_by_css_selector(selector)
 
     def element_exists(self, selector):
+        """
+        Check if an element exists on the page. This method will *not* wait for the element.
+        """
         try:
-            self.element(selector)
+            self.driver.find_element_by_css_selector(selector)
         except NoSuchElementException:
             return False
         return True
 
     def element_exists_by_test_id(self, selector):
+        """
+        Check if an element exists on the page using a data-test-id attribute.
+        This method will not wait for the element.
+        """
         return self.element_exists('[data-test-id="%s"]' % (selector))
 
     def click(self, selector):

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -62,9 +62,7 @@ class IssueDetailsPage(BasePage):
         return self.browser.find_element_by_css_selector('[data-test-id="note-input-form"]')
 
     def has_comment(self, text):
-        selector = '[data-test-id="activity-note-body"]'
-        self.browser.wait_until(selector)
-        element = self.browser.element(selector)
+        element = self.browser.element('[data-test-id="activity-note-body"]')
         return text in element.text
 
     def dismiss_assistant(self):

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -20,7 +20,6 @@ class OrganizationDeveloperSettingsAcceptanceTest(AcceptanceTestCase):
 
     def test_create_new_integration(self):
         with self.feature('organizations:sentry-apps'):
-
             self.load_page(self.org_developer_settings_path)
 
             self.browser.click('[aria-label="Create New Integration"]')


### PR DESCRIPTION
When using the `.element()` wrapper we should try waiting for the element as the current implementation has a race condition with repaints that can result in failed tests. By waiting a bit we add some resilience to the tests and reduce the number of places we'll need to add waits manually.