### PR TITLE
fix: Remove zoom css property.

### DIFF
--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -46,7 +46,6 @@ body {
 */
 
 body.narrow {
-  zoom: 1;
   padding: 0;
 
   background: #fff;
@@ -415,7 +414,6 @@ footer {
 
 @media (max-width: 767px) {
   body {
-    zoom: 0.85;
     padding-top: 0;
 
     // Hide fake sidebar on mobile


### PR DESCRIPTION
- It's non-standard: https://caniuse.com/#feat=css-zoom

- Previously introduced in https://github.com/getsentry/sentry/commit/a2f9fb0004c2e304028e0a9870d32f5ed4e3a242 and https://github.com/getsentry/sentry/pull/3076

- Primarily I want to remove this because this is causing mouse coordinate issues for the minimap trace view component in https://github.com/getsentry/sentry/pull/13920 on screen widths smaller than `767px`.  

- A workaround is hacky https://stackoverflow.com/questions/49127819/wrong-mouse-coordinates-when-using-css-zoom-property

- Replacement for this seems awkward https://medium.com/@sai_prasanna/simulating-css-zoom-with-css3-transform-scale-461d1b9762d6


