### PR TITLE
fix: Use default of None for SENTRY_ORGANIZATION

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -925,7 +925,7 @@ SENTRY_PROJECT_KEY = None
 
 # Default organization to represent the Internal Sentry project.
 # Used as a default when in SINGLE_ORGANIZATION mode.
-SENTRY_ORGANIZATION = 1
+SENTRY_ORGANIZATION = None
 
 # Project ID for recording frontend (javascript) exceptions
 SENTRY_FRONTEND_PROJECT = None

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -160,10 +160,12 @@ class Organization(Model):
         Return the organization used in single organization mode.
         """
 
-        return cls.objects.get(
-            id=settings.SENTRY_ORGANIZATION,
+        if settings.SENTRY_ORGANIZATION is not None:
+            return cls.objects.get(id=settings.SENTRY_ORGANIZATION)
+
+        return cls.objects.filter(
             status=OrganizationStatus.ACTIVE,
-        )
+        )[0]
 
     def __unicode__(self):
         return u'%s (%s)' % (self.name, self.slug)


### PR DESCRIPTION
Tests don't like relying on an org id of 1.

I attempted to fix this in tests, but there are too many side effects
related to fixtures and whatnot where tests fail. Turns out, relying on
a fixed id is not ideal for tests.

Followup to #13964