### PR TITLE
Revert "feat: Measure volume of transaction events"

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -90,10 +90,6 @@ def configure_sdk():
         upstream_transport = make_transport(get_options(options))
 
     def capture_event(event):
-        if event.get('type') == 'transaction':
-            metrics.incr('internal.apm.events', skip_internal=False)
-            return
-
         # Make sure we log to upstream when available first
         if upstream_transport is not None:
             # TODO(mattrobenolt): Bring this back safely.
@@ -113,10 +109,6 @@ def configure_sdk():
             RustInfoIntegration(),
         ],
         transport=capture_event,
-
-        # We use `capture_event` to discard all transaction events and just
-        # make a statsd metric. Figure out how much we would send.
-        traces_sample_rate=1.0,
         **options
     )
 


### PR DESCRIPTION
Reverts getsentry/sentry#13954.
Too high of a negative impact on Production to keep in the codebase after Vienna working hours.