### PR TITLE
feat(apm) Expose transaction start & end timestamp

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -285,6 +285,11 @@ class EventSerializer(Serializer):
                 'tags': tags_meta,
             },
         }
+        # transaction events have start and end-times that are
+        # timestamp floats.
+        if obj.get_event_type() == 'transaction':
+            d['startTimestamp'] = obj.data.get('start_timestamp')
+            d['timestamp'] = obj.data.get('timestamp')
         return d
 
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -282,12 +282,12 @@ class EventSerializer(Serializer):
         }
         # Serialize attributes that are specific to different types of events.
         if obj.get_event_type() == 'transaction':
-            d.update(self.serialize_transaction_attrs(attrs, obj))
+            d.update(self.__serialize_transaction_attrs(attrs, obj))
         else:
-            d.update(self.serialize_error_attrs(attrs, obj))
+            d.update(self.__serialize_error_attrs(attrs, obj))
         return d
 
-    def serialize_transaction_attrs(self, attrs, obj):
+    def __serialize_transaction_attrs(self, attrs, obj):
         """
         Add attributes that are only present on transaction events.
         """
@@ -296,7 +296,7 @@ class EventSerializer(Serializer):
             'endTimestamp': obj.data.get('timestamp'),
         }
 
-    def serialize_error_attrs(self, attrs, obj):
+    def __serialize_error_attrs(self, attrs, obj):
         """
         Add attributes that are present on error and default event types
         """

--- a/src/sentry/data/samples/transaction.json
+++ b/src/sentry/data/samples/transaction.json
@@ -1,0 +1,160 @@
+{
+   "platform": "python",
+   "message": "",
+   "tags": [
+      [
+         "application",
+         "countries"
+      ],
+      [
+         "browser",
+         "Python Requests 2.22"
+      ],
+      [
+         "browser.name",
+         "Python Requests"
+      ],
+      [
+         "environment",
+         "dev"
+      ],
+      [
+         "release",
+         "v0.1"
+      ],
+      [
+         "user",
+         "ip:127.0.0.1"
+      ],
+      [
+         "trace",
+         "a7d67cf796774551a95be6543cacd459"
+      ],
+      [
+         "trace.ctx",
+         "a7d67cf796774551a95be6543cacd459-babaae0d4b7512d9"
+      ],
+      [
+         "trace.span",
+         "babaae0d4b7512d9"
+      ],
+      [
+         "transaction",
+         "/country_by_code/"
+      ],
+      [
+         "url",
+         "http://countries:8010/country_by_code/"
+      ]
+   ],
+   "breadcrumbs": {
+      "values": [
+         {
+            "category": "query",
+            "timestamp":1562681591.0,
+            "message": "SELECT \"countries\".\"id\", \"countries\".\"name\", \"countries\".\"continent\", \"countries\".\"region\", \"countries\".\"surface_area\", \"coun...'CAN'",
+            "type": "default",
+            "level": "info"
+         }
+      ]
+   },
+   "contexts": {
+      "runtime": {
+         "version": "3.7.3",
+         "type": "runtime",
+         "name": "CPython",
+         "build": "3.7.3 (default, Jun 27 2019, 22:53:21) \n[GCC 8.3.0]"
+      },
+      "trace": {
+         "parent_span_id": "8988cec7cc0779c1",
+         "type": "trace",
+         "trace_id": "a7d67cf796774551a95be6543cacd459",
+         "span_id": "babaae0d4b7512d9"
+      },
+      "browser": {
+         "version": "2.22",
+         "type": "browser",
+         "name": "Python Requests"
+      }
+   },
+   "culprit": "/country_by_code/",
+   "environment": "dev",
+   "extra": {},
+   "logger": "",
+   "metadata": {
+      "location": "/country_by_code/",
+      "title": "/country_by_code/"
+   },
+   "request": {
+      "url": "http://countries:8010/country_by_code/",
+      "headers": [
+         [
+            "Accept",
+            "*/*"
+         ],
+         [
+            "Accept-Encoding",
+            "gzip, deflate"
+         ],
+         [
+            "Connection",
+            "keep-alive"
+         ],
+         [
+            "Content-Length",
+            ""
+         ],
+         [
+            "Content-Type",
+            "text/plain"
+         ],
+         [
+            "Host",
+            "countries:8010"
+         ],
+         [
+            "Sentry-Trace",
+            "a7d67cf796774551a95be6543cacd459-8988cec7cc0779c1-1"
+         ],
+         [
+            "User-Agent",
+            "python-requests/2.22.0"
+         ]
+      ],
+      "env": {
+         "SERVER_PORT": "8010",
+         "SERVER_NAME": "a90286977562"
+      },
+      "query_string": [
+         [
+            "code",
+            "CAN"
+         ]
+      ],
+      "method": "GET",
+      "inferred_content_type": "text/plain"
+   },
+   "spans": [
+      {
+         "start_timestamp": 1562681591.0,
+         "same_process_as_parent":true,
+         "description": "Django: SELECT \"countries\".\"id\", \"countries\".\"name\", \"countries\".\"continent\", \"countries\".\"region\", \"countries\".\"surface_area\", \"coun...'CAN'",
+         "tags": {
+            "error":false
+         },
+         "timestamp":1562681591.0,
+         "parent_span_id": "babaae0d4b7512d9",
+         "trace_id": "a7d67cf796774551a95be6543cacd459",
+         "op": "db",
+         "data": {},
+         "span_id": "b048b4c8fdc5168c"
+      }
+   ],
+   "start_timestamp": 1562681591.0,
+   "timestamp": 1562681591.0,
+   "transaction": "/country_by_code/",
+   "type": "transaction",
+   "user": {
+      "ip_address": "127.0.0.1"
+   }
+}

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
@@ -95,7 +95,10 @@ const EventMetadata = props => {
       <MetadataContainer data-test-id="event-id">ID {event.eventID}</MetadataContainer>
       <MetadataContainer>
         <DateTime
-          date={getDynamicText({value: event.dateCreated, fixed: 'Dummy timestamp'})}
+          date={getDynamicText({
+            value: event.dateCreated || event.endTimestamp * 1000,
+            fixed: 'Dummy timestamp',
+          })}
         />
         <ExternalLink href={eventJsonUrl} className="json-link">
           JSON (<FileSize bytes={event.size} />)

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/modalLineGraph.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/modalLineGraph.jsx
@@ -27,7 +27,9 @@ import {MODAL_QUERY_KEYS, PIN_ICON} from './data';
  */
 const getCurrentEventMarker = currentEvent => {
   const title = t('Current Event');
-  const eventTime = +new Date(currentEvent.dateCreated);
+  const eventTime = +new Date(
+    currentEvent.dateCreated || currentEvent.endTimestamp * 1000
+  );
 
   return {
     type: 'line',
@@ -42,7 +44,7 @@ const getCurrentEventMarker = currentEvent => {
         },
       },
       tooltip: {
-        formatter: ({data}) => {
+        formatter: () => {
           return `<div>${getFormattedDate(eventTime, 'MMM D, YYYY LT')}</div>`;
         },
       },

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -132,7 +132,7 @@ def load_data(platform, default=None, sample_name=None):
         return
 
     data = CanonicalKeyDict(data)
-    if platform in ('csp', 'hkpk', 'expectct', 'expectstaple'):
+    if platform in ('transaction', 'csp', 'hkpk', 'expectct', 'expectstaple'):
         return data
 
     data['platform'] = platform

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -11,6 +11,7 @@ from sentry.api.serializers.models.event import (
 )
 from sentry.models import EventError
 from sentry.testutils import TestCase
+from sentry.utils.samples import load_data
 
 
 class EventSerializerTest(TestCase):
@@ -181,6 +182,18 @@ class EventSerializerTest(TestCase):
         assert result['sdk'] is None
         assert result['contexts'] == {}
 
+    def test_transaction_event(self):
+        event_data = load_data('transaction')
+        event = self.store_event(
+            data=event_data,
+            project_id=self.project.id
+        )
+        result = serialize(event)
+        assert result['timestamp'] == event.data.get('timestamp')
+        assert isinstance(result['timestamp'], float)
+        assert result['startTimestamp'] == event.data.get('start_timestamp')
+        assert isinstance(result['startTimestamp'], float)
+
 
 class SharedEventSerializerTest(TestCase):
     def test_simple(self):
@@ -199,7 +212,7 @@ class SharedEventSerializerTest(TestCase):
             assert entry['type'] != 'breadcrumbs'
 
 
-class SnubaEventSerializerTest(TestCase):
+class SimpleEventSerializerTest(TestCase):
     def test_user(self):
         """
         Use the SimpleEventSerializer to serialize an event

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -37,6 +37,8 @@ class EventSerializerTest(TestCase):
         assert 'data' in result['errors'][0]
         assert result['errors'][0]['type'] == EventError.INVALID_DATA
         assert result['errors'][0]['data'] == {'name': u'ü'}
+        assert 'startTimestamp' not in result
+        assert 'timestamp' not in result
 
     def test_hidden_eventerror(self):
         event = self.create_event(
@@ -181,6 +183,7 @@ class EventSerializerTest(TestCase):
         assert result['user'] is None
         assert result['sdk'] is None
         assert result['contexts'] == {}
+        assert 'startTimestamp' not in result
 
     def test_transaction_event(self):
         event_data = load_data('transaction')
@@ -189,10 +192,13 @@ class EventSerializerTest(TestCase):
             project_id=self.project.id
         )
         result = serialize(event)
-        assert result['timestamp'] == event.data.get('timestamp')
-        assert isinstance(result['timestamp'], float)
-        assert result['startTimestamp'] == event.data.get('start_timestamp')
+        assert isinstance(result['endTimestamp'], float)
+        assert result['endTimestamp'] == event.data.get('timestamp')
         assert isinstance(result['startTimestamp'], float)
+        assert result['startTimestamp'] == event.data.get('start_timestamp')
+        assert 'dateCreated' not in result
+        assert 'crashFile' not in result
+        assert 'fingerprints' not in result
 
 
 class SharedEventSerializerTest(TestCase):


### PR DESCRIPTION
On transaction events expose both the start and end timestamps. This will allow us to correctly display the transaction span length.

I've also added the transaction sample from my now closed tracing pull request. Having a sample transaction event should be useful when we have to do more endpoint and acceptance tests around transaction events.

Refs SEN-799