### PR TITLE
ref(app-platform): Remove sampling flags

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -186,8 +186,3 @@ register('symbolicator.minidump-refactor-random-sampling', default=0.0)  # unuse
 # Normalization after processors
 register('store.normalize-after-processing', default=0.0)  # unused
 register('store.disable-trim-in-renormalization', default=0.0)  # unused
-
-# Post Process Error Hook Sampling
-register('post-process.use-error-hook-sampling', default=False)
-# From 0.0 to 1.0: Randomly enqueue process_resource_change task
-register('post-process.error-hook-sample-rate', default=0.0)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -46,24 +46,6 @@ def _get_service_hooks(project_id):
 
 def _should_send_error_created_hooks(project):
     from sentry.models import ServiceHook, Organization
-    from sentry import options
-    import random
-
-    use_sampling = options.get('post-process.use-error-hook-sampling')
-
-    # XXX(Meredith): Sampling is used to test the process_resource_change task.
-    # We have an option to explicity say we want to use sampling, and the other
-    # to determine what that rate should be.
-    # Going forward the sampling will be removed and the task will only be
-    # gated using the integrations-event-hooks (i.e. gated by plan)
-    #
-    # We also don't want to cache the result in case we need to manually lower the
-    # sample rate immediately, or turn it down completely.
-    if use_sampling:
-        if random.random() >= options.get('post-process.error-hook-sample-rate'):
-            return False
-
-        return True
 
     cache_key = u'servicehooks-error-created:1:{}'.format(project.id)
     result = cache.get(cache_key)

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -7,7 +7,6 @@ from django.core.urlresolvers import reverse
 from requests.exceptions import RequestException
 
 from sentry import options
-from sentry import features
 from sentry.http import safe_urlopen
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import metrics
@@ -183,10 +182,7 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
         data = {}
         if issubclass(model, EventCommon):
             data[name] = _webhook_event_data(instance, instance.group_id, instance.project_id)
-            # XXX(Meredith): this flag is in place for testing the load this task creates
-            # and during testing we don't need to send the webhook.
-            if features.has('organizations:integrations-event-hooks', organization=org):
-                send_webhooks(installation, event, data=data)
+            send_webhooks(installation, event, data=data)
         else:
             data[name] = serialize(instance)
             send_webhooks(installation, event, data=data)


### PR DESCRIPTION
We've tested out `error.created` - we can now remove the options and the code that uses those options. 
From now on, the `integrations-event-hook` will be used to determine which events get passed through to the `process_resource_change` task. 