### PR TITLE
chore: Remove createReactClass from a few components

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationReleases/detail/releaseCommits.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/detail/releaseCommits.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import {omit} from 'lodash';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
 import {Panel, PanelHeader, PanelBody} from 'app/components/panels';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
@@ -14,20 +13,17 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import MenuItem from 'app/components/menuItem';
 
-const ReleaseCommits = createReactClass({
-  displayName: 'ReleaseCommits',
-  propTypes: {
+class ReleaseCommits extends React.Component {
+  static propTypes = {
     api: PropTypes.object,
-  },
+  };
 
-  getInitialState() {
-    return {
-      loading: true,
-      error: false,
-      commitList: [],
-      activeRepo: null,
-    };
-  },
+  state = {
+    loading: true,
+    error: false,
+    commitList: [],
+    activeRepo: null,
+  };
 
   componentDidMount() {
     this.props.api.request(this.getPath(), {
@@ -49,7 +45,7 @@ const ReleaseCommits = createReactClass({
         });
       },
     });
-  },
+  }
 
   getPath() {
     const {orgId, projectId, version} = this.props.params;
@@ -59,7 +55,7 @@ const ReleaseCommits = createReactClass({
     return projectId
       ? `/projects/${orgId}/${projectId}/releases/${encodedVersion}/commits/`
       : `/organizations/${orgId}/releases/${encodedVersion}/commits/`;
-  },
+  }
 
   emptyState() {
     return (
@@ -70,13 +66,13 @@ const ReleaseCommits = createReactClass({
         </EmptyStateWarning>
       </Panel>
     );
-  },
+  }
 
   setActiveRepo(repo) {
     this.setState({
       activeRepo: repo,
     });
-  },
+  }
 
   getCommitsByRepository() {
     const {commitList} = this.state;
@@ -90,7 +86,7 @@ const ReleaseCommits = createReactClass({
       return cbr;
     }, {});
     return commitsByRepository;
-  },
+  }
 
   renderCommitsForRepo(repo) {
     const commitsByRepository = this.getCommitsByRepository();
@@ -106,7 +102,7 @@ const ReleaseCommits = createReactClass({
         </PanelBody>
       </Panel>
     );
-  },
+  }
 
   render() {
     if (this.state.loading) {
@@ -120,7 +116,7 @@ const ReleaseCommits = createReactClass({
     const {commitList, activeRepo} = this.state;
 
     if (!commitList.length) {
-      return <this.emptyState />;
+      return this.emptyState();
     }
     const commitsByRepository = this.getCommitsByRepository();
     return (
@@ -169,8 +165,8 @@ const ReleaseCommits = createReactClass({
             })}
       </div>
     );
-  },
-});
+  }
+}
 
 export {ReleaseCommits};
 

--- a/src/sentry/static/sentry/app/views/organizationReleases/list/latestDeployOrReleaseTime.jsx
+++ b/src/sentry/static/sentry/app/views/organizationReleases/list/latestDeployOrReleaseTime.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
 import {t} from 'app/locale';
@@ -9,50 +8,45 @@ import TimeSince from 'app/components/timeSince';
 import Tooltip from 'app/components/tooltip';
 import space from 'app/styles/space';
 
-const LatestDeployOrReleaseTime = createReactClass({
-  displayName: 'LatestDeployOrReleaseTime',
+const LatestDeployOrReleaseTime = ({release}) => {
+  const earlierDeploysNum = release.totalDeploys - 1;
+  const latestDeploy = release.lastDeploy;
+  // if there are deploys associated with the release
+  // render the most recent deploy (API will return data ordered by dateFinished)
+  // otherwise, render the dateCreated associated with release
+  return (
+    <div>
+      {latestDeploy && latestDeploy.dateFinished ? (
+        <div className="deploy">
+          <p className="m-b-0 text-light">
+            <ReleaseRepoLabel
+              style={{
+                padding: 3,
+                width: 70,
+                maxWidth: 86,
+                fontSize: 12,
+              }}
+            >
+              {latestDeploy.environment + ' '}
+            </ReleaseRepoLabel>{' '}
+            <TimeWithIcon date={latestDeploy.dateFinished} />
+            {earlierDeploysNum > 0 && (
+              <Tooltip title={t('%s earlier deploys', earlierDeploysNum)}>
+                <span className="badge">{earlierDeploysNum}</span>
+              </Tooltip>
+            )}
+          </p>
+        </div>
+      ) : (
+        <TimeWithIcon date={release.dateCreated} />
+      )}
+    </div>
+  );
+};
 
-  propTypes: {
-    release: PropTypes.object.isRequired,
-  },
-
-  render() {
-    const {release} = this.props;
-    const earlierDeploysNum = release.totalDeploys - 1;
-    const latestDeploy = release.lastDeploy;
-    // if there are deploys associated with the release
-    // render the most recent deploy (API will return data ordered by dateFinished)
-    // otherwise, render the dateCreated associated with release
-    return (
-      <div>
-        {latestDeploy && latestDeploy.dateFinished ? (
-          <div className="deploy">
-            <p className="m-b-0 text-light">
-              <ReleaseRepoLabel
-                style={{
-                  padding: 3,
-                  width: 70,
-                  maxWidth: 86,
-                  fontSize: 12,
-                }}
-              >
-                {latestDeploy.environment + ' '}
-              </ReleaseRepoLabel>{' '}
-              <TimeWithIcon date={latestDeploy.dateFinished} />
-              {earlierDeploysNum > 0 && (
-                <Tooltip title={t('%s earlier deploys', earlierDeploysNum)}>
-                  <span className="badge">{earlierDeploysNum}</span>
-                </Tooltip>
-              )}
-            </p>
-          </div>
-        ) : (
-          <TimeWithIcon date={release.dateCreated} />
-        )}
-      </div>
-    );
-  },
-});
+LatestDeployOrReleaseTime.propTypes = {
+  release: PropTypes.object.isRequired,
+};
 
 export default LatestDeployOrReleaseTime;
 

--- a/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
@@ -3,7 +3,6 @@ import {Link, browserHistory} from 'react-router';
 import LazyLoad from 'react-lazyload';
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
 import {sortProjects} from 'app/utils';
@@ -117,15 +116,13 @@ class Dashboard extends React.Component {
   }
 }
 
-const OrganizationDashboard = createReactClass({
-  render() {
-    return (
-      <Flex flex="1" direction="column">
-        <Dashboard {...this.props} />
-      </Flex>
-    );
-  },
-});
+const OrganizationDashboard = props => {
+  return (
+    <Flex flex="1" direction="column">
+      <Dashboard {...props} />
+    </Flex>
+  );
+};
 
 const TeamLink = styled(Link)`
   display: flex;

--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/projectStatsGraph.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/projectStatsGraph.jsx
@@ -2,44 +2,37 @@ import LazyLoad from 'react-lazyload';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import createReactClass from 'create-react-class';
-
 import BarChart from 'app/components/barChart';
 import SentryTypes from 'app/sentryTypes';
 
-const ProjectStatsGraph = createReactClass({
-  displayName: 'ProjectListItem',
+const ProjectStatsGraph = ({project, stats}) => {
+  stats = stats || project.stats;
+  const chartData =
+    stats &&
+    stats.map(point => {
+      return {x: point[0], y: point[1]};
+    });
 
-  propTypes: {
-    project: SentryTypes.Project,
-    stats: PropTypes.array,
-  },
+  return (
+    <div>
+      {chartData && (
+        <LazyLoad height={25} debounce={50}>
+          <BarChart
+            height={25}
+            minHeights={[3]}
+            gap={1}
+            points={chartData}
+            label="events"
+          />
+        </LazyLoad>
+      )}
+    </div>
+  );
+};
 
-  render() {
-    const {project} = this.props;
-    const stats = this.props.stats || project.stats;
-    const chartData =
-      stats &&
-      stats.map(point => {
-        return {x: point[0], y: point[1]};
-      });
-
-    return (
-      <div>
-        {chartData && (
-          <LazyLoad height={25} debounce={50}>
-            <BarChart
-              height={25}
-              minHeights={[3]}
-              gap={1}
-              points={chartData}
-              label="events"
-            />
-          </LazyLoad>
-        )}
-      </div>
-    );
-  },
-});
+ProjectStatsGraph.propTypes = {
+  project: SentryTypes.Project,
+  stats: PropTypes.array,
+};
 
 export default ProjectStatsGraph;

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -686,7 +686,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                 className="css-7g8agk"
                                 is={null}
                               >
-                                <ProjectListItem
+                                <ProjectStatsGraph
                                   key="2"
                                   project={
                                     Object {
@@ -702,7 +702,7 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
                                   }
                                 >
                                   <div />
-                                </ProjectListItem>
+                                </ProjectStatsGraph>
                               </div>
                             </Base>
                           </Box>


### PR DESCRIPTION
Remove createReactClass from a few components and convert them into function components. While there are still a ton of createReactClass uses left this removes a few that I came across during view renames.