### PR TITLE
Fix custom ignore window

### DIFF
--- a/src/sentry/static/sentry/app/components/customIgnoreCountModal.jsx
+++ b/src/sentry/static/sentry/app/components/customIgnoreCountModal.jsx
@@ -25,10 +25,14 @@ export default class CustomIgnoreCountModal extends React.Component {
   }
 
   onSubmit = () => {
-    this.props.onSelected({
-      [this.props.countName]: this.state.count,
-      [this.props.windowName]: this.state.window,
-    });
+    const {count, window} = this.state;
+    const {countName, windowName} = this.props;
+
+    const statusDetails = {[countName]: count};
+    if (window) {
+      statusDetails[windowName] = window;
+    }
+    this.props.onSelected(statusDetails);
   };
 
   onChange = (name, value) => {


### PR DESCRIPTION
Choosing to ignore an issue "Until this occurs again..." or "Until this affects an additional..." with custom options and _not_ choosing the "optional" Time Window results in a 400 since the payload contains `ignoreWindow: ""` but the serializer is expecting an integer. 

Example:
<img width="929" alt="Screenshot 2019-07-15 12 33 40" src="https://user-images.githubusercontent.com/29959063/61243433-cc3c8b00-a6fc-11e9-80ab-b8239a641d00.png">


@lobsterkatie is the real MVP here