### PR TITLE
ref(ui): Remove implicit hookstore functionality from acl/feature

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/feature.jsx
+++ b/src/sentry/static/sentry/app/components/acl/feature.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {descopeFeatureName} from 'app/utils';
 import HookStore from 'app/stores/hookStore';
 import SentryTypes from 'app/sentryTypes';
 import withConfig from 'app/utils/withConfig';
@@ -48,19 +47,6 @@ class Feature extends React.Component {
      * When a custom render function is used, the same object that would be
      * passed to `children` if a func is provided there, will be used here,
      * aditionally `children` will also be passed.
-     *
-     * NOTE: HookStore capability.
-     *
-     * Enabling the renderDisabled prop (by setting `true` or passing a
-     * function) will enable functionality to check the HookStore for a hook to
-     * retrieve the no feature render function.
-     *
-     * The hookstore key that will be checked is:
-     *
-     *     feature-disabled:{unscoped-feature-name}
-     *
-     * This functionality will ONLY BE ACTIVATED when exactly ONE feature is
-     * provided through the feature property.
      */
     renderDisabled: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
 
@@ -74,8 +60,6 @@ class Feature extends React.Component {
      * When specified, the hookstore will be checked if the feature is
      * disabled, and the first available hook will be used as the render
      * function.
-     *
-     * This takes precidence over the renderDisabled hookstore functionality.
      */
     hookName: PropTypes.string,
 
@@ -161,9 +145,8 @@ class Feature extends React.Component {
 
     // Override the renderDisabled function with a hook store function if there
     // is one registered for the feature.
-    if (hookName || (renderDisabled !== false && features.length === 1)) {
-      const hookKey = hookName || descopeFeatureName(features[0]);
-      const hooks = HookStore.get(`feature-disabled:${hookKey}`);
+    if (hookName) {
+      const hooks = HookStore.get(`feature-disabled:${hookName}`);
 
       if (hooks.length > 0) {
         customDisabledRender = hooks[0];

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -59,8 +59,6 @@ const validHookNames = new Set([
   'feature-disabled:sso-basic',
   'feature-disabled:sso-rippling',
   'feature-disabled:sso-saml2',
-
-  // Explicit Feature hookNames
   'feature-disabled:events-page',
   'feature-disabled:events-sidebar-item',
   'feature-disabled:discover-page',

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
@@ -43,6 +43,7 @@ class DeleteActions extends React.Component {
   renderDiscardModal = ({Body, closeModal}) => (
     <Feature
       features={['projects:discard-groups']}
+      hookName="discard-groups"
       organization={this.props.organization}
       project={this.props.project}
       renderDisabled={this.renderDiscardDisabled}

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
@@ -12,6 +12,7 @@ import FeatureDisabled from 'app/components/acl/featureDisabled';
 import Hovercard from 'app/components/hovercard';
 import SentryTypes from 'app/sentryTypes';
 import Tag from 'app/views/settings/components/tag';
+import {descopeFeatureName} from 'app/utils';
 
 export default class ProviderItem extends React.PureComponent {
   static propTypes = {
@@ -50,9 +51,15 @@ export default class ProviderItem extends React.PureComponent {
   render() {
     const {provider, active} = this.props;
 
+    // TODO(epurkhiser): We should probably use a more explicit hook name,
+    // instead of just the feature names (sso-basic, sso-saml2, etc).
+    const featureKey = provider.requiredFeature;
+    const featureProps = featureKey ? {hookName: descopeFeatureName(featureKey)} : {};
+
     return (
       <Feature
-        features={[provider.requiredFeature].filter(f => f)}
+        {...featureProps}
+        features={[featureKey].filter(f => f)}
         renderDisabled={({children, ...props}) =>
           children({...props, renderDisabled: this.renderDisabledLock})
         }

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
@@ -198,6 +198,7 @@ class ProjectFiltersSettings extends AsyncComponent {
   renderCustomFilters = disabled => () => (
     <Feature
       features={['projects:custom-inbound-filters']}
+      hookName="custom-inbound-filters"
       renderDisabled={({children, ...props}) =>
         children({...props, renderDisabled: this.renderDisabledCustomFilters})
       }

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
@@ -214,6 +214,7 @@ class KeyRateLimitsForm extends React.Component {
       <Form saveOnBlur apiEndpoint={apiEndpoint} apiMethod="PUT" initialData={data}>
         <Feature
           features={['projects:rate-limits']}
+          hookName="rate-limits"
           renderDisabled={({children, ...props}) =>
             children({...props, renderDisabled: disabledAlert})
           }

--- a/src/sentry/static/sentry/app/views/settings/projectDataForwarding.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataForwarding.jsx
@@ -115,10 +115,7 @@ class ProjectDataForwarding extends AsyncComponent {
 
     return (
       <div data-test-id="data-forwarding-settings">
-        <Feature
-          features={['projects:data-forwarding']}
-          renderDisabled={p => p.children(p)}
-        >
+        <Feature features={['projects:data-forwarding']} hookName="data-forwarding">
           {({hasFeature, features}) => (
             <React.Fragment>
               <SettingsPageHeader title={t('Data Forwarding')} />

--- a/tests/js/spec/components/acl/feature.spec.jsx
+++ b/tests/js/spec/components/acl/feature.spec.jsx
@@ -265,42 +265,6 @@ describe('Feature', function() {
       delete HookStore.hooks['feature-disabled:org-baz'];
     });
 
-    it('calls renderDisabled function from HookStore when no features', function() {
-      const noFeatureRenderer = jest.fn(() => null);
-      const children = <div>The Child</div>;
-      const wrapper = mount(
-        <Feature features={['org-baz']} renderDisabled={noFeatureRenderer}>
-          {children}
-        </Feature>,
-        routerContext
-      );
-
-      expect(wrapper.find('Feature div')).toHaveLength(0);
-      expect(noFeatureRenderer).not.toHaveBeenCalled();
-
-      expect(hookFn).toHaveBeenCalledWith({
-        hasFeature: false,
-        children,
-        organization,
-        project,
-        features: ['org-baz'],
-      });
-    });
-
-    it('does not check hook store for multiple features', function() {
-      const noFeatureRenderer = jest.fn(() => null);
-      const wrapper = mount(
-        <Feature features={['org-baz', 'org-bazar']} renderDisabled={noFeatureRenderer}>
-          <div>The Child</div>
-        </Feature>,
-        routerContext
-      );
-
-      expect(wrapper.find('Feature div')).toHaveLength(0);
-      expect(hookFn).not.toHaveBeenCalled();
-      expect(noFeatureRenderer).toHaveBeenCalled();
-    });
-
     it('uses hookName if provided', function() {
       const children = <div>The Child</div>;
       const wrapper = mount(


### PR DESCRIPTION
Prior to this change, specifying a renderDisabled function would enable HookStore checking in the Feature component, looking for a hook store key of the form `disabled-feature:{descopedFeatureName}.

This tended to be a little bit too magical, especially in cases where we want to use the Feature component in different places, checking the same feature key. What would happen in this case is the hook store registered for that feature would be used in all places, which may not necissarily make sense.

Instead you now must explicitly pass the hookName to use.