### PR TITLE
fix(serverless): Pass referer from netlify api requests

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,6 +19,9 @@
   status = 200
   force = true
 
+  # Pass referer as sentry.io to avoid CSRF validation errors.
+  headers = {Referer = "https://sentry.io/"}
+
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
Needed for some mutation actions while proxying the API through netlify