### PR TITLE
fix(ui): Fix bulk issue actions affecting more than selected project

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/actions.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.jsx
@@ -23,7 +23,6 @@ import SentryTypes from 'app/sentryTypes';
 import ToolbarHeader from 'app/components/toolbarHeader';
 import Tooltip from 'app/components/tooltip';
 import withApi from 'app/utils/withApi';
-import GroupStore from 'app/stores/groupStore';
 
 const BULK_LIMIT = 1000;
 const BULK_LIMIT_STR = BULK_LIMIT.toLocaleString();
@@ -225,13 +224,14 @@ const IssueListActions = createReactClass({
     this.actionSelectedGroups(itemIds => {
       const loadingIndicator = IndicatorStore.add(t('Saving changes..'));
 
-      let projectId;
-
-      try {
-        projectId = GroupStore.get(itemIds[0]).project.slug;
-      } catch (err) {
-        // nothing
-      }
+      // If `itemIds` is undefined then it means we expect to bulk update all items
+      // that match the query. In this case we should respect the projects selected in the
+      // global selection header.
+      //
+      // Otherwise if we have a list of itemIds, then we don't need project constraints since
+      // they will be unique
+      const projectConstraints =
+        typeof itemIds === 'undefined' ? {project: selection.projects} : {};
 
       this.props.api.bulkUpdate(
         {
@@ -239,8 +239,8 @@ const IssueListActions = createReactClass({
           itemIds,
           data,
           query: this.props.query,
-          projectId,
           environment: selection.environments,
+          ...projectConstraints,
           ...selection.datetime,
         },
         {
@@ -330,7 +330,6 @@ const IssueListActions = createReactClass({
   },
 
   render() {
-    // TODO(mitsuhiko): very unclear how to translate this
     const {
       allResultsVisible,
       hasReleases,

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -31,7 +31,7 @@ describe('IssueListActions', function() {
             query=""
             queryCount={1500}
             orgId="1337"
-            projectId="1"
+            projectId="project-slug"
             selection={{
               projects: [1],
               environments: [],
@@ -89,6 +89,9 @@ describe('IssueListActions', function() {
         expect(apiMock).toHaveBeenCalledWith(
           expect.anything(),
           expect.objectContaining({
+            query: {
+              project: [1],
+            },
             data: {status: 'resolved'},
           })
         );
@@ -151,12 +154,68 @@ describe('IssueListActions', function() {
         expect(apiMock).toHaveBeenCalledWith(
           expect.anything(),
           expect.objectContaining({
+            query: {
+              project: [1],
+            },
             data: {status: 'resolved'},
           })
         );
 
         await tick();
         wrapper.update();
+      });
+    });
+
+    describe('Selected on page', function() {
+      beforeAll(function() {
+        SelectedGroupStore.records = {};
+        SelectedGroupStore.add([1, 2, 3]);
+        wrapper = mount(
+          <IssueListActions
+            api={new MockApiClient()}
+            allResultsVisible={true}
+            query=""
+            queryCount={15}
+            orgId="1337"
+            projectId="1"
+            selection={{
+              projects: [1],
+              environments: [],
+              datetime: {start: null, end: null, period: null, utc: true},
+            }}
+            groupIds={[1, 2, 3, 6, 9]}
+            onRealtimeChange={function() {}}
+            onSelectStatsPeriod={function() {}}
+            realtimeActive={false}
+            statsPeriod="24h"
+          />,
+          TestStubs.routerContext()
+        );
+      });
+
+      it('resolves selected items', function() {
+        const apiMock = MockApiClient.addMockResponse({
+          url: '/organizations/1337/issues/',
+          method: 'PUT',
+        });
+        jest
+          .spyOn(SelectedGroupStore, 'getSelectedIds')
+          .mockImplementation(() => new Set([3, 6, 9]));
+
+        wrapper.setState({allInQuerySelected: false, anySelected: true});
+        wrapper
+          .find('ResolveActions ActionLink')
+          .first()
+          .simulate('click');
+        expect(apiMock).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            query: {
+              id: [3, 6, 9],
+            },
+            data: {status: 'resolved'},
+          })
+        );
       });
     });
   });


### PR DESCRIPTION
This fixes a bug where a user bulk selects issues to perform an action on (e.g. resolve). In this case, the backend performs the action on all issues found via a query (instead of a list of ids). However, if the user has projects selected, they will not get passed to API resulting in a lot of unintended issues being included.

Now, in the case where we are selecting *all* issues, we use the projects in the global selection header, otherwise, if we have issue ids, project is not required. 