### PR TITLE
fix(API): Allow snoozeDuration to be null

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -261,7 +261,8 @@ class GroupValidator(serializers.Serializer):
     assignedTo = ActorField()
 
     # TODO(dcramer): remove in 9.0
-    snoozeDuration = serializers.IntegerField()
+    # for the moment, the CLI sends this for any issue update, so allow nulls
+    snoozeDuration = serializers.IntegerField(allow_null=True)
 
     def validate_assignedTo(self, value):
         if value and value.type is User and not self.context['project'].member_set.filter(


### PR DESCRIPTION
With the recent update of django rest framework, we now need to be more explicit about allowing or not allowing null values. In this case, the CLI sends a null `snoozeDuration` value when you try to resolve an issue, because its `IssueChanges` struct includes both `snoozeDuration` and `status` (see [here](https://github.com/getsentry/sentry-cli/blob/034555b0c5ca537a152ef14167f8f5cbd2940a08/src/api.rs#L1910-L1915)). Until such time as that changes, this makes the validator happy.