### PR TITLE
ref: Remove unused Group.get_oldest_event and legacy events behavior

### DIFF
--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -81,7 +81,7 @@ class GroupTest(TestCase):
             data={
                 'event_id': 'b' * 32,
                 'fingerprint': ['group-1'],
-                'timestamp': self.sec_ago,
+                'timestamp': self.min_ago,
             },
             project_id=self.project.id,
         )

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
 
-import six
-
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pytest
 from django.db.models import ProtectedError
@@ -16,6 +14,13 @@ from sentry.testutils import TestCase
 
 
 class GroupTest(TestCase):
+    def setUp(self):
+        super(GroupTest, self).setUp()
+        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        self.two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
+        self.sec_ago = (timezone.now() - timedelta(seconds=1)).isoformat()[:19]
+        self.two_sec_ago = (timezone.now() - timedelta(seconds=1)).isoformat()[:19]
+
     def test_is_resolved(self):
         group = self.create_group(status=GroupStatus.RESOLVED)
         assert group.is_resolved()
@@ -36,56 +41,68 @@ class GroupTest(TestCase):
 
         assert group.is_resolved()
 
-    def test_get_oldest_latest_event_no_events(self):
-        group = self.create_group()
+    def test_get_latest_event_no_events(self):
+        project = self.create_project()
+        group = self.create_group(project=project)
         assert group.get_latest_event() is None
-        assert group.get_oldest_event() is None
 
-    def test_get_oldest_latest_events(self):
-        group = self.create_group()
-        for i in range(0, 3):
-            self.create_event(
-                event_id=six.text_type(i),
-                group=group,
-                datetime=datetime(2013, 8, 13, 3, 8, i),
-            )
-
-        assert group.get_latest_event().event_id == '2'
-        assert group.get_oldest_event().event_id == '0'
-
-    def test_get_oldest_latest_identical_timestamps(self):
-        group = self.create_group()
-        for i in range(0, 3):
-            self.create_event(
-                event_id=six.text_type(i),
-                group=group,
-                datetime=datetime(2013, 8, 13, 3, 8, 50),
-            )
-
-        assert group.get_latest_event().event_id == '2'
-        assert group.get_oldest_event().event_id == '0'
-
-    def test_get_oldest_latest_almost_identical_timestamps(self):
-        group = self.create_group()
-        self.create_event(
-            event_id='0',
-            group=group,
-            datetime=datetime(2013, 8, 13, 3, 8, 0),  # earliest
+    def test_get_latest_event(self):
+        self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'fingerprint': ['group-1'],
+                'timestamp': self.two_min_ago,
+            },
+            project_id=self.project.id,
         )
-        for i in range(1, 3):
-            self.create_event(
-                event_id=six.text_type(i),
-                group=group,
-                datetime=datetime(2013, 8, 13, 3, 8, 30),  # all in the middle
-            )
-        self.create_event(
-            event_id='3',
-            group=group,
-            datetime=datetime(2013, 8, 13, 3, 8, 59),  # latest
+        self.store_event(
+            data={
+                'event_id': 'b' * 32,
+                'fingerprint': ['group-1'],
+                'timestamp': self.min_ago,
+            },
+            project_id=self.project.id,
         )
 
-        assert group.get_latest_event().event_id == '3'
-        assert group.get_oldest_event().event_id == '0'
+        group = Group.objects.first()
+
+        assert group.get_latest_event().event_id == 'b' * 32
+
+    def test_get_latest_identical_timestamps(self):
+        events = []
+        for i in 'abc':
+            event = self.store_event(
+                data={
+                    'event_id': i * 32,
+                    'fingerprint': ['group-1'],
+                    'timestamp': self.min_ago,
+                },
+                project_id=self.project.id,
+            )
+            events.append(event)
+
+        assert events[0].group.get_latest_event().event_id == 'c' * 32
+
+    def test_get_latest_almost_identical_timestamps(self):
+        self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'fingerprint': ['group-1'],
+                'timestamp': self.two_sec_ago,
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                'event_id': 'b' * 32,
+                'fingerprint': ['group-1'],
+                'timestamp': self.sec_ago,
+            },
+            project_id=self.project.id,
+        )
+        group = Group.objects.first()
+
+        assert group.get_latest_event().event_id == 'b' * 32
 
     def test_is_ignored_with_expired_snooze(self):
         group = self.create_group(

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -18,7 +18,6 @@ class GroupTest(TestCase):
         super(GroupTest, self).setUp()
         self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
         self.two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
-        self.sec_ago = (timezone.now() - timedelta(seconds=1)).isoformat()[:19]
         self.just_over_one_min_ago = (timezone.now() - timedelta(seconds=61)).isoformat()[:19]
 
     def test_is_resolved(self):

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -19,7 +19,7 @@ class GroupTest(TestCase):
         self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
         self.two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
         self.sec_ago = (timezone.now() - timedelta(seconds=1)).isoformat()[:19]
-        self.two_sec_ago = (timezone.now() - timedelta(seconds=1)).isoformat()[:19]
+        self.just_over_one_min_ago = (timezone.now() - timedelta(seconds=61)).isoformat()[:19]
 
     def test_is_resolved(self):
         group = self.create_group(status=GroupStatus.RESOLVED)
@@ -68,27 +68,12 @@ class GroupTest(TestCase):
 
         assert group.get_latest_event().event_id == 'b' * 32
 
-    def test_get_latest_identical_timestamps(self):
-        events = []
-        for i in 'abc':
-            event = self.store_event(
-                data={
-                    'event_id': i * 32,
-                    'fingerprint': ['group-1'],
-                    'timestamp': self.min_ago,
-                },
-                project_id=self.project.id,
-            )
-            events.append(event)
-
-        assert events[0].group.get_latest_event().event_id == 'c' * 32
-
     def test_get_latest_almost_identical_timestamps(self):
         self.store_event(
             data={
                 'event_id': 'a' * 32,
                 'fingerprint': ['group-1'],
-                'timestamp': self.two_sec_ago,
+                'timestamp': self.just_over_one_min_ago,
             },
             project_id=self.project.id,
         )


### PR DESCRIPTION
Removes the "snuba.events-queries.enabled" option and legacy code paths
that were not being used in production. Also removes the unused
Group.get_oldest_event method. Part 4 of #13905