### PR TITLE
feat: Update Group.get_latest_event to use Snuba event

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -22,9 +22,7 @@ from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
 
 from sentry import eventtypes, tagstore
-from sentry.constants import (
-    DEFAULT_LOGGER_NAME, EVENT_ORDERING_KEY, LOG_LEVELS, MAX_CULPRIT_LENGTH
-)
+from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS, MAX_CULPRIT_LENGTH
 from sentry.db.models import (
     BaseManager, BoundedBigIntegerField, BoundedIntegerField, BoundedPositiveIntegerField,
     FlexibleForeignKey, GzippedDictField, Model, sane_repr

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -407,20 +407,9 @@ class Group(Model):
         return type(self).calculate_score(self.times_seen, self.last_seen)
 
     def get_latest_event(self):
-        from sentry.models import Event
-
         if not hasattr(self, '_latest_event'):
-            latest_events = sorted(
-                Event.objects.filter(
-                    group_id=self.id,
-                ).order_by('-datetime')[0:5],
-                key=EVENT_ORDERING_KEY,
-                reverse=True,
-            )
-            try:
-                self._latest_event = latest_events[0]
-            except IndexError:
-                self._latest_event = None
+            self._latest_event = self.get_latest_event_for_environments()
+
         return self._latest_event
 
     def get_latest_event_for_environments(self, environments=()):

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -7,6 +7,8 @@ import six
 from exam import fixture
 from django.test import RequestFactory
 from time import time
+from datetime import timedelta
+from django.utils import timezone
 
 from sentry.integrations.exceptions import IntegrationError
 from sentry.integrations.vsts.integration import VstsIntegration
@@ -349,8 +351,15 @@ class VstsIssueFormTest(VstsIssueBase):
                 ]
             },
         )
-        self.group = self.create_group()
-        self.create_event(group=self.group)
+        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        event = self.store_event(
+            data={
+                'fingerprint': ['group1'],
+                'timestamp': min_ago,
+            },
+            project_id=self.project.id,
+        )
+        self.group = event.group
 
     def tearDown(self):
         responses.reset()

--- a/tests/sentry/plugins/bases/test_issue2.py
+++ b/tests/sentry/plugins/bases/test_issue2.py
@@ -4,7 +4,9 @@ from __future__ import absolute_import
 
 import json
 import mock
+from datetime import timedelta
 
+from django.utils import timezone
 from social_auth.models import UserSocialAuth
 
 from sentry.models import GroupMeta, User
@@ -80,12 +82,16 @@ class IssuePlugin2GroupActionTest(TestCase):
     def setUp(self):
         super(IssuePlugin2GroupActionTest, self).setUp()
         self.project = self.create_project()
-        self.group = self.create_group(project=self.project)
         self.plugin_instance = plugins.get(slug='issuetrackingplugin2')
-        self.event = self.create_event(
-            event_id='a',
-            group=self.group,
+        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        self.event = self.store_event(
+            data={
+                'timestamp': min_ago,
+                'fingerprint': ['group-1']
+            },
+            project_id=self.project.id
         )
+        self.group = self.event.group
 
     @mock.patch('sentry.plugins.IssueTrackingPlugin2.is_configured', return_value=True)
     def test_get_create(self, *args):


### PR DESCRIPTION
This is the fifth (and final) part of #13905
Group model now uses Snuba Event instead of Postgres Event everywhere.

Depends on https://github.com/getsentry/sentry/pull/14038