### PR TITLE
ref(app-platform): Verify install endpoints, mediators, ui

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -52,6 +52,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                 webhook_url=result.get('webhookUrl'),
                 redirect_url=result.get('redirectUrl'),
                 is_alertable=result.get('isAlertable'),
+                verify_install=result.get('verifyInstall'),
                 scopes=result.get('scopes'),
                 events=result.get('events'),
                 schema=result.get('schema'),

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -83,6 +83,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             data['redirect_url'] = data['redirectUrl']
             data['webhook_url'] = data['webhookUrl']
             data['is_alertable'] = data['isAlertable']
+            data['verify_install'] = data['verifyInstall']
 
             creator = InternalCreator if data.get('isInternal') else Creator
             sentry_app = creator.run(request=request, **data)

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -62,6 +62,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             'redirectUrl': request.json_body.get('redirectUrl'),
             'isAlertable': request.json_body.get('isAlertable'),
             'isInternal': request.json_body.get('isInternal'),
+            'verifyInstall': request.json_body.get('verifyInstall'),
             'scopes': request.json_body.get('scopes', []),
             'events': request.json_body.get('events', []),
             'schema': request.json_body.get('schema', {}),

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -23,6 +23,7 @@ class SentryAppSerializer(Serializer):
             'webhookUrl': obj.webhook_url,
             'redirectUrl': obj.redirect_url,
             'isAlertable': obj.is_alertable,
+            'verifyInstall': obj.verify_install,
             'overview': obj.overview,
         }
 

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -26,7 +26,7 @@ class ApiScopesField(serializers.Field):
 
 class EventListField(serializers.Field):
     def to_internal_value(self, data):
-        if not data:
+        if data is None:
             return
 
         if not set(data).issubset(VALID_EVENT_RESOURCES):
@@ -69,6 +69,7 @@ class SentryAppSerializer(Serializer):
     redirectUrl = URLField(required=False, allow_null=True, allow_blank=True)
     isAlertable = serializers.BooleanField(required=False, default=False)
     overview = serializers.CharField(required=False, allow_null=True)
+    verifyInstall = serializers.BooleanField(required=False, default=True)
 
     def validate_name(self, value):
         if not value:

--- a/src/sentry/mediators/sentry_app_installations/creator.py
+++ b/src/sentry/mediators/sentry_app_installations/creator.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import six
 
 from sentry import analytics
+from sentry.constants import SentryAppInstallationStatus
 from sentry.mediators import Mediator, Param, service_hooks
 from sentry.models import (
     AuditLogEntryEvent, ApiGrant, SentryApp, SentryAppInstallation
@@ -27,10 +28,15 @@ class Creator(Mediator):
         return self.install
 
     def _create_install(self):
+        status = SentryAppInstallationStatus.PENDING
+        if not self.sentry_app.verify_install:
+            status = SentryAppInstallationStatus.INSTALLED
+
         self.install = SentryAppInstallation.objects.create(
             organization_id=self.organization.id,
             sentry_app_id=self.sentry_app.id,
             api_grant_id=self.api_grant.id,
+            status=status,
         )
 
     def _create_api_grant(self):

--- a/src/sentry/mediators/sentry_apps/creator.py
+++ b/src/sentry/mediators/sentry_apps/creator.py
@@ -26,6 +26,7 @@ class Creator(Mediator):
     webhook_url = Param(six.string_types)
     redirect_url = Param(six.string_types, required=False)
     is_alertable = Param(bool, default=False)
+    verify_install = Param(bool, default=True)
     schema = Param(dict, default=lambda self: {})
     overview = Param(six.string_types, required=False)
     request = Param('rest_framework.request.Request', required=False)
@@ -65,6 +66,7 @@ class Creator(Mediator):
             webhook_url=self.webhook_url,
             redirect_url=self.redirect_url,
             is_alertable=self.is_alertable,
+            verify_install=self.verify_install,
             overview=self.overview,
         )
 

--- a/src/sentry/mediators/sentry_apps/internal_creator.py
+++ b/src/sentry/mediators/sentry_apps/internal_creator.py
@@ -23,6 +23,7 @@ class InternalCreator(Mediator):
     webhook_url = Param(six.string_types)
     redirect_url = Param(six.string_types, required=False)
     is_alertable = Param(bool, default=False)
+    verify_install = Param(bool, default=False)
     schema = Param(dict, default=lambda self: {})
     overview = Param(six.string_types, required=False)
     request = Param('rest_framework.request.Request', required=False)

--- a/src/sentry/mediators/sentry_apps/internal_creator.py
+++ b/src/sentry/mediators/sentry_apps/internal_creator.py
@@ -23,7 +23,6 @@ class InternalCreator(Mediator):
     webhook_url = Param(six.string_types)
     redirect_url = Param(six.string_types, required=False)
     is_alertable = Param(bool, default=False)
-    verify_install = Param(bool, default=False)
     schema = Param(dict, default=lambda self: {})
     overview = Param(six.string_types, required=False)
     request = Param('rest_framework.request.Request', required=False)
@@ -32,6 +31,7 @@ class InternalCreator(Mediator):
     def call(self):
         self.sentry_app = SentryAppCreator.run(**self.kwargs)
         self.sentry_app.status = SentryAppStatus.INTERNAL
+        self.sentry_app.verify_install = False
         self.sentry_app.save()
 
         self._create_access_token()

--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -23,6 +23,7 @@ class Updater(Mediator):
     webhook_url = Param(six.string_types, required=False)
     redirect_url = Param(six.string_types, required=False)
     is_alertable = Param(bool, required=False)
+    verify_install = Param(bool, required=False)
     schema = Param(dict, required=False)
     overview = Param(six.string_types, required=False)
     user = Param('sentry.models.User')
@@ -36,6 +37,7 @@ class Updater(Mediator):
         self._update_webhook_url()
         self._update_redirect_url()
         self._update_is_alertable()
+        self._update_verify_install()
         self._update_overview()
         self._update_schema()
         self.sentry_app.save()
@@ -92,6 +94,14 @@ class Updater(Mediator):
     @if_param('is_alertable')
     def _update_is_alertable(self):
         self.sentry_app.is_alertable = self.is_alertable
+
+    @if_param('verify_install')
+    def _update_verify_install(self):
+        if self.sentry_app.is_internal:
+            raise APIError(
+                u'Cannot update this option for internal integrations.',
+            )
+        self.sentry_app.verify_install = self.verify_install
 
     @if_param('overview')
     def _update_overview(self):

--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -99,7 +99,7 @@ class Updater(Mediator):
     def _update_verify_install(self):
         if self.sentry_app.is_internal:
             raise APIError(
-                u'Cannot update this option for internal integrations.',
+                u'Internal integrations do not require installation verification.',
             )
         self.sentry_app.verify_install = self.verify_install
 

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
@@ -5,7 +5,7 @@ const INTERNAL_OPTION_DISABLED_REASON = t(
   "This option can't be changed once selected. Please make a new integration if you no longer want it to be internal."
 );
 const VERIFY_INSTALL_OPTION_DISABLED_REASON = t(
-  'This option is always disabled for Internal integrations.'
+  'Internal integrations do not require installation verification.'
 );
 
 const forms = [

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
@@ -58,7 +58,7 @@ const forms = [
         name: 'verifyInstall',
         label: 'Verify Installation',
         type: 'boolean',
-        disabled: ({statusDisabled}) => statusDisabled,
+        disabled: ({changeVerifyDisabled}) => changeVerifyDisabled,
         disabledReason: VERIFY_INSTALL_OPTION_DISABLED_REASON,
         help:
           'If enabled, installations will need to be verified before becoming installed.',

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
@@ -4,6 +4,9 @@ import {t, tct} from 'app/locale';
 const INTERNAL_OPTION_DISABLED_REASON = t(
   "This option can't be changed once selected. Please make a new integration if you no longer want it to be internal."
 );
+const VERIFY_INSTALL_OPTION_DISABLED_REASON = t(
+  'This option is always disabled for Internal integrations.'
+);
 
 const forms = [
   {
@@ -50,6 +53,15 @@ const forms = [
         label: 'Redirect URL',
         placeholder: 'e.g. https://example.com/sentry/setup/',
         help: 'The URL Sentry will redirect users to after installation.',
+      },
+      {
+        name: 'verifyInstall',
+        label: 'Verify Installation',
+        type: 'boolean',
+        disabled: ({statusDisabled}) => statusDisabled,
+        disabledReason: VERIFY_INSTALL_OPTION_DISABLED_REASON,
+        help:
+          'If enabled, installations will need to be verified before becoming installed.',
       },
       {
         name: 'isAlertable',

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
@@ -86,12 +86,26 @@ export default class SentryApplicationDetails extends AsyncView {
     browserHistory.push(`/settings/${orgId}/developer-settings/`);
   };
 
+  onFieldChange = (name, value) => {
+    if (name === 'isInternal') {
+      if (value === true) {
+        //cannot have verifyInstall=true for internal apps
+        this.form.setValue('verifyInstall', false);
+      }
+      //trigger an update so we can change if verifyInstall is disabled or not
+      this.forceUpdate();
+    }
+  };
+
   renderBody() {
     const {orgId} = this.props.params;
     const {app} = this.state;
     const scopes = (app && [...app.scopes]) || [];
     const events = (app && this.normalize(app.events)) || [];
     const statusDisabled = app && app.status === 'internal' ? true : false;
+    // if the app is created and it is internal, don't need to check the form value
+    const changeVerifyDisabled =
+      statusDisabled || this.form.getValue('isInternal') ? true : false;
     const method = app ? 'PUT' : 'POST';
     const endpoint = app ? `/sentry-apps/${app.slug}/` : '/sentry-apps/';
 
@@ -112,9 +126,10 @@ export default class SentryApplicationDetails extends AsyncView {
           }}
           model={this.form}
           onSubmitSuccess={this.onSubmitSuccess}
+          onFieldChange={this.onFieldChange}
         >
           <JsonForm
-            additionalFieldProps={{statusDisabled}}
+            additionalFieldProps={{statusDisabled, changeVerifyDisabled}}
             location={this.props.location}
             forms={sentryApplicationForm}
           />

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
@@ -120,6 +120,7 @@ export default class SentryApplicationDetails extends AsyncView {
             organization: orgId,
             isAlertable: false,
             isInternal: app && app.status === 'internal' ? true : false,
+            verifyInstall: (app && app.verifyInstall) || false,
             schema: {},
             scopes: [],
             ...app,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -735,9 +735,11 @@ class Factories(object):
 
     @staticmethod
     def create_internal_integration(**kwargs):
-        return sentry_apps.InternalCreator.run(
+        app = sentry_apps.InternalCreator.run(
             **Factories._sentry_app_kwargs(**kwargs)
         )
+        app.update(verify_install=False)
+        return app
 
     @staticmethod
     def _sentry_app_kwargs(**kwargs):
@@ -747,6 +749,7 @@ class Factories(object):
             'organization': kwargs.get('organization', Factories.create_organization()),
             'author': kwargs.get('author', 'A Company'),
             'scopes': kwargs.get('scopes', ()),
+            'verify_install': kwargs.get('verify_install', True),
             'webhook_url': kwargs.get('webhook_url', 'https://example.com/webhook'),
             'events': [],
             'schema': {},

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -735,11 +735,9 @@ class Factories(object):
 
     @staticmethod
     def create_internal_integration(**kwargs):
-        app = sentry_apps.InternalCreator.run(
+        return sentry_apps.InternalCreator.run(
             **Factories._sentry_app_kwargs(**kwargs)
         )
-        app.update(verify_install=False)
-        return app
 
     @staticmethod
     def _sentry_app_kwargs(**kwargs):

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -43,6 +43,16 @@ describe('Sentry Application Details', function() {
       ).toBeDefined();
     });
 
+    it('disables verifyInstall if isInternal is enabled', function() {
+      const verifyInstallToggle = 'Switch[name="verifyInstall"]';
+
+      wrapper.find(verifyInstallToggle).simulate('click');
+      wrapper.find('Switch[name="isInternal"]').simulate('click');
+
+      expect(wrapper.find(verifyInstallToggle).prop('isDisabled')).toBe(true);
+      expect(wrapper.find(verifyInstallToggle).prop('isActive')).toBe(false);
+    });
+
     it('saves', function() {
       wrapper
         .find('Input[name="name"]')
@@ -83,6 +93,7 @@ describe('Sentry Application Details', function() {
         scopes: observable(['member:read', 'member:admin', 'event:read', 'event:admin']),
         events: observable(['issue']),
         isInternal: false,
+        verifyInstall: false,
         isAlertable: true,
         schema: {},
       };

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -49,6 +49,7 @@ class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
             'webhookUrl': self.unpublished_app.webhook_url,
             'redirectUrl': self.unpublished_app.redirect_url,
             'isAlertable': self.unpublished_app.is_alertable,
+            'verifyInstall': self.unpublished_app.verify_install,
             'clientId': self.unpublished_app.application.client_id,
             'clientSecret': self.unpublished_app.application.client_secret,
             'overview': self.unpublished_app.overview,

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -152,6 +152,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
             'webhookUrl': 'https://newurl.com',
             'redirectUrl': 'https://newredirecturl.com',
             'isAlertable': True,
+            'verifyInstall': self.published_app.verify_install,
             'clientId': self.published_app.application.client_id,
             'clientSecret': self.published_app.application.client_secret,
             'overview': self.published_app.overview,

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -75,6 +75,7 @@ class GetSentryAppsTest(SentryAppsTest):
             'webhookUrl': self.published_app.webhook_url,
             'redirectUrl': self.published_app.redirect_url,
             'isAlertable': self.published_app.is_alertable,
+            'verifyInstall': self.published_app.verify_install,
             'clientId': self.published_app.application.client_id,
             'clientSecret': self.published_app.application.client_secret,
             'overview': self.published_app.overview,
@@ -102,6 +103,7 @@ class GetSentryAppsTest(SentryAppsTest):
             'webhookUrl': self.internal_app.webhook_url,
             'redirectUrl': self.internal_app.redirect_url,
             'isAlertable': self.internal_app.is_alertable,
+            'verifyInstall': self.internal_app.verify_install,
             'overview': self.internal_app.overview,
             'schema': {},
             'installation': {
@@ -140,6 +142,7 @@ class GetSentryAppsTest(SentryAppsTest):
             'webhookUrl': self.internal_app.webhook_url,
             'redirectUrl': self.internal_app.redirect_url,
             'isAlertable': self.internal_app.is_alertable,
+            'verifyInstall': self.internal_app.verify_install,
             'overview': self.internal_app.overview,
             'schema': {},
             'installation': {
@@ -171,6 +174,7 @@ class GetSentryAppsTest(SentryAppsTest):
             'webhookUrl': self.published_app.webhook_url,
             'redirectUrl': self.published_app.redirect_url,
             'isAlertable': self.published_app.is_alertable,
+            'verifyInstall': self.published_app.verify_install,
             'clientId': self.published_app.application.client_id,
             'clientSecret': self.published_app.application.client_secret,
             'overview': self.published_app.overview,
@@ -213,6 +217,7 @@ class GetSentryAppsTest(SentryAppsTest):
             'webhookUrl': self.unpublished_app.webhook_url,
             'redirectUrl': self.unpublished_app.redirect_url,
             'isAlertable': self.unpublished_app.is_alertable,
+            'verifyInstall': self.unpublished_app.verify_install,
             'clientId': self.unpublished_app.application.client_id,
             'clientSecret': self.unpublished_app.application.client_secret,
             'overview': self.unpublished_app.overview,
@@ -433,6 +438,7 @@ class PostSentryAppsTest(SentryAppsTest):
 
         assert re.match(r'myapp\-[0-9a-zA-Z]+', response.data['slug'])
         assert response.data['status'] == SentryAppStatus.as_str(SentryAppStatus.INTERNAL)
+        assert not response.data['verifyInstall']
 
     def _post(self, **kwargs):
         body = {
@@ -445,6 +451,7 @@ class PostSentryAppsTest(SentryAppsTest):
             'webhookUrl': 'https://example.com',
             'redirectUrl': '',
             'isAlertable': False,
+            'verifyInstall': True,
         }
 
         body.update(**kwargs)

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -59,6 +59,17 @@ class TestUpdater(TestCase):
         with self.assertRaises(APIError):
             updater.call()
 
+    def test_doesnt_update_verify_install_if_internal(self):
+        self.create_project(organization=self.org)
+        sentry_app = self.create_internal_integration(
+            name='Internal',
+            organization=self.org,
+        )
+        updater = Updater(sentry_app=sentry_app, user=self.user)
+        updater.verify_install = True
+        with self.assertRaises(APIError):
+            updater.call()
+
     def test_updates_service_hook_events(self):
         sentry_app = self.create_sentry_app(
             name='sentry',


### PR DESCRIPTION
Adds **'Verify Installation**' as an option for a Sentry App
>![Screen Shot 2019-07-16 at 3 43 57 PM](https://user-images.githubusercontent.com/15368179/61334965-9a045980-a7e0-11e9-8aba-e7950b70c359.png)

However, '**Verify Installation**' is not an option for internal integrations
![Screen Shot 2019-07-16 at 3 47 20 PM](https://user-images.githubusercontent.com/15368179/61335069-054e2b80-a7e1-11e9-9459-6bb41811f47a.png)

