### PR TITLE
App platform/update permissions token auth

### DIFF
--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -45,7 +45,15 @@ def add_integration_platform_metric_tag(func):
 
 class SentryAppsPermission(SentryPermission):
     scope_map = {
-        'GET': (),  # Public endpoint.
+        # Public endpoint.
+        'GET': ('event:read',
+                'event:write',
+                'event:admin',
+                'project:releases',
+                'project:read',
+                'org:read',
+                'member:read',
+                'team:read',),
         'POST': ('org:read', 'org:integrations', 'org:write', 'org:admin'),
     }
 

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -118,11 +118,23 @@ class SentryAppPermission(SentryPermission):
     }
 
     published_scope_map = {
-        'GET': (),  # Public endpoint.
+        # Public endpoint.
+        'GET': ('event:read',
+                'event:write',
+                'event:admin',
+                'project:releases',
+                'project:read',
+                'org:read',
+                'member:read',
+                'team:read',),
         'PUT': ('org:write', 'org:admin'),
         'POST': ('org:write', 'org:admin'),
         'DELETE': ('org:admin'),
     }
+
+    @property
+    def scope_map(self):
+        return self.published_scope_map
 
     def has_object_permission(self, request, view, sentry_app):
         if not hasattr(request, 'user') or not request.user:

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -45,7 +45,8 @@ def add_integration_platform_metric_tag(func):
 
 class SentryAppsPermission(SentryPermission):
     scope_map = {
-        # Public endpoint.
+        # GET is ideally a public endpoint but for now we are allowing for
+        # anyone who has member permissions or above.
         'GET': ('event:read',
                 'event:write',
                 'event:admin',
@@ -126,7 +127,8 @@ class SentryAppPermission(SentryPermission):
     }
 
     published_scope_map = {
-        # Public endpoint.
+        # GET is ideally a public endpoint but for now we are allowing for
+        # anyone who has member permissions or above.
         'GET': ('event:read',
                 'event:write',
                 'event:admin',

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -36,6 +36,12 @@ class SentryAppPermissionTest(TestCase):
         with self.assertRaises(Http404):
             self.permission.has_object_permission(self.request, None, self.sentry_app)
 
+    def test_has_permission(self):
+        from sentry.models import ApiToken
+        token = ApiToken.objects.create(user=self.user, scope_list=['event:read', 'org:read'])
+        self.request = self.make_request(user=None, auth=token, method='GET')
+        assert self.permission.has_permission(self.request, None)
+
 
 class SentryAppBaseEndpointTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
**Problems:**

`SentryAppPermission` does not have an attribute `scope_map` so we were using the default scope map in `ScopedPermission` - which is no scopes. 
 
Because `has_permission` gets called before `has_object_permission`, both `SentryAppPermission` and `SentryAppsPermission` fail [here](https://github.com/getsentry/sentry/blob/master/src/sentry/api/permissions.py#L52):
```python
allowed_scopes = set(self.scope_map.get(request.method, []))
current_scopes = request.auth.get_scopes()
return any(s in allowed_scopes for s in current_scopes)
```

since `'GET': ()` is still no scopes. 

**Solution:**
* Add `scope_map` property that returns the `published_scope_map`
* Add scopes that equal what a member has for the `GET` endpoints (this is not _truly_ a public endpoint in this case but we can figure out what that looks like later) 