### PR TITLE
fix(api): Load 25 items on Incidents list by default to improve load times (SEN-848)

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_index.py
+++ b/src/sentry/api/endpoints/organization_incident_index.py
@@ -88,6 +88,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
             order_by='-date_started',
             paginator_cls=OffsetPaginator,
             on_results=lambda x: serialize(x, request.user),
+            default_per_page=25,
         )
 
     def post(self, request, organization):


### PR DESCRIPTION
This should get this endpoint loading in ~800ms consistently.