### PR TITLE
fix: Pass an empty array to $.param instead of an empty string when options.query is falsey

### DIFF
--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -166,6 +166,7 @@ export class Client {
     let query;
     try {
       query = $.param(options.query || '', true);
+      query = $.param(options.query || [], true);
     } catch (err) {
       Sentry.withScope(scope => {
         scope.setExtra('path', path);


### PR DESCRIPTION
~This is likely being loaded onto customer's browsers~

~https://github.com/splunk/splunk-sdk-javascript/blob/700d149fba3d5b38db06c0adf8739f5182aaf07d/lib/ui/charting/util.js#L1045-L1056~

and is causing `this.split is not a function` errors due to the way jQuery is building the params by traversing enumerable props and the props from the prototype chain: https://github.com/jquery/jquery/blob/b14ce54334a568eaaa107be4c441660a57c3db24/src/serialize.js#L82

The workaround is to use an empty array instead of an empty string when `options.query` is falsey. As per jquery's docs: https://api.jquery.com/jQuery.param/

<img width="448" alt="Screen Shot 2019-07-17 at 12 06 58 AM" src="https://user-images.githubusercontent.com/139499/61346713-f63e9c00-a827-11e9-95ef-bda27c402f65.png">


----

Fixes JAVASCRIPT-XYZ
Fixes JAVASCRIPT-1ABN