### PR TITLE
feat: Use option to force-disable transaction events

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -17,6 +17,7 @@ from sentry_sdk.consts import VERSION as SDK_VERSION
 from sentry_sdk.utils import Auth, capture_internal_exceptions
 from sentry_sdk.utils import logger as sdk_logger
 
+from sentry import options
 from sentry.utils import metrics
 from sentry.utils.rust import RustInfoIntegration
 
@@ -82,14 +83,17 @@ def configure_sdk():
 
     assert sentry_sdk.Hub.main.client is None
 
-    options = settings.SENTRY_SDK_CONFIG
+    sdk_options = settings.SENTRY_SDK_CONFIG
 
     internal_transport = InternalTransport()
     upstream_transport = None
-    if options.get('dsn'):
-        upstream_transport = make_transport(get_options(options))
+    if sdk_options.get('dsn'):
+        upstream_transport = make_transport(get_options(sdk_options))
 
     def capture_event(event):
+        if event.get('type') == 'transaction' and options.get('transaction-events.force-disable'):
+            return
+
         # Make sure we log to upstream when available first
         if upstream_transport is not None:
             # TODO(mattrobenolt): Bring this back safely.
@@ -109,7 +113,7 @@ def configure_sdk():
             RustInfoIntegration(),
         ],
         transport=capture_event,
-        **options
+        **sdk_options
     )
 
 


### PR DESCRIPTION
Add a killswitch for blocking all transaction events from the internal project since the upcoming deploys will be quite risky.

This is incomplete without #14056. It needs to be deployed in two stages to make the in-memory cache work.

#sync-getsentry