### PR TITLE
fix(ui): Fix resolve/ignore actions for accounts without multi project

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/actions.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.jsx
@@ -225,13 +225,12 @@ const IssueListActions = createReactClass({
       const loadingIndicator = IndicatorStore.add(t('Saving changes..'));
 
       // If `itemIds` is undefined then it means we expect to bulk update all items
-      // that match the query. In this case we should respect the projects selected in the
-      // global selection header.
+      // that match the query.
       //
-      // Otherwise if we have a list of itemIds, then we don't need project constraints since
-      // they will be unique
-      const projectConstraints =
-        typeof itemIds === 'undefined' ? {project: selection.projects} : {};
+      // We need to always respect the projects selected in the global selection header:
+      // * users with no global views requires a project to be specified
+      // * users with global views need to be explicit about what projects the query will run against
+      const projectConstraints = {project: selection.projects};
 
       this.props.api.bulkUpdate(
         {

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -212,6 +212,7 @@ describe('IssueListActions', function() {
           expect.objectContaining({
             query: {
               id: [3, 6, 9],
+              project: [1],
             },
             data: {status: 'resolved'},
           })


### PR DESCRIPTION
The endpoint requires an explicit project if you do not have access to the multi project feature.