### PR TITLE
Feat/mark sentry app installed put route

### DIFF
--- a/src/sentry/analytics/events/sentry_app_installation_updated.py
+++ b/src/sentry/analytics/events/sentry_app_installation_updated.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+from sentry import analytics
+
+
+class SentryAppInstallationUpdatedEvent(analytics.Event):
+    type = 'sentry_app_installation.updated'
+
+    attributes = (
+        analytics.Attribute('sentry_app_installation_id'),
+        analytics.Attribute('sentry_app_id'),
+        analytics.Attribute('organization_id'),
+    )
+
+
+analytics.register(SentryAppInstallationUpdatedEvent)

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -229,9 +229,8 @@ class SentryAppInstallationPermission(SentryPermission):
 
     def has_permission(self, request, *args, **kwargs):
         # To let the app mark the installation as installed, we don't care about permissions
-        if request.user.is_sentry_app:
-            if request.method == 'PUT':
-                return True
+        if request.user.is_sentry_app and request.method == 'PUT':
+            return True
         return super(SentryAppInstallationPermission, self).has_permission(request, *args, **kwargs)
 
     def has_object_permission(self, request, view, installation):

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -173,7 +173,7 @@ class SentryAppBaseEndpoint(IntegrationPlatformEndpoint):
 class SentryAppInstallationsPermission(SentryPermission):
     scope_map = {
         'GET': ('org:read', 'org:integrations', 'org:write', 'org:admin'),
-        'POST': ('org:integrations', 'org:write', 'org:admin'),
+        'POST': ('org:integrations', 'org:write', 'org:admin')
     }
 
     def has_object_permission(self, request, view, organization):
@@ -225,9 +225,11 @@ class SentryAppInstallationPermission(SentryPermission):
         # nested endpoints will probably need different scopes - figure out how
         # to deal with that when it happens.
         'POST': ('org:integrations', 'event:write', 'event:admin'),
+        'PUT': ('org:read')
     }
 
     def has_object_permission(self, request, view, installation):
+        print ("\n\n check permissions")
         if not hasattr(request, 'user') or not request.user:
             return False
 
@@ -246,7 +248,9 @@ class SentryAppInstallationPermission(SentryPermission):
 
 
 class SentryAppInstallationBaseEndpoint(IntegrationPlatformEndpoint):
+    # permission_classes = ( )
     permission_classes = (SentryAppInstallationPermission, )
+
 
     def convert_args(self, request, uuid, *args, **kwargs):
         try:

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from django.http import Http404
 from functools import wraps
-from django.conf import settings
 
 from sentry.utils.sdk import configure_scope
 from sentry.api.authentication import ClientIdSecretAuthentication
@@ -174,7 +173,7 @@ class SentryAppBaseEndpoint(IntegrationPlatformEndpoint):
 class SentryAppInstallationsPermission(SentryPermission):
     scope_map = {
         'GET': ('org:read', 'org:integrations', 'org:write', 'org:admin'),
-        'POST': ('org:integrations', 'org:write', 'org:admin')
+        'POST': ('org:integrations', 'org:write', 'org:admin'),
     }
 
     def has_object_permission(self, request, view, organization):

--- a/src/sentry/api/endpoints/sentry_app_installation_details.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_details.py
@@ -4,7 +4,8 @@ from rest_framework.response import Response
 
 from sentry.api.bases import SentryAppInstallationBaseEndpoint
 from sentry.api.serializers import serialize
-from sentry.mediators.sentry_app_installations import Destroyer
+from sentry.mediators.sentry_app_installations import Destroyer, Updater
+from sentry.api.serializers.rest_framework import SentryAppInstallationSerializer
 
 
 class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
@@ -19,3 +20,23 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
             request=request,
         )
         return Response(status=204)
+
+    def put(self, request, installation):
+        print("\n\n\n hey there")
+        serializer = SentryAppInstallationSerializer(
+            installation,
+            data=request.data,
+            partial=True,
+        )
+
+        if serializer.is_valid():
+            result = serializer.validated_data
+
+            updated_installation = Updater.run(
+                user=request.user,
+                sentry_app_installation=installation,
+                status=result.get('status'),
+            )
+
+            return Response(serialize(updated_installation, request.user))
+        return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/sentry_app_installation_details.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_details.py
@@ -22,7 +22,6 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
         return Response(status=204)
 
     def put(self, request, installation):
-        print("\n\n\n hey there")
         serializer = SentryAppInstallationSerializer(
             installation,
             data=request.data,

--- a/src/sentry/api/serializers/models/sentry_app_installation.py
+++ b/src/sentry/api/serializers/models/sentry_app_installation.py
@@ -8,6 +8,7 @@ from sentry.models import SentryAppInstallation
 @register(SentryAppInstallation)
 class SentryAppInstallationSerializer(Serializer):
     def serialize(self, install, attrs, user):
+        print ("id", install.id)
         data = {
             'app': {
                 'uuid': install.sentry_app.uuid,
@@ -17,6 +18,7 @@ class SentryAppInstallationSerializer(Serializer):
                 'slug': install.organization.slug,
             },
             'uuid': install.uuid,
+            'status': install.status,
         }
 
         if install.api_grant:

--- a/src/sentry/api/serializers/models/sentry_app_installation.py
+++ b/src/sentry/api/serializers/models/sentry_app_installation.py
@@ -3,12 +3,12 @@ from __future__ import absolute_import
 
 from sentry.api.serializers import Serializer, register
 from sentry.models import SentryAppInstallation
+from sentry.constants import SentryAppInstallationStatus
 
 
 @register(SentryAppInstallation)
 class SentryAppInstallationSerializer(Serializer):
     def serialize(self, install, attrs, user):
-        print ("id", install.id)
         data = {
             'app': {
                 'uuid': install.sentry_app.uuid,
@@ -18,7 +18,7 @@ class SentryAppInstallationSerializer(Serializer):
                 'slug': install.organization.slug,
             },
             'uuid': install.uuid,
-            'status': install.status,
+            'status': SentryAppInstallationStatus.as_str(install.status),
         }
 
         if install.api_grant:

--- a/src/sentry/api/serializers/rest_framework/sentry_app_installation.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app_installation.py
@@ -19,10 +19,12 @@ class SentryAppInstallationSerializer(Serializer):
                     SentryAppInstallationStatus.STATUS_MAP.keys(),
                 ),
             )
-        # convert status to str for comparison
-        last_status = SentryAppInstallationStatus.as_str(self.instance.status)
-        # make sure we don't go from installed to pending
-        if last_status == SentryAppInstallationStatus.INSTALLED_STR and new_status == SentryAppInstallationStatus.PENDING_STR:
-            raise ValidationError('Cannot change installed integration to pending')
+
+        if self.instance:
+            # convert status to str for comparison
+            last_status = SentryAppInstallationStatus.as_str(self.instance.status)
+            # make sure we don't go from installed to pending
+            if last_status == SentryAppInstallationStatus.INSTALLED_STR and new_status == SentryAppInstallationStatus.PENDING_STR:
+                raise ValidationError('Cannot change installed integration to pending')
 
         return new_status

--- a/src/sentry/api/serializers/rest_framework/sentry_app_installation.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app_installation.py
@@ -10,15 +10,11 @@ class SentryAppInstallationSerializer(Serializer):
     status = serializers.CharField()
 
     def validate_status(self, new_status):
-        # make sure the status in in our defined list
-        try:
-            SentryAppInstallationStatus.STATUS_MAP[new_status]
-        except KeyError:
+        # can only set status to installed
+        if new_status != SentryAppInstallationStatus.INSTALLED_STR:
             raise ValidationError(
-                'Invalid value for status. Valid values: {}'.format(
-                    SentryAppInstallationStatus.STATUS_MAP.keys(),
-                ),
-            )
+                u"Invalid value '{}' for status. Valid values: '{}'".format(
+                    new_status, SentryAppInstallationStatus.INSTALLED_STR))
 
         if self.instance:
             # convert status to str for comparison

--- a/src/sentry/api/serializers/rest_framework/sentry_app_installation.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app_installation.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+from jsonschema.exceptions import ValidationError as SchemaValidationError
+
+from rest_framework import serializers
+from rest_framework.serializers import Serializer, ValidationError
+
+from django.template.defaultfilters import slugify
+from sentry.api.validators.sentry_apps.schema import validate as validate_schema
+from sentry.models import ApiScopes, SentryApp
+from sentry.models.sentryapp import VALID_EVENT_RESOURCES, REQUIRED_EVENT_PERMISSIONS
+
+
+class SentryAppInstallationSerializer(Serializer):
+    status = serializers.CharField()
+
+    def validate_status(self, new_status):
+        last_status = self.instance.status
+        print ("last status", last_status)
+        print ("new status", new_status)
+        if last_status == 'installed':
+            if not new_status in ['installed']:
+                raise ValidationError('Cannot change installed integration to %s' % new_status)
+        elif last_status == 'pending':
+            if not new_status in ['pending', 'installed']:
+                raise ValidationError('Cannot change pending integration to %s' % new_status)
+
+        return new_status

--- a/src/sentry/api/serializers/rest_framework/sentry_app_installation.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app_installation.py
@@ -16,11 +16,4 @@ class SentryAppInstallationSerializer(Serializer):
                 u"Invalid value '{}' for status. Valid values: '{}'".format(
                     new_status, SentryAppInstallationStatus.INSTALLED_STR))
 
-        if self.instance:
-            # convert status to str for comparison
-            last_status = SentryAppInstallationStatus.as_str(self.instance.status)
-            # make sure we don't go from installed to pending
-            if last_status == SentryAppInstallationStatus.INSTALLED_STR and new_status == SentryAppInstallationStatus.PENDING_STR:
-                raise ValidationError('Cannot change installed integration to pending')
-
         return new_status

--- a/src/sentry/api/serializers/rest_framework/sentry_app_installation.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app_installation.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+
+from collections import OrderedDict
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 
 from rest_framework import serializers
@@ -9,20 +11,25 @@ from django.template.defaultfilters import slugify
 from sentry.api.validators.sentry_apps.schema import validate as validate_schema
 from sentry.models import ApiScopes, SentryApp
 from sentry.models.sentryapp import VALID_EVENT_RESOURCES, REQUIRED_EVENT_PERMISSIONS
+from sentry.constants import SentryAppInstallationStatus
 
 
 class SentryAppInstallationSerializer(Serializer):
     status = serializers.CharField()
 
     def validate_status(self, new_status):
+        # make sure the status in in our defined list
+        try:
+            SentryAppInstallationStatus.STATUS_MAP[new_status]
+        except KeyError as e:
+            raise ValidationError(
+                'Invalid value for status. Valid values: {}'.format(
+                    SentryAppInstallationStatus.STATUS_MAP.keys(),
+                ),
+            )
         last_status = self.instance.status
-        print ("last status", last_status)
-        print ("new status", new_status)
-        if last_status == 'installed':
-            if not new_status in ['installed']:
-                raise ValidationError('Cannot change installed integration to %s' % new_status)
-        elif last_status == 'pending':
-            if not new_status in ['pending', 'installed']:
-                raise ValidationError('Cannot change pending integration to %s' % new_status)
+        # make sure we don't go from installed to pending
+        if last_status == SentryAppInstallationStatus.INSTALLED_STR and new_status == SentryAppInstallationStatus.PENDING_STR:
+            raise ValidationError('Cannot change installed integration to pending')
 
         return new_status

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -402,20 +402,26 @@ class SentryAppStatus(object):
 class SentryAppInstallationStatus(object):
     PENDING = 0
     INSTALLED = 1
+    PENDING_STR = 'pending'
+    INSTALLED_STR = 'installed'
+    STATUS_MAP = OrderedDict([
+        (INSTALLED_STR, INSTALLED),
+        (PENDING_STR, PENDING),
+    ])
 
     @classmethod
     def as_choices(cls):
         return (
-            (cls.PENDING, 'pending'),
-            (cls.INSTALLED, 'installed'),
+            (cls.PENDING, cls.PENDING_STR),
+            (cls.INSTALLED, cls.INSTALLED_STR),
         )
 
     @classmethod
     def as_str(cls, status):
         if status == cls.PENDING:
-            return 'pending'
+            return cls.PENDING_STR
         elif status == cls.INSTALLED:
-            return 'installed'
+            return cls.INSTALLED_STR
 
 
 StatsPeriod = namedtuple('StatsPeriod', ('segments', 'interval'))

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -404,10 +404,6 @@ class SentryAppInstallationStatus(object):
     INSTALLED = 1
     PENDING_STR = 'pending'
     INSTALLED_STR = 'installed'
-    STATUS_MAP = OrderedDict([
-        (INSTALLED_STR, INSTALLED),
-        (PENDING_STR, PENDING),
-    ])
 
     @classmethod
     def as_choices(cls):

--- a/src/sentry/mediators/sentry_app_installations/__init__.py
+++ b/src/sentry/mediators/sentry_app_installations/__init__.py
@@ -2,4 +2,5 @@ from __future__ import absolute_import
 
 from .creator import Creator  # NOQA
 from .destroyer import Destroyer  # NOQA
+from .updater import Updater  # NOQA
 from .installation_notifier import InstallationNotifier  # NOQA

--- a/src/sentry/mediators/sentry_app_installations/updater.py
+++ b/src/sentry/mediators/sentry_app_installations/updater.py
@@ -21,7 +21,8 @@ class Updater(Mediator):
     @if_param('status')
     def _update_status(self):
         # convert from string to integer
-        self.sentry_app_installation.status = SentryAppInstallationStatus.STATUS_MAP[self.status]
+        if self.status == SentryAppInstallationStatus.INSTALLED_STR:
+            self.sentry_app_installation.status = SentryAppInstallationStatus.INSTALLED
 
     def record_analytics(self):
         # TODO: Add analytics

--- a/src/sentry/mediators/sentry_app_installations/updater.py
+++ b/src/sentry/mediators/sentry_app_installations/updater.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+import six
+
+from collections import Iterable
+
+from sentry import analytics
+from sentry.coreapi import APIError
+from sentry.constants import SentryAppStatus
+from sentry.mediators import Mediator, Param
+from sentry.mediators import service_hooks
+from sentry.mediators.param import if_param
+from sentry.models import SentryAppComponent, ServiceHook
+from sentry.models.sentryapp import REQUIRED_EVENT_PERMISSIONS
+
+
+class Updater(Mediator):
+    sentry_app_installation= Param('sentry.models.SentryAppInstallation')
+    status = Param(six.string_types, required=False)
+
+    def call(self):
+        self._update_status()
+        self.sentry_app_installation.save()
+        return self.sentry_app_installation
+
+    @if_param('status')
+    def _update_status(self):
+        print ("new status", self.status)
+        self.sentry_app_installation.status = self.status
+
+    def record_analytics(self):
+        pass
+        # TODO: Add analytics?
+        # analytics.record(
+        #     'sentry_app_installation.updated',
+        #     user_id=self.user.id,
+        #     sentry_app_installation=self.sentry_app_installation.id,
+        # )

--- a/src/sentry/mediators/sentry_app_installations/updater.py
+++ b/src/sentry/mediators/sentry_app_installations/updater.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 
-# from sentry import analytics
+from sentry import analytics
 from sentry.constants import SentryAppInstallationStatus
 from sentry.mediators import Mediator, Param
 from sentry.mediators.param import if_param
@@ -24,10 +24,10 @@ class Updater(Mediator):
         self.sentry_app_installation.status = SentryAppInstallationStatus.STATUS_MAP[self.status]
 
     def record_analytics(self):
-        pass
         # TODO: Add analytics
-        # analytics.record(
-        #     'sentry_app_installation.updated',
-        #     user_id=self.user.id,
-        #     sentry_app_installation=self.sentry_app_installation.id,
-        # )
+        analytics.record(
+            'sentry_app_installation.updated',
+            sentry_app_installation_id=self.sentry_app_installation.id,
+            sentry_app_id=self.sentry_app_installation.sentry_app.id,
+            organization_id=self.sentry_app_installation.organization.id
+        )

--- a/src/sentry/mediators/sentry_app_installations/updater.py
+++ b/src/sentry/mediators/sentry_app_installations/updater.py
@@ -2,16 +2,11 @@ from __future__ import absolute_import
 
 import six
 
-from collections import Iterable
 
-from sentry import analytics
-from sentry.coreapi import APIError
+# from sentry import analytics
 from sentry.constants import SentryAppInstallationStatus
 from sentry.mediators import Mediator, Param
-from sentry.mediators import service_hooks
 from sentry.mediators.param import if_param
-from sentry.models import SentryAppComponent, ServiceHook
-from sentry.models.sentryapp import REQUIRED_EVENT_PERMISSIONS
 
 
 class Updater(Mediator):
@@ -26,14 +21,11 @@ class Updater(Mediator):
     @if_param('status')
     def _update_status(self):
         # convert from string to integer
-        print("update status", self.status)
-        print("update status 1", SentryAppInstallationStatus.STATUS_MAP[self.status])
         self.sentry_app_installation.status = SentryAppInstallationStatus.STATUS_MAP[self.status]
-        print("hey")
 
     def record_analytics(self):
         pass
-        # TODO: Add analytics?
+        # TODO: Add analytics
         # analytics.record(
         #     'sentry_app_installation.updated',
         #     user_id=self.user.id,

--- a/src/sentry/mediators/sentry_app_installations/updater.py
+++ b/src/sentry/mediators/sentry_app_installations/updater.py
@@ -6,7 +6,7 @@ from collections import Iterable
 
 from sentry import analytics
 from sentry.coreapi import APIError
-from sentry.constants import SentryAppStatus
+from sentry.constants import SentryAppInstallationStatus
 from sentry.mediators import Mediator, Param
 from sentry.mediators import service_hooks
 from sentry.mediators.param import if_param
@@ -15,7 +15,7 @@ from sentry.models.sentryapp import REQUIRED_EVENT_PERMISSIONS
 
 
 class Updater(Mediator):
-    sentry_app_installation= Param('sentry.models.SentryAppInstallation')
+    sentry_app_installation = Param('sentry.models.SentryAppInstallation')
     status = Param(six.string_types, required=False)
 
     def call(self):
@@ -25,8 +25,11 @@ class Updater(Mediator):
 
     @if_param('status')
     def _update_status(self):
-        print ("new status", self.status)
-        self.sentry_app_installation.status = self.status
+        # convert from string to integer
+        print("update status", self.status)
+        print("update status 1", SentryAppInstallationStatus.STATUS_MAP[self.status])
+        self.sentry_app_installation.status = SentryAppInstallationStatus.STATUS_MAP[self.status]
+        print("hey")
 
     def record_analytics(self):
         pass

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -6,7 +6,6 @@ from mock import patch
 from sentry.testutils import APITestCase
 import responses
 from sentry.mediators.token_exchange import GrantExchanger
-from sentry.constants import SentryAppInstallationStatus
 
 
 class SentryAppInstallationDetailsTest(APITestCase):
@@ -134,24 +133,7 @@ class MarkInstalledSentryAppInstallationsTest(SentryAppInstallationDetailsTest):
             organization_id=self.installation.organization.id
         )
 
-    def test_sentry_app_installation_mark_bad_status(self):
-        self.url = reverse(
-            'sentry-api-0-sentry-app-installation-details',
-            args=[self.installation.uuid],
-        )
-        response = self.client.put(
-            self.url,
-            data={'status': 'other'},
-            HTTP_AUTHORIZATION=u'Bearer {}'.format(self.token.token),
-            format='json',
-        )
-        assert response.status_code == 400
-        assert response.data['status'][0] == u"Invalid value for status. Valid values: ['installed', 'pending']"
-
-    def test_sentry_app_installation_already_installed(self):
-        self.installation.status = SentryAppInstallationStatus.INSTALLED
-        self.installation.save()
-
+    def test_sentry_app_installation_mark_pending_status(self):
         self.url = reverse(
             'sentry-api-0-sentry-app-installation-details',
             args=[self.installation.uuid],
@@ -163,7 +145,7 @@ class MarkInstalledSentryAppInstallationsTest(SentryAppInstallationDetailsTest):
             format='json',
         )
         assert response.status_code == 400
-        assert response.data['status'][0] == "Cannot change installed integration to pending"
+        assert response.data['status'][0] == u"Invalid value 'pending' for status. Valid values: 'installed'"
 
     def test_sentry_app_installation_mark_installed_wrong_app(self):
         self.token = GrantExchanger.run(

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -58,6 +58,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
             },
             'uuid': self.installation2.uuid,
             'code': self.installation2.api_grant.code,
+            'status': 'pending',
         }]
 
         url = reverse(
@@ -78,6 +79,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
             },
             'uuid': self.installation.uuid,
             'code': self.installation.api_grant.code,
+            'status': 'pending'
         }]
 
     def test_users_only_sees_installs_on_their_org(self):
@@ -95,6 +97,7 @@ class GetSentryAppInstallationsTest(SentryAppInstallationsTest):
             },
             'uuid': self.installation2.uuid,
             'code': self.installation2.api_grant.code,
+            'status': 'pending',
         }]
 
         # Org the User is not a part of

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -63,6 +63,7 @@ class TestInstallationNotifier(TestCase):
                     },
                     'uuid': self.install.uuid,
                     'code': self.install.api_grant.code,
+                    'status': 'pending'
                 },
             },
             'actor': {
@@ -106,6 +107,7 @@ class TestInstallationNotifier(TestCase):
                     },
                     'uuid': self.install.uuid,
                     'code': self.install.api_grant.code,
+                    'status': 'pending'
                 },
             },
             'actor': {


### PR DESCRIPTION
This PR adds a route to mark a sentry app as installed after receiving an access token from the grant. Here's what the request object should look like in JS:
```
 {
     url: `api/0/sentry-app-installations/${installationId}/`,
     method: 'PUT',
     data: { status: 'installed'  }
}
```

There is validation on the value of `status`. It must either be `installed` or `pending`. And there is validation to make sure we never go from `installed` to `pending`.

I had to make a hack in `has_permission` in `SentryAppInstallationPermission` to ignore the usual permission checks for marking the sentry app as installed. This is because a sentry app that has no permissions should still be able to be marked as `installed` by the proxy hack. 