### PR TITLE
Fix: Remove extra $.param introduced in GH-14051

### DIFF
--- a/src/sentry/static/sentry/app/api.jsx
+++ b/src/sentry/static/sentry/app/api.jsx
@@ -165,7 +165,6 @@ export class Client {
   request(path, options = {}) {
     let query;
     try {
-      query = $.param(options.query || '', true);
       query = $.param(options.query || [], true);
     } catch (err) {
       Sentry.withScope(scope => {


### PR DESCRIPTION
Remove original `$.param` LOC that was supposed to be removed in https://github.com/getsentry/sentry/pull/14051