### PR TITLE
fix: Filter out groups that are pending deletion/merge from `by_qualified_short_id` (SEN-849)

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -130,7 +130,11 @@ class GroupManager(BaseManager):
                 raise ValueError()
         except ValueError:
             raise Group.DoesNotExist()
-        return Group.objects.get(
+        return Group.objects.exclude(status__in=[
+            GroupStatus.PENDING_DELETION,
+            GroupStatus.DELETION_IN_PROGRESS,
+            GroupStatus.PENDING_MERGE,
+        ]).get(
             project__organization=organization_id,
             project__slug=slug,
             short_id=short_id,

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -166,6 +166,10 @@ class GroupTest(TestCase):
 
         assert group2 == group
 
+        group.update(status=GroupStatus.PENDING_DELETION)
+        with self.assertRaises(Group.DoesNotExist):
+            Group.objects.by_qualified_short_id(group.organization.id, short_id)
+
     def test_first_last_release(self):
         project = self.create_project()
         release = Release.objects.create(


### PR DESCRIPTION
We had an issue where we could create grouplinks for groups that are pending deletion/merge/. The
invalid grouplinks prevented us from being able to deploy sentry.

I'm adding this in `by_qualified_short_id` because I don't think there are really valid conditions
where we'd want to fetch a group that will soon be removed by short id.

I feel that ideally we'd actually enforce this at the manager level for all groups, and then have
a separate manager for accessing deleted groups in the few cases where we need them, but probably not happening today.