### PR TITLE
fix(ui) Fix missing conditions in tag bars

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/tags.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/tags.jsx
@@ -56,7 +56,7 @@ class Tags extends React.Component {
           api,
           organization.slug,
           tag,
-          location.query
+          getQuery(view, location)
         );
 
         this.setState(state => ({tags: {...state.tags, [tag]: val}}));

--- a/tests/js/spec/views/organizationEventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/tags.spec.jsx
@@ -18,7 +18,7 @@ describe('Tags', function() {
         },
       },
       {
-        predicate: (url, options) => {
+        predicate: (_, options) => {
           return options.query.key === 'release';
         },
       }
@@ -35,8 +35,11 @@ describe('Tags', function() {
         },
       },
       {
-        predicate: (url, options) => {
-          return options.query.key === 'environment';
+        predicate: (_, options) => {
+          return (
+            options.query.key === 'environment' &&
+            options.query.query === 'event.type:csp'
+          );
         },
       }
     );
@@ -58,7 +61,9 @@ describe('Tags', function() {
     const view = {
       id: 'test',
       name: 'Test',
-      data: {},
+      data: {
+        query: 'event.type:csp',
+      },
       tags: ['release', 'environment'],
     };
     const wrapper = mount(


### PR DESCRIPTION
The tag distribution bars were not being passed the view query prefix resulting in CSP totals always being incorrect.

Fixes SEN-847