### PR TITLE
ref: Remove duplicate column

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -446,7 +446,6 @@ class SnubaEvent(EventCommon):
 
     # A list of all useful columns we can get from snuba.
     selected_columns = minimal_columns + [
-        'type',
         'culprit',
         'location',
         'message',


### PR DESCRIPTION
'type' column is already on this list, was accidentally re-added as part
of https://github.com/getsentry/sentry/pull/13100