### PR TITLE
build(kafka): confluent-kafka is no longer optional

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -4,6 +4,7 @@ botocore<1.5.71
 celery>=3.1.8,<3.1.19
 cffi>=1.11.5,<2.0
 click>=5.0,<7.0
+confluent-kafka==0.11.5
 # 'cryptography>=1.3,<1.4
 croniter>=0.3.26,<0.4.0
 cssutils>=0.9.9,<0.10.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,3 +1,4 @@
+batching-kafka-consumer==0.0.3
 BeautifulSoup>=3.2.1
 boto3>=1.4.1,<1.4.6
 botocore<1.5.71

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,5 +1,4 @@
 batching-kafka-consumer==0.0.3
-confluent-kafka==0.11.5
 GeoIP==1.3.2
 google-cloud-bigtable>=0.32.1,<0.33.0
 google-cloud-pubsub>=0.35.4,<0.36.0

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,4 +1,3 @@
-batching-kafka-consumer==0.0.3
 GeoIP==1.3.2
 google-cloud-bigtable>=0.32.1,<0.33.0
 google-cloud-pubsub>=0.35.4,<0.36.0


### PR DESCRIPTION
To be able to use Snuba effectively on any production system, we need Kafka, and for that we need confluent-kafka