### PR TITLE
ref(templates): Remove unused org_selector block

### DIFF
--- a/src/sentry/templates/sentry/bases/forceauth_modal.html
+++ b/src/sentry/templates/sentry/bases/forceauth_modal.html
@@ -3,7 +3,6 @@
 {% load i18n %}
 
 {% block wrapperclass %}{{ block.super }} narrow hide-sidebar{% endblock %}
-{% block org_selector %}{% endblock %}
 {% block account_nav %}{% endblock %}
 {% block global_sidebar %}{% endblock %}
 


### PR DESCRIPTION
This isn't declared anymore