### PR TITLE
feat(suspect-commits): Add analytics events

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
@@ -107,7 +107,7 @@ class EventCauseEmpty extends React.Component {
     trackAnalyticsEvent({
       eventKey,
       eventName,
-      org_id: parseInt(organization.id, 10),
+      organization_id: parseInt(organization.id, 10),
       project_id: parseInt(project.id, 10),
       platform: project.platform,
     });

--- a/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
@@ -46,17 +46,22 @@ class EventCauseEmpty extends React.Component {
   };
 
   componentDidMount() {
-    const {project, organization} = this.props;
-
     this.fetchData();
+  }
 
-    // send to reload only due to high event volume
-    trackAdhocEvent({
-      eventKey: 'feature.event_cause.viewed',
-      org_id: parseInt(organization.id, 10),
-      project_id: parseInt(project.id, 10),
-      platform: project.platform,
-    });
+  componentDidUpdate(prevProps, prevState) {
+    const {project, organization} = this.props;
+    const {shouldShow} = this.state;
+
+    if (!prevState.shouldShow && shouldShow) {
+      // send to reload only due to high event volume
+      trackAdhocEvent({
+        eventKey: 'feature.event_cause.viewed',
+        org_id: parseInt(organization.id, 10),
+        project_id: parseInt(project.id, 10),
+        platform: project.platform,
+      });
+    }
   }
 
   async fetchData() {

--- a/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
@@ -49,14 +49,14 @@ class EventCauseEmpty extends React.Component {
     this.fetchData();
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(_prevProps, prevState) {
     const {project, organization} = this.props;
     const {shouldShow} = this.state;
 
     if (!prevState.shouldShow && shouldShow) {
       // send to reload only due to high event volume
       trackAdhocEvent({
-        eventKey: 'feature.event_cause.viewed',
+        eventKey: 'event_cause.viewed',
         org_id: parseInt(organization.id, 10),
         project_id: parseInt(project.id, 10),
         platform: project.platform,
@@ -134,7 +134,7 @@ class EventCauseEmpty extends React.Component {
                 href="https://docs.sentry.io/workflow/releases/#create-release"
                 onClick={() =>
                   this.trackAnalytics({
-                    eventKey: 'feature.event_cause.docs_clicked',
+                    eventKey: 'event_cause.docs_clicked',
                     eventName: 'Event Cause Docs Clicked',
                   })
                 }
@@ -150,7 +150,7 @@ class EventCauseEmpty extends React.Component {
                     onClick={() =>
                       this.handleClick({
                         action: 'snoozed',
-                        eventKey: 'feature.event_cause.snoozed',
+                        eventKey: 'event_cause.snoozed',
                         eventName: 'Event Cause Snoozed',
                       })
                     }
@@ -164,7 +164,7 @@ class EventCauseEmpty extends React.Component {
                   onClick={() =>
                     this.handleClick({
                       action: 'dismissed',
-                      eventKey: 'feature.event_cause.dismissed',
+                      eventKey: 'event_cause.dismissed',
                       eventName: 'Event Cause Dismissed',
                     })
                   }

--- a/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
+++ b/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
@@ -43,7 +43,7 @@ describe('EventCauseEmpty', function() {
     expect(wrapper.find('CommitRow').exists()).toBe(true);
 
     expect(trackAdhocEvent).toHaveBeenCalledWith({
-      eventKey: 'feature.event_cause.viewed',
+      eventKey: 'event_cause.viewed',
       org_id: parseInt(organization.id, 10),
       project_id: parseInt(project.id, 10),
       platform: project.platform,
@@ -80,7 +80,7 @@ describe('EventCauseEmpty', function() {
     expect(wrapper.find('CommitRow').exists()).toBe(false);
 
     expect(trackAnalyticsEvent).toHaveBeenCalledWith({
-      eventKey: 'feature.event_cause.snoozed',
+      eventKey: 'event_cause.snoozed',
       eventName: 'Event Cause Snoozed',
       org_id: parseInt(organization.id, 10),
       project_id: parseInt(project.id, 10),
@@ -162,7 +162,7 @@ describe('EventCauseEmpty', function() {
     expect(wrapper.find('CommitRow').exists()).toBe(false);
 
     expect(trackAnalyticsEvent).toHaveBeenCalledWith({
-      eventKey: 'feature.event_cause.dismissed',
+      eventKey: 'event_cause.dismissed',
       eventName: 'Event Cause Dismissed',
       org_id: parseInt(organization.id, 10),
       project_id: parseInt(project.id, 10),
@@ -203,7 +203,7 @@ describe('EventCauseEmpty', function() {
       .simulate('click');
 
     expect(trackAnalyticsEvent).toHaveBeenCalledWith({
-      eventKey: 'feature.event_cause.docs_clicked',
+      eventKey: 'event_cause.docs_clicked',
       eventName: 'Event Cause Docs Clicked',
       org_id: parseInt(organization.id, 10),
       project_id: parseInt(project.id, 10),

--- a/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
+++ b/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
@@ -82,7 +82,7 @@ describe('EventCauseEmpty', function() {
     expect(trackAnalyticsEvent).toHaveBeenCalledWith({
       eventKey: 'event_cause.snoozed',
       eventName: 'Event Cause Snoozed',
-      org_id: parseInt(organization.id, 10),
+      organization_id: parseInt(organization.id, 10),
       project_id: parseInt(project.id, 10),
       platform: project.platform,
     });
@@ -164,7 +164,7 @@ describe('EventCauseEmpty', function() {
     expect(trackAnalyticsEvent).toHaveBeenCalledWith({
       eventKey: 'event_cause.dismissed',
       eventName: 'Event Cause Dismissed',
-      org_id: parseInt(organization.id, 10),
+      organization_id: parseInt(organization.id, 10),
       project_id: parseInt(project.id, 10),
       platform: project.platform,
     });
@@ -205,7 +205,7 @@ describe('EventCauseEmpty', function() {
     expect(trackAnalyticsEvent).toHaveBeenCalledWith({
       eventKey: 'event_cause.docs_clicked',
       eventName: 'Event Cause Docs Clicked',
-      org_id: parseInt(organization.id, 10),
+      organization_id: parseInt(organization.id, 10),
       project_id: parseInt(project.id, 10),
       platform: project.platform,
     });


### PR DESCRIPTION
Add analytics events for views and button clicks. Depends on [#117](https://github.com/getsentry/reload/pull/117)