### PR TITLE
ref(templates): Remove unused content block default

### DIFF
--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -92,18 +92,7 @@
 
     <div class="container">
       <div class="content">
-        {% block content %}
-        <div class="row" id="blk_content">
-          <div class="col-md-2">
-            {% block sidebar %}
-            {% endblock %}
-          </div>
-          <div class="col-md-10" id="blk_main">
-            {% block main %}
-            {% endblock %}
-          </div>
-        </div>
-        {% endblock %}
+        {% block content %}{% endblock %}
       </div>
     </div>
     <footer>


### PR DESCRIPTION
Again, no longer used anywhere, everything override the parent block