### PR TITLE
fix(InstallWizard): Fix exception when InstallWizard completed

### DIFF
--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -200,16 +200,13 @@ class App extends React.Component {
     e.stopPropagation();
   }
 
-  onConfigured() {
-    this.setState({needsUpgrade: false});
+  onConfigured = () => this.setState({needsUpgrade: false};
   }
 
-  handleNewsletterConsent = () => {
-    // this is somewhat hackish
-    this.setState({
-      newsletterConsentPrompt: false,
-    });
-  };
+  // this is somewhat hackish
+  handleNewsletterConsent = () => this.setState({
+    newsletterConsentPrompt: false,
+  });
 
   handleGlobalModalClose = () => {
     if (!this.mainContainerRef) {

--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -200,13 +200,13 @@ class App extends React.Component {
     e.stopPropagation();
   }
 
-  onConfigured = () => this.setState({needsUpgrade: false};
-  }
+  onConfigured = () => this.setState({needsUpgrade: false});
 
   // this is somewhat hackish
-  handleNewsletterConsent = () => this.setState({
-    newsletterConsentPrompt: false,
-  });
+  handleNewsletterConsent = () =>
+    this.setState({
+      newsletterConsentPrompt: false,
+    });
 
   handleGlobalModalClose = () => {
     if (!this.mainContainerRef) {


### PR DESCRIPTION
Since we don't have tests for the submit flow, we did not catch a regression from #13798 where the event handler was not bound to the class instance, causing an `this.setState` is not defined error when submitting the welcome form.

This patch fixes the issue. Will add tests to cover this soon after.