### PR TITLE
feat(servicehooks): Update servicehook URLs

### DIFF
--- a/src/sentry/tasks/servicehooks.py
+++ b/src/sentry/tasks/servicehooks.py
@@ -9,29 +9,19 @@ from sentry.http import safe_urlopen
 from sentry.models import ServiceHook
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json
-from sentry.utils.http import absolute_uri
 
 
 def get_payload_v0(event):
     group = event.group
     project = group.project
 
-    project_url_base = absolute_uri(u'/{}/{}'.format(
-        project.organization.slug,
-        project.slug,
-    ))
-
     group_context = serialize(group)
-    group_context['url'] = u'{}/issues/{}/'.format(
-        project_url_base,
-        group.id,
-    )
+    group_context['url'] = group.get_absolute_url()
 
     event_context = serialize(event)
-    event_context['url'] = u'{}/issues/{}/events/{}/'.format(
-        project_url_base,
-        group.id,
-        event.id,
+    event_context['url'] = u'{}events/{}/'.format(
+        group.get_absolute_url(),
+        event.event_id,
     )
     data = {
         'project': {

--- a/tests/sentry/tasks/test_servicehooks.py
+++ b/tests/sentry/tasks/test_servicehooks.py
@@ -66,3 +66,18 @@ class TestServiceHooks(TestCase):
             'X-ServiceHook-GUID',
             'X-ServiceHook-Signature',
         ))
+
+    def test_v0_payload(self):
+        event = self.create_event(project=self.project)
+
+        process_service_hook(self.hook.id, event)
+        body = get_payload_v0(event)
+        assert body['group']['url'] == 'http://testserver/organizations/{}/issues/{}/'.format(
+            self.organization.slug,
+            event.group.id,
+        )
+        assert body['event']['url'] == 'http://testserver/organizations/{}/issues/{}/events/{}/'.format(
+            self.organization.slug,
+            event.group.id,
+            event.event_id,
+        )


### PR DESCRIPTION
Updates the group and event URLs in servicehooks to align with the new
Sentry 10 routes. Also uses the hex event ID instead of the deprecated
autoincrement ID.