### PR TITLE
license: Remove license headers

### DIFF
--- a/src/sentry/__init__.py
+++ b/src/sentry/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry
-~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import os

--- a/src/sentry/__main__.py
+++ b/src/sentry/__main__.py
@@ -1,10 +1,3 @@
-"""
-sentry
-~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from .runner import main

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -1,10 +1,3 @@
-"""
-sentry.api.paginator
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import bisect

--- a/src/sentry/app.py
+++ b/src/sentry/app.py
@@ -1,10 +1,3 @@
-"""
-sentry.app
-~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from threading import local

--- a/src/sentry/attachments/base.py
+++ b/src/sentry/attachments/base.py
@@ -1,11 +1,3 @@
-"""
-sentry.attachments.base
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import zlib

--- a/src/sentry/attachments/default.py
+++ b/src/sentry/attachments/default.py
@@ -1,11 +1,3 @@
-"""
-sentry.attachments.default
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from sentry.cache import default_cache

--- a/src/sentry/attachments/redis.py
+++ b/src/sentry/attachments/redis.py
@@ -1,11 +1,3 @@
-"""
-sentry.attachments.redis
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import logging

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -1,10 +1,3 @@
-"""
-sentry.buffer.base
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import logging

--- a/src/sentry/buffer/inprocess.py
+++ b/src/sentry/buffer/inprocess.py
@@ -1,10 +1,3 @@
-"""
-sentry.buffer.inprocess
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from sentry.buffer import Buffer

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -1,10 +1,3 @@
-"""
-sentry.buffer.redis
-~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/cache/base.py
+++ b/src/sentry/cache/base.py
@@ -1,11 +1,3 @@
-"""
-sentry.cache.base
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/cache/django.py
+++ b/src/sentry/cache/django.py
@@ -1,11 +1,3 @@
-"""
-sentry.cache.django
-~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from django.core.cache import cache

--- a/src/sentry/cache/redis.py
+++ b/src/sentry/cache/redis.py
@@ -1,11 +1,3 @@
-"""
-sentry.cache.redis
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from sentry.utils import json

--- a/src/sentry/conf/__init__.py
+++ b/src/sentry/conf/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.conf
-~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1,11 +1,5 @@
 """
-sentry.conf.server
-~~~~~~~~~~~~~~~~~~
-
 These settings act as the default (base) settings for the Sentry-provided web-server
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import
 

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -1,12 +1,6 @@
 """
-sentry.constants
-~~~~~~~~~~~~~~~~
-
 These settings act as the default (base) settings for the Sentry-provided
 web-server
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
 """
 from __future__ import absolute_import, print_function
 

--- a/src/sentry/coreapi.py
+++ b/src/sentry/coreapi.py
@@ -1,10 +1,3 @@
-"""
-sentry.coreapi
-~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 # TODO: We should make the API a class, and UDP/HTTP just inherit from it
 #       This will make it so we can more easily control logging with various
 #       metadata (rather than generic log messages which aren't useful).

--- a/src/sentry/db/__init__.py
+++ b/src/sentry/db/__init__.py
@@ -1,9 +1,1 @@
-"""
-sentry.db
-~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import

--- a/src/sentry/db/exceptions.py
+++ b/src/sentry/db/exceptions.py
@@ -1,10 +1,3 @@
-"""
-sentry.db.exceptions
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 

--- a/src/sentry/db/models/__init__.py
+++ b/src/sentry/db/models/__init__.py
@@ -1,11 +1,3 @@
-"""
-sentry.db.models
-~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from .base import *  # NOQA

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -1,11 +1,3 @@
-"""
-sentry.db.models
-~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from copy import copy

--- a/src/sentry/db/models/fields/__init__.py
+++ b/src/sentry/db/models/fields/__init__.py
@@ -1,11 +1,3 @@
-"""
-sentry.db.models.fields
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from .array import *  # NOQA

--- a/src/sentry/db/models/fields/bounded.py
+++ b/src/sentry/db/models/fields/bounded.py
@@ -1,11 +1,3 @@
-"""
-sentry.db.models.fields.bounded
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/db/models/fields/citext.py
+++ b/src/sentry/db/models/fields/citext.py
@@ -1,11 +1,3 @@
-"""
-sentry.db.models.fields.citext
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 import six

--- a/src/sentry/db/models/fields/foreignkey.py
+++ b/src/sentry/db/models/fields/foreignkey.py
@@ -1,11 +1,3 @@
-"""
-sentry.db.models.fields.foreignkey
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/db/models/fields/gzippeddict.py
+++ b/src/sentry/db/models/fields/gzippeddict.py
@@ -1,11 +1,3 @@
-"""
-sentry.db.models.fields.gzippeddict
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -1,11 +1,3 @@
-"""
-sentry.db.models.fields.node
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 from base64 import b64encode

--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -1,11 +1,3 @@
-"""
-sentry.db.models.manager
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -1,11 +1,3 @@
-"""
-sentry.db.models.query
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import itertools

--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -1,11 +1,3 @@
-"""
-sentry.db.utils
-~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import operator

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1,9 +1,3 @@
-"""
-sentry.event_manager
-~~~~~~~~~~~~~~~~~~~~
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import time

--- a/src/sentry/http.py
+++ b/src/sentry/http.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.http
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/interfaces/__init__.py
+++ b/src/sentry/interfaces/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.interfaces
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import

--- a/src/sentry/interfaces/breadcrumbs.py
+++ b/src/sentry/interfaces/breadcrumbs.py
@@ -1,11 +1,3 @@
-"""
-sentry.interfaces.breadcrumbs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 __all__ = ('Breadcrumbs', )

--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -1,11 +1,3 @@
-"""
-sentry.interfaces.contexts
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -1,11 +1,3 @@
-"""
-sentry.interfaces.exception
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 __all__ = ('Exception', 'Mechanism', 'upgrade_legacy_mechanism')

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -1,11 +1,3 @@
-"""
-sentry.interfaces.http
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 __all__ = ('Http', )

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -1,11 +1,3 @@
-"""
-sentry.interfaces.message
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 __all__ = ('Message', )

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -1,11 +1,3 @@
-"""
-sentry.interfaces.schemas
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from functools32 import lru_cache

--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -1,11 +1,3 @@
-"""
-sentry.interfaces.security
-~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import jsonschema

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -1,11 +1,3 @@
-"""
-sentry.interfaces.stacktrace
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 __all__ = ('Stacktrace', )

--- a/src/sentry/interfaces/template.py
+++ b/src/sentry/interfaces/template.py
@@ -1,10 +1,3 @@
-"""
-sentry.interfaces.template
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 __all__ = ('Template', )

--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -1,10 +1,3 @@
-"""
-sentry.interfaces.user
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 __all__ = ('User', )

--- a/src/sentry/logging/__init__.py
+++ b/src/sentry/logging/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.logging
-~~~~~~~~~~~~~~
-:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from structlog import get_logger

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -1,9 +1,3 @@
-"""
-sentry.logging.handlers
-~~~~~~~~~~~~~~~~~~~~~~~
-:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import logging

--- a/src/sentry/management/__init__.py
+++ b/src/sentry/management/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.management
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import

--- a/src/sentry/management/commands/__init__.py
+++ b/src/sentry/management/commands/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.management.commands
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2012 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import

--- a/src/sentry/management/commands/backfill_eventstream.py
+++ b/src/sentry/management/commands/backfill_eventstream.py
@@ -1,10 +1,3 @@
-"""
-sentry.management.commands.backfill_eventstream
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2018 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import sys

--- a/src/sentry/management/commands/check_notifications.py
+++ b/src/sentry/management/commands/check_notifications.py
@@ -1,10 +1,3 @@
-"""
-sentry.management.commands.check_notifications
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from django.core.management.base import BaseCommand, CommandError

--- a/src/sentry/management/commands/collectstatic.py
+++ b/src/sentry/management/commands/collectstatic.py
@@ -1,10 +1,3 @@
-"""
-sentry.management.commands.collectstatic
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import os

--- a/src/sentry/management/commands/create_sample_event.py
+++ b/src/sentry/management/commands/create_sample_event.py
@@ -1,10 +1,3 @@
-"""
-sentry.management.commands.create_sample_event
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2012 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.core.management.base import BaseCommand, CommandError

--- a/src/sentry/management/commands/send_fake_data.py
+++ b/src/sentry/management/commands/send_fake_data.py
@@ -1,10 +1,3 @@
-"""
-sentry.management.commands.send_fake_data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2012 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import datetime

--- a/src/sentry/middleware/__init__.py
+++ b/src/sentry/middleware/__init__.py
@@ -1,9 +1,1 @@
-"""
-sentry.middleware
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import

--- a/src/sentry/middleware/debug.py
+++ b/src/sentry/middleware/debug.py
@@ -1,10 +1,3 @@
-"""
-sentry.middleware.debug
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from django.conf import settings

--- a/src/sentry/middleware/locale.py
+++ b/src/sentry/middleware/locale.py
@@ -1,11 +1,3 @@
-"""
-sentry.middleware.locale
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import pytz

--- a/src/sentry/middleware/maintenance.py
+++ b/src/sentry/middleware/maintenance.py
@@ -1,10 +1,3 @@
-"""
-sentry.middleware.maintenance
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/middleware/social_auth.py
+++ b/src/sentry/middleware/social_auth.py
@@ -1,11 +1,3 @@
-"""
-sentry.middleware.social_auth
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from social_auth.middleware import SocialAuthExceptionMiddleware

--- a/src/sentry/middleware/sudo.py
+++ b/src/sentry/middleware/sudo.py
@@ -1,10 +1,3 @@
-"""
-sentry.middleware.sudo
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from sudo.middleware import SudoMiddleware as BaseSudoMiddleware

--- a/src/sentry/models/__init__.py
+++ b/src/sentry/models/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.models
-~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.activity
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.apikey
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import six

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.auditlogentry
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 import six
 

--- a/src/sentry/models/authenticator.py
+++ b/src/sentry/models/authenticator.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.authenticator
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2016 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import os

--- a/src/sentry/models/broadcast.py
+++ b/src/sentry/models/broadcast.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.broadcast
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from datetime import timedelta

--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -1,11 +1,3 @@
-"""
-sentry.models.counter
-~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from django.db import connection, connections

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -1,11 +1,3 @@
-"""
-sentry.models.debugfile
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import re

--- a/src/sentry/models/distribution.py
+++ b/src/sentry/models/distribution.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.distribution
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import models

--- a/src/sentry/models/environment.py
+++ b/src/sentry/models/environment.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.environment
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from django.db import IntegrityError, models, transaction

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.event
-~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/models/eventmapping.py
+++ b/src/sentry/models/eventmapping.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.groupmeta
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import models

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -1,11 +1,3 @@
-"""
-sentry.models.file
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import os

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.group
-~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -1,9 +1,3 @@
-"""
-sentry.models.groupassignee
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 import logging
 import six

--- a/src/sentry/models/groupbookmark.py
+++ b/src/sentry/models/groupbookmark.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.groupbookmark
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/models/groupemailthread.py
+++ b/src/sentry/models/groupemailthread.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.groupemailthread
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import models

--- a/src/sentry/models/grouphash.py
+++ b/src/sentry/models/grouphash.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.grouphash
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/models/grouplink.py
+++ b/src/sentry/models/grouplink.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.grouplink
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import models

--- a/src/sentry/models/groupmeta.py
+++ b/src/sentry/models/groupmeta.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.groupmeta
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import threading

--- a/src/sentry/models/grouprulestatus.py
+++ b/src/sentry/models/grouprulestatus.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.grouprulestatus
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import models

--- a/src/sentry/models/groupseen.py
+++ b/src/sentry/models/groupseen.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.groupseen
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/models/groupshare.py
+++ b/src/sentry/models/groupshare.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.groupshare
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from uuid import uuid4

--- a/src/sentry/models/lostpasswordhash.py
+++ b/src/sentry/models/lostpasswordhash.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.useroption
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from datetime import timedelta

--- a/src/sentry/models/option.py
+++ b/src/sentry/models/option.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.option
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from django.db import models

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.organization
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/models/organizationaccessrequest.py
+++ b/src/sentry/models/organizationaccessrequest.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.organizationmember
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from django.core.urlresolvers import reverse

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.organizationmember
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import six

--- a/src/sentry/models/organizationonboardingtask.py
+++ b/src/sentry/models/organizationonboardingtask.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.organizationonboardingtask
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/models/organizationoption.py
+++ b/src/sentry/models/organizationoption.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.organizationoption
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from celery.signals import task_postrun

--- a/src/sentry/models/processingissue.py
+++ b/src/sentry/models/processingissue.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.processingissue
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from hashlib import sha1

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.project
-~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/models/projectbookmark.py
+++ b/src/sentry/models/projectbookmark.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.groupbookmark
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.projectkey
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import petname

--- a/src/sentry/models/projectoption.py
+++ b/src/sentry/models/projectoption.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.projectoption
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from celery.signals import task_postrun

--- a/src/sentry/models/rawevent.py
+++ b/src/sentry/models/rawevent.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.rawevent
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import models

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.release
-~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -1,11 +1,3 @@
-"""
-sentry.models.releasefile
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from django.db import models

--- a/src/sentry/models/reprocessingreport.py
+++ b/src/sentry/models/reprocessingreport.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.rawevent
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import models

--- a/src/sentry/models/rule.py
+++ b/src/sentry/models/rule.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.rule
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from django.db import models

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.team
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import warnings

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.user
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import logging

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.useroption
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from celery.signals import task_postrun

--- a/src/sentry/models/userreport.py
+++ b/src/sentry/models/userreport.py
@@ -1,10 +1,3 @@
-"""
-sentry.models.userreport
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import models

--- a/src/sentry/monitoring/queues.py
+++ b/src/sentry/monitoring/queues.py
@@ -1,10 +1,3 @@
-"""
-sentry.monitoring.queues
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2016 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from django.conf import settings

--- a/src/sentry/nodestore/base.py
+++ b/src/sentry/nodestore/base.py
@@ -1,11 +1,3 @@
-"""
-sentry.nodestore.base
-~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/nodestore/django/__init__.py
+++ b/src/sentry/nodestore/django/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.nodestore.django
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from .backend import DjangoNodeStorage  # NOQA

--- a/src/sentry/nodestore/django/backend.py
+++ b/src/sentry/nodestore/django/backend.py
@@ -1,11 +1,3 @@
-"""
-sentry.nodestore.django.backend
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import math

--- a/src/sentry/nodestore/django/models.py
+++ b/src/sentry/nodestore/django/models.py
@@ -1,11 +1,3 @@
-"""
-sentry.nodestore.django.models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from django.db import models

--- a/src/sentry/nodestore/models.py
+++ b/src/sentry/nodestore/models.py
@@ -1,11 +1,3 @@
-"""
-sentry.nodestore.models
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 # HACK(dcramer): Django doesn't play well with our naming schemes, and we prefer

--- a/src/sentry/nodestore/riak/__init__.py
+++ b/src/sentry/nodestore/riak/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.nodestore.riak
-~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from .backend import *  # NOQA

--- a/src/sentry/nodestore/riak/backend.py
+++ b/src/sentry/nodestore/riak/backend.py
@@ -1,11 +1,3 @@
-"""
-sentry.nodestore.riak.backend
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import os

--- a/src/sentry/nodestore/riak/client.py
+++ b/src/sentry/nodestore/riak/client.py
@@ -1,11 +1,3 @@
-"""
-sentry.nodestore.riak.client
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import functools

--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.options
-~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from .store import OptionsStore

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1,10 +1,3 @@
-"""
-sentry.options.defaults
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from sentry.logging import LoggingFormat

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -1,10 +1,3 @@
-"""
-sentry.options.manager
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import six

--- a/src/sentry/options/store.py
+++ b/src/sentry/options/store.py
@@ -1,10 +1,3 @@
-"""
-sentry.options.store
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/plugins/__init__.py
+++ b/src/sentry/plugins/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins
-~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 HIDDEN_PLUGINS = (

--- a/src/sentry/plugins/base/__init__.py
+++ b/src/sentry/plugins/base/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.base
-~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from .bindings import BindingManager

--- a/src/sentry/plugins/base/manager.py
+++ b/src/sentry/plugins/base/manager.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.base.manager
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 __all__ = ('PluginManager', )

--- a/src/sentry/plugins/base/notifier.py
+++ b/src/sentry/plugins/base/notifier.py
@@ -1,11 +1,3 @@
-"""
-sentry.plugins.base.notifier
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 __all__ = ('Notifier', )

--- a/src/sentry/plugins/base/response.py
+++ b/src/sentry/plugins/base/response.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.base.response
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 __all__ = ('Response', 'JSONResponse')

--- a/src/sentry/plugins/base/structs.py
+++ b/src/sentry/plugins/base/structs.py
@@ -1,11 +1,3 @@
-"""
-sentry.plugins.base.structs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 __all__ = ('Annotation', 'Notification')

--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.base.v1
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 __all__ = ('Plugin', )

--- a/src/sentry/plugins/base/v2.py
+++ b/src/sentry/plugins/base/v2.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.base.v2
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 __all__ = ('Plugin2', )

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.bases.issue
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.bases.notify
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/plugins/bases/tag.py
+++ b/src/sentry/plugins/bases/tag.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.bases.tag
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from sentry.constants import MAX_TAG_VALUE_LENGTH

--- a/src/sentry/plugins/helpers.py
+++ b/src/sentry/plugins/helpers.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.helpers
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from sentry import options

--- a/src/sentry/plugins/interfaces/releasehook.py
+++ b/src/sentry/plugins/interfaces/releasehook.py
@@ -1,11 +1,3 @@
-"""
-sentry.plugins.base.structs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 __all__ = ['ReleaseHook']

--- a/src/sentry/plugins/sentry_interface_types/__init__.py
+++ b/src/sentry/plugins/sentry_interface_types/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.plugins.sentry_interface_types
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import

--- a/src/sentry/plugins/sentry_interface_types/models.py
+++ b/src/sentry/plugins/sentry_interface_types/models.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.sentry_interface_types.models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/plugins/sentry_mail/__init__.py
+++ b/src/sentry/plugins/sentry_mail/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.plugins.sentry_mail
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import

--- a/src/sentry/plugins/sentry_mail/models.py
+++ b/src/sentry/plugins/sentry_mail/models.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.sentry_mail.models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import itertools

--- a/src/sentry/plugins/sentry_urls/__init__.py
+++ b/src/sentry/plugins/sentry_urls/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.plugins.sentry_urls
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import

--- a/src/sentry/plugins/sentry_urls/models.py
+++ b/src/sentry/plugins/sentry_urls/models.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.sentry_urls.models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import sentry

--- a/src/sentry/plugins/sentry_useragents/__init__.py
+++ b/src/sentry/plugins/sentry_useragents/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.plugins.sentry_useragents
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import

--- a/src/sentry/plugins/sentry_useragents/models.py
+++ b/src/sentry/plugins/sentry_useragents/models.py
@@ -1,10 +1,3 @@
-"""
-sentry.plugins.sentry_useragents.models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from ua_parser.user_agent_parser import Parse

--- a/src/sentry/projectoptions/__init__.py
+++ b/src/sentry/projectoptions/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.projectoptions
-~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2019 by the sentry team, see authors for more details.
-:license: bsd, see license for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from .manager import ProjectOptionsManager

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -1,10 +1,3 @@
-"""
-sentry.projectoptions.defaults
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2019 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 from sentry.projectoptions import register
 

--- a/src/sentry/projectoptions/manager.py
+++ b/src/sentry/projectoptions/manager.py
@@ -1,10 +1,3 @@
-"""
-sentry.projectoptions.manager
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2019 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -1,10 +1,3 @@
-"""
-sentry.quotas.base
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -1,10 +1,3 @@
-"""
-sentry.quotas.redis
-~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import functools

--- a/src/sentry/rules/__init__.py
+++ b/src/sentry/rules/__init__.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules
-~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from .base import *  # NOQA

--- a/src/sentry/rules/actions/__init__.py
+++ b/src/sentry/rules/actions/__init__.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules.actions
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from .base import *  # NOQA

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules.actions.base
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 from sentry.rules.base import RuleBase

--- a/src/sentry/rules/actions/notify_event.py
+++ b/src/sentry/rules/actions/notify_event.py
@@ -1,12 +1,6 @@
 """
-sentry.rules.actions.notify_event
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Used for notifying *all* enabled plugins
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
 """
-
 from __future__ import absolute_import
 
 from sentry.plugins import plugins

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -1,12 +1,6 @@
 """
-sentry.rules.actions.notify_event_service
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Used for notifying a *specific* plugin
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
 """
-
 from __future__ import absolute_import
 
 from django import forms

--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -1,10 +1,4 @@
 """
-sentry.rules.base
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-
 Rules apply either before an event gets stored, or immediately after.
 
 Basic actions:
@@ -32,9 +26,7 @@ by the rule's logic. Each rule condition may be associated with a form.
 
 - [ACTION:I want to get notified when] [RULE:an event is first seen]
 - [ACTION:I want to group events when] [RULE:an event matches [FORM]]
-
 """
-
 from __future__ import absolute_import
 
 import logging

--- a/src/sentry/rules/conditions/__init__.py
+++ b/src/sentry/rules/conditions/__init__.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules.conditions
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from .base import *  # NOQA

--- a/src/sentry/rules/conditions/base.py
+++ b/src/sentry/rules/conditions/base.py
@@ -1,10 +1,3 @@
-"""
-sentry.rules.conditions.base
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from sentry.rules.base import RuleBase

--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules.conditions.tagged_event
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import json

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules.conditions.event_frequency
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from datetime import timedelta

--- a/src/sentry/rules/conditions/every_event.py
+++ b/src/sentry/rules/conditions/every_event.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules.conditions.every_event
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from sentry.rules.conditions.base import EventCondition

--- a/src/sentry/rules/conditions/first_seen_event.py
+++ b/src/sentry/rules/conditions/first_seen_event.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules.conditions.first_seen_event
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from sentry.rules.conditions.base import EventCondition

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules.conditions.minimum_level
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from collections import OrderedDict

--- a/src/sentry/rules/conditions/reappeared_event.py
+++ b/src/sentry/rules/conditions/reappeared_event.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules.conditions.reappeared_event
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from sentry.rules.conditions.base import EventCondition

--- a/src/sentry/rules/conditions/regression_event.py
+++ b/src/sentry/rules/conditions/regression_event.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules.conditions.regression_event
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from sentry.rules.conditions.base import EventCondition

--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules.conditions.tagged_event
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from collections import OrderedDict

--- a/src/sentry/rules/registry.py
+++ b/src/sentry/rules/registry.py
@@ -1,11 +1,3 @@
-"""
-sentry.rules.registry
-~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner
-~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import os

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.backup
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import click

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.cleanup
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import os

--- a/src/sentry/runner/commands/config.py
+++ b/src/sentry/runner/commands/config.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.config
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import click

--- a/src/sentry/runner/commands/createuser.py
+++ b/src/sentry/runner/commands/createuser.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.createuser
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import click

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.devserver
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2016 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import click

--- a/src/sentry/runner/commands/django.py
+++ b/src/sentry/runner/commands/django.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.django
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import click

--- a/src/sentry/runner/commands/exec.py
+++ b/src/sentry/runner/commands/exec.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.exec
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2016 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import six

--- a/src/sentry/runner/commands/help.py
+++ b/src/sentry/runner/commands/help.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.help
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import click

--- a/src/sentry/runner/commands/init.py
+++ b/src/sentry/runner/commands/init.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.init
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import os

--- a/src/sentry/runner/commands/plugins.py
+++ b/src/sentry/runner/commands/plugins.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.plugins
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import click

--- a/src/sentry/runner/commands/queues.py
+++ b/src/sentry/runner/commands/queues.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.queues
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2016 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import click

--- a/src/sentry/runner/commands/repair.py
+++ b/src/sentry/runner/commands/repair.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.repair
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import os

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.run
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2016 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import sys

--- a/src/sentry/runner/commands/start.py
+++ b/src/sentry/runner/commands/start.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.start
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import sys

--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.commands.upgrade
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import click

--- a/src/sentry/runner/decorators.py
+++ b/src/sentry/runner/decorators.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.decorators
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import os

--- a/src/sentry/runner/importer.py
+++ b/src/sentry/runner/importer.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.importer
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import imp

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.initializer
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import click

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -1,10 +1,3 @@
-"""
-sentry.runner.settings
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import os

--- a/src/sentry/search/base.py
+++ b/src/sentry/search/base.py
@@ -1,11 +1,3 @@
-"""
-sentry.search.base
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from sentry.utils.services import Service

--- a/src/sentry/search/models.py
+++ b/src/sentry/search/models.py
@@ -1,9 +1,1 @@
-"""
-sentry.search.models
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import

--- a/src/sentry/services/__init__.py
+++ b/src/sentry/services/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.services
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function

--- a/src/sentry/services/base.py
+++ b/src/sentry/services/base.py
@@ -1,10 +1,3 @@
-"""
-sentry.services.base
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 

--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -1,10 +1,3 @@
-"""
-sentry.services.http
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import os

--- a/src/sentry/services/smtp.py
+++ b/src/sentry/services/smtp.py
@@ -1,10 +1,3 @@
-"""
-sentry.services.smtp
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import asyncore

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -1,11 +1,3 @@
-"""
-sentry.tagstore.base
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import re

--- a/src/sentry/tagstore/exceptions.py
+++ b/src/sentry/tagstore/exceptions.py
@@ -1,11 +1,3 @@
-"""
-sentry.tagstore.exceptions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 

--- a/src/sentry/tagstore/legacy/__init__.py
+++ b/src/sentry/tagstore/legacy/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.tagstore.legacy
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from .backend import LegacyTagStorage  # NOQA

--- a/src/sentry/tagstore/legacy/backend.py
+++ b/src/sentry/tagstore/legacy/backend.py
@@ -1,11 +1,3 @@
-"""
-sentry.tagstore.legacy.backend
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import collections

--- a/src/sentry/tagstore/legacy/models/__init__.py
+++ b/src/sentry/tagstore/legacy/models/__init__.py
@@ -1,11 +1,3 @@
-"""
-sentry.tagstore.legacy.models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from sentry.utils.imports import import_submodules

--- a/src/sentry/tagstore/legacy/models/eventtag.py
+++ b/src/sentry/tagstore/legacy/models/eventtag.py
@@ -1,10 +1,3 @@
-"""
-sentry.tagstore.legacy.models.eventtag
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import models

--- a/src/sentry/tagstore/legacy/models/grouptagkey.py
+++ b/src/sentry/tagstore/legacy/models/grouptagkey.py
@@ -1,10 +1,3 @@
-"""
-sentry.tagstore.legacy.models.grouptagkey
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import models, router, transaction, DataError

--- a/src/sentry/tagstore/legacy/models/grouptagvalue.py
+++ b/src/sentry/tagstore/legacy/models/grouptagvalue.py
@@ -1,10 +1,3 @@
-"""
-sentry.tagstore.legacy.models.grouptagvalue
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import models, router, transaction, DataError

--- a/src/sentry/tagstore/legacy/models/tagkey.py
+++ b/src/sentry/tagstore/legacy/models/tagkey.py
@@ -1,11 +1,3 @@
-"""
-sentry.tagstore.legacy.models.tagkey
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 from django.db import models

--- a/src/sentry/tagstore/legacy/models/tagvalue.py
+++ b/src/sentry/tagstore/legacy/models/tagvalue.py
@@ -1,10 +1,3 @@
-"""
-sentry.tagstore.legacy.models.tagvalue
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 from django.db import models

--- a/src/sentry/tagstore/models.py
+++ b/src/sentry/tagstore/models.py
@@ -1,11 +1,3 @@
-"""
-sentry.tagstore.models
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/tagstore/snuba/__init__.py
+++ b/src/sentry/tagstore/snuba/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.tagstore.snuba
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from .backend import SnubaTagStorage, SnubaCompatibilityTagStorage  # NOQA

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1,11 +1,3 @@
-"""
-sentry.tagstore.snuba.backend
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import functools

--- a/src/sentry/tagstore/tasks.py
+++ b/src/sentry/tagstore/tasks.py
@@ -1,11 +1,3 @@
-"""
-sentry.tagstore.tasks
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from uuid import uuid4

--- a/src/sentry/tagstore/v2/__init__.py
+++ b/src/sentry/tagstore/v2/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.tagstore.v2
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from .backend import V2TagStorage  # NOQA

--- a/src/sentry/tagstore/v2/backend.py
+++ b/src/sentry/tagstore/v2/backend.py
@@ -1,11 +1,3 @@
-"""
-sentry.tagstore.v2.backend
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import collections

--- a/src/sentry/tagstore/v2/models/__init__.py
+++ b/src/sentry/tagstore/v2/models/__init__.py
@@ -1,11 +1,3 @@
-"""
-sentry.tagstore.v2.models
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 from sentry.utils.imports import import_submodules

--- a/src/sentry/tagstore/v2/models/eventtag.py
+++ b/src/sentry/tagstore/v2/models/eventtag.py
@@ -1,10 +1,3 @@
-"""
-sentry.tagstore.v2.models.eventtag
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import models, router, connections

--- a/src/sentry/tagstore/v2/models/grouptagkey.py
+++ b/src/sentry/tagstore/v2/models/grouptagkey.py
@@ -1,10 +1,3 @@
-"""
-sentry.tagstore.v2.models.grouptagkey
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.db import router, transaction, DataError, connections

--- a/src/sentry/tagstore/v2/models/grouptagvalue.py
+++ b/src/sentry/tagstore/v2/models/grouptagvalue.py
@@ -1,10 +1,3 @@
-"""
-sentry.tagstore.v2.models.grouptagvalue
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/tagstore/v2/models/tagkey.py
+++ b/src/sentry/tagstore/v2/models/tagkey.py
@@ -1,11 +1,3 @@
-"""
-sentry.tagstore.v2.models.tagkey
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 from django.db import models, router, connections, transaction, IntegrityError

--- a/src/sentry/tagstore/v2/models/tagvalue.py
+++ b/src/sentry/tagstore/v2/models/tagvalue.py
@@ -1,10 +1,3 @@
-"""
-sentry.tagstore.v2.models.tagvalue
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2017 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import six

--- a/src/sentry/tasks/__init__.py
+++ b/src/sentry/tasks/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.tasks
-~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import

--- a/src/sentry/tasks/activity.py
+++ b/src/sentry/tasks/activity.py
@@ -1,11 +1,3 @@
-"""
-sentry.tasks.activity
-~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import logging

--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -1,10 +1,3 @@
-"""
-sentry.tasks.base
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import resource

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -1,11 +1,3 @@
-"""
-sentry.tasks.beacon
-~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 import json

--- a/src/sentry/tasks/check_auth.py
+++ b/src/sentry/tasks/check_auth.py
@@ -1,11 +1,3 @@
-"""
-sentry.tasks.check_alerts
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, division
 
 import logging

--- a/src/sentry/tasks/email.py
+++ b/src/sentry/tasks/email.py
@@ -1,11 +1,3 @@
-"""
-sentry.tasks.email
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -1,11 +1,3 @@
-"""
-sentry.tasks.merge
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import logging

--- a/src/sentry/tasks/options.py
+++ b/src/sentry/tasks/options.py
@@ -1,10 +1,3 @@
-"""
-sentry.tasks.options
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import logging

--- a/src/sentry/tasks/ping.py
+++ b/src/sentry/tasks/ping.py
@@ -1,11 +1,3 @@
-"""
-sentry.tasks.ping
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 import sentry

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1,11 +1,3 @@
-"""
-sentry.tasks.post_process
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -1,11 +1,3 @@
-"""
-sentry.tasks.process_buffer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import logging

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -1,11 +1,3 @@
-"""
-sentry.tasks.store
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 import logging

--- a/src/sentry/templatetags/__init__.py
+++ b/src/sentry/templatetags/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.templatetags
-~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import

--- a/src/sentry/templatetags/sentry_admin_helpers.py
+++ b/src/sentry/templatetags/sentry_admin_helpers.py
@@ -1,10 +1,3 @@
-"""
-sentry.templatetags.sentry_admin_helpers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2012 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import datetime

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -1,10 +1,3 @@
-"""
-sentry.templatetags.sentry_helpers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import functools

--- a/src/sentry/templatetags/sentry_plugins.py
+++ b/src/sentry/templatetags/sentry_plugins.py
@@ -1,10 +1,3 @@
-"""
-sentry.templatetags.sentry_plugins
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django import template

--- a/src/sentry/testutils/__init__.py
+++ b/src/sentry/testutils/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.testutils
-~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from .asserts import *  # NOQA

--- a/src/sentry/testutils/asserts.py
+++ b/src/sentry/testutils/asserts.py
@@ -1,10 +1,3 @@
-"""
-sentry.testutils.asserts
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 from sentry.models import CommitFileChange
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1,11 +1,3 @@
-"""
-sentry.testutils.cases
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import
 
 __all__ = (

--- a/src/sentry/testutils/helpers/__init__.py
+++ b/src/sentry/testutils/helpers/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.testutils.helpers
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from .auth_header import *  # NOQA

--- a/src/sentry/testutils/skips.py
+++ b/src/sentry/testutils/skips.py
@@ -1,10 +1,3 @@
-"""
-sentry.testutils.skips
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -1,10 +1,3 @@
-"""
-sentry.tsdb.base
-~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import collections

--- a/src/sentry/tsdb/dummy.py
+++ b/src/sentry/tsdb/dummy.py
@@ -1,10 +1,3 @@
-"""
-sentry.tsdb.dummy
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from sentry.tsdb.base import BaseTSDB

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -1,10 +1,3 @@
-"""
-sentry.tsdb.inmemory
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from collections import Counter, defaultdict

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -1,10 +1,3 @@
-"""
-sentry.tsdb.redis
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import itertools

--- a/src/sentry/utils/__init__.py
+++ b/src/sentry/utils/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils
-~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 # Make sure to not import anything here.  We want modules below

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.auth
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/utils/avatar.py
+++ b/src/sentry/utils/avatar.py
@@ -1,12 +1,6 @@
 """
-sentry.utils.avatar
-~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-
-Note: also see letterAvatar.jsx. Anything changed in this file (how colors are
-selected, the svg, etc) will also need to be changed there.
+Note: Also see letterAvatar.jsx. Anything changed in this file (how colors are
+      selected, the svg, etc) will also need to be changed there.
 """
 from __future__ import absolute_import
 

--- a/src/sentry/utils/cache.py
+++ b/src/sentry/utils/cache.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.cache
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import functools

--- a/src/sentry/utils/canonical.py
+++ b/src/sentry/utils/canonical.py
@@ -1,11 +1,3 @@
-"""
-sentry.utils.canonical
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2018 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 from django.conf import settings

--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.cursors
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/utils/data_filters.py
+++ b/src/sentry/utils/data_filters.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.data_filters.py
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import fnmatch

--- a/src/sentry/utils/data_scrubber.py
+++ b/src/sentry/utils/data_scrubber.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.data_scrubber
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2012 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import re

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.dates
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.db
-~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/utils/debug.py
+++ b/src/sentry/utils/debug.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.debug
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2012 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import cProfile

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.email
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import logging

--- a/src/sentry/utils/files.py
+++ b/src/sentry/utils/files.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.files
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import zlib

--- a/src/sentry/utils/gevent.py
+++ b/src/sentry/utils/gevent.py
@@ -1,4 +1,5 @@
-"""A wait callback to allow psycopg2 cooperation with gevent.
+"""
+A wait callback to allow psycopg2 cooperation with gevent.
 
 Use `make_psycopg_green()` to enable gevent support in Psycopg.
 """

--- a/src/sentry/utils/hashlib.py
+++ b/src/sentry/utils/hashlib.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.hashlib
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2015 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.http
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/utils/imports.py
+++ b/src/sentry/utils/imports.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.imports
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import pkgutil

--- a/src/sentry/utils/javascript.py
+++ b/src/sentry/utils/javascript.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.javascript
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.json
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 
 # Avoid shadowing the standard library json module
 from __future__ import absolute_import

--- a/src/sentry/utils/managers.py
+++ b/src/sentry/utils/managers.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.db
-~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/utils/math.py
+++ b/src/sentry/utils/math.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.math
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, division
 
 import math

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -1,9 +1,3 @@
-"""
-sentry.utils.outcomes.py
-~~~~~~~~~~~~~~~~~~~~
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from datetime import datetime

--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.query
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import progressbar

--- a/src/sentry/utils/runner.py
+++ b/src/sentry/utils/runner.py
@@ -1,11 +1,4 @@
 #!/usr/bin/env python
-"""
-sentry.utils.runner
-~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2012 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 # Backwards compatibility

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.safe
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import collections

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.samples
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2013 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import os.path

--- a/src/sentry/utils/settings.py
+++ b/src/sentry/utils/settings.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.settings
-~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import inspect

--- a/src/sentry/utils/sqlparser.py
+++ b/src/sentry/utils/sqlparser.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.sqlparser
-~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from sqlparse import engine

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.strings
-~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import base64

--- a/src/sentry/utils/types.py
+++ b/src/sentry/utils/types.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.types
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2016 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import six

--- a/src/sentry/utils/yaml.py
+++ b/src/sentry/utils/yaml.py
@@ -1,10 +1,3 @@
-"""
-sentry.utils.yaml
-~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from functools import partial

--- a/src/sentry/web/__init__.py
+++ b/src/sentry/web/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.web
-~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import

--- a/src/sentry/web/forms/__init__.py
+++ b/src/sentry/web/forms/__init__.py
@@ -1,10 +1,3 @@
-"""
-sentry.web.forms
-~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django import forms

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -1,10 +1,3 @@
-"""
-sentry.web.forms.accounts
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import pytz

--- a/src/sentry/web/forms/fields.py
+++ b/src/sentry/web/forms/fields.py
@@ -1,10 +1,3 @@
-"""
-sentry.web.forms.fields
-~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import six

--- a/src/sentry/web/frontend/__init__.py
+++ b/src/sentry/web/frontend/__init__.py
@@ -1,8 +1,1 @@
-"""
-sentry.web.frontend
-~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -1,10 +1,3 @@
-"""
-sentry.web.frontend.accounts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2012 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import logging

--- a/src/sentry/web/frontend/generic.py
+++ b/src/sentry/web/frontend/generic.py
@@ -1,10 +1,3 @@
-"""
-sentry.web.frontend.generic
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import os

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -1,10 +1,3 @@
-"""
-sentry.web.helpers
-~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import logging

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1,10 +1,3 @@
-"""
-sentry.web.urls
-~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/wsgi.py
+++ b/src/sentry/wsgi.py
@@ -1,10 +1,3 @@
-"""
-sentry.wsgi
-~~~~~~~~~~~
-
-:copyright: (c) 2010-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import os

--- a/tests/sentry/plugins/interfaces/test_releasehook.py
+++ b/tests/sentry/plugins/interfaces/test_releasehook.py
@@ -1,11 +1,3 @@
-"""
-sentry.plugins.base.structs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2010-2013 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
-
 from __future__ import absolute_import, print_function
 
 __all__ = ['ReleaseHook']


### PR DESCRIPTION
Some files have em some don't. Some header module names are wrong. Just kill em