### PR TITLE
ref(environments) Optimize environment queries

### DIFF
--- a/src/sentry/api/endpoints/project_environments.py
+++ b/src/sentry/api/endpoints/project_environments.py
@@ -45,6 +45,8 @@ class ProjectEnvironmentsEndpoint(ProjectEndpoint):
 
         queryset = EnvironmentProject.objects.filter(
             project=project,
+            # Including the organization_id is necessary for postgres to use indexes efficiently.
+            environment__organization_id=project.organization_id
         ).exclude(
             # HACK(mattrobenolt): We don't want to surface the
             # "No Environment" environment to the UI since it

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -277,6 +277,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
         ).exclude(
             is_hidden=True,
             # HACK(lb): avoiding the no environment value
+        ).exclude(
             environment__name=''
         ).values('project_id', 'environment__name')
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -272,9 +272,10 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
 
         project_envs = EnvironmentProject.objects.filter(
             project_id__in=[i.id for i in item_list],
+            # Including the organization_id is necessary for postgres to use indexes efficiently.
+            environment__organization_id=item_list[0].organization_id
         ).exclude(
-            is_hidden=True
-        ).exclude(
+            is_hidden=True,
             # HACK(lb): avoiding the no environment value
             environment__name=''
         ).values('project_id', 'environment__name')


### PR DESCRIPTION
Adding the organization_id to these queries allows postgres to use indexes better and makes queries much faster for organizations with many environments.