### PR TITLE
feat(eventsv2) Add basic transaction list

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -18,7 +18,7 @@ from sentry.utils.snuba import (
 from sentry import features
 from sentry.models.project import Project
 
-ALLOWED_GROUPINGS = frozenset(('issue.id', 'project.id'))
+ALLOWED_GROUPINGS = frozenset(('issue.id', 'project.id', 'transaction'))
 logger = logging.getLogger(__name__)
 
 

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -32,7 +32,6 @@ import SentryTypes from 'app/sentryTypes';
 import StacktraceInterface from 'app/components/events/interfaces/stacktrace';
 import TemplateInterface from 'app/components/events/interfaces/template';
 import ThreadsInterface from 'app/components/events/interfaces/threads';
-import SpansInterface from 'app/components/events/interfaces/spans';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -49,7 +48,6 @@ export const INTERFACES = {
   breadcrumbs: BreadcrumbsInterface,
   threads: ThreadsInterface,
   debugmeta: DebugMetaInterface,
-  spans: SpansInterface,
 };
 
 class EventEntries extends React.Component {

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -32,6 +32,7 @@ import SentryTypes from 'app/sentryTypes';
 import StacktraceInterface from 'app/components/events/interfaces/stacktrace';
 import TemplateInterface from 'app/components/events/interfaces/template';
 import ThreadsInterface from 'app/components/events/interfaces/threads';
+import SpansInterface from 'app/components/events/interfaces/spans';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -48,6 +49,7 @@ export const INTERFACES = {
   breadcrumbs: BreadcrumbsInterface,
   threads: ThreadsInterface,
   debugmeta: DebugMetaInterface,
+  spans: SpansInterface,
 };
 
 class EventEntries extends React.Component {

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -65,6 +65,28 @@ export const ALL_VIEWS = deepFreeze([
     ],
     columnWidths: ['3fr', '70px', '70px', '1fr', '1.5fr'],
   },
+  {
+    id: 'transactions',
+    name: 'Transactions',
+    data: {
+      fields: ['transaction', 'project', 'rpm', 'avg', '75th', '95th', '% total'],
+      sort: ['-timestamp', '-id'],
+      query: 'event.type:transaction',
+    },
+    tags: [
+      'event.type',
+      'release',
+      'project.name',
+      'user.email',
+      'user.ip',
+      'environment',
+      'trace',
+      'trace.ctx',
+      'trace.span',
+      'transaction',
+    ],
+    columnWidths: ['3fr', '1fr', '1fr', '1fr', '1fr', '1fr', '1fr'],
+  },
 ]);
 
 /**
@@ -73,6 +95,30 @@ export const ALL_VIEWS = deepFreeze([
  * displays with a custom render function.
  */
 export const SPECIAL_FIELDS = {
+  '% total': {
+    fields: [],
+    sortField: false,
+    renderFunc: () => {
+      return <Container>% total</Container>;
+    },
+  },
+  transaction: {
+    fields: ['title', 'id', 'project.name', 'transaction'],
+    sortField: 'transaction',
+    renderFunc: (data, {organization, location}) => {
+      const target = {
+        pathname: `/organizations/${organization.slug}/events/`,
+        query: {...location.query, eventSlug: `${data['project.name']}:${data.id}`},
+      };
+      return (
+        <Container>
+          <Link css={overflowEllipsis} to={target} data-test-id="event-title">
+            {data.transaction}
+          </Link>
+        </Container>
+      );
+    },
+  },
   event: {
     fields: ['title', 'id', 'project.name'],
     sortField: 'title',

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -12,6 +12,7 @@ import UserBadge from 'app/components/idBadge/userBadge';
 import DateTime from 'app/components/dateTime';
 import pinIcon from 'app/../images/location-pin.png';
 
+import {t} from 'app/locale';
 import {QueryLink} from './styles';
 
 export const MODAL_QUERY_KEYS = ['eventSlug', 'groupSlug'];
@@ -20,7 +21,7 @@ export const PIN_ICON = `image://${pinIcon}`;
 export const ALL_VIEWS = deepFreeze([
   {
     id: 'all',
-    name: 'All Events',
+    name: t('All Events'),
     data: {
       fields: ['event', 'type', 'project', 'user', 'time'],
       sort: ['-timestamp', '-id'],
@@ -37,7 +38,7 @@ export const ALL_VIEWS = deepFreeze([
   },
   {
     id: 'errors',
-    name: 'Errors',
+    name: t('Errors'),
     data: {
       fields: ['error', 'event_count', 'user_count', 'project', 'last_seen'],
       groupby: ['issue.id', 'project.id'],
@@ -49,7 +50,7 @@ export const ALL_VIEWS = deepFreeze([
   },
   {
     id: 'csp',
-    name: 'CSP',
+    name: t('CSP'),
     data: {
       fields: ['csp', 'event_count', 'user_count', 'project', 'last_seen'],
       groupby: ['issue.id', 'project.id'],
@@ -67,7 +68,7 @@ export const ALL_VIEWS = deepFreeze([
   },
   {
     id: 'transactions',
-    name: 'Transactions',
+    name: t('Transactions'),
     data: {
       fields: ['transaction', 'project'],
       groupby: ['transaction', 'project.id'],
@@ -92,13 +93,6 @@ export const ALL_VIEWS = deepFreeze([
  * displays with a custom render function.
  */
 export const SPECIAL_FIELDS = {
-  '% query': {
-    fields: [],
-    sortField: false,
-    renderFunc: () => {
-      return <Container>% query</Container>;
-    },
-  },
   transaction: {
     fields: ['project.name', 'transaction'],
     sortField: 'transaction',
@@ -112,7 +106,7 @@ export const SPECIAL_FIELDS = {
       };
       return (
         <Container>
-          <Link css={overflowEllipsis} to={target} data-test-id="event-title">
+          <Link css={overflowEllipsis} to={target} aria-label={data.transaction}>
             {data.transaction}
           </Link>
         </Container>
@@ -129,7 +123,7 @@ export const SPECIAL_FIELDS = {
       };
       return (
         <Container>
-          <Link css={overflowEllipsis} to={target} data-test-id="event-title">
+          <Link css={overflowEllipsis} to={target} aria-label={data.title}>
             {data.title}
           </Link>
         </Container>
@@ -218,7 +212,7 @@ export const SPECIAL_FIELDS = {
       };
       return (
         <Container>
-          <Link css={overflowEllipsis} to={target} data-test-id="event-title">
+          <Link css={overflowEllipsis} to={target} aria-label={data.issue_title}>
             {data.issue_title}
           </Link>
         </Container>
@@ -238,7 +232,7 @@ export const SPECIAL_FIELDS = {
       };
       return (
         <Container>
-          <Link css={overflowEllipsis} to={target} data-test-id="event-title">
+          <Link css={overflowEllipsis} to={target} aria-label={data.issue_title}>
             {data.issue_title}
           </Link>
         </Container>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -69,8 +69,9 @@ export const ALL_VIEWS = deepFreeze([
     id: 'transactions',
     name: 'Transactions',
     data: {
-      fields: ['transaction', 'project', 'rpm', 'avg', '75th', '95th', '% total'],
-      sort: ['-timestamp', '-id'],
+      fields: ['transaction', 'project'],
+      groupby: ['transaction', 'project.id'],
+      sort: ['-transaction'],
       query: 'event.type:transaction',
     },
     tags: [
@@ -80,10 +81,6 @@ export const ALL_VIEWS = deepFreeze([
       'user.email',
       'user.ip',
       'environment',
-      'trace',
-      'trace.ctx',
-      'trace.span',
-      'transaction',
     ],
     columnWidths: ['3fr', '1fr', '1fr', '1fr', '1fr', '1fr', '1fr'],
   },
@@ -95,20 +92,23 @@ export const ALL_VIEWS = deepFreeze([
  * displays with a custom render function.
  */
 export const SPECIAL_FIELDS = {
-  '% total': {
+  '% query': {
     fields: [],
     sortField: false,
     renderFunc: () => {
-      return <Container>% total</Container>;
+      return <Container>% query</Container>;
     },
   },
   transaction: {
-    fields: ['title', 'id', 'project.name', 'transaction'],
+    fields: ['project.name', 'transaction'],
     sortField: 'transaction',
     renderFunc: (data, {organization, location}) => {
       const target = {
         pathname: `/organizations/${organization.slug}/events/`,
-        query: {...location.query, eventSlug: `${data['project.name']}:${data.id}`},
+        query: {
+          ...location.query,
+          transactionSlug: `${data['project.name']}:${data.transaction}`,
+        },
       };
       return (
         <Container>

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -127,7 +127,7 @@ class OrganizationEventsTest(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
 
             # Click the event link to open the modal
-            self.browser.element('[data-test-id="event-title"]').click()
+            self.browser.element('[aria-label="{}"]'.format(event.title)).click()
             self.wait_until_loaded()
 
             header = self.browser.element('[data-test-id="modal-dialog"] h2')
@@ -169,7 +169,7 @@ class OrganizationEventsTest(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
 
             # Click the event link to open the modal
-            self.browser.element('[data-test-id="event-title"]').click()
+            self.browser.element('[aria-label="{}"]'.format(event.title)).click()
             self.wait_until_loaded()
 
             self.browser.snapshot('events-v2 - grouped error modal')

--- a/tests/js/spec/views/organizationEventsV2/index.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/index.spec.jsx
@@ -4,13 +4,14 @@ import {mount} from 'enzyme';
 import OrganizationEventsV2 from 'app/views/organizationEventsV2';
 
 describe('OrganizationEventsV2', function() {
+  const eventTitle = 'Oh no something bad';
   beforeEach(function() {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: [
         {
           id: 'deadbeef',
-          title: 'Oh no something bad',
+          title: eventTitle,
           'project.name': 'project-slug',
           timestamp: '2019-05-23T22:12:48+00:00',
         },
@@ -108,7 +109,7 @@ describe('OrganizationEventsV2', function() {
       TestStubs.routerContext()
     );
 
-    const link = wrapper.find('Table Link[data-test-id="event-title"]').first();
+    const link = wrapper.find(`Table Link[aria-label="${eventTitle}"]`).first();
     expect(link.props().to.query).toEqual({eventSlug: 'project-slug:deadbeef'});
   });
 

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -530,7 +530,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
                 },
             )
         assert response.status_code == 400, response.content
-        assert response.data['detail'] == 'Invalid groupby value requested. Allowed values are project.id, issue.id'
+        assert response.data['detail'] == 'Invalid groupby value requested. Allowed values are transaction, project.id, issue.id'
 
     def test_non_aggregated_fields_with_groupby(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
This adds a rudimentary and mostly not working version of the transaction list view. In a future pull request we'll be linking the transaction rows up to the modal (which doesn't yet exist on master)

Acceptance tests are blocked on the sample transaction payload in #14007

This is separated from @dashed's big pull request.

Refs SEN-796