### PR TITLE
fix(app-platform): Allow GET requests for published apps

### DIFF
--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -160,6 +160,11 @@ class SentryAppPermission(SentryPermission):
             if sentry_app.owner not in request.user.get_orgs():
                 raise Http404
 
+        # we can't use ensure_scoped_permission now that the public
+        # endpoint isn't denoted by '()'
+        if sentry_app.is_published and request.method == 'GET':
+            return True
+
         return ensure_scoped_permission(
             request,
             self._scopes_for_sentry_app(sentry_app).get(request.method),

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -160,8 +160,9 @@ class SentryAppPermission(SentryPermission):
             if sentry_app.owner not in request.user.get_orgs():
                 raise Http404
 
-        # we can't use ensure_scoped_permission now that the public
-        # endpoint isn't denoted by '()'
+        # TODO(meredith): make a better way to allow for public
+        # endpoints. we can't use ensure_scoped_permission now
+        # that the public endpoint isn't denoted by '()'
         if sentry_app.is_published and request.method == 'GET':
             return True
 


### PR DESCRIPTION
Installing a published integration in an org that is _not_ the owner of the integration is failing because we no longer have `'GET': ()` denoting a public endpoint - which we are using to get the integration feature set: `sentry-apps/<sentry_app_slug>/features/`

Instead of returning `True` in `ensure_scoped_permission` ([this piece](https://github.com/getsentry/sentry/blob/master/src/sentry/api/bases/sentryapps.py#L32)) we now return `False` because `request.access.scopes` is empty. 

This PR adds a quick fix, but we should probably rethink (again) what a 'public' endpoint is and where we are using them. 
