### PR TITLE
test(datasets): Make Sentry use generic test functions in Snuba

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -249,7 +249,7 @@ class SnubaEventStream(SnubaProtocolEventStream):
 
         try:
             resp = snuba._snuba_pool.urlopen(
-                'POST', '/tests/eventstream',
+                'POST', '/tests/events/eventstream',
                 body=json.dumps(data),
             )
             if resp.status != 200:

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -872,7 +872,7 @@ class SnubaTestCase(BaseTestCase):
     def init_snuba(self):
         self.snuba_eventstream = SnubaEventStream()
         self.snuba_tagstore = SnubaCompatibilityTagStorage()
-        assert requests.post(settings.SENTRY_SNUBA + '/tests/drop').status_code == 200
+        assert requests.post(settings.SENTRY_SNUBA + '/tests/events/drop').status_code == 200
 
     def store_event(self, *args, **kwargs):
         with contextlib.nested(
@@ -951,7 +951,7 @@ class SnubaTestCase(BaseTestCase):
             events = [events]
 
         assert requests.post(
-            settings.SENTRY_SNUBA + '/tests/insert',
+            settings.SENTRY_SNUBA + '/tests/events/insert',
             data=json.dumps(events)
         ).status_code == 200
 

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -101,7 +101,10 @@ class TagStorageTest(TestCase, SnubaTestCase):
             },
         }])
 
-        assert requests.post(settings.SENTRY_SNUBA + '/tests/insert', data=data).status_code == 200
+        assert requests.post(
+            settings.SENTRY_SNUBA +
+            '/tests/events/insert',
+            data=data).status_code == 200
 
     def test_get_group_tag_keys_and_top_values(self):
         result = list(self.ts.get_group_tag_keys_and_top_values(

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -133,7 +133,10 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             },
         } for r in range(0, 14400, 600)])  # Every 10 min for 4 hours
 
-        assert requests.post(settings.SENTRY_SNUBA + '/tests/insert', data=data).status_code == 200
+        assert requests.post(
+            settings.SENTRY_SNUBA +
+            '/tests/events/insert',
+            data=data).status_code == 200
 
         # snuba trims query windows based on first_seen/last_seen, so these need to be correct-ish
         self.proj1group1.first_seen = self.now


### PR DESCRIPTION
## Background
When we run tests in Sentry that hit Snuba, we insert records and delete the database at the end of every test run. We do this using the following test endpoints in Snuba:
* `/tests/insert`
* `/tests/eventstream`
* `/tests/drop`

## Problem
These endpoints only worked for the `events` dataset. We want it to work for any dataset.

## Solution
So, https://github.com/getsentry/snuba/pull/366 introduced 3 new test endpoints to Snuba with the goal of replacing the 3 endpoints mentioned earlier:
* `/tests/<datastream>/insert`
* `/tests/<datastream>/eventstream`
* `/tests/<datastream>/drop`

This PR makes Sentry use the new endpoints in Snuba. The next step is to remove the old non-generic endpoints from Snuba.