### PR TITLE
fix: Don't start pageload transaction

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.jsx
+++ b/src/sentry/static/sentry/app/bootstrap.jsx
@@ -44,12 +44,6 @@ Sentry.configureScope(scope => {
   if (window.__SENTRY__VERSION) {
     scope.setTag('sentry_version', window.__SENTRY__VERSION);
   }
-  scope.setSpan(
-    Sentry.getCurrentHub().startSpan({
-      op: 'pageload',
-      sampled: true,
-    })
-  );
 });
 
 // Used for operational metrics to determine that the application js
@@ -78,6 +72,14 @@ if (
     (config.urlPrefix &&
       (config.urlPrefix.includes('localhost') || config.urlPrefix.includes('127.0.0.1'))))
 ) {
+  Sentry.configureScope(scope => {
+    scope.setSpan(
+      Sentry.getCurrentHub().startSpan({
+        op: 'pageload',
+        sampled: true,
+      })
+    );
+  });
   startApm();
 }
 // -----------------------------------------------------------------


### PR DESCRIPTION
If we have a span on the scope outgoing XHR requests will attach the header with sample rate `1` which will emit transactions on the backend.
We only want to start a transaction for ourselves right now.