### PR TITLE
fix(azuredevops) Don't fail when a user account is deleted

### DIFF
--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -246,7 +246,15 @@ class VstsIssueSync(IssueSyncMixin):
 
     def get_done_states(self, project):
         client = self.get_client()
-        all_states = client.get_work_item_states(self.instance, project)['value']
+        try:
+            all_states = client.get_work_item_states(self.instance, project)['value']
+        except ApiError as err:
+            self.logger.info('vsts.get-done-states.failed', extra={
+                'integration_id': self.model.id,
+                'exception': err
+            })
+            return []
+
         done_states = [
             state['name'] for state in all_states if state['category'] in self.done_categories
         ]

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -311,6 +311,22 @@ class VstsIssueSyncTest(VstsIssueBase):
         assert should_resolve is False
 
     @responses.activate
+    def test_should_resolve_done_status_failure(self):
+        responses.reset()
+        responses.add(
+            responses.GET,
+            'https://fabrikam-fiber-inc.visualstudio.com/c0bf429a-c03c-4a99-9336-d45be74db5a6/_apis/wit/workitemtypes/Bug/states',
+            status=403,
+            json={'error': 'The requested operation is not allowed. Your account is pending deletion.'}
+        )
+        should_resolve = self.integration.should_resolve({
+            'project': self.project_id_with_states,
+            'old_state': 'Active',
+            'new_state': 'Resolved',
+        })
+        assert should_resolve is False
+
+    @responses.activate
     def test_should_unresolve_active_to_resolved(self):
         should_unresolve = self.integration.should_unresolve({
             'project': self.project_id_with_states,


### PR DESCRIPTION
When the integration bridge user is deleted in active directory we shouldn't 500 when handling webhooks. Instead the azure issue should not be transitioned to a new state and we can log the failure.

Fixes SENTRY-9xf