### PR TITLE
ref(suspect-commits): Add text changes

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
@@ -124,8 +124,8 @@ class EventCauseEmpty extends React.Component {
         <StyledPanel dashedBorder>
           <BoxHeader>
             <Description>
-              <h3>{t('Suspect Commits')}</h3>
-              <p>{t('Identify which commit caused this issue')}</p>
+              <h3>{t('Configure Suspect Commits')}</h3>
+              <p>{t('To identify which commit caused this issue')}</p>
             </Description>
             <ButtonList>
               <DocsButton

--- a/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
@@ -31,7 +31,7 @@ const DUMMY_COMMIT = {
   repository: {
     provider: {id: 'integrations:github', name: 'GitHub', status: 'active'},
   },
-  message: t('This commit accidentally broke something'),
+  message: t('This example commit broke something'),
 };
 
 class EventCauseEmpty extends React.Component {


### PR DESCRIPTION
Text changes to make the empty state more obvious
<img width="678" alt="Screen Shot 2019-07-23 at 1 12 55 PM" src="https://user-images.githubusercontent.com/16394317/61744235-a1c97e00-ad4b-11e9-8665-e122ae391a7d.png">
