### PR TITLE
fix(app-platform): Allow removing a schema

### DIFF
--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -38,8 +38,11 @@ class EventListField(serializers.Field):
 
 class SchemaField(serializers.Field):
     def to_internal_value(self, data):
-        if not data:
+        if data is None:
             return
+
+        if data == '' or data == {}:
+            return {}
 
         try:
             validate_schema(data)

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
@@ -186,7 +186,6 @@ export default class SentryApplicationRow extends React.PureComponent {
               {showPublishStatus ? (
                 <SentryAppLink
                   to={`/settings/${organization.slug}/developer-settings/${app.slug}/`}
-                  data-test-id={app.slug}
                 >
                   {app.name}
                 </SentryAppLink>

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
@@ -186,6 +186,7 @@ export default class SentryApplicationRow extends React.PureComponent {
               {showPublishStatus ? (
                 <SentryAppLink
                   to={`/settings/${organization.slug}/developer-settings/${app.slug}/`}
+                  data-test-id={app.slug}
                 >
                   {app.name}
                 </SentryAppLink>

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -3,13 +3,13 @@ from __future__ import absolute_import
 from sentry.testutils import AcceptanceTestCase
 
 
-class OrganizationDeveloperSettingsAcceptanceTest(AcceptanceTestCase):
+class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
     """
     As a developer, I can create an integration, install it, and uninstall it
     """
 
     def setUp(self):
-        super(OrganizationDeveloperSettingsAcceptanceTest, self).setUp()
+        super(OrganizationDeveloperSettingsNewAcceptanceTest, self).setUp()
         self.login_as(self.user)
         self.org_developer_settings_path = u'/settings/{}/developer-settings/'.format(
             self.organization.slug)
@@ -34,3 +34,57 @@ class OrganizationDeveloperSettingsAcceptanceTest(AcceptanceTestCase):
             self.browser.wait_until('.ref-success')
 
             assert self.browser.find_element_by_link_text('Tesla')
+
+
+class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
+    """
+    As a developer, I can edit an existing integration
+    """
+
+    def setUp(self):
+        super(OrganizationDeveloperSettingsEditAcceptanceTest, self).setUp()
+        self.user = self.create_user('foo@example.com')
+        self.org = self.create_organization(
+            name='Tesla',
+            owner=self.user,
+        )
+        self.team = self.create_team(organization=self.org, name='Tesla Motors')
+        self.project = self.create_project(
+            organization=self.org,
+            teams=[self.team],
+            name='Model S',
+        )
+        self.sentry_app = self.create_sentry_app(
+            name='Tesla App',
+            organization=self.org,
+            schema={'elements': [self.create_issue_link_schema()]}
+        )
+        self.login_as(self.user)
+
+        self.org_developer_settings_path = u'/settings/{}/developer-settings/{}'.format(
+            self.org.slug, self.sentry_app.slug)
+
+    def load_page(self, url):
+        self.browser.get(url)
+        self.browser.wait_until_not('.loading-indicator')
+
+    def test_edit_integration_schema(self):
+        with self.feature('organizations:sentry-apps'):
+            self.load_page(self.org_developer_settings_path)
+
+            textarea = self.browser.element('textarea[name="schema"]')
+            textarea.clear()
+            textarea.send_keys('{}')
+
+            self.browser.click('[aria-label="Save Changes"]')
+
+            self.browser.wait_until('.ref-success')
+
+            self.browser.click('[data-test-id="tesla-app"]')
+            link = self.browser.find_element_by_link_text('Tesla App')
+            link.click()
+
+            self.browser.wait_until_not('.loading-indicator')
+
+            schema = self.browser.element('textarea[name="schema"]')
+            assert schema.text == ""

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -80,7 +80,6 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
 
             self.browser.wait_until('.ref-success')
 
-            self.browser.click('[data-test-id="tesla-app"]')
             link = self.browser.find_element_by_link_text('Tesla App')
             link.click()
 


### PR DESCRIPTION
Another side effect from updating the serializer for Sentry Apps. We were returning `None` when we should have been returning `{}` (which is the default and means no schema)