### PR TITLE
fix(ui) Don't fail when trying to redirect to issueless events

### DIFF
--- a/src/sentry/static/sentry/app/views/projectEventRedirect.jsx
+++ b/src/sentry/static/sentry/app/views/projectEventRedirect.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import DetailedError from 'app/components/errors/detailedError';
 import {t} from 'app/locale';
 
 /**
@@ -18,9 +19,12 @@ class ProjectEventRedirect extends React.Component {
     router: PropTypes.object,
   };
 
-  constructor(props) {
-    super(props);
-    const {router} = props;
+  state = {
+    error: null,
+  };
+
+  componentDidMount() {
+    const {router} = this.props;
 
     // This presumes that _this_ React view/route is only reachable at
     // /:org/:project/events/:eventId (the same URL which serves the ProjectEventRedirect
@@ -39,6 +43,10 @@ class ProjectEventRedirect extends React.Component {
     xhr.send();
 
     xhr.onload = () => {
+      if (xhr.status === 404) {
+        this.setState({error: t('Could not find an issue for the provided event id')});
+        return;
+      }
       // responseURL is the URL of the document the browser ultimately loaded,
       // after following any redirects. It _should_ be the page we're trying
       // to reach; use the router to go there.
@@ -48,11 +56,20 @@ class ProjectEventRedirect extends React.Component {
       router.replace(xhr.responseURL);
     };
     xhr.onerror = () => {
-      throw new Error(t('An error occurred'));
+      this.setState({error: t('Could not load the requested event')});
     };
   }
 
   render() {
+    if (this.state.error) {
+      return (
+        <DetailedError
+          heading={t('Not found')}
+          message={this.state.error}
+          hideSupportLinks
+        />
+      );
+    }
     return null;
   }
 }

--- a/src/sentry/web/frontend/project_event.py
+++ b/src/sentry/web/frontend/project_event.py
@@ -22,6 +22,9 @@ class ProjectEventRedirect(ProjectView):
         if event is None:
             raise Http404
 
+        if not event.group_id:
+            raise Http404
+
         return HttpResponseRedirect(
             reverse(
                 'sentry-organization-event-detail',

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -55,3 +55,21 @@ class ProjectEventTest(TestCase):
                     self.project.slug,
                     'event1']))
         assert resp.status_code == 404
+
+    def test_event_not_found__event_no_group(self):
+        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        event = self.store_event(
+            data={
+                'type': 'transaction',
+                'timestamp': min_ago,
+                'start_timestamp': min_ago,
+                'spans': [],
+            },
+            project_id=self.project.id,
+        )
+
+        url = reverse(
+            'sentry-project-event-redirect',
+            args=[self.org.slug, self.project.slug, event.id])
+        resp = self.client.get(url)
+        assert resp.status_code == 404


### PR DESCRIPTION
If an event doesn't have a group we shouldn't try to redirect to the issue views for it. Instead display a 404 as that's about all we can do.

<img width="591" alt="Screen Shot 2019-07-23 at 10 56 09 PM" src="https://user-images.githubusercontent.com/24086/61762062-c3a02080-ad9e-11e9-8419-bba62d2bbdc7.png">

Fixes SENTRY-AGT