### PR TITLE
fix(store): Avoid database access when fetching project config

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -400,7 +400,7 @@ class APIView(BaseView):
             project_id = _get_project_id_from_request(
                 project_id, request, self.auth_helper_cls, helper)
 
-            project_config = get_project_config(project_id)
+            project_config = get_project_config(project_id, for_store=True)
 
             helper.context.bind_project(project_config.project)
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1348,7 +1348,7 @@ class EventManagerTest(TestCase):
             },
         }
 
-        project_config = get_project_config(self.project.id)
+        project_config = get_project_config(self.project.id, for_store=True)
         manager = EventManager(data, project=self.project, project_config=project_config)
 
         mock_is_valid_error_message.side_effect = [item.result for item in items]


### PR DESCRIPTION
Follow-up to #13992 

Fetching project configs introduced a query to the database to store requests. This patch avoids this by introducing a flag that skips this request.