### PR TITLE
fix(reprocessing): Skip minidump events

### DIFF
--- a/src/sentry/lang/native/error.py
+++ b/src/sentry/lang/native/error.py
@@ -4,7 +4,7 @@ import logging
 import six
 
 from sentry.utils.compat import implements_to_string
-from sentry.lang.native.utils import image_name
+from sentry.lang.native.utils import image_name, is_minidump_event
 from sentry.models import EventError
 from sentry.reprocessing import report_processing_issue
 
@@ -91,8 +91,9 @@ class SymbolicationFailed(Exception):
 
 def write_error(e, data, errors=None):
     # User fixable but fatal errors are reported as processing
-    # issues
-    if e.is_user_fixable and e.is_fatal:
+    # issues. We skip this for minidumps, as reprocessing is not
+    # possible without persisting minidumps.
+    if e.is_user_fixable and e.is_fatal and not is_minidump_event(data):
         report_processing_issue(
             data,
             scope='native',

--- a/src/sentry/static/sentry/app/data/forms/processingIssues.jsx
+++ b/src/sentry/static/sentry/app/data/forms/processingIssues.jsx
@@ -17,9 +17,15 @@ const formGroups = [
         help: t(`If reprocessing is enabled, Events with fixable issues will be
                 held back until you resolve them. Processing issues will then
                 show up in the list above with hints how to fix them.
-                If reprocessing is disabled Events with unresolved issues will also
-                show up in the stream.
+                If reprocessing is disabled, Events with unresolved issues will
+                also show up in the stream.
                 `),
+        saveOnBlur: false,
+        saveMessage: ({value}) =>
+          value
+            ? t('Reprocessing applies to future events only.')
+            : t(`All events with errors will be flushed into your issues stream.
+                Beware that this process may take some time and cannot be undone.`),
         getData: form => ({
           options: form,
         }),

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.jsx
@@ -50,7 +50,7 @@ const FormFieldErrorReason = styled('div')`
 
 const FormFieldError = styled('div')`
   color: ${p => p.theme.redDark};
-  animation: ${p => pulse(1.15)} 1s ease infinite;
+  animation: ${() => pulse(1.15)} 1s ease infinite;
 `;
 
 const FormFieldIsSaved = styled('div')`
@@ -205,7 +205,7 @@ class FormField extends React.Component {
      * If saveOnBlur is false, then an optional saveMessage can be used to let
      * the user know what's going to happen when they save a field.
      */
-    saveMessage: PropTypes.node,
+    saveMessage: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
 
     /**
      * The "alert type" to use for the save message.
@@ -261,7 +261,7 @@ class FormField extends React.Component {
     this.getModel().removeField(this.props.name);
   }
 
-  getError(props, context) {
+  getError(_props, _context) {
     return this.getModel().getError(this.props.name);
   }
 
@@ -350,14 +350,14 @@ class FormField extends React.Component {
   /**
    * Handle saving an individual field via UI button
    */
-  handleSaveField = (...args) => {
+  handleSaveField = () => {
     const {name} = this.props;
     const model = this.getModel();
 
     model.handleSaveField(name, model.getValue(name));
   };
 
-  handleCancelField = (...args) => {
+  handleCancelField = () => {
     const {name} = this.props;
     const model = this.getModel();
 
@@ -463,6 +463,7 @@ class FormField extends React.Component {
           <Observer>
             {() => {
               const showFieldSave = model.getFieldState(name, 'showSave');
+              const value = model.getValue(name);
 
               if (!showFieldSave) {
                 return null;
@@ -471,7 +472,11 @@ class FormField extends React.Component {
               return (
                 <PanelAlert type={saveMessageAlertType}>
                   <MessageAndActions>
-                    <div>{saveMessage}</div>
+                    <div>
+                      {typeof saveMessage === 'function'
+                        ? saveMessage({...props, value})
+                        : saveMessage}
+                    </div>
                     <Actions>
                       <CancelButton onClick={this.handleCancelField}>
                         {t('Cancel')}

--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {Panel} from 'app/components/panels';
+import {Panel, PanelAlert} from 'app/components/panels';
 import {addLoadingMessage, removeIndicator} from 'app/actionCreators/indicator';
 import {t, tn} from 'app/locale';
 import Access from 'app/components/acl/access';
@@ -70,7 +70,7 @@ class ProjectProcessingIssues extends React.Component {
       expected: this.state.expected + 2,
     });
     this.props.api.request(`/projects/${orgId}/${projectId}/`, {
-      success: (data, _, jqXHR) => {
+      success: data => {
         const expected = this.state.expected - 1;
         this.setState({
           expected,
@@ -121,7 +121,7 @@ class ProjectProcessingIssues extends React.Component {
     const {orgId, projectId} = this.props.params;
     this.props.api.request(`/projects/${orgId}/${projectId}/reprocessing/`, {
       method: 'POST',
-      success: (data, _, jqXHR) => {
+      success: () => {
         this.fetchData();
         this.setState({
           reprocessing: false,
@@ -145,7 +145,7 @@ class ProjectProcessingIssues extends React.Component {
     });
     this.props.api.request(`/projects/${orgId}/${projectId}/processingissues/discard/`, {
       method: 'DELETE',
-      success: (data, _, jqXHR) => {
+      success: () => {
         const expected = this.state.expected - 1;
         this.setState({
           expected,
@@ -174,7 +174,7 @@ class ProjectProcessingIssues extends React.Component {
     });
     this.props.api.request(`/projects/${orgId}/${projectId}/processingissues/`, {
       method: 'DELETE',
-      success: (data, _, jqXHR) => {
+      success: () => {
         const expected = this.state.expected - 1;
         this.setState({
           expected,
@@ -417,7 +417,19 @@ class ProjectProcessingIssues extends React.Component {
         apiMethod="PUT"
         initialData={formData}
       >
-        <JsonForm access={access} forms={formGroups} />
+        <JsonForm
+          access={access}
+          forms={formGroups}
+          renderHeader={() => (
+            <PanelAlert type="warning">
+              <TextBlock noMargin>
+                {t(`Reprocessing does not apply to Minidumps. Even when enabled,
+                    Minidump events with processing issues will show up in the
+                    issues stream immediately and cannot be reprocessed.`)}
+              </TextBlock>
+            </PanelAlert>
+          )}
+        />
       </Form>
     );
   };


### PR DESCRIPTION
Reprocessing requires the original input data for processing. Since we don't store minidumps for reprocessing, this is conceptionally broken. Let's skip minidump events for reprocessing, then, and show a disclaimer in the UI:

<img width="837" alt="Screenshot 2019-07-24 at 16 41 54" src="https://user-images.githubusercontent.com/1433023/61803669-e2e88d80-ae32-11e9-821f-ae6ea261bc0d.png">
