### PR TITLE
feat: Remove legacy group tags behavior

### DIFF
--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -24,16 +24,7 @@ class GroupTagsEndpoint(GroupEndpoint):
         else:
             value_limit = 10
 
-        use_snuba = request.GET.get('enable_snuba') == '1'
-
         environment_ids = [e.id for e in get_environments(request, group.project.organization)]
-
-        if not use_snuba:
-            # TODO(jess): This is just to ensure we're not breaking the old
-            # issue page somehow -- non-snuba tagstore versions will raise
-            # if more than one env is passed
-            if environment_ids:
-                environment_ids = environment_ids[:1]
 
         tag_keys = tagstore.get_group_tag_keys_and_top_values(
             group.project_id, group.id, environment_ids, keys=keys,

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -80,7 +80,6 @@ const GroupSidebar = createReactClass({
       query: pickBy({
         key: group.tags.map(data => data.key),
         environment: this.state.environments.map(env => env.name),
-        enable_snuba: '1',
       }),
       success: data => {
         this.setState({

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -408,7 +408,7 @@ class TagStorage(Service):
 
         # only the snuba backend supports multi env, and that overrides this method
         if environment_ids and len(environment_ids) > 1:
-            raise NotImplementedError
+            environment_ids = environment_ids[:1]
 
         # If keys is unspecified, we will grab all tag keys for this group.
         tag_keys = self.get_group_tag_keys(


### PR DESCRIPTION
Update the group tags endpoint to always allow more than one environment
ID. Previously if a user requested more than one environment param without
the enable_snuba query param, only data for the first environment would
be returned and the rest would be ignored.

Whilst "enable_snuba" was always being passed from the Sentry user
interface, it's possible that users may have been calling the API
directly with more than one environment. Since multiple environments
were ignored, counts might have been previously understated.