### PR TITLE
fix(discover) Persist synthetic event to retain target

### DIFF
--- a/src/sentry/static/sentry/app/views/discover/aggregations/aggregation.tsx
+++ b/src/sentry/static/sentry/app/views/discover/aggregations/aggregation.tsx
@@ -94,6 +94,7 @@ export default class AggregationRow extends React.Component<
   inputRenderer = (props: AggregationProps) => {
     const onChange = (evt: any) => {
       if (evt && evt.target && evt.target.value === '') {
+        evt.persist();
         // React select won't trigger an onChange event when a value is completely
         // cleared, so we'll force this before calling onChange
         this.setState({inputValue: evt.target.value}, () => {


### PR DESCRIPTION
Because setState() is async react was nulling out event.target on us. By using event.persist() we can remove the event from the pool and retain references to the source element.

Fixes JAVASCRIPT-1BKZ