### PR TITLE
feat(webhooks): Use hex event.id in webhook payload

### DIFF
--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -8,9 +8,7 @@ from django import forms
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
-from sentry import features
 from sentry.exceptions import PluginError
-from sentry.models import Event
 from sentry.plugins.bases import notify
 from sentry.http import is_valid_url, safe_urlopen
 from sentry.utils.safe import safe_execute
@@ -92,14 +90,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
         data['event'] = dict(event.data or {})
         data['event']['tags'] = event.tags
         data['event']['event_id'] = event.event_id
-        if features.has('organizations:legacy-event-id', group.project.organization):
-            try:
-                data['event']['id'] = Event.objects.filter(
-                    project_id=event.project_id,
-                    event_id=event.event_id,
-                ).values_list('id', flat=True).get()
-            except Event.DoesNotExist:
-                data['event']['id'] = None
+        data['event']['id'] = event.event_id
         return data
 
     def get_webhook_urls(self, project):

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -25,7 +25,7 @@ class WebHooksPluginTest(TestCase):
         responses.add(responses.POST, 'http://example.com')
         group = self.create_group(message='Hello world')
         event = self.create_event(
-            group=group, message='Hello world', tags={'level': 'warning'}, id=24
+            group=group, message='Hello world', tags={'level': 'warning'}
         )
         rule = Rule.objects.create(project=self.project, label='my rule')
         notification = Notification(event=event, rule=rule)
@@ -39,7 +39,7 @@ class WebHooksPluginTest(TestCase):
         payload = json.loads(responses.calls[0].request.body)
         assert payload['level'] == 'warning'
         assert payload['message'] == 'Hello world'
-        assert payload['event']['id'] == 24
+        assert payload['event']['id'] == event.event_id
         assert payload['event']['event_id'] == event.event_id
         assert payload['triggering_rules'] == ['my rule']
 

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -31,8 +31,7 @@ class WebHooksPluginTest(TestCase):
         notification = Notification(event=event, rule=rule)
         self.project.update_option('webhooks:urls', 'http://example.com')
 
-        with self.feature('organizations:legacy-event-id'):
-            self.plugin.notify(notification)
+        self.plugin.notify(notification)
 
         assert len(responses.calls) == 1
 


### PR DESCRIPTION
Replace the deprecated autoincrement ID with the hex event ID in the
webhook payload. This is the last place we expose the autoincrement ID
to end users.

This might affect any users that expect this value to be an integer.
See https://getsentry.atlassian.net/browse/ISSUE-237 for more context on
customers that may rely on this.

See https://www.notion.so/sentry/Future-of-Event-ID-f5ac79dc62994e68922d9b76ca0ee8d4
for further background on this topic.