### PR TITLE
tests(acceptance): Fix flakey Shared Issue Test

### DIFF
--- a/tests/acceptance/test_shared_issue.py
+++ b/tests/acceptance/test_shared_issue.py
@@ -47,5 +47,6 @@ class SharedIssueTest(AcceptanceTestCase):
         )
 
         self.browser.get(u'/share/issue/{}/'.format(group.get_share_id()))
+        self.browser.wait_until_not('.loading-indicator')
         self.browser.wait_until('.entries')
         self.browser.snapshot('shared issue cocoa')


### PR DESCRIPTION
Not sure if this will help, but wait for loading indicators to disappear before waiting for `.entries`