### PR TITLE
feat(api): Allow team admins to manage memberships of their teams

### DIFF
--- a/src/sentry/api/endpoints/organization_member_team_details.py
+++ b/src/sentry/api/endpoints/organization_member_team_details.py
@@ -45,7 +45,7 @@ class RelaxedOrganizationPermission(OrganizationPermission):
 class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
     permission_classes = [RelaxedOrganizationPermission]
 
-    def _can_access(self, request, member, organization, team_slug):
+    def _can_access(self, request, member, organization):
         """
         Conditions where user can modify the requested resource:
 

--- a/src/sentry/api/endpoints/organization_member_team_details.py
+++ b/src/sentry/api/endpoints/organization_member_team_details.py
@@ -77,19 +77,13 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
         return False
 
     def _can_admin_team(self, request, organization, team_slug):
-        try:
-            OrganizationMember.objects.get(
-                organization=organization,
-                user__id=request.user.id,
-                user__is_active=True,
-                role="admin",
-                organizationmemberteam__team__slug=team_slug,
-            )
-            return True
-        except OrganizationMember.DoesNotExist:
-            return False
-
-        return False
+        return OrganizationMember.objects.filter(
+            organization=organization,
+            user__id=request.user.id,
+            user__is_active=True,
+            role="admin",
+            organizationmemberteam__team__slug=team_slug,
+        ).exists()
 
     def _get_member(self, request, organization, member_id):
         if member_id == 'me':

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1242,7 +1242,7 @@ SENTRY_ROLES = (
     }, {
         'id': 'admin',
         'name': 'Admin',
-        'desc': 'Admin privileges on any teams of which they\'re a member. They can create new teams and projects, as well as remove teams and projects which they already hold membership on (or all teams, if open membership is on).',
+        'desc': 'Admin privileges on any teams of which they\'re a member. They can create new teams and projects, as well as remove teams and projects which they already hold membership on (or all teams, if open membership is on). Additionally, they can manage memberships of teams that they are members of.',
         'scopes': set(
             [
                 'event:read',


### PR DESCRIPTION
This changes the API to allow "Admins" (i.e. `team:admin` access) to invite/remove members from teams in which they belong.

Closes PROD-102