### PR TITLE
feat(ui) Wire transaction list view to modal

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -15,7 +15,7 @@ import pinIcon from 'app/../images/location-pin.png';
 import {t} from 'app/locale';
 import {QueryLink} from './styles';
 
-export const MODAL_QUERY_KEYS = ['eventSlug', 'groupSlug'];
+export const MODAL_QUERY_KEYS = ['eventSlug', 'groupSlug', 'transactionSlug'];
 export const PIN_ICON = `image://${pinIcon}`;
 
 export const ALL_VIEWS = deepFreeze([
@@ -83,7 +83,7 @@ export const ALL_VIEWS = deepFreeze([
       'user.ip',
       'environment',
     ],
-    columnWidths: ['3fr', '1fr', '1fr', '1fr', '1fr', '1fr', '1fr'],
+    columnWidths: ['3fr', '2fr'],
   },
 ]);
 
@@ -101,7 +101,7 @@ export const SPECIAL_FIELDS = {
         pathname: `/organizations/${organization.slug}/events/`,
         query: {
           ...location.query,
-          transactionSlug: `${data['project.name']}:${data.transaction}`,
+          transactionSlug: `${data['project.name']}:${data.transaction}:latest`,
         },
       };
       return (

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
@@ -53,9 +53,9 @@ export default class OrganizationEventsV2 extends React.Component {
 
   render() {
     const {organization, location, router} = this.props;
-    const {eventSlug, groupSlug} = location.query;
+    const {eventSlug, groupSlug, transactionSlug} = location.query;
     const currentView = getCurrentView(location.query.view);
-    const showModal = groupSlug || eventSlug;
+    const showModal = transactionSlug || groupSlug || eventSlug;
 
     return (
       <DocumentTitle title={`Events - ${organization.slug} - Sentry`}>
@@ -82,6 +82,7 @@ export default class OrganizationEventsV2 extends React.Component {
                 params={this.props.params}
                 eventSlug={eventSlug}
                 groupSlug={groupSlug}
+                transactionSlug={transactionSlug}
                 view={currentView}
                 location={location}
               />

--- a/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
@@ -171,6 +171,27 @@ describe('OrganizationEventsV2 > EventDetails', function() {
     });
   });
 
+  it('removes transactionSlug when close button is clicked', function() {
+    const wrapper = mount(
+      <EventDetails
+        organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
+        transactionSlug="project-slug:/users/login:latest"
+        location={{
+          pathname: '/organizations/org-slug/events/',
+          query: {groupSlug: 'project-slug:/users/login:latest'},
+        }}
+        view={allEventsView}
+      />,
+      TestStubs.routerContext()
+    );
+    const button = wrapper.find('DismissButton');
+    button.simulate('click');
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: '/organizations/org-slug/events/',
+      query: {},
+    });
+  });
+
   it('navigates when tag values are clicked', async function() {
     const {organization, routerContext} = initializeOrg({
       organization: TestStubs.Organization({projects: [TestStubs.Project()]}),


### PR DESCRIPTION
Connect the transaction aggregate view up to the details modal. Extend/reuse the 'get latest' event paradigm we use on error aggregation. This has required another querystring parameter as the parameters to event latest/oldest require different search terms.

Pagination buttons are not working just yet.

Refs SEN-865