### PR TITLE
(fix) Fix link on release progress bar

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/list/releaseProgress.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseProgress.jsx
@@ -26,7 +26,7 @@ const STEPS = {
   },
   commit: {
     desc: t('Associate commits'),
-    url: 'b-associate-commits-with-a-release',
+    url: 'associate-commits-with-a-release',
     msg: 'determining which commit caused an error, ',
   },
   deploy: {


### PR DESCRIPTION
the link might have changed recently or it might have been wrong all along