### PR TITLE
fix(ui): Fix Events chart zoom

### DIFF
--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -138,7 +138,7 @@ class EventsChart extends React.Component {
         environments={environments}
         {...props}
       >
-        {({zoomRenderProps}) => (
+        {zoomRenderProps => (
           <EventsRequest
             {...props}
             api={api}


### PR DESCRIPTION
This also fixes some other chart bugs since we are trying to extract a key from the render props with name `zoomRenderProps` which does not exist.