### PR TITLE
feat(ui) Add pagination controls to transaction events

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/modalPagination.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/modalPagination.jsx
@@ -35,7 +35,7 @@ function buildTargets(event, location) {
   };
 
   const links = {};
-  for (const [key, value] of Object.entries(urlMap)) {
+  Object.entries(urlMap).forEach(([key, value]) => {
     // If the urlMap has no value we want to skip this link as it is 'disabled';
     if (!value) {
       links[key] = null;
@@ -48,7 +48,7 @@ function buildTargets(event, location) {
         },
       };
     }
-  }
+  });
 
   return links;
 }

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/modalPagination.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/modalPagination.jsx
@@ -10,65 +10,74 @@ import SentryTypes from 'app/sentryTypes';
 import InlineSvg from 'app/components/inlineSvg';
 import space from 'app/styles/space';
 
-const ModalPagination = props => {
-  const {location, event} = props;
+import {MODAL_QUERY_KEYS} from './data';
 
+/**
+ * Generate a mapping of link names => link targets for pagination
+ */
+function buildTargets(event, location) {
   // Remove the groupSlug and eventSlug keys as we need to create new ones
-  const query = omit(location.query, ['groupSlug', 'eventSlug']);
-  const previousEventUrl = event.previousEventID
-    ? {
+  const baseQuery = omit(location.query, MODAL_QUERY_KEYS);
+
+  let queryKey, aggregateValue;
+  if (event.type === 'transaction') {
+    queryKey = 'transactionSlug';
+    aggregateValue = event.location;
+  } else {
+    queryKey = 'groupSlug';
+    aggregateValue = event.groupID;
+  }
+  const urlMap = {
+    previous: event.previousEventID,
+    next: event.nextEventID,
+    latest: 'latest',
+    oldest: 'oldest',
+  };
+
+  const links = {};
+  for (const [key, value] of Object.entries(urlMap)) {
+    // If the urlMap has no value we want to skip this link as it is 'disabled';
+    if (!value) {
+      links[key] = null;
+    } else {
+      links[key] = {
         pathname: location.pathname,
         query: {
-          ...query,
-          groupSlug: `${event.projectSlug}:${event.groupID}:${event.previousEventID}`,
+          ...baseQuery,
+          [queryKey]: `${event.projectSlug}:${aggregateValue}:${value}`,
         },
-      }
-    : null;
-  const nextEventUrl = event.nextEventID
-    ? {
-        pathname: location.pathname,
-        query: {
-          ...query,
-          groupSlug: `${event.projectSlug}:${event.groupID}:${event.nextEventID}`,
-        },
-      }
-    : null;
-  const newestUrl = {
-    pathname: location.pathname,
-    query: {
-      ...query,
-      groupSlug: `${event.projectSlug}:${event.groupID}:latest`,
-    },
-  };
-  const oldestUrl = {
-    pathname: location.pathname,
-    query: {
-      ...query,
-      groupSlug: `${event.projectSlug}:${event.groupID}:oldest`,
-    },
-  };
+      };
+    }
+  }
+
+  return links;
+}
+
+const ModalPagination = props => {
+  const {event, location} = props;
+  const links = buildTargets(event, location);
 
   return (
     <Wrapper>
       <ShadowBox>
-        <StyledLink to={oldestUrl} disabled={previousEventUrl === null}>
+        <StyledLink to={links.oldest} disabled={links.previous === null}>
           <InlineSvg src="icon-prev" size="14px" />
         </StyledLink>
         <StyledLink
           data-test-id="older-event"
-          to={previousEventUrl}
-          disabled={previousEventUrl === null}
+          to={links.previous}
+          disabled={links.previous === null}
         >
           {t('Older Event')}
         </StyledLink>
         <StyledLink
           data-test-id="newer-event"
-          to={nextEventUrl}
-          disabled={nextEventUrl === null}
+          to={links.next}
+          disabled={links.next === null}
         >
           {t('Newer Event')}
         </StyledLink>
-        <StyledLink to={newestUrl} disabled={nextEventUrl === null} isLast>
+        <StyledLink to={links.latest} disabled={links.next === null} isLast>
           <InlineSvg src="icon-next" size="14px" />
         </StyledLink>
       </ShadowBox>

--- a/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
@@ -9,6 +9,7 @@ import {ALL_VIEWS} from 'app/views/organizationEventsV2/data';
 describe('OrganizationEventsV2 > EventDetails', function() {
   const allEventsView = ALL_VIEWS.find(view => view.id === 'all');
   const errorsView = ALL_VIEWS.find(view => view.id === 'errors');
+  const transactionView = ALL_VIEWS.find(view => view.id === 'transactions');
 
   beforeEach(function() {
     MockApiClient.addMockResponse({
@@ -28,10 +29,11 @@ describe('OrganizationEventsV2 > EventDetails', function() {
       body: {
         id: '1234',
         size: 1200,
-        projectSlug: 'org-slug',
+        projectSlug: 'project-slug',
         eventID: 'deadbeef',
         groupID: '123',
         title: 'Oh no something bad',
+        location: '/users/login',
         message: 'It was not good',
         dateCreated: '2019-05-23T22:12:48+00:00',
         entries: [
@@ -57,28 +59,77 @@ describe('OrganizationEventsV2 > EventDetails', function() {
       },
     });
 
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/latest/',
-      method: 'GET',
-      body: {
-        id: '1234',
-        size: 1200,
-        projectSlug: 'org-slug',
-        eventID: 'deadbeef',
-        groupID: '123',
-        title: 'Oh no something bad',
-        message: 'It was not good',
-        dateCreated: '2019-05-23T22:12:48+00:00',
-        entries: [
-          {
-            type: 'message',
-            message: 'bad stuff',
-            data: {},
+    // Error event
+    MockApiClient.addMockResponse(
+      {
+        url: '/organizations/org-slug/events/latest/',
+        method: 'GET',
+        body: {
+          id: '5678',
+          size: 1200,
+          projectSlug: 'project-slug',
+          eventID: 'deadbeef',
+          groupID: '123',
+          type: 'error',
+          title: 'Oh no something bad',
+          message: 'It was not good',
+          dateCreated: '2019-05-23T22:12:48+00:00',
+          previousEventID: 'beefbeef',
+          metadata: {
+            type: 'Oh no something bad',
           },
-        ],
-        tags: [{key: 'browser', value: 'Firefox'}],
+          entries: [
+            {
+              type: 'message',
+              message: 'bad stuff',
+              data: {},
+            },
+          ],
+          tags: [{key: 'browser', value: 'Firefox'}],
+        },
       },
-    });
+      {
+        predicate: (_, options) => {
+          const query = options.query.query;
+          return (
+            query && (query.includes('event.type:error') || query.includes('issue.id'))
+          );
+        },
+      }
+    );
+
+    // Transaction event
+    MockApiClient.addMockResponse(
+      {
+        url: '/organizations/org-slug/events/latest/',
+        method: 'GET',
+        body: {
+          id: '5678',
+          size: 1200,
+          projectSlug: 'project-slug',
+          eventID: 'deadbeef',
+          type: 'transaction',
+          title: 'Oh no something bad',
+          location: '/users/login',
+          message: 'It was not good',
+          startTimestamp: 1564153693.2419,
+          endTimestamp: 1564153694.4191,
+          previousEventID: 'beefbeef',
+          entries: [
+            {
+              type: 'spans',
+              data: [],
+            },
+          ],
+          tags: [{key: 'browser', value: 'Firefox'}],
+        },
+      },
+      {
+        predicate: (_, options) => {
+          return options.query.query && options.query.query.includes('transaction');
+        },
+      }
+    );
   });
 
   it('renders', function() {
@@ -120,13 +171,47 @@ describe('OrganizationEventsV2 > EventDetails', function() {
       <EventDetails
         organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
         groupSlug="project-slug:123:latest"
-        location={{query: {groupSlug: 'project-slug:999:latest'}}}
+        location={{query: {groupSlug: 'project-slug:123:latest'}}}
         view={errorsView}
       />,
       TestStubs.routerContext()
     );
+
     const content = wrapper.find('ModalPagination');
     expect(content).toHaveLength(1);
+
+    const prevLink = content.find('StyledLink[data-test-id="older-event"]').first();
+    const target = prevLink.props().to;
+    expect(target.query.groupSlug).toEqual('project-slug:123:beefbeef');
+    expect(target.query.transactionSlug).toBeUndefined();
+    expect(target.query.eventSlug).toBeUndefined();
+
+    const nextLink = content.find('StyledLink[data-test-id="newer-event"]').first();
+    expect(nextLink.props().to).toBeNull();
+  });
+
+  it('renders pagination buttons in transaction view', function() {
+    const wrapper = mount(
+      <EventDetails
+        organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
+        transactionSlug="project-slug:/users/login:latest"
+        location={{query: {transactionSlug: 'project-slug:/users/login:latest'}}}
+        view={transactionView}
+      />,
+      TestStubs.routerContext()
+    );
+
+    const content = wrapper.find('ModalPagination');
+    expect(content).toHaveLength(1);
+
+    const prevLink = content.find('StyledLink[data-test-id="older-event"]').first();
+    const target = prevLink.props().to;
+    expect(target.query.transactionSlug).toEqual('project-slug:/users/login:beefbeef');
+    expect(target.query.groupSlug).toBeUndefined();
+    expect(target.query.eventSlug).toBeUndefined();
+
+    const nextLink = content.find('StyledLink[data-test-id="newer-event"]').first();
+    expect(nextLink.props().to).toBeNull();
   });
 
   it('removes eventSlug when close button is clicked', function() {
@@ -178,7 +263,7 @@ describe('OrganizationEventsV2 > EventDetails', function() {
         transactionSlug="project-slug:/users/login:latest"
         location={{
           pathname: '/organizations/org-slug/events/',
-          query: {groupSlug: 'project-slug:/users/login:latest'},
+          query: {transactionSlug: 'project-slug:/users/login:latest'},
         }}
         view={allEventsView}
       />,


### PR DESCRIPTION
Enable transaction events to be paginated like error events. While the summary graph does show the click to navigate in the graph is still broken and will be fixed separately.

Fixes SEN-861