### PR TITLE
 ref: Deprecate group_id field in EventAttachment

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -597,7 +597,6 @@ def main(num_events=1, extra_events=False):
 
                 EventAttachment.objects.create(
                     project_id=project.id,
-                    group_id=event1.group_id,
                     event_id=event1.event_id,
                     name='example-logfile.txt',
                     file=File.objects.get_or_create(

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -30,7 +30,6 @@ class GroupDeletionTask(ModelDeletionTask):
             models.GroupEmailThread,
             models.GroupSubscription,
             models.UserReport,
-            models.EventAttachment,
             IncidentGroup,
             # Event is last as its the most time consuming
             models.Event,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -39,7 +39,7 @@ from sentry.models import (
     Activity, Environment, Event, EventDict, EventError, EventMapping, EventUser, Group,
     GroupEnvironment, GroupHash, GroupLink, GroupRelease, GroupResolution, GroupStatus,
     Project, Release, ReleaseEnvironment, ReleaseProject,
-    ReleaseProjectEnvironment, UserReport, Organization, EventAttachment,
+    ReleaseProjectEnvironment, UserReport, Organization,
 )
 from sentry.plugins import plugins
 from sentry.signals import event_discarded, event_saved, first_event_received
@@ -834,14 +834,6 @@ class EventManager(object):
             ).update(
                 group=group,
                 environment=environment,
-            )
-
-            # Update any event attachment that arrived before the event group was defined.
-            EventAttachment.objects.filter(
-                project_id=project.id,
-                event_id=event_id,
-            ).update(
-                group_id=group.id,
             )
 
         # save the event unless its been sampled

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -10,6 +10,7 @@ class EventAttachment(Model):
     __core__ = False
 
     project_id = BoundedBigIntegerField()
+    # TODO(lyn): group_id is now deprecated, drop this
     group_id = BoundedBigIntegerField(null=True, db_index=True)
     event_id = models.CharField(max_length=32, db_index=True)
     file = FlexibleForeignKey('sentry.File')

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -436,7 +436,6 @@ def save_attachment(event, attachment):
 
     EventAttachment.objects.create(
         event_id=event.event_id,
-        group_id=event.group_id,
         project_id=event.project_id,
         name=attachment.name,
         file=file,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -669,7 +669,6 @@ class Factories(object):
 
         return EventAttachment.objects.create(
             project_id=event.project_id,
-            group_id=event.group_id,
             event_id=event.event_id,
             file=file,
             **kwargs

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -32,7 +32,6 @@ class CreateAttachmentMixin(object):
 
         self.attachment = EventAttachment.objects.create(
             event_id=self.event.event_id,
-            group_id=self.event.group_id,
             project_id=self.event.project_id,
             file=self.file,
             name='hello.png',

--- a/tests/sentry/api/endpoints/test_event_attachments.py
+++ b/tests/sentry/api/endpoints/test_event_attachments.py
@@ -31,7 +31,6 @@ class EventAttachmentsTest(APITestCase):
 
         attachment1 = EventAttachment.objects.create(
             event_id=event1.event_id,
-            group_id=event1.group_id,
             project_id=event1.project_id,
             file=File.objects.create(
                 name='hello.png',
@@ -42,7 +41,6 @@ class EventAttachmentsTest(APITestCase):
 
         EventAttachment.objects.create(
             event_id=event2.event_id,
-            group_id=event2.group_id,
             project_id=event2.project_id,
             file=File.objects.create(
                 name='hello.png',

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from sentry import tagstore
 from sentry.tagstore.models import EventTag
 from sentry.models import (
-    Event, EventAttachment, EventMapping, File, Group, GroupAssignee, GroupHash, GroupMeta, GroupRedirect,
+    Event, EventMapping, Group, GroupAssignee, GroupHash, GroupMeta, GroupRedirect,
     ScheduledDeletion, UserReport
 )
 from sentry.tasks.deletion import run_deletion
@@ -23,16 +23,6 @@ class DeleteGroupTest(TestCase):
             project_id=project.id,
             event_id='a' * 32,
             group_id=group.id,
-        )
-        EventAttachment.objects.create(
-            event_id=event.event_id,
-            group_id=event.group_id,
-            project_id=event.project_id,
-            file=File.objects.create(
-                name='hello.png',
-                type='image/png',
-            ),
-            name='hello.png',
         )
         UserReport.objects.create(
             group_id=group.id,
@@ -88,10 +78,6 @@ class DeleteGroupTest(TestCase):
             run_deletion(deletion.id)
 
         assert not Event.objects.filter(id=event.id).exists()
-        assert not EventAttachment.objects.filter(
-            event_id=event.event_id,
-            group_id=group.id,
-        ).exists()
         assert not EventMapping.objects.filter(
             group_id=group.id,
         ).exists()

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -20,7 +20,7 @@ from sentry.models import (
     Activity, Environment, Event, ExternalIssue, Group, GroupEnvironment,
     GroupHash, GroupLink, GroupRelease, GroupResolution, GroupStatus,
     GroupTombstone, EventMapping, Integration, Release,
-    ReleaseProjectEnvironment, OrganizationIntegration, UserReport, EventAttachment, File
+    ReleaseProjectEnvironment, OrganizationIntegration, UserReport
 )
 from sentry.signals import event_discarded, event_saved
 from sentry.testutils import assert_mock_called_once_with_partial, TestCase
@@ -999,28 +999,6 @@ class EventManagerTest(TestCase):
         )
 
         assert UserReport.objects.get(event_id=event_id).environment == environment
-
-    def test_event_attachment_gets_group_id(self):
-        project = self.create_project()
-        event_id = 'a' * 32
-        uploaded_file_name = 'attachment.zip'
-        EventAttachment.objects.create(
-            project_id=project.id,
-            event_id=event_id,
-            name=uploaded_file_name,
-            file=File.objects.create(
-                name=uploaded_file_name,
-            ),
-        )
-
-        event = self.store_event(
-            data=make_event(
-                event_id=event_id
-            ),
-            project_id=project.id
-        )
-
-        assert EventAttachment.objects.get(event_id=event_id).group_id == event.group_id
 
     def test_default_event_type(self):
         manager = EventManager(make_event(message='foo bar'))


### PR DESCRIPTION
 Since we never actually return the group ID from the EventAttachment table
 or use it for lookup we shouldn't store it there.

 As we migrate event storage fully to Snuba, getting this field
 populated when we store the attachment will be more complicated
 since it requires a lookup to the Event table to get the group
 ID and there'll be a race condition between the event and the event
 attachment being saved.