### PR TITLE
fix(api) Don't 500 when project ids aren't numbers

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ParseError
 
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -177,7 +177,7 @@ class OrganizationEndpoint(Endpoint):
         try:
             project_ids = set(map(int, request.GET.getlist('project')))
         except ValueError:
-            raise ResourceDoesNotExist(detail='Invalid project parameter. Values must be numbers.')
+            raise ParseError(detail='Invalid project parameter. Values must be numbers.')
 
         requested_projects = project_ids.copy()
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -174,7 +174,10 @@ class OrganizationEndpoint(Endpoint):
         standardize how this is used and remove this parameter.
         :return: A list of Project objects, or raises PermissionDenied.
         """
-        project_ids = set(map(int, request.GET.getlist('project')))
+        try:
+            project_ids = set(map(int, request.GET.getlist('project')))
+        except ValueError:
+            raise ResourceDoesNotExist(detail='Invalid project parameter. Values must be numbers.')
 
         requested_projects = project_ids.copy()
 


### PR DESCRIPTION
When we get an invalid project id we shouldn't raise a 500.

Fixes SENTRY-9PH