### PR TITLE
fix(api) Don't 500 when we get an invalid cursor

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -12,6 +12,7 @@ from django.views.decorators.csrf import csrf_exempt
 from enum import Enum
 from pytz import utc
 from rest_framework.authentication import SessionAuthentication
+from rest_framework.exceptions import ParseError
 from rest_framework.parsers import JSONParser
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
@@ -239,11 +240,13 @@ class Endpoint(APIView):
         assert (paginator and not paginator_kwargs) or (paginator_cls and paginator_kwargs)
 
         per_page = int(request.GET.get('per_page', default_per_page))
-        input_cursor = request.GET.get('cursor')
-        if input_cursor:
-            input_cursor = Cursor.from_string(input_cursor)
-        else:
-            input_cursor = None
+
+        input_cursor = None
+        if request.GET.get('cursor'):
+            try:
+                input_cursor = Cursor.from_string(request.GET.get('cursor'))
+            except ValueError:
+                raise ParseError(detail='Invalid cursor parameter.')
 
         assert per_page <= max(max_per_page, default_per_page)
 

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -11,6 +11,7 @@ from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 from rest_framework import serializers
+from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 
 from sentry import eventstream, features
@@ -65,9 +66,11 @@ def build_query_params_from_request(request, organization, projects, environment
             raise ValidationError('invalid limit')
 
     # TODO: proper pagination support
-    cursor = request.GET.get('cursor')
-    if cursor:
-        query_kwargs['cursor'] = Cursor.from_string(cursor)
+    if request.GET.get('cursor'):
+        try:
+            query_kwargs['cursor'] = Cursor.from_string(request.GET.get('cursor'))
+        except ValueError:
+            raise ParseError(detail='Invalid cursor parameter.')
 
     query = request.GET.get('query', 'is:unresolved').strip()
     if query:


### PR DESCRIPTION
Instead save our inboxes and let the client know they made a mistake.

Fixes SENTRY-AQ8