### PR TITLE
feat(api): Build alert rule list api (SEN-834)

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.api.serializers import (
+    Serializer,
+    register,
+)
+from sentry.incidents.models import AlertRule
+
+
+@register(AlertRule)
+class AlertRuleSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        return {
+            'id': six.text_type(obj.id),
+            'name': obj.name,
+            'projectId': six.text_type(obj.project_id),
+            'status': obj.status,
+            'thresholdType': obj.threshold_type,
+            'dataset': obj.dataset,
+            'query': obj.query,
+            'aggregations': [agg for agg in obj.aggregations],
+            'timeWindow': obj.time_window,
+            'resolution': obj.resolution,
+            'alertThreshold': obj.alert_threshold,
+            'resolveThreshold': obj.resolve_threshold,
+            'thresholdPeriod': obj.threshold_period,
+            'dateModified': obj.date_modified,
+            'dateAdded': obj.date_added,
+        }

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -6,10 +6,29 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
+from sentry.incidents.models import AlertRule
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer
 
 
 class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
+    def get(self, request, project):
+        """
+        Fetches alert rules for a project
+        """
+        if not features.has('organizations:incidents', project.organization, actor=request.user):
+            raise ResourceDoesNotExist
+
+        return self.paginate(
+            request,
+            queryset=AlertRule.objects.fetch_for_project(project),
+            order_by='-date_added',
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(x, request.user),
+            default_per_page=25,
+        )
+
     def post(self, request, project):
         """
         Create an alert rule
@@ -24,7 +43,6 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
 
         if serializer.is_valid():
             alert_rule = serializer.save()
-            # TODO: Implement serializer
-            return Response({'id': alert_rule.id}, status=status.HTTP_201_CREATED)
+            return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -522,7 +522,7 @@ def create_alert_rule(
             name=name,
             subscription_id=subscription_id,
             threshold_type=threshold_type.value,
-            dataset=SnubaDatasets.EVENTS,
+            dataset=SnubaDatasets.EVENTS.value,
             query=query,
             aggregations=[agg.value for agg in aggregations],
             time_window=time_window,

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -281,6 +281,9 @@ class AlertRuleManager(BaseManager):
             )
         )
 
+    def fetch_for_project(self, project):
+        return self.filter(project=project)
+
 
 class AlertRule(Model):
     __core__ = True

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import six
+
+from sentry.api.serializers import serialize
+from sentry.incidents.logic import create_alert_rule
+from sentry.incidents.models import (
+    AlertRuleAggregations,
+    AlertRuleThresholdType,
+)
+from sentry.testutils import TestCase
+
+
+class IncidentSerializerTest(TestCase):
+    def test_simple(self):
+        alert_rule = create_alert_rule(
+            self.project,
+            'hello',
+            AlertRuleThresholdType.ABOVE,
+            'level:error',
+            [AlertRuleAggregations.TOTAL],
+            10,
+            1000,
+            400,
+            1,
+        )
+        result = serialize(alert_rule)
+
+        assert result['id'] == six.text_type(alert_rule.id)
+        assert result['projectId'] == six.text_type(alert_rule.project_id)
+        assert result['name'] == alert_rule.name
+        assert result['thresholdType'] == alert_rule.threshold_type
+        assert result['dataset'] == alert_rule.dataset
+        assert result['query'] == alert_rule.query
+        assert result['aggregations'] == alert_rule.aggregations
+        assert result['timeWindow'] == alert_rule.time_window
+        assert result['resolution'] == alert_rule.resolution
+        assert result['alertThreshold'] == alert_rule.alert_threshold
+        assert result['resolveThreshold'] == alert_rule.resolve_threshold
+        assert result['thresholdPeriod'] == alert_rule.threshold_period
+        assert result['dateModified'] == alert_rule.date_modified
+        assert result['dateAdded'] == alert_rule.date_added

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -3,12 +3,63 @@ from __future__ import absolute_import
 from exam import fixture
 from freezegun import freeze_time
 
-from sentry.incidents.models import AlertRule
+from sentry.api.serializers import serialize
+from sentry.incidents.logic import create_alert_rule
+from sentry.incidents.models import (
+    AlertRule,
+    AlertRuleAggregations,
+    AlertRuleThresholdType,
+)
 from sentry.testutils import APITestCase
 
 
+class AlertRuleListEndpointTest(APITestCase):
+    endpoint = 'sentry-api-0-project-alert-rules'
+
+    @fixture
+    def organization(self):
+        return self.create_organization()
+
+    @fixture
+    def project(self):
+        return self.create_project(organization=self.organization)
+
+    @fixture
+    def user(self):
+        return self.create_user()
+
+    def test_empty(self):
+        self.create_team(organization=self.organization, members=[self.user])
+
+    def test_simple(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        alert_rule = create_alert_rule(
+            self.project,
+            'hello',
+            AlertRuleThresholdType.ABOVE,
+            'level:error',
+            [AlertRuleAggregations.TOTAL],
+            10,
+            1000,
+            400,
+            1,
+        )
+
+        self.login_as(self.user)
+        with self.feature('organizations:incidents'):
+            resp = self.get_valid_response(self.organization.slug, self.project.slug)
+
+        assert resp.data == serialize([alert_rule])
+
+    def test_no_feature(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        self.login_as(self.user)
+        resp = self.get_response(self.organization.slug, self.project.slug)
+        assert resp.status_code == 404
+
+
 @freeze_time()
-class IncidentCreateEndpointTest(APITestCase):
+class AlertRuleCreateEndpointTest(APITestCase):
     endpoint = 'sentry-api-0-project-alert-rules'
     method = 'post'
 
@@ -54,13 +105,7 @@ class IncidentCreateEndpointTest(APITestCase):
             )
         assert 'id' in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data['id'])
-        assert alert_rule.name == name
-        assert alert_rule.threshold_type == threshold_type
-        assert alert_rule.query == query
-        assert alert_rule.aggregations == aggregations
-        assert alert_rule.time_window == time_window
-        assert alert_rule.alert_threshold == alert_threshold
-        assert alert_rule.resolve_threshold == resolve_threshold
+        assert resp.data == serialize(alert_rule, self.user)
 
     def test_no_feature(self):
         self.create_member(

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -800,7 +800,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert alert_rule.status == AlertRuleStatus.PENDING.value
         assert alert_rule.subscription_id is not None
         assert alert_rule.threshold_type == threshold_type.value
-        assert alert_rule.dataset == SnubaDatasets.EVENTS
+        assert alert_rule.dataset == SnubaDatasets.EVENTS.value
         assert alert_rule.query == query
         assert alert_rule.aggregations == [agg.value for agg in aggregations]
         assert alert_rule.time_window == time_window


### PR DESCRIPTION
This also includes the serializer for alert rules. I wanted to include these serializers in the
incidents app, but due to the way our serializers are structured we're unable to do so due to
circular imports. Ideally we could split up our `api/` app into `api_framework/` and `api/` so that
it's more portable, but I'll leave that for now.