### PR TITLE
ref(ui) Convert a few utils modules to typescript

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -10,3 +10,29 @@ export type Project = {
   slug: string;
   isMember: boolean;
 };
+
+// This type is incomplete
+export type EventMetadata = {
+  value?: string;
+  message?: string;
+  directive?: string;
+  type?: string;
+  title?: string;
+  uri?: string;
+  filename?: string;
+  origin?: string;
+  function?: string;
+};
+
+// This type is incomplete
+export type Event = {
+  id: string;
+  eventID: string;
+  groupID?: string;
+  type: string;
+  title: string;
+  culprit: string;
+  metadata: EventMetadata;
+  message: string;
+  platform?: string;
+};

--- a/src/sentry/static/sentry/app/utils/__mocks__/domId.tsx
+++ b/src/sentry/static/sentry/app/utils/__mocks__/domId.tsx
@@ -1,4 +1,4 @@
-function domId(prefix) {
+function domId(prefix: string): string {
   return prefix + '123456';
 }
 

--- a/src/sentry/static/sentry/app/utils/domId.tsx
+++ b/src/sentry/static/sentry/app/utils/domId.tsx
@@ -1,4 +1,4 @@
-function domId(prefix) {
+function domId(prefix: string): string {
   return (
     prefix +
     Math.random()

--- a/src/sentry/static/sentry/app/utils/events.tsx
+++ b/src/sentry/static/sentry/app/utils/events.tsx
@@ -1,9 +1,10 @@
 import {isNativePlatform} from 'app/utils/platform';
+import {Event} from 'app/types';
 
 /**
  * Extract the display message from an event.
  */
-export function getMessage(event) {
+export function getMessage(event: Event): string | undefined {
   const {metadata, type, culprit} = event;
 
   switch (type) {
@@ -23,35 +24,41 @@ export function getMessage(event) {
 /**
  * Get the location from an event.
  */
-export function getLocation(event) {
+export function getLocation(event: Event): string | null {
   if (event.type === 'error' && isNativePlatform(event.platform)) {
-    const {metadata} = event || {};
-    return metadata.filename || null;
+    return event.metadata.filename || null;
   }
   return null;
 }
 
-export function getTitle(event) {
+type EventTitle = {
+  title: string;
+  subtitle: string;
+};
+
+export function getTitle(event: Event): EventTitle {
   const {metadata, type, culprit} = event;
-  let {title} = event;
-  let subtitle = null;
+  const result: EventTitle = {
+    title: event.title,
+    subtitle: '',
+  };
 
   if (type === 'error') {
-    subtitle = culprit;
+    result.subtitle = culprit;
     if (metadata.type) {
-      title = metadata.type;
+      result.title = metadata.type;
     } else {
-      title = metadata.function || '<unknown>';
+      result.title = metadata.function || '<unknown>';
     }
   } else if (type === 'csp') {
-    title = metadata.directive;
-    subtitle = metadata.uri;
+    result.title = metadata.directive || '';
+    result.subtitle = metadata.uri || '';
   } else if (type === 'expectct' || type === 'expectstaple' || type === 'hpkp') {
-    title = metadata.message;
-    subtitle = metadata.origin;
+    result.title = metadata.message || '';
+    result.subtitle = metadata.origin || '';
   } else if (type === 'default') {
-    title = metadata.title;
+    result.title = metadata.title || '';
   }
 
-  return {title, subtitle};
+  return result;
 }

--- a/src/sentry/static/sentry/app/utils/platform.tsx
+++ b/src/sentry/static/sentry/app/utils/platform.tsx
@@ -1,4 +1,4 @@
-export function isNativePlatform(platform) {
+export function isNativePlatform(platform: string | undefined): boolean {
   switch (platform) {
     case 'cocoa':
     case 'objc':


### PR DESCRIPTION
Convert a few modules into typescript and add types as needed. I checked all of the usage of `getTitle()` and no callers were relying on `null` coming back.