### PR TITLE
Remove actor from org experiment interface

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -129,7 +129,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             ).select_related('user')
         )
 
-        experiment_assignments = experiments.all(org=obj, actor=user)
+        experiment_assignments = experiments.all(org=obj)
 
         context = super(DetailedOrganizationSerializer, self).serialize(obj, attrs, user)
         max_rate = quotas.get_maximum_quota(obj)

--- a/src/sentry/experiments/manager.py
+++ b/src/sentry/experiments/manager.py
@@ -18,12 +18,10 @@ class ExperimentManager(object):
         self._experiments[experiment.__name__] = {
             'experiment': experiment, 'param': param}
 
-    def all(self, org, actor):
+    def all(self, org):
         """Returns an object with all the experiment assignments for the org."""
         assignments = {}
         for k, v in six.iteritems(self._experiments):
             cls = v['experiment']
-            assignments[k] = cls(
-                org=org, actor=actor).get_variant(
-                v['param'], log_exposure=False)
+            assignments[k] = cls(org=org).get_variant(v['param'], log_exposure=False)
         return assignments


### PR DESCRIPTION
Org experiments shouldn't decide their assignment based on the actor. This PR simplifies the interface by removing the actor param.

Depends on and should be merged just before https://github.com/getsentry/getsentry/pull/3085.