### PR TITLE
feat(apm) Enable chart navigation for transaction events

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -40,6 +40,9 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
         group_ids = request.GET.getlist('group')
         if group_ids:
+            # TODO(mark) This parameter should be removed in the long term.
+            # Instead of using this parameter clients should use `issue.id`
+            # in their query string.
             try:
                 group_ids = set(map(int, filter(None, group_ids)))
             except ValueError:
@@ -116,6 +119,9 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
         group_ids = request.GET.getlist('group')
         if group_ids:
+            # TODO(mark) This parameter should be removed in the long term.
+            # Instead of using this parameter clients should use `issue.id`
+            # in their query string.
             try:
                 group_ids = set(map(int, filter(None, group_ids)))
             except ValueError:

--- a/src/sentry/static/sentry/app/actionCreators/events.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.jsx
@@ -30,7 +30,6 @@ export const doEventsRequest = (
     includePrevious,
     query,
     yAxis,
-    groupId,
   }
 ) => {
   const shouldDoublePeriod = canIncludePreviousPeriod(includePrevious, period);
@@ -40,7 +39,6 @@ export const doEventsRequest = (
     environment,
     query,
     yAxis,
-    group: groupId,
   };
 
   // Doubling period for absolute dates is not accurate unless starting and

--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.jsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.jsx
@@ -70,6 +70,11 @@ class EventsRequest extends React.PureComponent {
     limit: PropTypes.number,
 
     /**
+     * The query string to search events by
+     */
+    query: PropTypes.string,
+
+    /**
      * Transform the response data to be something ingestible by charts
      */
     includeTransformedData: PropTypes.bool,
@@ -99,18 +104,12 @@ class EventsRequest extends React.PureComponent {
      * The yAxis being plotted
      */
     yAxis: PropTypes.string,
-
-    /**
-     * issue group id or groupids to filter results by.
-     */
-    groupId: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   };
 
   static defaultProps = {
     period: null,
     start: null,
     end: null,
-    groupId: null,
     interval: '1d',
     limit: 15,
     getCategory: i => i,

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
@@ -32,7 +32,9 @@ const EventModalContent = props => {
     <ColumnGrid>
       <HeaderBox>
         <EventHeader event={event} />
-        {isGroupedView && <ModalPagination event={event} location={location} />}
+        {isGroupedView && (
+          <ModalPagination view={view} event={event} location={location} />
+        )}
         {isGroupedView &&
           getDynamicText({
             value: (
@@ -40,6 +42,7 @@ const EventModalContent = props => {
                 organization={organization}
                 currentEvent={event}
                 location={location}
+                view={view}
               />
             ),
             fixed: 'events chart',

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/modalLineGraph.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/modalLineGraph.jsx
@@ -20,6 +20,7 @@ import withGlobalSelection from 'app/utils/withGlobalSelection';
 import theme from 'app/utils/theme';
 
 import {MODAL_QUERY_KEYS, PIN_ICON} from './data';
+import {getQueryString} from './utils';
 
 /**
  * Generate the data to display a vertical line for the current
@@ -71,24 +72,16 @@ const getCurrentEventMarker = currentEvent => {
  */
 const handleClick = async function(
   series,
-  {api, organization, groupId, interval, selection, location}
+  {api, organization, queryString, interval, selection, location}
 ) {
   // Get the timestamp that was clicked.
   const value = series.value[0];
-
-  // Apply the issue.id condition to the request.
-  let search = location.query.query;
-  if (search && search.length) {
-    search += ` issue.id:${groupId}`;
-  } else {
-    search = `issue.id:${groupId}`;
-  }
 
   // Get events that match the clicked timestamp
   // taking into account the group and current environment & query
   const query = {
     environment: selection.environments,
-    query: search,
+    query: queryString,
     start: getUtcDateString(value),
     end: getUtcDateString(value + intervalToMilliseconds(interval)),
   };
@@ -118,7 +111,7 @@ const handleClick = async function(
  * Render a graph of event volumes for the current group + event.
  */
 const ModalLineGraph = props => {
-  const {api, organization, location, selection, currentEvent} = props;
+  const {api, organization, location, selection, currentEvent, view} = props;
 
   const isUtc = selection.datetime.utc;
   const dateFormat = 'lll';
@@ -142,7 +135,16 @@ const ModalLineGraph = props => {
       return getFormattedDate(value, 'lll', {local: !isUtc});
     },
   };
-  const groupId = currentEvent.groupID;
+
+  // Generate a query string that finds events similar to our
+  // current event based on the type of view being used.
+  const eventConditions = {};
+  if (view.id === 'transactions') {
+    eventConditions.transaction = currentEvent.location;
+  } else {
+    eventConditions['issue.id'] = currentEvent.groupID;
+  }
+  const queryString = getQueryString(view, location, eventConditions);
 
   return (
     <Panel>
@@ -156,9 +158,8 @@ const ModalLineGraph = props => {
         end={selection.datetime.end}
         interval={interval}
         showLoading={true}
-        query={location.query.query}
+        query={queryString}
         includePrevious={false}
-        groupId={groupId}
       >
         {({loading, reloading, timeseriesData}) => (
           <LineChart
@@ -172,7 +173,7 @@ const ModalLineGraph = props => {
               handleClick(series, {
                 api,
                 organization,
-                groupId,
+                queryString,
                 interval,
                 selection,
                 location,
@@ -196,6 +197,7 @@ ModalLineGraph.propTypes = {
   location: PropTypes.object.isRequired,
   organization: SentryTypes.Organization.isRequired,
   selection: PropTypes.object.isRequired,
+  view: PropTypes.object.isRequired,
 };
 
 export default withGlobalSelection(withApi(ModalLineGraph));

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/modalPagination.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/modalPagination.jsx
@@ -15,12 +15,12 @@ import {MODAL_QUERY_KEYS} from './data';
 /**
  * Generate a mapping of link names => link targets for pagination
  */
-function buildTargets(event, location) {
-  // Remove the groupSlug and eventSlug keys as we need to create new ones
+function buildTargets(event, location, view) {
+  // Remove slug related keys as we need to create new ones
   const baseQuery = omit(location.query, MODAL_QUERY_KEYS);
 
   let queryKey, aggregateValue;
-  if (event.type === 'transaction') {
+  if (view.id === 'transactions') {
     queryKey = 'transactionSlug';
     aggregateValue = event.location;
   } else {
@@ -54,8 +54,8 @@ function buildTargets(event, location) {
 }
 
 const ModalPagination = props => {
-  const {event, location} = props;
-  const links = buildTargets(event, location);
+  const {event, location, view} = props;
+  const links = buildTargets(event, location, view);
 
   return (
     <Wrapper>
@@ -87,6 +87,7 @@ const ModalPagination = props => {
 ModalPagination.propTypes = {
   location: PropTypes.object.isRequired,
   event: SentryTypes.Event.isRequired,
+  view: PropTypes.object.isRequired,
 };
 
 const StyledLink = styled(Link, {shouldForwardProp: isPropValid})`

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
@@ -50,7 +50,6 @@ export function getQuery(view, location) {
     'utc',
     'statsPeriod',
     'cursor',
-    'query',
     'sort',
   ]);
 
@@ -60,15 +59,36 @@ export function getQuery(view, location) {
     data.sort = view.data.sort;
   }
   data.per_page = DEFAULT_PER_PAGE;
+  data.query = getQueryString(view, location);
 
-  if (view.data.query) {
-    if (data.query) {
-      data.query = `${data.query} ${view.data.query}`;
-    } else {
-      data.query = view.data.query;
-    }
-  }
   return data;
+}
+
+/**
+ * Generate a querystring based on the view defaults, current
+ * location and any additional parameters
+ *
+ * @param {Object} view defaults containing `.data.query`
+ * @param {Location} browser location
+ * @param {Object} additional parameters to merge into the query string.
+ */
+export function getQueryString(view, location, additional) {
+  const queryParts = [];
+  if (view.data.query) {
+    queryParts.push(view.data.query);
+  }
+  if (location.query && location.query.query) {
+    queryParts.push(location.query.query);
+  }
+  if (additional) {
+    Object.entries(additional).forEach(([key, value]) => {
+      if (value) {
+        queryParts.push(`${key}:${value}`);
+      }
+    });
+  }
+
+  return queryParts.join(' ');
 }
 
 /**

--- a/tests/js/spec/views/organizationEventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/utils.spec.jsx
@@ -1,6 +1,7 @@
 import {
   getCurrentView,
   getQuery,
+  getQueryString,
   getEventTagSearchUrl,
 } from 'app/views/organizationEventsV2/utils';
 import {ALL_VIEWS} from 'app/views/organizationEventsV2/data';
@@ -52,7 +53,65 @@ describe('getQuery()', function() {
     };
 
     expect(getQuery(view, {}).query).toEqual('event.type:csp');
-    expect(getQuery(view, {query: {query: 'test'}}).query).toEqual('test event.type:csp');
+  });
+
+  it('appends query conditions in location', function() {
+    const view = {
+      id: 'test',
+      name: 'test view',
+      data: {fields: ['id'], query: 'event.type:csp'},
+      tags: [],
+    };
+    const location = {
+      query: {
+        query: 'TypeError',
+      },
+    };
+    expect(getQuery(view, location).query).toEqual('event.type:csp TypeError');
+  });
+});
+
+describe('getQueryString()', function() {
+  it('excludes empty values', function() {
+    const view = {
+      data: {
+        query: 'event.type:transaction',
+      },
+    };
+    const location = {
+      query: {query: ''},
+    };
+    expect(getQueryString(view, location)).toEqual('event.type:transaction');
+  });
+
+  it('includes view, and location query data', function() {
+    const view = {
+      data: {
+        query: 'event.type:transaction',
+      },
+    };
+    const location = {
+      query: {query: 'TypeError'},
+    };
+    expect(getQueryString(view, location)).toEqual('event.type:transaction TypeError');
+  });
+
+  it('includes non-empty additional data', function() {
+    const view = {
+      data: {
+        query: 'event.type:transaction',
+      },
+    };
+    const location = {};
+    const additional = {
+      nope: '',
+      undef: undefined,
+      nullish: null,
+      yes: 'value',
+    };
+    expect(getQueryString(view, location, additional)).toEqual(
+      'event.type:transaction yes:value'
+    );
   });
 });
 


### PR DESCRIPTION
Refactor how the details summary chart finds new events and generates queries. By using the view configuration we can have less hardcoding and a more flexible implementation. This also opens the option for pushing condition generation into the view structure which decouples the code further.

Refs SEN-807