### PR TITLE
feat(frame): Display the absolute path of the file in a given frame as a tooltip

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -175,21 +175,13 @@ export const Frame = createReactClass({
         ? data.module || data.filename
         : data.filename || data.module;
 
-      if (defined(data.absPath)) {
-        title.push(
-          <Tooltip title={data.absPath || ''}>
-            <code key="filename" className="filename">
-              <Truncate value={pathName} maxLength={100} leftTrim={true} />
-            </code>
-          </Tooltip>
-        );
-      } else {
-        title.push(
+      title.push(
+        <Tooltip title={data.absPath} disabled={!defined(data.absPath)}>
           <code key="filename" className="filename">
             <Truncate value={pathName} maxLength={100} leftTrim={true} />
           </code>
-        );
-      }
+        </Tooltip>
+      );
 
       // in case we prioritized the module name but we also have a filename info
       // we want to show a litle (?) icon that on hover shows the actual filename

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -175,11 +175,21 @@ export const Frame = createReactClass({
         ? data.module || data.filename
         : data.filename || data.module;
 
-      title.push(
-        <code key="filename" className="filename">
-          <Truncate value={pathName} maxLength={100} leftTrim={true} />
-        </code>
-      );
+      if (defined(data.absPath)) {
+        title.push(
+          <Tooltip title={data.absPath || ''}>
+            <code key="filename" className="filename">
+              <Truncate value={pathName} maxLength={100} leftTrim={true} />
+            </code>
+          </Tooltip>
+        );
+      } else {
+        title.push(
+          <code key="filename" className="filename">
+            <Truncate value={pathName} maxLength={100} leftTrim={true} />
+          </code>
+        );
+      }
 
       // in case we prioritized the module name but we also have a filename info
       // we want to show a litle (?) icon that on hover shows the actual filename

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -462,13 +462,15 @@ export const Frame = createReactClass({
             <span className="symbol">
               <FunctionName frame={data} />{' '}
               {data.filename && (
-                <span
-                  className="filename"
-                  title={data.absPath !== data.filename ? data.absPath : null}
-                >
-                  {data.filename}
-                  {data.lineNo ? ':' + data.lineNo : ''}
-                </span>
+                <Tooltip title={data.absPath} disabled={!defined(data.absPath)}>
+                  <span
+                    className="filename"
+                    title={data.absPath !== data.filename ? data.absPath : null}
+                  >
+                    {data.filename}
+                    {data.lineNo ? ':' + data.lineNo : ''}
+                  </span>
+                </Tooltip>
               )}
               {hint !== null ? (
                 <Tooltip title={hint}>

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -175,8 +175,10 @@ export const Frame = createReactClass({
         ? data.module || data.filename
         : data.filename || data.module;
 
+      const enablePathTooltip = defined(data.absPath) && data.absPath !== pathName;
+
       title.push(
-        <Tooltip title={data.absPath} disabled={!defined(data.absPath)}>
+        <Tooltip title={data.absPath} disabled={enablePathTooltip}>
           <code key="filename" className="filename">
             <Truncate value={pathName} maxLength={100} leftTrim={true} />
           </code>

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -446,6 +446,9 @@ export const Frame = createReactClass({
   renderNativeLine() {
     const data = this.props.data;
     const hint = this.getFrameHint();
+
+    const enablePathTooltip = defined(data.absPath) && data.absPath !== data.filename;
+
     return (
       <StrictClick onClick={this.isExpandable() ? this.toggleContext : null}>
         <DefaultLine className="title as-table">
@@ -462,11 +465,8 @@ export const Frame = createReactClass({
             <span className="symbol">
               <FunctionName frame={data} />{' '}
               {data.filename && (
-                <Tooltip title={data.absPath} disabled={!defined(data.absPath)}>
-                  <span
-                    className="filename"
-                    title={data.absPath !== data.filename ? data.absPath : null}
-                  >
+                <Tooltip title={data.absPath} disabled={!enablePathTooltip}>
+                  <span className="filename">
                     {data.filename}
                     {data.lineNo ? ':' + data.lineNo : ''}
                   </span>


### PR DESCRIPTION
This is an ask from a zendesk ticket; see SEN-877.

@markstory Please let me know if I'm using this tooltip properly. 

## TODO

- [x] deploy to staging for customers with C++, golang, and swift stacktraces 
- [x] tooltips for default line
- [x] tooltips for native line

-----

Closes SEN-877