### PR TITLE
fix(ui) Remove scroll lock correctly

### DIFF
--- a/src/sentry/static/sentry/app/components/modalDialog.jsx
+++ b/src/sentry/static/sentry/app/components/modalDialog.jsx
@@ -80,9 +80,7 @@ class ModalDialog extends React.Component {
     document.removeEventListener('keydown', this.handleKeyDown);
 
     // Restore body scrolling.
-    if (this.previousOverflow) {
-      document.body.style.overflow = this.previousOverflow;
-    }
+    document.body.style.overflow = this.previousOverflow;
   }
 
   handleClose = event => {


### PR DESCRIPTION
The body element doesn't have a default overflow value most of the time. The conditional was preventing the scroll lock from being released.