### PR TITLE
feat(apm) Add a rough draft of related events

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventModalContent.jsx
@@ -15,6 +15,7 @@ import EventInterfaces from './eventInterfaces';
 import LinkedIssuePreview from './linkedIssuePreview';
 import ModalPagination from './modalPagination';
 import ModalLineGraph from './modalLineGraph';
+import RelatedEvents from './relatedEvents';
 import TagsTable from './tagsTable';
 
 /**
@@ -54,6 +55,9 @@ const EventModalContent = props => {
       <SidebarColumn>
         {event.groupID && (
           <LinkedIssuePreview groupId={event.groupID} eventId={event.eventID} />
+        )}
+        {event.type === 'transaction' && (
+          <RelatedEvents organization={organization} event={event} location={location} />
         )}
         <EventMetadata event={event} eventJsonUrl={eventJsonUrl} />
         <SidebarBlock>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/relatedEvents.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/relatedEvents.jsx
@@ -46,7 +46,7 @@ class RelatedEvents extends AsyncComponent {
           'timestamp',
         ],
         sort: ['-timestamp'],
-        query: `trace:${trace.value}`,
+        query: `trace:${trace.value} !id:${event.id}`,
       },
     };
 
@@ -58,7 +58,7 @@ class RelatedEvents extends AsyncComponent {
   }
 
   renderBody() {
-    const {event, location} = this.props;
+    const {location} = this.props;
     const {events} = this.state;
     if (!events) {
       return null;
@@ -69,35 +69,31 @@ class RelatedEvents extends AsyncComponent {
         <Title>
           <InlineSvg src="icon-link" size="12px" /> {t('Related Events')}
         </Title>
-        {events.length <= 1 ? (
+        {events.length < 1 ? (
           <Card>{t('No related events found.')}</Card>
         ) : (
-          events
-            // Don't show the current event. We don't have negation conditions
-            // in our API so we have to do this here.
-            .filter(item => item.id !== event.id)
-            .map(item => {
-              const eventUrl = {
-                pathname: location.pathname,
-                query: {
-                  ...omit(location.query, MODAL_QUERY_KEYS),
-                  eventSlug: `${item['project.name']}:${item.id}`,
-                },
-              };
-              const project = {slug: item['project.name']};
-              return (
-                <Card key={item.id}>
-                  <EventLink to={eventUrl} data-test-id="linked-event">
-                    {item.title ? item.title : item.transaction}
-                  </EventLink>
-                  <StyledProjectBadge project={project} avatarSize={14} />
-                  <div>
-                    <StyledDateTime date={item.timestamp} />
-                    <Badge text={item['event.type']} />
-                  </div>
-                </Card>
-              );
-            })
+          events.map(item => {
+            const eventUrl = {
+              pathname: location.pathname,
+              query: {
+                ...omit(location.query, MODAL_QUERY_KEYS),
+                eventSlug: `${item['project.name']}:${item.id}`,
+              },
+            };
+            const project = {slug: item['project.name']};
+            return (
+              <Card key={item.id}>
+                <EventLink to={eventUrl} data-test-id="linked-event">
+                  {item.title ? item.title : item.transaction}
+                </EventLink>
+                <StyledProjectBadge project={project} avatarSize={14} />
+                <div>
+                  <StyledDateTime date={item.timestamp} />
+                  <Badge text={item['event.type']} />
+                </div>
+              </Card>
+            );
+          })
         )}
       </Container>
     );

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/relatedEvents.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/relatedEvents.jsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import styled from 'react-emotion';
+import PropTypes from 'prop-types';
+import {omit} from 'lodash';
+
+import {t} from 'app/locale';
+import SentryTypes from 'app/sentryTypes';
+import AsyncComponent from 'app/components/asyncComponent';
+import InlineSvg from 'app/components/inlineSvg';
+import Link from 'app/components/links/link';
+import Badge from 'app/components/badge';
+import Placeholder from 'app/components/placeholder';
+import ProjectBadge from 'app/components/idBadge/projectBadge';
+import DateTime from 'app/components/dateTime';
+import space from 'app/styles/space';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
+
+import {MODAL_QUERY_KEYS} from './data';
+
+class RelatedEvents extends AsyncComponent {
+  static propTypes = {
+    event: SentryTypes.Event.isRequired,
+    location: PropTypes.object.isRequired,
+    organization: SentryTypes.Organization.isRequired,
+  };
+
+  getEndpoints() {
+    // TODO what happens when global-views feature is not on the org?
+    const {event, organization} = this.props;
+    const eventsUrl = `/organizations/${organization.slug}/events/`;
+    const trace = event.tags.find(tag => tag.key === 'trace');
+
+    if (!trace) {
+      return [];
+    }
+
+    const params = {
+      query: {
+        field: [
+          'project.name',
+          'title',
+          'transaction',
+          'id',
+          'issue.id',
+          'event.type',
+          'timestamp',
+        ],
+        sort: ['-timestamp'],
+        query: `trace:${trace.value}`,
+      },
+    };
+
+    return [['events', eventsUrl, params]];
+  }
+
+  renderLoading() {
+    return <Placeholder height="120px" bottomGutter={2} />;
+  }
+
+  renderBody() {
+    const {event, location} = this.props;
+    const {events} = this.state;
+    if (!events) {
+      return null;
+    }
+
+    return (
+      <Container>
+        <Title>
+          <InlineSvg src="icon-link" size="12px" /> {t('Related Events')}
+        </Title>
+        {events.length <= 1 ? (
+          <Card>{t('No related events found.')}</Card>
+        ) : (
+          events
+            // Don't show the current event. We don't have negation conditions
+            // in our API so we have to do this here.
+            .filter(item => item.id !== event.id)
+            .map(item => {
+              const eventUrl = {
+                pathname: location.pathname,
+                query: {
+                  ...omit(location.query, MODAL_QUERY_KEYS),
+                  eventSlug: `${item['project.name']}:${item.id}`,
+                },
+              };
+              const project = {slug: item['project.name']};
+              return (
+                <Card key={item.id}>
+                  <EventLink to={eventUrl} data-test-id="linked-event">
+                    {item.title ? item.title : item.transaction}
+                  </EventLink>
+                  <StyledProjectBadge project={project} avatarSize={14} />
+                  <div>
+                    <StyledDateTime date={item.timestamp} />
+                    <Badge text={item['event.type']} />
+                  </div>
+                </Card>
+              );
+            })
+        )}
+      </Container>
+    );
+  }
+}
+
+const Container = styled('div')`
+  position: relative;
+`;
+
+const Card = styled('div')`
+  display: flex;
+  flex-direction: column;
+  border: 1px solid ${p => p.theme.borderLight};
+  border-radius: ${p => p.theme.borderRadius};
+  margin-bottom: ${space(1)};
+  padding: ${space(1)};
+`;
+
+const EventLink = styled(Link)`
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin-bottom: ${space(0.5)};
+  ${overflowEllipsis};
+`;
+
+const Title = styled('h4')`
+  background: #fff;
+  color: ${p => p.theme.gray3};
+  padding: 0 ${space(1)};
+  margin-bottom: ${space(0.5)};
+
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: normal;
+`;
+
+const StyledDateTime = styled(DateTime)`
+  font-size: ${p => p.theme.fontSizeSmall};
+  line-height: ${p => p.theme.text.lineHeightBody};
+  color: ${p => p.theme.gray2};
+  margin-left: ${space(1)};
+`;
+
+const StyledProjectBadge = styled(ProjectBadge)`
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin-bottom: ${space(0.5)};
+`;
+
+export default RelatedEvents;


### PR DESCRIPTION
Use the current event's traceid to find other related events. The display is rough but it is a start.

![Screen Shot 2019-07-30 at 3 58 18 PM](https://user-images.githubusercontent.com/24086/62161384-0785af00-b2e4-11e9-994e-9908d3d2c704.png)


Refs SEN-860