### PR TITLE
ref: Improve Snuba client retention querying

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -187,8 +187,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         conditions.extend(time_condition)
 
         result = snuba.raw_query(
-            start=start,
-            end=end,
+            query_strategy=snuba.CustomQueryStrategy(start, end),
             selected_columns=['event_id'],
             conditions=conditions,
             filter_keys=snuba_args['filter_keys'],

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -465,8 +465,6 @@ class SnubaEvent(EventCommon):
     def get_event(cls, project_id, event_id, snuba_cols=selected_columns):
         from sentry.utils import snuba
         result = snuba.raw_query(
-            start=datetime.utcfromtimestamp(0),  # will be clamped to project retention
-            end=datetime.utcnow(),  # will be clamped to project retention
             selected_columns=snuba_cols,
             filter_keys={
                 'event_id': [event_id],


### PR DESCRIPTION
When Sentry wants to talk to Snuba, it needs to specify a `start` and `end` time. There are a few patterns we see when setting the `start` and `end` time.
1. Set it according to the customer's retention (most common)
1. Set it according to the query params and cap it by retention
1. Have a custom start and end time

WIP