### PR TITLE
fix(api) Enable superusers to have access to permalinks

### DIFF
--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -142,6 +142,18 @@ class GroupDetailsTest(APITestCase):
         assert response.data['annotations'] == \
             [u'<a href="https://example.com/issues/2">Issue#2</a>']
 
+    def test_permalink_superuser(self):
+        superuser = self.create_user(is_superuser=True)
+        self.login_as(user=superuser, superuser=True)
+
+        group = self.create_group(title='Oh no')
+        url = u'/api/0/issues/{}/'.format(group.id)
+        response = self.client.get(url, format='json')
+
+        result = response.data['permalink']
+        assert 'http://' in result
+        assert '{}/issues/{}'.format(group.organization.slug, group.id) in result
+
 
 class GroupUpdateTest(APITestCase):
     def test_resolve(self):

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -26,6 +26,18 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         self.day_ago = timezone.now() - timedelta(days=1)
         self.week_ago = timezone.now() - timedelta(days=7)
 
+    def test_permalink(self):
+        group = self.create_group(title='Oh no')
+        result = serialize(group, self.user, serializer=GroupSerializerSnuba())
+        assert 'http://' in result['permalink']
+        assert '{}/issues/{}'.format(group.organization.slug, group.id) in result['permalink']
+
+    def test_permalink_outside_org(self):
+        outside_user = self.create_user()
+        group = self.create_group(title='Oh no')
+        result = serialize(group, outside_user, serializer=GroupSerializerSnuba())
+        assert result['permalink'] is None
+
     def test_is_ignored_with_expired_snooze(self):
         now = timezone.now()
 


### PR DESCRIPTION
They can already see the group details, eliding only the permalink is not hiding anything.

Fixes SEN-881