### PR TITLE
feat(api): Allow empty `query` when creating Incident Alert Rule

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -27,6 +27,9 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             'resolve_threshold', 'threshold_period', 'aggregations',
         ]
         extra_kwargs = {
+            'query': {
+                'allow_blank': True,
+            },
             'threshold_period': {'default': 1, 'min_value': 1, 'max_value': 20},
             'time_window': {
                 'min_value': 1,

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -27,9 +27,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             'resolve_threshold', 'threshold_period', 'aggregations',
         ]
         extra_kwargs = {
-            'query': {
-                'allow_blank': True,
-            },
+            'query': {'allow_blank': True, },
             'threshold_period': {'default': 1, 'min_value': 1, 'max_value': 20},
             'time_window': {
                 'min_value': 1,


### PR DESCRIPTION
This allows an empty string for `query` when creating an Alert Rule. Most users search using the empty string or `is:unresolved`.