### PR TITLE
tests(acceptance): Fix Incident Details chart flakeyness

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/statusItem.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/details/activity/statusItem.jsx
@@ -62,12 +62,16 @@ class StatusItem extends React.Component {
         }
         date={getDynamicText({value: activity.dateCreated, fixed: new Date(0)})}
       >
-        {activity.eventStats && (
-          <Chart
-            data={activity.eventStats.data}
-            detected={(isCreated || isDetected) && incident && incident.dateStarted}
-          />
-        )}
+        {activity.eventStats &&
+          getDynamicText({
+            value: (
+              <Chart
+                data={activity.eventStats.data}
+                detected={(isCreated || isDetected) && incident && incident.dateStarted}
+              />
+            ),
+            fixed: 'Chart Placeholder for Percy',
+          })}
       </ActivityItem>
     );
   }


### PR DESCRIPTION
This fixes the Percy snapshot that keeps popping up with the chart on Incident Details activity list.