### PR TITLE
build(webpack): Change from multiple targets to multiple entries in single target

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -431,4 +431,4 @@ if (IS_PRODUCTION) {
   });
 }
 
-module.exports = [appConfig];
+module.exports = appConfig;


### PR DESCRIPTION
This combines changes our webpack configuration from a multi-target
config to a single target one. This change is being done so we can
simplify adding `CleanWebpackPlugin`, otherwise the plugin will clean
`dist` between target builds.