### PR TITLE
ref: Completely remove legacy-event-id feature

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -71,7 +71,6 @@ default_manager.add('organizations:incidents', OrganizationFeature)  # NOQA
 default_manager.add('organizations:sentry-apps', OrganizationFeature)  # NOQA
 default_manager.add('organizations:invite-members', OrganizationFeature)  # NOQA
 default_manager.add('organizations:large-debug-files', OrganizationFeature)  # NOQA
-default_manager.add('organizations:legacy-event-id', OrganizationFeature)  # NOQA
 default_manager.add('organizations:monitors', OrganizationFeature)  # NOQA
 default_manager.add('organizations:onboarding', OrganizationFeature)  # NOQA
 default_manager.add('organizations:org-saved-searches', OrganizationFeature)  # NOQA


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/14139