### PR TITLE
ref: Always use event.title as title

### DIFF
--- a/src/sentry/static/sentry/app/utils/events.tsx
+++ b/src/sentry/static/sentry/app/utils/events.tsx
@@ -45,19 +45,10 @@ export function getTitle(event: Event): EventTitle {
 
   if (type === 'error') {
     result.subtitle = culprit;
-    if (metadata.type) {
-      result.title = metadata.type;
-    } else {
-      result.title = metadata.function || '<unknown>';
-    }
   } else if (type === 'csp') {
-    result.title = metadata.directive || '';
     result.subtitle = metadata.uri || '';
   } else if (type === 'expectct' || type === 'expectstaple' || type === 'hpkp') {
-    result.title = metadata.message || '';
     result.subtitle = metadata.origin || '';
-  } else if (type === 'default') {
-    result.title = metadata.title || '';
   }
 
   return result;

--- a/tests/js/spec/components/__snapshots__/eventOrGroupTitle.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/eventOrGroupTitle.spec.jsx.snap
@@ -1,10 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EventOrGroupTitle renders with no subtitle when \`type = default\` 1`] = `
-<span>
-  metadata title
-</span>
-`;
+exports[`EventOrGroupTitle renders with no subtitle when \`type = default\` 1`] = `<span />`;
 
 exports[`EventOrGroupTitle renders with subtitle when \`type = csp\` 1`] = `
 <span>
@@ -14,9 +10,7 @@ exports[`EventOrGroupTitle renders with subtitle when \`type = csp\` 1`] = `
         "marginRight": 10,
       }
     }
-  >
-    metadata directive
-  </span>
+  />
   <em
     title="metadata uri"
   >
@@ -34,9 +28,7 @@ exports[`EventOrGroupTitle renders with subtitle when \`type = error\` 1`] = `
         "marginRight": 10,
       }
     }
-  >
-    metadata type
-  </span>
+  />
   <em
     title="culprit"
   >

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -1037,7 +1037,7 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                                 }
                                               }
                                             >
-                                              TypeError
+                                              TypeError: Cannot read property 'length' of undefined
                                             </span>
                                             <em
                                               title="length(app/views/groupSimilar/groupSimilarView)"

--- a/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
+++ b/tests/js/spec/views/organizationIncidents/details/index.spec.jsx
@@ -202,7 +202,9 @@ describe('IncidentDetails', function() {
         .find('RelatedItem Title')
         .at(0)
         .text()
-    ).toBe('RequestErrorfetchData(app/components/group/suggestedOwners)');
+    ).toBe(
+      'RequestError: GET /issues/ 404fetchData(app/components/group/suggestedOwners)'
+    );
 
     expect(
       wrapper


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/14211. The event.title field is always correctly populated now.