### PR TITLE
Feat (app-platform) remove uninstall button for internal integrations

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.jsx
@@ -177,6 +177,7 @@ class OrganizationIntegrations extends AsyncComponent {
         api={this.api}
         showPublishStatus
         isInternal
+        hideButtons
         onRemoveApp={() => this.onRemoveInternalApp(app)}
         organization={organization}
         app={app}

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow.jsx
@@ -29,14 +29,17 @@ export default class SentryApplicationRow extends React.PureComponent {
     onPublishRequest: PropTypes.func,
     showPublishStatus: PropTypes.bool,
     isInternal: PropTypes.bool,
+    hideButtons: PropTypes.bool,
   };
 
   static defaultProps = {
     showPublishStatus: false,
     isInternal: false,
+    hideButtons: false,
   };
 
-  renderUnpublishedAdminButtons(app) {
+  renderUnpublishedAdminButtons() {
+    const {app} = this.props;
     return (
       <ButtonHolder>
         {app.status === 'internal'
@@ -122,7 +125,8 @@ export default class SentryApplicationRow extends React.PureComponent {
     );
   }
 
-  renderUninstall(install) {
+  renderUninstallButton() {
+    const install = this.props.installs[0];
     const message = t(
       `Are you sure you want to remove the ${install.app.slug} installation ?`
     );
@@ -172,9 +176,51 @@ export default class SentryApplicationRow extends React.PureComponent {
     });
   };
 
-  render() {
-    const {app, organization, installs, showPublishStatus} = this.props;
+  renderInstallButton() {
+    return (
+      <Button
+        onClick={() => this.openLearnMore()}
+        size="small"
+        icon="icon-circle-add"
+        className="btn btn-default"
+      >
+        {t('Install')}
+      </Button>
+    );
+  }
+
+  renderUnpublishedAppButtons() {
+    return (
+      <Access access={['org:admin']}>
+        {({hasAccess}) => (
+          <React.Fragment>
+            {hasAccess
+              ? this.renderUnpublishedAdminButtons()
+              : this.renderUnpublishedNonAdminButtons()}
+          </React.Fragment>
+        )}
+      </Access>
+    );
+  }
+
+  renderButtons() {
+    const {app, showPublishStatus, hideButtons} = this.props;
     const isInstalled = this.isInstalled;
+
+    if (hideButtons) {
+      return null;
+    }
+    if (showPublishStatus) {
+      return app.status === 'published'
+        ? this.renderPublishedAppButtons()
+        : this.renderUnpublishedAppButtons();
+    }
+    //if installed, render the uninstall button and if installed, render uninstall
+    return isInstalled ? this.renderUninstallButton() : this.renderInstallButton();
+  }
+
+  render() {
+    const {app, organization, showPublishStatus} = this.props;
 
     return (
       <SentryAppItem data-test-id={app.slug}>
@@ -195,38 +241,7 @@ export default class SentryApplicationRow extends React.PureComponent {
             <SentryAppDetails>{this.renderStatus()}</SentryAppDetails>
           </SentryAppBox>
 
-          {!showPublishStatus ? (
-            <Box>
-              {!isInstalled ? (
-                <Button
-                  onClick={() => this.openLearnMore()}
-                  size="small"
-                  icon="icon-circle-add"
-                  className="btn btn-default"
-                >
-                  {t('Install')}
-                </Button>
-              ) : (
-                this.renderUninstall(installs[0])
-              )}
-            </Box>
-          ) : (
-            <Box>
-              {app.status !== 'published' ? (
-                <Access access={['org:admin']}>
-                  {({hasAccess}) => (
-                    <React.Fragment>
-                      {hasAccess
-                        ? this.renderUnpublishedAdminButtons(app)
-                        : this.renderUnpublishedNonAdminButtons()}
-                    </React.Fragment>
-                  )}
-                </Access>
-              ) : (
-                this.renderPublishedAppButtons()
-              )}
-            </Box>
-          )}
+          <Box>{this.renderButtons()}</Box>
         </StyledFlex>
       </SentryAppItem>
     );

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallations.spec.jsx.snap
@@ -76,6 +76,7 @@ exports[`Sentry App Installations when Apps exist displays all Apps owned by the
         "webhookUrl": "https://example.com/webhook",
       }
     }
+    hideButtons={false}
     isInternal={false}
     key="123456123456123456123456"
     onInstall={[Function]}


### PR DESCRIPTION
This PR removes the uninstall button for internal integrations on the "integrations" page. The reason for this change is that internal integrations get uninstalled by removing the integration from the "developer settings page". Here's the old view:

![Screen Shot 2019-07-31 at 4 13 18 PM](https://user-images.githubusercontent.com/8533851/62254486-2a7c9580-b3ae-11e9-94d7-3e7bc9df3fca.png)

New view:

![Screen Shot 2019-07-31 at 3 59 55 PM](https://user-images.githubusercontent.com/8533851/62254191-1dab7200-b3ad-11e9-9b9a-7097becb7415.png)
