### PR TITLE
feat(api): Implement alert rule deletion api (SEN-825)

### DIFF
--- a/src/sentry/deletions/base.py
+++ b/src/sentry/deletions/base.py
@@ -135,6 +135,7 @@ class BaseDeletionTask(object):
 
 class ModelDeletionTask(BaseDeletionTask):
     DEFAULT_QUERY_LIMIT = None
+    manager_name = 'objects'
 
     def __init__(self, manager, model, query, query_limit=None, order_by=None, **kwargs):
         super(ModelDeletionTask, self).__init__(manager, **kwargs)
@@ -167,7 +168,7 @@ class ModelDeletionTask(BaseDeletionTask):
         query_limit = self.query_limit
         remaining = self.chunk_size
         while remaining > 0:
-            queryset = self.model.objects.filter(**self.query)
+            queryset = getattr(self.model, self.manager_name).filter(**self.query)
             if self.order_by:
                 queryset = queryset.order_by(self.order_by)
 

--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -6,7 +6,7 @@ from ..base import (BulkModelDeletionTask, ModelDeletionTask, ModelRelation)
 class ProjectDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
         from sentry import models
-        from sentry.incidents.models import IncidentProject
+        from sentry.incidents.models import IncidentProject, AlertRule
 
         relations = [
             # ProjectKey gets revoked immediately, in bulk
@@ -20,7 +20,9 @@ class ProjectDeletionTask(ModelDeletionTask):
             models.GroupHash, models.GroupRelease, models.GroupRuleStatus, models.GroupSeen,
             models.GroupShare, models.GroupSubscription, models.ProjectBookmark, models.ProjectKey,
             models.ProjectTeam, models.PromptsActivity, models.SavedSearchUserDefault, models.SavedSearch,
-            models.ServiceHook, models.UserReport, models.DiscoverSavedQueryProject, IncidentProject
+            models.ServiceHook, models.UserReport, models.DiscoverSavedQueryProject, IncidentProject,
+            AlertRule,
+
         )
 
         relations.extend(

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -7,6 +7,10 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import AlertRuleSerializer
 from sentry.incidents.endpoints.bases import ProjectAlertRuleEndpoint
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
+from sentry.incidents.logic import (
+    AlreadyDeletedError,
+    delete_alert_rule,
+)
 
 
 class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
@@ -32,3 +36,13 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
             return Response(serialize(alert_rule, request.user), status=status.HTTP_200_OK)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, project, alert_rule):
+        try:
+            delete_alert_rule(alert_rule)
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except AlreadyDeletedError:
+            return Response(
+                'This rule has already been deleted',
+                status=status.HTTP_400_BAD_REQUEST,
+            )

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -289,6 +289,7 @@ class AlertRule(Model):
     __core__ = True
 
     objects = AlertRuleManager()
+    objects_with_deleted = BaseManager()
 
     project = FlexibleForeignKey('sentry.Project', db_index=False, db_constraint=False)
     name = models.TextField()

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -1,19 +1,28 @@
 from __future__ import absolute_import
 
+from uuid import uuid4
+
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from six.moves.urllib.parse import urlencode
 
+from sentry import deletions
 from sentry.app import locks
 from sentry.auth.access import from_user
+from sentry.exceptions import DeleteAborted
 from sentry.incidents.models import (
+    AlertRule,
+    AlertRuleStatus,
     Incident,
     IncidentActivity,
     IncidentActivityType,
     IncidentStatus,
     IncidentSuspectCommit,
 )
-from sentry.tasks.base import instrumented_task
+from sentry.tasks.base import (
+    instrumented_task,
+    retry,
+)
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 from sentry.utils.linksign import generate_signed_link
@@ -119,3 +128,45 @@ def calculate_incident_suspects(incident_id):
                 IncidentSuspectCommit(incident=incident, commit_id=commit_id, order=i)
                 for i, commit_id in enumerate(suspect_commits)
             ])
+
+
+@instrumented_task(
+    name='sentry.incidents.tasks.delete_alert_rule',
+    queue='cleanup',
+    default_retry_delay=60 * 5,
+    max_retries=1
+)
+@retry(exclude=(DeleteAborted, ))
+def delete_alert_rule(alert_rule_id, transaction_id=None, **kwargs):
+    from sentry.incidents.models import AlertRule
+    try:
+        instance = AlertRule.objects_with_deleted.get(id=alert_rule_id)
+    except AlertRule.DoesNotExist:
+        return
+
+    if instance.status not in (
+        AlertRuleStatus.DELETION_IN_PROGRESS.value,
+        AlertRuleStatus.PENDING_DELETION.value,
+    ):
+        raise DeleteAborted
+
+    task = deletions.get(
+        model=AlertRule,
+        query={
+            'id': alert_rule_id,
+        },
+        transaction_id=transaction_id or uuid4().hex,
+    )
+    has_more = task.chunk()
+    if has_more:
+        delete_alert_rule.apply_async(
+            kwargs={'alert_rule_id': alert_rule_id, 'transaction_id': transaction_id},
+            countdown=15,
+        )
+
+
+class AlertRuleDeletionTask(deletions.ModelDeletionTask):
+    manager_name = 'objects_with_deleted'
+
+
+deletions.default_manager.register(AlertRule, AlertRuleDeletionTask)


### PR DESCRIPTION
Implements an api for deleting alert rules. When we delete an alert rule we just mark it as deleted,
and trigger a task to completely delete it later.