### PR TITLE
ref(integrations): Don't add identity on GH installation

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -193,7 +193,7 @@ class GitHubIntegrationProvider(IntegrationProvider):
         return installation_resp
 
     def build_integration(self, state):
-        installation = self.get_installation_info(state['installation_id'])
+        installation = self.get_installation_info(state["installation_id"])
 
         integration = {
             "name": installation["account"]["login"],
@@ -210,15 +210,6 @@ class GitHubIntegrationProvider(IntegrationProvider):
                 "domain_name": installation["account"]["html_url"].replace("https://", ""),
                 "account_type": installation["account"]["type"],
             },
-            << << << < HEAD
-            "user_identity": {
-                "type": "github",
-                "external_id": user["id"],
-                "scopes": [],  # GitHub apps do not have user scopes
-                "data": {"access_token": identity["access_token"]},
-            },
-            == == == =
-            >>>>>> > remove github identity creation
         }
 
         if state.get("reinstall_id"):

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import
 from django.utils.translation import ugettext_lazy as _
 
 from sentry import http, options
-from sentry.identity.pipeline import IdentityProviderPipeline
-from sentry.identity.github import get_user_info
+
 from sentry.integrations import (
     IntegrationInstallation,
     IntegrationFeatures,
@@ -16,9 +15,8 @@ from sentry.integrations.exceptions import ApiError
 from sentry.integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.integrations.repositories import RepositoryMixin
 from sentry.models import Repository
-from sentry.pipeline import NestedPipelineView, PipelineView
+from sentry.pipeline import PipelineView
 from sentry.tasks.integrations import migrate_repo
-from sentry.utils.http import absolute_uri
 
 from .client import GitHubAppsClient
 from .issues import GitHubIssueBasic
@@ -178,21 +176,9 @@ class GitHubIntegrationProvider(IntegrationProvider):
             )
 
     def get_pipeline_views(self):
-        identity_pipeline_config = {
-            "oauth_scopes": (),
-            "redirect_url": absolute_uri("/extensions/github/setup/"),
-        }
+        return [GitHubInstallationRedirect()]
 
-        identity_pipeline_view = NestedPipelineView(
-            bind_key="identity",
-            provider_key="github",
-            pipeline_cls=IdentityProviderPipeline,
-            config=identity_pipeline_config,
-        )
-
-        return [GitHubInstallationRedirect(), identity_pipeline_view]
-
-    def get_installation_info(self, access_token, installation_id):
+    def get_installation_info(self, installation_id):
         session = http.build_session()
         resp = session.get(
             "https://api.github.com/app/installations/%s" % installation_id,
@@ -204,28 +190,10 @@ class GitHubIntegrationProvider(IntegrationProvider):
         resp.raise_for_status()
         installation_resp = resp.json()
 
-        resp = session.get(
-            "https://api.github.com/user/installations",
-            params={"access_token": access_token},
-            headers={"Accept": "application/vnd.github.machine-man-preview+json"},
-        )
-        resp.raise_for_status()
-        user_installations_resp = resp.json()
-
-        # verify that user actually has access to the installation
-        for installation in user_installations_resp["installations"]:
-            if installation["id"] == installation_resp["id"]:
-                return installation_resp
-
-        return None
+        return installation_resp
 
     def build_integration(self, state):
-        identity = state["identity"]["data"]
-
-        user = get_user_info(identity["access_token"])
-        installation = self.get_installation_info(
-            identity["access_token"], state["installation_id"]
-        )
+        installation = self.get_installation_info(state['installation_id'])
 
         integration = {
             "name": installation["account"]["login"],
@@ -242,12 +210,15 @@ class GitHubIntegrationProvider(IntegrationProvider):
                 "domain_name": installation["account"]["html_url"].replace("https://", ""),
                 "account_type": installation["account"]["type"],
             },
+            << << << < HEAD
             "user_identity": {
                 "type": "github",
                 "external_id": user["id"],
                 "scopes": [],  # GitHub apps do not have user scopes
                 "data": {"access_token": identity["access_token"]},
             },
+            == == == =
+            >>>>>> > remove github identity creation
         }
 
         if state.get("reinstall_id"):


### PR DESCRIPTION
**Current Status**
Most (if not all) of the first class Sentry integrations have to OAuth a user in the installation process. We added this to the GH integration as well event though it wasn't necessary*. This means that after the installation, we attempt the user OAuth dance and only after that succeeds do we connect the GH installation to the sentry organization.

*_it wasn't necessary because GH apps uses server-server authentication and therefore actions are done on behalf of the application, not a user._ 

**Problem**
If the user authentication piece fails, which happens more than enough times to be problematic, we are left with an 'orphaned' installation. What this means is that the installation is complete according to GH, but it's incomplete according to Sentry. This leads to confusion for users and can be difficult at times to debug _why_ the user authentication failed.

**Solution**
Take out the user authentication for the installation flow. We don't use it anywhere (except maybe for commit author stuff but you can also use an alternate email for that). We can also always add in a way to associate your GH identity outside of the installation flow down the road


**Note:**
GH does have a new option to request user authorization post setup: 
> <img width="583" alt="Screen Shot 2019-08-29 at 3 01 26 PM" src="https://user-images.githubusercontent.com/15368179/63968568-088a3780-ca6e-11e9-92f1-6e4eaf302db2.png">

but this means that it will use the redirect for the user auth url instead of the setup URL which would mess with our current pipeline flow
