### PR TITLE
ref(snuba): Remove `snuba.use_group_id_column` flag and test

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -142,7 +142,6 @@ register('vsts.client-id', flags=FLAG_PRIORITIZE_DISK)
 register('vsts.client-secret', flags=FLAG_PRIORITIZE_DISK)
 
 # Snuba
-register('snuba.use_group_id_column', default=True)
 register('snuba.search.pre-snuba-candidates-optimizer', type=Bool, default=False)
 register('snuba.search.pre-snuba-candidates-percentage', default=0.2)
 register('snuba.search.project-group-count-cache-time', default=24 * 60 * 60)

--- a/tests/snuba/test_snuba.py
+++ b/tests/snuba/test_snuba.py
@@ -102,31 +102,30 @@ class SnubaTest(TestCase, SnubaTestCase):
         group = self.create_group()
         self._insert_event_for_time(base_time, group_id=group.id)
 
-        with self.options({'snuba.use_group_id_column': True}):
-            # verify filter_keys and aggregation
-            assert snuba.query(
-                start=base_time - timedelta(days=1),
-                end=base_time + timedelta(days=1),
-                groupby=['issue'],
-                filter_keys={
-                    'project_id': [self.project.id],
-                    'issue': [group.id]
-                },
-            ) == {group.id: 1}
+        # verify filter_keys and aggregation
+        assert snuba.query(
+            start=base_time - timedelta(days=1),
+            end=base_time + timedelta(days=1),
+            groupby=['group_id'],
+            filter_keys={
+                'project_id': [self.project.id],
+                'group_id': [group.id]
+            },
+        ) == {group.id: 1}
 
-            # verify raw_query selecting issue row
-            assert snuba.raw_query(
-                start=base_time - timedelta(days=1),
-                end=base_time + timedelta(days=1),
-                selected_columns=['issue', 'timestamp'],
-                filter_keys={
-                    'project_id': [self.project.id],
-                    'issue': [group.id]
-                },
-            )['data'] == [{
-                'issue': group.id,
-                'timestamp': base_time.strftime('%Y-%m-%dT%H:%M:%S+00:00'),
-            }]
+        # verify raw_query selecting issue row
+        assert snuba.raw_query(
+            start=base_time - timedelta(days=1),
+            end=base_time + timedelta(days=1),
+            selected_columns=['group_id', 'timestamp'],
+            filter_keys={
+                'project_id': [self.project.id],
+                'group_id': [group.id]
+            },
+        )['data'] == [{
+            'group_id': group.id,
+            'timestamp': base_time.strftime('%Y-%m-%dT%H:%M:%S+00:00'),
+        }]
 
 
 class BulkRawQueryTest(TestCase, SnubaTestCase):

--- a/tests/snuba/test_snuba.py
+++ b/tests/snuba/test_snuba.py
@@ -97,36 +97,6 @@ class SnubaTest(TestCase, SnubaTestCase):
                 },
             ) == {}
 
-    def test_use_group_id(self):
-        base_time = datetime.utcnow()
-        group = self.create_group()
-        self._insert_event_for_time(base_time, group_id=group.id)
-
-        # verify filter_keys and aggregation
-        assert snuba.query(
-            start=base_time - timedelta(days=1),
-            end=base_time + timedelta(days=1),
-            groupby=['group_id'],
-            filter_keys={
-                'project_id': [self.project.id],
-                'group_id': [group.id]
-            },
-        ) == {group.id: 1}
-
-        # verify raw_query selecting issue row
-        assert snuba.raw_query(
-            start=base_time - timedelta(days=1),
-            end=base_time + timedelta(days=1),
-            selected_columns=['group_id', 'timestamp'],
-            filter_keys={
-                'project_id': [self.project.id],
-                'group_id': [group.id]
-            },
-        )['data'] == [{
-            'group_id': group.id,
-            'timestamp': base_time.strftime('%Y-%m-%dT%H:%M:%S+00:00'),
-        }]
-
 
 class BulkRawQueryTest(TestCase, SnubaTestCase):
     def test_simple(self):


### PR DESCRIPTION
You can't unflip this switch. It does nothing. `issues` is not supported any longer in Snuba, as of getsentry/snuba#203.

😩 