### PR TITLE
fix(ui): Improve avatar rescaling quality

### DIFF
--- a/src/sentry/models/avatar.py
+++ b/src/sentry/models/avatar.py
@@ -55,7 +55,7 @@ class AvatarBase(Model):
         if photo is None:
             photo_file = self.file.getfile()
             with Image.open(photo_file) as image:
-                image = image.resize((size, size))
+                image = image.resize((size, size), Image.LANCZOS)
                 image_file = BytesIO()
                 image.save(image_file, 'PNG')
                 photo = image_file.getvalue()


### PR DESCRIPTION
Right now uploading a PNG avatar (min size is 256px) is resized to one of the allowed sizes: `ALLOWED_SIZES = (20, 32, 36, 48, 52, 64, 80, 96, 120)`
This causes really choppy avatar edges and noticeably reduces quality.
Setting optional resample filter fixes that. 
Ref: https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.resize