### PR TITLE
Link to the source of the webhook plugin

### DIFF
--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -45,7 +45,7 @@ class WebHooksPlugin(notify.NotificationPlugin):
     description = "Integrates web hooks."
     resource_links = [
         ('Bug Tracker', 'https://github.com/getsentry/sentry/issues'),
-        ('Source', 'https://github.com/getsentry/sentry'),
+        ('Source', 'https://github.com/getsentry/sentry/tree/master/src/sentry/plugins/sentry_webhooks'),
     ]
 
     slug = 'webhooks'


### PR DESCRIPTION
It took me a while to find the source for this plugin. I think the link shouldn't point to the main repo, but instead point to the actual source code.