### PR TITLE
Clarify error message when using advanced search on mm1 plans

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -118,7 +118,7 @@ def validate_search_filter_permissions(organization, search_filters, user):
                     sender=validate_search_filter_permissions,
                 )
                 raise ValidationError(
-                    u'You need access to the advanced search feature to use {}'.format(
+                    u'The {} feature is available for organizations on the new Developer, Team, and Business plans.'.format(
                         feature_name),
                 )
 


### PR DESCRIPTION
Users don't know what "advanced search" means or how to be able to use it - hopefully this clears things up a bit for mm1 orgs who hit this message. cc @mikellykels 

Before:
<img width="1209" alt="Screenshot 2019-08-01 17 16 11" src="https://user-images.githubusercontent.com/29959063/62335490-d7274780-b480-11e9-8335-eb9687d30bc7.png">
Now:
<img width="1210" alt="Screenshot 2019-08-01 17 16 20" src="https://user-images.githubusercontent.com/29959063/62335496-dbebfb80-b480-11e9-8c54-1b1e8d7da5c1.png">

Before:
<img width="1195" alt="Screenshot 2019-08-01 17 17 37" src="https://user-images.githubusercontent.com/29959063/62335508-ea3a1780-b480-11e9-963c-55ab5c746494.png">
Now:
<img width="1216" alt="Screenshot 2019-08-01 17 18 33" src="https://user-images.githubusercontent.com/29959063/62335512-ec9c7180-b480-11e9-85f8-a9d6908101c9.png">

