### PR TITLE
feat(eventsv2) Remove transactionSlug and groupSlug

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -26,6 +26,11 @@ SPECIAL_FIELDS = {
     'user_count': {
         'aggregations': [['uniq', 'user', 'user_count']],
     },
+    'latest_event': {
+        'fields': [
+            ['argMax', ['id', 'timestamp'], 'latest_event'],
+        ],
+    },
 }
 
 

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -15,7 +15,7 @@ import space from 'app/styles/space';
 
 import {QueryLink} from './styles';
 
-export const MODAL_QUERY_KEYS = ['eventSlug', 'groupSlug', 'transactionSlug'];
+export const MODAL_QUERY_KEYS = ['eventSlug'];
 export const PIN_ICON = `image://${pinIcon}`;
 
 export const ALL_VIEWS = deepFreeze([
@@ -94,14 +94,14 @@ export const ALL_VIEWS = deepFreeze([
  */
 export const SPECIAL_FIELDS = {
   transaction: {
-    fields: ['project.name', 'transaction'],
+    fields: ['project.name', 'transaction', 'latest_event'],
     sortField: 'transaction',
     renderFunc: (data, {organization, location}) => {
       const target = {
         pathname: `/organizations/${organization.slug}/events/`,
         query: {
           ...location.query,
-          transactionSlug: `${data['project.name']}:${data.transaction}:latest`,
+          eventSlug: `${data['project.name']}:${data.latest_event}`,
         },
       };
       return (
@@ -207,14 +207,14 @@ export const SPECIAL_FIELDS = {
     ),
   },
   error: {
-    fields: ['issue_title', 'project.name', 'issue.id'],
+    fields: ['issue_title', 'project.name', 'latest_event'],
     sortField: 'issue_title',
     renderFunc: (data, {organization, location}) => {
       const target = {
         pathname: `/organizations/${organization.slug}/events/`,
         query: {
           ...location.query,
-          groupSlug: `${data['project.name']}:${data['issue.id']}:latest`,
+          eventSlug: `${data['project.name']}:${data.latest_event}`,
         },
       };
       return (
@@ -227,14 +227,14 @@ export const SPECIAL_FIELDS = {
     },
   },
   csp: {
-    fields: ['issue_title', 'project.name', 'issue.id'],
+    fields: ['issue_title', 'project.name', 'latest_event'],
     sortField: 'issue_title',
     renderFunc: (data, {organization, location}) => {
       const target = {
         pathname: `/organizations/${organization.slug}/events/`,
         query: {
           ...location.query,
-          groupSlug: `${data['project.name']}:${data['issue.id']}:latest`,
+          eventSlug: `${data['project.name']}:${data.latest_event}`,
         },
       };
       return (

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
@@ -53,9 +53,8 @@ export default class OrganizationEventsV2 extends React.Component {
 
   render() {
     const {organization, location, router} = this.props;
-    const {eventSlug, groupSlug, transactionSlug} = location.query;
+    const {eventSlug} = location.query;
     const currentView = getCurrentView(location.query.view);
-    const showModal = transactionSlug || groupSlug || eventSlug;
 
     return (
       <DocumentTitle title={`Events - ${organization.slug} - Sentry`}>
@@ -76,13 +75,11 @@ export default class OrganizationEventsV2 extends React.Component {
                 router={router}
               />
             </NoProjectMessage>
-            {showModal && (
+            {eventSlug && (
               <EventDetails
                 organization={organization}
                 params={this.props.params}
                 eventSlug={eventSlug}
-                groupSlug={groupSlug}
-                transactionSlug={transactionSlug}
                 view={currentView}
                 location={location}
               />

--- a/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
@@ -9,7 +9,6 @@ import {ALL_VIEWS} from 'app/views/organizationEventsV2/data';
 describe('OrganizationEventsV2 > EventDetails', function() {
   const allEventsView = ALL_VIEWS.find(view => view.id === 'all');
   const errorsView = ALL_VIEWS.find(view => view.id === 'errors');
-  const transactionView = ALL_VIEWS.find(view => view.id === 'transactions');
 
   beforeEach(function() {
     MockApiClient.addMockResponse({
@@ -153,8 +152,8 @@ describe('OrganizationEventsV2 > EventDetails', function() {
     const wrapper = mount(
       <EventDetails
         organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
-        groupSlug="project-slug:123:latest"
-        location={{query: {groupSlug: 'project-slug:123:latest'}}}
+        eventSlug="project-slug:deadbeef"
+        location={{query: {eventSlug: 'project-slug:deadbeef'}}}
         view={errorsView}
       />,
       TestStubs.routerContext()
@@ -166,54 +165,6 @@ describe('OrganizationEventsV2 > EventDetails', function() {
     expect(graph).toHaveLength(1);
   });
 
-  it('renders pagination buttons in grouped view', function() {
-    const wrapper = mount(
-      <EventDetails
-        organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
-        groupSlug="project-slug:123:latest"
-        location={{query: {groupSlug: 'project-slug:123:latest'}}}
-        view={errorsView}
-      />,
-      TestStubs.routerContext()
-    );
-
-    const content = wrapper.find('ModalPagination');
-    expect(content).toHaveLength(1);
-
-    const prevLink = content.find('StyledLink[data-test-id="older-event"]').first();
-    const target = prevLink.props().to;
-    expect(target.query.groupSlug).toEqual('project-slug:123:beefbeef');
-    expect(target.query.transactionSlug).toBeUndefined();
-    expect(target.query.eventSlug).toBeUndefined();
-
-    const nextLink = content.find('StyledLink[data-test-id="newer-event"]').first();
-    expect(nextLink.props().to).toBeNull();
-  });
-
-  it('renders pagination buttons in transaction view', function() {
-    const wrapper = mount(
-      <EventDetails
-        organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
-        transactionSlug="project-slug:/users/login:latest"
-        location={{query: {transactionSlug: 'project-slug:/users/login:latest'}}}
-        view={transactionView}
-      />,
-      TestStubs.routerContext()
-    );
-
-    const content = wrapper.find('ModalPagination');
-    expect(content).toHaveLength(1);
-
-    const prevLink = content.find('StyledLink[data-test-id="older-event"]').first();
-    const target = prevLink.props().to;
-    expect(target.query.transactionSlug).toEqual('project-slug:/users/login:beefbeef');
-    expect(target.query.groupSlug).toBeUndefined();
-    expect(target.query.eventSlug).toBeUndefined();
-
-    const nextLink = content.find('StyledLink[data-test-id="newer-event"]').first();
-    expect(nextLink.props().to).toBeNull();
-  });
-
   it('removes eventSlug when close button is clicked', function() {
     const wrapper = mount(
       <EventDetails
@@ -222,48 +173,6 @@ describe('OrganizationEventsV2 > EventDetails', function() {
         location={{
           pathname: '/organizations/org-slug/events/',
           query: {eventSlug: 'project-slug:deadbeef'},
-        }}
-        view={allEventsView}
-      />,
-      TestStubs.routerContext()
-    );
-    const button = wrapper.find('DismissButton');
-    button.simulate('click');
-    expect(browserHistory.push).toHaveBeenCalledWith({
-      pathname: '/organizations/org-slug/events/',
-      query: {},
-    });
-  });
-
-  it('removes groupSlug when close button is clicked', function() {
-    const wrapper = mount(
-      <EventDetails
-        organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
-        groupSlug="project-slug:123:latest"
-        location={{
-          pathname: '/organizations/org-slug/events/',
-          query: {groupSlug: 'project-slug:123:latest'},
-        }}
-        view={allEventsView}
-      />,
-      TestStubs.routerContext()
-    );
-    const button = wrapper.find('DismissButton');
-    button.simulate('click');
-    expect(browserHistory.push).toHaveBeenCalledWith({
-      pathname: '/organizations/org-slug/events/',
-      query: {},
-    });
-  });
-
-  it('removes transactionSlug when close button is clicked', function() {
-    const wrapper = mount(
-      <EventDetails
-        organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
-        transactionSlug="project-slug:/users/login:latest"
-        location={{
-          pathname: '/organizations/org-slug/events/',
-          query: {transactionSlug: 'project-slug:/users/login:latest'},
         }}
         view={allEventsView}
       />,

--- a/tests/js/spec/views/organizationEventsV2/index.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/index.spec.jsx
@@ -128,20 +128,4 @@ describe('OrganizationEventsV2', function() {
     const modal = wrapper.find('EventDetails');
     expect(modal).toHaveLength(1);
   });
-
-  it('opens a modal when groupSlug is present', async function() {
-    const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
-    const wrapper = mount(
-      <OrganizationEventsV2
-        organization={organization}
-        params={{orgId: organization.slug}}
-        location={{query: {groupSlug: 'project-slug:123:deadbeef'}}}
-        router={{}}
-      />,
-      TestStubs.routerContext()
-    );
-
-    const modal = wrapper.find('EventDetails');
-    expect(modal).toHaveLength(1);
-  });
 });


### PR DESCRIPTION
The upcoming work to adopt discover style queries means that we can no longer have special slugs. We can also use `argMax()` in snuba to get to the latest event when viewing an aggregated view.

This removes the special slug value handling, and relies entirely on eventSlug. Discover2 will require that all modal states need to be reachable from just the eventSlug and query state.

This change will break pagination in the short term but I'll be working on new endpoints that will allow that behavior to be restored in the short term.

Refs SEN-875