### PR TITLE
chore: Expand event manager logging

### DIFF
--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -323,7 +323,7 @@ class SnubaEventManager:
         event_id = normalize_event_id(id_or_event_id)
         if not event_id:
             logger.warning('Attempt to fetch SnubaEvent by primary key', exc_info=True, extra={
-                'stack': True
+                'event_id': event_id
             })
 
             event = Event.objects.from_event_id(id_or_event_id, project_id)


### PR DESCRIPTION
We are almost at a point where this should always be the UUID now.

Let's log all of the invalid event IDs that are being requested via the
event manager to verify that these values are not actually the autoincrement
ID here before removing this.