### PR TITLE
chore(API): Remove unused parameter in invite user request

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
@@ -147,7 +147,6 @@ class InviteMember extends React.Component {
         method: 'POST',
         data: {
           email,
-          user: email,
           teams: Array.from(selectedTeams.keys()),
           role: selectedRole,
           referrer: this.props.location.query.referrer,


### PR DESCRIPTION
`user` isn't used anywhere in the [corresponding endpoint](https://github.com/getsentry/sentry/blob/5fdb85bd2bfcb76cbbfb7a2aafb4406f8fabce39/src/sentry/api/endpoints/organization_member_index.py#L93).