### PR TITLE
ref(discover) Move discover endpoints into an 'app'

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -112,16 +112,6 @@ class OrganizationAuthProviderPermission(OrganizationPermission):
     }
 
 
-class OrganizationDiscoverSavedQueryPermission(OrganizationPermission):
-    # Relaxed permissions for saved queries in Discover
-    scope_map = {
-        'GET': ['org:read', 'org:write', 'org:admin'],
-        'POST': ['org:read', 'org:write', 'org:admin'],
-        'PUT': ['org:read', 'org:write', 'org:admin'],
-        'DELETE': ['org:read', 'org:write', 'org:admin'],
-    }
-
-
 class OrganizationUserReportsPermission(OrganizationPermission):
     scope_map = {
         'GET': ['project:read', 'project:write', 'project:admin'],

--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import six
 from sentry.api.serializers import Serializer, register
-from sentry.models import DiscoverSavedQuery
+from sentry.discover.models import DiscoverSavedQuery
 
 
 @register(DiscoverSavedQuery)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -81,11 +81,6 @@ from .endpoints.organization_dashboard_widget_details import (
 from .endpoints.organization_dashboard_widgets import OrganizationDashboardWidgetsEndpoint
 from .endpoints.organization_dashboards import OrganizationDashboardsEndpoint
 from .endpoints.organization_details import OrganizationDetailsEndpoint
-from .endpoints.organization_discover_query import OrganizationDiscoverQueryEndpoint
-from .endpoints.organization_discover_saved_queries import OrganizationDiscoverSavedQueriesEndpoint
-from .endpoints.organization_discover_saved_query_detail import (
-    OrganizationDiscoverSavedQueryDetailEndpoint
-)
 from .endpoints.organization_environments import OrganizationEnvironmentsEndpoint
 from .endpoints.organization_event_details import (
     OrganizationEventDetailsEndpoint, OrganizationEventDetailsLatestEndpoint,
@@ -273,6 +268,12 @@ from .endpoints.user_social_identities_index import UserSocialIdentitiesIndexEnd
 from .endpoints.user_social_identity_details import UserSocialIdentityDetailsEndpoint
 from .endpoints.user_subscriptions import UserSubscriptionsEndpoint
 from .endpoints.useravatar import UserAvatarEndpoint
+
+from sentry.discover.endpoints.discover_query import DiscoverQueryEndpoint
+from sentry.discover.endpoints.discover_saved_queries import DiscoverSavedQueriesEndpoint
+from sentry.discover.endpoints.discover_saved_query_detail import (
+    DiscoverSavedQueryDetailEndpoint
+)
 from sentry.incidents.endpoints.project_alert_rule_details import ProjectAlertRuleDetailsEndpoint
 from sentry.incidents.endpoints.project_alert_rule_index import ProjectAlertRuleIndexEndpoint
 
@@ -599,18 +600,18 @@ urlpatterns = patterns(
         # Discover
         url(
             r'^(?P<organization_slug>[^\/]+)/discover/query/$',
-            OrganizationDiscoverQueryEndpoint.as_view(),
-            name='sentry-api-0-organization-discover-query'
+            DiscoverQueryEndpoint.as_view(),
+            name='sentry-api-0-discover-query'
         ),
         url(
             r'^(?P<organization_slug>[^\/]+)/discover/saved/$',
-            OrganizationDiscoverSavedQueriesEndpoint.as_view(),
-            name='sentry-api-0-organization-discover-saved-queries'
+            DiscoverSavedQueriesEndpoint.as_view(),
+            name='sentry-api-0-discover-saved-queries'
         ),
         url(
             r'^(?P<organization_slug>[^\/]+)/discover/saved/(?P<query_id>[^\/]+)/$',
-            OrganizationDiscoverSavedQueryDetailEndpoint.as_view(),
-            name='sentry-api-0-organization-discover-saved-query-detail'
+            DiscoverSavedQueryDetailEndpoint.as_view(),
+            name='sentry-api-0-discover-saved-query-detail'
         ),
         url(
             r'^(?P<organization_slug>[^\/]+)/dashboards/(?P<dashboard_id>[^\/]+)/$',

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -256,7 +256,7 @@ INSTALLED_APPS = (
     'django.contrib.admin', 'django.contrib.auth', 'django.contrib.contenttypes',
     'django.contrib.messages', 'django.contrib.sessions', 'django.contrib.sites',
     'crispy_forms', 'debug_toolbar',
-    'rest_framework', 'sentry', 'sentry.analytics', 'sentry.incidents',
+    'rest_framework', 'sentry', 'sentry.analytics', 'sentry.incidents', 'sentry.discover',
     'sentry.analytics.events', 'sentry.nodestore', 'sentry.search', 'sentry.lang.java',
     'sentry.lang.javascript', 'sentry.lang.native', 'sentry.plugins.sentry_interface_types',
     'sentry.plugins.sentry_mail', 'sentry.plugins.sentry_urls', 'sentry.plugins.sentry_useragents',

--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -41,8 +41,6 @@ def load_defaults():
     default_manager.register(models.CommitAuthor, BulkModelDeletionTask)
     default_manager.register(models.CommitFileChange, BulkModelDeletionTask)
     default_manager.register(models.Dashboard, ModelDeletionTask)
-    default_manager.register(models.DiscoverSavedQuery, BulkModelDeletionTask)
-    default_manager.register(models.DiscoverSavedQueryProject, BulkModelDeletionTask)
     default_manager.register(models.EnvironmentProject, BulkModelDeletionTask)
     default_manager.register(models.Event, defaults.EventDeletionTask)
     default_manager.register(models.EventMapping, BulkModelDeletionTask)

--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -8,9 +8,10 @@ class OrganizationDeletionTask(ModelDeletionTask):
         from sentry.models import (
             OrganizationMember, Commit, CommitAuthor, CommitFileChange, Environment, Release,
             ReleaseCommit, ReleaseEnvironment, ReleaseFile, Distribution, ReleaseHeadCommit,
-            Repository, Team, Project, PullRequest, Dashboard, DiscoverSavedQuery, ExternalIssue, PromptsActivity
+            Repository, Team, Project, PullRequest, Dashboard, ExternalIssue, PromptsActivity
         )
         from sentry.incidents.models import Incident
+        from sentry.discover.models import DiscoverSavedQuery
 
         # Team must come first
         relations = [

--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -7,6 +7,7 @@ class ProjectDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
         from sentry import models
         from sentry.incidents.models import IncidentProject, AlertRule
+        from sentry.discover.models import DiscoverSavedQueryProject
 
         relations = [
             # ProjectKey gets revoked immediately, in bulk
@@ -20,7 +21,7 @@ class ProjectDeletionTask(ModelDeletionTask):
             models.GroupHash, models.GroupRelease, models.GroupRuleStatus, models.GroupSeen,
             models.GroupShare, models.GroupSubscription, models.ProjectBookmark, models.ProjectKey,
             models.ProjectTeam, models.PromptsActivity, models.SavedSearchUserDefault, models.SavedSearch,
-            models.ServiceHook, models.UserReport, models.DiscoverSavedQueryProject, IncidentProject,
+            models.ServiceHook, models.UserReport, DiscoverSavedQueryProject, IncidentProject,
             AlertRule,
 
         )

--- a/src/sentry/discover/__init__.py
+++ b/src/sentry/discover/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import absolute_import
+from . import tasks  # NOQA

--- a/src/sentry/discover/endpoints/__init__.py
+++ b/src/sentry/discover/endpoints/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry/discover/endpoints/bases.py
+++ b/src/sentry/discover/endpoints/bases.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import
+
+from sentry.api.bases.organization import OrganizationPermission
+
+
+class DiscoverSavedQueryPermission(OrganizationPermission):
+    # Relaxed permissions for saved queries in Discover
+    scope_map = {
+        'GET': ['org:read', 'org:write', 'org:admin'],
+        'POST': ['org:read', 'org:write', 'org:admin'],
+        'PUT': ['org:read', 'org:write', 'org:admin'],
+        'DELETE': ['org:read', 'org:write', 'org:admin'],
+    }

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -1,178 +1,29 @@
 from __future__ import absolute_import
 
 import re
-import six
 from functools import partial
 from copy import deepcopy
 
-from rest_framework import serializers
 from rest_framework.response import Response
 
-from sentry.api.serializers.rest_framework import ListField
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.bases import OrganizationEndpoint
-from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.api.utils import get_date_range_from_params, InvalidParams
 from sentry.models import Project, ProjectStatus
 from sentry.utils import snuba
-from sentry.utils.snuba import SENTRY_SNUBA_MAP
 from sentry import features
 
+from .serializers import DiscoverQuerySerializer
 
-class OrganizationDiscoverQueryPermission(OrganizationPermission):
+
+class DiscoverQueryPermission(OrganizationPermission):
     scope_map = {
         'POST': ['org:read', 'project:read'],
     }
 
 
-class DiscoverQuerySerializer(serializers.Serializer):
-    projects = ListField(
-        child=serializers.IntegerField(),
-        required=True,
-        allow_null=False,
-    )
-    start = serializers.CharField(required=False, allow_null=True)
-    end = serializers.CharField(required=False, allow_null=True)
-    range = serializers.CharField(required=False, allow_null=True)
-    statsPeriod = serializers.CharField(required=False, allow_null=True)
-    statsPeriodStart = serializers.CharField(required=False, allow_null=True)
-    statsPeriodEnd = serializers.CharField(required=False, allow_null=True)
-    fields = ListField(
-        child=serializers.CharField(),
-        required=False,
-        default=[],
-    )
-    conditionFields = ListField(
-        child=ListField(),
-        required=False,
-        allow_null=True,
-    )
-    limit = EmptyIntegerField(min_value=0, max_value=10000, required=False, allow_null=True)
-    rollup = EmptyIntegerField(required=False, allow_null=True)
-    orderby = serializers.CharField(required=False, default="", allow_blank=True)
-    conditions = ListField(
-        child=ListField(),
-        required=False,
-        allow_null=True,
-    )
-    aggregations = ListField(
-        child=ListField(),
-        required=False,
-        default=[]
-    )
-    groupby = ListField(
-        child=serializers.CharField(),
-        required=False,
-        allow_null=True,
-    )
-    turbo = serializers.BooleanField(required=False)
-
-    def __init__(self, *args, **kwargs):
-        super(DiscoverQuerySerializer, self).__init__(*args, **kwargs)
-
-        data = kwargs['data']
-
-        fields = data.get('fields') or []
-
-        match = next(
-            (
-                self.get_array_field(field).group(1)
-                for field
-                in fields
-                if self.get_array_field(field) is not None
-            ),
-            None
-        )
-        self.arrayjoin = match if match else None
-
-    def validate(self, data):
-        data['arrayjoin'] = self.arrayjoin
-
-        # prevent conflicting date ranges from being supplied
-        date_fields = ['start', 'statsPeriod', 'range', 'statsPeriodStart']
-        date_fields_provided = len([data.get(f) for f in date_fields if data.get(f) is not None])
-        if date_fields_provided == 0:
-            raise serializers.ValidationError('You must specify a date filter')
-        elif date_fields_provided > 1:
-            raise serializers.ValidationError('Conflicting date filters supplied')
-
-        if not data.get('fields') and not data.get('aggregations'):
-            raise serializers.ValidationError('Specify at least one field or aggregation')
-
-        try:
-            start, end = get_date_range_from_params({
-                'start': data.get('start'),
-                'end': data.get('end'),
-                'statsPeriod': data.get('statsPeriod') or data.get('range'),
-                'statsPeriodStart': data.get('statsPeriodStart'),
-                'statsPeriodEnd': data.get('statsPeriodEnd'),
-            }, optional=True)
-        except InvalidParams as exc:
-            raise serializers.ValidationError(exc.message)
-
-        if start is None or end is None:
-            raise serializers.ValidationError('Either start and end dates or range is required')
-
-        data['start'] = start
-        data['end'] = end
-
-        return data
-
-    def validate_conditions(self, value):
-        # Handle error (exception_stacks), stack(exception_frames)
-        return [self.get_condition(condition) for condition in value]
-
-    def validate_aggregations(self, value):
-        valid_functions = set(['count()', 'uniq', 'avg'])
-        requested_functions = set(agg[0] for agg in value)
-
-        if not requested_functions.issubset(valid_functions):
-            invalid_functions = ', '.join((requested_functions - valid_functions))
-
-            raise serializers.ValidationError(
-                u'Invalid aggregate function - {}'.format(invalid_functions)
-            )
-
-        return value
-
-    def get_array_field(self, field):
-        pattern = r"^(error|stack)\..+"
-        term = re.search(pattern, field)
-        if term and SENTRY_SNUBA_MAP.get(field):
-            return term
-        return None
-
-    def get_condition(self, condition):
-        array_field = self.get_array_field(condition[0])
-        has_equality_operator = condition[1] in ('=', '!=')
-
-        # Cast boolean values to 1 / 0
-        if isinstance(condition[2], bool):
-            condition[2] = int(condition[2])
-
-        # Strip double quotes on strings
-        if isinstance(condition[2], six.string_types):
-            match = re.search(r'^"(.*)"$', condition[2])
-            if match:
-                condition[2] = match.group(1)
-
-        # Apply has function to any array field if it's = / != and not part of arrayjoin
-        if array_field and has_equality_operator and (array_field.group(1) != self.arrayjoin):
-            value = condition[2]
-
-            if (isinstance(value, six.string_types)):
-                value = u"'{}'".format(value)
-
-            bool_value = 1 if condition[1] == '=' else 0
-
-            return [['has', [array_field.group(0), value]], '=', bool_value]
-
-        return condition
-
-
-class OrganizationDiscoverQueryEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationDiscoverQueryPermission, )
+class DiscoverQueryEndpoint(OrganizationEndpoint):
+    permission_classes = (DiscoverQueryPermission, )
 
     def get_json_type(self, snuba_type):
         """

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -3,15 +3,15 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 
 from sentry.api.serializers import serialize
-from sentry.api.bases.organization import OrganizationDiscoverSavedQueryPermission
 from sentry.api.bases.discoversavedquery import DiscoverSavedQuerySerializer
 from sentry.api.bases import OrganizationEndpoint
-from sentry.models import DiscoverSavedQuery
+from sentry.discover.models import DiscoverSavedQuery
 from sentry import features
+from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 
 
-class OrganizationDiscoverSavedQueriesEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationDiscoverSavedQueryPermission, )
+class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
+    permission_classes = (DiscoverSavedQueryPermission, )
 
     def get(self, request, organization):
         """

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -3,15 +3,15 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 from sentry.api.serializers import serialize
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.bases.organization import OrganizationDiscoverSavedQueryPermission
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.discoversavedquery import DiscoverSavedQuerySerializer
 from sentry import features
-from sentry.models import DiscoverSavedQuery
+from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
+from sentry.discover.models import DiscoverSavedQuery
 
 
-class OrganizationDiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationDiscoverSavedQueryPermission, )
+class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
+    permission_classes = (DiscoverSavedQueryPermission, )
 
     def get(self, request, organization, query_id):
         """

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -1,0 +1,155 @@
+from __future__ import absolute_import
+
+import six
+import re
+from rest_framework import serializers
+
+from sentry.api.fields.empty_integer import EmptyIntegerField
+from sentry.api.serializers.rest_framework import ListField
+from sentry.api.utils import get_date_range_from_params, InvalidParams
+from sentry.utils.snuba import SENTRY_SNUBA_MAP
+
+
+class DiscoverQuerySerializer(serializers.Serializer):
+    projects = ListField(
+        child=serializers.IntegerField(),
+        required=True,
+        allow_null=False,
+    )
+    start = serializers.CharField(required=False, allow_null=True)
+    end = serializers.CharField(required=False, allow_null=True)
+    range = serializers.CharField(required=False, allow_null=True)
+    statsPeriod = serializers.CharField(required=False, allow_null=True)
+    statsPeriodStart = serializers.CharField(required=False, allow_null=True)
+    statsPeriodEnd = serializers.CharField(required=False, allow_null=True)
+    fields = ListField(
+        child=serializers.CharField(),
+        required=False,
+        default=[],
+    )
+    conditionFields = ListField(
+        child=ListField(),
+        required=False,
+        allow_null=True,
+    )
+    limit = EmptyIntegerField(min_value=0, max_value=10000, required=False, allow_null=True)
+    rollup = EmptyIntegerField(required=False, allow_null=True)
+    orderby = serializers.CharField(required=False, default="", allow_blank=True)
+    conditions = ListField(
+        child=ListField(),
+        required=False,
+        allow_null=True,
+    )
+    aggregations = ListField(
+        child=ListField(),
+        required=False,
+        default=[]
+    )
+    groupby = ListField(
+        child=serializers.CharField(),
+        required=False,
+        allow_null=True,
+    )
+    turbo = serializers.BooleanField(required=False)
+
+    def __init__(self, *args, **kwargs):
+        super(DiscoverQuerySerializer, self).__init__(*args, **kwargs)
+
+        data = kwargs['data']
+
+        fields = data.get('fields') or []
+
+        match = next(
+            (
+                self.get_array_field(field).group(1)
+                for field
+                in fields
+                if self.get_array_field(field) is not None
+            ),
+            None
+        )
+        self.arrayjoin = match if match else None
+
+    def validate(self, data):
+        data['arrayjoin'] = self.arrayjoin
+
+        # prevent conflicting date ranges from being supplied
+        date_fields = ['start', 'statsPeriod', 'range', 'statsPeriodStart']
+        date_fields_provided = len([data.get(f) for f in date_fields if data.get(f) is not None])
+        if date_fields_provided == 0:
+            raise serializers.ValidationError('You must specify a date filter')
+        elif date_fields_provided > 1:
+            raise serializers.ValidationError('Conflicting date filters supplied')
+
+        if not data.get('fields') and not data.get('aggregations'):
+            raise serializers.ValidationError('Specify at least one field or aggregation')
+
+        try:
+            start, end = get_date_range_from_params({
+                'start': data.get('start'),
+                'end': data.get('end'),
+                'statsPeriod': data.get('statsPeriod') or data.get('range'),
+                'statsPeriodStart': data.get('statsPeriodStart'),
+                'statsPeriodEnd': data.get('statsPeriodEnd'),
+            }, optional=True)
+        except InvalidParams as exc:
+            raise serializers.ValidationError(exc.message)
+
+        if start is None or end is None:
+            raise serializers.ValidationError('Either start and end dates or range is required')
+
+        data['start'] = start
+        data['end'] = end
+
+        return data
+
+    def validate_conditions(self, value):
+        # Handle error (exception_stacks), stack(exception_frames)
+        return [self.get_condition(condition) for condition in value]
+
+    def validate_aggregations(self, value):
+        valid_functions = set(['count()', 'uniq', 'avg'])
+        requested_functions = set(agg[0] for agg in value)
+
+        if not requested_functions.issubset(valid_functions):
+            invalid_functions = ', '.join((requested_functions - valid_functions))
+
+            raise serializers.ValidationError(
+                u'Invalid aggregate function - {}'.format(invalid_functions)
+            )
+
+        return value
+
+    def get_array_field(self, field):
+        pattern = r"^(error|stack)\..+"
+        term = re.search(pattern, field)
+        if term and SENTRY_SNUBA_MAP.get(field):
+            return term
+        return None
+
+    def get_condition(self, condition):
+        array_field = self.get_array_field(condition[0])
+        has_equality_operator = condition[1] in ('=', '!=')
+
+        # Cast boolean values to 1 / 0
+        if isinstance(condition[2], bool):
+            condition[2] = int(condition[2])
+
+        # Strip double quotes on strings
+        if isinstance(condition[2], six.string_types):
+            match = re.search(r'^"(.*)"$', condition[2])
+            if match:
+                condition[2] = match.group(1)
+
+        # Apply has function to any array field if it's = / != and not part of arrayjoin
+        if array_field and has_equality_operator and (array_field.group(1) != self.arrayjoin):
+            value = condition[2]
+
+            if (isinstance(value, six.string_types)):
+                value = u"'{}'".format(value)
+
+            bool_value = 1 if condition[1] == '=' else 0
+
+            return [['has', [array_field.group(0), value]], '=', bool_value]
+
+        return condition

--- a/src/sentry/discover/models.py
+++ b/src/sentry/discover/models.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 from django.db import models, transaction
 from sentry.db.models.fields import JSONField
 from sentry.db.models import (

--- a/src/sentry/discover/tasks.py
+++ b/src/sentry/discover/tasks.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+from sentry import deletions
+
+from . import models
+
+deletions.default_manager.register(
+    models.DiscoverSavedQuery,
+    deletions.BulkModelDeletionTask)
+deletions.default_manager.register(
+    models.DiscoverSavedQueryProject,
+    deletions.BulkModelDeletionTask)

--- a/tests/sentry/discover/__init__.py
+++ b/tests/sentry/discover/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/discover/test_models.py
+++ b/tests/sentry/discover/test_models.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from sentry.testutils import TestCase
-from sentry.models import DiscoverSavedQuery, DiscoverSavedQueryProject
+from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryProject
 
 
 class DiscoverSavedQueryTest(TestCase):

--- a/tests/snuba/api/endpoints/test_discover_query.py
+++ b/tests/snuba/api/endpoints/test_discover_query.py
@@ -6,9 +6,9 @@ from sentry.testutils import APITestCase, SnubaTestCase
 from django.core.urlresolvers import reverse
 
 
-class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
+class DiscoverQueryTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationDiscoverQueryTest, self).setUp()
+        super(DiscoverQueryTest, self).setUp()
 
         self.now = datetime.now()
         one_second_ago = self.now - timedelta(seconds=1)
@@ -61,7 +61,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'platform.name'],
@@ -78,7 +78,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_relative_dates(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'platform.name'],
@@ -95,7 +95,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_invalid_date_request(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'platform'],
@@ -108,7 +108,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400, response.content
 
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'platform'],
@@ -142,7 +142,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
                 },
             )
 
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'aggregations': [['count()', None, 'count']],
@@ -188,7 +188,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_invalid_range_value(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'platform'],
@@ -202,7 +202,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_invalid_aggregation_function(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'platform'],
@@ -217,7 +217,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_boolean_condition(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'platform.name', 'stack.in_app'],
@@ -235,7 +235,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_strip_double_quotes_in_condition_strings(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message'],
@@ -250,7 +250,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_array_join(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['message', 'error.type'],
@@ -265,7 +265,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_array_condition_equals(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'conditions': [['error.type', '=', 'ValidationError']],
@@ -280,7 +280,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_array_condition_not_equals(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'conditions': [['error.type', '!=', 'ValidationError']],
@@ -296,7 +296,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_array_condition_custom_tag(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'conditions': [['error.custom', '!=', 'custom']],
@@ -312,7 +312,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_select_project_name(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['project.name'],
@@ -327,7 +327,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_groupby_project_name(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'aggregations': [['count()', '', 'count']],
@@ -344,7 +344,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_zerofilled_dates_when_rollup_relative(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'aggregations': [['count()', '', 'count']],
@@ -364,7 +364,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_zerofilled_dates_when_rollup_absolute(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'aggregations': [['count()', '', 'count']],
@@ -385,7 +385,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_uniq_project_name(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'aggregations': [['uniq', 'project.name', 'uniq_project_name']],
@@ -400,7 +400,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_meta_types(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.project.id],
                 'fields': ['project.id', 'project.name'],
@@ -418,7 +418,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
         ]
 
     def test_no_feature_access(self):
-        url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+        url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
         response = self.client.post(url, {
             'projects': [self.project.id],
             'fields': ['message', 'platform'],
@@ -432,7 +432,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
 
     def test_invalid_project(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.org.slug])
             response = self.client.post(url, {
                 'projects': [self.other_project.id],
                 'fields': ['message', 'platform'],
@@ -453,7 +453,7 @@ class OrganizationDiscoverQueryTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user, superuser=True)
 
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-query', args=[self.new_org.slug])
+            url = reverse('sentry-api-0-discover-query', args=[self.new_org.slug])
             response = self.client.post(url, {
                 'projects': [self.new_project.id],
                 'fields': ['message', 'platform'],

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -3,12 +3,12 @@ from __future__ import absolute_import
 from sentry.testutils import APITestCase, SnubaTestCase
 from django.core.urlresolvers import reverse
 
-from sentry.models import DiscoverSavedQuery
+from sentry.discover.models import DiscoverSavedQuery
 
 
-class OrganizationDiscoverSavedQueriesTest(APITestCase, SnubaTestCase):
+class DiscoverSavedQueriesTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationDiscoverSavedQueriesTest, self).setUp()
+        super(DiscoverSavedQueriesTest, self).setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
         self.project_ids = [
@@ -31,7 +31,7 @@ class OrganizationDiscoverSavedQueriesTest(APITestCase, SnubaTestCase):
 
     def test_get(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-saved-queries', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-saved-queries', args=[self.org.slug])
             response = self.client.get(url)
 
         assert response.status_code == 200, response.content
@@ -44,7 +44,7 @@ class OrganizationDiscoverSavedQueriesTest(APITestCase, SnubaTestCase):
 
     def test_post(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-saved-queries', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-saved-queries', args=[self.org.slug])
             response = self.client.post(url, {
                 'name': 'New query',
                 'projects': self.project_ids,
@@ -65,7 +65,7 @@ class OrganizationDiscoverSavedQueriesTest(APITestCase, SnubaTestCase):
 
     def test_post_invalid_projects(self):
         with self.feature('organizations:discover'):
-            url = reverse('sentry-api-0-organization-discover-saved-queries', args=[self.org.slug])
+            url = reverse('sentry-api-0-discover-saved-queries', args=[self.org.slug])
             response = self.client.post(url, {
                 'name': 'New query',
                 'projects': self.project_ids_without_access,

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -4,12 +4,12 @@ import six
 from sentry.testutils import APITestCase, SnubaTestCase
 from django.core.urlresolvers import reverse
 
-from sentry.models import DiscoverSavedQuery, DiscoverSavedQueryProject
+from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryProject
 
 
-class OrganizationDiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
+class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationDiscoverSavedQueryDetailTest, self).setUp()
+        super(DiscoverSavedQueryDetailTest, self).setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
         self.org_without_access = self.create_organization()
@@ -40,7 +40,7 @@ class OrganizationDiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
     def test_get(self):
         with self.feature('organizations:discover'):
             url = reverse(
-                'sentry-api-0-organization-discover-saved-query-detail',
+                'sentry-api-0-discover-saved-query-detail',
                 args=[
                     self.org.slug,
                     self.query_id])
@@ -56,7 +56,7 @@ class OrganizationDiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
     def test_get_org_without_access(self):
         with self.feature('organizations:discover'):
             url = reverse(
-                'sentry-api-0-organization-discover-saved-query-detail',
+                'sentry-api-0-discover-saved-query-detail',
                 args=[
                     self.org_without_access.slug,
                     self.query_id])
@@ -67,7 +67,7 @@ class OrganizationDiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
     def test_put(self):
         with self.feature('organizations:discover'):
             url = reverse(
-                'sentry-api-0-organization-discover-saved-query-detail',
+                'sentry-api-0-discover-saved-query-detail',
                 args=[
                     self.org.slug,
                     self.query_id])
@@ -93,7 +93,7 @@ class OrganizationDiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
     def test_put_query_without_access(self):
         with self.feature('organizations:discover'):
             url = reverse(
-                'sentry-api-0-organization-discover-saved-query-detail',
+                'sentry-api-0-discover-saved-query-detail',
                 args=[
                     self.org.slug,
                     self.query_id_without_access])
@@ -109,7 +109,7 @@ class OrganizationDiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
     def test_put_org_without_access(self):
         with self.feature('organizations:discover'):
             url = reverse(
-                'sentry-api-0-organization-discover-saved-query-detail',
+                'sentry-api-0-discover-saved-query-detail',
                 args=[
                     self.org_without_access.slug,
                     self.query_id])
@@ -124,7 +124,7 @@ class OrganizationDiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
     def test_delete(self):
         with self.feature('organizations:discover'):
             url = reverse(
-                'sentry-api-0-organization-discover-saved-query-detail',
+                'sentry-api-0-discover-saved-query-detail',
                 args=[
                     self.org.slug,
                     self.query_id])
@@ -138,7 +138,7 @@ class OrganizationDiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
     def test_delete_removes_projects(self):
         with self.feature('organizations:discover'):
             url = reverse(
-                'sentry-api-0-organization-discover-saved-query-detail',
+                'sentry-api-0-discover-saved-query-detail',
                 args=[
                     self.org.slug,
                     self.query_id])
@@ -154,7 +154,7 @@ class OrganizationDiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
     def test_delete_query_without_access(self):
         with self.feature('organizations:discover'):
             url = reverse(
-                'sentry-api-0-organization-discover-saved-query-detail',
+                'sentry-api-0-discover-saved-query-detail',
                 args=[
                     self.org.slug,
                     self.query_id_without_access])
@@ -166,7 +166,7 @@ class OrganizationDiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
     def test_delete_org_without_access(self):
         with self.feature('organizations:discover'):
             url = reverse(
-                'sentry-api-0-organization-discover-saved-query-detail',
+                'sentry-api-0-discover-saved-query-detail',
                 args=[
                     self.org_without_access.slug,
                     self.query_id])


### PR DESCRIPTION
Move discover code into a django app like incidents is. This should help keep the various bits of discover closer together as it is going to grow a bit in the upcoming weeks.

Refs SEN-810