### PR TITLE
feat(api): Call snuba subscriptions endpoint to create alert rule subscriptions (SEN-827)

### DIFF
--- a/tests/sentry/net/test_socket.py
+++ b/tests/sentry/net/test_socket.py
@@ -17,8 +17,11 @@ from sentry.net.socket import (
 class SocketTest(TestCase):
     @override_blacklist('10.0.0.0/8', '127.0.0.1')
     def test_is_ipaddress_allowed(self):
+        is_ipaddress_allowed.cache_clear()
         assert is_ipaddress_allowed('127.0.0.1') is False
+        is_ipaddress_allowed.cache_clear()
         assert is_ipaddress_allowed('10.0.1.1') is False
+        is_ipaddress_allowed.cache_clear()
         assert is_ipaddress_allowed('1.1.1.1') is True
 
     @override_blacklist('10.0.0.0/8', '127.0.0.1')


### PR DESCRIPTION
This implements `create_snuba_subscription` to call snuba and use the subscription id provided.

An example payload looks like 
```
{
    'time_window': 10, 
    'aggregates': [('count()', '', 'count')],
    'dataset': 'events', 
    'conditions': [['email', '=', 'dfuller@sentry.io']],
    'project_id': 2,
    'resolution': 1,
}
```