### PR TITLE
meta(readme): Update product screenshots in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,9 @@ language, in any application.
 .. raw:: html
 
    <p align="center">
-     <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-1.png" height="180" width="290">
-     <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-2.png" height="180" width="290">
-     <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-3.png" height="180" width="290">
+     <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-1.png" width="290">
+     <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-2.png" width="290">
+     <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-3.png" width="290">
    </p>
 
 Official Sentry SDKs

--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,9 @@ language, in any application.
 .. raw:: html
 
    <p align="center">
-     <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-1.png" height="180">
-     <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-2.png" height="180">
-     <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-3.png" height="180">
+     <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-1.png" height="180" width="290">
+     <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-2.png" height="180" width="290">
+     <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-3.png" height="180" width="290">
    </p>
 
 Official Sentry SDKs


### PR DESCRIPTION
Make them fit in one row when at max width

Before:
![image](https://user-images.githubusercontent.com/79684/62484400-f834b480-b76e-11e9-839d-b897d8d84ca0.png)

After:
![image](https://user-images.githubusercontent.com/79684/62484438-0682d080-b76f-11e9-9a62-0327806bc1ab.png)

