### PR TITLE
test: Do not pass `enable_snuba` to project event details

### DIFF
--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -54,9 +54,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
                 'organization_slug': self.cur_event.project.organization.slug,
             }
         )
-        response = self.client.get(url, format='json', data={
-            'enable_snuba': '1',
-        })
+        response = self.client.get(url, format='json')
 
         assert response.status_code == 200, response.content
         assert response.data['id'] == six.text_type(self.cur_event.event_id)
@@ -73,9 +71,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
                 'organization_slug': self.cur_event.project.organization.slug,
             }
         )
-        response = self.client.get(url, format='json', data={
-            'enable_snuba': '1',
-        })
+        response = self.client.get(url, format='json')
 
         assert response.status_code == 200, response.content
         assert response.data['id'] == six.text_type(self.cur_event.event_id)
@@ -92,9 +88,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
                 'organization_slug': self.prev_event.project.organization.slug,
             }
         )
-        response = self.client.get(url, format='json', data={
-            'enable_snuba': '1'
-        })
+        response = self.client.get(url, format='json')
 
         assert response.status_code == 200, response.content
         assert response.data['id'] == six.text_type(self.prev_event.event_id)
@@ -112,7 +106,6 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
             }
         )
         response = self.client.get(url, format='json', data={
-            'enable_snuba': '1',
             'environment': ['production', 'staging']
         })
 


### PR DESCRIPTION
Snuba is enabled by default now, the temporary `enable_snuba` URL
parameter that was used as a switch has been removed.