### PR TITLE
ref: Use defaults for start and end times to Snuba

### DIFF
--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
-from django.utils import timezone
 from functools import partial
 
 from sentry.api.base import DocSection
@@ -48,12 +46,9 @@ class ProjectEventsEndpoint(ProjectEndpoint):
 
         full = request.GET.get('full', False)
         snuba_cols = SnubaEvent.minimal_columns if full else SnubaEvent.selected_columns
-        now = timezone.now()
         data_fn = partial(
             # extract 'data' from raw_query result
             lambda *args, **kwargs: raw_query(*args, **kwargs)['data'],
-            start=now - timedelta(days=90),
-            end=now,
             conditions=conditions,
             filter_keys={'project_id': [project.id]},
             selected_columns=snuba_cols,

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -6,7 +6,6 @@ import warnings
 import pytz
 
 from collections import OrderedDict
-from datetime import datetime
 from dateutil.parser import parse as parse_date
 from django.db import models
 from django.utils import timezone
@@ -465,8 +464,6 @@ class SnubaEvent(EventCommon):
     def get_event(cls, project_id, event_id, snuba_cols=selected_columns):
         from sentry.utils import snuba
         result = snuba.raw_query(
-            start=datetime.utcfromtimestamp(0),  # will be clamped to project retention
-            end=datetime.utcnow(),  # will be clamped to project retention
             selected_columns=snuba_cols,
             filter_keys={
                 'event_id': [event_id],
@@ -627,7 +624,6 @@ class SnubaEvent(EventCommon):
 
         result = snuba.raw_query(
             start=self.datetime,  # gte current event
-            end=datetime.utcnow(),  # will be clamped to project retention
             selected_columns=['event_id'],
             conditions=conditions,
             filter_keys={
@@ -656,7 +652,6 @@ class SnubaEvent(EventCommon):
             conditions.append(['environment', 'IN', environments])
 
         result = snuba.raw_query(
-            start=datetime.utcfromtimestamp(0),  # will be clamped to project retention
             end=self.datetime,  # lte current event
             selected_columns=['event_id'],
             conditions=conditions,

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -7,7 +7,7 @@ import warnings
 from collections import namedtuple
 from enum import Enum
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
@@ -135,8 +135,6 @@ def get_oldest_or_latest_event_for_environments(
         conditions.append(['environment', 'IN', environments])
 
     result = snuba.raw_query(
-        start=datetime.utcfromtimestamp(0),
-        end=datetime.utcnow(),
         selected_columns=SnubaEvent.selected_columns,
         conditions=conditions,
         filter_keys={
@@ -213,8 +211,6 @@ class GroupManager(BaseManager):
         from sentry.utils import snuba
 
         data = snuba.raw_query(
-            start=datetime.utcfromtimestamp(0),
-            end=datetime.utcnow(),
             selected_columns=['issue'],
             conditions=[['issue', 'IS NOT NULL', None]],
             filter_keys={

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -2,9 +2,7 @@ from __future__ import absolute_import
 
 import functools
 from collections import defaultdict, Iterable
-from datetime import timedelta
 from dateutil.parser import parse as parse_datetime
-from django.utils import timezone
 import six
 
 from sentry.tagstore import TagKeyStatus
@@ -55,17 +53,7 @@ class SnubaTagStorage(TagStorage):
         'user',
     ])
 
-    def get_time_range(self, days=90):
-        """
-        Returns the default (start, end) time range for querrying snuba.
-        The snuba util may further reduce this range based on the project
-        retention, and first/last seen dates of the groups being queried.
-        """
-        end = timezone.now()
-        return (end - timedelta(days=days), end)
-
     def __get_tag_key(self, project_id, group_id, environment_id, key):
-        start, end = self.get_time_range()
         tag = u'tags[{}]'.format(key)
         filters = {
             'project_id': get_project_list(project_id),
@@ -80,7 +68,7 @@ class SnubaTagStorage(TagStorage):
             ['count()', '', 'count']
         ]
 
-        result = snuba.query(start, end, [], conditions, filters, aggregations,
+        result = snuba.query(conditions=conditions, filter_keys=filters, aggregations=aggregations,
                              referrer='tagstore.__get_tag_key')
         if result is None or result['count'] == 0:
             raise TagKeyNotFound if group_id is None else GroupTagKeyNotFound
@@ -97,10 +85,6 @@ class SnubaTagStorage(TagStorage):
 
     def __get_tag_key_and_top_values(self, project_id, group_id, environment_id,
                                      key, limit=3, raise_on_empty=True, **kwargs):
-
-        default_start, default_end = self.get_time_range()
-        start = kwargs.get('start', default_start)
-        end = kwargs.get('end', default_end)
 
         tag = u'tags[{}]'.format(key)
         filters = {
@@ -122,7 +106,7 @@ class SnubaTagStorage(TagStorage):
         ]
 
         result, totals = snuba.query(
-            start, end, [tag], conditions, filters, aggregations,
+            kwargs.get('start'), kwargs.get('end'), [tag], conditions, filters, aggregations,
             orderby='-count', limit=limit, totals=True,
             referrer='tagstore.__get_tag_key_and_top_values'
         )
@@ -158,16 +142,12 @@ class SnubaTagStorage(TagStorage):
         self, project_id, group_id, environment_ids, limit=1000, keys=None,
         include_values_seen=True, **kwargs
     ):
-        default_start, default_end = self.get_time_range()
-        start = kwargs.get('start', default_start)
-        end = kwargs.get('end', default_end)
-
         return self.__get_tag_keys_for_projects(
             get_project_list(project_id),
             group_id,
             environment_ids,
-            start,
-            end,
+            kwargs.get('start'),
+            kwargs.get('end'),
             limit,
             keys,
             include_values_seen=include_values_seen,
@@ -220,7 +200,6 @@ class SnubaTagStorage(TagStorage):
         return results
 
     def __get_tag_value(self, project_id, group_id, environment_id, key, value):
-        start, end = self.get_time_range()
         tag = u'tags[{}]'.format(key)
         filters = {
             'project_id': get_project_list(project_id),
@@ -236,7 +215,7 @@ class SnubaTagStorage(TagStorage):
             ['max', SEEN_COLUMN, 'last_seen'],
         ]
 
-        data = snuba.query(start, end, [], conditions, filters, aggregations,
+        data = snuba.query(conditions=conditions, filter_keys=filters, aggregations=aggregations,
                            referrer='tagstore.__get_tag_value')
         if not data['times_seen'] > 0:
             raise TagValueNotFound if group_id is None else GroupTagValueNotFound
@@ -309,7 +288,6 @@ class SnubaTagStorage(TagStorage):
         return set(key.top_values)
 
     def get_group_list_tag_value(self, project_ids, group_id_list, environment_ids, key, value):
-        start, end = self.get_time_range()
         tag = u'tags[{}]'.format(key)
         filters = {
             'project_id': project_ids,
@@ -326,7 +304,7 @@ class SnubaTagStorage(TagStorage):
             ['max', SEEN_COLUMN, 'last_seen'],
         ]
 
-        result = snuba.query(start, end, ['issue'], conditions, filters, aggregations,
+        result = snuba.query(groupby=['issue'], conditions=conditions, filter_keys=filters, aggregations=aggregations,
                              referrer='tagstore.get_group_list_tag_value')
 
         return {
@@ -341,8 +319,6 @@ class SnubaTagStorage(TagStorage):
     def get_group_seen_values_for_environments(self, project_ids, group_id_list, environment_ids,
                                                start=None, end=None):
         # Get the total times seen, first seen, and last seen across multiple environments
-        if start is None or end is None:
-            start, end = self.get_time_range()
         filters = {
             'project_id': project_ids,
             'issue': group_id_list,
@@ -365,7 +341,6 @@ class SnubaTagStorage(TagStorage):
         }
 
     def get_group_tag_value_count(self, project_id, group_id, environment_id, key):
-        start, end = self.get_time_range()
         tag = u'tags[{}]'.format(key)
         filters = {
             'project_id': get_project_list(project_id),
@@ -376,7 +351,7 @@ class SnubaTagStorage(TagStorage):
         conditions = [[tag, '!=', '']]
         aggregations = [['count()', '', 'count']]
 
-        return snuba.query(start, end, [], conditions, filters, aggregations,
+        return snuba.query(conditions=conditions, filter_keys=filters, aggregations=aggregations,
                            referrer='tagstore.get_group_tag_value_count')
 
     def get_top_group_tag_values(self, project_id, group_id,
@@ -391,13 +366,9 @@ class SnubaTagStorage(TagStorage):
         # for all the keys provided. value_limit in this case means the number
         # of top values for each key, so the total rows returned should be
         # num_keys * limit.
-        default_start, default_end = self.get_time_range()
-        start = kwargs.get('start', default_start)
-        end = kwargs.get('end', default_end)
 
         # First get totals and unique counts by key.
-        keys_with_counts = self.get_group_tag_keys(
-            project_id, group_id, environment_ids, keys=keys, start=start, end=end)
+        keys_with_counts = self.get_group_tag_keys(project_id, group_id, environment_ids, keys=keys)
 
         # Then get the top values with first_seen/last_seen/count for each
         filters = {
@@ -420,7 +391,8 @@ class SnubaTagStorage(TagStorage):
             conditions.append(['tags_key', 'NOT IN', self.EXCLUDE_TAG_KEYS])
 
         values_by_key = snuba.query(
-            start, end, ['tags_key', 'tags_value'], conditions, filters, aggregations,
+            kwargs.get('start'), kwargs.get('end'), [
+                'tags_key', 'tags_value'], conditions, filters, aggregations,
             orderby='-count', limitby=[value_limit, 'tags_key'],
             referrer='tagstore.__get_tag_keys_and_top_values'
         )
@@ -447,7 +419,6 @@ class SnubaTagStorage(TagStorage):
         return keys_with_counts
 
     def __get_release(self, project_id, group_id, first=True):
-        start, end = self.get_time_range()
         filters = {
             'project_id': get_project_list(project_id),
         }
@@ -457,9 +428,15 @@ class SnubaTagStorage(TagStorage):
         aggregations = [['min' if first else 'max', SEEN_COLUMN, 'seen']]
         orderby = 'seen' if first else '-seen'
 
-        result = snuba.query(start, end, ['tags[sentry:release]'], conditions, filters,
-                             aggregations, limit=1, orderby=orderby,
-                             referrer='tagstore.__get_release')
+        result = snuba.query(
+            groupby=['tags[sentry:release]'],
+            conditions=conditions,
+            filter_keys=filters,
+            aggregations=aggregations,
+            limit=1,
+            orderby=orderby,
+            referrer='tagstore.__get_release'
+        )
         if not result:
             return None
         else:
@@ -472,7 +449,6 @@ class SnubaTagStorage(TagStorage):
         return self.__get_release(project_id, group_id, False)
 
     def get_release_tags(self, project_ids, environment_id, versions):
-        start, end = self.get_time_range()
         filters = {
             'project_id': project_ids,
         }
@@ -490,8 +466,8 @@ class SnubaTagStorage(TagStorage):
             ['max', SEEN_COLUMN, 'last_seen'],
         ]
 
-        result = snuba.query(start, end, ['project_id', col],
-                             conditions, filters, aggregations,
+        result = snuba.query(groupby=['project_id', col],
+                             conditions=conditions, filter_keys=filters, aggregations=aggregations,
                              referrer='tagstore.get_release_tags')
 
         values = []
@@ -508,7 +484,6 @@ class SnubaTagStorage(TagStorage):
         return set(values)
 
     def get_group_ids_for_users(self, project_ids, event_users, limit=100):
-        start, end = self.get_time_range()
         filters = {
             'project_id': project_ids,
         }
@@ -517,13 +492,12 @@ class SnubaTagStorage(TagStorage):
         ]
         aggregations = [['max', SEEN_COLUMN, 'last_seen']]
 
-        result = snuba.query(start, end, ['issue'], conditions, filters,
-                             aggregations, limit=limit, orderby='-last_seen',
+        result = snuba.query(groupby=['issue'], conditions=conditions, filter_keys=filters,
+                             aggregations=aggregations, limit=limit, orderby='-last_seen',
                              referrer='tagstore.get_group_ids_for_users')
         return set(result.keys())
 
     def get_group_tag_values_for_users(self, event_users, limit=100):
-        start, end = self.get_time_range()
         filters = {
             'project_id': [eu.project_id for eu in event_users]
         }
@@ -536,8 +510,8 @@ class SnubaTagStorage(TagStorage):
             ['max', SEEN_COLUMN, 'last_seen'],
         ]
 
-        result = snuba.query(start, end, ['issue', 'user_id'], conditions, filters,
-                             aggregations, orderby='-last_seen', limit=limit,
+        result = snuba.query(groupby=['issue', 'user_id'], conditions=conditions, filter_keys=filters,
+                             aggregations=aggregations, orderby='-last_seen', limit=limit,
                              referrer='tagstore.get_group_tag_values_for_users')
 
         values = []
@@ -554,8 +528,6 @@ class SnubaTagStorage(TagStorage):
         return values
 
     def get_groups_user_counts(self, project_ids, group_ids, environment_ids, start=None, end=None):
-        if start is None or end is None:
-            start, end = self.get_time_range()
         filters = {
             'project_id': project_ids,
             'issue': group_ids,
@@ -570,18 +542,15 @@ class SnubaTagStorage(TagStorage):
 
     def get_tag_value_paginator(self, project_id, environment_id, key, query=None,
                                 order_by='-last_seen'):
-        start, end = self.get_time_range()
         return self.get_tag_value_paginator_for_projects(
             get_project_list(project_id),
             [environment_id] if environment_id else None,
             key,
-            start,
-            end,
             query=query,
             order_by=order_by,
         )
 
-    def get_tag_value_paginator_for_projects(self, projects, environments, key, start, end,
+    def get_tag_value_paginator_for_projects(self, projects, environments, key, start=None, end=None,
                                              query=None, order_by='-last_seen'):
         from sentry.api.paginator import SequencePaginator
 
@@ -640,7 +609,6 @@ class SnubaTagStorage(TagStorage):
         )
 
     def get_group_tag_value_iter(self, project_id, group_id, environment_id, key, callbacks=()):
-        start, end = self.get_time_range()
         filters = {
             'project_id': get_project_list(project_id),
             'tags_key': [key],
@@ -649,8 +617,6 @@ class SnubaTagStorage(TagStorage):
         if environment_id:
             filters['environment'] = [environment_id]
         results = snuba.query(
-            start=start,
-            end=end,
             groupby=['tags_value'],
             filter_keys=filters,
             aggregations=[
@@ -708,10 +674,6 @@ class SnubaTagStorage(TagStorage):
         raise NotImplementedError
 
     def get_group_event_filter(self, project_id, group_id, environment_ids, tags, start, end):
-        default_start, default_end = self.get_time_range()
-        start = max(start, default_start) if start else default_start
-        end = min(end, default_end) if end else default_end
-
         filters = {
             'project_id': get_project_list(project_id),
             'issue': [group_id],
@@ -724,7 +686,7 @@ class SnubaTagStorage(TagStorage):
             operator = 'IN' if isinstance(tag_val, list) else '='
             conditions.append([u'tags[{}]'.format(tag_name), operator, tag_val])
 
-        result = snuba.raw_query(start, end, selected_columns=['event_id'],
+        result = snuba.raw_query(start=start, end=end, selected_columns=['event_id'],
                                  conditions=conditions, orderby='-timestamp', filter_keys=filters,
                                  limit=1000, referrer='tagstore.get_group_event_filter')
 

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -79,7 +79,8 @@ class SnubaTSDB(BaseTSDB):
 
         if keys:
             result = snuba.query(
-                start, end,
+                start=start,
+                end=end,
                 groupby=groupby,
                 conditions=None,
                 filter_keys=keys_map,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -627,12 +627,12 @@ class SnubaQueryParams(object):
     """
 
     def __init__(
-        self, start, end, groupby=None, conditions=None, filter_keys=None,
+        self, start=None, end=None, groupby=None, conditions=None, filter_keys=None,
         aggregations=None, rollup=None, referrer=None, is_grouprelease=False,
         **kwargs
     ):
-        self.start = start
-        self.end = end
+        self.start = start or datetime.utcfromtimestamp(0)  # will be clamped to project retention
+        self.end = end or datetime.utcnow()
         self.groupby = groupby or []
         self.conditions = conditions or []
         self.aggregations = aggregations or []
@@ -643,7 +643,7 @@ class SnubaQueryParams(object):
         self.kwargs = kwargs
 
 
-def raw_query(start, end, groupby=None, conditions=None, filter_keys=None,
+def raw_query(start=None, end=None, groupby=None, conditions=None, filter_keys=None,
               aggregations=None, rollup=None, referrer=None,
               is_grouprelease=False, **kwargs):
     """
@@ -728,7 +728,7 @@ def bulk_raw_query(snuba_param_list, referrer=None):
     return results
 
 
-def query(start, end, groupby, conditions=None, filter_keys=None, aggregations=None,
+def query(start=None, end=None, groupby=None, conditions=None, filter_keys=None, aggregations=None,
           selected_columns=None, totals=None, **kwargs):
 
     aggregations = aggregations or [['count()', '', 'aggregate']]
@@ -737,7 +737,7 @@ def query(start, end, groupby, conditions=None, filter_keys=None, aggregations=N
 
     try:
         body = raw_query(
-            start, end, groupby=groupby, conditions=conditions, filter_keys=filter_keys,
+            start=start, end=end, groupby=groupby, conditions=conditions, filter_keys=filter_keys,
             aggregations=aggregations, selected_columns=selected_columns, totals=totals,
             **kwargs
         )

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -734,6 +734,7 @@ def query(start=None, end=None, groupby=None, conditions=None, filter_keys=None,
     aggregations = aggregations or [['count()', '', 'aggregate']]
     filter_keys = filter_keys or {}
     selected_columns = selected_columns or []
+    groupby = groupby or []
 
     try:
         body = raw_query(


### PR DESCRIPTION
We have the following logic in a few places:
```
snuba.raw_query(
    start=datetime.utcfromtimestamp(0),  # will be clamped to project retention
    end=datetime.utcnow(),  # will be clamped to project retention
    ...
)
```

However, we have some pretty reasonable defaults for `start` and `end`, so, let's use them.