### PR TITLE
fix (ui): fixes bug where settings breadcrumb moves the user one step too far back

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/index.jsx
@@ -63,7 +63,7 @@ class SettingsBreadcrumb extends React.Component {
             ? Menu
             : () => (
                 <Crumb route={route} isLast={isLast}>
-                  <TextLink to={recreateRoute(route, {routes, params, stepBack: -1})}>
+                  <TextLink to={recreateRoute(route, {routes, params})}>
                     {pathTitle || route.name}{' '}
                   </TextLink>
                   <Divider isLast={isLast} />


### PR DESCRIPTION
Clicking an item on the settings breadcrumb takes the user back one level too far