### PR TITLE
ref: Use Snuba for project user reports

### DIFF
--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -16,11 +16,10 @@ from sentry.api.serializers import (
 from sentry.api.paginator import DateTimePaginator
 from sentry.models import (
     Environment,
-    Event,
     EventUser,
-    Group,
     GroupStatus,
     ProjectKey,
+    SnubaEvent,
     UserReport)
 from sentry.signals import user_feedback_received
 from sentry.utils.apidocs import scenario, attach_scenarios
@@ -140,21 +139,17 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
         report['event_id'] = report['event_id'].lower()
         report['project'] = project
 
+        event = SnubaEvent.objects.from_event_id(report['event_id'], project.id)
+
         # TODO(dcramer): we should probably create the user if they dont
         # exist, and ideally we'd also associate that with the event
-        euser = self.find_event_user(report)
+        euser = self.find_event_user(report, event)
         if euser and not euser.name and report['name']:
             euser.update(name=report['name'])
         if euser:
             report['event_user_id'] = euser.id
 
-        event = Event.objects.from_event_id(report['event_id'], project.id)
-        if not event:
-            try:
-                report['group'] = Group.objects.from_event_id(project, report['event_id'])
-            except Group.DoesNotExist:
-                pass
-        else:
+        if event:
             # if the event is more than 30 minutes old, we dont allow updates
             # as it might be abusive
             if event.datetime < timezone.now() - timedelta(minutes=30):
@@ -198,20 +193,18 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
             if report_instance.group:
                 report_instance.notify()
 
-        user_feedback_received.send(project=report_instance.project, group=report_instance.group, sender=self)
+        user_feedback_received.send(
+            project=report_instance.project,
+            group=report_instance.group,
+            sender=self)
 
         return self.respond(serialize(report_instance, request.user, UserReportWithGroupSerializer(
             environment_func=self._get_environment_func(
                 request, project.organization_id)
         )))
 
-    def find_event_user(self, report_data):
-        try:
-            event = Event.objects.get(
-                group_id=report_data.get('group_id'),
-                event_id=report_data['event_id'],
-            )
-        except Event.DoesNotExist:
+    def find_event_user(self, report_data, event):
+        if not event:
             if not report_data.get('email'):
                 return None
             try:

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -524,6 +524,8 @@ class TwoFactorAPITestCase(APITestCase):
         return non_compliant_members
 
 
+# TODO(lyn): Should be deprecated, we should use `store_event` instead for testing
+# events in Snuba
 class UserReportEnvironmentTestCase(APITestCase):
     def setUp(self):
 

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -3,15 +3,64 @@ from __future__ import absolute_import
 import six
 from datetime import timedelta
 from django.utils import timezone
-from exam import fixture
 from uuid import uuid4
 
-from sentry.testutils import APITestCase, UserReportEnvironmentTestCase
+from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.models import EventUser, Environment, GroupStatus, UserReport
-from sentry.event_manager import EventManager
+# from sentry.event_manager import EventManager
 
 
-class ProjectUserReportListTest(APITestCase):
+class ProjectUserReportTestCase(APITestCase, SnubaTestCase):
+    def make_environment(self, project, name='production'):
+        environment = Environment.objects.create(
+            project_id=project.id,
+            organization_id=project.organization_id,
+            name=name,
+        )
+        environment.add_project(project)
+        return environment
+
+
+class ProjectUserReportListTest(ProjectUserReportTestCase):
+    def setUp(self):
+        super(ProjectUserReportListTest, self).setUp()
+        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        self.environment = self.make_environment(self.project)
+        self.event = self.store_event(
+            data={
+                'event_id': 'a' * 32,
+                'timestamp': self.min_ago,
+                'environment': self.environment.name,
+            },
+            project_id=self.project.id
+        )
+        self.environment2 = self.make_environment(self.project, name='staging')
+        self.event2 = self.store_event(
+            data={
+                'event_id': 'b' * 32,
+                'timestamp': self.min_ago,
+                'environment': self.environment2.name,
+            },
+            project_id=self.project.id
+        )
+        self.report = UserReport.objects.create(
+            project=self.project,
+            environment=self.environment,
+            event_id='a' * 32,
+            name='Foo',
+            email='foo@example.com',
+            comments='Hello world',
+            group=self.event.group,
+        )
+        self.report2 = UserReport.objects.create(
+            project=self.project,
+            event_id='b' * 32,
+            name='Foo',
+            email='foo@example.com',
+            comments='Hello world',
+            group=self.event.group,
+        )
+
     def test_simple(self):
         self.login_as(user=self.user)
 
@@ -106,38 +155,77 @@ class ProjectUserReportListTest(APITestCase):
             ]
         )
 
+    def test_environments(self):
+        self.login_as(user=self.user)
 
-class CreateProjectUserReportTest(APITestCase):
-    def make_environment(self, project, name='production'):
-        environment = Environment.objects.create(
-            project_id=project.id,
-            organization_id=project.organization_id,
-            name=name,
+        base_url = u'/api/0/projects/{}/{}/user-feedback/'.format(
+            self.project.organization.slug,
+            self.project.slug,
         )
-        environment.add_project(project)
-        return environment
+
+        # Specify environment
+        response = self.client.get(base_url + '?environment=production')
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]['eventID'] == 'a' * 32
+
+        # No environment
+        response = self.client.get(base_url + '?environment=')
+        assert response.status_code == 200
+        assert response.data == []
+
+        # All environments
+        response = self.client.get(base_url)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        assert set([report['eventID'] for report in response.data]) == set(['a' * 32, 'b' * 32])
+
+        # Invalid environment
+        response = self.client.get(base_url + '?environment=invalid_env')
+        assert response.status_code == 200
+        assert response.data == []
+
+
+class CreateProjectUserReportTest(ProjectUserReportTestCase):
+    def setUp(self):
+        super(CreateProjectUserReportTest, self).setUp()
+        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        self.hour_ago = (timezone.now() - timedelta(minutes=60)).isoformat()[:19]
+
+        self.project = self.create_project()
+        self.environment = self.make_environment(self.project)
+        self.event = self.store_event(
+            data={
+                'timestamp': self.min_ago,
+                'environment': self.environment.name,
+                'user': {
+                    'email': 'foo@example.com',
+                }
+            },
+            project_id=self.project.id
+        )
+        self.old_event = self.store_event(
+            data={
+                'timestamp': self.hour_ago,
+                'environment': self.environment.name,
+            },
+            project_id=self.project.id
+        )
 
     def test_simple(self):
         self.login_as(user=self.user)
 
-        project = self.create_project()
-        environment = self.make_environment(project)
-        event = self.store_event(
-            data={
-                'tags': {'environment': environment.name}
-            },
-            project_id=project.id
-        )
-
         url = u'/api/0/projects/{}/{}/user-feedback/'.format(
-            project.organization.slug,
-            project.slug,
+            self.project.organization.slug,
+            self.project.slug,
         )
 
         response = self.client.post(
             url,
             data={
-                'event_id': event.event_id,
+                'event_id': self.event.event_id,
                 'email': 'foo@example.com',
                 'name': 'Foo Bar',
                 'comments': 'It broke!',
@@ -149,33 +237,24 @@ class CreateProjectUserReportTest(APITestCase):
         report = UserReport.objects.get(
             id=response.data['id'],
         )
-        assert report.project == project
-        assert report.group == event.group
+        assert report.project == self.project
+        assert report.group == self.event.group
         assert report.email == 'foo@example.com'
         assert report.name == 'Foo Bar'
         assert report.comments == 'It broke!'
 
     def test_with_dsn_auth(self):
-        project = self.create_project()
-        project_key = self.create_project_key(project=project)
-        environment = self.make_environment(project)
-        event = self.store_event(
-            data={
-                'environment': environment.name
-            },
-            project_id=project.id
-        )
-
+        project_key = self.create_project_key(project=self.project)
         url = u'/api/0/projects/{}/{}/user-feedback/'.format(
-            project.organization.slug,
-            project.slug,
+            self.project.organization.slug,
+            self.project.slug,
         )
 
         response = self.client.post(
             url,
             HTTP_AUTHORIZATION=u'DSN {}'.format(project_key.dsn_public),
             data={
-                'event_id': event.event_id,
+                'event_id': self.event.event_id,
                 'email': 'foo@example.com',
                 'name': 'Foo Bar',
                 'comments': 'It broke!',
@@ -185,9 +264,8 @@ class CreateProjectUserReportTest(APITestCase):
         assert response.status_code == 200, response.content
 
     def test_with_dsn_auth_invalid_project(self):
-        project = self.create_project()
         project2 = self.create_project()
-        project_key = self.create_project_key(project=project)
+        project_key = self.create_project_key(project=self.project)
 
         url = u'/api/0/projects/{}/{}/user-feedback/'.format(
             project2.organization.slug,
@@ -209,33 +287,25 @@ class CreateProjectUserReportTest(APITestCase):
 
     def test_already_present(self):
         self.login_as(user=self.user)
-        project = self.create_project()
-        environment = self.make_environment(project)
-        event = self.store_event(
-            data={
-                'environment': environment.name
-            },
-            project_id=project.id
-        )
 
         UserReport.objects.create(
-            group=event.group,
-            project=project,
-            event_id=event.event_id,
+            group=self.event.group,
+            project=self.project,
+            event_id=self.event.event_id,
             name='foo',
             email='bar@example.com',
             comments='',
         )
 
         url = u'/api/0/projects/{}/{}/user-feedback/'.format(
-            project.organization.slug,
-            project.slug,
+            self.project.organization.slug,
+            self.project.slug,
         )
 
         response = self.client.post(
             url,
             data={
-                'event_id': event.event_id,
+                'event_id': self.event.event_id,
                 'email': 'foo@example.com',
                 'name': 'Foo Bar',
                 'comments': 'It broke!',
@@ -247,8 +317,8 @@ class CreateProjectUserReportTest(APITestCase):
         report = UserReport.objects.get(
             id=response.data['id'],
         )
-        assert report.project == project
-        assert report.group == event.group
+        assert report.project == self.project
+        assert report.group == self.event.group
         assert report.email == 'foo@example.com'
         assert report.name == 'Foo Bar'
         assert report.comments == 'It broke!'
@@ -256,41 +326,29 @@ class CreateProjectUserReportTest(APITestCase):
     def test_already_present_with_matching_user(self):
         self.login_as(user=self.user)
 
-        project = self.create_project()
-        environment = self.make_environment(project)
-        event = self.create_event(
-            data={
-                'tags': {
-                    'sentry:user': 'email:foo@example.com',
-                    'environment': environment.name,
-                }
-            },
-            project_id=project.id
-        )
-
-        euser = EventUser.objects.create(
-            project_id=project.id,
-            name='',
+        euser = EventUser.objects.get(
+            project_id=self.project.id,
             email='foo@example.com',
         )
+
         UserReport.objects.create(
-            group=event.group,
-            project=project,
-            event_id=event.event_id,
+            group=self.event.group,
+            project=self.project,
+            event_id=self.event.event_id,
             name='foo',
             email='bar@example.com',
             comments='',
         )
 
         url = u'/api/0/projects/{}/{}/user-feedback/'.format(
-            project.organization.slug,
-            project.slug,
+            self.project.organization.slug,
+            self.project.slug,
         )
 
         response = self.client.post(
             url,
             data={
-                'event_id': event.event_id,
+                'event_id': self.event.event_id,
                 'email': 'foo@example.com',
                 'name': 'Foo Bar',
                 'comments': 'It broke!',
@@ -302,8 +360,8 @@ class CreateProjectUserReportTest(APITestCase):
         report = UserReport.objects.get(
             id=response.data['id'],
         )
-        assert report.project == project
-        assert report.group == event.group
+        assert report.project == self.project
+        assert report.group == self.event.group
         assert report.email == 'foo@example.com'
         assert report.name == 'Foo Bar'
         assert report.comments == 'It broke!'
@@ -315,21 +373,10 @@ class CreateProjectUserReportTest(APITestCase):
     def test_already_present_after_deadline(self):
         self.login_as(user=self.user)
 
-        project = self.create_project()
-        environment = self.make_environment(project)
-        event = self.create_event(
-            data={
-                'tags': {
-                    'environment': environment.name
-                }
-            },
-            project_id=project.id
-        )
-
         UserReport.objects.create(
-            group=event.group,
-            project=project,
-            event_id=event.event_id,
+            group=self.old_event.group,
+            project=self.project,
+            event_id=self.old_event.event_id,
             name='foo',
             email='bar@example.com',
             comments='',
@@ -337,14 +384,14 @@ class CreateProjectUserReportTest(APITestCase):
         )
 
         url = u'/api/0/projects/{}/{}/user-feedback/'.format(
-            project.organization.slug,
-            project.slug,
+            self.project.organization.slug,
+            self.project.slug,
         )
 
         response = self.client.post(
             url,
             data={
-                'event_id': event.event_id,
+                'event_id': self.old_event.event_id,
                 'email': 'foo@example.com',
                 'name': 'Foo Bar',
                 'comments': 'It broke!',
@@ -356,24 +403,15 @@ class CreateProjectUserReportTest(APITestCase):
     def test_after_event_deadline(self):
         self.login_as(user=self.user)
 
-        project = self.create_project()
-        group = self.create_group(project=project)
-        environment = self.make_environment(project)
-        event = self.create_event(
-            group=group,
-            tags={'environment': environment.name},
-            datetime=timezone.now() - timedelta(minutes=60),
-        )
-
         url = u'/api/0/projects/{}/{}/user-feedback/'.format(
-            project.organization.slug,
-            project.slug,
+            self.project.organization.slug,
+            self.project.slug,
         )
 
         response = self.client.post(
             url,
             data={
-                'event_id': event.event_id,
+                'event_id': self.old_event.event_id,
                 'email': 'foo@example.com',
                 'name': 'Foo Bar',
                 'comments': 'It broke!',
@@ -382,44 +420,18 @@ class CreateProjectUserReportTest(APITestCase):
 
         assert response.status_code == 409, response.content
 
+    def test_environments(self):
+        self.login_as(user=self.user)
 
-class ProjectUserReportByEnvironmentsTest(UserReportEnvironmentTestCase):
-
-    def setUp(self):
-        super(ProjectUserReportByEnvironmentsTest, self).setUp()
-        group_2 = self.create_group()
-        env1_events = self.create_events_for_environment(group_2, self.env1, 5)
-        env2_events = self.create_events_for_environment(group_2, self.env2, 5)
-
-        self.env1_userreports += self.create_user_report_for_events(
-            self.project, group_2, env1_events, self.env1)
-        self.env2_userreports += self.create_user_report_for_events(
-            self.project, group_2, env2_events, self.env2)
-
-        self.env1_events += env1_events
-        self.env2_events += env2_events
-
-    @fixture
-    def path(self):
-        return u'/api/0/projects/{}/{}/user-feedback/'.format(
+        url = u'/api/0/projects/{}/{}/user-feedback/'.format(
             self.project.organization.slug,
             self.project.slug,
         )
 
-    def test_environment_gets_user_report(self):
-        event_id = 'a' * 32
-        manager = EventManager(
-            self.make_event(
-                environment=self.env1.name,
-                event_id=event_id))
-        manager.normalize()
-        manager.save(self.project.id)
-
-        self.login_as(user=self.user)
         response = self.client.post(
-            self.path,
+            url,
             data={
-                'event_id': event_id,
+                'event_id': self.event.event_id,
                 'email': 'foo@example.com',
                 'name': 'Foo Bar',
                 'comments': 'It broke!',
@@ -427,73 +439,4 @@ class ProjectUserReportByEnvironmentsTest(UserReportEnvironmentTestCase):
         )
 
         assert response.status_code == 200, response.content
-        assert UserReport.objects.get(event_id=event_id).environment == self.env1
-
-    def test_user_report_gets_environment(self):
-        event_id = 'a' * 32
-        self.login_as(user=self.user)
-        response = self.client.post(
-            self.path,
-            data={
-                'event_id': event_id,
-                'email': 'foo@example.com',
-                'name': 'Foo Bar',
-                'comments': 'It broke!',
-            }
-        )
-
-        manager = EventManager(
-            self.make_event(
-                environment=self.env1.name,
-                event_id=event_id))
-        manager.normalize()
-        manager.save(self.project.id)
-        assert response.status_code == 200, response.content
-        assert UserReport.objects.get(event_id=event_id).environment == self.env1
-
-    def test_specified_enviroment(self):
-        self.login_as(user=self.user)
-
-        response = self.client.get(self.path + '?environment=' + self.env1.name)
-        assert response.status_code == 200, response.content
-        assert len(response.data) == len(self.env1_events)
-        self.assert_same_userreports(response.data, self.env1_userreports)
-
-        response = self.client.get(self.path + '?environment=' + self.env2.name)
-        assert response.status_code == 200, response.content
-        assert len(response.data) == len(self.env2_events)
-        self.assert_same_userreports(response.data, self.env2_userreports)
-
-    def test_no_environment_does_not_exists(self):
-        self.login_as(user=self.user)
-        response = self.client.get(self.path + '?environment=')
-        assert response.status_code == 200
-        assert response.data == []
-
-    def test_no_environment(self):
-        self.login_as(user=self.user)
-
-        empty_env = self.create_environment(self.project, u'')
-        empty_env_events = self.create_events_for_environment(self.group, empty_env, 5)
-        userreports = self.create_user_report_for_events(
-            self.project, self.group, empty_env_events, empty_env)
-        response = self.client.get(self.path + '?environment=')
-
-        assert response.status_code == 200, response.content
-        assert len(response.data) == len(userreports)
-        self.assert_same_userreports(response.data, userreports)
-
-    def test_all_environments(self):
-        self.login_as(user=self.user)
-        response = self.client.get(self.path)
-        userreports = self.env1_userreports + self.env2_userreports
-
-        assert response.status_code == 200, response.content
-        assert len(response.data) == len(userreports)
-        self.assert_same_userreports(response.data, userreports)
-
-    def test_invalid_environment(self):
-        self.login_as(user=self.user)
-        response = self.client.get(self.path + '?environment=invalid_env')
-        assert response.status_code == 200
-        assert response.data == []
+        assert UserReport.objects.get(event_id=self.event.event_id).environment == self.environment


### PR DESCRIPTION
This code should eventually get events from eventstore instead of using `Events.objects.from_event_id` as per https://github.com/getsentry/sentry/pull/14249.

This is just the first step to get things working properly with Snuba, and 
to update the tests to use `store_event` instead of `create_event`.