### PR TITLE
fix: Fix `testutils.helpers.socker.override_blacklist` test helper to cleanup properly.

### DIFF
--- a/src/sentry/testutils/helpers/socket.py
+++ b/src/sentry/testutils/helpers/socket.py
@@ -14,7 +14,12 @@ def override_blacklist(*ip_addresses):
             net_socket.DISALLOWED_IPS = frozenset(
                 ipaddress.ip_network(six.text_type(ip)) for ip in ip_addresses
             )
-            func(*args, **kwargs)
-            net_socket.DISALLOWED_IPS = disallowed_ips
+            try:
+                func(*args, **kwargs)
+            finally:
+                net_socket.DISALLOWED_IPS = disallowed_ips
+                # We end up caching these disallowed ips on this function, so
+                # make sure we clear the cache as part of cleanup
+                net_socket.is_ipaddress_allowed.cache_clear()
         return wrapper
     return decorator


### PR DESCRIPTION
`override_blacklist` temporarily overrides `sentry.net.socket.DISALLOWED_IPS`. This module variable is used by `sentry.net.socket.is_ipaddress_allowed`, which uses `lru_cache`. This means that if `is_ipaddress_allowed` is called while `DISALLOWED_IPS` is overridden it ends up caching the result, and so the override leaks into other tests. This is causing issues in https://github.com/getsentry/sentry/pull/14274.

Also added a try/finally so that we always clean up in the case of a test throwing an exception.