### PR TITLE
ref(ui): Remove error robot from projects page

### DIFF
--- a/src/sentry/static/sentry/app/components/resourceCard.jsx
+++ b/src/sentry/static/sentry/app/components/resourceCard.jsx
@@ -24,22 +24,13 @@ export default class ResourceCard extends React.Component {
     return (
       <ResourceCardWrapper onClick={this.recordClick}>
         <StyledLink href={link}>
-          <div className="m-b-1">
-            <img src={imgUrl} alt={title} />
-          </div>
+          <StyledImg src={imgUrl} alt={title} />
           <StyledTitle>{title}</StyledTitle>
         </StyledLink>
       </ResourceCardWrapper>
     );
   }
 }
-
-const StyledTitle = styled('div')`
-  color: #493e54;
-  font-size: 16px;
-  text-align: center;
-  font-weight: bold;
-`;
 
 const ResourceCardWrapper = styled(Panel)`
   display: flex;
@@ -51,4 +42,18 @@ const ResourceCardWrapper = styled(Panel)`
 
 const StyledLink = styled(ExternalLink)`
   flex: 1;
+`;
+
+const StyledImg = styled('img')`
+  display: block;
+  margin: 0 auto;
+  padding-bottom: 20px;
+  height: 180px;
+`;
+
+const StyledTitle = styled('div')`
+  color: #493e54;
+  font-size: 16px;
+  text-align: center;
+  font-weight: bold;
 `;

--- a/src/sentry/static/sentry/app/components/resourceCard.jsx
+++ b/src/sentry/static/sentry/app/components/resourceCard.jsx
@@ -5,6 +5,7 @@ import styled from 'react-emotion';
 import {analytics} from 'app/utils/analytics';
 import ExternalLink from 'app/components/links/externalLink';
 import {Panel} from 'app/components/panels';
+import space from 'app/styles/space';
 
 export default class ResourceCard extends React.Component {
   static propTypes = {
@@ -36,7 +37,7 @@ const ResourceCardWrapper = styled(Panel)`
   display: flex;
   flex: 1;
   align-items: center;
-  padding: 20px;
+  padding: ${space(3)};
   margin-bottom: 0;
 `;
 
@@ -46,14 +47,13 @@ const StyledLink = styled(ExternalLink)`
 
 const StyledImg = styled('img')`
   display: block;
-  margin: 0 auto;
-  padding-bottom: 20px;
-  height: 180px;
+  margin: 0 auto ${space(3)} auto;
+  height: 160px;
 `;
 
 const StyledTitle = styled('div')`
-  color: #493e54;
-  font-size: 16px;
+  color: ${p => p.theme.gray4};
+  font-size: ${p => p.theme.fontSizeLarge};
   text-align: center;
   font-weight: bold;
 `;

--- a/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
@@ -49,18 +49,20 @@ class Dashboard extends React.Component {
     const sortedProjects = sortProjects(projects);
 
     const {isSuperuser} = ConfigStore.get('user');
-
     const {projectsByTeam} = getProjectsByTeams(teams, sortedProjects, isSuperuser);
     const teamSlugs = Object.keys(projectsByTeam).sort();
     const favorites = projects.filter(project => project.isBookmarked);
+
     const access = new Set(organization.access);
     const canCreateProjects = access.has('project:admin');
     const teamsMap = new Map(teams.map(teamObj => [teamObj.slug, teamObj]));
-
     const hasTeamAdminAccess = access.has('team:admin');
 
-    if (projects.length === 1 && !projects[0].firstEvent) {
-      return <Resources org={organization} project={projects[0]} />;
+    const showEmptyMessage = teamSlugs.length === 0 && favorites.length === 0;
+    const showResources = projects.length === 1 && !projects[0].firstEvent;
+
+    if (showEmptyMessage) {
+      return <NoProjectMessage organization={organization}>{null}</NoProjectMessage>;
     }
 
     return (
@@ -78,6 +80,7 @@ class Dashboard extends React.Component {
               }
               to={`/organizations/${organization.slug}/projects/new/`}
               icon="icon-circle-add"
+              data-test-id="create-project"
             >
               {t('Create Project')}
             </Button>
@@ -108,9 +111,8 @@ class Dashboard extends React.Component {
             </LazyLoad>
           );
         })}
-        {teamSlugs.length === 0 && favorites.length === 0 && (
-          <NoProjectMessage organization={organization}>{null}</NoProjectMessage>
-        )}
+
+        {showResources && <Resources />}
       </React.Fragment>
     );
   }

--- a/src/sentry/static/sentry/app/views/projectsDashboard/resources.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/resources.jsx
@@ -18,7 +18,7 @@ export default class Resources extends React.Component {
 
   render() {
     return (
-      <ResourcesWrapper>
+      <ResourcesWrapper data-test-id="resources">
         <ResourcesSection>
           <PageHeading>{t('Resources')}</PageHeading>
           <ResourceCards>

--- a/src/sentry/static/sentry/app/views/projectsDashboard/resources.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/resources.jsx
@@ -5,6 +5,7 @@ import styled from 'react-emotion';
 import {analytics} from 'app/utils/analytics';
 import PageHeading from 'app/components/pageHeading';
 import ResourceCard from 'app/components/resourceCard';
+import space from 'app/styles/space';
 import {t} from 'app/locale';
 
 import releasesImg from '../../../images/releases.svg';
@@ -19,22 +20,24 @@ export default class Resources extends React.Component {
   render() {
     return (
       <ResourcesWrapper data-test-id="resources">
-        <ResourcesSection>
-          <PageHeading>{t('Resources')}</PageHeading>
-          <ResourceCards>
-            <ResourceCard
-              link="https://blog.sentry.io/2018/03/06/the-sentry-workflow"
-              imgUrl={releasesImg}
-              title="The Sentry Workflow"
-            />
-            <ResourceCard
-              link="https://sentry.io/vs/logging/"
-              imgUrl={breadcrumbsImg}
-              title="Sentry vs Logging"
-            />
-            <ResourceCard link="https://docs.sentry.io/" imgUrl={docsImg} title="Docs" />
-          </ResourceCards>
-        </ResourcesSection>
+        <PageHeading>{t('Resources')}</PageHeading>
+        <ResourceCards>
+          <ResourceCard
+            link="https://blog.sentry.io/2018/03/06/the-sentry-workflow"
+            imgUrl={releasesImg}
+            title={t('The Sentry Workflow')}
+          />
+          <ResourceCard
+            link="https://sentry.io/vs/logging/"
+            imgUrl={breadcrumbsImg}
+            title={t('Sentry vs Logging')}
+          />
+          <ResourceCard
+            link="https://docs.sentry.io/"
+            imgUrl={docsImg}
+            title={t('Docs')}
+          />
+        </ResourceCards>
       </ResourcesWrapper>
     );
   }
@@ -42,15 +45,12 @@ export default class Resources extends React.Component {
 
 const ResourcesWrapper = styled('div')`
   border-top: 1px solid ${p => p.theme.borderLight};
-`;
-
-const ResourcesSection = styled('div')`
-  padding: 30px 30px 10px 30px;
+  padding: 25px 30px 10px 30px;
 `;
 
 const ResourceCards = styled(Flex)`
   display: grid;
   grid-template-columns: repeat(3, auto);
-  margin-top: 25px;
-  grid-gap: 30px;
+  grid-gap: ${space(4)};
+  margin-top: ${space(3)};
 `;

--- a/src/sentry/static/sentry/app/views/projectsDashboard/resources.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/resources.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Flex} from 'grid-emotion';
 import styled from 'react-emotion';
 
 import {analytics} from 'app/utils/analytics';
@@ -48,7 +47,7 @@ const ResourcesWrapper = styled('div')`
   padding: 25px 30px 10px 30px;
 `;
 
-const ResourceCards = styled(Flex)`
+const ResourceCards = styled('div')`
   display: grid;
   grid-template-columns: repeat(3, auto);
   grid-gap: ${space(4)};

--- a/src/sentry/static/sentry/app/views/projectsDashboard/resources.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/resources.jsx
@@ -3,6 +3,7 @@ import {Flex} from 'grid-emotion';
 import styled from 'react-emotion';
 
 import {analytics} from 'app/utils/analytics';
+import PageHeading from 'app/components/pageHeading';
 import ResourceCard from 'app/components/resourceCard';
 import {t} from 'app/locale';
 
@@ -19,30 +20,20 @@ export default class Resources extends React.Component {
     return (
       <ResourcesWrapper>
         <ResourcesSection>
-          <h4>{t('Resources')}</h4>
-          <Flex justify="space-between">
-            <Flex width={3 / 10}>
-              <ResourceCard
-                link="https://blog.sentry.io/2018/03/06/the-sentry-workflow"
-                imgUrl={releasesImg}
-                title="The Sentry Workflow"
-              />
-            </Flex>
-            <Flex width={3 / 10}>
-              <ResourceCard
-                link="https://sentry.io/vs/logging/"
-                imgUrl={breadcrumbsImg}
-                title="Sentry vs Logging"
-              />
-            </Flex>
-            <Flex width={3 / 10}>
-              <ResourceCard
-                link="https://docs.sentry.io/"
-                imgUrl={docsImg}
-                title="Docs"
-              />
-            </Flex>
-          </Flex>
+          <PageHeading>{t('Resources')}</PageHeading>
+          <ResourceCards>
+            <ResourceCard
+              link="https://blog.sentry.io/2018/03/06/the-sentry-workflow"
+              imgUrl={releasesImg}
+              title="The Sentry Workflow"
+            />
+            <ResourceCard
+              link="https://sentry.io/vs/logging/"
+              imgUrl={breadcrumbsImg}
+              title="Sentry vs Logging"
+            />
+            <ResourceCard link="https://docs.sentry.io/" imgUrl={docsImg} title="Docs" />
+          </ResourceCards>
         </ResourcesSection>
       </ResourcesWrapper>
     );
@@ -51,9 +42,15 @@ export default class Resources extends React.Component {
 
 const ResourcesWrapper = styled('div')`
   border-top: 1px solid ${p => p.theme.borderLight};
-  padding-top: 20px;
 `;
 
 const ResourcesSection = styled('div')`
-  padding: 0 30px 20px 30px;
+  padding: 30px 30px 10px 30px;
+`;
+
+const ResourceCards = styled(Flex)`
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  margin-top: 25px;
+  grid-gap: 30px;
 `;

--- a/src/sentry/static/sentry/app/views/projectsDashboard/resources.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/resources.jsx
@@ -4,9 +4,6 @@ import styled from 'react-emotion';
 
 import {analytics} from 'app/utils/analytics';
 import ResourceCard from 'app/components/resourceCard';
-import SentryTypes from 'app/sentryTypes';
-import ErrorRobot from 'app/components/errorRobot';
-import {Panel} from 'app/components/panels';
 import {t} from 'app/locale';
 
 import releasesImg from '../../../images/releases.svg';
@@ -14,11 +11,6 @@ import breadcrumbsImg from '../../../images/breadcrumbs-generic.svg';
 import docsImg from '../../../images/code-arguments-tags-mirrored.svg';
 
 export default class Resources extends React.Component {
-  static propTypes = {
-    org: SentryTypes.Organization,
-    project: SentryTypes.Project,
-  };
-
   componentDidMount() {
     analytics('orgdash.resources_shown');
   }
@@ -26,9 +18,6 @@ export default class Resources extends React.Component {
   render() {
     return (
       <ResourcesWrapper>
-        <RobotPanel>
-          <ErrorRobot org={this.props.org} project={this.props.project} />
-        </RobotPanel>
         <ResourcesSection>
           <h4>{t('Resources')}</h4>
           <Flex justify="space-between">
@@ -62,10 +51,7 @@ export default class Resources extends React.Component {
 
 const ResourcesWrapper = styled('div')`
   border-top: 1px solid ${p => p.theme.borderLight};
-`;
-
-const RobotPanel = styled(Panel)`
-  margin: 30px 30px 20px 30px;
+  padding-top: 20px;
 `;
 
 const ResourcesSection = styled('div')`

--- a/tests/acceptance/test_dashboard.py
+++ b/tests/acceptance/test_dashboard.py
@@ -56,13 +56,12 @@ class DashboardTest(AcceptanceTestCase, SnubaTestCase):
         self.login_as(self.user)
         self.path = u'/organizations/{}/projects/'.format(self.org.slug)
 
-    def test_no_issues(self):
-        # I think no "activity" would be more accurate?
+    def test_project_with_no_first_event(self):
         self.project.update(first_event=None)
         self.browser.get(self.path)
         self.browser.wait_until_not('.loading-indicator')
-        self.browser.wait_until_test_id('awaiting-events')
-        self.browser.snapshot('org dash no issues')
+        self.browser.wait_until_test_id('resources')
+        self.browser.snapshot('org dash no first event')
 
     def test_one_issue(self):
         self.init_snuba()

--- a/tests/acceptance/test_dashboard.py
+++ b/tests/acceptance/test_dashboard.py
@@ -61,6 +61,7 @@ class DashboardTest(AcceptanceTestCase, SnubaTestCase):
         self.browser.get(self.path)
         self.browser.wait_until_not('.loading-indicator')
         self.browser.wait_until_test_id('resources')
+        self.browser.wait_until('[data-test-id] figure')
         self.browser.snapshot('org dash no first event')
 
     def test_one_issue(self):


### PR DESCRIPTION
Remove the error robot from Projects page if there's one project, and show the project instead. Continue to show the Resources section below if the user hasn’t sent a first event.

<img width="1042" alt="Screen Shot 2019-08-06 at 11 57 47 AM" src="https://user-images.githubusercontent.com/16394317/62569364-5b901680-b843-11e9-885e-e20285b67cd6.png">
