### PR TITLE
test: Refactor group user reports tests

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 
 __all__ = (
-    'TestCase', 'TransactionTestCase', 'APITestCase', 'TwoFactorAPITestCase', 'AuthProviderTestCase', 'RuleTestCase',
-    'PermissionTestCase', 'PluginTestCase', 'CliTestCase', 'AcceptanceTestCase',
-    'IntegrationTestCase', 'UserReportEnvironmentTestCase', 'SnubaTestCase',
-    'IntegrationRepositoryTestCase',
-    'ReleaseCommitPatchTest', 'SetRefsTestCase', 'OrganizationDashboardWidgetTestCase'
+    'TestCase', 'TransactionTestCase', 'APITestCase', 'TwoFactorAPITestCase',
+    'AuthProviderTestCase', 'RuleTestCase', 'PermissionTestCase', 'PluginTestCase',
+    'CliTestCase', 'AcceptanceTestCase', 'IntegrationTestCase', 'SnubaTestCase',
+    'IntegrationRepositoryTestCase', 'ReleaseCommitPatchTest', 'SetRefsTestCase',
+    'OrganizationDashboardWidgetTestCase'
 )
 
 import base64
@@ -17,7 +17,6 @@ import pytest
 import requests
 import six
 import types
-import logging
 import mock
 
 from click.testing import CliRunner
@@ -49,7 +48,7 @@ from sentry.constants import MODULE_ROOT
 from sentry.eventstream.snuba import SnubaEventStream
 from sentry.models import (
     GroupEnvironment, GroupHash, GroupMeta, ProjectOption, Repository, DeletedOrganization,
-    Environment, GroupStatus, Organization, TotpInterface, UserReport,
+    Environment, Organization, TotpInterface,
     Dashboard, ObjectStatus, WidgetDataSource, WidgetDataSourceTypes
 )
 from sentry.plugins import plugins
@@ -522,71 +521,6 @@ class TwoFactorAPITestCase(APITestCase):
             else:
                 non_compliant_members.append(user.email)
         return non_compliant_members
-
-
-# TODO(lyn): Should be deprecated, we should use `store_event` instead for testing
-# events in Snuba
-class UserReportEnvironmentTestCase(APITestCase):
-    def setUp(self):
-
-        self.project = self.create_project()
-        self.env1 = self.create_environment(self.project, 'production')
-        self.env2 = self.create_environment(self.project, 'staging')
-
-        self.group = self.create_group(project=self.project, status=GroupStatus.UNRESOLVED)
-
-        self.env1_events = self.create_events_for_environment(self.group, self.env1, 5)
-        self.env2_events = self.create_events_for_environment(self.group, self.env2, 5)
-
-        self.env1_userreports = self.create_user_report_for_events(
-            self.project, self.group, self.env1_events, self.env1)
-        self.env2_userreports = self.create_user_report_for_events(
-            self.project, self.group, self.env2_events, self.env2)
-
-    def make_event(self, **kwargs):
-        result = {
-            'event_id': 'a' * 32,
-            'message': 'foo',
-            'timestamp': 1403007314.570599,
-            'level': logging.ERROR,
-            'logger': 'default',
-            'tags': [],
-        }
-        result.update(kwargs)
-        return result
-
-    def create_environment(self, project, name):
-        env = Environment.objects.create(
-            project_id=project.id,
-            organization_id=project.organization_id,
-            name=name,
-        )
-        env.add_project(project)
-        return env
-
-    def create_events_for_environment(self, group, environment, num_events):
-        return [self.create_event(group=group, tags={
-            'environment': environment.name}) for __i in range(num_events)]
-
-    def create_user_report_for_events(self, project, group, events, environment):
-        reports = []
-        for i, event in enumerate(events):
-            reports.append(UserReport.objects.create(
-                group=group,
-                project=project,
-                event_id=event.event_id,
-                name='foo%d' % i,
-                email='bar%d@example.com' % i,
-                comments='It Broke!!!',
-                environment=environment,
-            ))
-        return reports
-
-    def assert_same_userreports(self, response_data, userreports):
-        assert sorted(int(r.get('id')) for r in response_data) == sorted(
-            r.id for r in userreports)
-        assert sorted(r.get('eventID') for r in response_data) == sorted(
-            r.event_id for r in userreports)
 
 
 class AuthProviderTestCase(TestCase):

--- a/tests/sentry/api/endpoints/test_group_user_reports.py
+++ b/tests/sentry/api/endpoints/test_group_user_reports.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 from exam import fixture
-import logging
 
 from sentry.models import Environment, GroupStatus, UserReport
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/sentry/api/endpoints/test_group_user_reports.py
+++ b/tests/sentry/api/endpoints/test_group_user_reports.py
@@ -1,14 +1,66 @@
 from __future__ import absolute_import
-from sentry.testutils import UserReportEnvironmentTestCase
 from exam import fixture
+import logging
+
+from sentry.models import Environment, GroupStatus, UserReport
+from sentry.testutils import APITestCase, SnubaTestCase
 
 
-class GroupUserReport(UserReportEnvironmentTestCase):
+class GroupUserReport(APITestCase, SnubaTestCase):
+
+    def setUp(self):
+        self.project = self.create_project()
+        self.env1 = self.create_environment(self.project, 'production')
+        self.env2 = self.create_environment(self.project, 'staging')
+
+        self.group = self.create_group(project=self.project, status=GroupStatus.UNRESOLVED)
+
+        self.env1_events = self.create_events_for_environment(self.group, self.env1, 5)
+        self.env2_events = self.create_events_for_environment(self.group, self.env2, 5)
+
+        self.env1_userreports = self.create_user_report_for_events(
+            self.project, self.group, self.env1_events, self.env1)
+        self.env2_userreports = self.create_user_report_for_events(
+            self.project, self.group, self.env2_events, self.env2)
+
     @fixture
     def path(self):
         return u'/api/0/groups/{}/user-feedback/'.format(
             self.group.id,
         )
+
+    def create_environment(self, project, name):
+        env = Environment.objects.create(
+            project_id=project.id,
+            organization_id=project.organization_id,
+            name=name,
+        )
+        env.add_project(project)
+        return env
+
+    def create_events_for_environment(self, group, environment, num_events):
+        return [self.create_event(group=group, tags={
+            'environment': environment.name}) for __i in range(num_events)]
+
+    def create_user_report_for_events(self, project, group, events, environment):
+        reports = []
+        for i, event in enumerate(events):
+            reports.append(UserReport.objects.create(
+                group=group,
+                project=project,
+                event_id=event.event_id,
+                name='foo%d' % i,
+                email='bar%d@example.com' % i,
+                comments='It Broke!!!',
+                environment=environment,
+            ))
+        return reports
+
+    def assert_same_userreports(self, response_data, userreports):
+        assert sorted(int(r.get('id')) for r in response_data) == sorted(
+            r.id for r in userreports)
+        assert sorted(r.get('eventID') for r in response_data) == sorted(
+            r.event_id for r in userreports)
 
     def test_specified_enviroment(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -6,26 +6,14 @@ from django.utils import timezone
 from uuid import uuid4
 
 from sentry.testutils import APITestCase, SnubaTestCase
-from sentry.models import EventUser, Environment, GroupStatus, UserReport
-# from sentry.event_manager import EventManager
+from sentry.models import EventUser, GroupStatus, UserReport
 
 
-class ProjectUserReportTestCase(APITestCase, SnubaTestCase):
-    def make_environment(self, project, name='production'):
-        environment = Environment.objects.create(
-            project_id=project.id,
-            organization_id=project.organization_id,
-            name=name,
-        )
-        environment.add_project(project)
-        return environment
-
-
-class ProjectUserReportListTest(ProjectUserReportTestCase):
+class ProjectUserReportListTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(ProjectUserReportListTest, self).setUp()
         self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        self.environment = self.make_environment(self.project)
+        self.environment = self.create_environment(project=self.project, name='production')
         self.event = self.store_event(
             data={
                 'event_id': 'a' * 32,
@@ -34,7 +22,7 @@ class ProjectUserReportListTest(ProjectUserReportTestCase):
             },
             project_id=self.project.id
         )
-        self.environment2 = self.make_environment(self.project, name='staging')
+        self.environment2 = self.create_environment(project=self.project, name='staging')
         self.event2 = self.store_event(
             data={
                 'event_id': 'b' * 32,
@@ -188,14 +176,14 @@ class ProjectUserReportListTest(ProjectUserReportTestCase):
         assert response.data == []
 
 
-class CreateProjectUserReportTest(ProjectUserReportTestCase):
+class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(CreateProjectUserReportTest, self).setUp()
         self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
         self.hour_ago = (timezone.now() - timedelta(minutes=60)).isoformat()[:19]
 
         self.project = self.create_project()
-        self.environment = self.make_environment(self.project)
+        self.environment = self.create_environment(project=self.project)
         self.event = self.store_event(
             data={
                 'timestamp': self.min_ago,


### PR DESCRIPTION
Remove the base test class UserReportEnvironmentTestCase since we only use
this in one place now.
This is a follow up to https://github.com/getsentry/sentry/pull/14293