### PR TITLE
ref(eventstore): Use eventstore.get_event_by_id in a few places

### DIFF
--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -5,7 +5,7 @@ import six
 from enum import Enum
 
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
-from sentry import features
+from sentry import eventstore, features
 from sentry.models import SnubaEvent
 from sentry.models.project import Project
 from sentry.api.serializers import serialize
@@ -40,7 +40,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
 
         # We return the requested event if we find a match regardless of whether
         # it occurred within the range specified
-        event = SnubaEvent.objects.from_event_id(event_id, project.id)
+        event = eventstore.get_event_by_id(project.id, event_id)
 
         if event is None:
             return Response({'detail': 'Event not found'}, status=404)

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -5,7 +5,7 @@ import functools
 import six
 from rest_framework.response import Response
 
-from sentry import analytics, search
+from sentry import analytics, eventstore, search
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.helpers.group_index import (
@@ -15,7 +15,7 @@ from sentry.api.helpers.group_index import (
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializer
 from sentry.models import Environment, Group, GroupStatus
-from sentry.models.event import Event, SnubaEvent
+from sentry.models.event import Event
 from sentry.models.savedsearch import DEFAULT_SAVED_SEARCH_QUERIES
 from sentry.signals import advanced_search
 from sentry.utils.apidocs import attach_scenarios, scenario
@@ -151,7 +151,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                 except Group.DoesNotExist:
                     pass
                 else:
-                    matching_event = SnubaEvent.objects.from_event_id(event_id, project.id)
+                    matching_event = eventstore.get_event_by_id(project.id, event_id)
                     if matching_event is not None:
                         Event.objects.bind_nodes([matching_event], 'data')
             elif matching_group is None:

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
 
-from sentry import eventtypes, tagstore
+from sentry import eventstore, eventtypes, tagstore
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS, MAX_CULPRIT_LENGTH
 from sentry.db.models import (
     BaseManager, BoundedBigIntegerField, BoundedIntegerField, BoundedPositiveIntegerField,
@@ -191,10 +191,9 @@ class GroupManager(BaseManager):
         Resolves the 32 character event_id string into
         a Group for which it is found.
         """
-        from sentry.models import SnubaEvent
         group_id = None
 
-        event = SnubaEvent.objects.from_event_id(event_id, project.id)
+        event = eventstore.get_event_by_id(project.id, event_id)
 
         if event:
             group_id = event.group_id

--- a/src/sentry/web/frontend/project_event.py
+++ b/src/sentry/web/frontend/project_event.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from django.http import HttpResponseRedirect, Http404
 from django.core.urlresolvers import reverse
 
-from sentry.models import SnubaEvent
+from sentry import eventstore
 from sentry.web.frontend.base import ProjectView
 
 
@@ -14,7 +14,7 @@ class ProjectEventRedirect(ProjectView):
         """
         Given a client event id and project, redirects to the event page
         """
-        event = SnubaEvent.objects.from_event_id(client_event_id, project.id)
+        event = eventstore.get_event_by_id(project.id, client_event_id)
 
         if event is None:
             raise Http404


### PR DESCRIPTION
Use eventstore.get_event_by_id instead of SnubaEvent.objects.from_event_id in a few
places where it can be easily replaced.