### PR TITLE
Fix test_transaction_event test

### DIFF
--- a/src/sentry/data/samples/transaction.json
+++ b/src/sentry/data/samples/transaction.json
@@ -151,7 +151,6 @@
       }
    ],
    "start_timestamp": 1562681591.0,
-   "timestamp": 1562681591.0,
    "transaction": "/country_by_code/",
    "type": "transaction",
    "user": {


### PR DESCRIPTION
The hardcode timestamp in the example is now 30 days old, thus the event gets rejected by event_manager