### PR TITLE
ref(app-platform): Render client secret for internal apps

### DIFF
--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -30,14 +30,13 @@ class SentryAppSerializer(Serializer):
         if is_active_superuser(env.request) or (
             hasattr(user, 'get_orgs') and obj.owner in user.get_orgs()
         ):
-            if not obj.is_internal:
-                data.update({
-                    'clientId': obj.application.client_id,
-                    'clientSecret': obj.application.client_secret,
-                    'owner': {
-                        'id': obj.owner.id,
-                        'slug': obj.owner.slug,
-                    },
-                })
+            data.update({
+                'clientId': obj.application.client_id,
+                'clientSecret': obj.application.client_secret,
+                'owner': {
+                    'id': obj.owner.id,
+                    'slug': obj.owner.slug,
+                },
+            })
 
         return data

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.jsx
@@ -208,51 +208,51 @@ export default class SentryApplicationDetails extends AsyncView {
 
           <PermissionsObserver scopes={scopes} events={events} />
 
+          {app && app.status === 'internal' && (
+            <Panel>
+              <PanelHeader hasButtons>
+                {t('Tokens')}
+                <Button
+                  size="xsmall"
+                  icon="icon-circle-add"
+                  onClick={evt => this.onAddToken(evt)}
+                  data-test-id="token-add"
+                >
+                  {t('New Token')}
+                </Button>
+              </PanelHeader>
+              <PanelBody>{this.renderTokens()}</PanelBody>
+            </Panel>
+          )}
+
           {app && (
-            <React.Fragment>
-              {app.status === 'internal' ? (
-                <Panel>
-                  <PanelHeader hasButtons>
-                    {t('Tokens')}
-                    <Button
-                      size="xsmall"
-                      icon="icon-circle-add"
-                      onClick={evt => this.onAddToken(evt)}
-                      data-test-id="token-add"
-                    >
-                      {t('New Token')}
-                    </Button>
-                  </PanelHeader>
-                  <PanelBody>{this.renderTokens()}</PanelBody>
-                </Panel>
-              ) : (
-                <Panel>
-                  <PanelHeader>{t('Credentials')}</PanelHeader>
-                  <PanelBody>
-                    <FormField name="clientId" label="Client ID" overflow>
-                      {({value}) => {
-                        return (
-                          <TextCopyInput>
-                            {getDynamicText({value, fixed: 'PERCY_CLIENT_ID'})}
-                          </TextCopyInput>
-                        );
-                      }}
-                    </FormField>
-                    <FormField overflow name="clientSecret" label="Client Secret">
-                      {({value}) => {
-                        return value ? (
-                          <TextCopyInput>
-                            {getDynamicText({value, fixed: 'PERCY_CLIENT_SECRET'})}
-                          </TextCopyInput>
-                        ) : (
-                          <em>hidden</em>
-                        );
-                      }}
-                    </FormField>
-                  </PanelBody>
-                </Panel>
-              )}
-            </React.Fragment>
+            <Panel>
+              <PanelHeader>{t('Credentials')}</PanelHeader>
+              <PanelBody>
+                {app.status !== 'internal' && (
+                  <FormField name="clientId" label="Client ID" overflow>
+                    {({value}) => {
+                      return (
+                        <TextCopyInput>
+                          {getDynamicText({value, fixed: 'PERCY_CLIENT_ID'})}
+                        </TextCopyInput>
+                      );
+                    }}
+                  </FormField>
+                )}
+                <FormField overflow name="clientSecret" label="Client Secret">
+                  {({value}) => {
+                    return value ? (
+                      <TextCopyInput>
+                        {getDynamicText({value, fixed: 'PERCY_CLIENT_SECRET'})}
+                      </TextCopyInput>
+                    ) : (
+                      <em>hidden</em>
+                    );
+                  }}
+                </FormField>
+              </PanelBody>
+            </Panel>
           )}
         </Form>
       </div>

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -192,10 +192,15 @@ describe('Sentry Application Details', function() {
       expect(
         wrapper
           .find('PanelHeader')
-          .last()
+          .at(3)
           .text()
       ).toContain('Tokens');
       expect(wrapper.find('TokenItem').exists()).toBe(true);
+    });
+
+    it('shows just clientSecret', function() {
+      expect(wrapper.find('#clientSecret').exists()).toBe(true);
+      expect(wrapper.find('#clientId').exists()).toBe(false);
     });
   });
 

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -106,7 +106,13 @@ class GetSentryAppsTest(SentryAppsTest):
             'isAlertable': self.internal_app.is_alertable,
             'verifyInstall': self.internal_app.verify_install,
             'overview': self.internal_app.overview,
-            'schema': {}
+            'schema': {},
+            'clientId': self.internal_app.application.client_id,
+            'clientSecret': self.internal_app.application.client_secret,
+            'owner': {
+                'id': self.internal_org.id,
+                'slug': self.internal_org.slug,
+            }
         } in json.loads(response.content)
 
         response_uuids = set(o['uuid'] for o in response.data)
@@ -142,6 +148,12 @@ class GetSentryAppsTest(SentryAppsTest):
             'verifyInstall': self.internal_app.verify_install,
             'overview': self.internal_app.overview,
             'schema': {},
+            'clientId': self.internal_app.application.client_id,
+            'clientSecret': self.internal_app.application.client_secret,
+            'owner': {
+                'id': self.internal_org.id,
+                'slug': self.internal_org.slug,
+            }
         } in json.loads(response.content)
 
         response_uuids = set(o['uuid'] for o in response.data)


### PR DESCRIPTION
Adding in the client secret for internal apps since they will need that to verify the hook signature if they are using webhooks.

![Screen Shot 2019-08-08 at 11 10 33 AM](https://user-images.githubusercontent.com/15368179/62730009-fddf0400-b9d3-11e9-94df-092c23aa8730.png)
