### PR TITLE
feat(event-filtering): Add LastPass error to browser extension filter

### DIFF
--- a/src/sentry/message_filters.py
+++ b/src/sentry/message_filters.py
@@ -236,7 +236,7 @@ _EXTENSION_EXC_VALUES = re.compile(
         # See: https://forum.sentry.io/t/error-in-raven-js-plugin-setsuspendstate/481/
         'plugin.setSuspendState is not a function',
         # lastpass
-        'should_do_lastpass_here'
+        'should_do_lastpass_here',
     ))), re.I)
 
 _EXTENSION_EXC_SOURCES = re.compile(

--- a/src/sentry/message_filters.py
+++ b/src/sentry/message_filters.py
@@ -235,6 +235,8 @@ _EXTENSION_EXC_VALUES = re.compile(
         # Dragon Web Extension from Nuance Communications
         # See: https://forum.sentry.io/t/error-in-raven-js-plugin-setsuspendstate/481/
         'plugin.setSuspendState is not a function',
+        # lastpass
+        'should_do_lastpass_here'
     ))), re.I)
 
 _EXTENSION_EXC_SOURCES = re.compile(


### PR DESCRIPTION
Full error message from an event we'd like to block:

`l.LegacyGlobal.should_do_lastpass_here is not a function. (In 'l.LegacyGlobal.should_do_lastpass_here(document)', 'l.LegacyGlobal.should_do_lastpass_here' is undefined)
`