### PR TITLE
feat(eventstore): Do not query Snuba if event ID format is invalid

### DIFF
--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from sentry.models import SnubaEvent
 from sentry.eventstore.base import EventStorage
+from sentry.utils.validators import normalize_event_id
 
 
 class SnubaEventStorage(EventStorage):
@@ -15,6 +16,11 @@ class SnubaEventStorage(EventStorage):
         Returns None if an event cannot be found
         """
         cols = self.__get_columns(additional_columns)
+
+        event_id = normalize_event_id(event_id)
+
+        if not event_id:
+            return None
 
         return SnubaEvent.get_event(project_id, event_id, snuba_cols=cols)
 


### PR DESCRIPTION
The get_event_by_id method checks that the event ID is a valid UUID
before sending the query to Snuba, and returns None immediately if
invalid.