### PR TITLE
build(webpack): Fix vendor bundle not being split

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -167,12 +167,12 @@ const localeRestrictionPlugins = [
 const cacheGroups = {
   vendors: {
     name: 'vendor',
-
-    /**
-     * Do not split platformicons into its own (css) bundle -- keep it in the `sentry` css bundle
-     * TODO: kill platformicons css completely
-     */
-    test: /[\\/]node_modules[\\/](!platformicons)[\\/]/,
+    // This `platformicons` check is required otherwise it will get put into this chunk instead
+    // of `sentry.css` bundle
+    // TODO(platformicons): Simplify this if we move platformicons into repo
+    test: module =>
+      !/platformicons/.test(module.resource) &&
+      /[\\/]node_modules[\\/]/.test(module.resource),
     priority: -10,
     enforce: true,
     chunks: 'initial',
@@ -342,6 +342,7 @@ const appConfig = {
       'app-test': path.join(__dirname, 'tests', 'js'),
       'sentry-locale': path.join(__dirname, 'src', 'sentry', 'locale'),
     },
+
     modules: ['node_modules'],
     extensions: ['.jsx', '.js', '.json', '.ts', '.tsx', '.less'],
   },


### PR DESCRIPTION
This is a bad regex introduced in https://github.com/getsentry/sentry/pull/14229 causing the vendor bundle to not be split from main application bundle.

It was originally in there because I saw `platformicons` being bundled in the `app` bundle, but the regex does not make sense, so not sure what happened. Re-running WBA with this change does not show `platformicons` being bundled inside of the `app` bundle.