### PR TITLE
feat(events2) Add metadata to responses and generalize column formatting

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -10,11 +10,7 @@ from sentry.api.helpers.events import get_direct_hit_response
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import EventSerializer, serialize, SimpleEventSerializer
 from sentry.models import SnubaEvent
-from sentry.utils.snuba import (
-    raw_query,
-    SnubaError,
-    transform_aliases_and_query,
-)
+from sentry.utils import snuba
 from sentry import features
 from sentry.models.project import Project
 
@@ -49,8 +45,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             }, status=400)
 
         data_fn = partial(
-            lambda **kwargs: transform_aliases_and_query(
-                skip_conditions=True, **kwargs)['data'],
+            lambda **kwargs: snuba.transform_aliases_and_query(skip_conditions=True, **kwargs),
             referrer='api.organization-events-v2',
             **snuba_args
         )
@@ -59,10 +54,10 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             return self.paginate(
                 request=request,
                 paginator=GenericOffsetPaginator(data_fn=data_fn),
-                on_results=lambda results: self.handle_results(
+                on_results=lambda results: self.handle_results_with_meta(
                     request, organization, params['project_id'], results),
             )
-        except SnubaError as error:
+        except snuba.SnubaError as error:
             logger.info(
                 'organization.events.snuba-error',
                 extra={
@@ -105,7 +100,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             snuba_cols = SnubaEvent.minimal_columns if full else SnubaEvent.selected_columns
             data_fn = partial(
                 # extract 'data' from raw_query result
-                lambda *args, **kwargs: raw_query(*args, **kwargs)['data'],
+                lambda *args, **kwargs: snuba.raw_query(*args, **kwargs)['data'],
                 selected_columns=snuba_cols,
                 orderby='-timestamp',
                 referrer='api.organization-events',
@@ -119,6 +114,21 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 [SnubaEvent(row) for row in results], request.user, serializer),
             paginator=GenericOffsetPaginator(data_fn=data_fn)
         )
+
+    def handle_results_with_meta(self, request, organization, project_ids, results):
+        data = self.handle_results(request, organization, project_ids, results.get('data'))
+        if not data:
+            return {'data': [], 'meta': {}}
+
+        meta = {value['name']: snuba.get_json_type(value['type']) for value in results['meta']}
+        # Ensure all columns in the result have types.
+        for key in data[0]:
+            if key not in meta:
+                meta[key] = 'string'
+        return {
+            'meta': meta,
+            'data': data,
+        }
 
     def handle_results(self, request, organization, project_ids, results):
         if not results:

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import re
 from functools import partial
 from copy import deepcopy
 
@@ -24,34 +23,6 @@ class DiscoverQueryPermission(OrganizationPermission):
 
 class DiscoverQueryEndpoint(OrganizationEndpoint):
     permission_classes = (DiscoverQueryPermission, )
-
-    def get_json_type(self, snuba_type):
-        """
-        Convert Snuba/Clickhouse type to JSON type
-        Default is string
-        """
-
-        # Ignore Nullable part
-        nullable_match = re.search(r'^Nullable\((.+)\)$', snuba_type)
-
-        if nullable_match:
-            snuba_type = nullable_match.group(1)
-        # Check for array
-
-        array_match = re.search(r'^Array\(.+\)$', snuba_type)
-        if array_match:
-            return 'array'
-
-        types = {
-            'UInt8': 'boolean',
-            'UInt16': 'integer',
-            'UInt32': 'integer',
-            'UInt64': 'integer',
-            'Float32': 'number',
-            'Float64': 'number',
-        }
-
-        return types.get(snuba_type, 'string')
 
     def handle_results(self, snuba_results, requested_query, projects):
         if 'project.name' in requested_query['selected_columns']:
@@ -88,7 +59,7 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
 
         # Convert snuba types to json types
         for col in snuba_results['meta']:
-            col['type'] = self.get_json_type(col.get('type'))
+            col['type'] = snuba.get_json_type(col.get('type'))
 
         return snuba_results
 

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/relatedEvents.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/relatedEvents.jsx
@@ -62,7 +62,7 @@ class RelatedEvents extends AsyncComponent {
   renderBody() {
     const {location, projects, event} = this.props;
     const {events} = this.state;
-    if (!events) {
+    if (!events || !events.data) {
       return null;
     }
 
@@ -71,10 +71,10 @@ class RelatedEvents extends AsyncComponent {
         <Title>
           <InlineSvg src="icon-link" size="12px" /> {t('Related Events')}
         </Title>
-        {events.length < 1 ? (
+        {events.data.length < 1 ? (
           <Card>{t('No related events found.')}</Card>
         ) : (
-          events.map(item => {
+          events.data.map(item => {
             const eventUrl = {
               pathname: location.pathname,
               query: {

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -786,6 +786,36 @@ def nest_groups(data, groups, aggregate_cols):
         )
 
 
+JSON_TYPE_MAP = {
+    'UInt8': 'boolean',
+    'UInt16': 'integer',
+    'UInt32': 'integer',
+    'UInt64': 'integer',
+    'Float32': 'number',
+    'Float64': 'number',
+    'DateTime': 'date',
+}
+
+
+def get_json_type(snuba_type):
+    """
+    Convert Snuba/Clickhouse type to JSON type
+    Default is string
+    """
+    # Ignore Nullable part
+    nullable_match = re.search(r'^Nullable\((.+)\)$', snuba_type)
+
+    if nullable_match:
+        snuba_type = nullable_match.group(1)
+
+    # Check for array
+    array_match = re.search(r'^Array\(.+\)$', snuba_type)
+    if array_match:
+        return 'array'
+
+    return JSON_TYPE_MAP.get(snuba_type, 'string')
+
+
 # The following are functions for resolving information from sentry models
 # about projects, environments, and issues (groups). Having this snuba
 # implementation have to know about these relationships is not ideal, and

--- a/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
@@ -13,14 +13,22 @@ describe('OrganizationEventsV2 > EventDetails', function() {
   beforeEach(function() {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
-      body: [
-        {
-          id: 'deadbeef',
-          title: 'Oh no something bad',
-          'project.name': 'project-slug',
-          timestamp: '2019-05-23T22:12:48+00:00',
+      body: {
+        meta: {
+          id: 'string',
+          title: 'string',
+          'project.name': 'string',
+          timestamp: 'date',
         },
-      ],
+        data: [
+          {
+            id: 'deadbeef',
+            title: 'Oh no something bad',
+            'project.name': 'project-slug',
+            timestamp: '2019-05-23T22:12:48+00:00',
+          },
+        ],
+      },
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/project-slug:deadbeef/',

--- a/tests/js/spec/views/organizationEventsV2/index.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/index.spec.jsx
@@ -8,14 +8,22 @@ describe('OrganizationEventsV2', function() {
   beforeEach(function() {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
-      body: [
-        {
-          id: 'deadbeef',
-          title: eventTitle,
-          'project.name': 'project-slug',
-          timestamp: '2019-05-23T22:12:48+00:00',
+      body: {
+        meta: {
+          id: 'string',
+          title: 'string',
+          'project.name': 'string',
+          timestamp: 'date',
         },
-      ],
+        data: [
+          {
+            id: 'deadbeef',
+            title: eventTitle,
+            'project.name': 'project-slug',
+            timestamp: '2019-05-23T22:12:48+00:00',
+          },
+        ],
+      },
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/project-slug:deadbeef/',

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1349,3 +1349,16 @@ class ResolveFieldListTest(unittest.TestCase):
             ['argMax(project_id, timestamp)', '', 'projectid'],
         ]
         assert result['groupby'] == []
+
+    def test_orderby_field_aggregate(self):
+        fields = ['count(id)', 'count_unique(user)']
+        snuba_args = {'orderby': '-count(id)'}
+        result = resolve_field_list(fields, snuba_args)
+        assert result['orderby'] == ['-count_id']
+        assert result['aggregations'] == [
+            ['count', 'id', 'count_id'],
+            ['uniq', 'user', 'count_unique_user'],
+            ['argMax(event_id, timestamp)', '', 'latest_event'],
+            ['argMax(project_id, timestamp)', '', 'projectid'],
+        ]
+        assert result['groupby'] == []

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -5,7 +5,7 @@ import pytz
 
 from sentry.models import GroupRelease, Release
 from sentry.testutils import TestCase
-from sentry.utils.snuba import get_snuba_translators, zerofill
+from sentry.utils.snuba import get_snuba_translators, zerofill, get_json_type
 
 
 class SnubaUtilsTest(TestCase):
@@ -183,3 +183,16 @@ class SnubaUtilsTest(TestCase):
 
         assert results[0]['time'] == 1546387200
         assert results[7]['time'] == 1546992000
+
+    def test_get_json_type(self):
+        assert get_json_type('UInt8') == 'boolean'
+        assert get_json_type('UInt16') == 'integer'
+        assert get_json_type('UInt32') == 'integer'
+        assert get_json_type('UInt64') == 'integer'
+        assert get_json_type('Float32') == 'number'
+        assert get_json_type('Float64') == 'number'
+        assert get_json_type('Nullable(Float64)') == 'number'
+        assert get_json_type('Array(String)') == 'array'
+        assert get_json_type('Char') == 'string'
+        assert get_json_type('unknown') == 'string'
+        assert get_json_type('') == 'string'

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -126,10 +126,17 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
             )
 
         assert response.status_code == 200, response.content
-        assert len(response.data) == 2
-        assert response.data[0]['id'] == 'b' * 32
-        assert response.data[0]['project.id'] == project.id
-        assert response.data[0]['user.email'] == 'foo@example.com'
+        data = response.data['data']
+        assert len(data) == 2
+        assert data[0]['id'] == 'b' * 32
+        assert data[0]['project.id'] == project.id
+        assert data[0]['user.email'] == 'foo@example.com'
+        meta = response.data['meta']
+        assert meta['id'] == 'string'
+        assert meta['project.name'] == 'string'
+        assert meta['user.email'] == 'string'
+        assert meta['user.ip'] == 'string'
+        assert meta['timestamp'] == 'date'
 
     def test_project_name(self):
         self.login_as(user=self.user)
@@ -153,10 +160,10 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
             )
 
         assert response.status_code == 200, response.content
-        assert len(response.data) == 1
-        assert response.data[0]['project.name'] == project.slug
-        assert 'project.id' not in response.data[0]
-        assert response.data[0]['environment'] == 'staging'
+        assert len(response.data['data']) == 1
+        assert response.data['data'][0]['project.name'] == project.slug
+        assert 'project.id' not in response.data['data'][0]
+        assert response.data['data'][0]['environment'] == 'staging'
 
     def test_implicit_groupby(self):
         self.login_as(user=self.user)
@@ -197,21 +204,24 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
             )
 
         assert response.status_code == 200, response.content
-        assert len(response.data) == 2
-        assert response.data[0] == {
+        assert len(response.data['data']) == 2
+        data = response.data['data']
+        assert data[0] == {
             'project.id': project.id,
             'project.name': project.slug,
             'issue.id': event1.group_id,
             'count_id': 2,
             'latest_event': event1.event_id,
         }
-        assert response.data[1] == {
+        assert data[1] == {
             'project.id': project.id,
             'project.name': project.slug,
             'issue.id': event2.group_id,
             'count_id': 1,
             'latest_event': event2.event_id,
         }
+        meta = response.data['meta']
+        assert meta['count_id'] == 'integer'
 
     def test_automatic_id_and_project(self):
         self.login_as(user=self.user)
@@ -243,12 +253,17 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
             )
 
         assert response.status_code == 200, response.content
-        assert len(response.data) == 1
-        assert response.data[0] == {
+        assert len(response.data['data']) == 1
+        data = response.data['data']
+        assert data[0] == {
             'project.name': project.slug,
             'count_id': 2,
             'latest_event': event.event_id,
         }
+        meta = response.data['meta']
+        assert meta['count_id'] == 'integer'
+        assert meta['project.name'] == 'string'
+        assert meta['latest_event'] == 'string'
 
     def test_orderby(self):
         self.login_as(user=self.user)
@@ -285,9 +300,10 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
             )
 
         assert response.status_code == 200, response.content
-        assert response.data[0]['id'] == 'c' * 32
-        assert response.data[1]['id'] == 'b' * 32
-        assert response.data[2]['id'] == 'a' * 32
+        data = response.data['data']
+        assert data[0]['id'] == 'c' * 32
+        assert data[1]['id'] == 'b' * 32
+        assert data[2]['id'] == 'a' * 32
 
     def test_sort_title(self):
         self.login_as(user=self.user)
@@ -327,9 +343,10 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
             )
 
         assert response.status_code == 200, response.content
-        assert response.data[0]['id'] == 'c' * 32
-        assert response.data[1]['id'] == 'b' * 32
-        assert response.data[2]['id'] == 'a' * 32
+        data = response.data['data']
+        assert data[0]['id'] == 'c' * 32
+        assert data[1]['id'] == 'b' * 32
+        assert data[2]['id'] == 'a' * 32
 
     def test_sort_invalid(self):
         self.login_as(user=self.user)
@@ -401,17 +418,18 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
             )
 
         assert response.status_code == 200, response.content
-        assert len(response.data) == 2
-        assert response.data[0]['issue.id'] == event1.group_id
-        assert response.data[0]['count_id'] == 1
-        assert response.data[0]['count_unique_user'] == 1
-        assert 'latest_event' in response.data[0]
-        assert 'project.name' in response.data[0]
-        assert 'projectid' not in response.data[0]
-        assert 'project.id' not in response.data[0]
-        assert response.data[1]['issue.id'] == event2.group_id
-        assert response.data[1]['count_id'] == 2
-        assert response.data[1]['count_unique_user'] == 2
+        assert len(response.data['data']) == 2
+        data = response.data['data']
+        assert data[0]['issue.id'] == event1.group_id
+        assert data[0]['count_id'] == 1
+        assert data[0]['count_unique_user'] == 1
+        assert 'latest_event' in data[0]
+        assert 'project.name' in data[0]
+        assert 'projectid' not in data[0]
+        assert 'project.id' not in data[0]
+        assert data[1]['issue.id'] == event2.group_id
+        assert data[1]['count_id'] == 2
+        assert data[1]['count_unique_user'] == 2
 
     @pytest.mark.xfail(reason='aggregate comparisons need parser improvements')
     def test_aggregation_comparison(self):
@@ -486,10 +504,11 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
 
         assert response.status_code == 200, response.content
 
-        assert len(response.data) == 1
-        assert response.data[0]['issue.id'] == event.group_id
-        assert response.data[0]['count_id'] == 2
-        assert response.data[0]['count_unique_user'] == 2
+        assert len(response.data['data']) == 1
+        data = response.data['data']
+        assert data[0]['issue.id'] == event.group_id
+        assert data[0]['count_id'] == 2
+        assert data[0]['count_unique_user'] == 2
 
     @pytest.mark.xfail(reason='aggregate comparisons need parser improvements')
     def test_aggregation_comparison_with_conditions(self):
@@ -557,9 +576,10 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
 
         assert response.status_code == 200, response.content
 
-        assert len(response.data) == 1
-        assert response.data[0]['issue.id'] == event.group_id
-        assert response.data[0]['count_id'] == 2
+        assert len(response.data['data']) == 1
+        data = response.data['data']
+        assert data[0]['issue.id'] == event.group_id
+        assert data[0]['count_id'] == 2
 
     def test_nonexistent_fields(self):
         self.login_as(user=self.user)
@@ -583,7 +603,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
                 },
             )
         assert response.status_code == 200, response.content
-        assert response.data[0]['issue_world.id'] == ''
+        assert response.data['data'][0]['issue_world.id'] == ''
 
     def test_no_requested_fields_or_grouping(self):
         self.login_as(user=self.user)
@@ -636,7 +656,7 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
             )
 
         assert response.status_code == 200, response.content
-        assert len(response.data) == 0
+        assert len(response.data['data']) == 0
 
     def test_group_filtering(self):
         user = self.create_user()


### PR DESCRIPTION
Add metadata to responses to allow the API to convey data types to the
client. This allows us to generalize column formatting so that arbitrary function expressions can be formatted correctly.

Refs SEN-908