### PR TITLE
feat(onboarding): Add extra-chrome hook

### DIFF
--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -41,6 +41,7 @@ const validHookNames = new Set([
 
   // Onboarding experience
   'onboarding:invite-members',
+  'onboarding:extra-chrome',
 
   // Used to provide a component for integration features.
   'integrations:feature-gates',

--- a/src/sentry/static/sentry/app/views/onboarding/onboarding.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/onboarding.jsx
@@ -8,6 +8,7 @@ import styled from 'react-emotion';
 
 import {analytics} from 'app/utils/analytics';
 import {t} from 'app/locale';
+import Hook from 'app/components/hook';
 import InlineSvg from 'app/components/inlineSvg';
 import OnboardingPlatform from 'app/views/onboarding/platform';
 import OnboardingProjectSetup from 'app/views/onboarding/projectSetup';
@@ -196,6 +197,7 @@ class Onboarding extends React.Component {
         <Container>
           <PoseGroup flipMove={false}>{this.renderOnboardingSteps()}</PoseGroup>
         </Container>
+        <Hook name="onboarding:extra-chrome" />
       </OnboardingWrapper>
     );
   }


### PR DESCRIPTION
Going to use this in getsentry for a 'contact support' link