### PR TITLE
ref(relay_config): Move data filters config into filter_settings

### DIFF
--- a/src/sentry/message_filters.py
+++ b/src/sentry/message_filters.py
@@ -170,8 +170,7 @@ def _get_filter_settings(project_config, flt):
     :return: the options for the filter
     """
     filter_settings = project_config.config.get('filter_settings', {})
-    filter_key = flt.spec.id.replace('-', '_')
-    return filter_settings.get(filter_key, None)
+    return filter_settings.get(get_filter_key(flt), None)
 
 
 def _is_filter_enabled(project_config, flt):
@@ -181,6 +180,10 @@ def _is_filter_enabled(project_config, flt):
         raise ValueError("unknown filter", flt.spec.id)
 
     return filter_options['is_enabled']
+
+
+def get_filter_key(flt):
+    return flt.spec.id.replace('-', '_')
 
 
 # ************* local host filter *************

--- a/src/sentry/message_filters.py
+++ b/src/sentry/message_filters.py
@@ -170,7 +170,7 @@ def _get_filter_settings(project_config, flt):
     :return: the options for the filter
     """
     filter_settings = project_config.config.get('filter_settings', {})
-    filter_key = flt.spec.id
+    filter_key = flt.spec.id.replace('-', '_')
     return filter_settings.get(filter_key, None)
 
 

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -11,7 +11,7 @@ from pytz import utc
 from sentry.coreapi import APIError
 from sentry.grouping.api import get_grouping_config_dict_for_project
 from sentry.interfaces.security import DEFAULT_DISALLOWED_SOURCES
-from sentry.message_filters import get_all_filters
+from sentry.message_filters import get_all_filters, get_filter_key
 
 from sentry.models.organization import Organization
 from sentry.models.organizationoption import OrganizationOption
@@ -113,7 +113,7 @@ def get_project_config(project_id, full_config=True, for_store=False):
     project_cfg['filter_settings'] = filter_settings
 
     for flt in get_all_filters():
-        filter_id = flt.spec.id.replace('-', '_')
+        filter_id = get_filter_key(flt)
         settings = _load_filter_settings(flt, project)
         filter_settings[filter_id] = settings
 

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -113,7 +113,7 @@ def get_project_config(project_id, full_config=True, for_store=False):
     project_cfg['filter_settings'] = filter_settings
 
     for flt in get_all_filters():
-        filter_id = flt.spec.id
+        filter_id = flt.spec.id.replace('-', '_')
         settings = _load_filter_settings(flt, project)
         filter_settings[filter_id] = settings
 

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -108,25 +108,6 @@ def get_project_config(project_id, full_config=True, for_store=False):
 
     project_cfg = cfg['config']
 
-    invalid_releases = project.get_option(u'sentry:{}'.format(FilterTypes.RELEASES))
-    if invalid_releases is not None:
-        project_cfg[FilterTypes.RELEASES] = invalid_releases
-
-    blacklisted_ips = project.get_option('sentry:blacklisted_ips')
-    if blacklisted_ips is not None:
-        project_cfg['blacklisted_ips'] = blacklisted_ips
-
-    error_messages = project.get_option(u'sentry:{}'.format(FilterTypes.ERROR_MESSAGES))
-    if error_messages is not None:
-        project_cfg[FilterTypes.ERROR_MESSAGES] = error_messages
-
-    csp_disallowed_sources = []
-    if bool(project.get_option('sentry:csp_ignored_sources_defaults', True)):
-        csp_disallowed_sources += DEFAULT_DISALLOWED_SOURCES
-    csp_disallowed_sources += project.get_option('sentry:csp_ignored_sources', [])
-
-    project_cfg['csp_disallowed_sources'] = csp_disallowed_sources
-
     # get the filter settings for this project
     filter_settings = {}
     project_cfg['filter_settings'] = filter_settings
@@ -135,6 +116,25 @@ def get_project_config(project_id, full_config=True, for_store=False):
         filter_id = flt.spec.id
         settings = _load_filter_settings(flt, project)
         filter_settings[filter_id] = settings
+
+    invalid_releases = project.get_option(u'sentry:{}'.format(FilterTypes.RELEASES))
+    if invalid_releases:
+        filter_settings[FilterTypes.RELEASES] = {'releases': invalid_releases}
+
+    blacklisted_ips = project.get_option('sentry:blacklisted_ips')
+    if blacklisted_ips:
+        filter_settings['client_ips'] = {'blacklisted_ips': blacklisted_ips}
+
+    error_messages = project.get_option(u'sentry:{}'.format(FilterTypes.ERROR_MESSAGES))
+    if error_messages:
+        filter_settings[FilterTypes.ERROR_MESSAGES] = {'patterns': error_messages}
+
+    csp_disallowed_sources = []
+    if bool(project.get_option('sentry:csp_ignored_sources_defaults', True)):
+        csp_disallowed_sources += DEFAULT_DISALLOWED_SOURCES
+    csp_disallowed_sources += project.get_option('sentry:csp_ignored_sources', [])
+    if csp_disallowed_sources:
+        filter_settings['csp'] = {'disallowed_sources': csp_disallowed_sources}
 
     scrub_ip_address = (org_options.get('sentry:require_scrub_ip_address', False) or
                         project.get_option('sentry:scrub_ip_address', False))

--- a/src/sentry/utils/data_filters.py
+++ b/src/sentry/utils/data_filters.py
@@ -7,6 +7,7 @@ import six
 from django.utils.encoding import force_text
 
 from sentry import tsdb
+from sentry.utils.safe import get_path
 
 
 class FilterStatKeys(object):
@@ -46,7 +47,7 @@ def is_valid_ip(project_config, ip_address):
     Verify that an IP address is not being blacklisted
     for the given project.
     """
-    blacklist = project_config.config.get('blacklisted_ips')
+    blacklist = get_path(project_config.config, 'filter_settings', 'client_ips', 'blacklisted_ips')
     if not blacklist:
         return True
 
@@ -75,7 +76,13 @@ def is_valid_release(project_config, release):
     Verify that a release is not being filtered
     for the given project.
     """
-    invalid_versions = project_config.config.get(FilterTypes.RELEASES)
+    invalid_versions = get_path(
+        project_config.config,
+        'filter_settings',
+        FilterTypes.RELEASES,
+        'releases'
+    )
+
     if not invalid_versions:
         return True
 
@@ -93,7 +100,13 @@ def is_valid_error_message(project_config, message):
     Verify that an error message is not being filtered
     for the given project.
     """
-    filtered_errors = project_config.config.get(FilterTypes.ERROR_MESSAGES)
+    filtered_errors = get_path(
+        project_config.config,
+        'filter_settings',
+        FilterTypes.ERROR_MESSAGES,
+        'patterns'
+    )
+
     if not filtered_errors:
         return True
 

--- a/tests/sentry/filters/test_legacy_browsers.py
+++ b/tests/sentry/filters/test_legacy_browsers.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 
-from sentry.message_filters import _legacy_browsers_filter  # noqa
+from sentry.message_filters import _legacy_browsers_filter, get_filter_key  # noqa
 from sentry.models.projectoption import ProjectOption
 from sentry.models.auditlogentry import AuditLogEntry, AuditLogEntryEvent
 from sentry.testutils import APITestCase, TestCase
@@ -268,8 +268,9 @@ class LegacyBrowsersFilterTest(TestCase):
         filter_settings = {}
         config['filter_settings'] = filter_settings
         if filter_opt is not None:
-            key = _legacy_browsers_filter.spec.id
-            filter_settings[key] = _filter_option_to_config_setting(_legacy_browsers_filter, filter_opt)
+            key = get_filter_key(_legacy_browsers_filter)
+            filter_settings[key] = _filter_option_to_config_setting(
+                _legacy_browsers_filter, filter_opt)
         return ret_val
 
     def test_filters_android_2_by_default(self):


### PR DESCRIPTION
This is a follow-up to #14285, moving all filters configuration into the same place. This makes it more consistent for Relay to run filters.

Additionally, this PR fixes a bug where filter configs where serialized with dashes instead of camel-cased.

Required by https://github.com/getsentry/semaphore/pull/220