### PR TITLE
bf: Gracefully handle removing fk constraints

### DIFF
--- a/src/sentry/south_migrations/0229_drop_event_constraints.py
+++ b/src/sentry/south_migrations/0229_drop_event_constraints.py
@@ -13,9 +13,7 @@ class Migration(SchemaMigration):
             db.delete_foreign_key('sentry_message', 'project_id')
             db.delete_foreign_key('sentry_eventmapping', 'group_id')
             db.delete_foreign_key('sentry_eventmapping', 'project_id')
-        except OperationalError:
-            pass
-        except ValueError:
+        except (OperationalError, ValueError):
             pass
 
     def backwards(self, orm):

--- a/src/sentry/south_migrations/0229_drop_event_constraints.py
+++ b/src/sentry/south_migrations/0229_drop_event_constraints.py
@@ -15,6 +15,8 @@ class Migration(SchemaMigration):
             db.delete_foreign_key('sentry_eventmapping', 'project_id')
         except OperationalError:
             pass
+        except ValueError:
+            pass
 
     def backwards(self, orm):
         pass

--- a/src/sentry/south_migrations/0317_drop_grouptagvalue_constraints.py
+++ b/src/sentry/south_migrations/0317_drop_grouptagvalue_constraints.py
@@ -11,9 +11,7 @@ class Migration(SchemaMigration):
         try:
             db.delete_foreign_key('sentry_messagefiltervalue', 'group_id')
             db.delete_foreign_key('sentry_messagefiltervalue', 'project_id')
-        except OperationalError:
-            pass
-        except ValueError:
+        except (OperationalError, ValueError):
             pass
 
     def backwards(self, orm):

--- a/src/sentry/south_migrations/0317_drop_grouptagvalue_constraints.py
+++ b/src/sentry/south_migrations/0317_drop_grouptagvalue_constraints.py
@@ -13,6 +13,8 @@ class Migration(SchemaMigration):
             db.delete_foreign_key('sentry_messagefiltervalue', 'project_id')
         except OperationalError:
             pass
+        except ValueError:
+            pass
 
     def backwards(self, orm):
         "Write your backwards methods here."

--- a/src/sentry/south_migrations/0349_drop_constraints_filterkey_filtervalue_grouptagkey.py
+++ b/src/sentry/south_migrations/0349_drop_constraints_filterkey_filtervalue_grouptagkey.py
@@ -14,7 +14,7 @@ class Migration(SchemaMigration):
             db.delete_foreign_key('sentry_filtervalue', 'project_id')
             db.delete_foreign_key('sentry_grouptagkey', 'project_id')
             db.delete_foreign_key('sentry_grouptagkey', 'group_id')
-        except OperationalError:
+        except (OperationalError, ValueError):
             pass
 
     def backwards(self, orm):

--- a/src/sentry/south_migrations/0353_auto__del_field_eventuser_project__add_field_eventuser_project_id__del.py
+++ b/src/sentry/south_migrations/0353_auto__del_field_eventuser_project__add_field_eventuser_project_id__del.py
@@ -11,7 +11,7 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
         try:
             db.delete_foreign_key('sentry_eventuser', 'project_id')
-        except OperationalError:
+        except (OperationalError, ValueError):
             pass
 
     def backwards(self, orm):


### PR DESCRIPTION
```
Running migrations for sentry:
 - Migrating forwards to 0472_auto__add_field_sentryapp_author.
 > sentry:0229_drop_event_constraints
   = 
                SELECT kc.constraint_name, kc.column_name, c.constraint_type
                FROM information_schema.constraint_column_usage AS kc
                JOIN information_schema.table_constraints AS c ON
                    kc.table_schema = c.table_schema AND
                    kc.table_name = c.table_name AND
                    kc.constraint_name = c.constraint_name
                WHERE
                    kc.table_schema = %s AND
                    kc.table_name = %s
             ['public', 'sentry_message']
   = 
                SELECT kc.constraint_name, kc.column_name, c.constraint_type
                FROM information_schema.key_column_usage AS kc
                JOIN information_schema.table_constraints AS c ON
                    kc.table_schema = c.table_schema AND
                    kc.table_name = c.table_name AND
                    kc.constraint_name = c.constraint_name
                WHERE
                    kc.table_schema = %s AND
                    kc.table_name = %s
             ['public', 'sentry_message']
Error in migration: sentry:0229_drop_event_constraints
Traceback (most recent call last):
  File "/usr/local/bin/sentry", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/sentry/runner/__init__.py", line 162, in main
    cli(prog_name=get_prog(), obj={}, max_content_width=100)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/sentry/runner/decorators.py", line 36, in inner
    return ctx.invoke(f, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/sentry/runner/commands/upgrade.py", line 75, in upgrade
    _upgrade(not noinput, traceback, verbosity, not no_repair)
  File "/usr/local/lib/python2.7/site-packages/sentry/runner/commands/upgrade.py", line 30, in _upgrade
    ignore_ghost_migrations=True,
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 159, in call_command
    return klass.execute(*args, **defaults)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 415, in handle
    return self.handle_noargs(**options)
  File "/usr/local/lib/python2.7/site-packages/south/management/commands/syncdb.py", line 125, in handle_noargs
    management.call_command('south_migrate', **options)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 159, in call_command
    return klass.execute(*args, **defaults)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 285, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python2.7/site-packages/south/management/commands/south_migrate.py", line 105, in handle
    ignore_ghosts=ignore_ghosts,
  File "/usr/local/lib/python2.7/site-packages/south/migration/__init__.py", line 231, in migrate_app
    success = migrator.migrate_many(target, workplan, database)
  File "/usr/local/lib/python2.7/site-packages/south/migration/migrators.py", line 291, in migrate_many
    result = self.migrate(migration, database)
  File "/usr/local/lib/python2.7/site-packages/south/migration/migrators.py", line 132, in migrate
    result = self.run(migration, database)
  File "/usr/local/lib/python2.7/site-packages/south/migration/migrators.py", line 241, in run
    return super(Forwards, self).run(migration, database)
  File "/usr/local/lib/python2.7/site-packages/south/migration/migrators.py", line 114, in run
    return self.run_migration(migration, database)
  File "/usr/local/lib/python2.7/site-packages/south/migration/migrators.py", line 85, in run_migration
    migration_function()
  File "/usr/local/lib/python2.7/site-packages/south/migration/migrators.py", line 61, in <lambda>
    return (lambda: direction(orm))
  File "/usr/local/lib/python2.7/site-packages/sentry/south_migrations/0229_drop_event_constraints.py", line 12, in forwards
    db.delete_foreign_key('sentry_message', 'group_id')
  File "/usr/local/lib/python2.7/site-packages/south/db/generic.py", line 53, in _cache_clear
    return func(self, table, *args, **opts)
  File "/usr/local/lib/python2.7/site-packages/south/db/generic.py", line 827, in delete_foreign_key
    (table_name, column))
ValueError: Cannot find a FOREIGN KEY constraint on table sentry_message, column group_id
```
Seems like https://github.com/getsentry/sentry/pull/2539 was trying to handle this.
If it doesn't exist, why fail on trying to delete it