### PR TITLE
enh: Add safety check for fk

### DIFF
--- a/src/south/db/generic.py
+++ b/src/south/db/generic.py
@@ -797,6 +797,10 @@ class DatabaseOperations(object):
         """
         constraint_name = '%s_refs_%s_%s' % (
             from_column_name, to_column_name, self._digest(from_table_name, to_table_name))
+        constraints = self._find_foreign_constraints(to_table_name, constraint_name)
+        if constraints:
+            # no-op, fk already exists
+            return "NULL;"
         return self.add_foreign_key_sql % (
             self.quote_name(from_table_name),
             self.quote_name(self.shorten_name(constraint_name)),

--- a/src/south/db/generic.py
+++ b/src/south/db/generic.py
@@ -99,6 +99,7 @@ class DatabaseOperations(object):
     delete_primary_key_sql = "ALTER TABLE %(table)s DROP CONSTRAINT %(constraint)s"
     add_check_constraint_fragment = "ADD CONSTRAINT %(constraint)s CHECK (%(check)s)"
     rename_table_sql = "ALTER TABLE %s RENAME TO %s;"
+    add_foreign_key_sql = 'ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)%s;'
     backend_name = None
 
     default_schema_name = "public"
@@ -796,7 +797,7 @@ class DatabaseOperations(object):
         """
         constraint_name = '%s_refs_%s_%s' % (
             from_column_name, to_column_name, self._digest(from_table_name, to_table_name))
-        return 'ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)%s;' % (
+        return self.add_foreign_key_sql % (
             self.quote_name(from_table_name),
             self.quote_name(self.shorten_name(constraint_name)),
             self.quote_name(from_column_name),

--- a/src/south/db/generic.py
+++ b/src/south/db/generic.py
@@ -799,8 +799,9 @@ class DatabaseOperations(object):
             from_column_name, to_column_name, self._digest(from_table_name, to_table_name))
         constraints = self._find_foreign_constraints(to_table_name, constraint_name)
         if constraints:
-            # no-op, fk already exists
-            return "NULL;"
+            raise ValueError(
+                "FOREIGN KEY constraint already exists on table %s, column %s" %
+                (to_table_name, constraint_name))
         return self.add_foreign_key_sql % (
             self.quote_name(from_table_name),
             self.quote_name(self.shorten_name(constraint_name)),


### PR DESCRIPTION
If the foreign key already exists, we can prematurely detect and throw an error. This allows us to at least handle it later. 