### PR TITLE
chore(linting): Remove unused params in context `getTitle` methods

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contexts/app.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/app.jsx
@@ -40,8 +40,6 @@ class AppContextType extends React.Component {
   }
 }
 
-AppContextType.getTitle = function(value) {
-  return 'App';
-};
+AppContextType.getTitle = () => 'App';
 
 export default AppContextType;

--- a/src/sentry/static/sentry/app/components/events/contexts/device.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device.jsx
@@ -120,8 +120,6 @@ class DeviceContextType extends React.Component {
   }
 }
 
-DeviceContextType.getTitle = function(value) {
-  return 'Device';
-};
+DeviceContextType.getTitle = () => 'Device';
 
 export default DeviceContextType;

--- a/src/sentry/static/sentry/app/components/events/contexts/gpu.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/gpu.jsx
@@ -58,8 +58,6 @@ class GpuContextType extends React.Component {
   }
 }
 
-GpuContextType.getTitle = function(value) {
-  return 'GPU';
-};
+GpuContextType.getTitle = () => 'GPU';
 
 export default GpuContextType;

--- a/src/sentry/static/sentry/app/components/events/contexts/os.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/os.jsx
@@ -27,8 +27,6 @@ class OsContextType extends React.Component {
   }
 }
 
-OsContextType.getTitle = function(value) {
-  return 'Operating System';
-};
+OsContextType.getTitle = () => 'Operating System';
 
 export default OsContextType;

--- a/src/sentry/static/sentry/app/components/events/contexts/runtime.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/runtime.jsx
@@ -21,8 +21,6 @@ class RuntimeContextType extends React.Component {
   }
 }
 
-RuntimeContextType.getTitle = function(value) {
-  return 'Runtime';
-};
+RuntimeContextType.getTitle = () => 'Runtime';
 
 export default RuntimeContextType;

--- a/src/sentry/static/sentry/app/components/events/contexts/user.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/user.jsx
@@ -72,8 +72,6 @@ class UserContextType extends React.Component {
   }
 }
 
-UserContextType.getTitle = function(value) {
-  return 'User';
-};
+UserContextType.getTitle = () => 'User';
 
 export default UserContextType;


### PR DESCRIPTION
To keep eslint happy. ES6ified them while I was at it.