### PR TITLE
feat: Increase received events cache to 1 hour

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -289,7 +289,7 @@ def process_event(event_manager, project, key, remote_addr, helper, attachments,
     # mutates data (strips a lot of context if not queued)
     helper.insert_data_to_database(data, start_time=start_time, attachments=attachments)
 
-    cache.set(cache_key, '', 60 * 5)
+    cache.set(cache_key, '', 60 * 60)  # Cache for 1 hour
 
     api_logger.debug('New event received (%s)', event_id)
 


### PR DESCRIPTION
Increase caching of received event IDs from 5 minutes to 1 hour.

Motivation for this change:
- We currently receive a large volume of duplicate events (~27 per second in the outcomes table)
- In future we will process all duplicate events received after this
window in post processing

Ref: https://getsentry.atlassian.net/browse/SNS-239