### PR TITLE
fix(apm): Adjust margins of span tree

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/spanBar.tsx
@@ -132,6 +132,10 @@ const INTERSECTION_THRESHOLDS: Array<number> = [
   1.0,
 ];
 
+const TOGGLE_BUTTON_MARGIN_RIGHT = 8;
+const TOGGLE_BUTTON_MAX_WIDTH = 40;
+const TOGGLE_BORDER_BOX = TOGGLE_BUTTON_MAX_WIDTH + TOGGLE_BUTTON_MARGIN_RIGHT;
+
 type SpanBarProps = {
   trace: Readonly<ParsedTraceType>;
   span: Readonly<SpanType>;
@@ -243,7 +247,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     const chevron = this.props.showSpanTree ? <ChevronOpen /> : <ChevronClosed />;
 
     if (numOfSpanChildren <= 0) {
-      return null;
+      return <SpanTreeTogglerContainer style={{left: `${left}px`}} />;
     }
 
     return (
@@ -274,11 +278,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     const description = get(span, 'description', span.span_id);
 
     const MARGIN_LEFT = 8;
-    const TOGGLE_BUTTON_MARGIN_RIGHT = 8;
-    const TOGGLE_BUTTON_MAX_WIDTH = 40;
-
-    const left =
-      treeDepth * (TOGGLE_BUTTON_MAX_WIDTH + TOGGLE_BUTTON_MARGIN_RIGHT) + MARGIN_LEFT;
+    const left = treeDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
 
     return (
       <SpanBarTitleContainer>


### PR DESCRIPTION
Before:

<img width="1127" alt="Screen Shot 2019-08-13 at 12 09 34 AM" src="https://user-images.githubusercontent.com/139499/62914581-d59e2f00-bd5e-11e9-9db1-ba9e9c015660.png">

After:

<img width="1127" alt="Screen Shot 2019-08-13 at 12 09 41 AM" src="https://user-images.githubusercontent.com/139499/62914584-d931b600-bd5e-11e9-91b3-6bca4653421d.png">

------

Adjust margins of the spans in the tree to make relationships more explicit. e.g. `lonely` span visually appears to have descendants when, really, it does not have any (see before screenshot). 
