### PR TITLE
ref: Stop writing to the event mapping table

### DIFF
--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -37,7 +37,6 @@ def merge_groups(
         GroupRuleStatus,
         GroupSubscription,
         Environment,
-        EventMapping,
         Event,
         UserReport,
         GroupRedirect,
@@ -99,8 +98,7 @@ def merge_groups(
     else:
         model_list = tuple(EXTRA_MERGE_MODELS) + (
             Activity, GroupAssignee, GroupEnvironment, GroupHash, GroupRuleStatus,
-            GroupSubscription, EventMapping, Event, UserReport, GroupRedirect,
-            GroupMeta,
+            GroupSubscription, Event, UserReport, GroupRedirect, GroupMeta,
         )
 
         has_more = merge_objects(

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -10,8 +10,8 @@ from sentry.app import tsdb
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS_MAP
 from sentry.event_manager import generate_culprit
 from sentry.models import (
-    Activity, Environment, Event, EventMapping, EventUser, Group,
-    GroupEnvironment, GroupHash, GroupRelease, Project, Release, UserReport
+    Activity, Environment, Event, EventUser, Group, GroupEnvironment, GroupHash,
+    GroupRelease, Project, Release, UserReport
 )
 from sentry.similarity import features
 from sentry.tasks.base import instrumented_task
@@ -240,11 +240,6 @@ def migrate_events(caches, project, source_id, destination_id,
     )
 
     event_event_id_set = set(event.event_id for event in events)
-
-    EventMapping.objects.filter(
-        project_id=project.id,
-        event_id__in=event_event_id_set,
-    ).update(group_id=destination_id)
 
     UserReport.objects.filter(
         project_id=project.id,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -29,7 +29,7 @@ from sentry.incidents.models import (
 )
 from sentry.mediators import sentry_apps, sentry_app_installations, sentry_app_installation_tokens, service_hooks
 from sentry.models import (
-    Activity, Environment, Event, EventError, EventMapping, Group, Organization, OrganizationMember,
+    Activity, Environment, Event, EventError, Group, Organization, OrganizationMember,
     OrganizationMemberTeam, Project, ProjectBookmark, Team, User, UserEmail, Release, Commit, ReleaseCommit,
     CommitAuthor, Repository, CommitFileChange, ProjectDebugFile, File, UserPermission, EventAttachment,
     UserReport, PlatformExternalIssue,
@@ -497,12 +497,6 @@ class Factories(object):
         )
 
         event = Event(event_id=event_id, group=group, **kwargs)
-        if group:
-            EventMapping.objects.create(
-                project_id=event.project.id,
-                event_id=event_id,
-                group=group,
-            )
         # emulate EventManager refs
         event.data.bind_ref(event)
         event.save()

--- a/tests/sentry/deletions/test_event.py
+++ b/tests/sentry/deletions/test_event.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from sentry import tagstore
 from sentry.tagstore.models import EventTag
 from sentry.models import (
-    Event, EventAttachment, EventMapping, File, ScheduledDeletion, UserReport
+    Event, EventAttachment, File, ScheduledDeletion, UserReport
 )
 from sentry.tasks.deletion import run_deletion
 from sentry.testutils import TestCase
@@ -61,10 +61,6 @@ class DeleteEventTest(TestCase):
 
         assert not Event.objects.filter(id=event.id).exists()
         assert not EventAttachment.objects.filter(
-            event_id=event.event_id,
-            project_id=project.id,
-        ).exists()
-        assert not EventMapping.objects.filter(
             event_id=event.event_id,
             project_id=project.id,
         ).exists()

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from sentry import tagstore
 from sentry.tagstore.models import EventTag
 from sentry.models import (
-    Event, EventMapping, Group, GroupAssignee, GroupHash, GroupMeta, GroupRedirect,
+    Event, Group, GroupAssignee, GroupHash, GroupMeta, GroupRedirect,
     ScheduledDeletion, UserReport
 )
 from sentry.tasks.deletion import run_deletion
@@ -19,11 +19,7 @@ class DeleteGroupTest(TestCase):
             project=project,
         )
         event = self.create_event(group=group)
-        EventMapping.objects.create(
-            project_id=project.id,
-            event_id='a' * 32,
-            group_id=group.id,
-        )
+
         UserReport.objects.create(
             group_id=group.id,
             project_id=event.project_id,
@@ -78,9 +74,6 @@ class DeleteGroupTest(TestCase):
             run_deletion(deletion.id)
 
         assert not Event.objects.filter(id=event.id).exists()
-        assert not EventMapping.objects.filter(
-            group_id=group.id,
-        ).exists()
         assert not EventTag.objects.filter(event_id=event.id).exists()
         assert not UserReport.objects.filter(group_id=group.id).exists()
         assert not GroupRedirect.objects.filter(group_id=group.id).exists()

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -11,8 +11,8 @@ from sentry.tagstore.models import EventTag
 from sentry.constants import ObjectStatus
 from sentry.exceptions import DeleteAborted
 from sentry.models import (
-    ApiApplication, ApiApplicationStatus, ApiGrant, ApiToken, Commit, CommitAuthor, Environment,
-    EnvironmentProject, Event, EventMapping, Group, GroupAssignee, GroupHash, GroupMeta,
+    ApiApplication, ApiApplicationStatus, ApiGrant, ApiToken, Commit, CommitAuthor,
+    Environment, EnvironmentProject, Event, Group, GroupAssignee, GroupHash, GroupMeta,
     GroupRedirect, GroupResolution, GroupStatus, Organization, OrganizationStatus, Project,
     ProjectStatus, Release, ReleaseCommit, ReleaseEnvironment, Repository, Team, TeamStatus
 )
@@ -296,11 +296,6 @@ class DeleteGroupTest(TestCase):
             status=GroupStatus.PENDING_DELETION,
         )
         event = self.create_event(group=group)
-        EventMapping.objects.create(
-            project_id=project.id,
-            event_id='a' * 32,
-            group_id=group.id,
-        )
         tv, _ = tagstore.get_or_create_tag_value(project.id, self.environment.id, 'key1', 'value1')
         tagstore.create_event_tags(
             event_id=event.id,
@@ -335,10 +330,6 @@ class DeleteGroupTest(TestCase):
             delete_groups(object_ids=[group.id])
 
         assert not Event.objects.filter(id=event.id).exists()
-        assert not EventMapping.objects.filter(
-            event_id='a' * 32,
-            group_id=group.id,
-        ).exists()
         assert not EventTag.objects.filter(event_id=event.id).exists()
         assert not GroupRedirect.objects.filter(group_id=group.id).exists()
         assert not GroupHash.objects.filter(group_id=group.id).exists()

--- a/tests/sentry/tasks/test_unmerge.py
+++ b/tests/sentry/tasks/test_unmerge.py
@@ -17,7 +17,7 @@ from sentry import tagstore
 from sentry.tagstore.models import GroupTagValue
 from sentry.app import tsdb
 from sentry.models import (
-    Activity, Environment, EnvironmentProject, Event, EventMapping, Group, GroupHash, GroupRelease,
+    Activity, Environment, EnvironmentProject, Event, Group, GroupHash, GroupRelease,
     Release, UserReport
 )
 from sentry.similarity import features, _make_index_backend
@@ -266,13 +266,6 @@ class UnmergeTestCase(TestCase):
                     tags=event.tags,
                 )
 
-            EventMapping.objects.create(
-                project_id=project.id,
-                group_id=source.id,
-                event_id=event_id,
-                date_added=event.datetime,
-            )
-
             UserReport.objects.create(
                 project_id=project.id,
                 group_id=source.id,
@@ -436,12 +429,6 @@ class UnmergeTestCase(TestCase):
         )
 
         assert set(
-            EventMapping.objects.filter(
-                group_id=source.id,
-            ).values_list('event_id', flat=True)
-        ) == set(source_event_event_ids)
-
-        assert set(
             UserReport.objects.filter(
                 group_id=source.id,
             ).values_list('event_id', flat=True)
@@ -494,12 +481,6 @@ class UnmergeTestCase(TestCase):
             lambda event: event.event_id,
             events.values()[1],
         )
-
-        assert set(
-            EventMapping.objects.filter(
-                group_id=destination.id,
-            ).values_list('event_id', flat=True)
-        ) == set(destination_event_event_ids)
 
         assert set(
             UserReport.objects.filter(


### PR DESCRIPTION
This is not needed since events are not sampled in Snuba. This table should be removed as a follow up.

https://getsentry.atlassian.net/browse/SNS-240