### PR TITLE
ref(discover2) Move endpoints for discover2/events2

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -20,8 +20,71 @@ logger = logging.getLogger(__name__)
 class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
     def get(self, request, organization):
+        # Check for a direct hit on event ID
+        query = request.GET.get('query', '').strip()
+
+        try:
+            direct_hit_resp = get_direct_hit_response(
+                request,
+                query,
+                self.get_filter_params(request, organization),
+                'api.organization-events'
+            )
+        except (OrganizationEventsError, NoProjects):
+            pass
+        else:
+            if direct_hit_resp:
+                return direct_hit_resp
+
+        full = request.GET.get('full', False)
+        try:
+            snuba_args = self.get_snuba_query_args_legacy(request, organization)
+        except OrganizationEventsError as exc:
+            return Response({'detail': exc.message}, status=400)
+        except NoProjects:
+            # return empty result if org doesn't have projects
+            # or user doesn't have access to projects in org
+            data_fn = lambda *args, **kwargs: []
+        else:
+            snuba_cols = SnubaEvent.minimal_columns if full else SnubaEvent.selected_columns
+            data_fn = partial(
+                # extract 'data' from raw_query result
+                lambda *args, **kwargs: snuba.raw_query(*args, **kwargs)['data'],
+                selected_columns=snuba_cols,
+                orderby='-timestamp',
+                referrer='api.organization-events',
+                **snuba_args
+            )
+
+        serializer = EventSerializer() if full else SimpleEventSerializer()
+        return self.paginate(
+            request=request,
+            on_results=lambda results: serialize(
+                [SnubaEvent(row) for row in results], request.user, serializer),
+            paginator=GenericOffsetPaginator(data_fn=data_fn)
+        )
+
+    def handle_results(self, request, organization, project_ids, results):
+        projects = {p['id']: p['slug'] for p in Project.objects.filter(
+            organization=organization,
+            id__in=project_ids).values('id', 'slug')}
+
+        fields = request.GET.getlist('field')
+
+        if 'project.name' in fields:
+            for result in results:
+                result['project.name'] = projects[result['project.id']]
+                if 'project.id' not in fields:
+                    del result['project.id']
+
+        return results
+
+
+class OrganizationEventsV2Endpoint(OrganizationEventsEndpointBase):
+
+    def get(self, request, organization):
         if not features.has('organizations:events-v2', organization, actor=request.user):
-            return self.get_legacy(request, organization)
+            return Response(status=404)
 
         try:
             params = self.get_filter_params(request, organization)
@@ -70,53 +133,8 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 'detail': 'Invalid query.'
             }, status=400)
 
-    def get_legacy(self, request, organization):
-        # Check for a direct hit on event ID
-        query = request.GET.get('query', '').strip()
-
-        try:
-            direct_hit_resp = get_direct_hit_response(
-                request,
-                query,
-                self.get_filter_params(request, organization),
-                'api.organization-events'
-            )
-        except (OrganizationEventsError, NoProjects):
-            pass
-        else:
-            if direct_hit_resp:
-                return direct_hit_resp
-
-        full = request.GET.get('full', False)
-        try:
-            snuba_args = self.get_snuba_query_args_legacy(request, organization)
-        except OrganizationEventsError as exc:
-            return Response({'detail': exc.message}, status=400)
-        except NoProjects:
-            # return empty result if org doesn't have projects
-            # or user doesn't have access to projects in org
-            data_fn = lambda *args, **kwargs: []
-        else:
-            snuba_cols = SnubaEvent.minimal_columns if full else SnubaEvent.selected_columns
-            data_fn = partial(
-                # extract 'data' from raw_query result
-                lambda *args, **kwargs: snuba.raw_query(*args, **kwargs)['data'],
-                selected_columns=snuba_cols,
-                orderby='-timestamp',
-                referrer='api.organization-events',
-                **snuba_args
-            )
-
-        serializer = EventSerializer() if full else SimpleEventSerializer()
-        return self.paginate(
-            request=request,
-            on_results=lambda results: serialize(
-                [SnubaEvent(row) for row in results], request.user, serializer),
-            paginator=GenericOffsetPaginator(data_fn=data_fn)
-        )
-
     def handle_results_with_meta(self, request, organization, project_ids, results):
-        data = self.handle_results(request, organization, project_ids, results.get('data'))
+        data = self.handle_data(request, organization, project_ids, results.get('data'))
         if not data:
             return {'data': [], 'meta': {}}
 
@@ -130,7 +148,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             'data': data,
         }
 
-    def handle_results(self, request, organization, project_ids, results):
+    def handle_data(self, request, organization, project_ids, results):
         if not results:
             return results
 

--- a/src/sentry/api/endpoints/organization_events_distribution.py
+++ b/src/sentry/api/endpoints/organization_events_distribution.py
@@ -16,6 +16,8 @@ PROJECT_KEY = 'project.name'
 
 class OrganizationEventsDistributionEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
+        if not features.has('organizations:events-v2', organization, actor=request.user):
+            return Response(status=404)
         try:
             params = self.get_filter_params(request, organization)
             snuba_args = self.get_snuba_query_args(request, organization, params)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -87,7 +87,10 @@ from .endpoints.organization_event_details import (
     OrganizationEventDetailsOldestEndpoint
 )
 from .endpoints.organization_eventid import EventIdLookupEndpoint
-from .endpoints.organization_events import OrganizationEventsEndpoint
+from .endpoints.organization_events import (
+    OrganizationEventsEndpoint,
+    OrganizationEventsV2Endpoint
+)
 from .endpoints.organization_events_distribution import OrganizationEventsDistributionEndpoint
 from .endpoints.organization_events_meta import OrganizationEventsMetaEndpoint
 from .endpoints.organization_events_stats import OrganizationEventsStatsEndpoint
@@ -712,6 +715,12 @@ urlpatterns = patterns(
             r'^(?P<organization_slug>[^\/]+)/events/$',
             OrganizationEventsEndpoint.as_view(),
             name='sentry-api-0-organization-events'
+        ),
+        # This is temporary while we alpha test eventsv2
+        url(
+            r'^(?P<organization_slug>[^\/]+)/eventsv2/$',
+            OrganizationEventsV2Endpoint.as_view(),
+            name='sentry-api-0-organization-eventsv2'
         ),
         url(
             r'^(?P<organization_slug>[^\/]+)/events/(?P<project_slug>[^\/]+):(?P<event_id>(?:\d+|[A-Fa-f0-9]{32}))/$',

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -260,8 +260,7 @@ class Sidebar extends React.Component {
                   />
 
                   <Feature
-                    features={['events', 'events-v2']}
-                    requireAll={false}
+                    features={['events']}
                     hookName="events-sidebar-item"
                     organization={organization}
                   >
@@ -277,6 +276,26 @@ class Sidebar extends React.Component {
                       label={t('Events')}
                       to={`/organizations/${organization.slug}/events/`}
                       id="events"
+                    />
+                  </Feature>
+
+                  <Feature
+                    features={['events-v2']}
+                    hookName="events-sidebar-item"
+                    organization={organization}
+                  >
+                    <SidebarItem
+                      {...sidebarItemProps}
+                      onClick={(_id, evt) =>
+                        this.navigateWithGlobalSelection(
+                          `/organizations/${organization.slug}/eventsv2/`,
+                          evt
+                        )
+                      }
+                      icon={<InlineSvg src="icon-labs" />}
+                      label={t('Events V2')}
+                      to={`/organizations/${organization.slug}/eventsv2/`}
+                      id="events-v2"
                     />
                   </Feature>
 

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -976,6 +976,13 @@ function routes() {
             />
           </Route>
           <Route
+            path="/organizations/:orgId/eventsv2/"
+            componentPromise={() =>
+              import(/* webpackChunkName: "EventsV2" */ 'app/views/organizationEventsV2')
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
             path="/organizations/:orgId/monitors/"
             componentPromise={() =>
               import(/* webpackChunkName: "MonitorsContainer" */ 'app/views/monitors')

--- a/src/sentry/static/sentry/app/views/events/index.jsx
+++ b/src/sentry/static/sentry/app/views/events/index.jsx
@@ -13,7 +13,6 @@ import PageHeading from 'app/components/pageHeading';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import {PageContent, PageHeader} from 'app/styles/organization';
-import LazyLoad from 'app/components/lazyLoad';
 
 import SearchBar from './searchBar';
 
@@ -41,24 +40,7 @@ class EventsContainer extends React.Component {
   };
 
   render() {
-    const {organization, location, children, ...props} = this.props;
-
-    const hasEventsV2 = new Set(organization.features).has('events-v2');
-
-    if (hasEventsV2) {
-      return (
-        <LazyLoad
-          component={() =>
-            import(/* webpackChunkName: "OrganizationEventsV2" */ 'app/views/organizationEventsV2').then(
-              mod => mod.default
-            )
-          }
-          organization={organization}
-          location={location}
-          {...props}
-        />
-      );
-    }
+    const {organization, location, children} = this.props;
 
     return (
       <Feature features={['events']} hookName="events-page" renderDisabled>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.jsx
@@ -163,9 +163,9 @@ export const FIELD_FORMATTERS = {
 export const SPECIAL_FIELDS = {
   transaction: {
     sortField: 'transaction',
-    renderFunc: (data, {organization, location}) => {
+    renderFunc: (data, {location}) => {
       const target = {
-        pathname: `/organizations/${organization.slug}/events/`,
+        pathname: location.pathname,
         query: {
           ...location.query,
           eventSlug: `${data['project.name']}:${data.latest_event}`,
@@ -182,9 +182,9 @@ export const SPECIAL_FIELDS = {
   },
   title: {
     sortField: 'title',
-    renderFunc: (data, {organization, location}) => {
+    renderFunc: (data, {location}) => {
       const target = {
-        pathname: `/organizations/${organization.slug}/events/`,
+        pathname: location.pathname,
         query: {...location.query, eventSlug: `${data['project.name']}:${data.id}`},
       };
       return (
@@ -198,9 +198,9 @@ export const SPECIAL_FIELDS = {
   },
   type: {
     sortField: 'event.type',
-    renderFunc: (data, {location, organization}) => {
+    renderFunc: (data, {location}) => {
       const target = {
-        pathname: `/organizations/${organization.slug}/events/`,
+        pathname: location.pathname,
         query: {
           ...location.query,
           query: `event.type:${data['event.type']}`,
@@ -227,7 +227,7 @@ export const SPECIAL_FIELDS = {
   },
   user: {
     sortField: 'user.id',
-    renderFunc: (data, {organization, location}) => {
+    renderFunc: (data, {location}) => {
       const userObj = {
         id: data['user.id'],
         name: data['user.name'],
@@ -245,7 +245,7 @@ export const SPECIAL_FIELDS = {
       }
 
       const target = {
-        pathname: `/organizations/${organization.slug}/events/`,
+        pathname: location.pathname,
         query: {
           ...location.query,
           query: `user:${data.user}`,
@@ -257,9 +257,9 @@ export const SPECIAL_FIELDS = {
   },
   issue_title: {
     sortField: 'issue_title',
-    renderFunc: (data, {organization, location}) => {
+    renderFunc: (data, {location}) => {
       const target = {
-        pathname: `/organizations/${organization.slug}/events/`,
+        pathname: location.pathname,
         query: {
           ...location.query,
           eventSlug: `${data['project.name']}:${data.latest_event}`,

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/events.jsx
@@ -107,7 +107,7 @@ class EventsTable extends AsyncComponent {
     return [
       [
         'data',
-        `/organizations/${organization.slug}/events/`,
+        `/organizations/${organization.slug}/eventsv2/`,
         {
           query: getQuery(view, location),
         },

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/index.jsx
@@ -8,16 +8,18 @@ import GlobalSelectionHeader from 'app/components/organizations/globalSelectionH
 import {PageContent, PageHeader} from 'app/styles/organization';
 import PageHeading from 'app/components/pageHeading';
 import BetaTag from 'app/components/betaTag';
+import Feature from 'app/components/acl/feature';
 import NavTabs from 'app/components/navTabs';
 import ListLink from 'app/components/links/listLink';
 import NoProjectMessage from 'app/components/noProjectMessage';
+import withOrganization from 'app/utils/withOrganization';
 
 import Events from './events';
 import EventDetails from './eventDetails';
 import {ALL_VIEWS} from './data';
 import {getCurrentView} from './utils';
 
-export default class OrganizationEventsV2 extends React.Component {
+class OrganizationEventsV2 extends React.Component {
   static propTypes = {
     organization: SentryTypes.Organization.isRequired,
     location: PropTypes.object.isRequired,
@@ -25,8 +27,8 @@ export default class OrganizationEventsV2 extends React.Component {
   };
 
   renderTabs() {
-    const {organization} = this.props;
-    const currentView = getCurrentView(this.props.location.query.view);
+    const {location} = this.props;
+    const currentView = getCurrentView(location.query.view);
 
     return (
       <NavTabs underlined={true}>
@@ -34,7 +36,7 @@ export default class OrganizationEventsV2 extends React.Component {
           <ListLink
             key={view.id}
             to={{
-              pathname: `/organizations/${organization.slug}/events/`,
+              pathname: location.pathname,
               query: {
                 ...this.props.location.query,
                 view: view.id,
@@ -57,36 +59,41 @@ export default class OrganizationEventsV2 extends React.Component {
     const currentView = getCurrentView(location.query.view);
 
     return (
-      <DocumentTitle title={`Events - ${organization.slug} - Sentry`}>
-        <React.Fragment>
-          <GlobalSelectionHeader organization={organization} />
-          <PageContent>
-            <NoProjectMessage organization={organization}>
-              <PageHeader>
-                <PageHeading>
-                  {t('Events')} <BetaTag />
-                </PageHeading>
-              </PageHeader>
-              {this.renderTabs()}
-              <Events
-                organization={organization}
-                view={currentView}
-                location={location}
-                router={router}
-              />
-            </NoProjectMessage>
-            {eventSlug && (
-              <EventDetails
-                organization={organization}
-                params={this.props.params}
-                eventSlug={eventSlug}
-                view={currentView}
-                location={location}
-              />
-            )}
-          </PageContent>
-        </React.Fragment>
-      </DocumentTitle>
+      <Feature features={['events-v2']} organization={organization} renderDisabled>
+        <DocumentTitle title={`Events - ${organization.slug} - Sentry`}>
+          <React.Fragment>
+            <GlobalSelectionHeader organization={organization} />
+            <PageContent>
+              <NoProjectMessage organization={organization}>
+                <PageHeader>
+                  <PageHeading>
+                    {t('Events')} <BetaTag />
+                  </PageHeading>
+                </PageHeader>
+                {this.renderTabs()}
+                <Events
+                  organization={organization}
+                  view={currentView}
+                  location={location}
+                  router={router}
+                />
+              </NoProjectMessage>
+              {eventSlug && (
+                <EventDetails
+                  organization={organization}
+                  params={this.props.params}
+                  eventSlug={eventSlug}
+                  view={currentView}
+                  location={location}
+                />
+              )}
+            </PageContent>
+          </React.Fragment>
+        </DocumentTitle>
+      </Feature>
     );
   }
 }
+
+export default withOrganization(OrganizationEventsV2);
+export {OrganizationEventsV2};

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/relatedEvents.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/relatedEvents.jsx
@@ -29,7 +29,7 @@ class RelatedEvents extends AsyncComponent {
   getEndpoints() {
     // TODO what happens when global-views feature is not on the org?
     const {event, organization} = this.props;
-    const eventsUrl = `/organizations/${organization.slug}/events/`;
+    const eventsUrl = `/organizations/${organization.slug}/eventsv2/`;
     const trace = event.tags.find(tag => tag.key === 'trace');
 
     if (!trace) {

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -12,9 +12,9 @@ from sentry.utils.samples import load_data
 FEATURE_NAME = 'organizations:events-v2'
 
 
-class OrganizationEventsTest(AcceptanceTestCase, SnubaTestCase):
+class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsTest, self).setUp()
+        super(OrganizationEventsV2Test, self).setUp()
         self.user = self.create_user('foo@example.com')
         self.org = self.create_organization(owner=None, name='Rowdy Tiger')
         self.team = self.create_team(organization=self.org, name='Mariachi Band')
@@ -31,7 +31,7 @@ class OrganizationEventsTest(AcceptanceTestCase, SnubaTestCase):
         )
 
         self.login_as(self.user)
-        self.path = u'/organizations/{}/events/'.format(self.org.slug)
+        self.path = u'/organizations/{}/eventsv2/'.format(self.org.slug)
 
     def wait_until_loaded(self):
         self.browser.wait_until_not('.loading-indicator')

--- a/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
@@ -12,7 +12,7 @@ describe('OrganizationEventsV2 > EventDetails', function() {
 
   beforeEach(function() {
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
+      url: '/organizations/org-slug/eventsv2/',
       body: {
         meta: {
           id: 'string',

--- a/tests/js/spec/views/organizationEventsV2/index.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/index.spec.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import {mount} from 'enzyme';
 
-import OrganizationEventsV2 from 'app/views/organizationEventsV2';
+import {OrganizationEventsV2} from 'app/views/organizationEventsV2';
 
 describe('OrganizationEventsV2', function() {
   const eventTitle = 'Oh no something bad';
+  const features = ['events-v2'];
+
   beforeEach(function() {
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
+      url: '/organizations/org-slug/eventsv2/',
       body: {
         meta: {
           id: 'string',
@@ -50,7 +52,7 @@ describe('OrganizationEventsV2', function() {
   it('renders', function() {
     const wrapper = mount(
       <OrganizationEventsV2
-        organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
+        organization={TestStubs.Organization({features, projects: [TestStubs.Project()]})}
         location={{query: {}}}
         router={{}}
       />,
@@ -63,7 +65,7 @@ describe('OrganizationEventsV2', function() {
   it('handles no projects', function() {
     const wrapper = mount(
       <OrganizationEventsV2
-        organization={TestStubs.Organization()}
+        organization={TestStubs.Organization({features})}
         location={{query: {}}}
         router={{}}
       />,
@@ -77,7 +79,7 @@ describe('OrganizationEventsV2', function() {
   it('generates an active sort link based on default sort', function() {
     const wrapper = mount(
       <OrganizationEventsV2
-        organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
+        organization={TestStubs.Organization({features, projects: [TestStubs.Project()]})}
         location={{query: {}}}
         router={{}}
       />,
@@ -110,7 +112,7 @@ describe('OrganizationEventsV2', function() {
   it('generates links to modals', async function() {
     const wrapper = mount(
       <OrganizationEventsV2
-        organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
+        organization={TestStubs.Organization({features, projects: [TestStubs.Project()]})}
         location={{query: {}}}
         router={{}}
       />,
@@ -122,7 +124,10 @@ describe('OrganizationEventsV2', function() {
   });
 
   it('opens a modal when eventSlug is present', async function() {
-    const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
+    const organization = TestStubs.Organization({
+      features,
+      projects: [TestStubs.Project()],
+    });
     const wrapper = mount(
       <OrganizationEventsV2
         organization={organization}

--- a/tests/snuba/api/endpoints/test_organization_events_distribution.py
+++ b/tests/snuba/api/endpoints/test_organization_events_distribution.py
@@ -10,6 +10,8 @@ from sentry.testutils import APITestCase, SnubaTestCase
 
 
 class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
+    feature_list = ('organizations:events-v2', 'organizations:global-views')
+
     def setUp(self):
         super(OrganizationEventsDistributionEndpointTest, self).setUp()
         self.min_ago = (timezone.now() - timedelta(minutes=1)).replace(microsecond=0)
@@ -51,7 +53,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
             project_id=self.project.id
         )
 
-        with self.feature('organizations:global-views'):
+        with self.feature(self.feature_list):
             response = self.client.get(self.url, {'key': 'number'}, format='json')
 
         assert response.status_code == 200, response.content
@@ -101,7 +103,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
             project_id=self.project2.id
         )
 
-        with self.feature('organizations:global-views'):
+        with self.feature(self.feature_list):
             response = self.client.get(
                 self.url, {
                     'query': 'delet', 'key': 'color'}, format='json')
@@ -153,7 +155,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
             project_id=self.project2.id
         )
 
-        with self.feature('organizations:global-views'):
+        with self.feature(self.feature_list):
             response = self.client.get(
                 self.url, {
                     'query': 'color:yellow', 'key': 'color'}, format='json')
@@ -209,7 +211,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
             project_id=self.project2.id
         )
 
-        with self.feature('organizations:global-views'):
+        with self.feature(self.feature_list):
             response = self.client.get(
                 self.url,
                 {
@@ -260,14 +262,15 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
             project_id=self.project.id
         )
 
-        response = self.client.get(
-            self.url,
-            {
-                'key': 'user',
-                'project': [self.project.id]
-            },
-            format='json'
-        )
+        with self.feature(self.feature_list):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'key': 'user',
+                    'project': [self.project.id]
+                },
+            )
 
         assert response.status_code == 200, response.content
         assert response.data == {
@@ -294,12 +297,14 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
                 'organization_slug': org.slug,
             }
         )
-        response = self.client.get(url, {'key': 'color'}, format='json')
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(url, {'key': 'color'}, format='json')
         assert response.status_code == 400, response.content
         assert response.data == {'detail': 'A valid project must be included.'}
 
     def test_no_key_param(self):
-        response = self.client.get(self.url, {'project': [self.project.id]}, format='json')
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(self.url, {'project': [self.project.id]}, format='json')
         assert response.status_code == 400, response.content
         assert response.data == {'detail': 'Tag key must be specified.'}
 
@@ -317,7 +322,8 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
             project_id=self.project2.id
         )
 
-        response = self.client.get(self.url, {'key': 'color'}, format='json')
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(self.url, {'key': 'color'}, format='json')
         assert response.status_code == 400, response.content
         assert response.data == {'detail': 'You cannot view events from multiple projects.'}
 
@@ -339,7 +345,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
             project_id=self.project2.id
         )
 
-        with self.feature('organizations:global-views'):
+        with self.feature(self.feature_list):
             response = self.client.get(
                 self.url,
                 {'key': 'number', 'project': [self.project.id]},
@@ -390,7 +396,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
             project_id=self.project.id
         )
 
-        with self.feature('organizations:global-views'):
+        with self.feature(self.feature_list):
             response = self.client.get(
                 self.url, {'key': 'project.name'}, format='json')
 
@@ -460,7 +466,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
             project_id=self.project.id
         )
 
-        with self.feature('organizations:global-views'):
+        with self.feature(self.feature_list):
             response = self.client.get(
                 self.url, {'key': 'user.email'}, format='json')
 
@@ -508,7 +514,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
             },
             project_id=self.project2.id
         )
-        with self.feature('organizations:global-views'):
+        with self.feature(self.feature_list):
             response = self.client.get(
                 self.url, {'key': 'color'}, format='json')
 
@@ -534,16 +540,25 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
             project_id=self.project2.id
         )
 
-        response = self.client.get(
-            self.url, {
-                'key': ['color'], 'query': '\n\n\n\n'}, format='json')
+        with self.feature(self.feature_list):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'key': ['color'],
+                    'query': '\n\n\n\n'
+                })
         assert response.status_code == 400, response.content
         assert response.data == {
             'detail': "Parse error: 'search' (column 1). This is commonly caused by unmatched-parentheses. Enclose any text in double quotes."}
 
     def test_invalid_tag(self):
-        response = self.client.get(
-            self.url, {
-                'key': ['color;;;']}, format='json')
+        with self.feature(self.feature_list):
+            response = self.client.get(
+                self.url,
+                data={
+                    'key': ['color;;;']
+                },
+                format='json')
         assert response.status_code == 400, response.content
         assert response.data == {'detail': "Tag key color;;; is not valid."}

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -9,23 +9,17 @@ from sentry.testutils import APITestCase, SnubaTestCase
 import pytest
 
 
-class OrganizationEventsTestBase(APITestCase, SnubaTestCase):
+class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsTestBase, self).setUp()
+        super(OrganizationEventsV2EndpointTest, self).setUp()
         self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
         self.two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
         self.url = reverse(
-            'sentry-api-0-organization-events',
+            'sentry-api-0-organization-eventsv2',
             kwargs={
                 'organization_slug': self.organization.slug,
             }
         )
-
-    def assert_events_in_response(self, response, event_ids):
-        assert sorted(map(lambda x: x['eventID'], response.data)) == sorted(event_ids)
-
-
-class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
 
     def test_no_projects(self):
         self.login_as(user=self.user)
@@ -657,73 +651,3 @@ class OrganizationEventsV2EndpointTest(OrganizationEventsTestBase):
 
         assert response.status_code == 200, response.content
         assert len(response.data['data']) == 0
-
-    def test_group_filtering(self):
-        user = self.create_user()
-        org = self.create_organization(owner=user)
-        self.login_as(user=user)
-
-        team = self.create_team(organization=org, members=[user])
-
-        self.login_as(user=user)
-
-        project = self.create_project(organization=org, teams=[team])
-        events = []
-        for event_id, fingerprint in [
-            ('a' * 32, 'put-me-in-group1'),
-            ('b' * 32, 'put-me-in-group1'),
-            ('c' * 32, 'put-me-in-group2'),
-            ('d' * 32, 'put-me-in-group3'),
-        ]:
-            events.append(self.store_event(
-                data={
-                    'event_id': event_id,
-                    'timestamp': self.min_ago,
-                    'fingerprint': [fingerprint],
-                },
-                project_id=project.id
-            ))
-
-        event_1, event_2, event_3, event_4 = events
-        group_1, group_2, group_3 = event_1.group, event_3.group, event_4.group
-
-        base_url = reverse(
-            'sentry-api-0-organization-events',
-            kwargs={
-                'organization_slug': org.slug,
-            }
-        )
-
-        response = self.client.get(base_url, format='json', data={'group': [group_1.id]})
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 2
-        self.assert_events_in_response(response, [event_1.event_id, event_2.event_id])
-
-        response = self.client.get(base_url, format='json', data={'group': [group_3.id]})
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 1
-        self.assert_events_in_response(response, [event_4.event_id])
-
-        response = self.client.get(
-            base_url,
-            format='json',
-            data={'group': [group_1.id, group_3.id]},
-        )
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 3
-        self.assert_events_in_response(
-            response,
-            [event_1.event_id, event_2.event_id, event_4.event_id],
-        )
-
-        response = self.client.get(
-            base_url,
-            format='json',
-            data={'group': [group_1.id, group_2.id, group_3.id]},
-        )
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 4
-        self.assert_events_in_response(
-            response,
-            [event_1.event_id, event_2.event_id, event_3.event_id, event_4.event_id],
-        )


### PR DESCRIPTION
We want to enable users to access both implementations at the same time. That requires moving the main search endpoint out so that it isn't a single feature-gated endpoint. The events2 URL is temporary and will be removed when discover2 is mainlined.

I've used the labs icon for eventsv2 until we get a more permanent icon.

Refs SEN-909