### PR TITLE
fix(suspect-commits): Fix when empty state renders

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
@@ -14,7 +14,6 @@ import {snoozedDays} from 'app/utils/promptsActivity';
 import space from 'app/styles/space';
 import {t} from 'app/locale';
 import {trackAdhocEvent, trackAnalyticsEvent} from 'app/utils/analytics';
-import Tooltip from 'app/components/tooltip';
 import withApi from 'app/utils/withApi';
 
 const EXAMPLE_COMMITS = ['dec0de', 'de1e7e', '5ca1ed'];
@@ -144,36 +143,34 @@ class EventCauseEmpty extends React.Component {
               </DocsButton>
 
               <div>
-                <Tooltip title={t('Remind me next week')}>
-                  <SnoozeButton
-                    size="small"
-                    onClick={() =>
-                      this.handleClick({
-                        action: 'snoozed',
-                        eventKey: 'event_cause.snoozed',
-                        eventName: 'Event Cause Snoozed',
-                      })
-                    }
-                    data-test-id="snoozed"
-                  >
-                    {t('Snooze')}
-                  </SnoozeButton>
-                </Tooltip>
-                <Tooltip title={t('Dismiss for this project')}>
-                  <DismissButton
-                    size="small"
-                    onClick={() =>
-                      this.handleClick({
-                        action: 'dismissed',
-                        eventKey: 'event_cause.dismissed',
-                        eventName: 'Event Cause Dismissed',
-                      })
-                    }
-                    data-test-id="dismissed"
-                  >
-                    {t('Dismiss')}
-                  </DismissButton>
-                </Tooltip>
+                <SnoozeButton
+                  title={t('Remind me next week')}
+                  size="small"
+                  onClick={() =>
+                    this.handleClick({
+                      action: 'snoozed',
+                      eventKey: 'event_cause.snoozed',
+                      eventName: 'Event Cause Snoozed',
+                    })
+                  }
+                  data-test-id="snoozed"
+                >
+                  {t('Snooze')}
+                </SnoozeButton>
+                <DismissButton
+                  title={t('Dismiss for this project')}
+                  size="small"
+                  onClick={() =>
+                    this.handleClick({
+                      action: 'dismissed',
+                      eventKey: 'event_cause.dismissed',
+                      eventName: 'Event Cause Dismissed',
+                    })
+                  }
+                  data-test-id="dismissed"
+                >
+                  {t('Dismiss')}
+                </DismissButton>
               </div>
             </ButtonList>
           </BoxHeader>

--- a/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
@@ -137,7 +137,6 @@ class EventCauseEmpty extends React.Component {
                     eventName: 'Event Cause Docs Clicked',
                   })
                 }
-                data-test-id="read-the-docs"
               >
                 {t('Read the docs')}
               </DocsButton>
@@ -153,7 +152,6 @@ class EventCauseEmpty extends React.Component {
                       eventName: 'Event Cause Snoozed',
                     })
                   }
-                  data-test-id="snoozed"
                 >
                   {t('Snooze')}
                 </SnoozeButton>
@@ -167,7 +165,6 @@ class EventCauseEmpty extends React.Component {
                       eventName: 'Event Cause Dismissed',
                     })
                   }
-                  data-test-id="dismissed"
                 >
                   {t('Dismiss')}
                 </DismissButton>

--- a/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
@@ -159,19 +159,21 @@ class EventCauseEmpty extends React.Component {
                     {t('Snooze')}
                   </SnoozeButton>
                 </Tooltip>
-                <DismissButton
-                  size="small"
-                  onClick={() =>
-                    this.handleClick({
-                      action: 'dismissed',
-                      eventKey: 'event_cause.dismissed',
-                      eventName: 'Event Cause Dismissed',
-                    })
-                  }
-                  data-test-id="dismissed"
-                >
-                  {t('Dismiss')}
-                </DismissButton>
+                <Tooltip title={t('Dismiss for this project')}>
+                  <DismissButton
+                    size="small"
+                    onClick={() =>
+                      this.handleClick({
+                        action: 'dismissed',
+                        eventKey: 'event_cause.dismissed',
+                        eventName: 'Event Cause Dismissed',
+                      })
+                    }
+                    data-test-id="dismissed"
+                  >
+                    {t('Dismiss')}
+                  </DismissButton>
+                </Tooltip>
               </div>
             </ButtonList>
           </BoxHeader>

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -82,7 +82,10 @@ class EventEntries extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    return this.props.event.id !== nextProps.event.id;
+    return (
+      this.props.event.id !== nextProps.event.id ||
+      this.props.showExampleCommit !== nextProps.showExampleCommit
+    );
   }
 
   recordIssueError(errorTypes, errorMessages) {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails.jsx
@@ -38,7 +38,7 @@ class GroupEventDetails extends React.Component {
       error: false,
       event: null,
       eventNavLinks: '',
-      setupReleases: [],
+      releasesCompletion: null,
     };
   }
 
@@ -118,7 +118,7 @@ class GroupEventDetails extends React.Component {
       .requestPromise(`/projects/${orgSlug}/${projSlug}/releases/completion/`)
       .then(data => {
         this.setState({
-          setupReleases: data,
+          releasesCompletion: data,
         });
       });
 
@@ -142,9 +142,12 @@ class GroupEventDetails extends React.Component {
     fetchSentryAppComponents(api, orgSlug, projectId);
   };
 
-  get hasSetupCommits() {
-    const {setupReleases} = this.state;
-    return setupReleases.some(({step, complete}) => step === 'commit' && complete);
+  get showExampleCommit() {
+    const {releasesCompletion} = this.state;
+    return (
+      releasesCompletion &&
+      releasesCompletion.some(({step, complete}) => step === 'commit' && !complete)
+    );
   }
 
   render() {
@@ -192,7 +195,7 @@ class GroupEventDetails extends React.Component {
                 event={evt}
                 orgId={organization.slug}
                 project={project}
-                showExampleCommit={!this.hasSetupCommits}
+                showExampleCommit={this.showExampleCommit}
               />
             )}
           </div>

--- a/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
+++ b/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
@@ -60,7 +60,7 @@ describe('EventCauseEmpty', function() {
     wrapper.update();
 
     wrapper
-      .find('[data-test-id="snoozed"]')
+      .find('button[data-test-id="snoozed"]')
       .first()
       .simulate('click');
 
@@ -142,7 +142,7 @@ describe('EventCauseEmpty', function() {
     wrapper.update();
 
     wrapper
-      .find('[data-test-id="dismissed"]')
+      .find('button[data-test-id="dismissed"]')
       .first()
       .simulate('click');
 

--- a/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
+++ b/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
@@ -60,7 +60,7 @@ describe('EventCauseEmpty', function() {
     wrapper.update();
 
     wrapper
-      .find('button[data-test-id="snoozed"]')
+      .find('button[aria-label="Snooze"]')
       .first()
       .simulate('click');
 
@@ -142,7 +142,7 @@ describe('EventCauseEmpty', function() {
     wrapper.update();
 
     wrapper
-      .find('button[data-test-id="dismissed"]')
+      .find('button[aria-label="Dismiss"]')
       .first()
       .simulate('click');
 
@@ -198,7 +198,7 @@ describe('EventCauseEmpty', function() {
     wrapper.update();
 
     wrapper
-      .find('[data-test-id="read-the-docs"]')
+      .find('[aria-label="Read the docs"]')
       .first()
       .simulate('click');
 


### PR DESCRIPTION
There's a race where `EventCauseEmpty` occasionally renders when suspect commits are configured. Also, if the `/releases/completion/` request errors it renders the empty state by default.

- Changes the default to not render the empty state
- Updates EventEntries when the `/releases/completion/` request finishes
- Also, adds a tooltip on the `EventCauseEmpty` dismiss button