### PR TITLE
feat(frontend): Add metrics to accepted org invites

### DIFF
--- a/src/sentry/web/frontend/accept_organization_invite.py
+++ b/src/sentry/web/frontend/accept_organization_invite.py
@@ -5,6 +5,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.utils.crypto import constant_time_compare
 from django.utils.translation import ugettext_lazy as _
+from sentry.utils import metrics
 
 from sentry.models import AuditLogEntryEvent, Authenticator, OrganizationMember
 from sentry.signals import member_joined
@@ -169,6 +170,7 @@ class BaseInviteHelper(object):
             )
 
             self.handle_success()
+            metrics.incr('organization.invite-accepted')
 
     def remove_invite_cookie(self, response):
         if PENDING_INVITE in self.request.COOKIES:


### PR DESCRIPTION
Adding this for https://github.com/getsentry/sentry/pull/14281 so we can get a baseline of how many invites are accepted over time, giving us a good baseline to make sure nothing goes wrong.

Depending on how statistically significant this metric is, we may be able to add some datadog alerts as well.