### PR TITLE
Implement consumer for receiving query updates from Snuba. (SEN-832)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -320,6 +320,7 @@ INSTALLED_APPS = (
     "sentry.analytics.events",
     "sentry.nodestore",
     "sentry.search",
+    "sentry.snuba",
     "sentry.lang.java",
     "sentry.lang.javascript",
     "sentry.lang.native",
@@ -1674,10 +1675,15 @@ KAFKA_CLUSTERS = {
 
 KAFKA_EVENTS = "events"
 KAFKA_OUTCOMES = "outcomes"
+KAFKA_SNUBA_QUERY_SUBSCRIPTIONS = "snuba-query-subscriptions"
 
 KAFKA_TOPICS = {
     KAFKA_EVENTS: {"cluster": "default", "topic": KAFKA_EVENTS},
     KAFKA_OUTCOMES: {"cluster": "default", "topic": KAFKA_OUTCOMES},
+    KAFKA_SNUBA_QUERY_SUBSCRIPTIONS: {
+        "cluster": "default",
+        "topic": KAFKA_SNUBA_QUERY_SUBSCRIPTIONS,
+    },
 }
 
 # Enable this to use the legacy Slack Workspace Token apps. You will likely

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -32,13 +32,16 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             "aggregations",
         ]
         extra_kwargs = {
-            "query": {"allow_blank": True},
+            "query": {"allow_blank": True, "required": True},
             "threshold_period": {"default": 1, "min_value": 1, "max_value": 20},
+            "alert_threshold": {"required": True},
+            "resolve_threshold": {"required": True},
             "time_window": {
                 "min_value": 1,
                 "max_value": int(timedelta(days=1).total_seconds() / 60),
+                "required": True,
             },
-            "aggregations": {"min_length": 1, "max_length": 10},
+            "aggregations": {"min_length": 1, "max_length": 10, "required": True},
             "name": {"min_length": 1, "max_length": 64},
         }
 

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -270,20 +270,23 @@ class AlertRule(Model):
     objects_with_deleted = BaseManager()
 
     project = FlexibleForeignKey("sentry.Project", db_index=False, db_constraint=False)
+    query_subscription = FlexibleForeignKey("sentry.QuerySubscription", unique=True, null=True)
     name = models.TextField()
     status = models.SmallIntegerField(default=AlertRuleStatus.PENDING.value)
-    subscription_id = models.UUIDField(db_index=True)
     threshold_type = models.SmallIntegerField()
-    dataset = models.TextField()
-    query = models.TextField()
-    aggregations = ArrayField(of=models.IntegerField)
-    time_window = models.IntegerField()
-    resolution = models.IntegerField()
     alert_threshold = models.IntegerField()
     resolve_threshold = models.IntegerField()
     threshold_period = models.IntegerField()
     date_modified = models.DateTimeField(default=timezone.now)
     date_added = models.DateTimeField(default=timezone.now)
+    # These will be removed after we've made these columns nullable. Moving to
+    # QuerySubscription
+    subscription_id = models.UUIDField(db_index=True, null=True)
+    dataset = models.TextField(null=True)
+    query = models.TextField(null=True)
+    aggregations = ArrayField(of=models.IntegerField, null=True)
+    time_window = models.IntegerField(null=True)
+    resolution = models.IntegerField(null=True)
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -19,11 +19,14 @@ from sentry.incidents.models import (
     IncidentStatus,
     IncidentSuspectCommit,
 )
+from sentry.snuba.query_subscription_consumer import register_subscriber
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 from sentry.utils.linksign import generate_signed_link
 from sentry.utils.retries import TimedRetryPolicy
+
+INCIDENTS_SNUBA_SUBSCRIPTION_TYPE = "incidents"
 
 
 @instrumented_task(name="sentry.incidents.tasks.send_subscriber_notifications", queue="incidents")
@@ -155,3 +158,15 @@ class AlertRuleDeletionTask(deletions.ModelDeletionTask):
 
 
 deletions.default_manager.register(AlertRule, AlertRuleDeletionTask)
+
+
+@register_subscriber(INCIDENTS_SNUBA_SUBSCRIPTION_TYPE)
+def handle_snuba_query_update(subscription_update, subscription):
+    """
+    Handles a subscription update for a `QuerySubscription`.
+    :param subscription_update: dict formatted according to schemas in
+    sentry/snuba/json_schemas.py
+    :param subscription: The `QuerySubscription` that this update is for
+    """
+    # TODO: Implement
+    pass

--- a/src/sentry/snuba/__init__.py
+++ b/src/sentry/snuba/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry/snuba/json_schemas.py
+++ b/src/sentry/snuba/json_schemas.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+
+
+SUBSCRIPTION_WRAPPER_SCHEMA = {
+    "type": "object",
+    "properties": {"version": {"type": "integer"}, "payload": {"type": "object"}},
+    "required": ["version", "payload"],
+    "additionalProperties": False,
+}
+
+
+SUBSCRIPTION_PAYLOAD_VERSIONS = {
+    1: {
+        "type": "object",
+        "properties": {
+            "subscription_id": {"type": "string", "minLength": 1},
+            "values": {
+                "type": "object",
+                "minProperties": 1,
+                "additionalProperties": {"type": "number"},
+            },
+            "timestamp": {"type": "number", "minimum": 0},
+            "interval": {"type": "number", "minimum": 0},
+            "partition": {"type": "number"},
+            "offset": {"type": "number"},
+        },
+        "required": ["subscription_id", "values", "timestamp", "interval", "partition", "offset"],
+        "additionalProperties": False,
+    }
+}

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+from django.db import models
+from django.utils import timezone
+
+from sentry.db.models import ArrayField, FlexibleForeignKey, Model
+
+
+class QuerySubscription(Model):
+    __core__ = True
+
+    project = FlexibleForeignKey("sentry.Project", db_constraint=False)
+    type = models.TextField()
+    subscription_id = models.TextField(unique=True)
+    dataset = models.TextField()
+    query = models.TextField()
+    aggregations = ArrayField(of=models.IntegerField)
+    time_window = models.IntegerField()
+    resolution = models.IntegerField()
+    date_added = models.DateTimeField(default=timezone.now)
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_querysubscription"

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -1,0 +1,200 @@
+from __future__ import absolute_import
+import logging
+from json import loads
+
+import jsonschema
+from confluent_kafka import Consumer, KafkaException, TopicPartition
+from django.conf import settings
+
+from sentry.snuba.json_schemas import SUBSCRIPTION_PAYLOAD_VERSIONS, SUBSCRIPTION_WRAPPER_SCHEMA
+from sentry.snuba.models import QuerySubscription
+from sentry.utils import metrics
+
+logger = logging.getLogger(__name__)
+
+
+subscriber_registry = {}
+
+
+def register_subscriber(subscriber_key):
+    def inner(func):
+        if subscriber_key in subscriber_registry:
+            raise Exception("Handler already registered for %s" % subscriber_key)
+        subscriber_registry[subscriber_key] = func
+        return func
+
+    return inner
+
+
+class InvalidMessageError(Exception):
+    pass
+
+
+class InvalidSchemaError(InvalidMessageError):
+    pass
+
+
+class QuerySubscriptionConsumer(object):
+    """
+    A Kafka consumer that processes query subscription update messages. Each message has
+    a related subscription id and the latest values related to the subscribed query.
+    These values are passed along to a callback associated with the subscription.
+    """
+
+    def __init__(
+        self, group_id, topic=None, commit_batch_size=100, initial_offset_reset="earliest"
+    ):
+        self.group_id = group_id
+        if not topic:
+            topic = settings.KAFKA_SNUBA_QUERY_SUBSCRIPTIONS
+        self.topic = topic
+        cluster_name = settings.KAFKA_TOPICS[topic]["cluster"]
+        self.bootstrap_servers = settings.KAFKA_CLUSTERS[cluster_name]["bootstrap.servers"]
+        self.commit_batch_size = commit_batch_size
+        self.initial_offset_reset = initial_offset_reset
+        self.offsets = {}
+        self.consumer = None
+
+    def run(self):
+        logger.debug("Starting snuba query subscriber")
+        self.offsets.clear()
+
+        conf = {
+            "bootstrap.servers": self.bootstrap_servers,
+            "group.id": self.group_id,
+            "session.timeout.ms": 6000,
+            "auto.offset.reset": self.initial_offset_reset,
+            "enable.auto.commit": "false",
+            "enable.auto.offset.store": "false",
+            "enable.partition.eof": "false",
+            "default.topic.config": {"auto.offset.reset": self.initial_offset_reset},
+        }
+
+        def on_revoke(consumer, partitions):
+            self.commit_offsets()
+
+        self.consumer = Consumer(conf)
+        self.consumer.subscribe([self.topic], on_revoke=on_revoke)
+
+        try:
+            i = 0
+            while True:
+                message = self.consumer.poll(0.1)
+                if message is None:
+                    continue
+
+                error = message.error()
+                if error is not None:
+                    raise KafkaException(error)
+
+                i = i + 1
+
+                self.handle_message(message)
+
+                # Track latest completed message here, for use in `shutdown` handler.
+                self.offsets[message.partition()] = message.offset() + 1
+
+                if i % self.commit_batch_size == 0:
+                    logger.debug("Committing offsets")
+                    self.commit_offsets()
+        except KeyboardInterrupt:
+            pass
+
+        self.shutdown()
+
+    def commit_offsets(self):
+        if self.offsets and self.consumer:
+            to_commit = [
+                TopicPartition(self.topic, partition, offset)
+                for partition, offset in self.offsets.items()
+            ]
+            self.consumer.commit(offsets=to_commit)
+            self.offsets.clear()
+
+    def shutdown(self):
+        logger.debug("Committing offsets and closing consumer")
+        self.commit_offsets()
+        self.consumer.close()
+
+    def handle_message(self, message):
+        """
+        Parses the value from Kafka, and if valid passes the payload to the callback defined by the
+        subscription. If the subscription has been removed, or no longer has a valid callback then
+        just log metrics/errors and continue.
+        :param message:
+        :return:
+        """
+        try:
+            contents = self.parse_message_value(message.value())
+        except InvalidMessageError:
+            # If the message is in an invalid format, just log the error
+            # and continue
+            logger.exception(
+                "Subscription update could not be parsed",
+                extra={
+                    "offset": message.offset(),
+                    "partition": message.partition(),
+                    "value": message.value(),
+                },
+            )
+            return
+
+        try:
+            subscription = QuerySubscription.objects.get(
+                subscription_id=contents["subscription_id"]
+            )
+        except QuerySubscription.DoesNotExist:
+            metrics.incr("snuba_query_subscriber.subscription_doesnt_exist")
+            logger.error(
+                "Received subscription update, but subscription does not exist",
+                extra={
+                    "offset": message.offset(),
+                    "partition": message.partition(),
+                    "value": message.value(),
+                },
+            )
+            return
+
+        if subscription.type not in subscriber_registry:
+            metrics.incr("snuba_query_subscriber.subscription_type_not_registered")
+            logger.error(
+                "Received subscription update, but no subscription handler registered",
+                extra={
+                    "offset": message.offset(),
+                    "partition": message.partition(),
+                    "value": message.value(),
+                },
+            )
+            return
+
+        callback = subscriber_registry[subscription.type]
+        with metrics.timer("snuba_query_subscriber.callback.duration", instance=subscription.type):
+            callback(contents, subscription)
+
+    def parse_message_value(self, value):
+        """
+        Parses the value received via the Kafka consumer and verifies that it
+        matches the expected schema.
+        :param value: A json formatted string
+        :return: A dict with the parsed message
+        """
+        wrapper = loads(value)
+        try:
+            jsonschema.validate(wrapper, SUBSCRIPTION_WRAPPER_SCHEMA)
+        except jsonschema.ValidationError:
+            metrics.incr("snuba_query_subscriber.message_wrapper_invalid")
+            raise InvalidSchemaError("Message wrapper does not match schema")
+
+        schema_version = wrapper["version"]
+        if schema_version not in SUBSCRIPTION_PAYLOAD_VERSIONS:
+            metrics.incr("snuba_query_subscriber.message_wrapper_invalid_version")
+            raise InvalidMessageError("Version specified in wrapper has no schema")
+
+        payload = wrapper["payload"]
+        try:
+            jsonschema.validate(payload, SUBSCRIPTION_PAYLOAD_VERSIONS[schema_version])
+        except jsonschema.ValidationError:
+            metrics.incr("snuba_query_subscriber.message_payload_invalid")
+            raise InvalidSchemaError("Message payload does not match schema")
+
+        return payload

--- a/src/sentry/south_migrations/0497_query_subscription.py
+++ b/src/sentry/south_migrations/0497_query_subscription.py
@@ -1,0 +1,5294 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    # Flag to indicate if this migration is too risky
+    # to run online and needs to be coordinated for offline
+    is_dangerous = False
+
+    def forwards(self, orm):
+        # Adding model 'QuerySubscription'
+        db.create_table(
+            "sentry_querysubscription",
+            (
+                (
+                    "id",
+                    self.gf("sentry.db.models.fields.bounded.BoundedBigAutoField")(
+                        primary_key=True
+                    ),
+                ),
+                (
+                    "project_id",
+                    self.gf("sentry.db.models.fields.bounded.BoundedBigIntegerField")(
+                        db_index=True
+                    ),
+                ),
+                ("type", self.gf("django.db.models.fields.TextField")()),
+                ("subscription_id", self.gf("django.db.models.fields.TextField")(unique=True)),
+                ("dataset", self.gf("django.db.models.fields.TextField")()),
+                ("query", self.gf("django.db.models.fields.TextField")()),
+                (
+                    "aggregations",
+                    self.gf("sentry.db.models.fields.array.ArrayField")(
+                        of=(u"django.db.models.fields.IntegerField", [], {})
+                    ),
+                ),
+                ("time_window", self.gf("django.db.models.fields.IntegerField")()),
+                ("resolution", self.gf("django.db.models.fields.IntegerField")()),
+                (
+                    "date_added",
+                    self.gf("django.db.models.fields.DateTimeField")(default=datetime.datetime.now),
+                ),
+            ),
+        )
+        db.send_create_signal("sentry", ["QuerySubscription"])
+
+        # Adding field 'AlertRule.query_subscription'
+        db.add_column(
+            "sentry_alertrule",
+            "query_subscription",
+            self.gf("sentry.db.models.fields.foreignkey.FlexibleForeignKey")(
+                to=orm["sentry.QuerySubscription"], unique=True, null=True
+            ),
+            keep_default=False,
+        )
+
+        # Changing field 'AlertRule.time_window'
+        db.alter_column(
+            "sentry_alertrule",
+            "time_window",
+            self.gf("django.db.models.fields.IntegerField")(null=True),
+        )
+
+        # Changing field 'AlertRule.dataset'
+        db.alter_column(
+            "sentry_alertrule", "dataset", self.gf("django.db.models.fields.TextField")(null=True)
+        )
+
+        # Changing field 'AlertRule.query'
+        db.alter_column(
+            "sentry_alertrule", "query", self.gf("django.db.models.fields.TextField")(null=True)
+        )
+
+        # Changing field 'AlertRule.subscription_id'
+        db.alter_column(
+            "sentry_alertrule",
+            "subscription_id",
+            self.gf("django.db.models.fields.UUIDField")(max_length=32, null=True),
+        )
+
+        # Changing field 'AlertRule.resolution'
+        db.alter_column(
+            "sentry_alertrule",
+            "resolution",
+            self.gf("django.db.models.fields.IntegerField")(null=True),
+        )
+
+    def backwards(self, orm):
+        from uuid import uuid4
+
+        # Deleting model 'QuerySubscription'
+        db.delete_table("sentry_querysubscription")
+
+        # Deleting field 'AlertRule.query_subscription'
+        db.delete_column("sentry_alertrule", u"query_subscription_id")
+
+        # Changing field 'AlertRule.time_window'
+        db.alter_column(
+            "sentry_alertrule",
+            "time_window",
+            self.gf("django.db.models.fields.IntegerField")(default=1),
+        )
+
+        # Changing field 'AlertRule.dataset'
+        db.alter_column(
+            "sentry_alertrule",
+            "dataset",
+            self.gf("django.db.models.fields.TextField")(default="events"),
+        )
+
+        # Changing field 'AlertRule.query'
+        db.alter_column(
+            "sentry_alertrule", "query", self.gf("django.db.models.fields.TextField")(default="")
+        )
+
+        # Changing field 'AlertRule.subscription_id'
+        db.alter_column(
+            "sentry_alertrule",
+            "subscription_id",
+            self.gf("django.db.models.fields.UUIDField")(default=uuid4(), max_length=32),
+        )
+
+        # Changing field 'AlertRule.resolution'
+        db.alter_column(
+            "sentry_alertrule",
+            "resolution",
+            self.gf("django.db.models.fields.IntegerField")(default=1),
+        )
+
+    models = {
+        "sentry.activity": {
+            "Meta": {"unique_together": "()", "object_name": "Activity", "index_together": "()"},
+            "data": ("sentry.db.models.fields.gzippeddict.GzippedDictField", [], {"null": "True"}),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "type": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "null": "True"},
+            ),
+        },
+        "sentry.alertrule": {
+            "Meta": {
+                "unique_together": "(('project', 'name'),)",
+                "object_name": "AlertRule",
+                "index_together": "()",
+            },
+            "aggregations": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.IntegerField", [], {})},
+            ),
+            "alert_threshold": ("django.db.models.fields.IntegerField", [], {}),
+            "dataset": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_modified": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.TextField", [], {}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "db_index": "False"},
+            ),
+            "query": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "query_subscription": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.QuerySubscription']", "unique": "True", "null": "True"},
+            ),
+            "resolution": ("django.db.models.fields.IntegerField", [], {"null": "True"}),
+            "resolve_threshold": ("django.db.models.fields.IntegerField", [], {}),
+            "status": ("django.db.models.fields.SmallIntegerField", [], {"default": "0"}),
+            "subscription_id": (
+                "django.db.models.fields.UUIDField",
+                [],
+                {"max_length": "32", "null": "True", "db_index": "True"},
+            ),
+            "threshold_period": ("django.db.models.fields.IntegerField", [], {}),
+            "threshold_type": ("django.db.models.fields.SmallIntegerField", [], {}),
+            "time_window": ("django.db.models.fields.IntegerField", [], {"null": "True"}),
+        },
+        "sentry.apiapplication": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "ApiApplication",
+                "index_together": "()",
+            },
+            "allowed_origins": (
+                "django.db.models.fields.TextField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "client_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {
+                    "default": "'88cf44b015eb49e8a843a191ab7eb443b893d138a7114388aa3af10dc72ddf97'",
+                    "unique": "True",
+                    "max_length": "64",
+                },
+            ),
+            "client_secret": (
+                "sentry.db.models.fields.encrypted.EncryptedTextField",
+                [],
+                {"default": "'a3ff1be2fa7d4435b4f3e28d7814d02f9414f11603ed45dfa6ff7e17fd69a177'"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "homepage_url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "'Rich Meerkat'", "max_length": "64", "blank": "True"},
+            ),
+            "owner": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+            "privacy_url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True"},
+            ),
+            "redirect_uris": ("django.db.models.fields.TextField", [], {}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "terms_url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True"},
+            ),
+        },
+        "sentry.apiauthorization": {
+            "Meta": {
+                "unique_together": "(('user', 'application'),)",
+                "object_name": "ApiAuthorization",
+                "index_together": "()",
+            },
+            "application": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ApiApplication']", "null": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "scope_list": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "scopes": ("django.db.models.fields.BigIntegerField", [], {"default": "None"}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.apigrant": {
+            "Meta": {"unique_together": "()", "object_name": "ApiGrant", "index_together": "()"},
+            "application": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ApiApplication']"},
+            ),
+            "code": (
+                "django.db.models.fields.CharField",
+                [],
+                {
+                    "default": "'14150901ee2046e7b7d44749629d80ba'",
+                    "max_length": "64",
+                    "db_index": "True",
+                },
+            ),
+            "expires_at": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime(2019, 8, 20, 0, 0)", "db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "redirect_uri": ("django.db.models.fields.CharField", [], {"max_length": "255"}),
+            "scope_list": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "scopes": ("django.db.models.fields.BigIntegerField", [], {"default": "None"}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.apikey": {
+            "Meta": {"unique_together": "()", "object_name": "ApiKey", "index_together": "()"},
+            "allowed_origins": (
+                "django.db.models.fields.TextField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "32"},
+            ),
+            "label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "'Default'", "max_length": "64", "blank": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'key_set'", "to": "orm['sentry.Organization']"},
+            ),
+            "scope_list": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "scopes": ("django.db.models.fields.BigIntegerField", [], {"default": "None"}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+        },
+        "sentry.apitoken": {
+            "Meta": {"unique_together": "()", "object_name": "ApiToken", "index_together": "()"},
+            "application": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ApiApplication']", "null": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "expires_at": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime(2019, 9, 19, 0, 0)", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "refresh_token": (
+                "django.db.models.fields.CharField",
+                [],
+                {
+                    "default": "'691b799a3051447497d7a060cc4a5b521dd232cc09fc4cc78f5d98dc00f455f4'",
+                    "max_length": "64",
+                    "unique": "True",
+                    "null": "True",
+                },
+            ),
+            "scope_list": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "scopes": ("django.db.models.fields.BigIntegerField", [], {"default": "None"}),
+            "token": (
+                "django.db.models.fields.CharField",
+                [],
+                {
+                    "default": "'b1ca2eabb0d04e259e1dc52fe245019c08a19cb86c2d4805b69b2f4efa0fc9e3'",
+                    "unique": "True",
+                    "max_length": "64",
+                },
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.assistantactivity": {
+            "Meta": {
+                "unique_together": "(('user', 'guide_id'),)",
+                "object_name": "AssistantActivity",
+                "db_table": "'sentry_assistant_activity'",
+                "index_together": "()",
+            },
+            "dismissed_ts": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "guide_id": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "useful": (
+                "django.db.models.fields.NullBooleanField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+            "viewed_ts": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+        },
+        "sentry.auditlogentry": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "AuditLogEntry",
+                "index_together": "()",
+            },
+            "actor": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "blank": "True",
+                    "related_name": "u'audit_actors'",
+                    "null": "True",
+                    "to": "orm['sentry.User']",
+                },
+            ),
+            "actor_key": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ApiKey']", "null": "True", "blank": "True"},
+            ),
+            "actor_label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True", "blank": "True"},
+            ),
+            "data": ("sentry.db.models.fields.gzippeddict.GzippedDictField", [], {}),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "event": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ip_address": (
+                "django.db.models.fields.GenericIPAddressField",
+                [],
+                {"max_length": "39", "null": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "target_object": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "target_user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "blank": "True",
+                    "related_name": "u'audit_targets'",
+                    "null": "True",
+                    "to": "orm['sentry.User']",
+                },
+            ),
+        },
+        "sentry.authenticator": {
+            "Meta": {
+                "unique_together": "(('user', 'type'),)",
+                "object_name": "Authenticator",
+                "db_table": "'auth_authenticator'",
+                "index_together": "()",
+            },
+            "config": ("sentry.db.models.fields.encrypted.EncryptedPickledObjectField", [], {}),
+            "created_at": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": ("sentry.db.models.fields.bounded.BoundedAutoField", [], {"primary_key": "True"}),
+            "last_used_at": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "type": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.authidentity": {
+            "Meta": {
+                "unique_together": "(('auth_provider', 'ident'), ('auth_provider', 'user'))",
+                "object_name": "AuthIdentity",
+                "index_together": "()",
+            },
+            "auth_provider": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.AuthProvider']"},
+            ),
+            "data": ("sentry.db.models.fields.encrypted.EncryptedJsonField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "last_synced": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "last_verified": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.authprovider": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "AuthProvider",
+                "index_together": "()",
+            },
+            "config": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "default_global_access": (
+                "django.db.models.fields.BooleanField",
+                [],
+                {"default": "True"},
+            ),
+            "default_role": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "50"},
+            ),
+            "default_teams": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {"to": "orm['sentry.Team']", "symmetrical": "False", "blank": "True"},
+            ),
+            "flags": ("django.db.models.fields.BigIntegerField", [], {"default": "0"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_sync": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']", "unique": "True"},
+            ),
+            "provider": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "sync_time": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+        },
+        "sentry.broadcast": {
+            "Meta": {"unique_together": "()", "object_name": "Broadcast", "index_together": "()"},
+            "cta": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "256", "null": "True", "blank": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_expires": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {
+                    "default": "datetime.datetime(2019, 8, 27, 0, 0)",
+                    "null": "True",
+                    "blank": "True",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_active": (
+                "django.db.models.fields.BooleanField",
+                [],
+                {"default": "True", "db_index": "True"},
+            ),
+            "link": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True", "blank": "True"},
+            ),
+            "message": ("django.db.models.fields.CharField", [], {"max_length": "256"}),
+            "title": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "upstream_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True", "blank": "True"},
+            ),
+        },
+        "sentry.broadcastseen": {
+            "Meta": {
+                "unique_together": "(('broadcast', 'user'),)",
+                "object_name": "BroadcastSeen",
+                "index_together": "()",
+            },
+            "broadcast": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Broadcast']"},
+            ),
+            "date_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.commit": {
+            "Meta": {
+                "unique_together": "(('repository_id', 'key'),)",
+                "object_name": "Commit",
+                "index_together": "(('repository_id', 'date_added'),)",
+            },
+            "author": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.CommitAuthor']", "null": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "message": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "repository_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {},
+            ),
+        },
+        "sentry.commitauthor": {
+            "Meta": {
+                "unique_together": "(('organization_id', 'email'), ('organization_id', 'external_id'))",
+                "object_name": "CommitAuthor",
+                "index_together": "()",
+            },
+            "email": ("django.db.models.fields.EmailField", [], {"max_length": "75"}),
+            "external_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "164", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "128", "null": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+        },
+        "sentry.commitfilechange": {
+            "Meta": {
+                "unique_together": "(('commit', 'filename'),)",
+                "object_name": "CommitFileChange",
+                "index_together": "()",
+            },
+            "commit": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Commit']"},
+            ),
+            "filename": ("django.db.models.fields.CharField", [], {"max_length": "255"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "type": ("django.db.models.fields.CharField", [], {"max_length": "1"}),
+        },
+        "sentry.counter": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "Counter",
+                "db_table": "'sentry_projectcounter'",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "unique": "True"},
+            ),
+            "value": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.dashboard": {
+            "Meta": {
+                "unique_together": "(('organization', 'title'),)",
+                "object_name": "Dashboard",
+                "index_together": "()",
+            },
+            "created_by": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "title": ("django.db.models.fields.CharField", [], {"max_length": "255"}),
+        },
+        "sentry.deletedorganization": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "DeletedOrganization",
+                "index_together": "()",
+            },
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "actor_key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True"},
+            ),
+            "actor_label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "date_created": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "date_deleted": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ip_address": (
+                "django.db.models.fields.GenericIPAddressField",
+                [],
+                {"max_length": "39", "null": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "64", "null": "True"}),
+            "reason": ("django.db.models.fields.TextField", [], {"null": "True", "blank": "True"}),
+            "slug": ("django.db.models.fields.CharField", [], {"max_length": "50", "null": "True"}),
+        },
+        "sentry.deletedproject": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "DeletedProject",
+                "index_together": "()",
+            },
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "actor_key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True"},
+            ),
+            "actor_label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "date_created": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "date_deleted": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ip_address": (
+                "django.db.models.fields.GenericIPAddressField",
+                [],
+                {"max_length": "39", "null": "True"},
+            ),
+            "name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "200", "null": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "organization_name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "organization_slug": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "50", "null": "True"},
+            ),
+            "platform": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "reason": ("django.db.models.fields.TextField", [], {"null": "True", "blank": "True"}),
+            "slug": ("django.db.models.fields.CharField", [], {"max_length": "50", "null": "True"}),
+        },
+        "sentry.deletedteam": {
+            "Meta": {"unique_together": "()", "object_name": "DeletedTeam", "index_together": "()"},
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "actor_key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True"},
+            ),
+            "actor_label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "date_created": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "date_deleted": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ip_address": (
+                "django.db.models.fields.GenericIPAddressField",
+                [],
+                {"max_length": "39", "null": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "64", "null": "True"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "organization_name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "organization_slug": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "50", "null": "True"},
+            ),
+            "reason": ("django.db.models.fields.TextField", [], {"null": "True", "blank": "True"}),
+            "slug": ("django.db.models.fields.CharField", [], {"max_length": "50", "null": "True"}),
+        },
+        "sentry.deploy": {
+            "Meta": {"unique_together": "()", "object_name": "Deploy", "index_together": "()"},
+            "date_finished": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_started": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "environment_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True", "blank": "True"},
+            ),
+            "notified": (
+                "django.db.models.fields.NullBooleanField",
+                [],
+                {"default": "False", "null": "True", "db_index": "True", "blank": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+            "url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True", "blank": "True"},
+            ),
+        },
+        "sentry.discoversavedquery": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "DiscoverSavedQuery",
+                "index_together": "()",
+            },
+            "created_by": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "null": "True", "on_delete": "models.SET_NULL"},
+            ),
+            "date_created": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"auto_now_add": "True", "blank": "True"},
+            ),
+            "date_updated": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"auto_now": "True", "blank": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "255"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "projects": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "to": "orm['sentry.Project']",
+                    "through": "orm['sentry.DiscoverSavedQueryProject']",
+                    "symmetrical": "False",
+                },
+            ),
+            "query": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+        },
+        "sentry.discoversavedqueryproject": {
+            "Meta": {
+                "unique_together": "(('project', 'discover_saved_query'),)",
+                "object_name": "DiscoverSavedQueryProject",
+                "index_together": "()",
+            },
+            "discover_saved_query": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.DiscoverSavedQuery']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.distribution": {
+            "Meta": {
+                "unique_together": "(('release', 'name'),)",
+                "object_name": "Distribution",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+        },
+        "sentry.email": {
+            "Meta": {"unique_together": "()", "object_name": "Email", "index_together": "()"},
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "email": (
+                "sentry.db.models.fields.citext.CIEmailField",
+                [],
+                {"unique": "True", "max_length": "75"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+        },
+        "sentry.environment": {
+            "Meta": {
+                "unique_together": "(('organization_id', 'name'),)",
+                "object_name": "Environment",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "projects": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "to": "orm['sentry.Project']",
+                    "through": "orm['sentry.EnvironmentProject']",
+                    "symmetrical": "False",
+                },
+            ),
+        },
+        "sentry.environmentproject": {
+            "Meta": {
+                "unique_together": "(('project', 'environment'),)",
+                "object_name": "EnvironmentProject",
+                "index_together": "()",
+            },
+            "environment": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Environment']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_hidden": (
+                "django.db.models.fields.NullBooleanField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.event": {
+            "Meta": {
+                "unique_together": "(('project_id', 'event_id'),)",
+                "object_name": "Event",
+                "db_table": "'sentry_message'",
+                "index_together": "(('group_id', 'datetime'),)",
+            },
+            "data": (
+                "sentry.db.models.fields.node.NodeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "event_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True", "db_column": "'message_id'"},
+            ),
+            "group_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "message": ("django.db.models.fields.TextField", [], {}),
+            "platform": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "time_spent": (
+                "sentry.db.models.fields.bounded.BoundedIntegerField",
+                [],
+                {"null": "True"},
+            ),
+        },
+        "sentry.eventattachment": {
+            "Meta": {
+                "unique_together": "(('project_id', 'event_id', 'file'),)",
+                "object_name": "EventAttachment",
+                "index_together": "(('project_id', 'date_added'),)",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "event_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "db_index": "True"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.File']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.TextField", [], {}),
+            "project_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.eventmapping": {
+            "Meta": {
+                "unique_together": "(('project_id', 'event_id'),)",
+                "object_name": "EventMapping",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "event_id": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "group_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.eventprocessingissue": {
+            "Meta": {
+                "unique_together": "(('raw_event', 'processing_issue'),)",
+                "object_name": "EventProcessingIssue",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "processing_issue": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ProcessingIssue']"},
+            ),
+            "raw_event": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.RawEvent']"},
+            ),
+        },
+        "sentry.eventtag": {
+            "Meta": {
+                "unique_together": "(('event_id', 'key_id', 'value_id'),)",
+                "object_name": "EventTag",
+                "index_together": "(('group_id', 'key_id', 'value_id'),)",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "event_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "group_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "project_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "value_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.eventuser": {
+            "Meta": {
+                "unique_together": "(('project_id', 'ident'), ('project_id', 'hash'))",
+                "object_name": "EventUser",
+                "index_together": "(('project_id', 'email'), ('project_id', 'username'), ('project_id', 'ip_address'))",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "email": (
+                "django.db.models.fields.EmailField",
+                [],
+                {"max_length": "75", "null": "True"},
+            ),
+            "hash": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "128", "null": "True"},
+            ),
+            "ip_address": (
+                "django.db.models.fields.GenericIPAddressField",
+                [],
+                {"max_length": "39", "null": "True"},
+            ),
+            "name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "128", "null": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "username": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "128", "null": "True"},
+            ),
+        },
+        "sentry.externalissue": {
+            "Meta": {
+                "unique_together": "(('organization_id', 'integration_id', 'key'),)",
+                "object_name": "ExternalIssue",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "description": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "integration_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "metadata": ("sentry.db.models.fields.jsonfield.JSONField", [], {"null": "True"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {},
+            ),
+            "title": ("django.db.models.fields.TextField", [], {"null": "True"}),
+        },
+        "sentry.featureadoption": {
+            "Meta": {
+                "unique_together": "(('organization', 'feature_id'),)",
+                "object_name": "FeatureAdoption",
+                "index_together": "()",
+            },
+            "applicable": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "complete": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_completed": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "feature_id": ("django.db.models.fields.PositiveIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+        },
+        "sentry.file": {
+            "Meta": {"unique_together": "()", "object_name": "File", "index_together": "()"},
+            "blob": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'legacy_blob'", "null": "True", "to": "orm['sentry.FileBlob']"},
+            ),
+            "blobs": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "to": "orm['sentry.FileBlob']",
+                    "through": "orm['sentry.FileBlobIndex']",
+                    "symmetrical": "False",
+                },
+            ),
+            "checksum": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "40", "null": "True", "db_index": "True"},
+            ),
+            "headers": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.TextField", [], {}),
+            "path": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "size": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "timestamp": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "type": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+        },
+        "sentry.fileblob": {
+            "Meta": {"unique_together": "()", "object_name": "FileBlob", "index_together": "()"},
+            "checksum": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "40"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "path": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "size": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "timestamp": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+        },
+        "sentry.fileblobindex": {
+            "Meta": {
+                "unique_together": "(('file', 'blob', 'offset'),)",
+                "object_name": "FileBlobIndex",
+                "index_together": "()",
+            },
+            "blob": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.FileBlob']"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.File']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "offset": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+        },
+        "sentry.fileblobowner": {
+            "Meta": {
+                "unique_together": "(('blob', 'organization'),)",
+                "object_name": "FileBlobOwner",
+                "index_together": "()",
+            },
+            "blob": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.FileBlob']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+        },
+        "sentry.group": {
+            "Meta": {
+                "unique_together": "(('project', 'short_id'),)",
+                "object_name": "Group",
+                "db_table": "'sentry_groupedmessage'",
+                "index_together": "(('project', 'first_release'),)",
+            },
+            "active_at": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "culprit": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "200", "null": "True", "db_column": "'view'", "blank": "True"},
+            ),
+            "data": (
+                "sentry.db.models.fields.gzippeddict.GzippedDictField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "first_release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']", "null": "True", "on_delete": "models.PROTECT"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_public": (
+                "django.db.models.fields.NullBooleanField",
+                [],
+                {"default": "False", "null": "True", "blank": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "level": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "40", "db_index": "True", "blank": "True"},
+            ),
+            "logger": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "''", "max_length": "64", "db_index": "True", "blank": "True"},
+            ),
+            "message": ("django.db.models.fields.TextField", [], {}),
+            "num_comments": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+            "platform": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "null": "True"},
+            ),
+            "resolved_at": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "score": ("sentry.db.models.fields.bounded.BoundedIntegerField", [], {"default": "0"}),
+            "short_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "time_spent_count": (
+                "sentry.db.models.fields.bounded.BoundedIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "time_spent_total": (
+                "sentry.db.models.fields.bounded.BoundedIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "times_seen": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "1", "db_index": "True"},
+            ),
+        },
+        "sentry.groupassignee": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "GroupAssignee",
+                "db_table": "'sentry_groupasignee'",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'assignee_set'", "unique": "True", "to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'assignee_set'", "to": "orm['sentry.Project']"},
+            ),
+            "team": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "related_name": "u'sentry_assignee_set'",
+                    "null": "True",
+                    "to": "orm['sentry.Team']",
+                },
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "related_name": "u'sentry_assignee_set'",
+                    "null": "True",
+                    "to": "orm['sentry.User']",
+                },
+            ),
+        },
+        "sentry.groupbookmark": {
+            "Meta": {
+                "unique_together": "(('project', 'user', 'group'),)",
+                "object_name": "GroupBookmark",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'bookmark_set'", "to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'bookmark_set'", "to": "orm['sentry.Project']"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'sentry_bookmark_set'", "to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.groupcommitresolution": {
+            "Meta": {
+                "unique_together": "(('group_id', 'commit_id'),)",
+                "object_name": "GroupCommitResolution",
+                "index_together": "()",
+            },
+            "commit_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "group_id": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+        },
+        "sentry.groupemailthread": {
+            "Meta": {
+                "unique_together": "(('email', 'group'), ('email', 'msgid'))",
+                "object_name": "GroupEmailThread",
+                "index_together": "()",
+            },
+            "date": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "email": ("django.db.models.fields.EmailField", [], {"max_length": "75"}),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'groupemail_set'", "to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "msgid": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'groupemail_set'", "to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.groupenvironment": {
+            "Meta": {
+                "unique_together": "(('group', 'environment'),)",
+                "object_name": "GroupEnvironment",
+                "index_together": "(('environment', 'first_release'),)",
+            },
+            "environment": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Environment']"},
+            ),
+            "first_release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']", "null": "True", "on_delete": "models.DO_NOTHING"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True", "db_index": "True"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+        },
+        "sentry.grouphash": {
+            "Meta": {
+                "unique_together": "(('project', 'hash'),)",
+                "object_name": "GroupHash",
+                "index_together": "()",
+            },
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "null": "True"},
+            ),
+            "group_tombstone_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "hash": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "null": "True"},
+            ),
+            "state": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+        },
+        "sentry.grouplink": {
+            "Meta": {
+                "unique_together": "(('group_id', 'linked_type', 'linked_id'),)",
+                "object_name": "GroupLink",
+                "index_together": "()",
+            },
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "group_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "linked_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "linked_type": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "1"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "relationship": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "2"},
+            ),
+        },
+        "sentry.groupmeta": {
+            "Meta": {
+                "unique_together": "(('group', 'key'),)",
+                "object_name": "GroupMeta",
+                "index_together": "()",
+            },
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "value": ("django.db.models.fields.TextField", [], {}),
+        },
+        "sentry.groupredirect": {
+            "Meta": {
+                "unique_together": "(('organization_id', 'previous_short_id', 'previous_project_slug'),)",
+                "object_name": "GroupRedirect",
+                "index_together": "()",
+            },
+            "group_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "previous_group_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"unique": "True"},
+            ),
+            "previous_project_slug": (
+                "django.db.models.fields.SlugField",
+                [],
+                {"max_length": "50", "null": "True"},
+            ),
+            "previous_short_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+        },
+        "sentry.grouprelease": {
+            "Meta": {
+                "unique_together": "(('group_id', 'release_id', 'environment'),)",
+                "object_name": "GroupRelease",
+                "index_together": "()",
+            },
+            "environment": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "''", "max_length": "64"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "group_id": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "release_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+        },
+        "sentry.groupresolution": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "GroupResolution",
+                "index_together": "()",
+            },
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "unique": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "type": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+        },
+        "sentry.grouprulestatus": {
+            "Meta": {
+                "unique_together": "(('rule', 'group'),)",
+                "object_name": "GroupRuleStatus",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_active": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "rule": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Rule']"},
+            ),
+            "status": ("django.db.models.fields.PositiveSmallIntegerField", [], {"default": "0"}),
+        },
+        "sentry.groupseen": {
+            "Meta": {
+                "unique_together": "(('user', 'group'),)",
+                "object_name": "GroupSeen",
+                "index_together": "()",
+            },
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "db_index": "False"},
+            ),
+        },
+        "sentry.groupshare": {
+            "Meta": {"unique_together": "()", "object_name": "GroupShare", "index_together": "()"},
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "unique": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "null": "True"},
+            ),
+            "uuid": (
+                "django.db.models.fields.CharField",
+                [],
+                {
+                    "default": "'f13eb6212ba24484bb412ccc94c1cdd5'",
+                    "unique": "True",
+                    "max_length": "32",
+                },
+            ),
+        },
+        "sentry.groupsnooze": {
+            "Meta": {"unique_together": "()", "object_name": "GroupSnooze", "index_together": "()"},
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "count": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "unique": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "state": ("sentry.db.models.fields.jsonfield.JSONField", [], {"null": "True"}),
+            "until": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "user_count": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "user_window": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "window": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+        },
+        "sentry.groupsubscription": {
+            "Meta": {
+                "unique_together": "(('group', 'user'),)",
+                "object_name": "GroupSubscription",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'subscription_set'", "to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_active": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'subscription_set'", "to": "orm['sentry.Project']"},
+            ),
+            "reason": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.grouptagkey": {
+            "Meta": {
+                "unique_together": "(('project_id', 'group_id', 'key'),)",
+                "object_name": "GroupTagKey",
+                "index_together": "()",
+            },
+            "group_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "values_seen": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.grouptagvalue": {
+            "Meta": {
+                "unique_together": "(('group_id', 'key', 'value'),)",
+                "object_name": "GroupTagValue",
+                "db_table": "'sentry_messagefiltervalue'",
+                "index_together": "(('project_id', 'key', 'value', 'last_seen'),)",
+            },
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True", "db_index": "True"},
+            ),
+            "group_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True", "db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "times_seen": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "value": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
+        },
+        "sentry.grouptombstone": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "GroupTombstone",
+                "index_together": "()",
+            },
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "culprit": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "200", "null": "True", "blank": "True"},
+            ),
+            "data": (
+                "sentry.db.models.fields.gzippeddict.GzippedDictField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "level": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "40", "blank": "True"},
+            ),
+            "message": ("django.db.models.fields.TextField", [], {}),
+            "previous_group_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"unique": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.identity": {
+            "Meta": {
+                "unique_together": "(('idp', 'external_id'), ('idp', 'user'))",
+                "object_name": "Identity",
+                "index_together": "()",
+            },
+            "data": ("sentry.db.models.fields.encrypted.EncryptedJsonField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_verified": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "external_id": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "idp": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.IdentityProvider']"},
+            ),
+            "scopes": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.identityprovider": {
+            "Meta": {
+                "unique_together": "(('type', 'external_id'),)",
+                "object_name": "IdentityProvider",
+                "index_together": "()",
+            },
+            "config": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "external_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "type": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+        },
+        "sentry.incident": {
+            "Meta": {
+                "unique_together": "(('organization', 'identifier'),)",
+                "object_name": "Incident",
+                "index_together": "()",
+            },
+            "alert_rule": (
+                "django.db.models.fields.related.ForeignKey",
+                [],
+                {"to": "orm['sentry.AlertRule']", "null": "True", "on_delete": "models.SET_NULL"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_closed": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "date_detected": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_started": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "detection_uuid": (
+                "sentry.db.models.fields.uuid.UUIDField",
+                [],
+                {"max_length": "32", "null": "True", "db_index": "True"},
+            ),
+            "groups": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'incidents'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.IncidentGroup']",
+                    "to": "orm['sentry.Group']",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "identifier": ("django.db.models.fields.IntegerField", [], {}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "projects": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'incidents'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.IncidentProject']",
+                    "to": "orm['sentry.Project']",
+                },
+            ),
+            "query": ("django.db.models.fields.TextField", [], {}),
+            "status": ("django.db.models.fields.PositiveSmallIntegerField", [], {"default": "1"}),
+            "title": ("django.db.models.fields.TextField", [], {}),
+            "type": ("django.db.models.fields.PositiveSmallIntegerField", [], {"default": "1"}),
+        },
+        "sentry.incidentactivity": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "IncidentActivity",
+                "index_together": "()",
+            },
+            "comment": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "event_stats_snapshot": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.TimeSeriesSnapshot']", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Incident']"},
+            ),
+            "previous_value": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "type": ("django.db.models.fields.IntegerField", [], {}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "null": "True"},
+            ),
+            "value": ("django.db.models.fields.TextField", [], {"null": "True"}),
+        },
+        "sentry.incidentgroup": {
+            "Meta": {
+                "unique_together": "(('group', 'incident'),)",
+                "object_name": "IncidentGroup",
+                "index_together": "()",
+            },
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "db_index": "False"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Incident']"},
+            ),
+        },
+        "sentry.incidentproject": {
+            "Meta": {
+                "unique_together": "(('project', 'incident'),)",
+                "object_name": "IncidentProject",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Incident']"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "db_index": "False"},
+            ),
+        },
+        "sentry.incidentseen": {
+            "Meta": {
+                "unique_together": "(('user', 'incident'),)",
+                "object_name": "IncidentSeen",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Incident']"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "db_index": "False"},
+            ),
+        },
+        "sentry.incidentsnapshot": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "IncidentSnapshot",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "event_stats_snapshot": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.TimeSeriesSnapshot']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "django.db.models.fields.related.OneToOneField",
+                [],
+                {"to": "orm['sentry.Incident']", "unique": "True"},
+            ),
+            "total_events": ("django.db.models.fields.IntegerField", [], {}),
+            "unique_users": ("django.db.models.fields.IntegerField", [], {}),
+        },
+        "sentry.incidentsubscription": {
+            "Meta": {
+                "unique_together": "(('incident', 'user'),)",
+                "object_name": "IncidentSubscription",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Incident']", "db_index": "False"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.incidentsuspectcommit": {
+            "Meta": {
+                "unique_together": "(('incident', 'commit'),)",
+                "object_name": "IncidentSuspectCommit",
+                "index_together": "()",
+            },
+            "commit": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Commit']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Incident']", "db_index": "False"},
+            ),
+            "order": ("django.db.models.fields.SmallIntegerField", [], {}),
+        },
+        "sentry.integration": {
+            "Meta": {
+                "unique_together": "(('provider', 'external_id'),)",
+                "object_name": "Integration",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "external_id": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "metadata": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
+            "organizations": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'integrations'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.OrganizationIntegration']",
+                    "to": "orm['sentry.Organization']",
+                },
+            ),
+            "projects": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'integrations'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.ProjectIntegration']",
+                    "to": "orm['sentry.Project']",
+                },
+            ),
+            "provider": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+        },
+        "sentry.integrationexternalproject": {
+            "Meta": {
+                "unique_together": "(('organization_integration_id', 'external_id'),)",
+                "object_name": "IntegrationExternalProject",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "external_id": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "organization_integration_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "resolved_status": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "unresolved_status": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+        },
+        "sentry.integrationfeature": {
+            "Meta": {
+                "unique_together": "(('sentry_app', 'feature'),)",
+                "object_name": "IntegrationFeature",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "feature": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "sentry_app": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.SentryApp']"},
+            ),
+            "user_description": ("django.db.models.fields.TextField", [], {"null": "True"}),
+        },
+        "sentry.latestrelease": {
+            "Meta": {
+                "unique_together": "(('repository_id', 'environment_id'),)",
+                "object_name": "LatestRelease",
+                "index_together": "()",
+            },
+            "commit_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "deploy_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "environment_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "release_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "repository_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.lostpasswordhash": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "LostPasswordHash",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "hash": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "unique": "True"},
+            ),
+        },
+        "sentry.monitor": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "Monitor",
+                "index_together": "(('type', 'next_checkin'),)",
+            },
+            "config": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "guid": (
+                "sentry.db.models.fields.uuid.UUIDField",
+                [],
+                {"auto_add": "'uuid:uuid4'", "unique": "True", "max_length": "32"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_checkin": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "next_checkin": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "type": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.monitorcheckin": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "MonitorCheckIn",
+                "index_together": "()",
+            },
+            "config": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_updated": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "duration": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "guid": (
+                "sentry.db.models.fields.uuid.UUIDField",
+                [],
+                {"auto_add": "'uuid:uuid4'", "unique": "True", "max_length": "32"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "location": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.MonitorLocation']", "null": "True"},
+            ),
+            "monitor": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Monitor']"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.monitorlocation": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "MonitorLocation",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "guid": (
+                "sentry.db.models.fields.uuid.UUIDField",
+                [],
+                {"auto_add": "'uuid:uuid4'", "unique": "True", "max_length": "32"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+        },
+        "sentry.option": {
+            "Meta": {"unique_together": "()", "object_name": "Option", "index_together": "()"},
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "64"},
+            ),
+            "last_updated": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "value": ("sentry.db.models.fields.encrypted.EncryptedPickledObjectField", [], {}),
+        },
+        "sentry.organization": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "Organization",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "default_role": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "'member'", "max_length": "32"},
+            ),
+            "flags": ("django.db.models.fields.BigIntegerField", [], {"default": "1"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "members": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'org_memberships'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.OrganizationMember']",
+                    "to": "orm['sentry.User']",
+                },
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "slug": (
+                "django.db.models.fields.SlugField",
+                [],
+                {"unique": "True", "max_length": "50"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.organizationaccessrequest": {
+            "Meta": {
+                "unique_together": "(('team', 'member'),)",
+                "object_name": "OrganizationAccessRequest",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "member": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.OrganizationMember']"},
+            ),
+            "team": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Team']"},
+            ),
+        },
+        "sentry.organizationavatar": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "OrganizationAvatar",
+                "index_together": "()",
+            },
+            "avatar_type": (
+                "django.db.models.fields.PositiveSmallIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "to": "orm['sentry.File']",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "32", "db_index": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'avatar'", "unique": "True", "to": "orm['sentry.Organization']"},
+            ),
+        },
+        "sentry.organizationintegration": {
+            "Meta": {
+                "unique_together": "(('organization', 'integration'),)",
+                "object_name": "OrganizationIntegration",
+                "index_together": "()",
+            },
+            "config": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "default_auth_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "integration": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Integration']"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.organizationmember": {
+            "Meta": {
+                "unique_together": "(('organization', 'user'), ('organization', 'email'))",
+                "object_name": "OrganizationMember",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "email": (
+                "django.db.models.fields.EmailField",
+                [],
+                {"max_length": "75", "null": "True", "blank": "True"},
+            ),
+            "flags": ("django.db.models.fields.BigIntegerField", [], {"default": "0"}),
+            "has_global_access": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'member_set'", "to": "orm['sentry.Organization']"},
+            ),
+            "role": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "'member'", "max_length": "32"},
+            ),
+            "teams": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "to": "orm['sentry.Team']",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.OrganizationMemberTeam']",
+                    "blank": "True",
+                },
+            ),
+            "token": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "unique": "True", "null": "True", "blank": "True"},
+            ),
+            "token_expires_at": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "None", "null": "True"},
+            ),
+            "type": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "50", "blank": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "blank": "True",
+                    "related_name": "u'sentry_orgmember_set'",
+                    "null": "True",
+                    "to": "orm['sentry.User']",
+                },
+            ),
+        },
+        "sentry.organizationmemberteam": {
+            "Meta": {
+                "unique_together": "(('team', 'organizationmember'),)",
+                "object_name": "OrganizationMemberTeam",
+                "db_table": "'sentry_organizationmember_teams'",
+                "index_together": "()",
+            },
+            "id": ("sentry.db.models.fields.bounded.BoundedAutoField", [], {"primary_key": "True"}),
+            "is_active": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "organizationmember": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.OrganizationMember']"},
+            ),
+            "team": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Team']"},
+            ),
+        },
+        "sentry.organizationonboardingtask": {
+            "Meta": {
+                "unique_together": "(('organization', 'task'),)",
+                "object_name": "OrganizationOnboardingTask",
+                "index_together": "()",
+            },
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_completed": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "status": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "task": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "null": "True"},
+            ),
+        },
+        "sentry.organizationoption": {
+            "Meta": {
+                "unique_together": "(('organization', 'key'),)",
+                "object_name": "OrganizationOption",
+                "db_table": "'sentry_organizationoptions'",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "value": ("sentry.db.models.fields.encrypted.EncryptedPickledObjectField", [], {}),
+        },
+        "sentry.platformexternalissue": {
+            "Meta": {
+                "unique_together": "(('group_id', 'service_type'),)",
+                "object_name": "PlatformExternalIssue",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "display_name": ("django.db.models.fields.TextField", [], {}),
+            "group_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "service_type": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "web_url": ("django.db.models.fields.URLField", [], {"max_length": "200"}),
+        },
+        "sentry.processingissue": {
+            "Meta": {
+                "unique_together": "(('project', 'checksum', 'type'),)",
+                "object_name": "ProcessingIssue",
+                "index_together": "()",
+            },
+            "checksum": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "40", "db_index": "True"},
+            ),
+            "data": ("sentry.db.models.fields.gzippeddict.GzippedDictField", [], {}),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "type": ("django.db.models.fields.CharField", [], {"max_length": "30"}),
+        },
+        "sentry.project": {
+            "Meta": {
+                "unique_together": "(('organization', 'slug'),)",
+                "object_name": "Project",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "first_event": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "flags": (
+                "django.db.models.fields.BigIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+            "forced_color": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "6", "null": "True", "blank": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "platform": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "public": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "slug": ("django.db.models.fields.SlugField", [], {"max_length": "50", "null": "True"}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "teams": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'teams'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.ProjectTeam']",
+                    "to": "orm['sentry.Team']",
+                },
+            ),
+        },
+        "sentry.projectavatar": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "ProjectAvatar",
+                "index_together": "()",
+            },
+            "avatar_type": (
+                "django.db.models.fields.PositiveSmallIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "to": "orm['sentry.File']",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "32", "db_index": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'avatar'", "unique": "True", "to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.projectbookmark": {
+            "Meta": {
+                "unique_together": "(('project', 'user'),)",
+                "object_name": "ProjectBookmark",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "null": "True", "blank": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.projectdebugfile": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "ProjectDebugFile",
+                "db_table": "'sentry_projectdsymfile'",
+                "index_together": "(('project', 'debug_id'), ('project', 'code_id'))",
+            },
+            "code_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "cpu_name": ("django.db.models.fields.CharField", [], {"max_length": "40"}),
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"null": "True"}),
+            "debug_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "db_column": "'uuid'"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.File']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "object_name": ("django.db.models.fields.TextField", [], {}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "null": "True"},
+            ),
+        },
+        "sentry.projectintegration": {
+            "Meta": {
+                "unique_together": "(('project', 'integration'),)",
+                "object_name": "ProjectIntegration",
+                "index_together": "()",
+            },
+            "config": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "integration": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Integration']"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.projectkey": {
+            "Meta": {"unique_together": "()", "object_name": "ProjectKey", "index_together": "()"},
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True", "blank": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'key_set'", "to": "orm['sentry.Project']"},
+            ),
+            "public_key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "unique": "True", "null": "True"},
+            ),
+            "rate_limit_count": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "rate_limit_window": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "roles": ("django.db.models.fields.BigIntegerField", [], {"default": "1"}),
+            "secret_key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "unique": "True", "null": "True"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+        },
+        "sentry.projectoption": {
+            "Meta": {
+                "unique_together": "(('project', 'key'),)",
+                "object_name": "ProjectOption",
+                "db_table": "'sentry_projectoptions'",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "value": ("sentry.db.models.fields.encrypted.EncryptedPickledObjectField", [], {}),
+        },
+        "sentry.projectownership": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "ProjectOwnership",
+                "index_together": "()",
+            },
+            "auto_assignment": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "date_created": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "fallthrough": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_active": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "last_updated": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "unique": "True"},
+            ),
+            "raw": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "schema": ("sentry.db.models.fields.jsonfield.JSONField", [], {"null": "True"}),
+        },
+        "sentry.projectplatform": {
+            "Meta": {
+                "unique_together": "(('project_id', 'platform'),)",
+                "object_name": "ProjectPlatform",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "platform": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "project_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.projectredirect": {
+            "Meta": {
+                "unique_together": "(('organization', 'redirect_slug'),)",
+                "object_name": "ProjectRedirect",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "redirect_slug": ("django.db.models.fields.SlugField", [], {"max_length": "50"}),
+        },
+        "sentry.projectteam": {
+            "Meta": {
+                "unique_together": "(('project', 'team'),)",
+                "object_name": "ProjectTeam",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "team": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Team']"},
+            ),
+        },
+        "sentry.promptsactivity": {
+            "Meta": {
+                "unique_together": "(('user', 'feature', 'organization_id', 'project_id'),)",
+                "object_name": "PromptsActivity",
+                "index_together": "()",
+            },
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "feature": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.pullrequest": {
+            "Meta": {
+                "unique_together": "(('repository_id', 'key'),)",
+                "object_name": "PullRequest",
+                "db_table": "'sentry_pull_request'",
+                "index_together": "(('repository_id', 'date_added'), ('organization_id', 'merge_commit_sha'))",
+            },
+            "author": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.CommitAuthor']", "null": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "merge_commit_sha": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "message": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "repository_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {},
+            ),
+            "title": ("django.db.models.fields.TextField", [], {"null": "True"}),
+        },
+        "sentry.pullrequestcommit": {
+            "Meta": {
+                "unique_together": "(('pull_request', 'commit'),)",
+                "object_name": "PullRequestCommit",
+                "db_table": "'sentry_pullrequest_commit'",
+                "index_together": "()",
+            },
+            "commit": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Commit']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "pull_request": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.PullRequest']"},
+            ),
+        },
+        "sentry.querysubscription": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "QuerySubscription",
+                "index_together": "()",
+            },
+            "aggregations": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.IntegerField", [], {})},
+            ),
+            "dataset": ("django.db.models.fields.TextField", [], {}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "query": ("django.db.models.fields.TextField", [], {}),
+            "resolution": ("django.db.models.fields.IntegerField", [], {}),
+            "subscription_id": ("django.db.models.fields.TextField", [], {"unique": "True"}),
+            "time_window": ("django.db.models.fields.IntegerField", [], {}),
+            "type": ("django.db.models.fields.TextField", [], {}),
+        },
+        "sentry.rawevent": {
+            "Meta": {
+                "unique_together": "(('project', 'event_id'),)",
+                "object_name": "RawEvent",
+                "index_together": "()",
+            },
+            "data": (
+                "sentry.db.models.fields.node.NodeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "event_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.recentsearch": {
+            "Meta": {
+                "unique_together": "(('user', 'organization', 'type', 'query_hash'),)",
+                "object_name": "RecentSearch",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "query": ("django.db.models.fields.TextField", [], {}),
+            "query_hash": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "type": ("django.db.models.fields.PositiveSmallIntegerField", [], {}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "db_index": "False"},
+            ),
+        },
+        "sentry.relay": {
+            "Meta": {"unique_together": "()", "object_name": "Relay", "index_together": "()"},
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_internal": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "public_key": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
+            "relay_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "64"},
+            ),
+        },
+        "sentry.release": {
+            "Meta": {
+                "unique_together": "(('organization', 'version'),)",
+                "object_name": "Release",
+                "index_together": "()",
+            },
+            "authors": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "commit_count": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_released": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "date_started": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_commit_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "last_deploy_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "new_groups": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "owner": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "to": "orm['sentry.User']",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                    "blank": "True",
+                },
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "projects": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'releases'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.ReleaseProject']",
+                    "to": "orm['sentry.Project']",
+                },
+            ),
+            "ref": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "250", "null": "True", "blank": "True"},
+            ),
+            "total_deploys": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+            "url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True", "blank": "True"},
+            ),
+            "version": ("django.db.models.fields.CharField", [], {"max_length": "250"}),
+        },
+        "sentry.releasecommit": {
+            "Meta": {
+                "unique_together": "(('release', 'commit'), ('release', 'order'))",
+                "object_name": "ReleaseCommit",
+                "index_together": "()",
+            },
+            "commit": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Commit']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "order": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+        },
+        "sentry.releaseenvironment": {
+            "Meta": {
+                "unique_together": "(('organization', 'release', 'environment'),)",
+                "object_name": "ReleaseEnvironment",
+                "db_table": "'sentry_environmentrelease'",
+                "index_together": "()",
+            },
+            "environment": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Environment']"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+        },
+        "sentry.releasefile": {
+            "Meta": {
+                "unique_together": "(('release', 'ident'),)",
+                "object_name": "ReleaseFile",
+                "index_together": "(('release', 'name'),)",
+            },
+            "dist": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Distribution']", "null": "True"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.File']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": ("django.db.models.fields.CharField", [], {"max_length": "40"}),
+            "name": ("django.db.models.fields.TextField", [], {}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+        },
+        "sentry.releaseheadcommit": {
+            "Meta": {
+                "unique_together": "(('repository_id', 'release'),)",
+                "object_name": "ReleaseHeadCommit",
+                "index_together": "()",
+            },
+            "commit": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Commit']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+            "repository_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {},
+            ),
+        },
+        "sentry.releaseproject": {
+            "Meta": {
+                "unique_together": "(('project', 'release'),)",
+                "object_name": "ReleaseProject",
+                "db_table": "'sentry_release_project'",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "new_groups": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+        },
+        "sentry.releaseprojectenvironment": {
+            "Meta": {
+                "unique_together": "(('project', 'release', 'environment'),)",
+                "object_name": "ReleaseProjectEnvironment",
+                "index_together": "()",
+            },
+            "environment": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Environment']"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_deploy_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "new_issues_count": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+        },
+        "sentry.repository": {
+            "Meta": {
+                "unique_together": "(('organization_id', 'name'), ('organization_id', 'provider', 'external_id'))",
+                "object_name": "Repository",
+                "index_together": "()",
+            },
+            "config": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "external_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "integration_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "provider": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "url": ("django.db.models.fields.URLField", [], {"max_length": "200", "null": "True"}),
+        },
+        "sentry.reprocessingreport": {
+            "Meta": {
+                "unique_together": "(('project', 'event_id'),)",
+                "object_name": "ReprocessingReport",
+                "index_together": "()",
+            },
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "event_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.rule": {
+            "Meta": {"unique_together": "()", "object_name": "Rule", "index_together": "()"},
+            "data": ("sentry.db.models.fields.gzippeddict.GzippedDictField", [], {}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "environment_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "label": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+        },
+        "sentry.savedsearch": {
+            "Meta": {
+                "unique_together": "(('project', 'name'), ('organization', 'owner', 'type'))",
+                "object_name": "SavedSearch",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_default": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "is_global": (
+                "django.db.models.fields.NullBooleanField",
+                [],
+                {"default": "False", "null": "True", "db_index": "True", "blank": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']", "null": "True"},
+            ),
+            "owner": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "null": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "null": "True"},
+            ),
+            "query": ("django.db.models.fields.TextField", [], {}),
+            "type": (
+                "django.db.models.fields.PositiveSmallIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+        },
+        "sentry.savedsearchuserdefault": {
+            "Meta": {
+                "unique_together": "(('project', 'user'),)",
+                "object_name": "SavedSearchUserDefault",
+                "db_table": "'sentry_savedsearch_userdefault'",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "savedsearch": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.SavedSearch']"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.scheduleddeletion": {
+            "Meta": {
+                "unique_together": "(('app_label', 'model_name', 'object_id'),)",
+                "object_name": "ScheduledDeletion",
+                "index_together": "()",
+            },
+            "aborted": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "app_label": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_scheduled": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime(2019, 9, 19, 0, 0)"},
+            ),
+            "guid": (
+                "django.db.models.fields.CharField",
+                [],
+                {
+                    "default": "'6cc169a491274805a61637b8b5f906e5'",
+                    "unique": "True",
+                    "max_length": "32",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "in_progress": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "model_name": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "object_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.scheduledjob": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "ScheduledJob",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_scheduled": ("django.db.models.fields.DateTimeField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "payload": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+        },
+        "sentry.sentryapp": {
+            "Meta": {"unique_together": "()", "object_name": "SentryApp", "index_together": "()"},
+            "application": (
+                "django.db.models.fields.related.OneToOneField",
+                [],
+                {
+                    "related_name": "u'sentry_app'",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                    "to": "orm['sentry.ApiApplication']",
+                },
+            ),
+            "author": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_deleted": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "date_updated": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "events": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_alertable": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "name": ("django.db.models.fields.TextField", [], {}),
+            "overview": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "owner": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'owned_sentry_apps'", "to": "orm['sentry.Organization']"},
+            ),
+            "proxy_user": (
+                "django.db.models.fields.related.OneToOneField",
+                [],
+                {
+                    "related_name": "u'sentry_app'",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                    "to": "orm['sentry.User']",
+                },
+            ),
+            "redirect_url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True"},
+            ),
+            "schema": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "scope_list": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "scopes": ("django.db.models.fields.BigIntegerField", [], {"default": "None"}),
+            "slug": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "64"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "uuid": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "'12f9b773-ebd8-42f0-9409-d8bc83ce323f'", "max_length": "64"},
+            ),
+            "verify_install": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "webhook_url": ("django.db.models.fields.URLField", [], {"max_length": "200"}),
+        },
+        "sentry.sentryappavatar": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "SentryAppAvatar",
+                "index_together": "()",
+            },
+            "avatar_type": (
+                "django.db.models.fields.PositiveSmallIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "to": "orm['sentry.File']",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "32", "db_index": "True"},
+            ),
+            "sentry_app": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'avatar'", "unique": "True", "to": "orm['sentry.SentryApp']"},
+            ),
+        },
+        "sentry.sentryappcomponent": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "SentryAppComponent",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "schema": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "sentry_app": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'components'", "to": "orm['sentry.SentryApp']"},
+            ),
+            "type": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "uuid": (
+                "sentry.db.models.fields.uuid.UUIDField",
+                [],
+                {"auto_add": "'uuid:uuid4'", "unique": "True", "max_length": "32"},
+            ),
+        },
+        "sentry.sentryappinstallation": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "SentryAppInstallation",
+                "index_together": "()",
+            },
+            "api_grant": (
+                "django.db.models.fields.related.OneToOneField",
+                [],
+                {
+                    "related_name": "u'sentry_app_installation'",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                    "to": "orm['sentry.ApiGrant']",
+                },
+            ),
+            "api_token": (
+                "django.db.models.fields.related.OneToOneField",
+                [],
+                {
+                    "related_name": "u'sentry_app_installation'",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                    "to": "orm['sentry.ApiToken']",
+                },
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_deleted": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "date_updated": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'sentry_app_installations'", "to": "orm['sentry.Organization']"},
+            ),
+            "sentry_app": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'installations'", "to": "orm['sentry.SentryApp']"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "uuid": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "'e2c727e8-4bce-4c34-bbca-b6a74ebd4cd1'", "max_length": "64"},
+            ),
+        },
+        "sentry.sentryappinstallationtoken": {
+            "Meta": {
+                "unique_together": "(('sentry_app_installation', 'api_token'),)",
+                "object_name": "SentryAppInstallationToken",
+                "index_together": "()",
+            },
+            "api_token": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ApiToken']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "sentry_app_installation": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.SentryAppInstallation']"},
+            ),
+        },
+        "sentry.servicehook": {
+            "Meta": {"unique_together": "()", "object_name": "ServiceHook", "index_together": "()"},
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "application": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ApiApplication']", "null": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "events": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "guid": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "unique": "True", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "secret": (
+                "sentry.db.models.fields.encrypted.EncryptedTextField",
+                [],
+                {"default": "'08a6e637bcc84da9873e9492551c76f3ba5883fd25e149a9bd9edfb49faf3069'"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "url": ("django.db.models.fields.URLField", [], {"max_length": "512"}),
+            "version": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.servicehookproject": {
+            "Meta": {
+                "unique_together": "(('service_hook', 'project_id'),)",
+                "object_name": "ServiceHookProject",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "service_hook": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ServiceHook']"},
+            ),
+        },
+        "sentry.tagkey": {
+            "Meta": {
+                "unique_together": "(('project_id', 'key'),)",
+                "object_name": "TagKey",
+                "db_table": "'sentry_filterkey'",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "values_seen": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.tagvalue": {
+            "Meta": {
+                "unique_together": "(('project_id', 'key', 'value'),)",
+                "object_name": "TagValue",
+                "db_table": "'sentry_filtervalue'",
+                "index_together": "(('project_id', 'key', 'last_seen'),)",
+            },
+            "data": (
+                "sentry.db.models.fields.gzippeddict.GzippedDictField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True", "db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True", "db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "times_seen": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "value": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
+        },
+        "sentry.team": {
+            "Meta": {
+                "unique_together": "(('organization', 'slug'),)",
+                "object_name": "Team",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "slug": ("django.db.models.fields.SlugField", [], {"max_length": "50"}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.teamavatar": {
+            "Meta": {"unique_together": "()", "object_name": "TeamAvatar", "index_together": "()"},
+            "avatar_type": (
+                "django.db.models.fields.PositiveSmallIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "to": "orm['sentry.File']",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "32", "db_index": "True"},
+            ),
+            "team": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'avatar'", "unique": "True", "to": "orm['sentry.Team']"},
+            ),
+        },
+        "sentry.timeseriessnapshot": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "TimeSeriesSnapshot",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "end": ("django.db.models.fields.DateTimeField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "period": ("django.db.models.fields.IntegerField", [], {}),
+            "start": ("django.db.models.fields.DateTimeField", [], {}),
+            "values": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"sentry.db.models.fields.array.ArrayField", [], {"null": "True"})},
+            ),
+        },
+        "sentry.user": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "User",
+                "db_table": "'auth_user'",
+                "index_together": "()",
+            },
+            "date_joined": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "email": (
+                "django.db.models.fields.EmailField",
+                [],
+                {"max_length": "75", "blank": "True"},
+            ),
+            "flags": (
+                "django.db.models.fields.BigIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+            "id": ("sentry.db.models.fields.bounded.BoundedAutoField", [], {"primary_key": "True"}),
+            "is_active": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "is_managed": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "is_password_expired": (
+                "django.db.models.fields.BooleanField",
+                [],
+                {"default": "False"},
+            ),
+            "is_sentry_app": (
+                "django.db.models.fields.NullBooleanField",
+                [],
+                {"default": "None", "null": "True", "blank": "True"},
+            ),
+            "is_staff": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "is_superuser": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "last_active": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "last_login": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "last_password_change": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "200", "db_column": "'first_name'", "blank": "True"},
+            ),
+            "password": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "session_nonce": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "12", "null": "True"},
+            ),
+            "username": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "128"},
+            ),
+        },
+        "sentry.useravatar": {
+            "Meta": {"unique_together": "()", "object_name": "UserAvatar", "index_together": "()"},
+            "avatar_type": (
+                "django.db.models.fields.PositiveSmallIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "to": "orm['sentry.File']",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "32", "db_index": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'avatar'", "unique": "True", "to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.useremail": {
+            "Meta": {
+                "unique_together": "(('user', 'email'),)",
+                "object_name": "UserEmail",
+                "index_together": "()",
+            },
+            "date_hash_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "email": ("django.db.models.fields.EmailField", [], {"max_length": "75"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_verified": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'emails'", "to": "orm['sentry.User']"},
+            ),
+            "validation_hash": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "u'rwyf9OZGXMalklduyoVRpfrOAjkzU7dE'", "max_length": "32"},
+            ),
+        },
+        "sentry.userip": {
+            "Meta": {
+                "unique_together": "(('user', 'ip_address'),)",
+                "object_name": "UserIP",
+                "index_together": "()",
+            },
+            "country_code": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "16", "null": "True"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ip_address": (
+                "django.db.models.fields.GenericIPAddressField",
+                [],
+                {"max_length": "39"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "region_code": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "16", "null": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.useroption": {
+            "Meta": {
+                "unique_together": "(('user', 'project', 'key'), ('user', 'organization', 'key'))",
+                "object_name": "UserOption",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']", "null": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "null": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+            "value": ("sentry.db.models.fields.encrypted.EncryptedPickledObjectField", [], {}),
+        },
+        "sentry.userpermission": {
+            "Meta": {
+                "unique_together": "(('user', 'permission'),)",
+                "object_name": "UserPermission",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "permission": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.userreport": {
+            "Meta": {
+                "unique_together": "(('project', 'event_id'),)",
+                "object_name": "UserReport",
+                "index_together": "(('project', 'event_id'), ('project', 'date_added'))",
+            },
+            "comments": ("django.db.models.fields.TextField", [], {}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "email": ("django.db.models.fields.EmailField", [], {"max_length": "75"}),
+            "environment": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Environment']", "null": "True"},
+            ),
+            "event_id": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "event_user_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.widget": {
+            "Meta": {
+                "unique_together": "(('dashboard', 'order'), ('dashboard', 'title'))",
+                "object_name": "Widget",
+                "index_together": "()",
+            },
+            "dashboard": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Dashboard']"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "display_options": (
+                "sentry.db.models.fields.jsonfield.JSONField",
+                [],
+                {"default": "{}"},
+            ),
+            "display_type": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "order": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "title": ("django.db.models.fields.CharField", [], {"max_length": "255"}),
+        },
+        "sentry.widgetdatasource": {
+            "Meta": {
+                "unique_together": "(('widget', 'name'), ('widget', 'order'))",
+                "object_name": "WidgetDataSource",
+                "index_together": "()",
+            },
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "255"}),
+            "order": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "type": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "widget": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Widget']"},
+            ),
+        },
+    }
+
+    complete_apps = ["sentry"]

--- a/tests/sentry/snuba/__init__.py
+++ b/tests/sentry/snuba/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -1,0 +1,165 @@
+from __future__ import absolute_import
+
+import json
+import unittest
+from copy import deepcopy
+
+from exam import fixture, patcher
+from mock import Mock
+
+from sentry.snuba.models import QuerySubscription
+from sentry.snuba.query_subscription_consumer import (
+    InvalidMessageError,
+    InvalidSchemaError,
+    QuerySubscriptionConsumer,
+    register_subscriber,
+    subscriber_registry,
+)
+from sentry.testutils.cases import TestCase
+
+
+class BaseQuerySubscriptionTest(object):
+    @fixture
+    def consumer(self):
+        return QuerySubscriptionConsumer("hello")
+
+    @fixture
+    def valid_wrapper(self):
+        return {"version": 1, "payload": self.valid_payload}
+
+    @fixture
+    def valid_payload(self):
+        return {
+            "subscription_id": "1234",
+            "values": {"hello": 50},
+            "timestamp": 1235,
+            "interval": 5,
+            "partition": 50,
+            "offset": 10,
+        }
+
+    def build_mock_message(self, data):
+        message = Mock()
+        message.value.return_value = json.dumps(data)
+        return message
+
+
+class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
+    metrics = patcher("sentry.snuba.query_subscription_consumer.metrics")
+
+    def test_no_subscription(self):
+        self.consumer.handle_message(self.build_mock_message(self.valid_wrapper))
+        self.metrics.incr.assert_called_once_with(
+            "snuba_query_subscriber.subscription_doesnt_exist"
+        )
+
+    def test_subscription_not_registered(self):
+        sub = QuerySubscription.objects.create(
+            project=self.project,
+            type="unregistered",
+            subscription_id="an_id",
+            dataset="something",
+            query="hello",
+            aggregations=[],
+            time_window=1,
+            resolution=1,
+        )
+        data = self.valid_wrapper
+        data["payload"]["subscription_id"] = sub.subscription_id
+        self.consumer.handle_message(self.build_mock_message(data))
+        self.metrics.incr.assert_called_once_with(
+            "snuba_query_subscriber.subscription_type_not_registered"
+        )
+
+    def test_subscription_registered(self):
+        registration_key = "registered_test"
+        mock_callback = Mock()
+        register_subscriber(registration_key)(mock_callback)
+        sub = QuerySubscription.objects.create(
+            project=self.project,
+            type=registration_key,
+            subscription_id="an_id",
+            dataset="something",
+            query="hello",
+            aggregations=[],
+            time_window=1,
+            resolution=1,
+        )
+        data = self.valid_wrapper
+        data["payload"]["subscription_id"] = sub.subscription_id
+        self.consumer.handle_message(self.build_mock_message(data))
+        mock_callback.assert_called_once_with(data["payload"], sub)
+
+
+class ParseMessageValueTest(BaseQuerySubscriptionTest, unittest.TestCase):
+    def run_test(self, message):
+        self.consumer.parse_message_value(json.dumps(message))
+
+    def run_invalid_schema_test(self, message):
+        with self.assertRaises(InvalidSchemaError):
+            self.run_test(message)
+
+    def run_invalid_payload_test(self, remove_fields=None, update_fields=None):
+        payload = deepcopy(self.valid_payload)
+        if remove_fields:
+            for field in remove_fields:
+                payload.pop(field)
+        if update_fields:
+            payload.update(update_fields)
+        self.run_invalid_schema_test({"version": 1, "payload": payload})
+
+    def test_invalid_payload(self):
+        self.run_invalid_payload_test(remove_fields=["subscription_id"])
+        self.run_invalid_payload_test(remove_fields=["values"])
+        self.run_invalid_payload_test(remove_fields=["timestamp"])
+        self.run_invalid_payload_test(remove_fields=["interval"])
+        self.run_invalid_payload_test(remove_fields=["partition"])
+        self.run_invalid_payload_test(remove_fields=["offset"])
+        self.run_invalid_payload_test(update_fields={"subscription_id": ""})
+        self.run_invalid_payload_test(update_fields={"values": {}})
+        self.run_invalid_payload_test(update_fields={"values": {"hello": "hi"}})
+        self.run_invalid_payload_test(update_fields={"timestamp": -1})
+        self.run_invalid_payload_test(update_fields={"timestamp": "1"})
+        self.run_invalid_payload_test(update_fields={"interval": -1})
+        self.run_invalid_payload_test(update_fields={"interval": "1"})
+        self.run_invalid_payload_test(update_fields={"partition": "1"})
+        self.run_invalid_payload_test(update_fields={"offset": "1"})
+
+    def test_invalid_version(self):
+        with self.assertRaises(InvalidMessageError) as cm:
+            self.run_test({"version": 50, "payload": {}})
+        assert cm.exception.message == "Version specified in wrapper has no schema"
+
+    def test_valid(self):
+        self.run_test({"version": 1, "payload": self.valid_payload})
+
+    def test_invalid_wrapper(self):
+        self.run_invalid_schema_test({})
+        self.run_invalid_schema_test({"version": 1})
+        self.run_invalid_schema_test({"payload": self.valid_payload})
+
+
+class RegisterSubscriberTest(unittest.TestCase):
+    def setUp(self):
+        self.orig_registry = deepcopy(subscriber_registry)
+
+    def tearDown(self):
+        subscriber_registry.clear()
+        subscriber_registry.update(self.orig_registry)
+
+    def test_register(self):
+        callback = object()
+        other_callback = object()
+        register_subscriber("hello")(callback)
+        assert subscriber_registry["hello"] == callback
+        register_subscriber("goodbye")(other_callback)
+        assert subscriber_registry["goodbye"] == other_callback
+
+    def test_already_registered(self):
+        callback = object()
+        other_callback = object()
+        register_subscriber("hello")(callback)
+        assert subscriber_registry["hello"] == callback
+        with self.assertRaises(Exception) as cm:
+            register_subscriber("hello")(other_callback)
+        assert cm.exception.message == "Handler already registered for hello"

--- a/tests/snuba/snuba/__init__.py
+++ b/tests/snuba/snuba/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -1,0 +1,145 @@
+from __future__ import absolute_import
+
+import json
+from copy import deepcopy
+from uuid import uuid4
+
+from confluent_kafka import Producer
+from django.conf import settings
+from django.test.utils import override_settings
+from exam import fixture
+from mock import call, Mock
+
+from sentry.snuba.models import QuerySubscription
+from sentry.snuba.query_subscription_consumer import (
+    QuerySubscriptionConsumer,
+    register_subscriber,
+    subscriber_registry,
+)
+from sentry.testutils.cases import SnubaTestCase, TestCase
+
+
+class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
+    @fixture
+    def subscription_id(self):
+        return "1234"
+
+    @fixture
+    def valid_wrapper(self):
+        return {"version": 1, "payload": self.valid_payload}
+
+    @fixture
+    def valid_payload(self):
+        return {
+            "subscription_id": self.subscription_id,
+            "values": {"hello": 50},
+            "timestamp": 1235,
+            "interval": 5,
+            "partition": 50,
+            "offset": 10,
+        }
+
+    @fixture
+    def topic(self):
+        return uuid4().hex
+
+    @fixture
+    def producer(self):
+        cluster_name = settings.KAFKA_TOPICS[self.topic]["cluster"]
+        conf = {
+            "bootstrap.servers": settings.KAFKA_CLUSTERS[cluster_name]["bootstrap.servers"],
+            "session.timeout.ms": 6000,
+        }
+        return Producer(conf)
+
+    def setUp(self):
+        super(QuerySubscriptionConsumerTest, self).setUp()
+        self.override_settings_cm = override_settings(
+            KAFKA_TOPICS={self.topic: {"cluster": "default", "topic": self.topic}}
+        )
+        self.override_settings_cm.__enter__()
+        self.orig_registry = deepcopy(subscriber_registry)
+
+    def tearDown(self):
+        super(QuerySubscriptionConsumerTest, self).tearDown()
+        self.override_settings_cm.__exit__(None, None, None)
+        subscriber_registry.clear()
+        subscriber_registry.update(self.orig_registry)
+
+    @fixture
+    def registration_key(self):
+        return "registered_keyboard_interrupt"
+
+    def test_normal(self):
+        cluster_name = settings.KAFKA_TOPICS[self.topic]["cluster"]
+
+        conf = {
+            "bootstrap.servers": settings.KAFKA_CLUSTERS[cluster_name]["bootstrap.servers"],
+            "session.timeout.ms": 6000,
+        }
+
+        producer = Producer(conf)
+        producer.produce(self.topic, json.dumps(self.valid_wrapper))
+        producer.flush()
+        mock_callback = Mock()
+        mock_callback.side_effect = KeyboardInterrupt()
+        register_subscriber(self.registration_key)(mock_callback)
+        sub = QuerySubscription.objects.create(
+            project=self.project,
+            type=self.registration_key,
+            subscription_id=self.subscription_id,
+            dataset="something",
+            query="hello",
+            aggregations=[],
+            time_window=1,
+            resolution=1,
+        )
+        consumer = QuerySubscriptionConsumer("hi", topic=self.topic, commit_batch_size=1)
+        consumer.run()
+        mock_callback.assert_called_once_with(self.valid_payload, sub)
+
+    def test_shutdown(self):
+        self.producer.produce(self.topic, json.dumps(self.valid_wrapper))
+        valid_wrapper_2 = deepcopy(self.valid_wrapper)
+        valid_wrapper_2["payload"]["values"]["hello"] = 25
+        self.producer.produce(self.topic, json.dumps(valid_wrapper_2))
+        self.producer.flush()
+
+        counts = [0]
+
+        def mock_callback(*args, **kwargs):
+            counts[0] += 1
+            if counts[0] > 1:
+                raise KeyboardInterrupt()
+
+        mock = Mock()
+        mock.side_effect = mock_callback
+
+        register_subscriber(self.registration_key)(mock)
+        sub = QuerySubscription.objects.create(
+            project=self.project,
+            type=self.registration_key,
+            subscription_id=self.subscription_id,
+            dataset="something",
+            query="hello",
+            aggregations=[],
+            time_window=1,
+            resolution=1,
+        )
+        consumer = QuerySubscriptionConsumer("hi", topic=self.topic, commit_batch_size=100)
+        consumer.run()
+        mock.assert_has_calls(
+            [call(self.valid_payload, sub), call(valid_wrapper_2["payload"], sub)]
+        )
+        # Offset should be committed for the first message, so second run should process
+        # the second message again
+        valid_wrapper_3 = deepcopy(valid_wrapper_2)
+        valid_wrapper_3["payload"]["values"]["hello"] = 5000
+        self.producer.produce(self.topic, json.dumps(valid_wrapper_3))
+        self.producer.flush()
+        mock.reset_mock()
+        counts[0] = 0
+        consumer.run()
+        mock.assert_has_calls(
+            [call(valid_wrapper_2["payload"], sub), call(valid_wrapper_3["payload"], sub)]
+        )


### PR DESCRIPTION
This implements a kafka consumer for receiving updates about snuba query subscriptions. Each subscription is stored in the `QuerySubscription` model, which contains all the information that we need to know about the subscription. Most of these fields have been copied from `AlertRule` in incidents, and will be removed from that model in a later PR.

When a query update is received by the consumer, it validates the message, extracts the subscription id and loads the subscription model. It then grabs the registered callback associated with the subscription and passes the message payload and subscription to that callback. This should give us some flexibility in the future if we need to have other projects use these subscriptions, and is a decent split between alert rules and subscriptions.