### PR TITLE
fix(ui): Correctly report the current set of events being shown.

### DIFF
--- a/src/sentry/static/sentry/app/views/events/events.jsx
+++ b/src/sentry/static/sentry/app/views/events/events.jsx
@@ -26,8 +26,8 @@ const parseRowFromLinks = (links, numRows) => {
   if (!links.previous.results) {
     return `1-${numRows}`;
   }
-  const prevStart = links.previous.cursor.split(':')[1];
-  const nextStart = links.next.cursor.split(':')[1];
+  const prevStart = Number(links.previous.cursor.split(':')[1]);
+  const nextStart = Number(links.next.cursor.split(':')[1]);
   const currentStart = (prevStart + nextStart) / 2 + 1;
   return `${currentStart}-${currentStart + numRows - 1}`;
 };

--- a/tests/js/spec/views/events/events.spec.jsx
+++ b/tests/js/spec/views/events/events.spec.jsx
@@ -12,13 +12,20 @@ import ProjectsStore from 'app/stores/projectsStore';
 
 jest.mock('app/utils/withLatestContext');
 
-const pageOneLinks =
-  '<https://sentry.io/api/0/organizations/sentry/events/?statsPeriod=14d&cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1", ' +
-  '<https://sentry.io/api/0/organizations/sentry/events/?statsPeriod=14d&cursor=0:100:0>; rel="next"; results="true"; cursor="0:100:0"';
+const generatePageLinks = (current, windowSize) => {
+  const previous = current - windowSize;
+  const hasPrevious = previous >= 0;
 
-const pageTwoLinks =
-  '<https://sentry.io/api/0/organizations/sentry/events/?statsPeriod=14d&cursor=0:0:1>; rel="previous"; results="true"; cursor="0:0:1", ' +
-  '<https://sentry.io/api/0/organizations/sentry/events/?statsPeriod=14d&cursor=0:200:0>; rel="next"; results="false"; cursor="0:200:0"';
+  const next = current + windowSize;
+
+  return (
+    `<https://sentry.io/api/0/organizations/sentry/events/?statsPeriod=14d&cursor=0:${previous}:1>; rel="previous"; results="${hasPrevious}"; cursor="0:${previous}:1", ` +
+    `<https://sentry.io/api/0/organizations/sentry/events/?statsPeriod=14d&cursor=0:${next}:0>; rel="next"; results="true"; cursor="0:${next}:0"`
+  );
+};
+
+const pageOneLinks = generatePageLinks(0, 100);
+const pageTwoLinks = generatePageLinks(100, 100);
 
 const EventsWithRouter = withRouter(Events);
 
@@ -431,5 +438,30 @@ describe('parseRowFromLinks', function() {
   it('calculates rows for the second page', function() {
     expect(parseRowFromLinks(pageTwoLinks, 10)).toBe('101-110');
     expect(parseRowFromLinks(pageTwoLinks, 100)).toBe('101-200');
+  });
+
+  it('calculates rows for variable number of pages and window sizes', function() {
+    let currentWindowSize = 1;
+
+    while (currentWindowSize <= 100) {
+      let currentPage = 1; // 1-based index
+
+      while (currentPage <= 100) {
+        const zeroBasedCurrentPage = currentPage - 1; // 0-based index
+
+        const expectedStart = zeroBasedCurrentPage * currentWindowSize + 1;
+        const expectedEnd = currentWindowSize + expectedStart - 1;
+
+        const expectedString = `${expectedStart}-${expectedEnd}`;
+
+        const pageLinks = generatePageLinks(expectedStart - 1, currentWindowSize);
+
+        expect(parseRowFromLinks(pageLinks, currentWindowSize)).toBe(expectedString);
+
+        currentPage += 1;
+      }
+
+      currentWindowSize += 1;
+    }
   });
 });


### PR DESCRIPTION
Addresses this

<img width="1154" alt="Screen Shot 2019-08-13 at 5 38 06 PM" src="https://user-images.githubusercontent.com/139499/62992186-80c2ed00-be20-11e9-942d-e8bbc0cf18c4.png">

-------


Fixes SEN-925