### PR TITLE
chore(ts): webpack file-loader compatibility for TS

### DIFF
--- a/src/sentry/static/sentry/app/types/fileLoader.d.ts
+++ b/src/sentry/static/sentry/app/types/fileLoader.d.ts
@@ -1,0 +1,4 @@
+// Reference: https://github.com/Microsoft/TypeScript-React-Starter/issues/12#issuecomment-327860151
+// TS compatibility for https://github.com/webpack-contrib/file-loader
+
+declare module '*.png';


### PR DESCRIPTION
Ref: https://github.com/Microsoft/TypeScript-React-Starter/issues/12#issuecomment-327860151

------

Some files import `*.png` files, which works with webpack's file-loader; but confuses TypeScript.

We provide `.d.ts` types for these files.  