### PR TITLE
chore: Remove EventMapping from cleanup and deletions code

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -43,7 +43,6 @@ def load_defaults():
     default_manager.register(models.Dashboard, ModelDeletionTask)
     default_manager.register(models.EnvironmentProject, BulkModelDeletionTask)
     default_manager.register(models.Event, defaults.EventDeletionTask)
-    default_manager.register(models.EventMapping, BulkModelDeletionTask)
     default_manager.register(models.EventUser, BulkModelDeletionTask)
     default_manager.register(models.Group, defaults.GroupDeletionTask)
     default_manager.register(models.GroupAssignee, BulkModelDeletionTask)

--- a/src/sentry/deletions/defaults/event.py
+++ b/src/sentry/deletions/defaults/event.py
@@ -22,7 +22,6 @@ class EventDeletionTask(ModelDeletionTask):
         key = {'project_id': instance.project_id, 'event_id': instance.event_id}
         relations.extend([
             ModelRelation(models.EventAttachment, key),
-            ModelRelation(models.EventMapping, key),
             ModelRelation(models.UserReport, key),
         ])
         return relations

--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -13,7 +13,6 @@ class GroupDeletionTask(ModelDeletionTask):
         model_list = (
             # prioritize GroupHash
             models.GroupHash,
-            models.EventMapping,
             models.GroupAssignee,
             models.GroupCommitResolution,
             models.GroupLink,

--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -16,7 +16,7 @@ class ProjectDeletionTask(ModelDeletionTask):
 
         # in bulk
         model_list = (
-            models.Activity, models.EnvironmentProject, models.EventAttachment, models.EventMapping,
+            models.Activity, models.EnvironmentProject, models.EventAttachment,
             models.EventUser, models.GroupAssignee, models.GroupBookmark, models.GroupEmailThread,
             models.GroupHash, models.GroupRelease, models.GroupRuleStatus, models.GroupSeen,
             models.GroupShare, models.GroupSubscription, models.ProjectBookmark, models.ProjectKey,

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -68,7 +68,6 @@ def multiprocess_worker(task_queue):
             skip_models = [
                 # Handled by other parts of cleanup
                 models.Event,
-                models.EventMapping,
                 models.EventAttachment,
                 models.UserReport,
                 models.Group,
@@ -176,7 +175,6 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
     # Deletions that use `BulkDeleteQuery` (and don't need to worry about child relations)
     # (model, datetime_field, order_by)
     BULK_QUERY_DELETES = [
-        (models.EventMapping, 'date_added', '-date_added'),
         (models.EventAttachment, 'date_added', None),
         (models.UserReport, 'date_added', None),
         (models.GroupEmailThread, 'date', None),


### PR DESCRIPTION
We don't use EventMapping to store sampled events anymore.
This is a follow up to https://github.com/getsentry/sentry/pull/14371.
Model can be completely removed after this.