### PR TITLE
fix(native): Handle symbolicator 502 and attach event errors

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -385,12 +385,16 @@ class SymbolicatorSession(object):
                     # the symbolication task.
                     return None
 
-                if response.status_code == 503:
+                if response.status_code in (502, 503):
                     raise ServiceUnavailable()
 
-                response.raise_for_status()
-
-                json = response.json()
+                if response.ok:
+                    json = response.json()
+                else:
+                    json = {
+                        'status': 'failed',
+                        'message': 'internal server error',
+                    }
 
                 return json
             except (IOError, RequestException):


### PR DESCRIPTION
Retries Symbolicator's 502 (bad gateway) errors just like 503 (service unavailable) and emits an event error if symbolicator responds with any other non-200 status code.