### PR TITLE
ref(discover2) Remove dead groupid param

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -15,26 +15,6 @@ from sentry.models.project import Project
 class OrganizationEventsEndpointBase(OrganizationEndpoint):
     def get_snuba_query_args(self, request, organization, params):
         query = request.GET.get('query')
-
-        group_ids = request.GET.getlist('group')
-        if group_ids:
-            # TODO(mark) This parameter should be removed in the long term.
-            # Instead of using this parameter clients should use `issue.id`
-            # in their query string.
-            try:
-                group_ids = set(map(int, filter(None, group_ids)))
-            except ValueError:
-                raise OrganizationEventsError('Invalid group parameter. Values must be numbers')
-
-            projects = Project.objects.filter(
-                organization=organization,
-                group__id__in=group_ids,
-            ).distinct()
-            if any(p for p in projects if not request.access.has_project_access(p)):
-                raise PermissionDenied
-            params['issue.id'] = list(group_ids)
-            params['project_id'] = list(set([p.id for p in projects] + params['project_id']))
-
         try:
             snuba_args = get_snuba_query_args(query=query, params=params)
         except InvalidSearchQuery as exc:


### PR DESCRIPTION
We don't use (and have no immediate plans to use) the group query parameter. This code doesn't have any tests either.

Refs SEN-887