### PR TITLE
test: Rewrite tests that that use the Events table

### DIFF
--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -21,9 +21,9 @@ class SentryInternalClientTest(TestCase):
 
         event = nodestore.get(Event.generate_node_id(settings.SENTRY_PROJECT, event_id))
 
-        assert event['project'] == settings.SENTRY_PROJECT
-        assert event['event_id'] == event_id
-        assert event['logentry']['formatted'] == 'internal client test'
+        assert event["project"] == settings.SENTRY_PROJECT
+        assert event["event_id"] == event_id
+        assert event["logentry"]["formatted"] == "internal client test"
 
     def test_encoding(self):
         configure_sdk()
@@ -33,12 +33,12 @@ class SentryInternalClientTest(TestCase):
             pass
 
         with self.tasks():
-            event_id = raven.captureMessage('check the req', extra={
-                'request': NotJSONSerializable()
-            })
+            event_id = raven.captureMessage(
+                "check the req", extra={"request": NotJSONSerializable()}
+            )
 
         event = nodestore.get(Event.generate_node_id(settings.SENTRY_PROJECT, event_id))
 
-        assert event['project'] == settings.SENTRY_PROJECT
-        assert event['logentry']['formatted'] == 'check the req'
-        assert 'NotJSONSerializable' in event['extra']['request']
+        assert event["project"] == settings.SENTRY_PROJECT
+        assert event["logentry"]["formatted"] == "check the req"
+        assert "NotJSONSerializable" in event["extra"]["request"]

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -8,6 +8,7 @@ from sentry.app import raven
 
 from sentry.models import Event
 from sentry.testutils import TestCase
+from sentry import nodestore
 
 
 class SentryInternalClientTest(TestCase):
@@ -18,10 +19,11 @@ class SentryInternalClientTest(TestCase):
         with self.tasks():
             event_id = raven.captureMessage("internal client test")
 
-        event = Event.objects.get()
-        assert event.project_id == settings.SENTRY_PROJECT
-        assert event.event_id == event_id
-        assert event.data["logentry"]["formatted"] == "internal client test"
+        event = nodestore.get(Event.generate_node_id(settings.SENTRY_PROJECT, event_id))
+
+        assert event['project'] == settings.SENTRY_PROJECT
+        assert event['event_id'] == event_id
+        assert event['logentry']['formatted'] == 'internal client test'
 
     def test_encoding(self):
         configure_sdk()
@@ -31,9 +33,12 @@ class SentryInternalClientTest(TestCase):
             pass
 
         with self.tasks():
-            raven.captureMessage("check the req", extra={"request": NotJSONSerializable()})
+            event_id = raven.captureMessage('check the req', extra={
+                'request': NotJSONSerializable()
+            })
 
-        event = Event.objects.get()
-        assert event.project_id == settings.SENTRY_PROJECT
-        assert event.data["logentry"]["formatted"] == "check the req"
-        assert "NotJSONSerializable" in event.data["extra"]["request"]
+        event = nodestore.get(Event.generate_node_id(settings.SENTRY_PROJECT, event_id))
+
+        assert event['project'] == settings.SENTRY_PROJECT
+        assert event['logentry']['formatted'] == 'check the req'
+        assert 'NotJSONSerializable' in event['extra']['request']

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -56,7 +56,7 @@ REAL_RESOLVING_EVENT_DATA = {
 
 class ResolvingIntegrationTestBase(object):
     def get_event(self):
-        return eventstore.get_events(filter_keys={'project_id': [self.project.id]})[0]
+        return eventstore.get_events(filter_keys={"project_id": [self.project.id]})[0]
 
     def test_real_resolving(self):
         url = reverse(
@@ -91,7 +91,7 @@ class ResolvingIntegrationTestBase(object):
 
         event = self.get_event()
 
-        assert event.data['culprit'] == 'main'
+        assert event.data["culprit"] == "main"
         insta_snapshot_stacktrace_data(self, event.data)
 
     def test_debug_id_resolving(self):
@@ -151,7 +151,7 @@ class ResolvingIntegrationTestBase(object):
         assert resp.status_code == 200
 
         event = self.get_event()
-        assert event.data['culprit'] == 'main'
+        assert event.data["culprit"] == "main"
         insta_snapshot_stacktrace_data(self, event.data)
 
     def test_missing_dsym(self):
@@ -161,7 +161,7 @@ class ResolvingIntegrationTestBase(object):
         assert resp.status_code == 200
 
         event = self.get_event()
-        assert event.data['culprit'] == 'unknown'
+        assert event.data["culprit"] == "unknown"
         insta_snapshot_stacktrace_data(self, event.data)
 
     def test_missing_debug_images(self):
@@ -174,7 +174,7 @@ class ResolvingIntegrationTestBase(object):
         assert resp.status_code == 200
 
         event = self.get_event()
-        assert event.data['culprit'] == 'unknown'
+        assert event.data["culprit"] == "unknown"
         insta_snapshot_stacktrace_data(self, event.data)
 
 

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -78,20 +78,19 @@ class SymbolicatorUnrealIntegrationTest(TransactionTestCase):
                 resp = self._postUnrealWithHeader(f.read())
                 assert resp.status_code == 200
 
-        event = eventstore.get_events(filter_keys={'project_id': [self.project.id]})[0]
+        event = eventstore.get_events(filter_keys={"project_id": [self.project.id]})[0]
 
-        self.insta_snapshot({
-            'contexts': event.data.get('contexts'),
-            'exception': event.data.get('exception'),
-            'stacktrace': event.data.get('stacktrace'),
-            'threads': event.data.get('threads'),
-            'extra': event.data.get('extra')
-        })
+        self.insta_snapshot(
+            {
+                "contexts": event.data.get("contexts"),
+                "exception": event.data.get("exception"),
+                "stacktrace": event.data.get("stacktrace"),
+                "threads": event.data.get("threads"),
+                "extra": event.data.get("extra"),
+            }
+        )
 
-        return sorted(
-            EventAttachment.objects.filter(
-                event_id=event.event_id),
-            key=lambda x: x.name)
+        return sorted(EventAttachment.objects.filter(event_id=event.event_id), key=lambda x: x.name)
 
     def test_unreal_crash_with_attachments(self):
         attachments = self.unreal_crash_test_impl(get_unreal_crash_file())


### PR DESCRIPTION
Since events soon won't be written to the events table, we need to
rewrite these tests that check the Events table to use nodestore
or eventstore instead.