### PR TITLE
chore(ts): Mark proptypes of AsyncComponent to be any

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.tsx
@@ -33,7 +33,7 @@ export default class AsyncComponent<
   P extends AsyncComponentProps = AsyncComponentProps,
   S extends AsyncComponentState = AsyncComponentState
 > extends React.Component<P, S> {
-  static propTypes = {
+  static propTypes: any = {
     location: PropTypes.object,
     router: PropTypes.object,
   };


### PR DESCRIPTION
These proptypes can cause type issues. They should be ignored and thus should be marked as `any`. 

This PR is a dependency for https://github.com/getsentry/sentry/pull/14345