### PR TITLE
feat(discover2) Enable events-stats to be fetched for any aggregate 

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -17,7 +17,7 @@ from sentry.utils.snuba import raw_query, SnubaTSResult
 class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
         try:
-            if features.has('organizations:events-v2', organization, actor=request.user):
+            if features.has("organizations:events-v2", organization, actor=request.user):
                 params = self.get_filter_params(request, organization)
                 snuba_args = self.get_snuba_query_args(request, organization, params)
             else:
@@ -35,8 +35,8 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
         snuba_args = self.get_field(request, snuba_args)
 
         result = raw_query(
-            orderby='time',
-            groupby=['time'],
+            orderby="time",
+            groupby=["time"],
             rollup=rollup,
             referrer="api.organization-events-stats",
             limit=10000,
@@ -51,19 +51,19 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
         )
 
     def get_field(self, request, snuba_args):
-        y_axis = request.GET.get('yAxis', None)
+        y_axis = request.GET.get("yAxis", None)
         # These aliases are used by v1 of events.
-        if not y_axis or y_axis == 'event_count':
-            y_axis = 'count()'
-        elif y_axis == 'user_count':
-            y_axis = 'count_unique(user)'
+        if not y_axis or y_axis == "event_count":
+            y_axis = "count()"
+        elif y_axis == "user_count":
+            y_axis = "count_unique(user)"
 
         try:
             resolved = resolve_field_list([y_axis], {})
         except InvalidSearchQuery as err:
             raise ParseError(detail=six.text_type(err))
-        aggregate = resolved['aggregations'][0]
-        aggregate[2] = 'count'
-        snuba_args['aggregations'] = [aggregate]
+        aggregate = resolved["aggregations"][0]
+        aggregate[2] = "count"
+        snuba_args["aggregations"] = [aggregate]
 
         return snuba_args

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -11,7 +11,7 @@ from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsE
 from sentry.api.event_search import resolve_field_list, InvalidSearchQuery
 from sentry.api.serializers.snuba import SnubaTSResultSerializer
 from sentry.utils.dates import parse_stats_period
-from sentry.utils.snuba import raw_query, SnubaTSResult
+from sentry.utils import snuba
 
 
 class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
@@ -34,7 +34,8 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
 
         snuba_args = self.get_field(request, snuba_args)
 
-        result = raw_query(
+        result = snuba.transform_aliases_and_query(
+            skip_conditions=True,
             orderby="time",
             groupby=["time"],
             rollup=rollup,
@@ -45,7 +46,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
         serializer = SnubaTSResultSerializer(organization, None, request.user)
         return Response(
             serializer.serialize(
-                SnubaTSResult(result, snuba_args["start"], snuba_args["end"], rollup)
+                snuba.SnubaTSResult(result, snuba_args["start"], snuba_args["end"], rollup)
             ),
             status=200,
         )

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -1,9 +1,14 @@
 from __future__ import absolute_import
 
+import six
+
 from datetime import timedelta
 from rest_framework.response import Response
+from rest_framework.exceptions import ParseError
 
+from sentry import features
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
+from sentry.api.event_search import resolve_field_list, InvalidSearchQuery
 from sentry.api.serializers.snuba import SnubaTSResultSerializer
 from sentry.utils.dates import parse_stats_period
 from sentry.utils.snuba import raw_query, SnubaTSResult
@@ -12,37 +17,31 @@ from sentry.utils.snuba import raw_query, SnubaTSResult
 class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
         try:
-            snuba_args = self.get_snuba_query_args_legacy(request, organization)
+            if features.has('organizations:events-v2', organization, actor=request.user):
+                params = self.get_filter_params(request, organization)
+                snuba_args = self.get_snuba_query_args(request, organization, params)
+            else:
+                snuba_args = self.get_snuba_query_args_legacy(request, organization)
         except OrganizationEventsError as exc:
-            return Response({"detail": exc.message}, status=400)
+            raise ParseError(detail=six.text_type(exc))
         except NoProjects:
             return Response({"data": []})
 
         interval = parse_stats_period(request.GET.get("interval", "1h"))
         if interval is None:
             interval = timedelta(hours=1)
-
         rollup = int(interval.total_seconds())
 
-        y_axis = request.GET.get("yAxis", None)
-        if not y_axis or y_axis == "event_count":
-            aggregations = [("count()", "", "count")]
-        elif y_axis == "user_count":
-            aggregations = [("uniq", "tags[sentry:user]", "count")]
-            snuba_args["filter_keys"]["tags_key"] = ["sentry:user"]
-        else:
-            return Response({"detail": "Param yAxis value %s not recognized." % y_axis}, status=400)
+        snuba_args = self.get_field(request, snuba_args)
 
         result = raw_query(
-            aggregations=aggregations,
-            orderby="time",
-            groupby=["time"],
+            orderby='time',
+            groupby=['time'],
             rollup=rollup,
             referrer="api.organization-events-stats",
             limit=10000,
             **snuba_args
         )
-
         serializer = SnubaTSResultSerializer(organization, None, request.user)
         return Response(
             serializer.serialize(
@@ -50,3 +49,21 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
             ),
             status=200,
         )
+
+    def get_field(self, request, snuba_args):
+        y_axis = request.GET.get('yAxis', None)
+        # These aliases are used by v1 of events.
+        if not y_axis or y_axis == 'event_count':
+            y_axis = 'count()'
+        elif y_axis == 'user_count':
+            y_axis = 'count_unique(user)'
+
+        try:
+            resolved = resolve_field_list([y_axis], {})
+        except InvalidSearchQuery as err:
+            raise ParseError(detail=six.text_type(err))
+        aggregate = resolved['aggregations'][0]
+        aggregate[2] = 'count'
+        snuba_args['aggregations'] = [aggregate]
+
+        return snuba_args

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -665,35 +665,14 @@ FIELD_ALIASES = {
 }
 
 VALID_AGGREGATES = {
-    'count_unique': {
-        'snuba_name': 'uniq',
-        'fields': '*',
-    },
-    'count': {
-        'snuba_name': 'count',
-        'fields': '*'
-    },
-    'min': {
-        'snuba_name': 'min',
-        'fields': ['timestamp', 'duration'],
-    },
-    'max': {
-        'snuba_name': 'max',
-        'fields': ['timestamp', 'duration'],
-    },
-    'sum': {
-        'snuba_name': 'sum',
-        'fields': ['duration'],
-    },
+    "count_unique": {"snuba_name": "uniq", "fields": "*"},
+    "count": {"snuba_name": "count", "fields": "*"},
+    "min": {"snuba_name": "min", "fields": ["timestamp", "duration"]},
+    "max": {"snuba_name": "max", "fields": ["timestamp", "duration"]},
+    "sum": {"snuba_name": "sum", "fields": ["duration"]},
     # These don't entirely work yet but are intended to be illustrative
-    'avg': {
-        'snuba_name': 'avg',
-        'fields': ['duration'],
-    },
-    'p75': {
-        'snuba_name': 'quantileTiming(0.75)',
-        'fields': ['duration'],
-    },
+    "avg": {"snuba_name": "avg", "fields": ["duration"]},
+    "p75": {"snuba_name": "quantileTiming(0.75)", "fields": ["duration"]},
 }
 
 AGGREGATE_PATTERN = re.compile(r"^(?P<function>[^\(]+)\((?P<column>[a-z\._]*)\)$")
@@ -740,8 +719,8 @@ def resolve_orderby(orderby, fields, aggregations):
 
 
 def get_aggregate_alias(match):
-    column = match.group('column').replace('.', '_')
-    return u'{}_{}'.format(match.group('function'), column).rstrip('_')
+    column = match.group("column").replace(".", "_")
+    return u"{}_{}".format(match.group("function"), column).rstrip("_")
 
 
 def resolve_field_list(fields, snuba_args):
@@ -780,11 +759,13 @@ def resolve_field_list(fields, snuba_args):
             continue
 
         validate_aggregate(field, match)
-        aggregations.append([
-            VALID_AGGREGATES[match.group('function')]['snuba_name'],
-            get_snuba_column_name(match.group('column')),
-            get_aggregate_alias(match)
-        ])
+        aggregations.append(
+            [
+                VALID_AGGREGATES[match.group("function")]["snuba_name"],
+                get_snuba_column_name(match.group("column")),
+                get_aggregate_alias(match),
+            ]
+        )
 
     rollup = snuba_args.get("rollup")
     if not rollup:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -762,7 +762,7 @@ def resolve_field_list(fields, snuba_args):
         aggregations.append(
             [
                 VALID_AGGREGATES[match.group("function")]["snuba_name"],
-                get_snuba_column_name(match.group("column")),
+                match.group("column"),
                 get_aggregate_alias(match),
             ]
         )

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -719,7 +719,8 @@ def resolve_orderby(orderby, fields, aggregations):
 
 
 def get_aggregate_alias(match):
-    return u"{}_{}".format(match.group("function"), match.group("column")).rstrip("_")
+    column = match.group('column').replace('.', '_')
+    return u'{}_{}'.format(match.group('function'), column).rstrip('_')
 
 
 def resolve_field_list(fields, snuba_args):

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -665,14 +665,35 @@ FIELD_ALIASES = {
 }
 
 VALID_AGGREGATES = {
-    "count_unique": {"snuba_name": "uniq", "fields": "*"},
-    "count": {"snuba_name": "count", "fields": "*"},
-    "avg": {"snuba_name": "avg", "fields": ["duration"]},
-    "min": {"snuba_name": "min", "fields": ["timestamp", "duration"]},
-    "max": {"snuba_name": "max", "fields": ["timestamp", "duration"]},
-    "sum": {"snuba_name": "sum", "fields": ["duration"]},
-    # This doesn't work yet, but is an illustration of how it could work
-    "p75": {"snuba_name": "quantileTiming(0.75)", "fields": ["duration"]},
+    'count_unique': {
+        'snuba_name': 'uniq',
+        'fields': '*',
+    },
+    'count': {
+        'snuba_name': 'count',
+        'fields': '*'
+    },
+    'min': {
+        'snuba_name': 'min',
+        'fields': ['timestamp', 'duration'],
+    },
+    'max': {
+        'snuba_name': 'max',
+        'fields': ['timestamp', 'duration'],
+    },
+    'sum': {
+        'snuba_name': 'sum',
+        'fields': ['duration'],
+    },
+    # These don't entirely work yet but are intended to be illustrative
+    'avg': {
+        'snuba_name': 'avg',
+        'fields': ['duration'],
+    },
+    'p75': {
+        'snuba_name': 'quantileTiming(0.75)',
+        'fields': ['duration'],
+    },
 }
 
 AGGREGATE_PATTERN = re.compile(r"^(?P<function>[^\(]+)\((?P<column>[a-z\._]*)\)$")
@@ -759,13 +780,11 @@ def resolve_field_list(fields, snuba_args):
             continue
 
         validate_aggregate(field, match)
-        aggregations.append(
-            [
-                VALID_AGGREGATES[match.group("function")]["snuba_name"],
-                match.group("column"),
-                get_aggregate_alias(match),
-            ]
-        )
+        aggregations.append([
+            VALID_AGGREGATES[match.group('function')]['snuba_name'],
+            get_snuba_column_name(match.group('column')),
+            get_aggregate_alias(match)
+        ])
 
     rollup = snuba_args.get("rollup")
     if not rollup:

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -303,7 +303,7 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
         for k, v in data:
             row = []
             for r in v:
-                item = {"count": r["count"]}
+                item = {"count": r.get("count", 0)}
                 if self.lookup:
                     value = value_from_row(r, self.lookup.columns)
                     item[self.lookup.name] = (attrs.get(value),)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -35,7 +35,6 @@ MAX_HASHES = 5000
 
 SAFE_FUNCTION_RE = re.compile(r"-?[a-zA-Z_][a-zA-Z0-9_]*$")
 QUOTED_LITERAL_RE = re.compile(r"^'.*'$")
-TAGKEY_RE = re.compile(r"^tags\[[^\]]+\]$")
 
 
 # Global Snuba request option override dictionary. Only intended
@@ -298,9 +297,6 @@ def get_snuba_column_name(name):
     if not name or QUOTED_LITERAL_RE.match(name):
         return name
 
-    if TAGKEY_RE.match(name):
-        return name
-
     return SENTRY_SNUBA_MAP.get(name, u"tags[{}]".format(name))
 
 
@@ -457,8 +453,9 @@ def transform_aliases_and_query(skip_conditions=False, **kwargs):
         aggregation[1] = get_snuba_column_name(aggregation[1])
 
     for (col, _value) in six.iteritems(filter_keys):
-        name = get_snuba_column_name(col)
-        filter_keys[name] = filter_keys.pop(col)
+        if not skip_conditions:
+            name = get_snuba_column_name(col)
+            filter_keys[name] = filter_keys.pop(col)
 
     def handle_condition(cond):
         if isinstance(cond, (list, tuple)) and len(cond):

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -452,8 +452,8 @@ def transform_aliases_and_query(skip_conditions=False, **kwargs):
         derived_columns.add(aggregation[2])
         aggregation[1] = get_snuba_column_name(aggregation[1])
 
-    for (col, _value) in six.iteritems(filter_keys):
-        if not skip_conditions:
+    if not skip_conditions:
+        for (col, _value) in six.iteritems(filter_keys):
             name = get_snuba_column_name(col)
             filter_keys[name] = filter_keys.pop(col)
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -301,7 +301,7 @@ def get_snuba_column_name(name):
     if TAGKEY_RE.match(name):
         return name
 
-    return SENTRY_SNUBA_MAP.get(name, u'tags[{}]'.format(name))
+    return SENTRY_SNUBA_MAP.get(name, u"tags[{}]".format(name))
 
 
 def get_function_index(column_expr, depth=0):

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -35,6 +35,7 @@ MAX_HASHES = 5000
 
 SAFE_FUNCTION_RE = re.compile(r"-?[a-zA-Z_][a-zA-Z0-9_]*$")
 QUOTED_LITERAL_RE = re.compile(r"^'.*'$")
+TAGKEY_RE = re.compile(r"^tags\[[^\]]+\]$")
 
 
 # Global Snuba request option override dictionary. Only intended
@@ -297,7 +298,10 @@ def get_snuba_column_name(name):
     if not name or QUOTED_LITERAL_RE.match(name):
         return name
 
-    return SENTRY_SNUBA_MAP.get(name, u"tags[{}]".format(name))
+    if TAGKEY_RE.match(name):
+        return name
+
+    return SENTRY_SNUBA_MAP.get(name, u'tags[{}]'.format(name))
 
 
 def get_function_index(column_expr, depth=0):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1128,24 +1128,24 @@ class ResolveFieldListTest(unittest.TestCase):
         ]
 
     def test_aggregate_function_expansion(self):
-        fields = ["count_unique(user)", "count(id)", "avg(duration)"]
+        fields = ['count_unique(user)', 'count(id)', 'min(timestamp)']
         result = resolve_field_list(fields, {})
         # Automatic fields should be inserted
-        assert result["selected_columns"] == []
-        assert result["aggregations"] == [
-            ["uniq", "user", "count_unique_user"],
-            ["count", "id", "count_id"],
-            ["avg", "duration", "avg_duration"],
-            ["argMax(event_id, timestamp)", "", "latest_event"],
-            ["argMax(project_id, timestamp)", "", "projectid"],
+        assert result['selected_columns'] == []
+        assert result['aggregations'] == [
+            ['uniq', 'tags[sentry:user]', 'count_unique_user'],
+            ['count', 'event_id', 'count_id'],
+            ['min', 'timestamp', 'min_timestamp'],
+            ['argMax(event_id, timestamp)', '', 'latest_event'],
+            ['argMax(project_id, timestamp)', '', 'projectid'],
         ]
         assert result["groupby"] == []
 
-    def test_aggregate_function_safe_alias(self):
+    def test_aggregate_function_dotted_argument(self):
         fields = ['count_unique(user.id)']
         result = resolve_field_list(fields, {})
         assert result['aggregations'] == [
-            ['uniq', 'user.id', 'count_unique_user_id'],
+            ['uniq', 'user_id', 'count_unique_user_id'],
             ['argMax(event_id, timestamp)', '', 'latest_event'],
             ['argMax(project_id, timestamp)', '', 'projectid'],
         ]
@@ -1188,9 +1188,11 @@ class ResolveFieldListTest(unittest.TestCase):
         fields = ["count_unique(user)"]
         snuba_args = {"rollup": 15}
         result = resolve_field_list(fields, snuba_args)
-        assert result["aggregations"] == [["uniq", "user", "count_unique_user"]]
-        assert result["selected_columns"] == []
-        assert result["groupby"] == []
+        assert result['aggregations'] == [
+            ['uniq', 'tags[sentry:user]', 'count_unique_user']
+        ]
+        assert result['selected_columns'] == []
+        assert result['groupby'] == []
 
     def test_orderby_unselected_field(self):
         fields = ["message"]
@@ -1223,11 +1225,11 @@ class ResolveFieldListTest(unittest.TestCase):
         fields = ["count(id)", "count_unique(user)"]
         snuba_args = {"orderby": "-count(id)"}
         result = resolve_field_list(fields, snuba_args)
-        assert result["orderby"] == ["-count_id"]
-        assert result["aggregations"] == [
-            ["count", "id", "count_id"],
-            ["uniq", "user", "count_unique_user"],
-            ["argMax(event_id, timestamp)", "", "latest_event"],
-            ["argMax(project_id, timestamp)", "", "projectid"],
+        assert result['orderby'] == ['-count_id']
+        assert result['aggregations'] == [
+            ['count', 'event_id', 'count_id'],
+            ['uniq', 'tags[sentry:user]', 'count_unique_user'],
+            ['argMax(event_id, timestamp)', '', 'latest_event'],
+            ['argMax(project_id, timestamp)', '', 'projectid'],
         ]
         assert result["groupby"] == []

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1133,8 +1133,8 @@ class ResolveFieldListTest(unittest.TestCase):
         # Automatic fields should be inserted
         assert result["selected_columns"] == []
         assert result["aggregations"] == [
-            ["uniq", "tags[sentry:user]", "count_unique_user"],
-            ["count", "event_id", "count_id"],
+            ["uniq", "user", "count_unique_user"],
+            ["count", "id", "count_id"],
             ["min", "timestamp", "min_timestamp"],
             ["argMax(event_id, timestamp)", "", "latest_event"],
             ["argMax(project_id, timestamp)", "", "projectid"],
@@ -1145,7 +1145,7 @@ class ResolveFieldListTest(unittest.TestCase):
         fields = ["count_unique(user.id)"]
         result = resolve_field_list(fields, {})
         assert result["aggregations"] == [
-            ["uniq", "user_id", "count_unique_user_id"],
+            ["uniq", "user.id", "count_unique_user_id"],
             ["argMax(event_id, timestamp)", "", "latest_event"],
             ["argMax(project_id, timestamp)", "", "projectid"],
         ]
@@ -1188,7 +1188,7 @@ class ResolveFieldListTest(unittest.TestCase):
         fields = ["count_unique(user)"]
         snuba_args = {"rollup": 15}
         result = resolve_field_list(fields, snuba_args)
-        assert result["aggregations"] == [["uniq", "tags[sentry:user]", "count_unique_user"]]
+        assert result["aggregations"] == [["uniq", "user", "count_unique_user"]]
         assert result["selected_columns"] == []
         assert result["groupby"] == []
 
@@ -1225,8 +1225,8 @@ class ResolveFieldListTest(unittest.TestCase):
         result = resolve_field_list(fields, snuba_args)
         assert result["orderby"] == ["-count_id"]
         assert result["aggregations"] == [
-            ["count", "event_id", "count_id"],
-            ["uniq", "tags[sentry:user]", "count_unique_user"],
+            ["count", "id", "count_id"],
+            ["uniq", "user", "count_unique_user"],
             ["argMax(event_id, timestamp)", "", "latest_event"],
             ["argMax(project_id, timestamp)", "", "projectid"],
         ]

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1128,26 +1128,26 @@ class ResolveFieldListTest(unittest.TestCase):
         ]
 
     def test_aggregate_function_expansion(self):
-        fields = ['count_unique(user)', 'count(id)', 'min(timestamp)']
+        fields = ["count_unique(user)", "count(id)", "min(timestamp)"]
         result = resolve_field_list(fields, {})
         # Automatic fields should be inserted
-        assert result['selected_columns'] == []
-        assert result['aggregations'] == [
-            ['uniq', 'tags[sentry:user]', 'count_unique_user'],
-            ['count', 'event_id', 'count_id'],
-            ['min', 'timestamp', 'min_timestamp'],
-            ['argMax(event_id, timestamp)', '', 'latest_event'],
-            ['argMax(project_id, timestamp)', '', 'projectid'],
+        assert result["selected_columns"] == []
+        assert result["aggregations"] == [
+            ["uniq", "tags[sentry:user]", "count_unique_user"],
+            ["count", "event_id", "count_id"],
+            ["min", "timestamp", "min_timestamp"],
+            ["argMax(event_id, timestamp)", "", "latest_event"],
+            ["argMax(project_id, timestamp)", "", "projectid"],
         ]
         assert result["groupby"] == []
 
     def test_aggregate_function_dotted_argument(self):
-        fields = ['count_unique(user.id)']
+        fields = ["count_unique(user.id)"]
         result = resolve_field_list(fields, {})
-        assert result['aggregations'] == [
-            ['uniq', 'user_id', 'count_unique_user_id'],
-            ['argMax(event_id, timestamp)', '', 'latest_event'],
-            ['argMax(project_id, timestamp)', '', 'projectid'],
+        assert result["aggregations"] == [
+            ["uniq", "user_id", "count_unique_user_id"],
+            ["argMax(event_id, timestamp)", "", "latest_event"],
+            ["argMax(project_id, timestamp)", "", "projectid"],
         ]
 
     def test_aggregate_function_invalid_name(self):
@@ -1188,11 +1188,9 @@ class ResolveFieldListTest(unittest.TestCase):
         fields = ["count_unique(user)"]
         snuba_args = {"rollup": 15}
         result = resolve_field_list(fields, snuba_args)
-        assert result['aggregations'] == [
-            ['uniq', 'tags[sentry:user]', 'count_unique_user']
-        ]
-        assert result['selected_columns'] == []
-        assert result['groupby'] == []
+        assert result["aggregations"] == [["uniq", "tags[sentry:user]", "count_unique_user"]]
+        assert result["selected_columns"] == []
+        assert result["groupby"] == []
 
     def test_orderby_unselected_field(self):
         fields = ["message"]
@@ -1225,11 +1223,11 @@ class ResolveFieldListTest(unittest.TestCase):
         fields = ["count(id)", "count_unique(user)"]
         snuba_args = {"orderby": "-count(id)"}
         result = resolve_field_list(fields, snuba_args)
-        assert result['orderby'] == ['-count_id']
-        assert result['aggregations'] == [
-            ['count', 'event_id', 'count_id'],
-            ['uniq', 'tags[sentry:user]', 'count_unique_user'],
-            ['argMax(event_id, timestamp)', '', 'latest_event'],
-            ['argMax(project_id, timestamp)', '', 'projectid'],
+        assert result["orderby"] == ["-count_id"]
+        assert result["aggregations"] == [
+            ["count", "event_id", "count_id"],
+            ["uniq", "tags[sentry:user]", "count_unique_user"],
+            ["argMax(event_id, timestamp)", "", "latest_event"],
+            ["argMax(project_id, timestamp)", "", "projectid"],
         ]
         assert result["groupby"] == []

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1141,6 +1141,15 @@ class ResolveFieldListTest(unittest.TestCase):
         ]
         assert result["groupby"] == []
 
+    def test_aggregate_function_safe_alias(self):
+        fields = ['count_unique(user.id)']
+        result = resolve_field_list(fields, {})
+        assert result['aggregations'] == [
+            ['uniq', 'user.id', 'count_unique_user_id'],
+            ['argMax(event_id, timestamp)', '', 'latest_event'],
+            ['argMax(project_id, timestamp)', '', 'projectid'],
+        ]
+
     def test_aggregate_function_invalid_name(self):
         with pytest.raises(InvalidSearchQuery) as err:
             fields = ["derp(user)"]

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -5,12 +5,7 @@ import pytz
 
 from sentry.models import GroupRelease, Release
 from sentry.testutils import TestCase
-from sentry.utils.snuba import (
-    get_snuba_translators,
-    zerofill,
-    get_json_type,
-    get_snuba_column_name
-)
+from sentry.utils.snuba import get_snuba_translators, zerofill, get_json_type, get_snuba_column_name
 
 
 class SnubaUtilsTest(TestCase):
@@ -152,23 +147,23 @@ class SnubaUtilsTest(TestCase):
         assert results[7]["time"] == 1546992000
 
     def test_get_json_type(self):
-        assert get_json_type('UInt8') == 'boolean'
-        assert get_json_type('UInt16') == 'integer'
-        assert get_json_type('UInt32') == 'integer'
-        assert get_json_type('UInt64') == 'integer'
-        assert get_json_type('Float32') == 'number'
-        assert get_json_type('Float64') == 'number'
-        assert get_json_type('Nullable(Float64)') == 'number'
-        assert get_json_type('Array(String)') == 'array'
-        assert get_json_type('Char') == 'string'
-        assert get_json_type('unknown') == 'string'
-        assert get_json_type('') == 'string'
+        assert get_json_type("UInt8") == "boolean"
+        assert get_json_type("UInt16") == "integer"
+        assert get_json_type("UInt32") == "integer"
+        assert get_json_type("UInt64") == "integer"
+        assert get_json_type("Float32") == "number"
+        assert get_json_type("Float64") == "number"
+        assert get_json_type("Nullable(Float64)") == "number"
+        assert get_json_type("Array(String)") == "array"
+        assert get_json_type("Char") == "string"
+        assert get_json_type("unknown") == "string"
+        assert get_json_type("") == "string"
 
     def test_get_snuba_column_name(self):
-        assert get_snuba_column_name('project_id') == 'project_id'
-        assert get_snuba_column_name('start') == 'start'
+        assert get_snuba_column_name("project_id") == "project_id"
+        assert get_snuba_column_name("start") == "start"
         assert get_snuba_column_name("'thing'") == "'thing'"
-        assert get_snuba_column_name('id') == 'event_id'
-        assert get_snuba_column_name('geo.region') == 'geo_region'
-        assert get_snuba_column_name('tags[sentry:user]') == 'tags[sentry:user]'
-        assert get_snuba_column_name('organization') == 'tags[organization]'
+        assert get_snuba_column_name("id") == "event_id"
+        assert get_snuba_column_name("geo.region") == "geo_region"
+        assert get_snuba_column_name("tags[sentry:user]") == "tags[sentry:user]"
+        assert get_snuba_column_name("organization") == "tags[organization]"

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -5,7 +5,12 @@ import pytz
 
 from sentry.models import GroupRelease, Release
 from sentry.testutils import TestCase
-from sentry.utils.snuba import get_snuba_translators, zerofill, get_json_type
+from sentry.utils.snuba import (
+    get_snuba_translators,
+    zerofill,
+    get_json_type,
+    get_snuba_column_name
+)
 
 
 class SnubaUtilsTest(TestCase):
@@ -147,14 +152,23 @@ class SnubaUtilsTest(TestCase):
         assert results[7]["time"] == 1546992000
 
     def test_get_json_type(self):
-        assert get_json_type("UInt8") == "boolean"
-        assert get_json_type("UInt16") == "integer"
-        assert get_json_type("UInt32") == "integer"
-        assert get_json_type("UInt64") == "integer"
-        assert get_json_type("Float32") == "number"
-        assert get_json_type("Float64") == "number"
-        assert get_json_type("Nullable(Float64)") == "number"
-        assert get_json_type("Array(String)") == "array"
-        assert get_json_type("Char") == "string"
-        assert get_json_type("unknown") == "string"
-        assert get_json_type("") == "string"
+        assert get_json_type('UInt8') == 'boolean'
+        assert get_json_type('UInt16') == 'integer'
+        assert get_json_type('UInt32') == 'integer'
+        assert get_json_type('UInt64') == 'integer'
+        assert get_json_type('Float32') == 'number'
+        assert get_json_type('Float64') == 'number'
+        assert get_json_type('Nullable(Float64)') == 'number'
+        assert get_json_type('Array(String)') == 'array'
+        assert get_json_type('Char') == 'string'
+        assert get_json_type('unknown') == 'string'
+        assert get_json_type('') == 'string'
+
+    def test_get_snuba_column_name(self):
+        assert get_snuba_column_name('project_id') == 'project_id'
+        assert get_snuba_column_name('start') == 'start'
+        assert get_snuba_column_name("'thing'") == "'thing'"
+        assert get_snuba_column_name('id') == 'event_id'
+        assert get_snuba_column_name('geo.region') == 'geo_region'
+        assert get_snuba_column_name('tags[sentry:user]') == 'tags[sentry:user]'
+        assert get_snuba_column_name('organization') == 'tags[organization]'

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -165,5 +165,6 @@ class SnubaUtilsTest(TestCase):
         assert get_snuba_column_name("'thing'") == "'thing'"
         assert get_snuba_column_name("id") == "event_id"
         assert get_snuba_column_name("geo.region") == "geo_region"
-        assert get_snuba_column_name("tags[sentry:user]") == "tags[sentry:user]"
+        # This is odd behavior but captures what we do currently.
+        assert get_snuba_column_name("tags[sentry:user]") == "tags[tags[sentry:user]]"
         assert get_snuba_column_name("organization") == "tags[organization]"

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -46,18 +46,25 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             tags={"sentry:user": self.user2.email},
         )
         self.url = reverse(
-            'sentry-api-0-organization-events-stats',
-            kwargs={
-                'organization_slug': self.project.organization.slug,
-            }
+            "sentry-api-0-organization-events-stats",
+            kwargs={"organization_slug": self.project.organization.slug},
         )
 
     def test_simple(self):
-        response = self.client.get('%s?%s' % (self.url, urlencode({
-            'start': self.day_ago.isoformat()[:19],
-            'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
-            'interval': '1h',
-        })), format='json')
+        response = self.client.get(
+            "%s?%s"
+            % (
+                self.url,
+                urlencode(
+                    {
+                        "start": self.day_ago.isoformat()[:19],
+                        "end": (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+                        "interval": "1h",
+                    }
+                ),
+            ),
+            format="json",
+        )
 
         assert response.status_code == 200, response.content
         assert [attrs for time, attrs in response.data["data"]] == [
@@ -79,20 +86,25 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         assert len(response.data["data"]) == 0
 
     def test_groupid_filter(self):
-        url = '%s?%s' % (self.url, urlencode({
-            'start': self.day_ago.isoformat()[:19],
-            'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
-            'interval': '1h',
-            'group': self.group.id
-        }))
-        response = self.client.get(url, format='json')
+        url = "%s?%s" % (
+            self.url,
+            urlencode(
+                {
+                    "start": self.day_ago.isoformat()[:19],
+                    "end": (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+                    "interval": "1h",
+                    "group": self.group.id,
+                }
+            ),
+        )
+        response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data["data"])
 
     def test_groupid_filter_invalid_value(self):
-        url = '%s?group=not-a-number' % (self.url,)
-        response = self.client.get(url, format='json')
+        url = "%s?group=not-a-number" % (self.url,)
+        response = self.client.get(url, format="json")
 
         assert response.status_code == 400, response.content
 
@@ -103,26 +115,44 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             datetime=self.day_ago + timedelta(minutes=2),
             tags={"sentry:user": self.user2.email},
         )
-        response = self.client.get('%s?%s' % (self.url, urlencode({
-            'start': self.day_ago.isoformat()[:19],
-            'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
-            'interval': '1h',
-            'yAxis': 'user_count',
-        })), format='json')
+        response = self.client.get(
+            "%s?%s"
+            % (
+                self.url,
+                urlencode(
+                    {
+                        "start": self.day_ago.isoformat()[:19],
+                        "end": (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+                        "interval": "1h",
+                        "yAxis": "user_count",
+                    }
+                ),
+            ),
+            format="json",
+        )
         assert response.status_code == 200, response.content
-        assert [attrs for time, attrs in response.data['data']] == [
+        assert [attrs for time, attrs in response.data["data"]] == [
             [],
             [{"count": 2}],
             [{"count": 1}],
         ]
 
     def test_with_event_count_flag(self):
-        response = self.client.get('%s?%s' % (self.url, urlencode({
-            'start': self.day_ago.isoformat()[:19],
-            'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
-            'interval': '1h',
-            'yAxis': 'event_count',
-        })), format='json')
+        response = self.client.get(
+            "%s?%s"
+            % (
+                self.url,
+                urlencode(
+                    {
+                        "start": self.day_ago.isoformat()[:19],
+                        "end": (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+                        "interval": "1h",
+                        "yAxis": "event_count",
+                    }
+                ),
+            ),
+            format="json",
+        )
 
         assert response.status_code == 200, response.content
         assert [attrs for time, attrs in response.data["data"]] == [
@@ -132,50 +162,53 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         ]
 
     def test_aggregate_function_count(self):
-        with self.feature('organizations:events-v2'):
+        with self.feature("organizations:events-v2"):
             response = self.client.get(
                 self.url,
-                format='json',
+                format="json",
                 data={
-                    'start': self.day_ago.isoformat()[:19],
-                    'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
-                    'interval': '1h',
-                    'yAxis': 'count()',
-                })
+                    "start": self.day_ago.isoformat()[:19],
+                    "end": (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+                    "interval": "1h",
+                    "yAxis": "count()",
+                },
+            )
         assert response.status_code == 200, response.content
-        assert [attrs for time, attrs in response.data['data']] == [
+        assert [attrs for time, attrs in response.data["data"]] == [
             [],
-            [{'count': 1}],
-            [{'count': 2}],
+            [{"count": 1}],
+            [{"count": 2}],
         ]
 
     def test_aggregate_function_user_count(self):
-        with self.feature('organizations:events-v2'):
+        with self.feature("organizations:events-v2"):
             response = self.client.get(
                 self.url,
-                format='json',
+                format="json",
                 data={
-                    'start': self.day_ago.isoformat()[:19],
-                    'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
-                    'interval': '1h',
-                    'yAxis': 'count_unique(user)',
-                })
+                    "start": self.day_ago.isoformat()[:19],
+                    "end": (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+                    "interval": "1h",
+                    "yAxis": "count_unique(user)",
+                },
+            )
         assert response.status_code == 200, response.content
-        assert [attrs for time, attrs in response.data['data']] == [
+        assert [attrs for time, attrs in response.data["data"]] == [
             [],
-            [{'count': 1}],
-            [{'count': 1}],
+            [{"count": 1}],
+            [{"count": 1}],
         ]
 
     def test_aggregate_invalid(self):
-        with self.feature('organizations:events-v2'):
+        with self.feature("organizations:events-v2"):
             response = self.client.get(
                 self.url,
-                format='json',
+                format="json",
                 data={
-                    'start': self.day_ago.isoformat()[:19],
-                    'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
-                    'interval': '1h',
-                    'yAxis': 'nope(lol)',
-                })
+                    "start": self.day_ago.isoformat()[:19],
+                    "end": (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+                    "interval": "1h",
+                    "yAxis": "nope(lol)",
+                },
+            )
         assert response.status_code == 400, response.content

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -45,26 +45,19 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             datetime=self.day_ago + timedelta(hours=1, minutes=2),
             tags={"sentry:user": self.user2.email},
         )
+        self.url = reverse(
+            'sentry-api-0-organization-events-stats',
+            kwargs={
+                'organization_slug': self.project.organization.slug,
+            }
+        )
 
     def test_simple(self):
-        url = reverse(
-            "sentry-api-0-organization-events-stats",
-            kwargs={"organization_slug": self.project.organization.slug},
-        )
-        response = self.client.get(
-            "%s?%s"
-            % (
-                url,
-                urlencode(
-                    {
-                        "start": self.day_ago.isoformat()[:19],
-                        "end": (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
-                        "interval": "1h",
-                    }
-                ),
-            ),
-            format="json",
-        )
+        response = self.client.get('%s?%s' % (self.url, urlencode({
+            'start': self.day_ago.isoformat()[:19],
+            'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+            'interval': '1h',
+        })), format='json')
 
         assert response.status_code == 200, response.content
         assert [attrs for time, attrs in response.data["data"]] == [
@@ -86,33 +79,20 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         assert len(response.data["data"]) == 0
 
     def test_groupid_filter(self):
-        url = reverse(
-            "sentry-api-0-organization-events-stats",
-            kwargs={"organization_slug": self.organization.slug},
-        )
-        url = "%s?%s" % (
-            url,
-            urlencode(
-                {
-                    "start": self.day_ago.isoformat()[:19],
-                    "end": (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
-                    "interval": "1h",
-                    "group": self.group.id,
-                }
-            ),
-        )
-        response = self.client.get(url, format="json")
+        url = '%s?%s' % (self.url, urlencode({
+            'start': self.day_ago.isoformat()[:19],
+            'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+            'interval': '1h',
+            'group': self.group.id
+        }))
+        response = self.client.get(url, format='json')
 
         assert response.status_code == 200, response.content
         assert len(response.data["data"])
 
     def test_groupid_filter_invalid_value(self):
-        url = reverse(
-            "sentry-api-0-organization-events-stats",
-            kwargs={"organization_slug": self.organization.slug},
-        )
-        url = "%s?group=not-a-number" % (url,)
-        response = self.client.get(url, format="json")
+        url = '%s?group=not-a-number' % (self.url,)
+        response = self.client.get(url, format='json')
 
         assert response.status_code == 400, response.content
 
@@ -123,54 +103,26 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             datetime=self.day_ago + timedelta(minutes=2),
             tags={"sentry:user": self.user2.email},
         )
-        url = reverse(
-            "sentry-api-0-organization-events-stats",
-            kwargs={"organization_slug": self.project.organization.slug},
-        )
-        response = self.client.get(
-            "%s?%s"
-            % (
-                url,
-                urlencode(
-                    {
-                        "start": self.day_ago.isoformat()[:19],
-                        "end": (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
-                        "interval": "1h",
-                        "yAxis": "user_count",
-                    }
-                ),
-            ),
-            format="json",
-        )
-
+        response = self.client.get('%s?%s' % (self.url, urlencode({
+            'start': self.day_ago.isoformat()[:19],
+            'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+            'interval': '1h',
+            'yAxis': 'user_count',
+        })), format='json')
         assert response.status_code == 200, response.content
-
-        assert [attrs for time, attrs in response.data["data"]] == [
+        assert [attrs for time, attrs in response.data['data']] == [
             [],
             [{"count": 2}],
             [{"count": 1}],
         ]
 
     def test_with_event_count_flag(self):
-        url = reverse(
-            "sentry-api-0-organization-events-stats",
-            kwargs={"organization_slug": self.project.organization.slug},
-        )
-        response = self.client.get(
-            "%s?%s"
-            % (
-                url,
-                urlencode(
-                    {
-                        "start": self.day_ago.isoformat()[:19],
-                        "end": (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
-                        "interval": "1h",
-                        "yAxis": "event_count",
-                    }
-                ),
-            ),
-            format="json",
-        )
+        response = self.client.get('%s?%s' % (self.url, urlencode({
+            'start': self.day_ago.isoformat()[:19],
+            'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+            'interval': '1h',
+            'yAxis': 'event_count',
+        })), format='json')
 
         assert response.status_code == 200, response.content
         assert [attrs for time, attrs in response.data["data"]] == [
@@ -178,3 +130,52 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             [{"count": 1}],
             [{"count": 2}],
         ]
+
+    def test_aggregate_function_count(self):
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'start': self.day_ago.isoformat()[:19],
+                    'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+                    'interval': '1h',
+                    'yAxis': 'count()',
+                })
+        assert response.status_code == 200, response.content
+        assert [attrs for time, attrs in response.data['data']] == [
+            [],
+            [{'count': 1}],
+            [{'count': 2}],
+        ]
+
+    def test_aggregate_function_user_count(self):
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'start': self.day_ago.isoformat()[:19],
+                    'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+                    'interval': '1h',
+                    'yAxis': 'count_unique(user)',
+                })
+        assert response.status_code == 200, response.content
+        assert [attrs for time, attrs in response.data['data']] == [
+            [],
+            [{'count': 1}],
+            [{'count': 1}],
+        ]
+
+    def test_aggregate_invalid(self):
+        with self.feature('organizations:events-v2'):
+            response = self.client.get(
+                self.url,
+                format='json',
+                data={
+                    'start': self.day_ago.isoformat()[:19],
+                    'end': (self.day_ago + timedelta(hours=1, minutes=59)).isoformat()[:19],
+                    'interval': '1h',
+                    'yAxis': 'nope(lol)',
+                })
+        assert response.status_code == 400, response.content


### PR DESCRIPTION
In the near future we want to be able to generate timeseries data for any user provided aggregate. This enables that without breaking compatibility with the eventsv1 field names.

Refs SEN-805