### PR TITLE
chore(ts): Better generics for getDynamicText function

### DIFF
--- a/src/sentry/static/sentry/app/utils/getDynamicText.tsx
+++ b/src/sentry/static/sentry/app/utils/getDynamicText.tsx
@@ -2,12 +2,12 @@
 
 // Return a specified "fixed" string when we are in a testing environment
 // (more specifically in a PERCY env (e.g. CI))
-export default function getDynamicText({
+export default function getDynamicText<Value, Fixed = Value>({
   value,
   fixed,
 }: {
-  value: React.ReactNode;
-  fixed: string;
-}): React.ReactNode {
+  value: Value;
+  fixed: Fixed;
+}): Value | Fixed {
   return process.env.IS_PERCY ? fixed : value;
 }


### PR DESCRIPTION
We utilize generics to infer types based on the given `value` and `fixed` parameters, and as well as the matched types for anything consuming the `getDynamicText` function.

By default `fixed` is inferred to be the same type as `value`. 

This PR is a dependency for https://github.com/getsentry/sentry/pull/14345