### PR TITLE
fix(debug_files): Ignore code_ids and speed up queries

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ sqlparse>=0.1.16,<0.2.0
 statsd>=3.1.0,<3.2.0
 strict-rfc3339>=0.7
 structlog==16.1.0
-symbolic>=6.0.6,<7.0.0
+symbolic>=6.1.3,<7.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
 # for bitbucket client

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -107,17 +107,13 @@ class DebugFilesEndpoint(ProjectEndpoint):
         debug_id = request.GET.get('debug_id')
         query = request.GET.get('query')
 
-        if code_id:
-            # If a code identifier is provided, try to find an exact match and
-            # only consider the debug identifier if the DIF does not have a
-            # primary code identifier.
-            q = Q(code_id__exact=code_id)
-            if debug_id:
-                q |= Q(code_id__exact=None, debug_id__exact=debug_id)
-        elif debug_id:
-            # If only a debug ID is specified, do not consider the stored code
-            # identifier and strictly filter by debug identifier.
+        if debug_id:
+            # If a debug ID is specified, do not consider the stored code
+            # identifier and strictly filter by debug identifier. Often there
+            # are mismatches in the code identifier in PEs.
             q = Q(debug_id__exact=debug_id)
+        elif code_id:
+            q = Q(code_id__exact=code_id)
         elif query:
             if len(query) <= 45:
                 # If this query contains a debug identifier, normalize it to


### PR DESCRIPTION
It turns out that code identifiers are not reliable for checking PEs. We now skip to compare the code identifier if a debug identifier is given. 

Also, this speeds up queries in the UI if the debug_id is used.