### PR TITLE
feat(discover2) Event details graph should reflect current group

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -803,9 +803,9 @@ def resolve_field_list(fields, snuba_args):
     }
 
 
-def find_reference_event(snuba_args, reference_event_id):
+def find_reference_event(snuba_args, reference_event_slug):
     try:
-        project_slug, event_id = reference_event_id.split(":")
+        project_slug, event_id = reference_event_slug.split(":")
     except ValueError:
         raise InvalidSearchQuery("Invalid reference event")
     try:
@@ -814,7 +814,6 @@ def find_reference_event(snuba_args, reference_event_id):
         )
     except Project.DoesNotExist:
         raise InvalidSearchQuery("Invalid reference event")
-
     reference_event = eventstore.get_event_by_id(project.id, event_id, eventstore.full_columns)
     if not reference_event:
         raise InvalidSearchQuery("Invalid reference event")

--- a/src/sentry/static/sentry/app/actionCreators/events.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.tsx
@@ -17,6 +17,8 @@ type Options = {
   limit?: number;
   query?: string;
   yAxis?: 'event_count' | 'user_count';
+  field?: string[];
+  referenceEvent?: string;
 };
 
 /**
@@ -46,6 +48,8 @@ export const doEventsRequest = (
     includePrevious,
     query,
     yAxis,
+    field,
+    referenceEvent,
   }: Options
 ): Promise<EventsStats> => {
   const shouldDoublePeriod = canIncludePreviousPeriod(includePrevious, period);
@@ -56,6 +60,8 @@ export const doEventsRequest = (
       environment,
       query,
       yAxis,
+      field,
+      referenceEvent,
     }).filter(([, value]) => typeof value !== 'undefined')
   );
 

--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
@@ -38,6 +38,8 @@ type EventsRequestPartialProps = {
   start?: any;
   end?: any;
   interval?: string;
+  field?: string[];
+  referenceEvent?: string;
 
   limit?: number;
   query?: string;
@@ -154,6 +156,9 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
      * The yAxis being plotted
      */
     yAxis: PropTypes.string,
+
+    field: PropTypes.arrayOf(PropTypes.string),
+    referenceEvent: PropTypes.string,
   };
 
   static defaultProps = {

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -17,10 +17,8 @@ import {getQuery} from './utils';
 const slugValidator = function(props, propName, componentName) {
   const value = props[propName];
   // Accept slugs that look like:
-  // * project-slug:deadbeef:latest
-  // * project-slug:deadbeef:oldest
   // * project-slug:deadbeef
-  if (value && !/^(?:[^:]+):(?:[a-f0-9]+)(?:\:latest|oldest)?$/.test(value)) {
+  if (value && !/^(?:[^:]+):(?:[a-f0-9]+)$/.test(value)) {
     return new Error(`Invalid value for ${propName} provided to ${componentName}.`);
   }
   return null;
@@ -50,19 +48,7 @@ class EventDetails extends AsyncComponent {
   getEndpoints() {
     const {organization, eventSlug, view, location} = this.props;
     const query = getQuery(view, location);
-
-    // Check the eventid for the latest/oldest keyword and use that to choose
-    // the endpoint as oldest/latest have special endpoints.
-    const [projectId, eventId, keyword] = eventSlug.toString().split(':');
-
-    let url = `/organizations/${organization.slug}/events/`;
-    // TODO the latest/oldest links are currently broken as they require a
-    // new endpoint that works with the upcoming discover2 queries.
-    if (['latest', 'oldest'].includes(keyword)) {
-      url += `${keyword}/`;
-    } else {
-      url += `${projectId}:${eventId}/`;
-    }
+    const url = `/organizations/${organization.slug}/events/${eventSlug}/`;
 
     // Get a specific event. This could be coming from
     // a paginated group or standalone event.

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/modalLineGraph.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/modalLineGraph.jsx
@@ -67,26 +67,39 @@ const getCurrentEventMarker = currentEvent => {
  *
  * When a user clicks on a marker we want to update the modal
  * to display an event from that time slice. While each graph slice
- * could contain thousands of events, we use the /latest endpoint
- * to pick one.
+ * could contain thousands of events, we do a search to get the latest
+ * event in the slice.
  */
 const handleClick = async function(
   series,
-  {api, organization, queryString, interval, selection, location}
+  {api, currentEvent, organization, queryString, field, interval, selection, location}
 ) {
   // Get the timestamp that was clicked.
   const value = series.value[0];
+
+  // If the current fieldlist has a timestamp column sort
+  // by that. If there are no timestamp fields we will get non-deterministic
+  // results.
+  const sortField = field.includes('timestamp')
+    ? 'timestamp'
+    : field.includes('last_seen')
+    ? 'last_seen'
+    : null;
 
   // Get events that match the clicked timestamp
   // taking into account the group and current environment & query
   const query = {
     environment: selection.environments,
-    query: queryString,
     start: getUtcDateString(value),
     end: getUtcDateString(value + intervalToMilliseconds(interval)),
+    limit: 1,
+    sort: sortField,
+    referenceEvent: `${currentEvent.projectSlug}:${currentEvent.eventID}`,
+    query: queryString,
+    field,
   };
 
-  const url = `/organizations/${organization.slug}/events/latest/`;
+  const url = `/organizations/${organization.slug}/eventsv2/`;
   let response;
   try {
     response = await api.requestPromise(url, {
@@ -97,12 +110,17 @@ const handleClick = async function(
     // Do nothing, user could have clicked on a blank space.
     return;
   }
+  if (!response.data || !response.data.length) {
+    // Did not find anything.
+    return;
+  }
 
+  const event = response.data[0];
   browserHistory.push({
     pathname: location.pathname,
     query: {
       ...omit(location.query, MODAL_QUERY_KEYS),
-      eventSlug: `${response.projectSlug}:${response.eventID}`,
+      eventSlug: `${event['project.name']}:${event.id || event.latest_event}`,
     },
   });
 };
@@ -136,15 +154,8 @@ const ModalLineGraph = props => {
     },
   };
 
-  // Generate a query string that finds events similar to our
-  // current event based on the type of view being used.
-  const eventConditions = {};
-  if (view.id === 'transactions') {
-    eventConditions.transaction = currentEvent.location;
-  } else {
-    eventConditions['issue.id'] = currentEvent.groupID;
-  }
-  const queryString = getQueryString(view, location, eventConditions);
+  const queryString = getQueryString(view, location);
+  const referenceEvent = `${currentEvent.projectSlug}:${currentEvent.eventID}`;
 
   return (
     <Panel>
@@ -159,6 +170,8 @@ const ModalLineGraph = props => {
         interval={interval}
         showLoading={true}
         query={queryString}
+        field={view.data.fields}
+        referenceEvent={referenceEvent}
         includePrevious={false}
       >
         {({loading, reloading, timeseriesData}) => (
@@ -171,12 +184,14 @@ const ModalLineGraph = props => {
             }}
             onClick={series =>
               handleClick(series, {
+                field: view.data.fields,
                 api,
                 organization,
-                queryString,
+                currentEvent,
                 interval,
                 selection,
                 location,
+                queryString,
               })
             }
             tooltip={tooltip}

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/utils.jsx
@@ -71,22 +71,14 @@ export function getQuery(view, location) {
  *
  * @param {Object} view defaults containing `.data.query`
  * @param {Location} browser location
- * @param {Object} additional parameters to merge into the query string.
  */
-export function getQueryString(view, location, additional) {
+export function getQueryString(view, location) {
   const queryParts = [];
   if (view.data.query) {
     queryParts.push(view.data.query);
   }
   if (location.query && location.query.query) {
     queryParts.push(location.query.query);
-  }
-  if (additional) {
-    Object.entries(additional).forEach(([key, value]) => {
-      if (value) {
-        queryParts.push(`${key}:${value}`);
-      }
-    });
   }
 
   return queryParts.join(' ');

--- a/tests/js/spec/views/organizationEventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/utils.spec.jsx
@@ -71,24 +71,6 @@ describe('getQueryString()', function() {
     };
     expect(getQueryString(view, location)).toEqual('event.type:transaction TypeError');
   });
-
-  it('includes non-empty additional data', function() {
-    const view = {
-      data: {
-        query: 'event.type:transaction',
-      },
-    };
-    const location = {};
-    const additional = {
-      nope: '',
-      undef: undefined,
-      nullish: null,
-      yes: 'value',
-    };
-    expect(getQueryString(view, location, additional)).toEqual(
-      'event.type:transaction yes:value'
-    );
-  });
 });
 
 describe('eventTagSearchUrl()', function() {


### PR DESCRIPTION
The summary graph on the event details view needs to reflect the current 'group'. For example if you are group results by title, projectid, and view a result, the summary graph should show all events matching the currently selected result. By passing a 'reference event' and field list we can generate additional conditions to ensure only sibling events are included in the results.

Refs SEN-932