### PR TITLE
ref(ui): Remove uneeded ThemeProvider on the sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -1,4 +1,3 @@
-import {ThemeProvider} from 'emotion-theming';
 import {isEqual} from 'lodash';
 import {withRouter, browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
@@ -82,10 +81,13 @@ class Sidebar extends React.Component {
 
   // Sidebar doesn't use children, so don't use it to compare
   // Also ignore location, will re-render when routes change (instead of query params)
-  shouldComponentUpdate({children, location, ...nextPropsToCompare}, nextState) {
+  shouldComponentUpdate(
+    {children: _children, location: _location, ...nextPropsToCompare},
+    nextState
+  ) {
     const {
-      children: _children, // eslint-disable-line no-unused-vars
-      location: _location, // eslint-disable-line no-unused-vars
+      children: _childrenCurrent,
+      location: _locationCurrent,
       ...currentPropsToCompare
     } = this.props;
 
@@ -188,7 +190,7 @@ class Sidebar extends React.Component {
     });
   };
 
-  togglePanel = (panel, e) => {
+  togglePanel = panel => {
     if (this.state.currentPanel === panel) {
       this.hidePanel();
     } else {
@@ -500,11 +502,7 @@ const SidebarContainer = withRouter(
     },
 
     render() {
-      return (
-        <ThemeProvider theme={theme}>
-          <Sidebar {...this.props} collapsed={this.state.collapsed} />
-        </ThemeProvider>
-      );
+      return <Sidebar {...this.props} collapsed={this.state.collapsed} />;
     },
   })
 );
@@ -573,7 +571,7 @@ const PrimaryItems = styled('div')`
   -ms-overflow-style: -ms-autohiding-scrollbar;
   @media (max-height: 600px) and (min-width: ${p => p.theme.breakpoints[0]}) {
     border-bottom: 1px solid ${p => p.theme.gray3};
-    padding-bottom: ${p => space(1)};
+    padding-bottom: ${space(1)};
     box-shadow: rgba(0, 0, 0, 0.15) 0px -10px 10px inset;
     &::-webkit-scrollbar {
       background-color: transparent;
@@ -590,8 +588,8 @@ const PrimaryItems = styled('div')`
     height: 100%;
     align-items: center;
     border-right: 1px solid ${p => p.theme.gray3};
-    padding-right: ${p => space(1)};
-    margin-right: ${p => space(0.5)};
+    padding-right: ${space(1)};
+    margin-right: ${space(0.5)};
     box-shadow: rgba(0, 0, 0, 0.15) -10px 0px 10px inset;
     ::-webkit-scrollbar {
       display: none;

--- a/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
@@ -88,7 +88,8 @@ describe('OrganizationDetails', function() {
 
       it('should render a deletion in progress prompt', async function() {
         const tree = mount(
-          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />
+          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />,
+          TestStubs.routerContext()
         );
         await tick();
         await tick();


### PR DESCRIPTION
This was only required as the Sidebar could be rendered outside of the `App` tree before https://github.com/getsentry/sentry/pull/14105