### PR TITLE
fix(vsts) Fix azure devops failing when account list fails

### DIFF
--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -467,13 +467,13 @@ class AccountConfigView(PipelineView):
                 "accounts": accounts,
             },
         )
-        accounts = accounts["value"]
-        if not len(accounts):
+        if not accounts or not accounts.get("value"):
             return render_to_response(
                 template="sentry/integrations/vsts-config.html",
                 context={"no_accounts": True},
                 request=request,
             )
+        accounts = accounts["value"]
         pipeline.bind_state("accounts", accounts)
         account_form = AccountForm(accounts)
         return render_to_response(


### PR DESCRIPTION
If we get a non-200 response from Azure devops we should not hard fail. Instead we can let the user know we weren't able to find any related accounts in azure.

Fixes SENTRY-C08
Fixes SEN-926
Refs #14390