### PR TITLE
fix: Do chunking of prepare_project_series

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -164,7 +164,7 @@ def _query_tsdb_chunked(func, issue_ids, start, stop, rollup):
     combined = {}
 
     for chunk in chunked(issue_ids, BATCH_SIZE):
-        combined.update(func(tsdb.models.group, list(chunk), start, stop, rollup=rollup))
+        combined.update(func(tsdb.models.group, chunk, start, stop, rollup=rollup))
 
     return combined
 

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -263,7 +263,7 @@ class ReportTestCase(TestCase, SnubaTestCase):
         set_option_value([organization.id])
         assert user_subscribed_to_organization_reports(user, organization) is False
 
-    @mock.patch("sentry.tasks.reports.GET_SUMS_BATCH_SIZE", 1)
+    @mock.patch("sentry.tasks.reports.BATCH_SIZE", 1)
     def test_paginates_project_issue_summaries_and_reassembles_result(self):
         self.login_as(user=self.user)
 
@@ -295,7 +295,7 @@ class ReportTestCase(TestCase, SnubaTestCase):
 
         assert prepare_project_issue_summaries([two_min_ago, now], self.project) == [2, 0, 0]
 
-    @mock.patch("sentry.tasks.reports.GET_RANGE_BATCH_SIZE", 1)
+    @mock.patch("sentry.tasks.reports.BATCH_SIZE", 1)
     def test_paginates_project_series_and_reassembles_result(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
When a report is generated on Mondays, it goes through a few steps.

Two of those are `prepare_project_issue_summaries` and `prepare_project_series`. These two send a lot of issue IDs to snuba when trying to generate the report.

This causes us to cross the max query size limit in Clickhouse.

So, https://github.com/getsentry/sentry/pull/14379/files chunked the issue IDs in `prepare_project_issue_summaries`. This PR chunks up the issues IDs in `prepare_project_series`.

### Why not implement this in Snuba
See https://github.com/getsentry/sentry/pull/14379#issuecomment-522188791. 

I still feel it is most practical to solve the problem here, in Sentry, rather than in Snuba because for most of our use cases, we will not need to query for thousands of issue IDs.

Would love to hear other opinions. :)