### PR TITLE
fix(apm): Alternative visualization of the time pills

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/spanBar.tsx
@@ -604,7 +604,9 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
               }}
             />
           )}
-          <Duration>{durationString}</Duration>
+          <Duration>
+            <DurationPill>{durationString}</DurationPill>
+          </Duration>
           {this.renderWarningText({warningText: bounds.warning})}
         </SpanRowCell>
         {this.renderDivider(dividerHandlerChildrenProps)}
@@ -809,6 +811,21 @@ const Duration = styled('div')`
   padding-right: ${space(1)};
 
   user-select: none;
+
+  display: flex;
+  align-items: center;
+`;
+
+const DurationPill = styled('div')`
+  height: ${SPAN_ROW_HEIGHT - 10}px;
+  line-height: ${SPAN_ROW_HEIGHT - 10}px;
+
+  border-radius: 99px;
+
+  padding-left: 10px;
+  padding-right: 10px;
+
+  background-color: rgba(255, 255, 255, 0.6);
 `;
 
 const SpanBarRectangle = styled('div')`


### PR DESCRIPTION
For SEN-930 which Crissy is taking over.

Stashing some code here as backup. 

Visuals:

![Screen Shot 2019-08-19 at 5 35 28 PM](https://user-images.githubusercontent.com/139499/63302003-0542bf00-c2aa-11e9-9751-cad4646d647e.png)
