### PR TITLE
feat(ui): Add loading mask to Incident Rules chart

### DIFF
--- a/src/sentry/static/sentry/app/components/loadingMask.tsx
+++ b/src/sentry/static/sentry/app/components/loadingMask.tsx
@@ -1,0 +1,13 @@
+import styled from 'react-emotion';
+
+const LoadingMask = styled('div')`
+  background-color: ${p => p.theme.offWhite};
+  border-radius: ${p => p.theme.borderRadius};
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+`;
+
+export default LoadingMask;

--- a/src/sentry/static/sentry/app/views/dashboards/widget.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/widget.jsx
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-import {LoadingMask} from 'app/views/events/loadingPanel';
 import {Panel, PanelBody} from 'app/components/panels';
 import {t} from 'app/locale';
 import ErrorBoundary from 'app/components/errorBoundary';
+import LoadingMask from 'app/components/loadingMask';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import withGlobalSelection from 'app/utils/withGlobalSelection';

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -6,7 +6,8 @@ import styled from 'react-emotion';
 import {getInterval} from 'app/components/charts/utils';
 import ChartZoom from 'app/components/charts/chartZoom';
 import LineChart from 'app/components/charts/lineChart';
-import LoadingPanel, {LoadingMask} from 'app/views/events/loadingPanel';
+import LoadingMask from 'app/components/loadingMask';
+import LoadingPanel from 'app/views/events/loadingPanel';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
 import SentryTypes from 'app/sentryTypes';
 import withApi from 'app/utils/withApi';
@@ -219,6 +220,7 @@ export default EventsChartContainer;
 export {EventsChart};
 
 const TransparentLoadingMask = styled(LoadingMask)`
-  ${p => !p.visible && 'display: none;'} opacity: 0.4;
+  ${p => !p.visible && 'display: none;'};
+  opacity: 0.4;
   z-index: 1;
 `;

--- a/src/sentry/static/sentry/app/views/events/loadingPanel.jsx
+++ b/src/sentry/static/sentry/app/views/events/loadingPanel.jsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import styled from 'react-emotion';
 
-const LoadingMask = styled('div')`
-  background-color: ${p => p.theme.offWhite};
-  border-radius: ${p => p.theme.borderRadius};
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-`;
+import LoadingMask from 'app/components/loadingMask';
 
 const LoadingPanel = styled(props => (
   <div {...props}>
@@ -26,4 +18,3 @@ const LoadingPanel = styled(props => (
 `;
 
 export default LoadingPanel;
-export {LoadingMask};

--- a/src/sentry/static/sentry/app/views/settings/projectIncidentRules/ruleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectIncidentRules/ruleForm.tsx
@@ -1,6 +1,7 @@
 import {debounce} from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 
 import {EventsStatsData, Organization, Project} from 'app/types';
 import {PanelAlert} from 'app/components/panels';
@@ -9,6 +10,7 @@ import {t} from 'app/locale';
 import EventsRequest from 'app/views/events/utils/eventsRequest';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
+import LoadingMask from 'app/components/loadingMask';
 import Placeholder from 'app/components/placeholder';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
@@ -202,18 +204,21 @@ class RuleForm extends React.Component<Props, State> {
           }
           includePrevious={false}
         >
-          {({loading, timeseriesData}) =>
+          {({loading, reloading, timeseriesData}) =>
             loading ? (
               <Placeholder height="200px" bottomGutter={1} />
             ) : (
-              <IncidentRulesChart
-                onChangeIncidentThreshold={this.handleChangeIncidentThreshold}
-                alertThreshold={alertThreshold}
-                onChangeResolutionThreshold={this.handleChangeResolutionThreshold}
-                resolveThreshold={resolveThreshold}
-                isInverted={isInverted}
-                data={timeseriesData}
-              />
+              <React.Fragment>
+                <TransparentLoadingMask visible={reloading} />
+                <IncidentRulesChart
+                  onChangeIncidentThreshold={this.handleChangeIncidentThreshold}
+                  alertThreshold={alertThreshold}
+                  onChangeResolutionThreshold={this.handleChangeResolutionThreshold}
+                  resolveThreshold={resolveThreshold}
+                  isInverted={isInverted}
+                  data={timeseriesData}
+                />
+              </React.Fragment>
             )
           }
         </EventsRequest>
@@ -372,5 +377,12 @@ function RuleFormContainer({
     </Form>
   );
 }
+
+// TODO(ts): emotion
+const TransparentLoadingMask = styled(LoadingMask)`
+  ${(p: any) => !p.visible && 'display: none;'};
+  opacity: 0.4;
+  z-index: 1;
+`;
 
 export default withApi(withOrganization(withProject(RuleFormContainer)));

--- a/src/sentry/static/sentry/app/views/settings/projectIncidentRules/ruleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectIncidentRules/ruleForm.tsx
@@ -378,9 +378,8 @@ function RuleFormContainer({
   );
 }
 
-// TODO(ts): emotion
-const TransparentLoadingMask = styled(LoadingMask)`
-  ${(p: any) => !p.visible && 'display: none;'};
+const TransparentLoadingMask = styled(LoadingMask)<{visible: boolean}>`
+  ${p => !p.visible && 'display: none;'};
   opacity: 0.4;
   z-index: 1;
 `;


### PR DESCRIPTION
e.g. if you change Time Window, a semi-transparent loading mask will appear over the chart

Also refactors `<LoadingMask>` to `app/components` since 2 other components outside of `app/views/events` uses it.