### PR TITLE
feat(apm): Display cursor guide on the span rows on current timeslice

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/cursorGuideHandler.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/cursorGuideHandler.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
 import {rectOfContent, clamp} from './utils';
+import {ParsedTraceType} from './types';
+import {DragManagerChildrenProps} from './dragManager';
 
 export type CursorGuideManagerChildrenProps = {
   showCursorGuide: boolean;
   mouseLeft: number | undefined;
+  traceViewMouseLeft: number | undefined;
 
   displayCursorGuide: (mousePageX: number) => void;
   hideCursorGuide: () => void;
@@ -13,13 +16,16 @@ export type CursorGuideManagerChildrenProps = {
 const CursorGuideManagerContext = React.createContext<CursorGuideManagerChildrenProps>({
   showCursorGuide: false,
   mouseLeft: void 0,
+  traceViewMouseLeft: void 0,
 
   displayCursorGuide: () => {},
   hideCursorGuide: () => {},
 });
 
 type PropType = {
+  trace: ParsedTraceType;
   children: React.ReactNode;
+  dragProps: DragManagerChildrenProps;
 
   // this is the DOM element where the drag events occur. it's also the reference point
   // for calculating the relative mouse x coordinate.
@@ -29,12 +35,14 @@ type PropType = {
 type StateType = {
   showCursorGuide: boolean;
   mouseLeft: number | undefined;
+  traceViewMouseLeft: number | undefined;
 };
 
 export class Provider extends React.Component<PropType, StateType> {
   state: StateType = {
     showCursorGuide: false,
     mouseLeft: void 0,
+    traceViewMouseLeft: void 0,
   };
 
   hasInteractiveLayer = (): boolean => {
@@ -46,16 +54,36 @@ export class Provider extends React.Component<PropType, StateType> {
       return;
     }
 
+    const {trace, dragProps} = this.props;
+
     const interactiveLayer = this.props.interactiveLayerRef.current!;
 
     const rect = rectOfContent(interactiveLayer);
 
+    // duration of the entire trace in seconds
+    const traceDuration = trace.traceEndTimestamp - trace.traceStartTimestamp;
+
+    const viewStart = dragProps.viewWindowStart;
+    const viewEnd = dragProps.viewWindowEnd;
+
+    const viewStartTimestamp = trace.traceStartTimestamp + viewStart * traceDuration;
+    const viewEndTimestamp = trace.traceEndTimestamp - (1 - viewEnd) * traceDuration;
+    const viewDuration = viewEndTimestamp - viewStartTimestamp;
+
     // clamp mouseLeft to be within [0, 1]
     const mouseLeft = clamp((mousePageX - rect.x) / rect.width, 0, 1);
+
+    const duration =
+      mouseLeft * Math.abs(trace.traceEndTimestamp - trace.traceStartTimestamp);
+
+    const startTimestamp = trace.traceStartTimestamp + duration;
+
+    const start = (startTimestamp - viewStartTimestamp) / viewDuration;
 
     this.setState({
       showCursorGuide: true,
       mouseLeft,
+      traceViewMouseLeft: start,
     });
   };
 
@@ -67,6 +95,7 @@ export class Provider extends React.Component<PropType, StateType> {
     this.setState({
       showCursorGuide: false,
       mouseLeft: void 0,
+      traceViewMouseLeft: void 0,
     });
   };
 
@@ -74,6 +103,7 @@ export class Provider extends React.Component<PropType, StateType> {
     const childrenProps = {
       showCursorGuide: this.state.showCursorGuide,
       mouseLeft: this.state.mouseLeft,
+      traceViewMouseLeft: this.state.traceViewMouseLeft,
 
       displayCursorGuide: this.displayCursorGuide,
       hideCursorGuide: this.hideCursorGuide,

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/cursorGuideHandler.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/cursorGuideHandler.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+export type CursorGuideManagerChildrenProps = {
+  showCursorGuide: boolean;
+  mousePageX: number | undefined;
+
+  displayCursorGuide: (mousePageX: number) => void;
+  hideCursorGuide: () => void;
+};
+
+const CursorGuideManagerContext = React.createContext<CursorGuideManagerChildrenProps>({
+  showCursorGuide: false,
+  mousePageX: void 0,
+
+  displayCursorGuide: () => {},
+  hideCursorGuide: () => {},
+});
+
+type PropType = {
+  children: React.ReactNode;
+
+  // this is the DOM element where the drag events occur. it's also the reference point
+  // for calculating the relative mouse x coordinate.
+  //   interactiveLayerRef: React.RefObject<HTMLDivElement>;
+};
+
+type StateType = {
+  showCursorGuide: boolean;
+  mousePageX: number | undefined;
+};
+
+export class Provider extends React.Component<PropType, StateType> {
+  state: StateType = {
+    showCursorGuide: false,
+    mousePageX: void 0,
+  };
+
+  displayCursorGuide = (mousePageX: number) => {
+    this.setState({
+      showCursorGuide: true,
+      mousePageX,
+    });
+  };
+
+  hideCursorGuide = () => {
+    this.setState({
+      showCursorGuide: false,
+      mousePageX: void 0,
+    });
+  };
+
+  render() {
+    const childrenProps = {
+      showCursorGuide: this.state.showCursorGuide,
+      mousePageX: this.state.mousePageX,
+
+      displayCursorGuide: this.displayCursorGuide,
+      hideCursorGuide: this.hideCursorGuide,
+    };
+
+    return (
+      <CursorGuideManagerContext.Provider value={childrenProps}>
+        {this.props.children}
+      </CursorGuideManagerContext.Provider>
+    );
+  }
+}
+
+export const Consumer = CursorGuideManagerContext.Consumer;

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/cursorGuideHandler.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/cursorGuideHandler.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
+import {rectOfContent, clamp} from './utils';
+
 export type CursorGuideManagerChildrenProps = {
   showCursorGuide: boolean;
-  mousePageX: number | undefined;
+  mouseLeft: number | undefined;
 
   displayCursorGuide: (mousePageX: number) => void;
   hideCursorGuide: () => void;
@@ -10,7 +12,7 @@ export type CursorGuideManagerChildrenProps = {
 
 const CursorGuideManagerContext = React.createContext<CursorGuideManagerChildrenProps>({
   showCursorGuide: false,
-  mousePageX: void 0,
+  mouseLeft: void 0,
 
   displayCursorGuide: () => {},
   hideCursorGuide: () => {},
@@ -21,38 +23,57 @@ type PropType = {
 
   // this is the DOM element where the drag events occur. it's also the reference point
   // for calculating the relative mouse x coordinate.
-  //   interactiveLayerRef: React.RefObject<HTMLDivElement>;
+  interactiveLayerRef: React.RefObject<HTMLDivElement>;
 };
 
 type StateType = {
   showCursorGuide: boolean;
-  mousePageX: number | undefined;
+  mouseLeft: number | undefined;
 };
 
 export class Provider extends React.Component<PropType, StateType> {
   state: StateType = {
     showCursorGuide: false,
-    mousePageX: void 0,
+    mouseLeft: void 0,
+  };
+
+  hasInteractiveLayer = (): boolean => {
+    return !!this.props.interactiveLayerRef.current;
   };
 
   displayCursorGuide = (mousePageX: number) => {
+    if (!this.hasInteractiveLayer()) {
+      return;
+    }
+
+    const interactiveLayer = this.props.interactiveLayerRef.current!;
+
+    const rect = rectOfContent(interactiveLayer);
+
+    // clamp mouseLeft to be within [0, 1]
+    const mouseLeft = clamp((mousePageX - rect.x) / rect.width, 0, 1);
+
     this.setState({
       showCursorGuide: true,
-      mousePageX,
+      mouseLeft,
     });
   };
 
   hideCursorGuide = () => {
+    if (!this.hasInteractiveLayer()) {
+      return;
+    }
+
     this.setState({
       showCursorGuide: false,
-      mousePageX: void 0,
+      mouseLeft: void 0,
     });
   };
 
   render() {
     const childrenProps = {
       showCursorGuide: this.state.showCursorGuide,
-      mousePageX: this.state.mousePageX,
+      mouseLeft: this.state.mouseLeft,
 
       displayCursorGuide: this.displayCursorGuide,
       hideCursorGuide: this.hideCursorGuide,

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/minimap.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/minimap.tsx
@@ -237,8 +237,6 @@ class Minimap extends React.Component<PropType> {
   };
 
   render() {
-    console.log('foo');
-
     return (
       <MinimapContainer>
         <ActualMinimap trace={this.props.trace} />

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/minimap.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/minimap.tsx
@@ -6,7 +6,6 @@ import {get} from 'lodash';
 
 import {
   rectOfContent,
-  clamp,
   toPercent,
   getHumanDuration,
   pickSpanBarColour,
@@ -36,26 +35,15 @@ class Minimap extends React.Component<PropType> {
   renderCursorGuide = ({
     cursorGuideHeight,
     showCursorGuide,
-    mousePageX,
+    mouseLeft,
   }: {
     cursorGuideHeight: number;
     showCursorGuide: boolean;
-    mousePageX: number | undefined;
+    mouseLeft: number | undefined;
   }) => {
-    if (!showCursorGuide || !mousePageX) {
+    if (!showCursorGuide || !mouseLeft) {
       return null;
     }
-
-    const interactiveLayer = this.props.minimapInteractiveRef.current;
-
-    if (!interactiveLayer) {
-      return null;
-    }
-
-    const rect = rectOfContent(interactiveLayer);
-
-    // clamp mouseLeft to be within [0, 1]
-    const mouseLeft = clamp((mousePageX - rect.x) / rect.width, 0, 1);
 
     return (
       <CursorGuide
@@ -135,12 +123,12 @@ class Minimap extends React.Component<PropType> {
 
   renderDurationGuide = ({
     showCursorGuide,
-    mousePageX,
+    mouseLeft,
   }: {
     showCursorGuide: boolean;
-    mousePageX: number | undefined;
+    mouseLeft: number | undefined;
   }) => {
-    if (!showCursorGuide || !mousePageX) {
+    if (!showCursorGuide || !mouseLeft) {
       return null;
     }
 
@@ -151,9 +139,6 @@ class Minimap extends React.Component<PropType> {
     }
 
     const rect = rectOfContent(interactiveLayer);
-
-    // clamp mouseLeft to be within [0, 1]
-    const mouseLeft = clamp((mousePageX - rect.x) / rect.width, 0, 1);
 
     const {trace} = this.props;
 
@@ -173,10 +158,10 @@ class Minimap extends React.Component<PropType> {
 
   renderTimeAxis = ({
     showCursorGuide,
-    mousePageX,
+    mouseLeft,
   }: {
     showCursorGuide: boolean;
-    mousePageX: number | undefined;
+    mouseLeft: number | undefined;
   }) => {
     const {trace} = this.props;
 
@@ -240,23 +225,25 @@ class Minimap extends React.Component<PropType> {
         {lastTick}
         {this.renderCursorGuide({
           showCursorGuide,
-          mousePageX,
+          mouseLeft,
           cursorGuideHeight: TIME_AXIS_HEIGHT,
         })}
         {this.renderDurationGuide({
           showCursorGuide,
-          mousePageX,
+          mouseLeft,
         })}
       </TimeAxis>
     );
   };
 
   render() {
+    console.log('foo');
+
     return (
       <MinimapContainer>
         <ActualMinimap trace={this.props.trace} />
         <CursorGuideHandler.Consumer>
-          {({displayCursorGuide, hideCursorGuide, mousePageX, showCursorGuide}) => {
+          {({displayCursorGuide, hideCursorGuide, mouseLeft, showCursorGuide}) => {
             return (
               <div
                 ref={this.props.minimapInteractiveRef}
@@ -281,14 +268,14 @@ class Minimap extends React.Component<PropType> {
                   {this.renderFog(this.props.dragProps)}
                   {this.renderCursorGuide({
                     showCursorGuide,
-                    mousePageX,
+                    mouseLeft,
                     cursorGuideHeight: MINIMAP_HEIGHT,
                   })}
                   {this.renderViewHandles(this.props.dragProps)}
                 </InteractiveLayer>
                 {this.renderTimeAxis({
                   showCursorGuide,
-                  mousePageX,
+                  mouseLeft,
                 })}
               </div>
             );

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/spanBar.tsx
@@ -486,19 +486,19 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       <CursorGuideHandler.Consumer>
         {({
           showCursorGuide,
-          mouseLeft,
+          traceViewMouseLeft,
         }: {
           showCursorGuide: boolean;
-          mouseLeft: number | undefined;
+          traceViewMouseLeft: number | undefined;
         }) => {
-          if (!showCursorGuide || !mouseLeft) {
+          if (!showCursorGuide || !traceViewMouseLeft) {
             return null;
           }
 
           return (
             <CursorGuide
               style={{
-                left: toPercent(mouseLeft),
+                left: toPercent(traceViewMouseLeft),
               }}
             />
           );

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/spanBar.tsx
@@ -22,6 +22,7 @@ import {
 } from './minimap';
 import {SPAN_ROW_HEIGHT, SpanRow, zIndex} from './styles';
 import * as DividerHandlerManager from './dividerHandlerManager';
+import * as CursorGuideHandler from './cursorGuideHandler';
 import SpanDetail from './spanDetail';
 
 // TODO: maybe use babel-plugin-preval
@@ -480,6 +481,32 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     this.disconnectObservers();
   }
 
+  renderCursorGuide = () => {
+    return (
+      <CursorGuideHandler.Consumer>
+        {({
+          showCursorGuide,
+          mouseLeft,
+        }: {
+          showCursorGuide: boolean;
+          mouseLeft: number | undefined;
+        }) => {
+          if (!showCursorGuide || !mouseLeft) {
+            return null;
+          }
+
+          return (
+            <CursorGuide
+              style={{
+                left: toPercent(mouseLeft),
+              }}
+            />
+          );
+        }}
+      </CursorGuideHandler.Consumer>
+    );
+  };
+
   renderDivider = (
     dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
   ) => {
@@ -610,6 +637,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
           {this.renderWarningText({warningText: bounds.warning})}
         </SpanRowCell>
         {this.renderDivider(dividerHandlerChildrenProps)}
+        {this.renderCursorGuide()}
       </SpanRowCellContainer>
     );
   };
@@ -656,6 +684,17 @@ const SpanRowCell = styled('div')`
   height: ${SPAN_ROW_HEIGHT}px;
 
   overflow: hidden;
+`;
+
+const CursorGuide = styled('div')`
+  position: absolute;
+  top: 0;
+  width: 1px;
+  background-color: #e03e2f;
+
+  transform: translateX(-50%);
+
+  height: ${SPAN_ROW_HEIGHT}px;
 `;
 
 export const DividerLine = styled('div')`

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/spanBar.tsx
@@ -635,9 +635,9 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
             <DurationPill>{durationString}</DurationPill>
           </Duration>
           {this.renderWarningText({warningText: bounds.warning})}
+          {this.renderCursorGuide()}
         </SpanRowCell>
         {this.renderDivider(dividerHandlerChildrenProps)}
-        {this.renderCursorGuide()}
       </SpanRowCellContainer>
     );
   };

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/traceView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/traceView.tsx
@@ -9,6 +9,7 @@ import SpanTree from './spanTree';
 import {SpanType, SpanEntry, SentryEvent, ParsedTraceType} from './types';
 import {isValidSpanID} from './utils';
 import TraceViewMinimap from './minimap';
+import * as CursorGuideHandler from './cursorGuideHandler';
 
 type TraceContextType = {
   type: 'trace';
@@ -151,10 +152,10 @@ class TraceView extends React.Component<PropType> {
       <DragManager interactiveLayerRef={this.minimapInteractiveRef}>
         {(dragProps: DragManagerChildrenProps) => {
           return (
-            <React.Fragment>
+            <CursorGuideHandler.Provider>
               {this.renderMinimap(dragProps, parsedTrace)}
               <SpanTree trace={parsedTrace} dragProps={dragProps} />
-            </React.Fragment>
+            </CursorGuideHandler.Provider>
           );
         }}
       </DragManager>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/traceView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/traceView.tsx
@@ -152,7 +152,11 @@ class TraceView extends React.Component<PropType> {
       <DragManager interactiveLayerRef={this.minimapInteractiveRef}>
         {(dragProps: DragManagerChildrenProps) => {
           return (
-            <CursorGuideHandler.Provider interactiveLayerRef={this.minimapInteractiveRef}>
+            <CursorGuideHandler.Provider
+              interactiveLayerRef={this.minimapInteractiveRef}
+              dragProps={dragProps}
+              trace={parsedTrace}
+            >
               {this.renderMinimap(dragProps, parsedTrace)}
               <SpanTree trace={parsedTrace} dragProps={dragProps} />
             </CursorGuideHandler.Provider>

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/traceView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/transactionView/traceView.tsx
@@ -152,7 +152,7 @@ class TraceView extends React.Component<PropType> {
       <DragManager interactiveLayerRef={this.minimapInteractiveRef}>
         {(dragProps: DragManagerChildrenProps) => {
           return (
-            <CursorGuideHandler.Provider>
+            <CursorGuideHandler.Provider interactiveLayerRef={this.minimapInteractiveRef}>
               {this.renderMinimap(dragProps, parsedTrace)}
               <SpanTree trace={parsedTrace} dragProps={dragProps} />
             </CursorGuideHandler.Provider>


### PR DESCRIPTION
Visuals:

![Kapture 2019-08-20 at 10 08 00](https://user-images.githubusercontent.com/139499/63354452-73cb5f80-c332-11e9-8e9d-a35cd3080077.gif)
