### PR TITLE
ref(tests) Consolidate time creation/formatting helpers

### DIFF
--- a/src/sentry/testutils/helpers/datetime.py
+++ b/src/sentry/testutils/helpers/datetime.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+from datetime import timedelta
+
+__all__ = ["iso_format", "before_now"]
+
+
+from django.utils import timezone
+
+
+def iso_format(date):
+    return date.isoformat()[:19]
+
+
+def before_now(**kwargs):
+    return timezone.now() - timedelta(**kwargs)

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -1,22 +1,17 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
-from django.utils import timezone
 from django.core.urlresolvers import reverse
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.models import Group
-
-
-def create_timestamp(delta):
-    return (timezone.now() - delta).isoformat()[:19]
 
 
 class OrganizationEventDetailsTestBase(APITestCase, SnubaTestCase):
     def setUp(self):
         super(OrganizationEventDetailsTestBase, self).setUp()
-        min_ago = create_timestamp(timedelta(minutes=1))
-        two_min_ago = create_timestamp(timedelta(minutes=2))
-        three_min_ago = create_timestamp(timedelta(minutes=3))
+        min_ago = iso_format(before_now(minutes=1))
+        two_min_ago = iso_format(before_now(minutes=2))
+        three_min_ago = iso_format(before_now(minutes=3))
 
         self.login_as(user=self.user)
         self.project = self.create_project()
@@ -102,27 +97,27 @@ class OrganizationEventDetailsEndpointTest(OrganizationEventDetailsTestBase):
 
     def test_event_links_with_field_parameter(self):
         # Create older and newer events
-        ten_sec_ago = create_timestamp(timedelta(seconds=10))
+        ten_sec_ago = iso_format(before_now(seconds=10))
         self.store_event(
             data={"event_id": "2" * 32, "message": "no match", "timestamp": ten_sec_ago},
             project_id=self.project.id,
         )
-        thirty_sec_ago = create_timestamp(timedelta(seconds=30))
+        thirty_sec_ago = iso_format(before_now(seconds=30))
         self.store_event(
             data={"event_id": "1" * 32, "message": "very bad", "timestamp": thirty_sec_ago},
             project_id=self.project.id,
         )
-        five_min_ago = create_timestamp(timedelta(minutes=5))
+        five_min_ago = iso_format(before_now(minutes=5))
         self.store_event(
             data={"event_id": "d" * 32, "message": "very bad", "timestamp": five_min_ago},
             project_id=self.project.id,
         )
-        seven_min_ago = create_timestamp(timedelta(minutes=7))
+        seven_min_ago = iso_format(before_now(minutes=7))
         self.store_event(
             data={"event_id": "e" * 32, "message": "very bad", "timestamp": seven_min_ago},
             project_id=self.project.id,
         )
-        eight_min_ago = create_timestamp(timedelta(minutes=8))
+        eight_min_ago = iso_format(before_now(minutes=8))
         self.store_event(
             data={"event_id": "f" * 32, "message": "no match", "timestamp": eight_min_ago},
             project_id=self.project.id,

--- a/tests/snuba/api/endpoints/test_organization_eventid.py
+++ b/tests/snuba/api/endpoints/test_organization_eventid.py
@@ -1,19 +1,16 @@
 from __future__ import absolute_import
 
 import six
-from datetime import timedelta
-from django.utils import timezone
-
 from django.core.urlresolvers import reverse
 
-
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class EventIdLookupEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(EventIdLookupEndpointTest, self).setUp()
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         self.org = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.org)
 

--- a/tests/snuba/api/endpoints/test_organization_events_distribution.py
+++ b/tests/snuba/api/endpoints/test_organization_events_distribution.py
@@ -7,6 +7,10 @@ from uuid import uuid4
 
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import (
+    before_now,
+    iso_format
+)
 
 
 class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
@@ -14,8 +18,8 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
 
     def setUp(self):
         super(OrganizationEventsDistributionEndpointTest, self).setUp()
-        self.min_ago = (timezone.now() - timedelta(minutes=1)).replace(microsecond=0)
-        self.day_ago = (timezone.now() - timedelta(days=1)).replace(microsecond=0)
+        self.min_ago = before_now(minutes=1).replace(microsecond=0)
+        self.day_ago = before_now(days=1).replace(microsecond=0)
         self.login_as(user=self.user)
         self.project = self.create_project()
         self.project2 = self.create_project()
@@ -25,7 +29,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
                 'organization_slug': self.project.organization.slug,
             }
         )
-        self.min_ago_iso = self.min_ago.isoformat()
+        self.min_ago_iso = iso_format(self.min_ago)
 
     def test_simple(self):
         self.store_event(
@@ -181,7 +185,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
         self.store_event(
             data={
                 'event_id': uuid4().hex,
-                'timestamp': two_days_ago.isoformat(),
+                'timestamp': iso_format(two_days_ago),
                 'tags': {'color': 'red'},
             },
             project_id=self.project.id
@@ -189,7 +193,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
         self.store_event(
             data={
                 'event_id': uuid4().hex,
-                'timestamp': hour_ago.isoformat(),
+                'timestamp': iso_format(hour_ago),
                 'tags': {'color': 'red'},
             },
             project_id=self.project.id
@@ -197,7 +201,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
         self.store_event(
             data={
                 'event_id': uuid4().hex,
-                'timestamp': two_hours_ago.isoformat(),
+                'timestamp': iso_format(two_hours_ago),
                 'tags': {'color': 'red'},
             },
             project_id=self.project.id
@@ -205,7 +209,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
         self.store_event(
             data={
                 'event_id': uuid4().hex,
-                'timestamp': timezone.now().isoformat(),
+                'timestamp': iso_format(timezone.now()),
                 'tags': {'color': 'red'},
             },
             project_id=self.project2.id
@@ -215,8 +219,8 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
             response = self.client.get(
                 self.url,
                 {
-                    'start': self.day_ago.isoformat()[:19],
-                    'end': self.min_ago.isoformat()[:19],
+                    'start': iso_format(self.day_ago),
+                    'end': iso_format(self.min_ago),
                     'key': ['color'],
                 },
                 format='json'
@@ -240,7 +244,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
         self.store_event(
             data={
                 'event_id': uuid4().hex,
-                'timestamp': self.day_ago.isoformat(),
+                'timestamp': iso_format(self.day_ago),
                 'tags': {'sentry:user': self.user.email},
             },
             project_id=self.project.id
@@ -248,7 +252,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
         self.store_event(
             data={
                 'event_id': uuid4().hex,
-                'timestamp': self.day_ago.isoformat(),
+                'timestamp': iso_format(self.day_ago),
                 'tags': {'sentry:user': self.user2.email},
             },
             project_id=self.project.id
@@ -256,7 +260,7 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
         self.store_event(
             data={
                 'event_id': uuid4().hex,
-                'timestamp': self.day_ago.isoformat(),
+                'timestamp': iso_format(self.day_ago),
                 'tags': {'sentry:user': self.user2.email},
             },
             project_id=self.project.id

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -1,16 +1,15 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
-from django.utils import timezone
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now
 
 
 class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
     def setUp(self):
         super(OrganizationEventsMetaEndpoint, self).setUp()
-        self.min_ago = timezone.now() - timedelta(minutes=1)
+        self.min_ago = before_now(minutes=1)
 
     def test_simple(self):
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1,15 +1,11 @@
 from __future__ import absolute_import
 
 from datetime import timedelta
-from django.utils import timezone
 
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
-
-
-def iso_timestamp(date):
-    return date.isoformat()[:19]
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
@@ -17,9 +13,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         super(OrganizationEventsStatsEndpointTest, self).setUp()
         self.login_as(user=self.user)
 
-        self.day_ago = (timezone.now() - timedelta(days=1)).replace(
-            hour=10, minute=0, second=0, microsecond=0
-        )
+        self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
 
         self.project = self.create_project()
         self.project2 = self.create_project()
@@ -29,7 +23,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             data={
                 "event_id": "a" * 32,
                 "message": "very bad",
-                "timestamp": iso_timestamp(self.day_ago + timedelta(minutes=1)),
+                "timestamp": iso_format(self.day_ago + timedelta(minutes=1)),
                 "fingerprint": ["group1"],
                 "tags": {"sentry:user": self.user.email},
             },
@@ -39,7 +33,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             data={
                 "event_id": "b" * 32,
                 "message": "oh my",
-                "timestamp": iso_timestamp(self.day_ago + timedelta(hours=1, minutes=1)),
+                "timestamp": iso_format(self.day_ago + timedelta(hours=1, minutes=1)),
                 "fingerprint": ["group2"],
                 "tags": {"sentry:user": self.user2.email},
             },
@@ -49,7 +43,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             data={
                 "event_id": "c" * 32,
                 "message": "very bad",
-                "timestamp": iso_timestamp(self.day_ago + timedelta(hours=1, minutes=2)),
+                "timestamp": iso_format(self.day_ago + timedelta(hours=1, minutes=2)),
                 "fingerprint": ["group2"],
                 "tags": {"sentry:user": self.user2.email},
             },
@@ -64,8 +58,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         response = self.client.get(
             self.url,
             data={
-                "start": iso_timestamp(self.day_ago),
-                "end": iso_timestamp(self.day_ago + timedelta(hours=1, minutes=59)),
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                 "interval": "1h",
             },
             format="json",
@@ -94,8 +88,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         response = self.client.get(
             self.url,
             data={
-                "start": iso_timestamp(self.day_ago),
-                "end": iso_timestamp(self.day_ago + timedelta(hours=1, minutes=59)),
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                 "interval": "1h",
                 "group": self.group.id,
             },
@@ -116,7 +110,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             data={
                 "event_id": "d" * 32,
                 "message": "something",
-                "timestamp": iso_timestamp(self.day_ago + timedelta(minutes=2)),
+                "timestamp": iso_format(self.day_ago + timedelta(minutes=2)),
                 "tags": {"sentry:user": self.user2.email},
                 "fingerprint": ["group2"],
             },
@@ -125,8 +119,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         response = self.client.get(
             self.url,
             data={
-                "start": iso_timestamp(self.day_ago),
-                "end": iso_timestamp(self.day_ago + timedelta(hours=1, minutes=59)),
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                 "interval": "1h",
                 "yAxis": "user_count",
             },
@@ -143,8 +137,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         response = self.client.get(
             self.url,
             data={
-                "start": iso_timestamp(self.day_ago),
-                "end": iso_timestamp(self.day_ago + timedelta(hours=1, minutes=59)),
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                 "interval": "1h",
                 "yAxis": "event_count",
             },
@@ -164,8 +158,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
                 self.url,
                 format="json",
                 data={
-                    "start": iso_timestamp(self.day_ago),
-                    "end": iso_timestamp(self.day_ago + timedelta(hours=1, minutes=59)),
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                     "interval": "1h",
                     "yAxis": "count()",
                 },
@@ -183,8 +177,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
                 self.url,
                 format="json",
                 data={
-                    "start": iso_timestamp(self.day_ago),
-                    "end": iso_timestamp(self.day_ago + timedelta(hours=1, minutes=59)),
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                     "interval": "1h",
                     "yAxis": "count_unique(user)",
                 },
@@ -202,8 +196,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
                 self.url,
                 format="json",
                 data={
-                    "start": iso_timestamp(self.day_ago),
-                    "end": iso_timestamp(self.day_ago + timedelta(hours=1, minutes=59)),
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                     "interval": "1h",
                     "yAxis": "nope(lol)",
                 },
@@ -216,8 +210,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
                 self.url,
                 format="json",
                 data={
-                    "start": iso_timestamp(self.day_ago),
-                    "end": iso_timestamp(self.day_ago + timedelta(hours=1, minutes=59)),
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                     "interval": "1h",
                     "referenceEvent": "nope-invalid",
                     "yAxis": "count()",
@@ -232,7 +226,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             data={
                 "event_id": "e" * 32,
                 "message": "oh my",
-                "timestamp": iso_timestamp(self.day_ago + timedelta(minutes=2)),
+                "timestamp": iso_format(self.day_ago + timedelta(minutes=2)),
                 "tags": {"sentry:user": "bob@example.com"},
                 "fingerprint": ["group3"],
             },
@@ -243,8 +237,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
                 self.url,
                 format="json",
                 data={
-                    "start": iso_timestamp(self.day_ago),
-                    "end": iso_timestamp(self.day_ago + timedelta(hours=1, minutes=59)),
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                     "interval": "1h",
                     "referenceEvent": "%s:%s" % (self.project.slug, event.event_id),
                     "yAxis": "count()",
@@ -264,7 +258,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             data={
                 "event_id": "e" * 32,
                 "message": "oh my",
-                "timestamp": iso_timestamp(self.day_ago + timedelta(minutes=2)),
+                "timestamp": iso_format(self.day_ago + timedelta(minutes=2)),
                 "tags": {"sentry:user": "bob@example.com"},
                 "fingerprint": ["group3"],
             },
@@ -275,8 +269,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
                 self.url,
                 format="json",
                 data={
-                    "start": iso_timestamp(self.day_ago),
-                    "end": iso_timestamp(self.day_ago + timedelta(hours=1, minutes=59)),
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
                     "field": ["message", "count()"],
                     "interval": "1h",
                     "referenceEvent": "%s:%s" % (self.project.slug, event.event_id),

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1,19 +1,18 @@
 from __future__ import absolute_import
 
 
-from datetime import timedelta
-from django.utils import timezone
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
 import pytest
 
 
 class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(OrganizationEventsV2EndpointTest, self).setUp()
-        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        self.two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
+        self.min_ago = iso_format(before_now(minutes=1))
+        self.two_min_ago = iso_format(before_now(minutes=2))
         self.url = reverse(
             "sentry-api-0-organization-eventsv2",
             kwargs={"organization_slug": self.organization.slug},

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -32,6 +32,7 @@ from sentry.models import (
 )
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
+from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
 class GroupListTest(APITestCase, SnubaTestCase):
@@ -39,7 +40,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
     def setUp(self):
         super(GroupListTest, self).setUp()
-        self.min_ago = timezone.now() - timedelta(minutes=1)
+        self.min_ago = before_now(minutes=1)
 
     def _parse_links(self, header):
         # links come in {url: {...attrs}}, but we need {rel: {...attrs}}
@@ -152,7 +153,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         self.store_event(
             data={
                 "fingerprint": ["put-me-in-group1"],
-                "timestamp": self.min_ago.isoformat()[:19],
+                "timestamp": iso_format(self.min_ago),
                 "environment": "production",
             },
             project_id=self.project.id,
@@ -160,7 +161,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         self.store_event(
             data={
                 "fingerprint": ["put-me-in-group2"],
-                "timestamp": self.min_ago.isoformat()[:19],
+                "timestamp": iso_format(self.min_ago),
                 "environment": "staging",
             },
             project_id=self.project.id,
@@ -195,7 +196,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         project.update_option("sentry:resolve_age", 1)
         event_id = "c" * 32
         event = self.store_event(
-            data={"event_id": event_id, "timestamp": self.min_ago.isoformat()[:19]},
+            data={"event_id": event_id, "timestamp": iso_format(self.min_ago)},
             project_id=self.project.id,
         )
 
@@ -209,12 +210,12 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
     def test_lookup_by_event_id_incorrect_project_id(self):
         self.store_event(
-            data={"event_id": "a" * 32, "timestamp": self.min_ago.isoformat()[:19]},
+            data={"event_id": "a" * 32, "timestamp": iso_format(self.min_ago)},
             project_id=self.project.id,
         )
         event_id = "b" * 32
         event = self.store_event(
-            data={"event_id": event_id, "timestamp": self.min_ago.isoformat()[:19]},
+            data={"event_id": event_id, "timestamp": iso_format(self.min_ago)},
             project_id=self.project.id,
         )
 
@@ -235,7 +236,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         project.update_option("sentry:resolve_age", 1)
         event_id = "c" * 32
         event = self.store_event(
-            data={"event_id": event_id, "timestamp": self.min_ago.isoformat()[:19]},
+            data={"event_id": event_id, "timestamp": iso_format(self.min_ago)},
             project_id=self.project.id,
         )
 
@@ -1048,7 +1049,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
                 data={
                     "fingerprint": ["put-me-in-group-1"],
                     "user": {"id": six.binary_type(i)},
-                    "timestamp": (self.min_ago - timedelta(seconds=i)).isoformat()[:19],
+                    "timestamp": iso_format(self.min_ago - timedelta(seconds=i)),
                 },
                 project_id=self.project.id,
             )

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
-from django.utils import timezone
 from django.core.urlresolvers import reverse
 from exam import fixture
 
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now
 
 
 class OrganizationTagKeyValuesTest(APITestCase, SnubaTestCase):
@@ -13,8 +12,8 @@ class OrganizationTagKeyValuesTest(APITestCase, SnubaTestCase):
 
     def setUp(self):
         super(OrganizationTagKeyValuesTest, self).setUp()
-        self.min_ago = timezone.now() - timedelta(minutes=1)
-        self.day_ago = timezone.now() - timedelta(days=1)
+        self.min_ago = before_now(minutes=1)
+        self.day_ago = before_now(days=1)
         user = self.create_user()
         self.org = self.create_organization()
         self.team = self.create_team(organization=self.org)
@@ -82,13 +81,13 @@ class OrganizationTagKeyValuesTest(APITestCase, SnubaTestCase):
         self.create_event(
             event_id="c" * 32,
             group=self.group,
-            datetime=timezone.now() - timedelta(seconds=10),
+            datetime=before_now(seconds=10),
             user={"email": "baz@example.com"},
         )
         self.create_event(
             event_id="d" * 32,
             group=self.group,
-            datetime=timezone.now() - timedelta(seconds=10),
+            datetime=before_now(seconds=10),
             user={"email": "baz@example.com"},
         )
         self.run_test(
@@ -118,7 +117,7 @@ class OrganizationTagKeyValuesTest(APITestCase, SnubaTestCase):
         self.create_event(
             event_id="d" * 32,
             group=self.group,
-            datetime=timezone.now() - timedelta(seconds=10),
+            datetime=before_now(seconds=10),
             tags={"sentry:release": "5.1.2"},
         )
         self.run_test("release", expected=[("5.1.2", 1), ("4.1.2", 1), ("3.1.2", 2)])
@@ -136,7 +135,7 @@ class OrganizationTagKeyValuesTest(APITestCase, SnubaTestCase):
         self.create_event(
             event_id="d" * 32,
             group=self.group,
-            datetime=timezone.now() - timedelta(seconds=10),
+            datetime=before_now(seconds=10),
             tags={"sentry:user": "3"},
         )
         self.run_test("user", expected=[("3", 1), ("2", 1), ("1", 2)])

--- a/tests/snuba/api/endpoints/test_organization_tags.py
+++ b/tests/snuba/api/endpoints/test_organization_tags.py
@@ -1,16 +1,15 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
-from django.utils import timezone
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now
 
 
 class OrganizationTagsTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(OrganizationTagsTest, self).setUp()
-        self.min_ago = timezone.now() - timedelta(minutes=1)
+        self.min_ago = before_now(minutes=1)
 
     def test_simple(self):
         user = self.create_user()

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -2,10 +2,9 @@ from __future__ import absolute_import
 
 import six
 
-from datetime import timedelta
-from django.utils import timezone
 from django.core.urlresolvers import reverse
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
 class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
@@ -14,10 +13,10 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
         project = self.create_project()
 
-        one_min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
-        three_min_ago = (timezone.now() - timedelta(minutes=3)).isoformat()[:19]
-        four_min_ago = (timezone.now() - timedelta(minutes=4)).isoformat()[:19]
+        one_min_ago = iso_format(before_now(minutes=1))
+        two_min_ago = iso_format(before_now(minutes=2))
+        three_min_ago = iso_format(before_now(minutes=3))
+        four_min_ago = iso_format(before_now(minutes=4))
 
         self.prev_event = self.store_event(
             data={"event_id": "a" * 32, "timestamp": four_min_ago, "fingerprint": ["group-1"]},
@@ -128,7 +127,7 @@ class ProjectEventJsonEndpointTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
         self.event_id = "c" * 32
         self.fingerprint = ["group_2"]
-        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        self.min_ago = iso_format(before_now(minutes=1))
         self.event = self.store_event(
             data={
                 "event_id": self.event_id,


### PR DESCRIPTION
We had a few different ways to create times and format them in snuba related tests. I've consolidated the most repetitive patterns into a pair of helper functions that make tests less verbose and use fewer magic 19s.

Fixes SEN-938