### PR TITLE
feat(app-platform): Add limit as a valid querystring for pagination

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -237,7 +237,9 @@ class Endpoint(APIView):
     ):
         assert (paginator and not paginator_kwargs) or (paginator_cls and paginator_kwargs)
 
-        per_page = int(request.GET.get("per_page", default_per_page))
+        per_page = int(request.GET.get('per_page') or
+                       request.GET.get('limit') or
+                       default_per_page)
 
         input_cursor = None
         if request.GET.get("cursor"):


### PR DESCRIPTION
- Pagination/page size is handled differently in various endpoints
  - `/organizations/org-slug/issues` uses `limit=<number>`
  - `/organizations/org-slug/releases` uses `per_page=<number>`

This was discovered while working on SEN-852. This commit adds `limit` into the Paginator object. It's not 100% necessary but imo it's nice to have. 