### PR TITLE
fix(devserver): Fix broken uWSGI config for bare HTTP

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -75,7 +75,7 @@ def devserver(reload, watchers, workers, experimental_spa, styleguide, prefix, e
         # have a proxy/load-balancer in front in dev mode.
         'http': '%s:%s' % (parsed_url.hostname, parsed_url.port),
         'protocol': 'uwsgi',
-        # This is need to prevent https://git.io/fj7Lw
+        # This is needed to prevent https://git.io/fj7Lw
         'uwsgi-socket': None,
         'http-keepalive': True,
         # Make sure we reload really quickly for local dev in case it

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -71,8 +71,13 @@ def devserver(reload, watchers, workers, experimental_spa, styleguide, prefix, e
             )
 
     uwsgi_overrides = {
-        # Make sure we don't try and use uwsgi protocol
-        "protocol": "http",
+        # Make sure uWSGI spawns an HTTP server for us as we don't
+        # have a proxy/load-balancer in front in dev mode.
+        'http': '%s:%s' % (parsed_url.hostname, parsed_url.port),
+        'protocol': 'uwsgi',
+        # This is need to prevent https://git.io/fj7Lw
+        'uwsgi-socket': None,
+        'http-keepalive': True,
         # Make sure we reload really quickly for local dev in case it
         # doesn't want to shut down nicely on it's own, NO MERCY
         "worker-reload-mercy": 2,


### PR DESCRIPTION
We've been using uWSGI in HTTP-proxy mode which was meant to
communicate with upstream front-proxies like Nginx. We also lacked
the keep-alive option which broke `sentry-cli` for certain
operations. This patch fixes those and is a port of
getsentry/onpremise#237. Fixes getsentry/sentry-cli#40 while using
the devserver.