### PR TITLE
fix(make): Ensurue we have the latet pip on 'make develop'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ YARN = ./bin/yarn
 
 bootstrap: install-system-pkgs develop init-config run-dependent-services create-db apply-migrations
 
-develop: setup-git ensure-venv develop-only
+develop: setup-git ensure-venv ensure-latest-pip develop-only
 
 develop-only: update-submodules install-yarn-pkgs install-sentry-dev
 
@@ -28,6 +28,9 @@ test: develop lint test-js test-python test-cli
 
 ensure-venv:
 	@./scripts/ensure-venv.sh
+
+ensure-latest-pip:
+	python -m pip install -U pip
 
 build: locale
 


### PR DESCRIPTION
The newly introduced `--no-use-pep517` option does not exist in pip 18 which was installed on some people's venv, causing `make develop` to fail. This patch fixes that issue. We should probably pin to a known pip version and use that instead of blindly installing the latest but this works for now and is better than nothing.