### PR TITLE
fix(integrations): Modifying Slack integration to prefer event data over group data

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -76,10 +76,7 @@ def get_assignee(group):
         return None
 
 
-def build_attachment_title(group, event=None):
-    # XXX(mitsuhiko): This is all super event specific and ideally could just use a
-    # combination of `group.title` and `group.title + group.culprit`.
-    obj = event if event is not None else group
+def build_attachment_title(obj):
     ev_metadata = obj.get_event_metadata()
     ev_type = obj.get_event_type()
 
@@ -153,8 +150,6 @@ def build_group_attachment(group, event=None, tags=None, identity=None, actions=
 
     members = get_member_assignees(group)
     teams = get_team_assignees(group)
-    if event is None:
-        event = group.get_latest_event()
 
     logo_url = absolute_uri(get_asset_url("sentry", "images/sentry-email-avatar.png"))
     color = (
@@ -250,10 +245,10 @@ def build_group_attachment(group, event=None, tags=None, identity=None, actions=
         if len(rules) > 1:
             footer += u" (+{} other)".format(len(rules) - 1)
 
-    fallback_title = event.title if event is not None else group.title
+    obj = event if event is not None else group
     return {
-        "fallback": u"[{}] {}".format(group.project.slug, fallback_title),
-        "title": build_attachment_title(group, event),
+        "fallback": u"[{}] {}".format(obj.project.slug, obj.title),
+        "title": build_attachment_title(obj),
         "title_link": group.get_absolute_url(params={"referrer": "slack"}),
         "text": text,
         "fields": fields,

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import six
 
 from django.core.urlresolvers import reverse
 
@@ -54,7 +55,7 @@ class BuildIncidentAttachmentTest(TestCase):
         )
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         group = self.create_group(project=self.project)
-
+        # import pdb; pdb.set_trace();
         ts = group.last_seen
         assert build_group_attachment(group) == {
             "color": "#E03E2F",
@@ -66,11 +67,21 @@ class BuildIncidentAttachmentTest(TestCase):
                     "option_groups": [
                         {
                             "text": "Teams",
-                            "options": [{"text": u"#mariachi-band", "value": u"team:25"}],
+                            "options": [
+                                {
+                                    "text": u"#mariachi-band",
+                                    "value": u"team:" + six.text_type(self.team.id),
+                                }
+                            ],
                         },
                         {
                             "text": "People",
-                            "options": [{"text": u"foo@example.com", "value": u"user:35"}],
+                            "options": [
+                                {
+                                    "text": u"foo@example.com",
+                                    "value": u"user:" + six.text_type(self.user.id),
+                                }
+                            ],
                         },
                     ],
                     "text": "Select Assignee...",
@@ -84,8 +95,10 @@ class BuildIncidentAttachmentTest(TestCase):
             "fields": [],
             "footer": u"BENGAL-ELEPHANT-GIRAFFE-TREE-HOUSE-1",
             "ts": to_timestamp(ts),
-            "title_link": u"http://testserver/organizations/rowdy-tiger/issues/23/?referrer=slack",
-            "callback_id": '{"issue":23}',
+            "title_link": u"http://testserver/organizations/rowdy-tiger/issues/"
+            + six.text_type(group.id)
+            + "/?referrer=slack",
+            "callback_id": '{"issue":' + six.text_type(group.id) + "}",
             "fallback": u"[{}] {}".format(self.project.slug, group.title),
             "footer_icon": u"http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
         }
@@ -101,11 +114,21 @@ class BuildIncidentAttachmentTest(TestCase):
                     "option_groups": [
                         {
                             "text": "Teams",
-                            "options": [{"text": u"#mariachi-band", "value": u"team:25"}],
+                            "options": [
+                                {
+                                    "text": u"#mariachi-band",
+                                    "value": u"team:" + six.text_type(self.team.id),
+                                }
+                            ],
                         },
                         {
                             "text": "People",
-                            "options": [{"text": u"foo@example.com", "value": u"user:35"}],
+                            "options": [
+                                {
+                                    "text": u"foo@example.com",
+                                    "value": u"user:" + six.text_type(self.user.id),
+                                }
+                            ],
                         },
                     ],
                     "text": "Select Assignee...",
@@ -119,8 +142,10 @@ class BuildIncidentAttachmentTest(TestCase):
             "fields": [],
             "footer": u"BENGAL-ELEPHANT-GIRAFFE-TREE-HOUSE-1",
             "ts": to_timestamp(ts),
-            "title_link": u"http://testserver/organizations/rowdy-tiger/issues/23/?referrer=slack",
-            "callback_id": '{"issue":23}',
+            "title_link": u"http://testserver/organizations/rowdy-tiger/issues/"
+            + six.text_type(group.id)
+            + "/?referrer=slack",
+            "callback_id": '{"issue":' + six.text_type(group.id) + "}",
             "fallback": u"[{}] {}".format(self.project.slug, event.title),
             "footer_icon": u"http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
         }

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -2,7 +2,11 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 
-from sentry.integrations.slack.utils import build_incident_attachment, LEVEL_TO_COLOR
+from sentry.integrations.slack.utils import (
+    build_incident_attachment,
+    build_group_attachment,
+    LEVEL_TO_COLOR,
+)
 from sentry.testutils import TestCase
 from sentry.utils.assets import get_asset_url
 from sentry.utils.dates import to_timestamp
@@ -39,4 +43,84 @@ class BuildIncidentAttachmentTest(TestCase):
             "ts": to_timestamp(incident.date_started),
             "color": LEVEL_TO_COLOR["error"],
             "actions": [],
+        }
+
+    def test_build_group_attachment(self):
+        self.user = self.create_user("foo@example.com")
+        self.org = self.create_organization(name="Rowdy Tiger", owner=None)
+        self.team = self.create_team(organization=self.org, name="Mariachi Band")
+        self.project = self.create_project(
+            organization=self.org, teams=[self.team], name="Bengal-Elephant-Giraffe-Tree-House"
+        )
+        self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
+        group = self.create_group(project=self.project)
+
+        ts = group.last_seen
+        assert build_group_attachment(group) == {
+            "color": "#E03E2F",
+            "text": "",
+            "actions": [
+                {"name": "status", "text": "Resolve", "type": "button", "value": "resolved"},
+                {"text": "Ignore", "type": "button", "name": "status", "value": "ignored"},
+                {
+                    "option_groups": [
+                        {
+                            "text": "Teams",
+                            "options": [{"text": u"#mariachi-band", "value": u"team:25"}],
+                        },
+                        {
+                            "text": "People",
+                            "options": [{"text": u"foo@example.com", "value": u"user:35"}],
+                        },
+                    ],
+                    "text": "Select Assignee...",
+                    "selected_options": [None],
+                    "type": "select",
+                    "name": "assign",
+                },
+            ],
+            "mrkdwn_in": ["text"],
+            "title": group.title,
+            "fields": [],
+            "footer": u"BENGAL-ELEPHANT-GIRAFFE-TREE-HOUSE-1",
+            "ts": to_timestamp(ts),
+            "title_link": u"http://testserver/organizations/rowdy-tiger/issues/23/?referrer=slack",
+            "callback_id": '{"issue":23}',
+            "fallback": u"[{}] {}".format(self.project.slug, group.title),
+            "footer_icon": u"http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
+        }
+        event = self.create_event()
+        ts = event.datetime
+        assert build_group_attachment(group, event) == {
+            "color": "error",
+            "text": "",
+            "actions": [
+                {"name": "status", "text": "Resolve", "type": "button", "value": "resolved"},
+                {"text": "Ignore", "type": "button", "name": "status", "value": "ignored"},
+                {
+                    "option_groups": [
+                        {
+                            "text": "Teams",
+                            "options": [{"text": u"#mariachi-band", "value": u"team:25"}],
+                        },
+                        {
+                            "text": "People",
+                            "options": [{"text": u"foo@example.com", "value": u"user:35"}],
+                        },
+                    ],
+                    "text": "Select Assignee...",
+                    "selected_options": [None],
+                    "type": "select",
+                    "name": "assign",
+                },
+            ],
+            "mrkdwn_in": ["text"],
+            "title": event.title,
+            "fields": [],
+            "footer": u"BENGAL-ELEPHANT-GIRAFFE-TREE-HOUSE-1",
+            "ts": to_timestamp(ts),
+            "title_link": u"http://testserver/organizations/rowdy-tiger/issues/23/?referrer=slack",
+            "callback_id": '{"issue":23}',
+            "fallback": u"[{}] {}".format(self.project.slug, event.title),
+            "footer_icon": u"http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
         }


### PR DESCRIPTION
Instead of always using group title, we now try to use the event title and use the group as a fallback if event is None. An addition to build_group_attachment also tries to get the latest group event if it gets called with event=None.   

Additionally, references to culprit have been removed.

Fixes SEN-882 & ISSUE-529