### PR TITLE
fix(ui) Handle missing events

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -93,16 +93,9 @@ class EventDetails extends AsyncComponent {
     const notFound = Object.values(this.state.errors).find(
       resp => resp && resp.status === 404
     );
-    if (notFound) {
-      return (
-        <ModalDialog onDismiss={this.onDismiss} className={modalStyles}>
-          <NotFound />
-        </ModalDialog>
-      );
-    }
     return (
       <ModalDialog onDismiss={this.onDismiss} className={modalStyles}>
-        {super.renderError(error, true, true)}
+        {notFound ? <NotFound /> : super.renderError(error, true, true)}
       </ModalDialog>
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventDetails.jsx
@@ -7,6 +7,7 @@ import {css} from 'react-emotion';
 import SentryTypes from 'app/sentryTypes';
 import AsyncComponent from 'app/components/asyncComponent';
 import ModalDialog from 'app/components/modalDialog';
+import NotFound from 'app/components/errors/notFound';
 import withApi from 'app/utils/withApi';
 import theme from 'app/utils/theme';
 import space from 'app/styles/space';
@@ -84,6 +85,24 @@ class EventDetails extends AsyncComponent {
           view={view}
           location={location}
         />
+      </ModalDialog>
+    );
+  }
+
+  renderError(error) {
+    const notFound = Object.values(this.state.errors).find(
+      resp => resp && resp.status === 404
+    );
+    if (notFound) {
+      return (
+        <ModalDialog onDismiss={this.onDismiss} className={modalStyles}>
+          <NotFound />
+        </ModalDialog>
+      );
+    }
+    return (
+      <ModalDialog onDismiss={this.onDismiss} className={modalStyles}>
+        {super.renderError(error, true, true)}
       </ModalDialog>
     );
   }

--- a/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
@@ -66,6 +66,14 @@ describe('OrganizationEventsV2 > EventDetails', function() {
       },
     });
 
+    // Missing event
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/project-slug:abad1/',
+      method: 'GET',
+      statusCode: 404,
+      body: {},
+    });
+
     // Error event
     MockApiClient.addMockResponse(
       {
@@ -154,6 +162,20 @@ describe('OrganizationEventsV2 > EventDetails', function() {
 
     const graph = wrapper.find('ModalLineGraph');
     expect(graph).toHaveLength(0);
+  });
+
+  it('renders a 404', function() {
+    const wrapper = mount(
+      <EventDetails
+        organization={TestStubs.Organization({projects: [TestStubs.Project()]})}
+        eventSlug="project-slug:abad1"
+        location={{query: {eventSlug: 'project-slug:abad1'}}}
+        view={allEventsView}
+      />,
+      TestStubs.routerContext()
+    );
+    const content = wrapper.find('NotFound');
+    expect(content).toHaveLength(1);
   });
 
   it('renders a chart in grouped view', function() {


### PR DESCRIPTION
Display a more helpful 404 error when events are missing. Because event ids are in URLs  it is likely users will get them wrong via copy/paste.

Fixes SEN-949