### PR TITLE
fix(ui): Searching releases no longer removes project filter

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/list/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/index.jsx
@@ -60,9 +60,11 @@ class OrganizationReleases extends AsyncView {
     const targetQueryParams = {};
     if (query !== '') {
       targetQueryParams.query = query;
+      targetQueryParams.project = this.props.location.query.project;
     }
 
     const {orgId} = this.props.params;
+
     browserHistory.push({
       pathname: `/organizations/${orgId}/releases/`,
       query: targetQueryParams,


### PR DESCRIPTION
The fix implemented for SEN-753 and ISSUE-549 is to retain the project filter when searching releases. This means that any release URL with an invalid project ID tied to it (such as https://sentry.io/organizations/jetbrains/releases/jetbrainscom%4016e327a37/artifacts/?project=1437227) will still be broken. But there should be no way to reach this via the UI now and someone would have to change the filter on the release page.

We should also consider implementing a way to lock their project selection to a project that the release belongs to as an additional solution. This is different than the issue lock solution because releases can be tied to more than one project, unlike issues which are 1:1. Or, once on a release page, lock them to the project filter they used to get there.

(kind of:)
Fixes SEN-753 & ISSUE-549
