### PR TITLE
feat(ui): Change some Incident alert warnings to info

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIncidents/list/index.jsx
@@ -162,7 +162,7 @@ class OrganizationIncidentsListContainer extends React.Component {
           </PageHeader>
 
           <AlertLink
-            priority="warning"
+            priority="info"
             to={`/organizations/${orgId}/issues/`}
             icon="icon-circle-info"
           >

--- a/src/sentry/static/sentry/app/views/settings/projectIncidentRules/ruleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectIncidentRules/ruleForm.tsx
@@ -225,7 +225,7 @@ class RuleForm extends React.Component<Props, State> {
         <JsonForm
           renderHeader={() => {
             return (
-              <PanelAlert type="warning">
+              <PanelAlert type="info">
                 {t(
                   'Sentry will automatically digest alerts sent by some services to avoid flooding your inbox with individual issue notifications. Use the sliders to control frequency.'
                 )}


### PR DESCRIPTION
Simple change of the alert types. "... if something has ! in front of it, it should be time sensitive."

Addresses SEN-941