### PR TITLE
fix(platform): Fix TimeSince not updating with new props

### DIFF
--- a/src/sentry/static/sentry/app/components/timeSince.jsx
+++ b/src/sentry/static/sentry/app/components/timeSince.jsx
@@ -11,6 +11,9 @@ class TimeSince extends React.PureComponent {
     date: PropTypes.any.isRequired,
     suffix: PropTypes.string,
   };
+  static defaultProps = {
+    suffix: 'ago',
+  };
 
   static getDateObj(date) {
     if (_.isString(date) || _.isNumber(date)) {
@@ -19,14 +22,27 @@ class TimeSince extends React.PureComponent {
     return date;
   }
 
-  static defaultProps = {
-    suffix: 'ago',
+  static getRelativeDate = (currentDateTime, suffix) => {
+    const date = TimeSince.getDateObj(currentDateTime);
+
+    if (!suffix) {
+      return moment(date).fromNow(true);
+    } else if (suffix === 'ago') {
+      return moment(date).fromNow();
+    } else if (suffix === 'old') {
+      return t('%(time)s old', {time: moment(date).fromNow(true)});
+    } else {
+      throw new Error('Unsupported time format suffix');
+    }
   };
 
   constructor(props) {
     super(props);
-    this.state = {
-      relative: this.getRelativeDate(),
+  }
+
+  static getDerivedStateFromProps(props) {
+    return {
+      relative: TimeSince.getRelativeDate(props.date, props.suffix),
     };
   }
 
@@ -46,23 +62,10 @@ class TimeSince extends React.PureComponent {
 
     this.ticker = setTimeout(() => {
       this.setState({
-        relative: this.getRelativeDate(),
+        relative: TimeSince.getRelativeDate(this.props.date, this.props.suffix),
       });
       this.setRelativeDateTicker();
     }, ONE_MINUTE_IN_MS);
-  };
-
-  getRelativeDate = () => {
-    const date = TimeSince.getDateObj(this.props.date);
-    if (!this.props.suffix) {
-      return moment(date).fromNow(true);
-    } else if (this.props.suffix === 'ago') {
-      return moment(date).fromNow();
-    } else if (this.props.suffix === 'old') {
-      return t('%(time)s old', {time: moment(date).fromNow(true)});
-    } else {
-      throw new Error('Unsupported time format suffix');
-    }
   };
 
   render() {


### PR DESCRIPTION
Cause:
- Display string was taken from component state
- State was not updated when props are updated

Fix:
- Used getDerivedStateFromProps
- Convert getRelativeDate to a static method so it'll not use "this" context

Fix SEN-944