### PR TITLE
ref(ts): Remove AsyncView/Comp export of State and Prop types

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.tsx
@@ -14,13 +14,13 @@ import PermissionDenied from 'app/views/permissionDenied';
 import RouteError from 'app/views/routeError';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 
-export type AsyncComponentProps = {
+type AsyncComponentProps = {
   location?: Location;
   router?: any;
   params?: any;
 };
 
-export type AsyncComponentState = {
+type AsyncComponentState = {
   loading: boolean;
   reloading: boolean;
   error: boolean;

--- a/src/sentry/static/sentry/app/views/asyncView.tsx
+++ b/src/sentry/static/sentry/app/views/asyncView.tsx
@@ -1,13 +1,10 @@
 import DocumentTitle from 'react-document-title';
 import React from 'react';
 
-import AsyncComponent, {
-  AsyncComponentProps,
-  AsyncComponentState,
-} from 'app/components/asyncComponent';
+import AsyncComponent from 'app/components/asyncComponent';
 
-export type AsyncViewState = AsyncComponentState;
-export type AsyncViewProps = AsyncComponentProps;
+type AsyncViewState = AsyncComponent['state'];
+type AsyncViewProps = AsyncComponent['props'];
 
 export default class AsyncView<
   P extends AsyncViewProps = AsyncViewProps,

--- a/src/sentry/static/sentry/app/views/settings/projectIncidentRules/details.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectIncidentRules/details.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import {addSuccessMessage} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
-import AsyncView, {AsyncViewState} from 'app/views/asyncView';
+import AsyncView from 'app/views/asyncView';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 
 import {IncidentRule} from './types';
@@ -11,7 +11,7 @@ import RuleForm from './ruleForm';
 
 type State = {
   rule: IncidentRule;
-} & AsyncViewState;
+} & AsyncView['state'];
 
 type RouteParams = {
   orgId: string;

--- a/src/sentry/static/sentry/app/views/settings/projectIncidentRules/list.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectIncidentRules/list.tsx
@@ -5,7 +5,7 @@ import styled from 'react-emotion';
 
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import {t} from 'app/locale';
-import AsyncView, {AsyncViewState} from 'app/views/asyncView';
+import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
@@ -18,7 +18,7 @@ import {deleteRule} from './actions';
 
 type State = {
   rules: IncidentRule[];
-} & AsyncViewState;
+} & AsyncView['state'];
 type RouteParams = {
   orgId: string;
   projectId: string;


### PR DESCRIPTION
These are equivalent right? This way we do not have to export/import the types