### PR TITLE
fix(platform): Fix warning message caused by #14477

### DIFF
--- a/src/sentry/static/sentry/app/components/timeSince.jsx
+++ b/src/sentry/static/sentry/app/components/timeSince.jsx
@@ -36,13 +36,9 @@ class TimeSince extends React.PureComponent {
     }
   };
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      relative: '',
-    };
-  }
+  state = {
+    relative: '',
+  };
 
   static getDerivedStateFromProps(props) {
     return {

--- a/src/sentry/static/sentry/app/components/timeSince.jsx
+++ b/src/sentry/static/sentry/app/components/timeSince.jsx
@@ -38,6 +38,10 @@ class TimeSince extends React.PureComponent {
 
   constructor(props) {
     super(props);
+
+    this.state = {
+      relative: '',
+    };
   }
 
   static getDerivedStateFromProps(props) {


### PR DESCRIPTION
@billyvg reported an warning message caused by PR #14477

```
 `TimeSince` uses `getDerivedStateFromProps` but its initial state is undefined. This is not recommended. Instead, define the initial state by assigning an object to `this.state` in the constructor of `TimeSince`. This ensures that `getDerivedStateFromProps` arguments have a consistent shape.
```

Initializing the state in the constructor will fix the issue.