### PR TITLE
ref: Remove short version from release model

### DIFF
--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -87,7 +87,6 @@ class CommitWithReleaseSerializer(CommitSerializer):
         data["releases"] = [
             {
                 "version": r.version,
-                "shortVersion": r.short_version,
                 "ref": r.ref,
                 "url": r.url,
                 "dateReleased": r.date_released,

--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -87,6 +87,7 @@ class CommitWithReleaseSerializer(CommitSerializer):
         data["releases"] = [
             {
                 "version": r.version,
+                "shortVersion": r.version,
                 "ref": r.ref,
                 "url": r.url,
                 "dateReleased": r.date_released,

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -253,6 +253,7 @@ class ReleaseSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
         d = {
             "version": obj.version,
+            "shortVersion": obj.version,
             "ref": obj.ref,
             "url": obj.url,
             "dateReleased": obj.date_released,

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -253,7 +253,6 @@ class ReleaseSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
         d = {
             "version": obj.version,
-            "shortVersion": obj.short_version,
             "ref": obj.ref,
             "url": obj.url,
             "dateReleased": obj.date_released,

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -24,7 +24,7 @@ def serialize_releases(organization, item_list, user, lookup):
     return {
         (r.version,): {
             HEALTH_ID_KEY: make_health_id(lookup, [r.version]),
-            "value": {"id": r.id, "version": r.version, "shortVersion": r.short_version},
+            "value": {"id": r.id, "version": r.version},
         }
         for r in Release.objects.filter(
             organization=organization, version__in={i[0] for i in item_list}

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -228,19 +228,6 @@ class Release(Model):
 
             release.delete()
 
-    @property
-    def short_version(self):
-        return Release.get_display_version(self.version)
-
-    @staticmethod
-    def get_display_version(version):
-        match = _dotted_path_prefix_re.match(version)
-        if match is not None:
-            version = version[match.end() :]
-        if _sha1_re.match(version):
-            return version[:7]
-        return version
-
     def add_dist(self, name, date_added=None):
         from sentry.models import Distribution
 

--- a/src/sentry/plugins/sentry_mail/activity/release.py
+++ b/src/sentry/plugins/sentry_mail/activity/release.py
@@ -230,7 +230,7 @@ class ReleaseActivityEmail(ActivityEmail):
         }
 
     def get_subject(self):
-        return u"Deployed version {} to {}".format(self.release.short_version, self.environment)
+        return u"Deployed version {} to {}".format(self.release.version, self.environment)
 
     def get_template(self):
         return "sentry/emails/activity/release.txt"

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -138,10 +138,6 @@ class TagStorage(Service):
                 label = value[len("username:") :]
             elif value.startswith("ip:"):
                 label = value[len("ip:") :]
-        elif key == "sentry:release":
-            from sentry.models import Release
-
-            label = Release.get_display_version(value)
 
         return label
 

--- a/src/sentry/templates/sentry/emails/activity/release.html
+++ b/src/sentry/templates/sentry/emails/activity/release.html
@@ -8,7 +8,7 @@
 
 {% block activity %}
     <h2 style="margin-bottom: 10px">
-        Version {{ release.short_version }} was deployed to {{ environment }}
+        Version {{ release.version }} was deployed to {{ environment }}
     </h2>
     <p class="muted"><small><strong style="color: #72697d;">{{ deploy.date_finished }}</strong> <span class="divider">&nbsp;</span>  {{ commit_count }} commit{{ commit_count|pluralize }}, {{ author_count }} author{{ author_count|pluralize }}, and {{ file_count }} file{{ file_count|pluralize }} changed across {{ project_count }} project{{ project_count|pluralize }}</small></p>
 

--- a/src/sentry/templates/sentry/emails/activity/release.txt
+++ b/src/sentry/templates/sentry/emails/activity/release.txt
@@ -1,4 +1,4 @@
-Version {{ release.short_version }} was deployed to {{ environment }} on {{ deploy.date_finished }}
+Version {{ release.version }} was deployed to {{ environment }} on {{ deploy.date_finished }}
 
 {% for project, release_link, resolved_issue_count in projects %}
     {{ release_link }}

--- a/tests/fixtures/emails/release.txt
+++ b/tests/fixtures/emails/release.txt
@@ -6,3 +6,4 @@ Version 6c998f755f304593a4713abd123eaf8833a2de5e was deployed to production on O
     http://testserver/organizations/organization/releases/6c998f755f304593a4713abd123eaf8833a2de5e/?project=2
 
     http://testserver/organizations/organization/releases/6c998f755f304593a4713abd123eaf8833a2de5e/?project=3
+

--- a/tests/fixtures/emails/release.txt
+++ b/tests/fixtures/emails/release.txt
@@ -1,4 +1,4 @@
-Version 6c998f7 was deployed to production on Oct. 12, 2016, 3:39 p.m.
+Version 6c998f755f304593a4713abd123eaf8833a2de5e was deployed to production on Oct. 12, 2016, 3:39 p.m.
 
 
     http://testserver/organizations/organization/releases/6c998f755f304593a4713abd123eaf8833a2de5e/?project=1
@@ -6,4 +6,3 @@ Version 6c998f7 was deployed to production on Oct. 12, 2016, 3:39 p.m.
     http://testserver/organizations/organization/releases/6c998f755f304593a4713abd123eaf8833a2de5e/?project=2
 
     http://testserver/organizations/organization/releases/6c998f755f304593a4713abd123eaf8833a2de5e/?project=3
-

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -101,7 +101,6 @@ class ReleaseSerializerTest(TestCase):
 
         result = serialize(release, user)
         assert result["version"] == release.version
-        assert result["shortVersion"] == release.version
         # should be sum of all projects
         assert result["newGroups"] == 2
         # should be tags from all projects
@@ -118,11 +117,6 @@ class ReleaseSerializerTest(TestCase):
         # should be tags from one project
         assert result["firstEvent"] == tagvalue1.first_seen
         assert result["lastEvent"] == tagvalue1.last_seen
-
-        # Make sure a sha1 value gets truncated
-        release.version = "0" * 40
-        result = serialize(release, user)
-        assert result["shortVersion"] == "0" * 7
 
     def test_no_tag_data(self):
         user = self.create_user()

--- a/tests/sentry/api/serializers/test_tagvalue.py
+++ b/tests/sentry/api/serializers/test_tagvalue.py
@@ -39,7 +39,7 @@ class TagValueSerializerTest(TestCase):
         result = serialize(tagvalue, user)
         assert result["key"] == "release"
         assert result["value"] == "df84bccbb23ca15f2868be1f2a5f7c7a6464fadd"
-        assert result["name"] == "df84bcc"
+        assert result["name"] == "df84bccbb23ca15f2868be1f2a5f7c7a6464fadd"
         assert "query" not in result
 
 

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -161,14 +161,6 @@ class MergeReleasesTest(TestCase):
         assert not Release.objects.filter(id=release2.id).exists()
         assert not Release.objects.filter(id=release3.id).exists()
 
-    def test_short_version_dotted_prefix(self):
-        org = self.create_organization()
-
-        release = Release.objects.create(version="foo.bar.Baz-1.0", organization=org)
-
-        assert release.version == "foo.bar.Baz-1.0"
-        assert release.short_version == "1.0"
-
 
 class SetCommitsTestCase(TestCase):
     def test_simple(self):


### PR DESCRIPTION
This is the server side part of https://github.com/getsentry/sentry/pull/13889

Talked to @mitsuhiko offline and we want to kill `short_version` of the release with 🔥 

Email:
![image](https://user-images.githubusercontent.com/363802/63515806-f64b4f00-c4eb-11e9-85e9-a05f90c2e772.png)
