### PR TITLE
fix(snuba): Ensure limits are provided as integers, not floats

### DIFF
--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -86,7 +86,7 @@ class SnubaTSDB(BaseTSDB):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
         start = to_datetime(series[0])
         end = to_datetime(series[-1] + rollup)
-        limit = min(10000, len(keys) * ((end - start).total_seconds() / rollup))
+        limit = int(min(10000, len(keys) * ((end - start).total_seconds() / rollup)))
 
         if keys:
             result = snuba.query(

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -86,7 +86,7 @@ class SnubaTSDB(BaseTSDB):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
         start = to_datetime(series[0])
         end = to_datetime(series[-1] + rollup)
-        limit = int(min(10000, len(keys) * ((end - start).total_seconds() / rollup)))
+        limit = min(10000, int(len(keys) * ((end - start).total_seconds() / rollup)))
 
         if keys:
             result = snuba.query(


### PR DESCRIPTION
These restrictions were tightened in getsentry/snuba#436 to prevent
problems with invalid limit and offset values being provided, and ended
up causing new problems.

Fixes SENTRY-CD7.