### PR TITLE
fix(api) Don't fail on serialized users in notes

### DIFF
--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -45,9 +45,16 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
         serializer = NoteSerializer(data=request.data)
 
         if serializer.is_valid():
+            payload = serializer.validated_data
+            # TODO adding mentions to a note doesn't do subscriptions
+            # or notifications. Should it?
+            # Remove mentions as they shouldn't go into the database
+            payload.pop("mentions", [])
+
             # Would be nice to have a last_modified timestamp we could bump here
-            note.data.update(dict(serializer.validated_data))
+            note.data.update(dict(payload))
             note.save()
+
             if note.data.get("external_id"):
                 self.update_external_comment(request, group, note)
             return Response(serialize(note, request.user), status=200)

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -91,8 +91,7 @@ class ActivitySerializer(Serializer):
             # attribute of group notes which needs to be removed
             # While group_note update has been fixed there are still many skunky comments
             # in the database.
-            if "mentions" in data:
-                del data["mentions"]
+            data.pop("mentions", None)
 
         return {
             "id": six.text_type(obj.id),

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -87,6 +87,12 @@ class ActivitySerializer(Serializer):
             data = {"fingerprints": obj.data["fingerprints"], "destination": attrs["destination"]}
         else:
             data = obj.data
+            # XXX: We had a problem where Users were embedded into the mentions
+            # attribute of group notes which needs to be removed
+            # While group_note update has been fixed there are still many skunky comments
+            # in the database.
+            if "mentions" in data:
+                del data["mentions"]
 
         return {
             "id": six.text_type(obj.id),


### PR DESCRIPTION
The issue note update API is currently storing Users in a gzipped dict, the API serializers are not prepared for this and fail when Users cannot be converted to JSON. Given that we don't store mentions when notes are created, I've opted to exclude mentions from the update result as well.

Fixes SEN-957
Fixes SENTRY-B2M