### PR TITLE
upgrade(ui): dreamy components

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "react-virtualized": "^9.20.1",
     "reflux": "0.4.1",
     "scroll-to-element": "^2.0.0",
-    "sentry-dreamy-components": "^1.0.2",
+    "sentry-dreamy-components": "^2.0.0",
     "sprintf-js": "1.0.3",
     "style-loader": "^0.23.1",
     "svg-sprite-loader": "^3.9.0",

--- a/src/sentry/static/sentry/app/types/fileLoader.d.ts
+++ b/src/sentry/static/sentry/app/types/fileLoader.d.ts
@@ -2,3 +2,8 @@
 // TS compatibility for https://github.com/webpack-contrib/file-loader
 
 declare module '*.png';
+
+declare module '*.svg' {
+  const content: any;
+  export default content;
+}

--- a/src/sentry/static/sentry/app/views/releases/list/releaseLanding.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseLanding.jsx
@@ -2,13 +2,11 @@ import React from 'react';
 import {t} from 'app/locale';
 import styled from 'react-emotion';
 
-import {
-  BashCard,
-  Issues,
-  SuggestedAssignees,
-  Emails,
-  Contributors,
-} from 'sentry-dreamy-components';
+import minified from 'sentry-dreamy-components/dist/minified.svg';
+import emails from 'sentry-dreamy-components/dist/emails.svg';
+import issues from 'sentry-dreamy-components/dist/issues.svg';
+import suggestedAssignees from 'sentry-dreamy-components/dist/suggested-assignees.svg';
+import contributors from 'sentry-dreamy-components/dist/contributors.svg';
 
 import {analytics} from 'app/utils/analytics';
 import SentryTypes from 'app/sentryTypes';
@@ -16,14 +14,9 @@ import withApi from 'app/utils/withApi';
 
 import ReleaseLandingCard from './releaseLandingCard';
 
-const StyledSuggestedAssignees = styled(SuggestedAssignees)`
-  width: 70px;
-  height: 70px;
-  margin-left: 250px;
-
-  @media (max-width: 1150px) {
-    margin-left: 100px;
-  }
+const Illustration = styled('object')`
+  width: 100%;
+  height: 100%;
 `;
 
 const cards = [
@@ -32,33 +25,33 @@ const cards = [
     message: t(
       'Releases provide additional context, with rich commits, so you know which errors were addressed and which were introduced in a release'
     ),
-    component: Contributors,
+    svg: <Illustration type="image/svg+xml" data={contributors} />,
   },
   {
     title: t('Suspect Commits'),
     message: t(
       'Sentry suggests which commit caused an issue and who is likely responsible so you can triage'
     ),
-    component: StyledSuggestedAssignees,
+    svg: <Illustration type="image/svg+xml" data={suggestedAssignees} />,
   },
   {
     title: t('Release Stats'),
     message: t(
       'See the commits in each release, and which issues were introduced or fixed in the release'
     ),
-    component: Issues,
+    svg: <Illustration type="image/svg+xml" data={issues} />,
   },
   {
     title: t('Easy Resolution'),
     message: t(
       'Automatically resolve issues by including the issue number in your commit message'
     ),
-    component: BashCard,
+    svg: <Illustration type="image/svg+xml" data={minified} />,
   },
   {
     title: t('Deploy Emails'),
     message: t('Receive email notifications when your code gets deployed'),
-    component: Emails,
+    svg: <Illustration type="image/svg+xml" data={emails} />,
   },
 ];
 

--- a/src/sentry/static/sentry/app/views/releases/list/releaseLanding.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseLanding.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {t} from 'app/locale';
 import styled from 'react-emotion';
 
@@ -14,7 +15,30 @@ import withApi from 'app/utils/withApi';
 
 import ReleaseLandingCard from './releaseLandingCard';
 
-const Illustration = styled('object')`
+class Illustration extends React.Component {
+  static propTypes = {
+    data: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const {data} = this.props;
+
+    // Currently, we need a fallback because object doesn't work in msedge,
+    // and img doesn't work in safari. Hopefully we can choose one soon.
+    return (
+      <ObjectIllustration type="image/svg+xml" data={data}>
+        <ImgIllustration type="image/svg+xml" src={data} />
+      </ObjectIllustration>
+    );
+  }
+}
+
+const ObjectIllustration = styled('object')`
+  width: 100%;
+  height: 100%;
+`;
+
+const ImgIllustration = styled('img')`
   width: 100%;
   height: 100%;
 `;
@@ -25,33 +49,33 @@ const cards = [
     message: t(
       'Releases provide additional context, with rich commits, so you know which errors were addressed and which were introduced in a release'
     ),
-    svg: <Illustration type="image/svg+xml" data={contributors} />,
+    svg: <Illustration data={contributors} />,
   },
   {
     title: t('Suspect Commits'),
     message: t(
       'Sentry suggests which commit caused an issue and who is likely responsible so you can triage'
     ),
-    svg: <Illustration type="image/svg+xml" data={suggestedAssignees} />,
+    svg: <Illustration data={suggestedAssignees} />,
   },
   {
     title: t('Release Stats'),
     message: t(
       'See the commits in each release, and which issues were introduced or fixed in the release'
     ),
-    svg: <Illustration type="image/svg+xml" data={issues} />,
+    svg: <Illustration data={issues} />,
   },
   {
     title: t('Easy Resolution'),
     message: t(
       'Automatically resolve issues by including the issue number in your commit message'
     ),
-    svg: <Illustration type="image/svg+xml" data={minified} />,
+    svg: <Illustration data={minified} />,
   },
   {
     title: t('Deploy Emails'),
     message: t('Receive email notifications when your code gets deployed'),
-    svg: <Illustration type="image/svg+xml" data={emails} />,
+    svg: <Illustration data={emails} />,
   },
 ];
 

--- a/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
@@ -7,15 +7,16 @@ import emails from 'sentry-dreamy-components/dist/emails.svg';
 import issues from 'sentry-dreamy-components/dist/issues.svg';
 import suggestedAssignees from 'sentry-dreamy-components/dist/suggested-assignees.svg';
 import contributors from 'sentry-dreamy-components/dist/contributors.svg';
-import SentryTypes from 'app/sentryTypes';
+import {Project, Organization} from 'app/types';
 
 import {analytics} from 'app/utils/analytics';
-import withApi from 'app/utils/withApi';
+import withOrganization from 'app/utils/withOrganization';
+import withProject from 'app/utils/withProject';
 
 import ReleaseLandingCard from './releaseLandingCard';
 
 type IllustrationProps = {
-  data: string;
+  data: string,
 };
 
 class Illustration extends React.Component<IllustrationProps> {
@@ -78,16 +79,17 @@ const cards = [
   },
 ];
 
-type State = {
-  stepId: number;
+type ReleaseLandingProps = {
+  organization: Organization,
+  project: Project,
 };
 
-const ReleaseLanding = withApi(
-  class ReleaseLanding extends React.Component<{}, State> {
-    static contextTypes = {
-      organization: SentryTypes.Organization,
-      project: SentryTypes.Project,
-    };
+type State = {
+  stepId: number,
+}
+
+const ReleaseLanding = withOrganization(withProject(
+  class ReleaseLanding extends React.Component<ReleaseLandingProps, State> {
 
     constructor(props) {
       super(props);
@@ -97,7 +99,7 @@ const ReleaseLanding = withApi(
     }
 
     componentDidMount() {
-      const {organization, project} = this.context;
+      const {organization, project} = this.props;
 
       analytics('releases.landing_card_viewed', {
         org_id: parseInt(organization.id, 10),
@@ -107,7 +109,7 @@ const ReleaseLanding = withApi(
 
     handleClick = () => {
       const {stepId} = this.state;
-      const {organization, project} = this.context;
+      const {organization, project} = this.props;
 
       const title = cards[stepId].title;
       if (stepId >= cards.length - 1) {
@@ -147,6 +149,6 @@ const ReleaseLanding = withApi(
       );
     }
   }
-);
+));
 
 export default ReleaseLanding;

--- a/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
@@ -16,29 +16,15 @@ import withProject from 'app/utils/withProject';
 import ReleaseLandingCard from './releaseLandingCard';
 
 type IllustrationProps = {
-  data: string,
+  data: string;
+  className?: string;
 };
 
-class Illustration extends React.Component<IllustrationProps> {
-  render() {
-    const {data} = this.props;
-
-    // Currently, we need a fallback because <object> doesn't work in msedge,
-    // and <img> doesn't work in safari. Hopefully we can choose one soon.
-    return (
-      <ObjectIllustration data={data}>
-        <ImgIllustration src={data} />
-      </ObjectIllustration>
-    );
-  }
-}
-
-const ObjectIllustration = styled('object')`
-  width: 100%;
-  height: 100%;
-`;
-
-const ImgIllustration = styled('img')`
+const Illustration = styled(({data, className}: IllustrationProps) => (
+  <object data={data} className={className}>
+    <img src={data} className={className} />
+  </object>
+))`
   width: 100%;
   height: 100%;
 `;
@@ -80,75 +66,76 @@ const cards = [
 ];
 
 type ReleaseLandingProps = {
-  organization: Organization,
-  project: Project,
+  organization: Organization;
+  project: Project;
 };
 
 type State = {
-  stepId: number,
-}
+  stepId: number;
+};
 
-const ReleaseLanding = withOrganization(withProject(
-  class ReleaseLanding extends React.Component<ReleaseLandingProps, State> {
-
-    constructor(props) {
-      super(props);
-      this.state = {
-        stepId: 0,
-      };
-    }
-
-    componentDidMount() {
-      const {organization, project} = this.props;
-
-      analytics('releases.landing_card_viewed', {
-        org_id: parseInt(organization.id, 10),
-        project_id: project && parseInt(project.id, 10),
-      });
-    }
-
-    handleClick = () => {
-      const {stepId} = this.state;
-      const {organization, project} = this.props;
-
-      const title = cards[stepId].title;
-      if (stepId >= cards.length - 1) {
-        return;
+const ReleaseLanding = withOrganization(
+  withProject(
+    class ReleaseLanding extends React.Component<ReleaseLandingProps, State> {
+      constructor(props) {
+        super(props);
+        this.state = {
+          stepId: 0,
+        };
       }
-      this.setState(state => ({
-        stepId: state.stepId + 1,
-      }));
 
-      analytics('releases.landing_card_clicked', {
-        org_id: parseInt(organization.id, 10),
-        project_id: project && parseInt(project.id, 10),
-        step_id: stepId,
-        step_title: title,
-      });
-    };
+      componentDidMount() {
+        const {organization, project} = this.props;
 
-    getCard = stepId => {
-      return cards[stepId];
-    };
+        analytics('releases.landing_card_viewed', {
+          org_id: parseInt(organization.id, 10),
+          project_id: project && parseInt(project.id, 10),
+        });
+      }
 
-    render() {
-      const {stepId} = this.state;
-      const card = this.getCard(stepId);
+      handleClick = () => {
+        const {stepId} = this.state;
+        const {organization, project} = this.props;
 
-      return (
-        <div className="container">
-          <div className="row">
-            <ReleaseLandingCard
-              onClick={this.handleClick}
-              card={card}
-              step={stepId}
-              cardsLength={cards.length}
-            />
+        const title = cards[stepId].title;
+        if (stepId >= cards.length - 1) {
+          return;
+        }
+        this.setState(state => ({
+          stepId: state.stepId + 1,
+        }));
+
+        analytics('releases.landing_card_clicked', {
+          org_id: parseInt(organization.id, 10),
+          project_id: project && parseInt(project.id, 10),
+          step_id: stepId,
+          step_title: title,
+        });
+      };
+
+      getCard = stepId => {
+        return cards[stepId];
+      };
+
+      render() {
+        const {stepId} = this.state;
+        const card = this.getCard(stepId);
+
+        return (
+          <div className="container">
+            <div className="row">
+              <ReleaseLandingCard
+                onClick={this.handleClick}
+                card={card}
+                step={stepId}
+                cardsLength={cards.length}
+              />
+            </div>
           </div>
-        </div>
-      );
+        );
+      }
     }
-  }
-));
+  )
+);
 
 export default ReleaseLanding;

--- a/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {t} from 'app/locale';
 import styled from 'react-emotion';
 
@@ -8,26 +7,26 @@ import emails from 'sentry-dreamy-components/dist/emails.svg';
 import issues from 'sentry-dreamy-components/dist/issues.svg';
 import suggestedAssignees from 'sentry-dreamy-components/dist/suggested-assignees.svg';
 import contributors from 'sentry-dreamy-components/dist/contributors.svg';
+import SentryTypes from 'app/sentryTypes';
 
 import {analytics} from 'app/utils/analytics';
-import SentryTypes from 'app/sentryTypes';
 import withApi from 'app/utils/withApi';
 
 import ReleaseLandingCard from './releaseLandingCard';
 
-class Illustration extends React.Component {
-  static propTypes = {
-    data: PropTypes.object.isRequired,
-  };
+type IllustrationProps = {
+  data: string;
+};
 
+class Illustration extends React.Component<IllustrationProps> {
   render() {
     const {data} = this.props;
 
-    // Currently, we need a fallback because object doesn't work in msedge,
-    // and img doesn't work in safari. Hopefully we can choose one soon.
+    // Currently, we need a fallback because <object> doesn't work in msedge,
+    // and <img> doesn't work in safari. Hopefully we can choose one soon.
     return (
-      <ObjectIllustration type="image/svg+xml" data={data}>
-        <ImgIllustration type="image/svg+xml" src={data} />
+      <ObjectIllustration data={data}>
+        <ImgIllustration src={data} />
       </ObjectIllustration>
     );
   }
@@ -79,8 +78,12 @@ const cards = [
   },
 ];
 
+type State = {
+  stepId: number;
+};
+
 const ReleaseLanding = withApi(
-  class ReleaseLanding extends React.Component {
+  class ReleaseLanding extends React.Component<{}, State> {
     static contextTypes = {
       organization: SentryTypes.Organization,
       project: SentryTypes.Project,
@@ -95,6 +98,7 @@ const ReleaseLanding = withApi(
 
     componentDidMount() {
       const {organization, project} = this.context;
+
       analytics('releases.landing_card_viewed', {
         org_id: parseInt(organization.id, 10),
         project_id: project && parseInt(project.id, 10),

--- a/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
@@ -20,6 +20,8 @@ type IllustrationProps = {
   className?: string;
 };
 
+// Currently, we need a fallback because <object> doesn't work in msedge,
+// and <img> doesn't work in safari. Hopefully we can choose one soon.
 const Illustration = styled(({data, className}: IllustrationProps) => (
   <object data={data} className={className}>
     <img src={data} className={className} />

--- a/src/sentry/static/sentry/app/views/releases/list/releaseLandingCard.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseLandingCard.jsx
@@ -64,7 +64,7 @@ const Container = styled('div')`
 
 const StyledBox = styled('div')`
   flex: 1;
-  padding: 20px;
+  padding: ${space(3)};
 `;
 
 const IllustrationContainer = styled(StyledBox)`

--- a/src/sentry/static/sentry/app/views/releases/list/releaseLandingCard.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseLandingCard.jsx
@@ -27,14 +27,11 @@ class ReleaseLandingCard extends React.Component {
 
   render() {
     const {card, cardsLength, step} = this.props;
-    const CardComponent = card.component;
     const finalStep = step === cardsLength - 1;
     return (
       <Container>
         <IllustrationContainer>
-          <CardComponentContainer>
-            <CardComponent />
-          </CardComponentContainer>
+          <CardComponentContainer>{card.svg}</CardComponentContainer>
         </IllustrationContainer>
 
         <StyledBox>
@@ -60,13 +57,14 @@ const Container = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 450px;
+  flex-wrap: wrap;
+  min-height: 450px;
   padding: ${space(1)};
 `;
 
 const StyledBox = styled('div')`
   flex: 1;
-  padding: 40px;
+  padding: 20px;
 `;
 
 const IllustrationContainer = styled(StyledBox)`
@@ -76,7 +74,8 @@ const IllustrationContainer = styled(StyledBox)`
 `;
 
 const CardComponentContainer = styled('div')`
-  width: 450px;
+  width: 550px;
+  height: 340px;
 
   img {
     vertical-align: baseline;
@@ -84,12 +83,13 @@ const CardComponentContainer = styled('div')`
 
   @media (max-width: 1150px) {
     font-size: 14px;
-    width: 350px;
+    width: 450px;
   }
 
   @media (max-width: 1000px) {
     font-size: 12px;
-    width: 280px;
+    width: 320px;
+    max-height: 180px;
   }
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12660,10 +12660,10 @@ send@0.16.2:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
-sentry-dreamy-components@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/sentry-dreamy-components/-/sentry-dreamy-components-1.0.2.tgz#18f5c1997e4a2c42faf079304a2d920466db87f3"
-  integrity sha512-z/L3AFA8YBF4BmxrMd4HVxQ1LFChJor7SfESSVqpwtWloQJPIFiBJQbolq0VxEDNS850WwIE4C8lfzyJRFk04w==
+sentry-dreamy-components@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sentry-dreamy-components/-/sentry-dreamy-components-2.0.0.tgz#674679f0e2dcf594abc3f5888f46911907a86a08"
+  integrity sha512-tndDgfnkMoGyaWnabrAi+PQnFatddMYruhoS0HYGbqJOrFd0qG4FAGnUfojmQooYVh63a7aifxLn+MfF9r6RqA==
 
 serialize-javascript@^1.4.0:
   version "1.5.0"


### PR DESCRIPTION
![updated-dreamies-in-context](https://user-images.githubusercontent.com/435981/63549052-7c639780-c4e4-11e9-87e3-6b5ae9e2addc.gif)

This upgrades to Dreamy Components 2.0. You can read more about how the new version works [here](https://github.com/getsentry/dreamy-components), and the reasoning behind the changes [here](https://github.com/getsentry/dreamy-components/pull/19). 

This was verified in Chrome, Firefox, Safari, MSEdge and iOS.