### PR TITLE
ref(relay): Move datascrubbing settings to own namespace in projectconfig

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -256,17 +256,19 @@ def process_event(event_manager, project, key, remote_addr, helper, attachments,
         raise APIForbidden("An event with the same ID already exists (%s)" % (event_id,))
 
     config = project_config.config
-    scrub_ip_address = config.get("scrub_ip_addresses")
+    datascrubbing_settings = config.get("datascrubbingSettings") or {}
 
-    scrub_data = config.get("scrub_data")
+    scrub_ip_address = datascrubbing_settings.get("scrubIpAddresses")
+
+    scrub_data = datascrubbing_settings.get("scrubData")
 
     if scrub_data:
         # We filter data immediately before it ever gets into the queue
-        sensitive_fields = config.get("sensitive_fields")
+        sensitive_fields = datascrubbing_settings.get("sensitiveFields")
 
-        exclude_fields = config.get("exclude_fields")
+        exclude_fields = datascrubbing_settings.get("excludeFields")
 
-        scrub_defaults = config.get("scrub_defaults")
+        scrub_defaults = datascrubbing_settings.get("scrubDefaults")
 
         SensitiveDataFilter(
             fields=sensitive_fields, include_defaults=scrub_defaults, exclude_fields=exclude_fields

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -95,12 +95,12 @@ class RelayQueryGetProjectConfigTest(APITestCase):
         assert safe.get_path(cfg, "config", "filterSettings") is not None
         assert safe.get_path(cfg, "config", "groupingConfig", "enhancements") is not None
         assert safe.get_path(cfg, "config", "groupingConfig", "id") is not None
-        assert safe.get_path(cfg, "config", "piiConfig", "applications") is not None
-        assert safe.get_path(cfg, "config", "piiConfig", "rules") is not None
-        assert safe.get_path(cfg, "config", "scrubData") is True
-        assert safe.get_path(cfg, "config", "scrubDefaults") is True
-        assert safe.get_path(cfg, "config", "scrubIpAddresses") is True
-        assert safe.get_path(cfg, "config", "sensitiveFields") == []
+        assert safe.get_path(cfg, "config", "piiConfig", "applications") is None
+        assert safe.get_path(cfg, "config", "piiConfig", "rules") is None
+        assert safe.get_path(cfg, "config", "datascrubbingSettings", "scrubData") is True
+        assert safe.get_path(cfg, "config", "datascrubbingSettings", "scrubDefaults") is True
+        assert safe.get_path(cfg, "config", "datascrubbingSettings", "scrubIpAddresses") is True
+        assert safe.get_path(cfg, "config", "datascrubbingSettings", "sensitiveFields") == []
 
     def test_trusted_external_relays_should_not_be_able_to_request_full_configs(self):
         self._setup_relay(False, True)
@@ -154,12 +154,10 @@ class RelayQueryGetProjectConfigTest(APITestCase):
         assert safe.get_path(cfg, "config", "trustedRelays") == [self.relay.public_key]
         assert safe.get_path(cfg, "config", "filterSettings") is None
         assert safe.get_path(cfg, "config", "groupingConfig") is None
-        assert safe.get_path(cfg, "config", "piiConfig", "applications") is not None
-        assert safe.get_path(cfg, "config", "piiConfig", "rules") is not None
-        assert safe.get_path(cfg, "config", "scrubData") is None
-        assert safe.get_path(cfg, "config", "scrubDefaults") is None
-        assert safe.get_path(cfg, "config", "scrubIpAddresses") is None
-        assert safe.get_path(cfg, "config", "sensitiveFields") is None
+        assert safe.get_path(cfg, "config", "datascrubbingSettings", "scrubData") is not None
+        assert safe.get_path(cfg, "config", "datascrubbingSettings", "scrubIpAddresses") is not None
+        assert safe.get_path(cfg, "config", "piiConfig", "rules") is None
+        assert safe.get_path(cfg, "config", "piiConfig", "applications") is None
 
     def test_untrusted_external_relays_should_not_receive_configs(self):
         self._setup_relay(False, False)


### PR DESCRIPTION
Counterpart to https://github.com/getsentry/semaphore/pull/227, just moves some keys into subkeys.

Also gets rid of broken `generate_pii_config` because we handle that in relay now