### PR TITLE
chore: Make sure incident tasks are imported in celery

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -529,6 +529,7 @@ CELERY_CREATE_MISSING_QUEUES = True
 CELERY_REDIRECT_STDOUTS = False
 CELERYD_HIJACK_ROOT_LOGGER = False
 CELERY_IMPORTS = (
+    "sentry.incidents.tasks",
     "sentry.tasks.auth",
     "sentry.tasks.auto_resolve_issues",
     "sentry.tasks.beacon",
@@ -847,8 +848,7 @@ SENTRY_FEATURES = {
     # Enable inviting members to organizations.
     "organizations:invite-members": True,
     # Enable org-wide saved searches and user pinned search
-    'organizations:org-saved-searches': False,
-
+    "organizations:org-saved-searches": False,
     # Enable the relay functionality, for use with sentry semaphore. See
     # https://github.com/getsentry/semaphore.
     "organizations:relay": False,


### PR DESCRIPTION
These are likely getting imported by chance via other modules. Just including here so that incident
tasks don't mysteriously break at some point.