### PR TITLE
fix(api) Align ProjectKey.label max length to database

### DIFF
--- a/src/sentry/api/endpoints/project_keys.py
+++ b/src/sentry/api/endpoints/project_keys.py
@@ -28,7 +28,7 @@ def create_key_scenario(runner):
 
 
 class KeySerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=200, required=False, allow_blank=True, allow_null=True)
+    name = serializers.CharField(max_length=64, required=False, allow_blank=True, allow_null=True)
     public = serializers.RegexField(r"^[a-f0-9]{32}$", required=False, allow_null=True)
     secret = serializers.RegexField(r"^[a-f0-9]{32}$", required=False, allow_null=True)
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/projectKeyDetails.jsx
@@ -368,6 +368,7 @@ const KeySettings = createReactClass({
                     label={t('Name')}
                     disabled={!hasAccess}
                     required={false}
+                    maxLength={64}
                   />
                   <BooleanField
                     name="isActive"


### PR DESCRIPTION
Make the serializer for ProjectKey have the same length as in the database field.

Fixes SENTRY-CC6