### PR TITLE
fix(ui): Handling 404 from Release endpoint

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/index.jsx
@@ -117,21 +117,16 @@ class OrganizationReleaseDetails extends AsyncView {
       return (
         <PageContent>
           <Alert type="error" icon="icon-circle-exclamation">
-            <h3>{t('Release Not Found')}</h3>
-            <p>
-              {t(
-                'This release may not be in your selected project' +
-                  (selected_projects.length > 1 ? 's' : '')
-              )}
-              :{' '}
-              {selected_projects
-                .map(p => {
-                  return all_projects.find(pp => {
-                    return parseInt(pp.id, 10) === p;
-                  }).name;
-                })
-                .join(', ')}
-            </p>
+            {t(
+              'This release may not be in your selected project' +
+                (selected_projects.length > 1 ? 's' : '')
+            )}
+            :{' '}
+            {selected_projects
+              .map(p => {
+                return all_projects.find(pp => parseInt(pp.id, 10) === p).name;
+              })
+              .join(', ')}
           </Alert>
         </PageContent>
       );

--- a/src/sentry/static/sentry/app/views/releases/detail/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/index.jsx
@@ -10,6 +10,8 @@ import Alert from 'app/components/alert';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import withOrganization from 'app/utils/withOrganization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
+import withProjects from 'app/utils/withProjects';
+
 import AsyncView from 'app/views/asyncView';
 import {PageContent} from 'app/styles/organization';
 import {t} from 'app/locale';
@@ -32,6 +34,14 @@ class OrganizationReleaseDetails extends AsyncView {
   static propTypes = {
     organization: SentryTypes.Organization,
     project: SentryTypes.Project,
+    /**
+     * Currently selected values(s)
+     */
+    selection: SentryTypes.GlobalSelection,
+    /**
+     * List of projects to display in project selector
+     */
+    projects: PropTypes.arrayOf(SentryTypes.Project).isRequired,
   };
 
   static childContextTypes = {
@@ -101,14 +111,26 @@ class OrganizationReleaseDetails extends AsyncView {
     );
     if (has404Errors) {
       // This catches a 404 coming from the release endpoint and displays a custom error message.
+      const {projects: all_projects} = this.props;
+      const {projects: selected_projects} = this.props.selection;
+
       return (
         <PageContent>
           <Alert type="error" icon="icon-circle-exclamation">
-            <h3>{t('The Release you are looking for could not be found.')}</h3>
+            <h3>{t('Release Not Found')}</h3>
             <p>
               {t(
-                'If you have just changed projects, it is possible that this release is not associated with any of your selected projects. If so, include a project that this release is associated with.'
+                'This release may not be in your selected project' +
+                  (selected_projects.length > 1 ? 's' : '')
               )}
+              :{' '}
+              {selected_projects
+                .map(p => {
+                  return all_projects.find(pp => {
+                    return parseInt(pp.id, 10) === p;
+                  }).name;
+                })
+                .join(', ')}
             </p>
           </Alert>
         </PageContent>
@@ -118,4 +140,6 @@ class OrganizationReleaseDetails extends AsyncView {
   }
 }
 
-export default withOrganization(withGlobalSelection(ReleaseDetailsContainer));
+export default withProjects(
+  withOrganization(withGlobalSelection(ReleaseDetailsContainer))
+);

--- a/src/sentry/static/sentry/app/views/releases/detail/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/index.jsx
@@ -6,6 +6,7 @@ import SentryTypes from 'app/sentryTypes';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
+import Alert from 'app/components/alert';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import withOrganization from 'app/utils/withOrganization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
@@ -95,44 +96,24 @@ class OrganizationReleaseDetails extends AsyncView {
   }
 
   renderError(error, disableLog = false, disableReport = false) {
-    const fourOhFourErrors = Object.values(this.state.errors).find(
-      resp => resp && resp.status === 404 && resp.responseJSON && resp.responseJSON.detail
+    const has404Errors = Object.values(this.state.errors).find(
+      resp => resp && resp.status === 404
     );
-    if (fourOhFourErrors) {
+    if (has404Errors) {
       // This catches a 404 coming from the release endpoint and displays a custom error message.
       return (
-        <div className="alert alert-block alert-error" style={{margin: '30px 0 10px'}}>
-          <div style={{fontSize: 24, marginBottom: 10}}>
-            <span className="icon-exclamation" style={{fontSize: 20, marginRight: 10}} />
-            <span>{t('Release Not Found')}</span>
-          </div>
-          <p>The release you are looking for was not found.</p>
-          <p>You may wish to try the following:</p>
-          <ul>
-            <li>
-              If you have just changed projects, it is possible that this release is not
-              associated with any of your selected projects. If so, include a project that
-              this release is associated with.
-            </li>
-            <li>
-              If you entered the address manually, double check the path. Does the release
-              ID look correct?
-            </li>
-            <li>
-              If all else fails,{' '}
-              <a href="http://github.com/getsentry/sentry/issues">create an issue</a> with
-              more details.
-            </li>
-          </ul>
+        <Alert type="error" icon="icon-circle-exclamation">
+          <h3>{t('The Release you are looking for could not be found.')}</h3>
           <p>
-            Not sure what to do? <a href="/">Return to the dashboard</a>
+            {t(
+              'If you have just changed projects, it is possible that this release is not associated with any of your selected projects. If so, include a project that this release is associated with.'
+            )}
           </p>
-        </div>
+        </Alert>
       );
     }
     return super.renderError(error, disableLog, disableReport);
   }
 }
 
-// export default withOrganization(ReleaseDetailsContainer);
 export default withOrganization(withGlobalSelection(ReleaseDetailsContainer));

--- a/src/sentry/static/sentry/app/views/releases/detail/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/index.jsx
@@ -102,14 +102,16 @@ class OrganizationReleaseDetails extends AsyncView {
     if (has404Errors) {
       // This catches a 404 coming from the release endpoint and displays a custom error message.
       return (
-        <Alert type="error" icon="icon-circle-exclamation">
-          <h3>{t('The Release you are looking for could not be found.')}</h3>
-          <p>
-            {t(
-              'If you have just changed projects, it is possible that this release is not associated with any of your selected projects. If so, include a project that this release is associated with.'
-            )}
-          </p>
-        </Alert>
+        <PageContent>
+          <Alert type="error" icon="icon-circle-exclamation">
+            <h3>{t('The Release you are looking for could not be found.')}</h3>
+            <p>
+              {t(
+                'If you have just changed projects, it is possible that this release is not associated with any of your selected projects. If so, include a project that this release is associated with.'
+              )}
+            </p>
+          </Alert>
+        </PageContent>
       );
     }
     return super.renderError(error, disableLog, disableReport);

--- a/src/sentry/static/sentry/app/views/releases/list/index.jsx
+++ b/src/sentry/static/sentry/app/views/releases/list/index.jsx
@@ -57,10 +57,8 @@ class OrganizationReleases extends AsyncView {
   }
 
   onSearch = query => {
-    const targetQueryParams = {};
-    if (query !== '') {
-      targetQueryParams.query = query;
-    }
+    const targetQueryParams = getQuery(this.props.location).query;
+    targetQueryParams.query = query;
 
     const {orgId} = this.props.params;
     browserHistory.push({

--- a/tests/js/spec/views/organizationReleases/detail/releaseDetails.spec.jsx
+++ b/tests/js/spec/views/organizationReleases/detail/releaseDetails.spec.jsx
@@ -41,6 +41,7 @@ describe('ReleaseDetails', function() {
     };
     const location = {
       pathname: '/',
+      query: [],
     };
 
     const wrapper = mount(

--- a/tests/js/spec/views/organizationReleases/detail/releaseDetails.spec.jsx
+++ b/tests/js/spec/views/organizationReleases/detail/releaseDetails.spec.jsx
@@ -41,7 +41,7 @@ describe('ReleaseDetails', function() {
     };
     const location = {
       pathname: '/',
-      query: [],
+      query: {},
     };
 
     const wrapper = mount(


### PR DESCRIPTION
This PR fixes two things:
1) Searching on the releases page retains all filter / selections (project, date range, environment)
2) Navigating to a release page, then changing the project filters to something that the release isn't associated with will now display an error. Previously, the release would display but it wouldn't load data "properly" (Paging artifacts caused an error - the original source of all this work)
1st draft error:
<img width="1472" alt="image" src="https://user-images.githubusercontent.com/6395250/63708996-e42b2280-c803-11e9-95c1-76e3fc80e75f.png">
Using Alert class (updated based on Billy's suggestion):
<img width="1472" alt="image" src="https://user-images.githubusercontent.com/6395250/63793188-28362a00-c8cd-11e9-8c28-b4a5c74a7c2a.png">




Fixes SEN-753 & ISSUE-549