### PR TITLE
feat(ui) Add events v2 landing page

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationEventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import DocumentTitle from 'react-document-title';
 import PropTypes from 'prop-types';
+import styled from 'react-emotion';
 import * as ReactRouter from 'react-router';
 import {Params} from 'react-router/lib/Router';
 import {Location} from 'history';
@@ -13,14 +14,13 @@ import {PageContent, PageHeader} from 'app/styles/organization';
 import PageHeading from 'app/components/pageHeading';
 import BetaTag from 'app/components/betaTag';
 import Feature from 'app/components/acl/feature';
-import NavTabs from 'app/components/navTabs';
-import ListLink from 'app/components/links/listLink';
+import Link from 'app/components/links/link';
 import NoProjectMessage from 'app/components/noProjectMessage';
+import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
 
 import Events from './events';
 import EventDetails from './eventDetails';
-import {ALL_VIEWS} from './data';
 import {getCurrentView, getFirstQueryString} from './utils';
 
 type Props = {
@@ -37,31 +37,57 @@ class OrganizationEventsV2 extends React.Component<Props> {
     router: PropTypes.object.isRequired,
   };
 
-  renderTabs(): React.ReactNode {
+  renderQueryList() {
     const {location} = this.props;
-    const firstView = getFirstQueryString(location.query, 'view');
-    const currentView = getCurrentView(firstView);
-
+    const allEvents = {
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        view: 'all',
+      },
+    };
+    const errors = {
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        view: 'errors',
+        cursor: undefined,
+        sort: undefined,
+      },
+    };
+    const csp = {
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        view: 'csp',
+        cursor: undefined,
+        sort: undefined,
+      },
+    };
+    const transactions = {
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        view: 'transactions',
+        cursor: undefined,
+        sort: undefined,
+      },
+    };
     return (
-      <NavTabs underlined={true}>
-        {ALL_VIEWS.map(view => (
-          <ListLink
-            key={view.id}
-            to={{
-              pathname: location.pathname,
-              query: {
-                ...this.props.location.query,
-                view: view.id,
-                cursor: undefined,
-                sort: undefined,
-              },
-            }}
-            isActive={() => view.id === currentView.id}
-          >
-            {view.name}
-          </ListLink>
-        ))}
-      </NavTabs>
+      <LinkList>
+        <LinkContainer>
+          <Link to={allEvents}>All Events</Link>
+        </LinkContainer>
+        <LinkContainer>
+          <Link to={errors}>Errors</Link>
+        </LinkContainer>
+        <LinkContainer>
+          <Link to={csp}>CSP</Link>
+        </LinkContainer>
+        <LinkContainer>
+          <Link to={transactions}>Transactions</Link>
+        </LinkContainer>
+      </LinkList>
     );
   }
 
@@ -71,6 +97,8 @@ class OrganizationEventsV2 extends React.Component<Props> {
     const view = getFirstQueryString(location.query, 'view');
 
     const currentView = getCurrentView(view);
+    const hasQuery =
+      location.query.field || location.query.eventSlug || location.query.view;
 
     return (
       <Feature features={['events-v2']} organization={organization} renderDisabled>
@@ -84,23 +112,25 @@ class OrganizationEventsV2 extends React.Component<Props> {
                     {t('Events')} <BetaTag />
                   </PageHeading>
                 </PageHeader>
-                {this.renderTabs()}
-                <Events
-                  organization={organization}
-                  view={currentView}
-                  location={location}
-                  router={router}
-                />
+                {!hasQuery && this.renderQueryList()}
+                {hasQuery && (
+                  <Events
+                    organization={organization}
+                    view={currentView}
+                    location={location}
+                    router={router}
+                  />
+                )}
+                {hasQuery && eventSlug && (
+                  <EventDetails
+                    organization={organization}
+                    params={this.props.params}
+                    eventSlug={eventSlug}
+                    view={currentView}
+                    location={location}
+                  />
+                )}
               </NoProjectMessage>
-              {eventSlug && (
-                <EventDetails
-                  organization={organization}
-                  params={this.props.params}
-                  eventSlug={eventSlug}
-                  view={currentView}
-                  location={location}
-                />
-              )}
             </PageContent>
           </React.Fragment>
         </DocumentTitle>
@@ -108,6 +138,21 @@ class OrganizationEventsV2 extends React.Component<Props> {
     );
   }
 }
+
+const LinkList = styled('ul')`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+`;
+
+const LinkContainer = styled('li')`
+  background: ${p => p.theme.white};
+  line-height: 1.4;
+  border: 1px solid ${p => p.theme.borderLight};
+  border-radius: ${p => p.theme.borderRadius};
+  margin-bottom: ${space(1)};
+  padding: ${space(1)};
+`;
 
 export default withOrganization(OrganizationEventsV2);
 export {OrganizationEventsV2};

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -30,7 +30,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     def test_all_events_empty(self):
         with self.feature(FEATURE_NAME):
-            self.browser.get(self.path)
+            self.browser.get(self.path + "?view=all")
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - all events empty state")
 
@@ -50,7 +50,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         )
 
         with self.feature(FEATURE_NAME):
-            self.browser.get(self.path)
+            self.browser.get(self.path + "?view=all")
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - all events")
 

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -114,7 +114,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
         with self.feature(FEATURE_NAME):
             # Get the list page.
-            self.browser.get(self.path)
+            self.browser.get(self.path + "?view=all")
             self.wait_until_loaded()
 
             # Click the event link to open the modal

--- a/tests/js/spec/views/organizationEventsV2/index.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/index.spec.jsx
@@ -49,7 +49,7 @@ describe('OrganizationEventsV2', function() {
     });
   });
 
-  it('renders', function() {
+  it('renders a link list', function() {
     const wrapper = mount(
       <OrganizationEventsV2
         organization={TestStubs.Organization({features, projects: [TestStubs.Project()]})}
@@ -60,13 +60,27 @@ describe('OrganizationEventsV2', function() {
     );
     const content = wrapper.find('PageContent');
     expect(content.text()).toContain('Events');
+    expect(content.find('LinkContainer').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('renders a list of events', function() {
+    const wrapper = mount(
+      <OrganizationEventsV2
+        organization={TestStubs.Organization({features, projects: [TestStubs.Project()]})}
+        location={{query: {view: 'all'}}}
+        router={{}}
+      />,
+      TestStubs.routerContext()
+    );
+    const content = wrapper.find('PageContent');
+    expect(content.find('Events Cell').length).toBeGreaterThan(0);
   });
 
   it('handles no projects', function() {
     const wrapper = mount(
       <OrganizationEventsV2
         organization={TestStubs.Organization({features})}
-        location={{query: {}}}
+        location={{query: {view: 'all'}}}
         router={{}}
       />,
       TestStubs.routerContext()
@@ -80,7 +94,7 @@ describe('OrganizationEventsV2', function() {
     const wrapper = mount(
       <OrganizationEventsV2
         organization={TestStubs.Organization({features, projects: [TestStubs.Project()]})}
-        location={{query: {}}}
+        location={{query: {view: 'all'}}}
         router={{}}
       />,
       TestStubs.routerContext()
@@ -102,25 +116,28 @@ describe('OrganizationEventsV2', function() {
     ).toEqual('icon-chevron-down');
 
     // Sort link should reverse.
-    expect(timestamp.props().to.query).toEqual({sort: 'timestamp'});
+    expect(timestamp.props().to.query).toEqual({view: 'all', sort: 'timestamp'});
 
     const userlink = findLink('user.id');
     // User link should be descending.
-    expect(userlink.props().to.query).toEqual({sort: '-user.id'});
+    expect(userlink.props().to.query).toEqual({view: 'all', sort: '-user.id'});
   });
 
   it('generates links to modals', async function() {
     const wrapper = mount(
       <OrganizationEventsV2
         organization={TestStubs.Organization({features, projects: [TestStubs.Project()]})}
-        location={{query: {}}}
+        location={{query: {view: 'all'}}}
         router={{}}
       />,
       TestStubs.routerContext()
     );
 
     const link = wrapper.find(`Table Link[aria-label="${eventTitle}"]`).first();
-    expect(link.props().to.query).toEqual({eventSlug: 'project-slug:deadbeef'});
+    expect(link.props().to.query).toEqual({
+      view: 'all',
+      eventSlug: 'project-slug:deadbeef',
+    });
   });
 
   it('opens a modal when eventSlug is present', async function() {


### PR DESCRIPTION
While this current links to the 3 pre-baked queries, later this week we plan on adding many more one URL based state lands.

![Screen Shot 2019-08-26 at 2 27 57 PM](https://user-images.githubusercontent.com/24086/63713684-20fc1700-c80e-11e9-8f5a-6acb627a417f.png)


Refs SEN-967