### PR TITLE
chore: pre-commit, black updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
     - id: black
       types: [python]
-      exclude: (.eggs|.git|.venv|build|dist|south_migrations|node_modules)
+      exclude: (south_migrations/)
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     rev: v1.3.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,7 @@ repos:
     rev: 19.3b0
     hooks:
     - id: black
-      python_version: python3
-      files: \.py$
+      types: [python]
       exclude: (.eggs|.git|.venv|build|dist|south_migrations|node_modules)
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     rev: v1.3.0

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ setup-git:
 	git config branch.autosetuprebase always
 	git config core.ignorecase false
 	cd .git/hooks && ln -sf ../../config/hooks/* ./
-	$(PIP) install "pre-commit>=1.10.1,<1.11.0" $(PIP_OPTS)
+	$(PIP) install "pre-commit==1.18.2" $(PIP_OPTS)
 	pre-commit install --install-hooks
 	@echo ""
 

--- a/bin/dump-command-help
+++ b/bin/dump-command-help
@@ -9,24 +9,26 @@ from sentry.runner import cli as root_command
 
 def get_opts(param):
     any_prefix_is_slash = []
+
     def _write(opts):
         rv, any_slashes = join_options(opts)
         if any_slashes:
             any_prefix_is_slash[:] = [True]
         if not param.is_flag and not param.count:
-            rv += ' ' + param.make_metavar()
+            rv += " " + param.make_metavar()
         return rv
+
     rv = [_write(param.opts)]
     if param.secondary_opts:
         rv.append(_write(param.secondary_opts))
-    return (any_prefix_is_slash and '; ' or ' / ').join(rv)
+    return (any_prefix_is_slash and "; " or " / ").join(rv)
 
 
 def write_page(out, data):
-    path = data['path']
-    filename = os.path.join(out, *path[1:]) + '/index.rst'
+    path = data["path"]
+    filename = os.path.join(out, *path[1:]) + "/index.rst"
     if len(path) == 1:
-        filename += '.inc'
+        filename += ".inc"
 
     dirname = os.path.dirname(filename)
     try:
@@ -34,41 +36,35 @@ def write_page(out, data):
     except OSError:
         pass
 
-    args = [x['metavar'] for x in data['arguments']]
-    title = '`%s`' % ' '.join(data['path'] + args)
-    body = [
-        title,
-        '-' * len(title),
-        '',
-        data['help'] or '',
-    ]
+    args = [x["metavar"] for x in data["arguments"]]
+    title = "`%s`" % " ".join(data["path"] + args)
+    body = [title, "-" * len(title), "", data["help"] or ""]
 
-    body.append('')
-    body.append('Options')
-    body.append('```````')
-    body.append('')
-    for opt in data['options']:
-        prefix = '- ``%s``: ' % opt['opt_string']
-        for line in click.wrap_text(
-                opt['help'], 74, prefix, '  ').splitlines() or ['']:
+    body.append("")
+    body.append("Options")
+    body.append("```````")
+    body.append("")
+    for opt in data["options"]:
+        prefix = "- ``%s``: " % opt["opt_string"]
+        for line in click.wrap_text(opt["help"], 74, prefix, "  ").splitlines() or [""]:
             body.append(line)
-    body.append('- ``--help``: print this help page.')
+    body.append("- ``--help``: print this help page.")
 
-    if data['subcommands']:
-        body.append('')
-        body.append('Subcommands')
-        body.append('```````````')
-        body.append('')
-        body.append('.. toctree::')
-        body.append(' :maxdepth: 1')
-        body.append('')
-        for subcmd in data['subcommands']:
-            body.append(' %s <%s/index>' % (subcmd, subcmd))
-        body.append('')
+    if data["subcommands"]:
+        body.append("")
+        body.append("Subcommands")
+        body.append("```````````")
+        body.append("")
+        body.append(".. toctree::")
+        body.append(" :maxdepth: 1")
+        body.append("")
+        for subcmd in data["subcommands"]:
+            body.append(" %s <%s/index>" % (subcmd, subcmd))
+        body.append("")
 
-    with open(filename, 'w') as f:
+    with open(filename, "w") as f:
         for line in body:
-            f.write('%s\n' % line.encode('utf-8'))
+            f.write("%s\n" % line.encode("utf-8"))
 
 
 class NoHelp(Exception):
@@ -79,29 +75,25 @@ def dump_command(out, cmd, path):
     if cmd.help is None:
         raise NoHelp
     data = {
-        'path': path,
-        'help': cmd.help.replace('\b', ''),
-        'options': [],
-        'arguments': [],
-        'subcommands': [],
+        "path": path,
+        "help": cmd.help.replace("\b", ""),
+        "options": [],
+        "arguments": [],
+        "subcommands": [],
     }
 
     for param in cmd.params:
         if isinstance(param, click.Option):
-            help_text = param.help or ''
+            help_text = param.help or ""
             if param.show_default:
-                help_text += '  [default: %s]' % (
-                         ', '.join('%s' % d for d in param.default)
-                         if isinstance(param.default, (list, tuple))
-                         else (param.default,))
-            data['options'].append({
-                'opt_string': get_opts(param),
-                'help': help_text,
-            })
+                help_text += "  [default: %s]" % (
+                    ", ".join("%s" % d for d in param.default)
+                    if isinstance(param.default, (list, tuple))
+                    else (param.default,)
+                )
+            data["options"].append({"opt_string": get_opts(param), "help": help_text})
         else:
-            data['arguments'].append({
-                'metavar': param.make_metavar(),
-            })
+            data["arguments"].append({"metavar": param.make_metavar()})
 
     if isinstance(cmd, click.Group):
         for child_name, child_cmd in six.iteritems(cmd.commands):
@@ -110,17 +102,16 @@ def dump_command(out, cmd, path):
             except NoHelp:
                 pass
             else:
-                data['subcommands'].append(child_name)
+                data["subcommands"].append(child_name)
 
     write_page(out, data)
 
 
 @click.command()
-@click.option('--output-path', 'out', type=click.Path(),
-              default='build/cli-help')
+@click.option("--output-path", "out", type=click.Path(), default="build/cli-help")
 def cli(out):
-    dump_command(out, root_command, ['sentry'])
+    dump_command(out, root_command, ["sentry"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/bin/find-good-catalogs
+++ b/bin/find-good-catalogs
@@ -20,15 +20,15 @@ def is_translated(msg):
 
 
 @click.command()
-@click.argument('catalog_file', type=click.Path())
+@click.argument("catalog_file", type=click.Path())
 def cli(catalog_file):
     # Read the old ones back.  Once we are in, we will never go.
     with open(catalog_file) as f:
-        rv = json.load(f)['supported_locales']
+        rv = json.load(f)["supported_locales"]
 
-    base = 'src/sentry/locale'
+    base = "src/sentry/locale"
     for locale in os.listdir(base):
-        fn = os.path.join(base, locale, 'LC_MESSAGES', 'django.po')
+        fn = os.path.join(base, locale, "LC_MESSAGES", "django.po")
         if not os.path.isfile(fn):
             continue
 
@@ -41,18 +41,13 @@ def cli(catalog_file):
                 if is_translated(msg):
                     translated_count += 1
         pct = translated_count / float(total_count) * 100
-        click.echo('% -7s % 2d%%' % (
-            locale,
-            pct,
-        ), err=True)
+        click.echo("% -7s % 2d%%" % (locale, pct), err=True)
         if pct >= MINIMUM and locale not in rv:
             rv.append(locale)
-    with open(catalog_file, 'w') as f:
-        json.dump({
-            'supported_locales': sorted(rv)
-        }, f, indent=2)
-        f.write('\n')
+    with open(catalog_file, "w") as f:
+        json.dump({"supported_locales": sorted(rv)}, f, indent=2)
+        f.write("\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/bin/lint
+++ b/bin/lint
@@ -5,7 +5,7 @@ import os
 import sys
 
 # This is to avoid needing to have the `sentry` package explicitly installed.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir, 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir, "src"))
 
 
 def run(files, js, python, format, parseable):
@@ -25,13 +25,13 @@ def run(files, js, python, format, parseable):
     return engine.run(files, js=js, py=python, format=format, parseable=parseable)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('files', nargs='*')
-    parser.add_argument('--js', default=None, action='store_true')
-    parser.add_argument('--python', default=None, action='store_true')
-    parser.add_argument('--format', action='store_true')
-    parser.add_argument('--parseable', action='store_true')
+    parser.add_argument("files", nargs="*")
+    parser.add_argument("--js", default=None, action="store_true")
+    parser.add_argument("--python", default=None, action="store_true")
+    parser.add_argument("--format", action="store_true")
+    parser.add_argument("--parseable", action="store_true")
     sys.exit(run(**vars(parser.parse_args())))

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from sentry.runner import configure
+
 configure()
 
 import itertools
@@ -22,11 +23,38 @@ from pytz import utc
 from sentry import buffer, roles, tsdb
 from sentry.event_manager import HashDiscarded
 from sentry.models import (
-    Activity, Broadcast, Commit, CommitAuthor, CommitFileChange, Deploy, EventAttachment, Event,
-    Environment, File, Group, GroupRelease, GroupTombstone, Organization,
-    OrganizationAccessRequest, OrganizationMember, Project, Release,
-    ReleaseCommit, ReleaseEnvironment, ReleaseProjectEnvironment, ReleaseFile, Repository,
-    Team, TOMBSTONE_FIELDS_FROM_GROUP, User, UserReport, Monitor, MonitorStatus, MonitorType, MonitorCheckIn, CheckInStatus
+    Activity,
+    Broadcast,
+    Commit,
+    CommitAuthor,
+    CommitFileChange,
+    Deploy,
+    EventAttachment,
+    Event,
+    Environment,
+    File,
+    Group,
+    GroupRelease,
+    GroupTombstone,
+    Organization,
+    OrganizationAccessRequest,
+    OrganizationMember,
+    Project,
+    Release,
+    ReleaseCommit,
+    ReleaseEnvironment,
+    ReleaseProjectEnvironment,
+    ReleaseFile,
+    Repository,
+    Team,
+    TOMBSTONE_FIELDS_FROM_GROUP,
+    User,
+    UserReport,
+    Monitor,
+    MonitorStatus,
+    MonitorType,
+    MonitorCheckIn,
+    CheckInStatus,
 )
 from sentry.signals import mocks_loaded
 from sentry.similarity import features
@@ -36,38 +64,15 @@ from sentry.utils.samples import generate_user
 
 loremipsum = Generator()
 
-PLATFORMS = itertools.cycle([
-    'ruby',
-    'php',
-    'python',
-    'java',
-    'javascript',
-])
+PLATFORMS = itertools.cycle(["ruby", "php", "python", "java", "javascript"])
 
-LEVELS = itertools.cycle([
-    'error',
-    'error',
-    'error',
-    'fatal',
-    'warning',
-])
+LEVELS = itertools.cycle(["error", "error", "error", "fatal", "warning"])
 
-ENVIRONMENTS = itertools.cycle([
-    'production',
-    'production',
-    'staging',
-    'alpha',
-    'beta',
-    ''
-])
+ENVIRONMENTS = itertools.cycle(["production", "production", "staging", "alpha", "beta", ""])
 
 MONITOR_NAMES = itertools.cycle(settings.CELERYBEAT_SCHEDULE.keys())
 
-MONITOR_SCHEDULES = itertools.cycle([
-    '* * * * *',
-    '0 * * * *',
-    '0 0 * * *',
-])
+MONITOR_SCHEDULES = itertools.cycle(["* * * * *", "0 * * * *", "0 0 * * *"])
 
 LONG_MESSAGE = """Code: 0.
 DB::Exception: String is too long for DateTime: 2018-10-26T19:14:18+00:00. Stack trace:
@@ -95,14 +100,14 @@ DB::Exception: String is too long for DateTime: 2018-10-26T19:14:18+00:00. Stack
 def make_sentence(words=None):
     if words is None:
         words = int(random.weibullvariate(8, 3))
-    return ' '.join(random.choice(loremipsum.words) for _ in range(words))
+    return " ".join(random.choice(loremipsum.words) for _ in range(words))
 
 
 def create_sample_event(*args, **kwargs):
     try:
         event = _create_sample_event(*args, **kwargs)
     except HashDiscarded as e:
-        print("> Skipping Event: {}".format(e.message))  # NOQA
+        print ("> Skipping Event: {}".format(e.message))  # NOQA
     else:
         if event is not None:
             features.record([event])
@@ -113,30 +118,25 @@ def generate_commits(user):
     commits = []
     for i in range(random.randint(1, 20)):
         if i == 1:
-            filename = 'raven/base.py'
+            filename = "raven/base.py"
         else:
-            filename = random.choice(loremipsum.words) + '.js'
+            filename = random.choice(loremipsum.words) + ".js"
         if random.randint(0, 5) == 1:
             author = (user.name, user.email)
         else:
             author = (
-                '{} {}'.format(
-                    random.choice(loremipsum.words),
-                    random.choice(loremipsum.words),
-                ),
-                '{}@example.com'.format(
-                    random.choice(loremipsum.words),
-                ),
+                "{} {}".format(random.choice(loremipsum.words), random.choice(loremipsum.words)),
+                "{}@example.com".format(random.choice(loremipsum.words)),
             )
 
-        commits.append({
-            'key': sha1(uuid4().hex).hexdigest(),
-            'message': 'feat: Do something to {}\n{}'.format(filename, make_sentence()),
-            'author': author,
-            'files': [
-                (filename, 'M'),
-            ],
-        })
+        commits.append(
+            {
+                "key": sha1(uuid4().hex).hexdigest(),
+                "message": "feat: Do something to {}\n{}".format(filename, make_sentence()),
+                "author": author,
+                "files": [(filename, "M")],
+            }
+        )
     return commits
 
 
@@ -145,10 +145,13 @@ def generate_tombstones(project, user):
     # that it won't conflict with any group ids
     prev_group_id = 100000
     try:
-        prev_group_id = max(
-            GroupTombstone.objects.order_by('-previous_group_id')[0].previous_group_id,
-            prev_group_id
-        ) + 1
+        prev_group_id = (
+            max(
+                GroupTombstone.objects.order_by("-previous_group_id")[0].previous_group_id,
+                prev_group_id,
+            )
+            + 1
+        )
     except IndexError:
         pass
 
@@ -166,30 +169,46 @@ def create_system_time_series():
 
     for _ in xrange(60):
         count = randint(1, 10)
-        tsdb.incr_multi((
-            (tsdb.models.internal, 'client-api.all-versions.responses.2xx'),
-            (tsdb.models.internal, 'client-api.all-versions.requests'),
-        ), now, int(count * 0.9))
-        tsdb.incr_multi((
-            (tsdb.models.internal, 'client-api.all-versions.responses.4xx'),
-        ), now, int(count * 0.05))
-        tsdb.incr_multi((
-            (tsdb.models.internal, 'client-api.all-versions.responses.5xx'),
-        ), now, int(count * 0.1))
+        tsdb.incr_multi(
+            (
+                (tsdb.models.internal, "client-api.all-versions.responses.2xx"),
+                (tsdb.models.internal, "client-api.all-versions.requests"),
+            ),
+            now,
+            int(count * 0.9),
+        )
+        tsdb.incr_multi(
+            ((tsdb.models.internal, "client-api.all-versions.responses.4xx"),),
+            now,
+            int(count * 0.05),
+        )
+        tsdb.incr_multi(
+            ((tsdb.models.internal, "client-api.all-versions.responses.5xx"),),
+            now,
+            int(count * 0.1),
+        )
         now = now - timedelta(seconds=1)
 
     for _ in xrange(24 * 30):
         count = randint(100, 1000)
-        tsdb.incr_multi((
-            (tsdb.models.internal, 'client-api.all-versions.responses.2xx'),
-            (tsdb.models.internal, 'client-api.all-versions.requests'),
-        ), now, int(count * 4.9))
-        tsdb.incr_multi((
-            (tsdb.models.internal, 'client-api.all-versions.responses.4xx'),
-        ), now, int(count * 0.05))
-        tsdb.incr_multi((
-            (tsdb.models.internal, 'client-api.all-versions.responses.5xx'),
-        ), now, int(count * 0.1))
+        tsdb.incr_multi(
+            (
+                (tsdb.models.internal, "client-api.all-versions.responses.2xx"),
+                (tsdb.models.internal, "client-api.all-versions.requests"),
+            ),
+            now,
+            int(count * 4.9),
+        )
+        tsdb.incr_multi(
+            ((tsdb.models.internal, "client-api.all-versions.responses.4xx"),),
+            now,
+            int(count * 0.05),
+        )
+        tsdb.incr_multi(
+            ((tsdb.models.internal, "client-api.all-versions.responses.5xx"),),
+            now,
+            int(count * 0.1),
+        )
         now = now - timedelta(hours=1)
 
 
@@ -197,7 +216,7 @@ def create_sample_time_series(event, release=None):
     if event is None:
         return
 
-    Event.objects.bind_nodes([event], 'data')
+    Event.objects.bind_nodes([event], "data")
 
     group = event.group
 
@@ -208,62 +227,53 @@ def create_sample_time_series(event, release=None):
     now = datetime.utcnow().replace(tzinfo=utc)
 
     environment = Environment.get_or_create(
-        project=project,
-        name=Environment.get_name_or_default(event.get_tag('environment')),
+        project=project, name=Environment.get_name_or_default(event.get_tag("environment"))
     )
 
     if release:
         ReleaseEnvironment.get_or_create(
-            project=project,
-            release=release,
-            environment=environment,
-            datetime=now,
+            project=project, release=release, environment=environment, datetime=now
         )
 
         grouprelease = GroupRelease.get_or_create(
-            group=group,
-            release=release,
-            environment=environment,
-            datetime=now,
+            group=group, release=release, environment=environment, datetime=now
         )
 
     for _ in xrange(60):
         count = randint(1, 10)
-        tsdb.incr_multi((
-            (tsdb.models.project, project.id),
-            (tsdb.models.group, group.id),
-        ), now, count, environment_id=environment.id)
-        tsdb.incr_multi((
-            (tsdb.models.organization_total_received, project.organization_id),
-            (tsdb.models.project_total_forwarded, project.id),
-            (tsdb.models.project_total_received, project.id),
-            (tsdb.models.key_total_received, key.id),
-        ), now, int(count * 1.1))
-        tsdb.incr_multi((
-            (tsdb.models.organization_total_rejected, project.organization_id),
-            (tsdb.models.project_total_rejected, project.id),
-            (tsdb.models.key_total_rejected, key.id),
-        ), now, int(count * 0.1))
+        tsdb.incr_multi(
+            ((tsdb.models.project, project.id), (tsdb.models.group, group.id)),
+            now,
+            count,
+            environment_id=environment.id,
+        )
+        tsdb.incr_multi(
+            (
+                (tsdb.models.organization_total_received, project.organization_id),
+                (tsdb.models.project_total_forwarded, project.id),
+                (tsdb.models.project_total_received, project.id),
+                (tsdb.models.key_total_received, key.id),
+            ),
+            now,
+            int(count * 1.1),
+        )
+        tsdb.incr_multi(
+            (
+                (tsdb.models.organization_total_rejected, project.organization_id),
+                (tsdb.models.project_total_rejected, project.id),
+                (tsdb.models.key_total_rejected, key.id),
+            ),
+            now,
+            int(count * 0.1),
+        )
 
         frequencies = [
-            (tsdb.models.frequent_issues_by_project, {
-                project.id: {
-                    group.id: count,
-                },
-            }),
-            (tsdb.models.frequent_environments_by_group, {
-                group.id: {
-                    environment.id: count,
-                },
-            })
+            (tsdb.models.frequent_issues_by_project, {project.id: {group.id: count}}),
+            (tsdb.models.frequent_environments_by_group, {group.id: {environment.id: count}}),
         ]
         if release:
             frequencies.append(
-                (tsdb.models.frequent_releases_by_group, {
-                    group.id: {
-                        grouprelease.id: count,
-                    },
-                })
+                (tsdb.models.frequent_releases_by_group, {group.id: {grouprelease.id: count}})
             )
 
         tsdb.record_frequency_multi(frequencies, now)
@@ -272,40 +282,38 @@ def create_sample_time_series(event, release=None):
 
     for _ in xrange(24 * 30):
         count = randint(100, 1000)
-        tsdb.incr_multi((
-            (tsdb.models.project, group.project.id),
-            (tsdb.models.group, group.id),
-        ), now, count, environment_id=environment.id)
-        tsdb.incr_multi((
-            (tsdb.models.organization_total_received, project.organization_id),
-            (tsdb.models.project_total_received, project.id),
-            (tsdb.models.key_total_received, key.id),
-        ), now, int(count * 1.1))
-        tsdb.incr_multi((
-            (tsdb.models.organization_total_rejected, project.organization_id),
-            (tsdb.models.project_total_rejected, project.id),
-            (tsdb.models.key_total_rejected, key.id),
-        ), now, int(count * 0.1))
+        tsdb.incr_multi(
+            ((tsdb.models.project, group.project.id), (tsdb.models.group, group.id)),
+            now,
+            count,
+            environment_id=environment.id,
+        )
+        tsdb.incr_multi(
+            (
+                (tsdb.models.organization_total_received, project.organization_id),
+                (tsdb.models.project_total_received, project.id),
+                (tsdb.models.key_total_received, key.id),
+            ),
+            now,
+            int(count * 1.1),
+        )
+        tsdb.incr_multi(
+            (
+                (tsdb.models.organization_total_rejected, project.organization_id),
+                (tsdb.models.project_total_rejected, project.id),
+                (tsdb.models.key_total_rejected, key.id),
+            ),
+            now,
+            int(count * 0.1),
+        )
 
         frequencies = [
-            (tsdb.models.frequent_issues_by_project, {
-                project.id: {
-                    group.id: count,
-                },
-            }),
-            (tsdb.models.frequent_environments_by_group, {
-                group.id: {
-                    environment.id: count,
-                },
-            })
+            (tsdb.models.frequent_issues_by_project, {project.id: {group.id: count}}),
+            (tsdb.models.frequent_environments_by_group, {group.id: {environment.id: count}}),
         ]
         if release:
             frequencies.append(
-                (tsdb.models.frequent_releases_by_group, {
-                    group.id: {
-                        grouprelease.id: count,
-                    },
-                })
+                (tsdb.models.frequent_releases_by_group, {group.id: {grouprelease.id: count}})
             )
 
         tsdb.record_frequency_multi(frequencies, now)
@@ -317,17 +325,14 @@ def main(num_events=1, extra_events=False):
     user = User.objects.filter(is_superuser=True)[0]
 
     dummy_user, _ = User.objects.get_or_create(
-        username='dummy@example.com',
-        defaults={
-            'email': 'dummy@example.com',
-        }
+        username="dummy@example.com", defaults={"email": "dummy@example.com"}
     )
-    dummy_user.set_password('dummy')
+    dummy_user.set_password("dummy")
     dummy_user.save()
 
     mocks = (
-        ('Massive Dynamic', ('Ludic Science',)),
-        ('Captain Planet', ('Earth', 'Fire', 'Wind', 'Water', 'Heart')),
+        ("Massive Dynamic", ("Ludic Science",)),
+        ("Captain Planet", ("Earth", "Fire", "Wind", "Water", "Heart")),
     )
 
     Broadcast.objects.create(
@@ -338,55 +343,38 @@ def main(num_events=1, extra_events=False):
 
     if settings.SENTRY_SINGLE_ORGANIZATION:
         org = Organization.get_default()
-        print('Mocking org {}'.format(org.name))  # NOQA
+        print ("Mocking org {}".format(org.name))  # NOQA
     else:
-        print('Mocking org {}'.format('Default'))  # NOQA
-        org, _ = Organization.objects.get_or_create(
-            slug='default',
-        )
+        print ("Mocking org {}".format("Default"))  # NOQA
+        org, _ = Organization.objects.get_or_create(slug="default")
 
     OrganizationMember.objects.get_or_create(
-        user=user,
-        organization=org,
-        role=roles.get_top_dog().id,
+        user=user, organization=org, role=roles.get_top_dog().id
     )
 
     dummy_member, _ = OrganizationMember.objects.get_or_create(
-        user=dummy_user,
-        organization=org,
-        defaults={
-            'role': roles.get_default().id,
-        }
+        user=dummy_user, organization=org, defaults={"role": roles.get_default().id}
     )
 
     for team_name, project_names in mocks:
-        print('> Mocking team {}'.format(team_name))  # NOQA
-        team, _ = Team.objects.get_or_create(
-            name=team_name,
-            defaults={
-                'organization': org,
-            },
-        )
+        print ("> Mocking team {}".format(team_name))  # NOQA
+        team, _ = Team.objects.get_or_create(name=team_name, defaults={"organization": org})
 
         for project_name in project_names:
-            print('  > Mocking project {}'.format(project_name))  # NOQA
+            print ("  > Mocking project {}".format(project_name))  # NOQA
             project, _ = Project.objects.get_or_create(
                 name=project_name,
                 defaults={
-                    'organization': org,
-                    'first_event': timezone.now(),
-                    'flags': Project.flags.has_releases,
-                }
+                    "organization": org,
+                    "first_event": timezone.now(),
+                    "flags": Project.flags.has_releases,
+                },
             )
             project.add_team(team)
             if not project.first_event:
-                project.update(
-                    first_event=project.date_added,
-                )
+                project.update(first_event=project.date_added)
             if not project.flags.has_releases:
-                project.update(
-                    flags=F('flags').bitor(Project.flags.has_releases),
-                )
+                project.update(flags=F("flags").bitor(Project.flags.has_releases))
 
             monitor, created = Monitor.objects.get_or_create(
                 name=next(MONITOR_NAMES),
@@ -394,16 +382,14 @@ def main(num_events=1, extra_events=False):
                 organization_id=org.id,
                 type=MonitorType.CRON_JOB,
                 defaults={
-                    'config': {
-                        'schedule': next(MONITOR_SCHEDULES),
-                    },
-                    'next_checkin': timezone.now() + timedelta(minutes=60),
-                    'last_checkin': timezone.now(),
-                }
+                    "config": {"schedule": next(MONITOR_SCHEDULES)},
+                    "next_checkin": timezone.now() + timedelta(minutes=60),
+                    "last_checkin": timezone.now(),
+                },
             )
             if not created:
-                if not (monitor.config or {}).get('schedule'):
-                    monitor.config = {'schedule': next(MONITOR_SCHEDULES)}
+                if not (monitor.config or {}).get("schedule"):
+                    monitor.config = {"schedule": next(MONITOR_SCHEDULES)}
                 monitor.update(
                     config=monitor.config,
                     status=MonitorStatus.OK if randint(0, 10) < 7 else MonitorStatus.ERROR,
@@ -414,14 +400,16 @@ def main(num_events=1, extra_events=False):
             MonitorCheckIn.objects.create(
                 project_id=monitor.project_id,
                 monitor=monitor,
-                status=CheckInStatus.OK if monitor.status == MonitorStatus.OK else CheckInStatus.ERROR,
+                status=CheckInStatus.OK
+                if monitor.status == MonitorStatus.OK
+                else CheckInStatus.ERROR,
             )
 
             with transaction.atomic():
                 has_release = Release.objects.filter(
                     version=sha1(uuid4().bytes).hexdigest(),
                     organization_id=project.organization_id,
-                    projects=project
+                    projects=project,
                 ).exists()
                 if not has_release:
                     release = Release.objects.filter(
@@ -431,7 +419,7 @@ def main(num_events=1, extra_events=False):
                     if not release:
                         release = Release.objects.create(
                             version=sha1(uuid4().bytes).hexdigest(),
-                            organization_id=project.organization_id
+                            organization_id=project.organization_id,
                         )
                     release.add_project(project)
 
@@ -443,23 +431,23 @@ def main(num_events=1, extra_events=False):
                 with transaction.atomic():
                     repo, _ = Repository.objects.get_or_create(
                         organization_id=org.id,
-                        provider='integrations:github',
-                        external_id='example/example',
+                        provider="integrations:github",
+                        external_id="example/example",
                         defaults={
-                            'name': 'Example Repo',
-                            'url': 'https://github.com/example/example',
-                        }
+                            "name": "Example Repo",
+                            "url": "https://github.com/example/example",
+                        },
                     )
             except IntegrityError:
                 # for users with legacy github plugin
                 # upgrade to the new integration
                 repo = Repository.objects.get(
                     organization_id=org.id,
-                    provider='github',
-                    external_id='example/example',
-                    name='Example Repo',
+                    provider="github",
+                    external_id="example/example",
+                    name="Example Repo",
                 )
-                repo.provider = 'integrations:github'
+                repo.provider = "integrations:github"
                 repo.save()
 
             authors = set()
@@ -467,46 +455,34 @@ def main(num_events=1, extra_events=False):
             for commit_index, raw_commit in enumerate(raw_commits):
                 author = CommitAuthor.objects.get_or_create(
                     organization_id=org.id,
-                    email=raw_commit['author'][1],
-                    defaults={'name': raw_commit['author'][0]}
+                    email=raw_commit["author"][1],
+                    defaults={"name": raw_commit["author"][0]},
                 )[0]
                 commit = Commit.objects.get_or_create(
                     organization_id=org.id,
                     repository_id=repo.id,
-                    key=raw_commit['key'],
-                    defaults={
-                        'author': author,
-                        'message': raw_commit['message'],
-                    },
+                    key=raw_commit["key"],
+                    defaults={"author": author, "message": raw_commit["message"]},
                 )[0]
                 authors.add(author)
 
-                for file in raw_commit['files']:
+                for file in raw_commit["files"]:
                     ReleaseFile.objects.get_or_create(
                         organization_id=project.organization_id,
                         release=release,
                         name=file[0],
                         file=File.objects.get_or_create(
-                            name=file[0],
-                            type='release.file',
-                            checksum='abcde' * 8,
-                            size=13043,
+                            name=file[0], type="release.file", checksum="abcde" * 8, size=13043
                         )[0],
-                        defaults={'organization_id': project.organization_id}
+                        defaults={"organization_id": project.organization_id},
                     )
 
                     CommitFileChange.objects.get_or_create(
-                        organization_id=org.id,
-                        commit=commit,
-                        filename=file[0],
-                        type=file[1],
+                        organization_id=org.id, commit=commit, filename=file[0], type=file[1]
                     )
 
                 ReleaseCommit.objects.get_or_create(
-                    organization_id=org.id,
-                    release=release,
-                    commit=commit,
-                    order=commit_index,
+                    organization_id=org.id, release=release, commit=commit, order=commit_index
                 )
 
             # create an unreleased commit
@@ -515,12 +491,12 @@ def main(num_events=1, extra_events=False):
                 repository_id=repo.id,
                 key=sha1(uuid4().hex).hexdigest(),
                 defaults={
-                    'author': CommitAuthor.objects.get_or_create(
-                        organization_id=org.id,
-                        email=user.email,
-                        defaults={'name': user.name}
+                    "author": CommitAuthor.objects.get_or_create(
+                        organization_id=org.id, email=user.email, defaults={"name": user.name}
                     )[0],
-                    'message': 'feat: Do something to {}\n{}'.format(random.choice(loremipsum.words) + '.js', make_sentence()),
+                    "message": "feat: Do something to {}\n{}".format(
+                        random.choice(loremipsum.words) + ".js", make_sentence()
+                    ),
                 },
             )[0]
 
@@ -529,13 +505,10 @@ def main(num_events=1, extra_events=False):
                 project=project,
                 ident=release.version,
                 user=user,
-                data={'version': release.version},
+                data={"version": release.version},
             )
 
-            environment = Environment.get_or_create(
-                project=project,
-                name=six.next(ENVIRONMENTS)
-            )
+            environment = Environment.get_or_create(project=project, name=six.next(ENVIRONMENTS))
 
             deploy = Deploy.objects.create(
                 organization_id=project.organization_id,
@@ -555,7 +528,7 @@ def main(num_events=1, extra_events=False):
                 project=project,
                 environment=environment,
                 release=release,
-                defaults={'last_deploy_id': deploy.id}
+                defaults={"last_deploy_id": deploy.id},
             )
 
             Activity.objects.create(
@@ -563,9 +536,9 @@ def main(num_events=1, extra_events=False):
                 project=project,
                 ident=release.version,
                 data={
-                    'version': release.version,
-                    'deploy_id': deploy.id,
-                    'environment': environment.name
+                    "version": release.version,
+                    "deploy_id": deploy.id,
+                    "environment": environment.name,
                 },
                 datetime=deploy.date_finished,
             )
@@ -581,7 +554,7 @@ def main(num_events=1, extra_events=False):
                         release=release.version,
                         level=six.next(LEVELS),
                         environment=six.next(ENVIRONMENTS),
-                        message='This is a mostly useless example %s exception' % platform,
+                        message="This is a mostly useless example %s exception" % platform,
                         checksum=md5_text(platform + six.text_type(_)).hexdigest(),
                         user=generate_user(),
                     )
@@ -589,7 +562,7 @@ def main(num_events=1, extra_events=False):
             for _ in range(num_events):
                 event1 = create_sample_event(
                     project=project,
-                    platform='python',
+                    platform="python",
                     release=release.version,
                     environment=six.next(ENVIRONMENTS),
                     user=generate_user(),
@@ -598,32 +571,29 @@ def main(num_events=1, extra_events=False):
                 EventAttachment.objects.create(
                     project_id=project.id,
                     event_id=event1.event_id,
-                    name='example-logfile.txt',
+                    name="example-logfile.txt",
                     file=File.objects.get_or_create(
-                        name='example-logfile.txt',
-                        type='text/plain',
-                        checksum='abcde' * 8,
+                        name="example-logfile.txt",
+                        type="text/plain",
+                        checksum="abcde" * 8,
                         size=13043,
                     )[0],
                 )
 
                 event2 = create_sample_event(
                     project=project,
-                    platform='javascript',
+                    platform="javascript",
                     release=release.version,
                     environment=six.next(ENVIRONMENTS),
-                    sdk={
-                        'name': 'raven-js',
-                        'version': '2.1.0',
-                    },
+                    sdk={"name": "raven-js", "version": "2.1.0"},
                     user=generate_user(),
                 )
 
-                event3 = create_sample_event(project, 'java')
+                event3 = create_sample_event(project, "java")
 
                 event4 = create_sample_event(
                     project=project,
-                    platform='ruby',
+                    platform="ruby",
                     release=release.version,
                     environment=six.next(ENVIRONMENTS),
                     user=generate_user(),
@@ -631,7 +601,7 @@ def main(num_events=1, extra_events=False):
 
                 event5 = create_sample_event(
                     project=project,
-                    platform='cocoa',
+                    platform="cocoa",
                     release=release.version,
                     environment=six.next(ENVIRONMENTS),
                     user=generate_user(),
@@ -639,7 +609,7 @@ def main(num_events=1, extra_events=False):
 
                 create_sample_event(
                     project=project,
-                    platform='php',
+                    platform="php",
                     release=release.version,
                     environment=six.next(ENVIRONMENTS),
                     message=LONG_MESSAGE,
@@ -648,8 +618,8 @@ def main(num_events=1, extra_events=False):
 
                 create_sample_event(
                     project=project,
-                    platform='cocoa',
-                    sample_name='react-native',
+                    platform="cocoa",
+                    sample_name="react-native",
                     release=release.version,
                     environment=six.next(ENVIRONMENTS),
                     user=generate_user(),
@@ -657,7 +627,7 @@ def main(num_events=1, extra_events=False):
 
                 create_sample_event(
                     project=project,
-                    platform='pii',
+                    platform="pii",
                     release=release.version,
                     environment=six.next(ENVIRONMENTS),
                     user=generate_user(),
@@ -668,32 +638,26 @@ def main(num_events=1, extra_events=False):
                     repository_id=repo.id,
                     key=sha1(uuid4().hex).hexdigest(),
                     defaults={
-                        'author': CommitAuthor.objects.get_or_create(
-                            organization_id=org.id,
-                            email=user.email,
-                            defaults={'name': user.name}
+                        "author": CommitAuthor.objects.get_or_create(
+                            organization_id=org.id, email=user.email, defaults={"name": user.name}
                         )[0],
-                        'message': 'Ooops!\nFixes {}'.format(event5.group.qualified_short_id),
+                        "message": "Ooops!\nFixes {}".format(event5.group.qualified_short_id),
                     },
                 )[0]
 
-            create_sample_event(
-                project=project,
-                environment=six.next(ENVIRONMENTS),
-                platform='csp',
-            )
+            create_sample_event(project=project, environment=six.next(ENVIRONMENTS), platform="csp")
 
             if event3:
                 UserReport.objects.create(
                     project=project,
                     event_id=event3.event_id,
                     group=event3.group,
-                    name='Jane Doe',
-                    email='jane@example.com',
+                    name="Jane Doe",
+                    email="jane@example.com",
                     comments=make_sentence(),
                 )
 
-            print('    > Loading time series data'.format(project_name))  # NOQA
+            print ("    > Loading time series data".format(project_name))  # NOQA
 
             create_sample_time_series(event1, release=release)
             create_sample_time_series(event2, release=release)
@@ -701,44 +665,38 @@ def main(num_events=1, extra_events=False):
             create_sample_time_series(event4, release=release)
             create_sample_time_series(event5, release=release)
 
-            if hasattr(buffer, 'process_pending'):
-                print('    > Processing pending buffers')  # NOQA
+            if hasattr(buffer, "process_pending"):
+                print ("    > Processing pending buffers")  # NOQA
                 buffer.process_pending()
 
             mocks_loaded.send(project=project, sender=__name__)
 
-        OrganizationAccessRequest.objects.create_or_update(
-            member=dummy_member,
-            team=team,
-        )
+        OrganizationAccessRequest.objects.create_or_update(member=dummy_member, team=team)
 
     Activity.objects.create(
         type=Activity.RELEASE,
         project=project,
-        ident='4f38b65c62c4565aa94bba391ff8946922a8eed4',
+        ident="4f38b65c62c4565aa94bba391ff8946922a8eed4",
         user=user,
-        data={'version': '4f38b65c62c4565aa94bba391ff8946922a8eed4'},
+        data={"version": "4f38b65c62c4565aa94bba391ff8946922a8eed4"},
     )
 
     create_system_time_series()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     settings.CELERY_ALWAYS_EAGER = True
 
     from optparse import OptionParser
 
     parser = OptionParser()
-    parser.add_option('--events', dest='num_events', default=1, type=int)
-    parser.add_option('--extra-events', dest='extra_events', default=False, action='store_true')
+    parser.add_option("--events", dest="num_events", default=1, type=int)
+    parser.add_option("--extra-events", dest="extra_events", default=False, action="store_true")
 
     (options, args) = parser.parse_args()
 
     try:
-        main(
-            num_events=options.num_events,
-            extra_events=options.extra_events,
-        )
+        main(num_events=options.num_events, extra_events=options.extra_events)
     except Exception:
         # Avoid reporting any issues recursively back into Sentry
         import traceback

--- a/bin/merge-catalogs
+++ b/bin/merge-catalogs
@@ -6,25 +6,23 @@ import click
 from babel.messages.pofile import read_po, write_po
 
 
-JS_EXTENSIONS = ('.js', '.jsx')
+JS_EXTENSIONS = (".js", ".jsx")
 
 
 def merge_message(msg, frontend_msg):
     non_js_locations = [
-        (fn, lineno) for fn, lineno in msg.locations
-        if not fn.endswith(JS_EXTENSIONS)
+        (fn, lineno) for fn, lineno in msg.locations if not fn.endswith(JS_EXTENSIONS)
     ]
-    if (not msg.user_comments or not non_js_locations) \
-       and frontend_msg.user_comments:
+    if (not msg.user_comments or not non_js_locations) and frontend_msg.user_comments:
         msg.user_comments = frontend_msg.usr_comments
     msg.locations = non_js_locations + frontend_msg.locations
 
 
 @click.command()
-@click.argument('locale')
+@click.argument("locale")
 def cli(locale):
-    catalog_file = 'src/sentry/locale/%s/LC_MESSAGES/django.po' % locale
-    frontend_file = 'build/javascript.po'
+    catalog_file = "src/sentry/locale/%s/LC_MESSAGES/django.po" % locale
+    frontend_file = "build/javascript.po"
     if not os.path.isfile(frontend_file):
         return
 
@@ -34,7 +32,7 @@ def cli(locale):
         frontend = read_po(f, locale)
 
     for frontend_msg in frontend:
-        if frontend_msg.id == '':
+        if frontend_msg.id == "":
             continue
         msg = catalog.get(frontend_msg.id)
 
@@ -48,9 +46,9 @@ def cli(locale):
             merge_message(msg, frontend_msg)
         catalog[msg.id] = msg
 
-    with open(catalog_file, 'w') as f:
+    with open(catalog_file, "w") as f:
         write_po(f, catalog)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/bin/mock-event
+++ b/bin/mock-event
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # isort:skip_file
 from sentry.runner import configure
+
 configure()
 
 import sys
@@ -14,38 +15,26 @@ from sentry.utils.samples import create_sample_event
 import argparse
 
 
-def main(
-    project,
-    sample_type,
-):
-    org_slug, project_slug = project.split('/', 1)
+def main(project, sample_type):
+    org_slug, project_slug = project.split("/", 1)
 
-    project = Project.objects.get(
-        organization__slug=org_slug,
-        slug=project_slug,
-    )
+    project = Project.objects.get(organization__slug=org_slug, slug=project_slug)
 
-    event = create_sample_event(
-        project=project,
-        platform=sample_type,
-    )
+    event = create_sample_event(project=project, platform=sample_type)
     if not event:
-        sys.stderr.write('ERR: No event created. Was the sample type valid?\n')
+        sys.stderr.write("ERR: No event created. Was the sample type valid?\n")
         sys.exit(1)
 
     if not project.first_event:
         project.update(first_event=timezone.now())
 
-    print('> Created event {}'.format(event.event_id))
+    print ("> Created event {}".format(event.event_id))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('project')
-    parser.add_argument('sample_type')
+    parser.add_argument("project")
+    parser.add_argument("sample_type")
     args = parser.parse_args()
 
-    main(
-        project=args.project,
-        sample_type=args.sample_type,
-    )
+    main(project=args.project, sample_type=args.sample_type)

--- a/bin/mock-user
+++ b/bin/mock-user
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 # isort:skip_file
 from sentry.runner import configure
+
 configure()
 
 import argparse
 
 
-def main(
-    username,
-    newsletter_consent_prompt=None,
-):
+def main(username, newsletter_consent_prompt=None):
     from sentry.models import User
 
     user = User.objects.get(username__iexact=username)
@@ -19,14 +17,15 @@ def main(
         user.save()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('username', default=None, nargs='?')
-    parser.add_argument('--newsletter-consent-prompt', dest='newsletter_consent_prompt', action='store_true')
-    parser.add_argument('--no-newsletter-consent-prompt', dest='newsletter_consent_prompt', action='store_false')
+    parser.add_argument("username", default=None, nargs="?")
+    parser.add_argument(
+        "--newsletter-consent-prompt", dest="newsletter_consent_prompt", action="store_true"
+    )
+    parser.add_argument(
+        "--no-newsletter-consent-prompt", dest="newsletter_consent_prompt", action="store_false"
+    )
     args = parser.parse_args()
 
-    main(
-        username=args.username,
-        newsletter_consent_prompt=args.newsletter_consent_prompt,
-    )
+    main(username=args.username, newsletter_consent_prompt=args.newsletter_consent_prompt)

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -6,26 +6,21 @@ import sys
 
 from glob import glob
 
-text_type = type(u'')
+text_type = type(u"")
 
 # git usurbs your bin path for hooks and will always run system python
-if 'VIRTUAL_ENV' in os.environ:
-    site_packages = glob(
-        '%s/lib/*/site-packages' % os.environ['VIRTUAL_ENV'])[0]
+if "VIRTUAL_ENV" in os.environ:
+    site_packages = glob("%s/lib/*/site-packages" % os.environ["VIRTUAL_ENV"])[0]
     sys.path.insert(0, site_packages)
 
 
 def main():
     from sentry.lint.engine import get_modified_files, run
 
-    files_modified = [
-        text_type(f)
-        for f in get_modified_files(os.getcwd())
-        if os.path.exists(f)
-    ]
+    files_modified = [text_type(f) for f in get_modified_files(os.getcwd()) if os.path.exists(f)]
 
     return run(files_modified, test=True)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/src/sentry/analytics/events/sentry_app_schema_validation_error.py
+++ b/src/sentry/analytics/events/sentry_app_schema_validation_error.py
@@ -4,15 +4,15 @@ from sentry import analytics
 
 
 class SentryAppSchemaValidationError(analytics.Event):
-    type = 'sentry_app.schema_validation_error'
+    type = "sentry_app.schema_validation_error"
 
     attributes = (
-        analytics.Attribute('schema'),
-        analytics.Attribute('user_id'),
-        analytics.Attribute('sentry_app_id', required=False),
-        analytics.Attribute('sentry_app_name'),
-        analytics.Attribute('organization_id'),
-        analytics.Attribute('error_message'),
+        analytics.Attribute("schema"),
+        analytics.Attribute("user_id"),
+        analytics.Attribute("sentry_app_id", required=False),
+        analytics.Attribute("sentry_app_name"),
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("error_message"),
     )
 
 

--- a/src/sentry/api/endpoints/organization_events_distribution.py
+++ b/src/sentry/api/endpoints/organization_events_distribution.py
@@ -11,67 +11,68 @@ from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT
 
 # If the requested key is project.name, we get the distribution by project.id
 # from Snuba and convert those values back to names
-PROJECT_KEY = 'project.name'
+PROJECT_KEY = "project.name"
 
 
 class OrganizationEventsDistributionEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
-        if not features.has('organizations:events-v2', organization, actor=request.user):
+        if not features.has("organizations:events-v2", organization, actor=request.user):
             return Response(status=404)
         try:
             params = self.get_filter_params(request, organization)
             snuba_args = self.get_snuba_query_args(request, organization, params)
         except OrganizationEventsError as exc:
-            return Response({'detail': exc.message}, status=400)
+            return Response({"detail": exc.message}, status=400)
         except NoProjects:
-            return Response({'detail': 'A valid project must be included.'}, status=400)
+            return Response({"detail": "A valid project must be included."}, status=400)
 
         try:
             key = self._validate_key(request)
             self._validate_project_ids(request, organization, snuba_args)
         except OrganizationEventsError as error:
-            return Response({'detail': six.text_type(error)}, status=400)
+            return Response({"detail": six.text_type(error)}, status=400)
 
         if key == PROJECT_KEY:
-            colname = 'project_id'
-            conditions = snuba_args['conditions']
+            colname = "project_id"
+            conditions = snuba_args["conditions"]
         else:
             colname = get_snuba_column_name(key)
-            conditions = snuba_args['conditions'] + [[colname, 'IS NOT NULL', None]]
+            conditions = snuba_args["conditions"] + [[colname, "IS NOT NULL", None]]
 
         top_values = raw_query(
-            start=snuba_args['start'],
-            end=snuba_args['end'],
+            start=snuba_args["start"],
+            end=snuba_args["end"],
             conditions=conditions,
-            filter_keys=snuba_args['filter_keys'],
+            filter_keys=snuba_args["filter_keys"],
             groupby=[colname],
-            aggregations=[('count()', None, 'count')],
-            orderby='-count',
+            aggregations=[("count()", None, "count")],
+            orderby="-count",
             limit=TOP_VALUES_DEFAULT_LIMIT,
-            referrer='api.organization-events-distribution',
-        )['data']
+            referrer="api.organization-events-distribution",
+        )["data"]
 
         projects = {p.id: p.slug for p in self.get_projects(request, organization)}
 
         if key == PROJECT_KEY:
             resp = {
-                'key': PROJECT_KEY,
-                'topValues': [
+                "key": PROJECT_KEY,
+                "topValues": [
                     {
-                        'value': projects[v['project_id']],
-                        'name': projects[v['project_id']],
-                        'count': v['count'],
-                    } for v in top_values
-                ]
+                        "value": projects[v["project_id"]],
+                        "name": projects[v["project_id"]],
+                        "count": v["count"],
+                    }
+                    for v in top_values
+                ],
             }
         else:
             resp = {
-                'key': key,
-                'topValues': [
+                "key": key,
+                "topValues": [
                     {
-                        'value': v[colname],
-                        'name': tagstore.get_tag_value_label(colname, v[colname]),
-                        'count': v['count'],
+                        "value": v[colname],
+                        "name": tagstore.get_tag_value_label(colname, v[colname]),
+                        "count": v["count"],
                     }
                     for v in top_values
                 ],
@@ -80,25 +81,24 @@ class OrganizationEventsDistributionEndpoint(OrganizationEventsEndpointBase):
         return Response(resp)
 
     def _validate_key(self, request):
-        key = request.GET.get('key')
+        key = request.GET.get("key")
 
         if not key:
-            raise OrganizationEventsError('Tag key must be specified.')
+            raise OrganizationEventsError("Tag key must be specified.")
 
         if not tagstore.is_valid_key(key):
-            raise OrganizationEventsError('Tag key %s is not valid.' % key)
+            raise OrganizationEventsError("Tag key %s is not valid." % key)
 
         return key
 
     def _validate_project_ids(self, request, organization, snuba_args):
-        project_ids = snuba_args['filter_keys']['project_id']
+        project_ids = snuba_args["filter_keys"]["project_id"]
 
         has_global_views = features.has(
-            'organizations:global-views',
-            organization,
-            actor=request.user)
+            "organizations:global-views", organization, actor=request.user
+        )
 
         if not has_global_views and len(project_ids) > 1:
-            raise OrganizationEventsError('You cannot view events from multiple projects.')
+            raise OrganizationEventsError("You cannot view events from multiple projects.")
 
         return project_ids

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -847,8 +847,7 @@ SENTRY_FEATURES = {
     # Enable inviting members to organizations.
     "organizations:invite-members": True,
     # Enable org-wide saved searches and user pinned search
-    'organizations:org-saved-searches': False,
-
+    "organizations:org-saved-searches": False,
     # Enable the relay functionality, for use with sentry semaphore. See
     # https://github.com/getsentry/semaphore.
     "organizations:relay": False,

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -8,9 +8,9 @@ from sentry.identity.oauth2 import OAuth2Provider
 def get_user_info(access_token):
     session = http.build_session()
     resp = session.get(
-        'https://api.github.com/user',
-        params={'access_token': access_token},
-        headers={'Accept': 'application/vnd.github.machine-man-preview+json'}
+        "https://api.github.com/user",
+        params={"access_token": access_token},
+        headers={"Accept": "application/vnd.github.machine-man-preview+json"},
     )
     resp.raise_for_status()
     resp = resp.json()
@@ -25,32 +25,32 @@ def get_user_info(access_token):
 
 
 class GitHubIdentityProvider(OAuth2Provider):
-    key = 'github'
-    name = 'GitHub'
+    key = "github"
+    name = "GitHub"
 
-    oauth_access_token_url = 'https://github.com/login/oauth/access_token'
-    oauth_authorize_url = 'https://github.com/login/oauth/authorize'
+    oauth_access_token_url = "https://github.com/login/oauth/access_token"
+    oauth_authorize_url = "https://github.com/login/oauth/authorize"
 
     oauth_scopes = ()
 
     def get_oauth_client_id(self):
-        return options.get('github-app.client-id')
+        return options.get("github-app.client-id")
 
     def get_oauth_client_secret(self):
-        return options.get('github-app.client-secret')
+        return options.get("github-app.client-secret")
 
     def build_identity(self, data):
-        data = data['data']
-        user = get_user_info(data['access_token'])
+        data = data["data"]
+        user = get_user_info(data["access_token"])
 
         return {
-            'type': 'github',
-            'id': user['id'],
-            'email': user['email'],
-            'email_verified': bool(user['email']),
-            'login': user['login'],
-            'name': user['name'],
-            'company': user['company'],
-            'scopes': [],  # GitHub apps do not have user scopes
-            'data': self.get_oauth_data(data),
+            "type": "github",
+            "id": user["id"],
+            "email": user["email"],
+            "email_verified": bool(user["email"]),
+            "login": user["login"],
+            "name": user["name"],
+            "company": user["company"],
+            "scopes": [],  # GitHub apps do not have user scopes
+            "data": self.get_oauth_data(data),
         }

--- a/src/sentry/identity/github_enterprise/provider.py
+++ b/src/sentry/identity/github_enterprise/provider.py
@@ -7,10 +7,10 @@ from sentry.identity.oauth2 import OAuth2Provider
 def get_user_info(url, access_token):
     session = http.build_session()
     resp = session.get(
-        u'https://{}/api/v3/user'.format(url),
-        params={'access_token': access_token},
-        headers={'Accept': 'application/vnd.github.machine-man-preview+json'},
-        verify=False
+        u"https://{}/api/v3/user".format(url),
+        params={"access_token": access_token},
+        headers={"Accept": "application/vnd.github.machine-man-preview+json"},
+        verify=False,
     )
     resp.raise_for_status()
     resp = resp.json()
@@ -19,20 +19,20 @@ def get_user_info(url, access_token):
 
 
 class GitHubEnterpriseIdentityProvider(OAuth2Provider):
-    key = 'github_enterprise'
-    name = 'GitHub Enterprise'
+    key = "github_enterprise"
+    name = "GitHub Enterprise"
 
     oauth_scopes = ()
 
     def build_identity(self, data):
-        data = data['data']
+        data = data["data"]
         # todo(meredith): this doesn't work yet, need to pass in the base url
-        user = get_user_info(data['access_token'])
+        user = get_user_info(data["access_token"])
 
         return {
-            'type': 'github_enterprise',
-            'id': user['id'],
-            'email': user['email'],
-            'scopes': [],  # GitHub apps do not have user scopes
-            'data': self.get_oauth_data(data),
+            "type": "github_enterprise",
+            "id": user["id"],
+            "email": user["email"],
+            "scopes": [],  # GitHub apps do not have user scopes
+            "data": self.get_oauth_data(data),
         }

--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -8,11 +8,11 @@ from sentry.http import safe_urlopen, safe_urlread
 from sentry.identity.oauth2 import OAuth2Provider
 from sentry.utils import json
 
-logger = logging.getLogger('sentry.integration.gitlab')
+logger = logging.getLogger("sentry.integration.gitlab")
 
 
 def get_oauth_data(payload):
-    data = {'access_token': payload['access_token']}
+    data = {"access_token": payload["access_token"]}
 
     # https://docs.gitlab.com/ee/api/oauth2.html#2-requesting-access-token
     # doesn't seem to be correct, format we actually get:
@@ -23,12 +23,12 @@ def get_oauth_data(payload):
     #   "created_at": 1536798907,
     #   "scope": "api"
     # }
-    if 'refresh_token' in payload:
-        data['refresh_token'] = payload['refresh_token']
-    if 'token_type' in payload:
-        data['token_type'] = payload['token_type']
-    if 'created_at' in payload:
-        data['created_at'] = int(payload['created_at'])
+    if "refresh_token" in payload:
+        data["refresh_token"] = payload["refresh_token"]
+    if "token_type" in payload:
+        data["token_type"] = payload["token_type"]
+    if "created_at" in payload:
+        data["created_at"] = int(payload["created_at"])
 
     return data
 
@@ -36,81 +36,72 @@ def get_oauth_data(payload):
 def get_user_info(access_token, installation_data):
     session = http.build_session()
     resp = session.get(
-        u'{}/api/v4/user'.format(installation_data['url']),
-        headers={
-            'Accept': 'application/json',
-            'Authorization': 'Bearer %s' % access_token,
-        },
-        verify=installation_data['verify_ssl']
+        u"{}/api/v4/user".format(installation_data["url"]),
+        headers={"Accept": "application/json", "Authorization": "Bearer %s" % access_token},
+        verify=installation_data["verify_ssl"],
     )
     try:
         resp.raise_for_status()
     except Exception as e:
-        logger.info('gitlab.identity.get-user-info-failure',
-                    extra={
-                        'url': installation_data['url'],
-                        'verify_ssl': installation_data['verify_ssl'],
-                        'client_id': installation_data['client_id'],
-                        'error_status': e.code,
-                        'error_message': e.message,
-                    }
-                    )
+        logger.info(
+            "gitlab.identity.get-user-info-failure",
+            extra={
+                "url": installation_data["url"],
+                "verify_ssl": installation_data["verify_ssl"],
+                "client_id": installation_data["client_id"],
+                "error_status": e.code,
+                "error_message": e.message,
+            },
+        )
         raise e
     return resp.json()
 
 
 class GitlabIdentityProvider(OAuth2Provider):
-    key = 'gitlab'
-    name = 'Gitlab'
+    key = "gitlab"
+    name = "Gitlab"
 
-    oauth_scopes = ('api', )
+    oauth_scopes = ("api",)
 
     def build_identity(self, data):
-        data = data['data']
+        data = data["data"]
 
         return {
-            'type': 'gitlab',
-            'id': data['user']['id'],
-            'email': data['user']['email'],
-            'scopes': sorted(data['scope'].split(',')),
-            'data': self.get_oauth_data(data),
+            "type": "gitlab",
+            "id": data["user"]["id"],
+            "email": data["user"]["email"],
+            "scopes": sorted(data["scope"].split(",")),
+            "data": self.get_oauth_data(data),
         }
 
     def get_refresh_token_params(self, refresh_token, *args, **kwargs):
-        return {
-            'grant_type': 'refresh_token',
-            'refresh_token': refresh_token,
-        }
+        return {"grant_type": "refresh_token", "refresh_token": refresh_token}
 
     def refresh_identity(self, identity, *args, **kwargs):
-        refresh_token = identity.data.get('refresh_token')
-        refresh_token_url = kwargs.get('refresh_token_url')
+        refresh_token = identity.data.get("refresh_token")
+        refresh_token_url = kwargs.get("refresh_token_url")
 
         if not refresh_token:
-            raise IdentityNotValid('Missing refresh token')
+            raise IdentityNotValid("Missing refresh token")
 
         if not refresh_token_url:
-            raise IdentityNotValid('Missing refresh token url')
+            raise IdentityNotValid("Missing refresh token url")
 
         data = self.get_refresh_token_params(refresh_token, *args, **kwargs)
 
-        req = safe_urlopen(
-            url=refresh_token_url,
-            headers={},
-            data=data,
-        )
+        req = safe_urlopen(url=refresh_token_url, headers={}, data=data)
 
         try:
             body = safe_urlread(req)
             payload = json.loads(body)
         except Exception as e:
             self.logger(
-                'gitlab.refresh-identity-failure',
+                "gitlab.refresh-identity-failure",
                 extra={
-                    'identity_id': identity.id,
-                    'error_status': e.code,
-                    'error_message': e.message,
-                }
+                    "identity_id": identity.id,
+                    "error_status": e.code,
+                    "error_message": e.message,
+                },
             )
             payload = {}
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -9,8 +9,8 @@ from sentry.integrations.client import ApiClient
 class GitHubClientMixin(ApiClient):
     allow_redirects = True
 
-    base_url = 'https://api.github.com'
-    integration_name = 'github'
+    base_url = "https://api.github.com"
+    integration_name = "github"
 
     def get_jwt(self):
         return get_jwt()
@@ -19,79 +19,61 @@ class GitHubClientMixin(ApiClient):
         # return api request that fetches last ~30 commits
         # see https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
         # using end_sha as parameter
-        return self.get(
-            u'/repos/{}/commits'.format(
-                repo,
-            ),
-            params={'sha': end_sha},
-        )
+        return self.get(u"/repos/{}/commits".format(repo), params={"sha": end_sha})
 
     def compare_commits(self, repo, start_sha, end_sha):
         # see https://developer.github.com/v3/repos/commits/#compare-two-commits
         # where start sha is oldest and end is most recent
-        return self.get(u'/repos/{}/compare/{}...{}'.format(
-            repo,
-            start_sha,
-            end_sha,
-        ))
+        return self.get(u"/repos/{}/compare/{}...{}".format(repo, start_sha, end_sha))
 
     def repo_hooks(self, repo):
-        return self.get(u'/repos/{}/hooks'.format(repo))
+        return self.get(u"/repos/{}/hooks".format(repo))
 
     def get_commits(self, repo):
-        return self.get(u'/repos/{}/commits'.format(repo))
+        return self.get(u"/repos/{}/commits".format(repo))
 
     def get_commit(self, repo, sha):
-        return self.get(u'/repos/{}/commits/{}'.format(repo, sha))
+        return self.get(u"/repos/{}/commits/{}".format(repo, sha))
 
     def get_repo(self, repo):
-        return self.get(u'/repos/{}'.format(repo))
+        return self.get(u"/repos/{}".format(repo))
 
     def get_repositories(self):
-        repositories = self.get(
-            '/installation/repositories',
-            params={'per_page': 100},
-        )
-        return repositories['repositories']
+        repositories = self.get("/installation/repositories", params={"per_page": 100})
+        return repositories["repositories"]
 
     def search_repositories(self, query):
-        return self.get(
-            '/search/repositories',
-            params={'q': query},
-        )
+        return self.get("/search/repositories", params={"q": query})
 
     def get_assignees(self, repo):
-        return self.get(u'/repos/{}/assignees'.format(repo))
+        return self.get(u"/repos/{}/assignees".format(repo))
 
     def get_issues(self, repo):
-        return self.get(u'/repos/{}/issues'.format(repo))
+        return self.get(u"/repos/{}/issues".format(repo))
 
     def search_issues(self, query):
-        return self.get(
-            '/search/issues',
-            params={'q': query},
-        )
+        return self.get("/search/issues", params={"q": query})
 
     def get_issue(self, repo, number):
-        return self.get(u'/repos/{}/issues/{}'.format(repo, number))
+        return self.get(u"/repos/{}/issues/{}".format(repo, number))
 
     def create_issue(self, repo, data):
-        endpoint = u'/repos/{}/issues'.format(repo)
+        endpoint = u"/repos/{}/issues".format(repo)
         return self.post(endpoint, data=data)
 
     def create_comment(self, repo, issue_id, data):
-        endpoint = u'/repos/{}/issues/{}/comments'.format(repo, issue_id)
+        endpoint = u"/repos/{}/issues/{}/comments".format(repo, issue_id)
         return self.post(endpoint, data=data)
 
     def get_user(self, gh_username):
-        return self.get(u'/users/{}'.format(gh_username))
+        return self.get(u"/users/{}".format(gh_username))
 
     def request(self, method, path, headers=None, data=None, params=None):
         if headers is None:
             headers = {
-                'Authorization': 'token %s' % self.get_token(),
+                "Authorization": "token %s" % self.get_token(),
                 # TODO(jess): remove this whenever it's out of preview
-                'Accept': 'application/vnd.github.machine-man-preview+json',
+                "Accept": "application/vnd.github.machine-man-preview+json",
             }
         return self._request(method, path, headers=headers, data=data, params=params)
 
@@ -101,43 +83,36 @@ class GitHubClientMixin(ApiClient):
         Should the token have expried, a new token will be generated and
         automatically presisted into the integration.
         """
-        token = self.integration.metadata.get('access_token')
-        expires_at = self.integration.metadata.get('expires_at')
+        token = self.integration.metadata.get("access_token")
+        expires_at = self.integration.metadata.get("expires_at")
 
         if expires_at is not None:
-            expires_at = datetime.strptime(expires_at, '%Y-%m-%dT%H:%M:%S')
+            expires_at = datetime.strptime(expires_at, "%Y-%m-%dT%H:%M:%S")
 
         if not token or expires_at < datetime.utcnow() or force_refresh:
             res = self.create_token()
-            token = res['token']
-            expires_at = datetime.strptime(
-                res['expires_at'],
-                '%Y-%m-%dT%H:%M:%SZ',
-            )
+            token = res["token"]
+            expires_at = datetime.strptime(res["expires_at"], "%Y-%m-%dT%H:%M:%SZ")
 
-            self.integration.metadata.update({
-                'access_token': token,
-                'expires_at': expires_at.isoformat(),
-            })
+            self.integration.metadata.update(
+                {"access_token": token, "expires_at": expires_at.isoformat()}
+            )
             self.integration.save()
 
         return token
 
     def create_token(self):
         return self.post(
-            u'/installations/{}/access_tokens'.format(
-                self.integration.external_id,
-            ),
+            u"/installations/{}/access_tokens".format(self.integration.external_id),
             headers={
-                'Authorization': 'Bearer %s' % self.get_jwt(),
+                "Authorization": "Bearer %s" % self.get_jwt(),
                 # TODO(jess): remove this whenever it's out of preview
-                'Accept': 'application/vnd.github.machine-man-preview+json',
+                "Accept": "application/vnd.github.machine-man-preview+json",
             },
         )
 
 
 class GitHubAppsClient(GitHubClientMixin):
-
     def __init__(self, integration):
         self.integration = integration
         super(GitHubAppsClient, self).__init__()

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -6,8 +6,11 @@ from sentry import http, options
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.identity.github import get_user_info
 from sentry.integrations import (
-    IntegrationInstallation, IntegrationFeatures, IntegrationProvider,
-    IntegrationMetadata, FeatureDescription,
+    IntegrationInstallation,
+    IntegrationFeatures,
+    IntegrationProvider,
+    IntegrationMetadata,
+    FeatureDescription,
 )
 from sentry.integrations.exceptions import ApiError
 from sentry.integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
@@ -50,44 +53,41 @@ FEATURES = [
 ]
 
 disable_dialog = {
-    'actionText': 'Visit GitHub',
-    'body': 'Before deleting this integration, you must uninstall this'
-            ' integration from GitHub. After uninstalling, your integration will'
-            ' be disabled at which point you can choose to delete this'
-            ' integration.',
+    "actionText": "Visit GitHub",
+    "body": "Before deleting this integration, you must uninstall this"
+    " integration from GitHub. After uninstalling, your integration will"
+    " be disabled at which point you can choose to delete this"
+    " integration.",
 }
 
 removal_dialog = {
-    'actionText': 'Delete',
-    'body': 'Deleting this integration will delete all associated repositories'
-            ' and commit data. This action cannot be undone. Are you sure you'
-            ' want to delete your integration?',
+    "actionText": "Delete",
+    "body": "Deleting this integration will delete all associated repositories"
+    " and commit data. This action cannot be undone. Are you sure you"
+    " want to delete your integration?",
 }
 
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
     features=FEATURES,
-    author='The Sentry Team',
-    noun=_('Installation'),
-    issue_url='https://github.com/getsentry/sentry/issues/new?title=GitHub%20Integration:%20&labels=Component%3A%20Integrations',
-    source_url='https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/github',
-    aspects={
-        'disable_dialog': disable_dialog,
-        'removal_dialog': removal_dialog,
-    },
+    author="The Sentry Team",
+    noun=_("Installation"),
+    issue_url="https://github.com/getsentry/sentry/issues/new?title=GitHub%20Integration:%20&labels=Component%3A%20Integrations",
+    source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/github",
+    aspects={"disable_dialog": disable_dialog, "removal_dialog": removal_dialog},
 )
 
 API_ERRORS = {
-    404: 'GitHub returned a 404 Not Found error. If this repository exists, ensure'
-         ' that your installation has permission to access this repository'
-         ' (https://github.com/settings/installations).',
+    404: "GitHub returned a 404 Not Found error. If this repository exists, ensure"
+    " that your installation has permission to access this repository"
+    " (https://github.com/settings/installations).",
     401: ERR_UNAUTHORIZED,
 }
 
 
 def build_repository_query(metadata, name, query):
-    account_type = 'user' if metadata['account_type'] == 'User' else 'org'
-    return (u'%s:%s %s' % (account_type, name, query)).encode('utf-8')
+    account_type = "user" if metadata["account_type"] == "User" else "org"
+    return (u"%s:%s %s" % (account_type, name, query)).encode("utf-8")
 
 
 class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMixin):
@@ -98,34 +98,29 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
 
     def get_repositories(self, query=None):
         if not query:
-            return [{
-                'name': i['name'],
-                'identifier': i['full_name']
-            } for i in self.get_client().get_repositories()]
+            return [
+                {"name": i["name"], "identifier": i["full_name"]}
+                for i in self.get_client().get_repositories()
+            ]
 
         full_query = build_repository_query(self.model.metadata, self.model.name, query)
         response = self.get_client().search_repositories(full_query)
-        return [{
-            'name': i['name'],
-            'identifier': i['full_name']
-        } for i in response.get('items', [])]
+        return [
+            {"name": i["name"], "identifier": i["full_name"]} for i in response.get("items", [])
+        ]
 
     def search_issues(self, query):
         return self.get_client().search_issues(query)
 
     def get_unmigratable_repositories(self):
         accessible_repos = self.get_repositories()
-        accessible_repo_names = [r['identifier'] for r in accessible_repos]
+        accessible_repo_names = [r["identifier"] for r in accessible_repos]
 
         existing_repos = Repository.objects.filter(
-            organization_id=self.organization_id,
-            provider='github',
+            organization_id=self.organization_id, provider="github"
         )
 
-        return filter(
-            lambda repo: repo.name not in accessible_repo_names,
-            existing_repos,
-        )
+        return filter(lambda repo: repo.name not in accessible_repo_names, existing_repos)
 
     def reinstall(self):
         self.reinstall_repositories()
@@ -135,11 +130,9 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
             message = API_ERRORS.get(exc.code)
             if message:
                 return message
-            return (
-                'Error Communicating with GitHub (HTTP %s): %s' % (
-                    exc.code, exc.json.get('message', 'unknown error')
-                    if exc.json else 'unknown error',
-                )
+            return "Error Communicating with GitHub (HTTP %s): %s" % (
+                exc.code,
+                exc.json.get("message", "unknown error") if exc.json else "unknown error",
             )
         else:
             return ERR_INTERNAL
@@ -151,52 +144,48 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
             # use hooks endpoint since we explicity ask for those permissions
             # when installing the app (commits can be accessed for public repos)
             # https://developer.github.com/v3/repos/hooks/#list-hooks
-            client.repo_hooks(repo.config['name'])
+            client.repo_hooks(repo.config["name"])
         except ApiError:
             return False
         return True
 
 
 class GitHubIntegrationProvider(IntegrationProvider):
-    key = 'github'
-    name = 'GitHub'
+    key = "github"
+    name = "GitHub"
     metadata = metadata
     integration_cls = GitHubIntegration
-    features = frozenset([
-        IntegrationFeatures.COMMITS,
-        IntegrationFeatures.ISSUE_BASIC,
-    ])
+    features = frozenset([IntegrationFeatures.COMMITS, IntegrationFeatures.ISSUE_BASIC])
 
     can_disable = True
 
-    setup_dialog_config = {
-        'width': 1030,
-        'height': 1000,
-    }
+    setup_dialog_config = {"width": 1030, "height": 1000}
 
     def post_install(self, integration, organization):
         repo_ids = Repository.objects.filter(
             organization_id=organization.id,
-            provider__in=['github', 'integrations:github'],
+            provider__in=["github", "integrations:github"],
             integration_id__isnull=True,
-        ).values_list('id', flat=True)
+        ).values_list("id", flat=True)
 
         for repo_id in repo_ids:
-            migrate_repo.apply_async(kwargs={
-                'repo_id': repo_id,
-                'integration_id': integration.id,
-                'organization_id': organization.id,
-            })
+            migrate_repo.apply_async(
+                kwargs={
+                    "repo_id": repo_id,
+                    "integration_id": integration.id,
+                    "organization_id": organization.id,
+                }
+            )
 
     def get_pipeline_views(self):
         identity_pipeline_config = {
-            'oauth_scopes': (),
-            'redirect_url': absolute_uri('/extensions/github/setup/'),
+            "oauth_scopes": (),
+            "redirect_url": absolute_uri("/extensions/github/setup/"),
         }
 
         identity_pipeline_view = NestedPipelineView(
-            bind_key='identity',
-            provider_key='github',
+            bind_key="identity",
+            provider_key="github",
             pipeline_cls=IdentityProviderPipeline,
             config=identity_pipeline_config,
         )
@@ -206,85 +195,85 @@ class GitHubIntegrationProvider(IntegrationProvider):
     def get_installation_info(self, access_token, installation_id):
         session = http.build_session()
         resp = session.get(
-            'https://api.github.com/app/installations/%s' % installation_id,
+            "https://api.github.com/app/installations/%s" % installation_id,
             headers={
-                'Authorization': 'Bearer %s' % get_jwt(),
-                'Accept': 'application/vnd.github.machine-man-preview+json',
-            }
+                "Authorization": "Bearer %s" % get_jwt(),
+                "Accept": "application/vnd.github.machine-man-preview+json",
+            },
         )
         resp.raise_for_status()
         installation_resp = resp.json()
 
         resp = session.get(
-            'https://api.github.com/user/installations',
-            params={'access_token': access_token},
-            headers={'Accept': 'application/vnd.github.machine-man-preview+json'}
+            "https://api.github.com/user/installations",
+            params={"access_token": access_token},
+            headers={"Accept": "application/vnd.github.machine-man-preview+json"},
         )
         resp.raise_for_status()
         user_installations_resp = resp.json()
 
         # verify that user actually has access to the installation
-        for installation in user_installations_resp['installations']:
-            if installation['id'] == installation_resp['id']:
+        for installation in user_installations_resp["installations"]:
+            if installation["id"] == installation_resp["id"]:
                 return installation_resp
 
         return None
 
     def build_integration(self, state):
-        identity = state['identity']['data']
+        identity = state["identity"]["data"]
 
-        user = get_user_info(identity['access_token'])
+        user = get_user_info(identity["access_token"])
         installation = self.get_installation_info(
-            identity['access_token'], state['installation_id'])
+            identity["access_token"], state["installation_id"]
+        )
 
         integration = {
-            'name': installation['account']['login'],
+            "name": installation["account"]["login"],
             # TODO(adhiraj): This should be a constant representing the entire github cloud.
-            'external_id': installation['id'],
+            "external_id": installation["id"],
             # GitHub identity is associated directly to the application, *not*
             # to the installation itself.
-            'idp_external_id': installation['app_id'],
-            'metadata': {
+            "idp_external_id": installation["app_id"],
+            "metadata": {
                 # The access token will be populated upon API usage
-                'access_token': None,
-                'expires_at': None,
-                'icon': installation['account']['avatar_url'],
-                'domain_name': installation['account']['html_url'].replace('https://', ''),
-                'account_type': installation['account']['type'],
+                "access_token": None,
+                "expires_at": None,
+                "icon": installation["account"]["avatar_url"],
+                "domain_name": installation["account"]["html_url"].replace("https://", ""),
+                "account_type": installation["account"]["type"],
             },
-            'user_identity': {
-                'type': 'github',
-                'external_id': user['id'],
-                'scopes': [],  # GitHub apps do not have user scopes
-                'data': {'access_token': identity['access_token']},
+            "user_identity": {
+                "type": "github",
+                "external_id": user["id"],
+                "scopes": [],  # GitHub apps do not have user scopes
+                "data": {"access_token": identity["access_token"]},
             },
         }
 
-        if state.get('reinstall_id'):
-            integration['reinstall_id'] = state['reinstall_id']
+        if state.get("reinstall_id"):
+            integration["reinstall_id"] = state["reinstall_id"]
 
         return integration
 
     def setup(self):
         from sentry.plugins import bindings
+
         bindings.add(
-            'integration-repository.provider',
-            GitHubRepositoryProvider,
-            id='integrations:github',
+            "integration-repository.provider", GitHubRepositoryProvider, id="integrations:github"
         )
 
 
 class GitHubInstallationRedirect(PipelineView):
     def get_app_url(self):
-        name = options.get('github-app.name')
-        return 'https://github.com/apps/%s' % name
+        name = options.get("github-app.name")
+        return "https://github.com/apps/%s" % name
 
     def dispatch(self, request, pipeline):
-        if 'reinstall_id' in request.GET:
-            pipeline.bind_state('reinstall_id', request.GET['reinstall_id'])
+        if "reinstall_id" in request.GET:
+            pipeline.bind_state("reinstall_id", request.GET["reinstall_id"])
 
-        if 'installation_id' in request.GET:
-            pipeline.bind_state('installation_id', request.GET['installation_id'])
+        if "installation_id" in request.GET:
+            pipeline.bind_state("installation_id", request.GET["installation_id"])
             return pipeline.next_step()
 
         return self.redirect(self.get_app_url())

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -8,45 +8,39 @@ from sentry.utils.http import absolute_uri
 
 class GitHubIssueBasic(IssueBasicMixin):
     def make_external_key(self, data):
-        return u'{}#{}'.format(data['repo'], data['key'])
+        return u"{}#{}".format(data["repo"], data["key"])
 
     def get_issue_url(self, key):
-        domain_name, user = self.model.metadata['domain_name'].split('/')
-        repo, issue_id = key.split('#')
+        domain_name, user = self.model.metadata["domain_name"].split("/")
+        repo, issue_id = key.split("#")
         return u"https://{}/{}/issues/{}".format(domain_name, repo, issue_id)
 
     def after_link_issue(self, external_issue, **kwargs):
-        data = kwargs['data']
+        data = kwargs["data"]
         client = self.get_client()
 
-        repo, issue_num = external_issue.key.split('#')
+        repo, issue_num = external_issue.key.split("#")
         if not repo:
-            raise IntegrationError('repo must be provided')
+            raise IntegrationError("repo must be provided")
 
         if not issue_num:
-            raise IntegrationError('issue number must be provided')
+            raise IntegrationError("issue number must be provided")
 
-        comment = data.get('comment')
+        comment = data.get("comment")
         if comment:
             try:
-                client.create_comment(
-                    repo=repo,
-                    issue_id=issue_num,
-                    data={
-                        'body': comment,
-                    },
-                )
+                client.create_comment(repo=repo, issue_id=issue_num, data={"body": comment})
             except ApiError as e:
                 raise IntegrationError(self.message_from_error(e))
 
     def get_persisted_default_config_fields(self):
-        return ['repo']
+        return ["repo"]
 
     def create_default_repo_choice(self, default_repo):
-        return (default_repo, default_repo.split('/')[1])
+        return (default_repo, default_repo.split("/")[1])
 
     def get_create_issue_config(self, group, **kwargs):
-        kwargs['link_referrer'] = 'github_integration'
+        kwargs["link_referrer"] = "github_integration"
         fields = super(GitHubIssueBasic, self).get_create_issue_config(group, **kwargs)
         default_repo, repo_choices = self.get_repository_choices(group, **kwargs)
 
@@ -54,56 +48,61 @@ class GitHubIssueBasic(IssueBasicMixin):
 
         org = group.organization
         autocomplete_url = reverse(
-            'sentry-extensions-github-search', args=[org.slug, self.model.id],
+            "sentry-extensions-github-search", args=[org.slug, self.model.id]
         )
 
-        return [
-            {
-                'name': 'repo',
-                'label': 'GitHub Repository',
-                'type': 'select',
-                'default': default_repo,
-                'choices': repo_choices,
-                'url': autocomplete_url,
-                'updatesForm': True,
-                'required': True,
-            }
-        ] + fields + [
-            {
-                'name': 'assignee',
-                'label': 'Assignee',
-                'default': '',
-                'type': 'select',
-                'required': False,
-                'choices': assignees,
-            }
-        ]
+        return (
+            [
+                {
+                    "name": "repo",
+                    "label": "GitHub Repository",
+                    "type": "select",
+                    "default": default_repo,
+                    "choices": repo_choices,
+                    "url": autocomplete_url,
+                    "updatesForm": True,
+                    "required": True,
+                }
+            ]
+            + fields
+            + [
+                {
+                    "name": "assignee",
+                    "label": "Assignee",
+                    "default": "",
+                    "type": "select",
+                    "required": False,
+                    "choices": assignees,
+                }
+            ]
+        )
 
     def create_issue(self, data, **kwargs):
         client = self.get_client()
 
-        repo = data.get('repo')
+        repo = data.get("repo")
 
         if not repo:
-            raise IntegrationError('repo kwarg must be provided')
+            raise IntegrationError("repo kwarg must be provided")
 
         try:
             issue = client.create_issue(
                 repo=repo,
                 data={
-                    'title': data['title'],
-                    'body': data['description'],
-                    'assignee': data.get('assignee'),
-                })
+                    "title": data["title"],
+                    "body": data["description"],
+                    "assignee": data.get("assignee"),
+                },
+            )
         except ApiError as e:
             raise IntegrationError(self.message_from_error(e))
 
         return {
-            'key': issue['number'],
-            'title': issue['title'],
-            'description': issue['body'],
-            'url': issue['html_url'],
-            'repo': repo,
+            "key": issue["number"],
+            "title": issue["title"],
+            "description": issue["body"],
+            "url": issue["html_url"],
+            "repo": repo,
         }
 
     def get_link_issue_config(self, group, **kwargs):
@@ -111,57 +110,55 @@ class GitHubIssueBasic(IssueBasicMixin):
 
         org = group.organization
         autocomplete_url = reverse(
-            'sentry-extensions-github-search', args=[org.slug, self.model.id],
+            "sentry-extensions-github-search", args=[org.slug, self.model.id]
         )
 
         return [
             {
-                'name': 'repo',
-                'label': 'GitHub Repository',
-                'type': 'select',
-                'default': default_repo,
-                'choices': repo_choices,
-                'url': autocomplete_url,
-                'required': True,
-                'updatesForm': True,
+                "name": "repo",
+                "label": "GitHub Repository",
+                "type": "select",
+                "default": default_repo,
+                "choices": repo_choices,
+                "url": autocomplete_url,
+                "required": True,
+                "updatesForm": True,
             },
             {
-                'name': 'externalIssue',
-                'label': 'Issue',
-                'default': '',
-                'choices': [],
-                'type': 'select',
-                'url': autocomplete_url,
-                'required': True,
+                "name": "externalIssue",
+                "label": "Issue",
+                "default": "",
+                "choices": [],
+                "type": "select",
+                "url": autocomplete_url,
+                "required": True,
             },
             {
-                'name': 'comment',
-                'label': 'Comment',
-                'default': u'Sentry issue: [{issue_id}]({url})'.format(
+                "name": "comment",
+                "label": "Comment",
+                "default": u"Sentry issue: [{issue_id}]({url})".format(
                     url=absolute_uri(
-                        group.get_absolute_url(
-                            params={
-                                'referrer': 'github_integration'})),
+                        group.get_absolute_url(params={"referrer": "github_integration"})
+                    ),
                     issue_id=group.qualified_short_id,
                 ),
-                'type': 'textarea',
-                'required': False,
-                'help': ('Leave blank if you don\'t want to '
-                         'add a comment to the GitHub issue.'),
-            }
+                "type": "textarea",
+                "required": False,
+                "help": ("Leave blank if you don't want to " "add a comment to the GitHub issue."),
+            },
         ]
 
     def get_issue(self, issue_id, **kwargs):
-        data = kwargs['data']
-        repo = data.get('repo')
-        issue_num = data.get('externalIssue')
+        data = kwargs["data"]
+        repo = data.get("repo")
+        issue_num = data.get("externalIssue")
         client = self.get_client()
 
         if not repo:
-            raise IntegrationError('repo must be provided')
+            raise IntegrationError("repo must be provided")
 
         if not issue_num:
-            raise IntegrationError('issue must be provided')
+            raise IntegrationError("issue must be provided")
 
         try:
             issue = client.get_issue(repo, issue_num)
@@ -169,11 +166,11 @@ class GitHubIssueBasic(IssueBasicMixin):
             raise IntegrationError(self.message_from_error(e))
 
         return {
-            'key': issue['number'],
-            'title': issue['title'],
-            'description': issue['body'],
-            'url': issue['html_url'],
-            'repo': repo,
+            "key": issue["number"],
+            "title": issue["title"],
+            "description": issue["body"],
+            "url": issue["html_url"],
+            "repo": repo,
         }
 
     def get_allowed_assignees(self, repo):
@@ -183,9 +180,9 @@ class GitHubIssueBasic(IssueBasicMixin):
         except Exception as e:
             self.raise_error(e)
 
-        users = tuple((u['login'], u['login']) for u in response)
+        users = tuple((u["login"], u["login"]) for u in response)
 
-        return (('', 'Unassigned'), ) + users
+        return (("", "Unassigned"),) + users
 
     def get_repo_issues(self, repo):
         client = self.get_client()
@@ -194,6 +191,6 @@ class GitHubIssueBasic(IssueBasicMixin):
         except Exception as e:
             self.raise_error(e)
 
-        issues = tuple((i['number'], u'#{} {}'.format(i['number'], i['title'])) for i in response)
+        issues = tuple((i["number"], u"#{} {}".format(i["number"], i["title"])) for i in response)
 
         return issues

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -7,13 +7,13 @@ from sentry.integrations.exceptions import ApiError, IntegrationError
 from sentry.models import Integration
 from sentry.plugins import providers
 
-WEBHOOK_EVENTS = ['push', 'pull_request']
+WEBHOOK_EVENTS = ["push", "pull_request"]
 
 
 class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
-    name = 'GitHub'
-    logger = logging.getLogger('sentry.plugins.github')
-    repo_provider = 'github'
+    name = "GitHub"
+    logger = logging.getLogger("sentry.plugins.github")
+    repo_provider = "github"
 
     def _validate_repo(self, client, installation, repo):
         try:
@@ -28,47 +28,44 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
             # https://developer.github.com/v3/repos/hooks/#list-hooks
             client.repo_hooks(repo)
         except ApiError as e:
-            raise IntegrationError(u'You must grant Sentry access to {}'.format(repo))
+            raise IntegrationError(u"You must grant Sentry access to {}".format(repo))
 
         return repo_data
 
     def get_repository_data(self, organization, config):
-        integration = Integration.objects.get(
-            id=config['installation'], organizations=organization)
+        integration = Integration.objects.get(id=config["installation"], organizations=organization)
         installation = integration.get_installation(organization.id)
         client = installation.get_client()
 
-        repo = self._validate_repo(client, installation, config['identifier'])
-        config['external_id'] = six.text_type(repo['id'])
-        config['integration_id'] = integration.id
+        repo = self._validate_repo(client, installation, config["identifier"])
+        config["external_id"] = six.text_type(repo["id"])
+        config["integration_id"] = integration.id
 
         return config
 
     def build_repository_config(self, organization, data):
         return {
-            'name': data['identifier'],
-            'external_id': data['external_id'],
-            'url': u'https://github.com/{}'.format(data['identifier']),
-            'config': {
-                'name': data['identifier'],
-            },
-            'integration_id': data['integration_id']
+            "name": data["identifier"],
+            "external_id": data["external_id"],
+            "url": u"https://github.com/{}".format(data["identifier"]),
+            "config": {"name": data["identifier"]},
+            "integration_id": data["integration_id"],
         }
 
     def compare_commits(self, repo, start_sha, end_sha):
         def eval_commits(client):
             # use config name because that is kept in sync via webhooks
-            name = repo.config['name']
+            name = repo.config["name"]
             if start_sha is None:
                 res = client.get_last_commits(name, end_sha)
                 return self._format_commits(client, name, res[:20])
             else:
                 res = client.compare_commits(name, start_sha, end_sha)
-                return self._format_commits(client, name, res['commits'])
+                return self._format_commits(client, name, res["commits"])
 
         integration_id = repo.integration_id
         if integration_id is None:
-            raise NotImplementedError('GitHub apps requires an integration id to fetch commits')
+            raise NotImplementedError("GitHub apps requires an integration id to fetch commits")
         integration = Integration.objects.get(id=integration_id)
         installation = integration.get_installation(repo.organization_id)
         client = installation.get_client()
@@ -98,21 +95,22 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
         """
         return [
             {
-                'id': c['sha'],
-                'repository': repo_name,
-                'author_email': c['commit']['author'].get('email'),
-                'author_name': c['commit']['author'].get('name'),
-                'message': c['commit']['message'],
-                'timestamp': self.format_date(c['commit']['author'].get('date')),
-                'patch_set': self._get_patchset(client, repo_name, c['sha'])
-            } for c in commit_list
+                "id": c["sha"],
+                "repository": repo_name,
+                "author_email": c["commit"]["author"].get("email"),
+                "author_name": c["commit"]["author"].get("name"),
+                "message": c["commit"]["message"],
+                "timestamp": self.format_date(c["commit"]["author"].get("date")),
+                "patch_set": self._get_patchset(client, repo_name, c["sha"]),
+            }
+            for c in commit_list
         ]
 
     def _get_patchset(self, client, repo_name, sha):
         """Get the modified files for a commit
         """
         commit = client.get_commit(repo_name, sha)
-        return self._transform_patchset(commit['files'])
+        return self._transform_patchset(commit["files"])
 
     def _transform_patchset(self, diff):
         """Convert the patch data from GitHub into our internal format
@@ -121,34 +119,19 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
         """
         changes = []
         for change in diff:
-            if change['status'] == 'modified':
-                changes.append({
-                    'path': change['filename'],
-                    'type': 'M',
-                })
-            if change['status'] == 'added':
-                changes.append({
-                    'path': change['filename'],
-                    'type': 'A',
-                })
-            if change['status'] == 'removed':
-                changes.append({
-                    'path': change['filename'],
-                    'type': 'D',
-                })
-            if change['status'] == 'renamed':
-                changes.append({
-                    'path': change['previous_filename'],
-                    'type': 'D',
-                })
-                changes.append({
-                    'path': change['filename'],
-                    'type': 'A',
-                })
+            if change["status"] == "modified":
+                changes.append({"path": change["filename"], "type": "M"})
+            if change["status"] == "added":
+                changes.append({"path": change["filename"], "type": "A"})
+            if change["status"] == "removed":
+                changes.append({"path": change["filename"], "type": "D"})
+            if change["status"] == "renamed":
+                changes.append({"path": change["previous_filename"], "type": "D"})
+                changes.append({"path": change["filename"], "type": "A"})
         return changes
 
     def pull_request_url(self, repo, pull_request):
-        return u'{}/pull/{}'.format(repo.url, pull_request.key)
+        return u"{}/pull/{}".format(repo.url, pull_request.key)
 
     def repository_external_slug(self, repo):
         return repo.name

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -9,57 +9,57 @@ from sentry.models import Integration
 
 
 class GitHubSearchEndpoint(IntegrationEndpoint):
-
     def get(self, request, organization, integration_id):
         try:
-            integration = Integration.objects.get(
-                organizations=organization,
-                id=integration_id,
-            )
+            integration = Integration.objects.get(organizations=organization, id=integration_id)
         except Integration.DoesNotExist:
             return Response(status=404)
 
-        field = request.GET.get('field')
-        query = request.GET.get('query')
+        field = request.GET.get("field")
+        query = request.GET.get("query")
         if field is None:
-            return Response({'detail': 'field is a required parameter'}, status=400)
+            return Response({"detail": "field is a required parameter"}, status=400)
         if not query:
-            return Response({'detail': 'query is a required parameter'}, status=400)
+            return Response({"detail": "query is a required parameter"}, status=400)
 
         installation = integration.get_installation(organization.id)
-        if field == 'externalIssue':
-            repo = request.GET.get('repo')
+        if field == "externalIssue":
+            repo = request.GET.get("repo")
             if repo is None:
-                return Response({'detail': 'repo is a required parameter'}, status=400)
+                return Response({"detail": "repo is a required parameter"}, status=400)
 
             try:
                 response = installation.search_issues(
-                    query=(u'repo:%s %s' % (repo, query)).encode('utf-8'),
+                    query=(u"repo:%s %s" % (repo, query)).encode("utf-8")
                 )
             except ApiError as err:
                 if err.code == 403:
-                    return Response({'detail': 'Rate limit exceeded'}, status=429)
+                    return Response({"detail": "Rate limit exceeded"}, status=429)
                 raise
-            return Response([{
-                'label': '#%s %s' % (i['number'], i['title']),
-                'value': i['number']
-            } for i in response.get('items', [])])
+            return Response(
+                [
+                    {"label": "#%s %s" % (i["number"], i["title"]), "value": i["number"]}
+                    for i in response.get("items", [])
+                ]
+            )
 
-        if field == 'repo':
+        if field == "repo":
             full_query = build_repository_query(integration.metadata, integration.name, query)
             try:
                 response = installation.get_client().search_repositories(full_query)
             except ApiError as err:
                 if err.code == 403:
-                    return Response({'detail': 'Rate limit exceeded'}, status=429)
+                    return Response({"detail": "Rate limit exceeded"}, status=429)
                 if err.code == 422:
-                    return Response({
-                        'detail': 'Repositories could not be searched because they do not exist, or you do not have access to them.'
-                    }, status=404)
+                    return Response(
+                        {
+                            "detail": "Repositories could not be searched because they do not exist, or you do not have access to them."
+                        },
+                        status=404,
+                    )
                 raise
-            return Response([{
-                'label': i['name'],
-                'value': i['full_name']
-            } for i in response.get('items', [])])
+            return Response(
+                [{"label": i["name"], "value": i["full_name"]} for i in response.get("items", [])]
+            )
 
         return Response(status=400)

--- a/src/sentry/integrations/github/urls.py
+++ b/src/sentry/integrations/github/urls.py
@@ -6,10 +6,11 @@ from .webhook import GitHubIntegrationsWebhookEndpoint
 from .search import GitHubSearchEndpoint
 
 urlpatterns = patterns(
-    '',
-    url(r'^webhook/$', GitHubIntegrationsWebhookEndpoint.as_view()),
-    url(r'^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$',
+    "",
+    url(r"^webhook/$", GitHubIntegrationsWebhookEndpoint.as_view()),
+    url(
+        r"^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$",
         GitHubSearchEndpoint.as_view(),
-        name='sentry-extensions-github-search'
-        ),
+        name="sentry-extensions-github-search",
+    ),
 )

--- a/src/sentry/integrations/github/utils.py
+++ b/src/sentry/integrations/github/utils.py
@@ -10,18 +10,18 @@ from sentry import options
 
 def get_jwt(github_id=None, github_private_key=None):
     if github_id is None:
-        github_id = options.get('github-app.id')
+        github_id = options.get("github-app.id")
     if github_private_key is None:
-        github_private_key = options.get('github-app.private-key')
+        github_private_key = options.get("github-app.private-key")
     exp = datetime.datetime.utcnow() + datetime.timedelta(minutes=10)
     exp = calendar.timegm(exp.timetuple())
     # Generate the JWT
     payload = {
         # issued at time
-        'iat': int(time.time()),
+        "iat": int(time.time()),
         # JWT expiration time (10 minute maximum)
-        'exp': exp,
+        "exp": exp,
         # Integration's GitHub identifier
-        'iss': github_id,
+        "iss": github_id,
     }
-    return jwt.encode(payload, github_private_key, algorithm='RS256')
+    return jwt.encode(payload, github_private_key, algorithm="RS256")

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -18,65 +18,64 @@ from simplejson import JSONDecodeError
 from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.models import (
-    Commit, CommitAuthor, CommitFileChange, Identity, Integration, PullRequest,
-    Repository
+    Commit,
+    CommitAuthor,
+    CommitFileChange,
+    Identity,
+    Integration,
+    PullRequest,
+    Repository,
 )
 from sentry.utils import json
 
 from sentry.integrations.exceptions import ApiError
 from .repository import GitHubRepositoryProvider
 
-logger = logging.getLogger('sentry.webhooks')
+logger = logging.getLogger("sentry.webhooks")
 
 
 class Webhook(object):
-    provider = 'github'
+    provider = "github"
 
     def _handle(self, integration, event, organization, repo):
         raise NotImplementedError
 
     def __call__(self, event, host=None):
-        external_id = event['installation']['id']
+        external_id = event["installation"]["id"]
         if host:
-            external_id = u'{}:{}'.format(host, event['installation']['id'])
+            external_id = u"{}:{}".format(host, event["installation"]["id"])
 
         try:
-            integration = Integration.objects.get(
-                external_id=external_id,
-                provider=self.provider,
-            )
+            integration = Integration.objects.get(external_id=external_id, provider=self.provider)
         except Integration.DoesNotExist:
             # It seems possible for the GH or GHE app to be installed on their
             # end, but the integration to not exist. Possibly from deleting in
             # Sentry first or from a failed install flow (where the integration
             # didn't get created in the first place)
             logger.info(
-                'github.missing-integration',
+                "github.missing-integration",
                 extra={
-                    'action': event.get('action'),
-                    'repository': event.get('repository')['full_name'],
-                    'external_id': six.text_type(external_id),
-                }
+                    "action": event.get("action"),
+                    "repository": event.get("repository")["full_name"],
+                    "external_id": six.text_type(external_id),
+                },
             )
             return
 
-        if 'repository' in event:
+        if "repository" in event:
 
-            orgs = {
-                org.id: org
-                for org in integration.organizations.all()
-            }
+            orgs = {org.id: org for org in integration.organizations.all()}
 
             repos = Repository.objects.filter(
                 organization_id__in=orgs.keys(),
-                provider='integrations:%s' % self.provider,
-                external_id=six.text_type(event['repository']['id']),
+                provider="integrations:%s" % self.provider,
+                external_id=six.text_type(event["repository"]["id"]),
             )
             for repo in repos:
                 # We need to track GitHub's "full_name" which is the repository slug.
                 # This is needed to access the API since `external_id` isn't sufficient.
-                if repo.config.get('name') != event['repository']['full_name']:
-                    repo.config['name'] = event['repository']['full_name']
+                if repo.config.get("name") != event["repository"]["full_name"]:
+                    repo.config["name"] = event["repository"]["full_name"]
                     repo.save()
 
                 self._handle(integration, event, orgs[repo.organization_id], repo)
@@ -85,15 +84,14 @@ class Webhook(object):
 class InstallationEventWebhook(Webhook):
     # https://developer.github.com/v3/activity/events/types/#installationevent
     def __call__(self, event, host=None):
-        installation = event['installation']
-        if installation and event['action'] == 'deleted':
-            external_id = event['installation']['id']
+        installation = event["installation"]
+        if installation and event["action"] == "deleted":
+            external_id = event["installation"]["id"]
             if host:
-                external_id = u'{}:{}'.format(host, event['installation']['id'])
+                external_id = u"{}:{}".format(host, event["installation"]["id"])
             try:
                 integration = Integration.objects.get(
-                    external_id=external_id,
-                    provider=self.provider,
+                    external_id=external_id, provider=self.provider
                 )
                 self._handle_delete(event, integration)
             except Integration.DoesNotExist:
@@ -102,12 +100,12 @@ class InstallationEventWebhook(Webhook):
                 # Sentry first or from a failed install flow (where the integration
                 # didn't get created in the first place)
                 logger.info(
-                    'github.deletion-missing-integration',
+                    "github.deletion-missing-integration",
                     extra={
-                        'action': event['action'],
-                        'installation_name': event['account']['login'],
-                        'external_id': six.text_type(external_id),
-                    }
+                        "action": event["action"],
+                        "installation_name": event["account"]["login"],
+                        "external_id": six.text_type(external_id),
+                    },
                 )
 
     def _handle_delete(self, event, integration):
@@ -116,8 +114,8 @@ class InstallationEventWebhook(Webhook):
         integration.update(status=ObjectStatus.DISABLED)
 
         Repository.objects.filter(
-            organization_id__in=organizations.values_list('id', flat=True),
-            provider='integrations:%s' % self.provider,
+            organization_id__in=organizations.values_list("id", flat=True),
+            provider="integrations:%s" % self.provider,
             integration_id=integration.id,
         ).update(status=ObjectStatus.DISABLED)
 
@@ -132,37 +130,35 @@ class PushEventWebhook(Webhook):
     # https://developer.github.com/v3/activity/events/types/#pushevent
 
     def is_anonymous_email(self, email):
-        return email[-25:] == '@users.noreply.github.com'
+        return email[-25:] == "@users.noreply.github.com"
 
     def get_external_id(self, username):
-        return 'github:%s' % username
+        return "github:%s" % username
 
     def get_idp_external_id(self, integration, host=None):
-        return options.get('github-app.id')
+        return options.get("github-app.id")
 
     def should_ignore_commit(self, commit):
-        return GitHubRepositoryProvider.should_ignore_commit(commit['message'])
+        return GitHubRepositoryProvider.should_ignore_commit(commit["message"])
 
     def _handle(self, integration, event, organization, repo, host=None):
         authors = {}
         client = integration.get_installation(organization_id=organization.id).get_client()
         gh_username_cache = {}
 
-        for commit in event['commits']:
-            if not commit['distinct']:
+        for commit in event["commits"]:
+            if not commit["distinct"]:
                 continue
 
             if self.should_ignore_commit(commit):
                 continue
 
-            author_email = commit['author']['email']
-            if '@' not in author_email:
-                author_email = u'{}@localhost'.format(
-                    author_email[:65],
-                )
+            author_email = commit["author"]["email"]
+            if "@" not in author_email:
+                author_email = u"{}@localhost".format(author_email[:65])
             # try to figure out who anonymous emails are
             elif self.is_anonymous_email(author_email):
-                gh_username = commit['author'].get('username')
+                gh_username = commit["author"].get("username")
                 # bot users don't have usernames
                 if gh_username:
                     external_id = self.get_external_id(gh_username)
@@ -171,8 +167,7 @@ class PushEventWebhook(Webhook):
                     else:
                         try:
                             commit_author = CommitAuthor.objects.get(
-                                external_id=external_id,
-                                organization_id=organization.id,
+                                external_id=external_id, organization_id=organization.id
                             )
                         except CommitAuthor.DoesNotExist:
                             commit_author = None
@@ -193,7 +188,12 @@ class PushEventWebhook(Webhook):
                                 gh_username_cache[gh_username] = None
                                 try:
                                     identity = Identity.objects.get(
-                                        external_id=gh_user['id'], idp__type=self.provider, idp__external_id=self.get_idp_external_id(integration, host))
+                                        external_id=gh_user["id"],
+                                        idp__type=self.provider,
+                                        idp__external_id=self.get_idp_external_id(
+                                            integration, host
+                                        ),
+                                    )
                                 except Identity.DoesNotExist:
                                     pass
                                 else:
@@ -203,8 +203,7 @@ class PushEventWebhook(Webhook):
                                         try:
                                             with transaction.atomic():
                                                 commit_author.update(
-                                                    email=author_email,
-                                                    external_id=external_id,
+                                                    email=author_email, external_id=external_id
                                                 )
                                         except IntegrityError:
                                             pass
@@ -220,22 +219,21 @@ class PushEventWebhook(Webhook):
                 authors[author_email] = author = CommitAuthor.objects.get_or_create(
                     organization_id=organization.id,
                     email=author_email,
-                    defaults={
-                        'name': commit['author']['name'][:128],
-                    }
+                    defaults={"name": commit["author"]["name"][:128]},
                 )[0]
 
                 update_kwargs = {}
 
-                if author.name != commit['author']['name'][:128]:
-                    update_kwargs['name'] = commit['author']['name'][:128]
+                if author.name != commit["author"]["name"][:128]:
+                    update_kwargs["name"] = commit["author"]["name"][:128]
 
-                gh_username = commit['author'].get('username')
+                gh_username = commit["author"].get("username")
                 if gh_username:
                     external_id = self.get_external_id(gh_username)
                     if author.external_id != external_id and not self.is_anonymous_email(
-                            author.email):
-                        update_kwargs['external_id'] = external_id
+                        author.email
+                    ):
+                        update_kwargs["external_id"] = external_id
 
                 if update_kwargs:
                     try:
@@ -251,33 +249,24 @@ class PushEventWebhook(Webhook):
                     c = Commit.objects.create(
                         repository_id=repo.id,
                         organization_id=organization.id,
-                        key=commit['id'],
-                        message=commit['message'],
+                        key=commit["id"],
+                        message=commit["message"],
                         author=author,
-                        date_added=dateutil.parser.parse(
-                            commit['timestamp'],
-                        ).astimezone(timezone.utc),
+                        date_added=dateutil.parser.parse(commit["timestamp"]).astimezone(
+                            timezone.utc
+                        ),
                     )
-                    for fname in commit['added']:
+                    for fname in commit["added"]:
                         CommitFileChange.objects.create(
-                            organization_id=organization.id,
-                            commit=c,
-                            filename=fname,
-                            type='A',
+                            organization_id=organization.id, commit=c, filename=fname, type="A"
                         )
-                    for fname in commit['removed']:
+                    for fname in commit["removed"]:
                         CommitFileChange.objects.create(
-                            organization_id=organization.id,
-                            commit=c,
-                            filename=fname,
-                            type='D',
+                            organization_id=organization.id, commit=c, filename=fname, type="D"
                         )
-                    for fname in commit['modified']:
+                    for fname in commit["modified"]:
                         CommitFileChange.objects.create(
-                            organization_id=organization.id,
-                            commit=c,
-                            filename=fname,
-                            type='M',
+                            organization_id=organization.id, commit=c, filename=fname, type="M"
                         )
             except IntegrityError:
                 pass
@@ -286,39 +275,41 @@ class PushEventWebhook(Webhook):
 class PullRequestEventWebhook(Webhook):
     # https://developer.github.com/v3/activity/events/types/#pullrequestevent
     def is_anonymous_email(self, email):
-        return email[-25:] == '@users.noreply.github.com'
+        return email[-25:] == "@users.noreply.github.com"
 
     def get_external_id(self, username):
-        return 'github:%s' % username
+        return "github:%s" % username
 
     def get_idp_external_id(self, integration, host=None):
-        return options.get('github-app.id')
+        return options.get("github-app.id")
 
     def _handle(self, integration, event, organization, repo, host=None):
-        pull_request = event['pull_request']
-        number = pull_request['number']
-        title = pull_request['title']
-        body = pull_request['body']
-        user = pull_request['user']
+        pull_request = event["pull_request"]
+        number = pull_request["number"]
+        title = pull_request["title"]
+        body = pull_request["body"]
+        user = pull_request["user"]
 
         # The value of the merge_commit_sha attribute changes depending on the state of the pull request. Before a pull request is merged, the merge_commit_sha attribute holds the SHA of the test merge commit. After a pull request is merged, the attribute changes depending on how the pull request was merged:
         # - If the pull request was merged as a merge commit, the attribute represents the SHA of the merge commit.
         # - If the pull request was merged via a squash, the attribute represents the SHA of the squashed commit on the base branch.
         # - If the pull request was rebased, the attribute represents the commit that the base branch was updated to.
         # https://developer.github.com/v3/pulls/#get-a-single-pull-request
-        merge_commit_sha = pull_request['merge_commit_sha'] if pull_request['merged'] else None
+        merge_commit_sha = pull_request["merge_commit_sha"] if pull_request["merged"] else None
 
-        author_email = u'{}@localhost'.format(user['login'][:65])
+        author_email = u"{}@localhost".format(user["login"][:65])
         try:
             commit_author = CommitAuthor.objects.get(
-                external_id=self.get_external_id(user['login']),
-                organization_id=organization.id,
+                external_id=self.get_external_id(user["login"]), organization_id=organization.id
             )
             author_email = commit_author.email
         except CommitAuthor.DoesNotExist:
             try:
                 identity = Identity.objects.get(
-                    external_id=user['id'], idp__type=self.provider, idp__external_id=self.get_idp_external_id(integration, host))
+                    external_id=user["id"],
+                    idp__type=self.provider,
+                    idp__external_id=self.get_idp_external_id(integration, host),
+                )
             except Identity.DoesNotExist:
                 pass
             else:
@@ -326,21 +317,19 @@ class PullRequestEventWebhook(Webhook):
 
         try:
             author = CommitAuthor.objects.get(
-                organization_id=organization.id,
-                external_id=self.get_external_id(user['login']),
+                organization_id=organization.id, external_id=self.get_external_id(user["login"])
             )
         except CommitAuthor.DoesNotExist:
             try:
                 author = CommitAuthor.objects.get(
-                    organization_id=organization.id,
-                    email=author_email,
+                    organization_id=organization.id, email=author_email
                 )
             except CommitAuthor.DoesNotExist:
                 author = CommitAuthor.objects.create(
                     organization_id=organization.id,
                     email=author_email,
-                    external_id=self.get_external_id(user['login']),
-                    name=user['login'][:128]
+                    external_id=self.get_external_id(user["login"]),
+                    name=user["login"][:128],
                 )
 
         try:
@@ -349,11 +338,11 @@ class PullRequestEventWebhook(Webhook):
                 repository_id=repo.id,
                 key=number,
                 values={
-                    'organization_id': organization.id,
-                    'title': title,
-                    'author': author,
-                    'message': body,
-                    'merge_commit_sha': merge_commit_sha,
+                    "organization_id": organization.id,
+                    "title": title,
+                    "author": author,
+                    "message": body,
+                    "merge_commit_sha": merge_commit_sha,
                 },
             )
         except IntegrityError:
@@ -366,20 +355,16 @@ class GitHubWebhookBase(View):
         return self._handlers.get(event_type)
 
     def is_valid_signature(self, method, body, secret, signature):
-        if method == 'sha1':
+        if method == "sha1":
             mod = hashlib.sha1
         else:
-            raise NotImplementedError('signature method %s is not supported' % (method, ))
-        expected = hmac.new(
-            key=secret.encode('utf-8'),
-            msg=body,
-            digestmod=mod,
-        ).hexdigest()
+            raise NotImplementedError("signature method %s is not supported" % (method,))
+        expected = hmac.new(key=secret.encode("utf-8"), msg=body, digestmod=mod).hexdigest()
         return constant_time_compare(expected, signature)
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
-        if request.method != 'POST':
+        if request.method != "POST":
             return HttpResponse(status=405)
 
         return super(GitHubWebhookBase, self).dispatch(request, *args, **kwargs)
@@ -394,55 +379,38 @@ class GitHubWebhookBase(View):
         secret = self.get_secret()
 
         if secret is None:
-            logger.error(
-                'github.webhook.missing-secret',
-                extra=self.get_logging_data(),
-            )
+            logger.error("github.webhook.missing-secret", extra=self.get_logging_data())
             return HttpResponse(status=401)
 
         body = six.binary_type(request.body)
         if not body:
-            logger.error(
-                'github.webhook.missing-body',
-                extra=self.get_logging_data(),
-            )
+            logger.error("github.webhook.missing-body", extra=self.get_logging_data())
             return HttpResponse(status=400)
 
         try:
-            handler = self.get_handler(request.META['HTTP_X_GITHUB_EVENT'])
+            handler = self.get_handler(request.META["HTTP_X_GITHUB_EVENT"])
         except KeyError:
-            logger.error(
-                'github.webhook.missing-event',
-                extra=self.get_logging_data(),
-            )
+            logger.error("github.webhook.missing-event", extra=self.get_logging_data())
             return HttpResponse(status=400)
 
         if not handler:
             return HttpResponse(status=204)
 
         try:
-            method, signature = request.META['HTTP_X_HUB_SIGNATURE'].split('=', 1)
+            method, signature = request.META["HTTP_X_HUB_SIGNATURE"].split("=", 1)
         except (KeyError, IndexError):
-            logger.error(
-                'github.webhook.missing-signature',
-                extra=self.get_logging_data(),
-            )
+            logger.error("github.webhook.missing-signature", extra=self.get_logging_data())
             return HttpResponse(status=400)
 
         if not self.is_valid_signature(method, body, self.get_secret(), signature):
-            logger.error(
-                'github.webhook.invalid-signature',
-                extra=self.get_logging_data(),
-            )
+            logger.error("github.webhook.invalid-signature", extra=self.get_logging_data())
             return HttpResponse(status=401)
 
         try:
-            event = json.loads(body.decode('utf-8'))
+            event = json.loads(body.decode("utf-8"))
         except JSONDecodeError:
             logger.error(
-                'github.webhook.invalid-json',
-                extra=self.get_logging_data(),
-                exc_info=True,
+                "github.webhook.invalid-json", extra=self.get_logging_data(), exc_info=True
             )
             return HttpResponse(status=400)
 
@@ -452,21 +420,21 @@ class GitHubWebhookBase(View):
 
 class GitHubIntegrationsWebhookEndpoint(GitHubWebhookBase):
     _handlers = {
-        'push': PushEventWebhook,
-        'pull_request': PullRequestEventWebhook,
-        'installation': InstallationEventWebhook,
-        'installation_repositories': InstallationRepositoryEventWebhook,
+        "push": PushEventWebhook,
+        "pull_request": PullRequestEventWebhook,
+        "installation": InstallationEventWebhook,
+        "installation_repositories": InstallationRepositoryEventWebhook,
     }
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
-        if request.method != 'POST':
+        if request.method != "POST":
             return HttpResponse(status=405)
 
         return super(GitHubIntegrationsWebhookEndpoint, self).dispatch(request, *args, **kwargs)
 
     def get_secret(self):
-        return options.get('github-app.webhook-secret')
+        return options.get("github-app.webhook-secret")
 
     def post(self, request):
         return self.handle(request)

--- a/src/sentry/integrations/github_enterprise/client.py
+++ b/src/sentry/integrations/github_enterprise/client.py
@@ -20,12 +20,10 @@ class GitHubEnterpriseAppsClient(GitHubClientMixin):
 
     def create_token(self):
         return self.post(
-            u'/installations/{}/access_tokens'.format(
-                self.integration.metadata['installation_id'],
-            ),
+            u"/installations/{}/access_tokens".format(self.integration.metadata["installation_id"]),
             headers={
-                'Authorization': 'Bearer %s' % self.get_jwt(),
+                "Authorization": "Bearer %s" % self.get_jwt(),
                 # TODO(jess): remove this whenever it's out of preview
-                'Accept': 'application/vnd.github.machine-man-preview+json',
+                "Accept": "application/vnd.github.machine-man-preview+json",
             },
         )

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -8,7 +8,12 @@ from sentry import http
 from sentry.web.helpers import render_to_response
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.identity.github_enterprise import get_user_info
-from sentry.integrations import IntegrationMetadata, IntegrationInstallation, FeatureDescription, IntegrationFeatures
+from sentry.integrations import (
+    IntegrationMetadata,
+    IntegrationInstallation,
+    FeatureDescription,
+    IntegrationFeatures,
+)
 from sentry.integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.integrations.exceptions import ApiError
 from sentry.integrations.repositories import RepositoryMixin
@@ -50,84 +55,80 @@ FEATURES = [
 
 
 disable_dialog = {
-    'actionText': 'Visit GitHub Enterprise',
-    'body': 'Before deleting this integration, you must uninstall it from your'
-            ' GitHub Enterprise instance. After uninstalling, your integration'
-            ' will be disabled at which point you can choose to delete this'
-            ' integration.'
+    "actionText": "Visit GitHub Enterprise",
+    "body": "Before deleting this integration, you must uninstall it from your"
+    " GitHub Enterprise instance. After uninstalling, your integration"
+    " will be disabled at which point you can choose to delete this"
+    " integration.",
 }
 
 removal_dialog = {
-    'actionText': 'Delete',
-    'body': 'Deleting this integration will delete all associated repositories'
-            ' and commit data. This action cannot be undone. Are you sure you'
-            ' want to delete your integration?'
+    "actionText": "Delete",
+    "body": "Deleting this integration will delete all associated repositories"
+    " and commit data. This action cannot be undone. Are you sure you"
+    " want to delete your integration?",
 }
 
 setup_alert = {
-    'type': 'warning',
-    'icon': 'icon-warning-sm',
-    'text': 'Your GitHub enterprise instance must be able to communicate with'
-            ' Sentry. Sentry makes outbound requests from a [static set of IP'
-            ' addresses](https://docs.sentry.io/ip-ranges/) that you may wish'
-            ' to whitelist to support this integration.',
+    "type": "warning",
+    "icon": "icon-warning-sm",
+    "text": "Your GitHub enterprise instance must be able to communicate with"
+    " Sentry. Sentry makes outbound requests from a [static set of IP"
+    " addresses](https://docs.sentry.io/ip-ranges/) that you may wish"
+    " to whitelist to support this integration.",
 }
 
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
     features=FEATURES,
-    author='The Sentry Team',
-    noun=_('Installation'),
-    issue_url='https://github.com/getsentry/sentry/issues/new?title=GitHub%20Integration:%20&labels=Component%3A%20Integrations',
-    source_url='https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/github_enterprise',
+    author="The Sentry Team",
+    noun=_("Installation"),
+    issue_url="https://github.com/getsentry/sentry/issues/new?title=GitHub%20Integration:%20&labels=Component%3A%20Integrations",
+    source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/github_enterprise",
     aspects={
-        'disable_dialog': disable_dialog,
-        'removal_dialog': removal_dialog,
-        'alerts': [setup_alert],
+        "disable_dialog": disable_dialog,
+        "removal_dialog": removal_dialog,
+        "alerts": [setup_alert],
     },
 )
 
 
-API_ERRORS = {
-    404: 'GitHub Enterprise returned a 404 Not Found error.',
-    401: ERR_UNAUTHORIZED,
-}
+API_ERRORS = {404: "GitHub Enterprise returned a 404 Not Found error.", 401: ERR_UNAUTHORIZED}
 
 
 class GitHubEnterpriseIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMixin):
     repo_search = True
 
     def get_client(self):
-        base_url = self.model.metadata['domain_name'].split('/')[0]
+        base_url = self.model.metadata["domain_name"].split("/")[0]
         return GitHubEnterpriseAppsClient(
             base_url=base_url,
             integration=self.model,
-            private_key=self.model.metadata['installation']['private_key'],
-            app_id=self.model.metadata['installation']['id'],
-            verify_ssl=self.model.metadata['installation']['verify_ssl'],
+            private_key=self.model.metadata["installation"]["private_key"],
+            app_id=self.model.metadata["installation"]["id"],
+            verify_ssl=self.model.metadata["installation"]["verify_ssl"],
         )
 
     def get_repositories(self, query=None):
         if not query:
-            return [{
-                'name': i['name'],
-                'identifier': i['full_name']
-            } for i in self.get_client().get_repositories()]
+            return [
+                {"name": i["name"], "identifier": i["full_name"]}
+                for i in self.get_client().get_repositories()
+            ]
 
         full_query = build_repository_query(self.model.metadata, self.model.name, query)
         response = self.get_client().search_repositories(full_query)
-        return [{
-            'name': i['name'],
-            'identifier': i['full_name']
-        } for i in response.get('items', [])]
+        return [
+            {"name": i["name"], "identifier": i["full_name"]} for i in response.get("items", [])
+        ]
 
     def search_issues(self, query):
         return self.get_client().search_issues(query)
 
     def reinstall(self):
-        installation_id = self.model.external_id.split(':')[1]
+        installation_id = self.model.external_id.split(":")[1]
         metadata = self.model.metadata
-        metadata['installation_id'] = installation_id
+        metadata["installation_id"] = installation_id
         self.model.update(metadata=metadata)
         self.reinstall_repositories()
 
@@ -136,11 +137,9 @@ class GitHubEnterpriseIntegration(IntegrationInstallation, GitHubIssueBasic, Rep
             message = API_ERRORS.get(exc.code)
             if message:
                 return message
-            return (
-                'Error Communicating with GitHub Enterprise (HTTP %s): %s' % (
-                    exc.code, exc.json.get('message', 'unknown error')
-                    if exc.json else 'unknown error',
-                )
+            return "Error Communicating with GitHub Enterprise (HTTP %s): %s" % (
+                exc.code,
+                exc.json.get("message", "unknown error") if exc.json else "unknown error",
             )
         else:
             return ERR_INTERNAL
@@ -149,114 +148,117 @@ class GitHubEnterpriseIntegration(IntegrationInstallation, GitHubIssueBasic, Rep
 class InstallationForm(forms.Form):
     url = forms.CharField(
         label="Installation Url",
-        help_text=_('The "base URL" for your GitHub enterprise instance, '
-                    'includes the host and protocol.'),
-        widget=forms.TextInput(
-            attrs={'placeholder': _('https://github.example.com')}
+        help_text=_(
+            'The "base URL" for your GitHub enterprise instance, ' "includes the host and protocol."
         ),
+        widget=forms.TextInput(attrs={"placeholder": _("https://github.example.com")}),
     )
     id = forms.CharField(
         label="GitHub App ID",
-        help_text=_('The App ID of your Sentry app. This can be '
-                    'found on your apps configuration page.'),
-        widget=forms.TextInput(
-            attrs={'placeholder': _('1')}
-        )
+        help_text=_(
+            "The App ID of your Sentry app. This can be " "found on your apps configuration page."
+        ),
+        widget=forms.TextInput(attrs={"placeholder": _("1")}),
     )
     name = forms.CharField(
         label="GitHub App Name",
-        help_text=_('The GitHub App name of your Sentry app. '
-                    'This can be found on the apps configuration '
-                    'page.'),
-        widget=forms.TextInput(
-            attrs={'placeholder': _('our-sentry-app')}
-        )
+        help_text=_(
+            "The GitHub App name of your Sentry app. "
+            "This can be found on the apps configuration "
+            "page."
+        ),
+        widget=forms.TextInput(attrs={"placeholder": _("our-sentry-app")}),
     )
     verify_ssl = forms.BooleanField(
         label=_("Verify SSL"),
-        help_text=_('By default, we verify SSL certificates '
-                    'when delivering payloads to your GitHub '
-                    'Enterprise instance'),
+        help_text=_(
+            "By default, we verify SSL certificates "
+            "when delivering payloads to your GitHub "
+            "Enterprise instance"
+        ),
         widget=forms.CheckboxInput(),
-        required=False
+        required=False,
     )
     webhook_secret = forms.CharField(
         label="GitHub App Webhook Secret",
-        help_text=_('We require a webhook secret to be '
-                    'configured. This can be generated as any '
-                    'random string value of your choice and '
-                    'should match your GitHub app '
-                    'configuration.'),
-        widget=forms.TextInput(
-            attrs={'placeholder': _('XXXXXXXXXXXXXXXXXXXXXXXXXXX')}
-        )
+        help_text=_(
+            "We require a webhook secret to be "
+            "configured. This can be generated as any "
+            "random string value of your choice and "
+            "should match your GitHub app "
+            "configuration."
+        ),
+        widget=forms.TextInput(attrs={"placeholder": _("XXXXXXXXXXXXXXXXXXXXXXXXXXX")}),
     )
     private_key = forms.CharField(
         label="GitHub App Private Key",
-        help_text=_('The Private Key generated for your Sentry '
-                    'GitHub App.'),
+        help_text=_("The Private Key generated for your Sentry " "GitHub App."),
         widget=forms.Textarea(
-            attrs={'rows': '60',
-                   'placeholder': _("-----BEGIN RSA PRIVATE KEY-----\n"
-                                    "XXXXXXXXXXXXXXXXXXXXXXXXXXX\n"
-                                    "XXXXXXXXXXXXXXXXXXXXXXXXXXX\n"
-                                    "XXXXXXXXXXXXXXXXXXXXXXXXXXX\n"
-                                    "XXXXXXXXXXXXXXXXXXXXXXXXXXX\n"
-                                    "-----END RSA PRIVATE KEY-----"), }
-        )
+            attrs={
+                "rows": "60",
+                "placeholder": _(
+                    "-----BEGIN RSA PRIVATE KEY-----\n"
+                    "XXXXXXXXXXXXXXXXXXXXXXXXXXX\n"
+                    "XXXXXXXXXXXXXXXXXXXXXXXXXXX\n"
+                    "XXXXXXXXXXXXXXXXXXXXXXXXXXX\n"
+                    "XXXXXXXXXXXXXXXXXXXXXXXXXXX\n"
+                    "-----END RSA PRIVATE KEY-----"
+                ),
+            }
+        ),
     )
     client_id = forms.CharField(
-        label="GitHub App OAuth Client ID",
-        widget=forms.TextInput(
-            attrs={'placeholder': _('1')}
-        )
+        label="GitHub App OAuth Client ID", widget=forms.TextInput(attrs={"placeholder": _("1")})
     )
     client_secret = forms.CharField(
         label="GitHub App OAuth Client Secret",
-        widget=forms.TextInput(
-            attrs={'placeholder': _('XXXXXXXXXXXXXXXXXXXXXXXXXXX')}
-        )
+        widget=forms.TextInput(attrs={"placeholder": _("XXXXXXXXXXXXXXXXXXXXXXXXXXX")}),
     )
 
     def __init__(self, *args, **kwargs):
         super(InstallationForm, self).__init__(*args, **kwargs)
-        self.fields['verify_ssl'].initial = True
+        self.fields["verify_ssl"].initial = True
 
 
 class InstallationConfigView(PipelineView):
     def dispatch(self, request, pipeline):
-        if request.method == 'POST':
+        if request.method == "POST":
             form = InstallationForm(request.POST)
             if form.is_valid():
                 form_data = form.cleaned_data
-                form_data['url'] = urlparse(form_data['url']).netloc
+                form_data["url"] = urlparse(form_data["url"]).netloc
 
-                pipeline.bind_state('installation_data', form_data)
+                pipeline.bind_state("installation_data", form_data)
 
-                pipeline.bind_state('oauth_config_information', {
-                    "access_token_url": u"https://{}/login/oauth/access_token".format(form_data.get('url')),
-                    "authorize_url": u"https://{}/login/oauth/authorize".format(form_data.get('url')),
-                    "client_id": form_data.get('client_id'),
-                    "client_secret": form_data.get('client_secret'),
-                    "verify_ssl": form_data.get('verify_ssl'),
-                })
+                pipeline.bind_state(
+                    "oauth_config_information",
+                    {
+                        "access_token_url": u"https://{}/login/oauth/access_token".format(
+                            form_data.get("url")
+                        ),
+                        "authorize_url": u"https://{}/login/oauth/authorize".format(
+                            form_data.get("url")
+                        ),
+                        "client_id": form_data.get("client_id"),
+                        "client_secret": form_data.get("client_secret"),
+                        "verify_ssl": form_data.get("verify_ssl"),
+                    },
+                )
 
                 return pipeline.next_step()
         else:
             form = InstallationForm()
 
         return render_to_response(
-            template='sentry/integrations/github-enterprise-config.html',
-            context={
-                'form': form,
-            },
+            template="sentry/integrations/github-enterprise-config.html",
+            context={"form": form},
             request=request,
         )
 
 
 class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
-    key = 'github_enterprise'
-    name = 'GitHub Enterprise'
+    key = "github_enterprise"
+    name = "GitHub Enterprise"
     metadata = metadata
     integration_cls = GitHubEnterpriseIntegration
 
@@ -269,25 +271,26 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
         """
         identity_pipeline_config = dict(
             oauth_scopes=(),
-            redirect_url=absolute_uri('/extensions/github-enterprise/setup/'),
-            **self.pipeline.fetch_state('oauth_config_information')
+            redirect_url=absolute_uri("/extensions/github-enterprise/setup/"),
+            **self.pipeline.fetch_state("oauth_config_information")
         )
 
         return NestedPipelineView(
-            bind_key='identity',
-            provider_key='github_enterprise',
+            bind_key="identity",
+            provider_key="github_enterprise",
             pipeline_cls=IdentityProviderPipeline,
             config=identity_pipeline_config,
         )
 
     def get_pipeline_views(self):
-        return [InstallationConfigView(),
-                GitHubEnterpriseInstallationRedirect(),
-
-                # The identity provider pipeline should be constructed at execution
-                # time, this allows for the oauth configuration parameters to be made
-                # available from the installation config view.
-                lambda: self._make_identity_pipeline_view()]
+        return [
+            InstallationConfigView(),
+            GitHubEnterpriseInstallationRedirect(),
+            # The identity provider pipeline should be constructed at execution
+            # time, this allows for the oauth configuration parameters to be made
+            # available from the installation config view.
+            lambda: self._make_identity_pipeline_view(),
+        ]
 
     def post_install(self, integration, organization):
         pass
@@ -295,97 +298,102 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
     def get_installation_info(self, installation_data, access_token, installation_id):
         session = http.build_session()
         resp = session.get(
-            u'https://{}/api/v3/app/installations/{}'.format(
-                installation_data['url'], installation_id),
+            u"https://{}/api/v3/app/installations/{}".format(
+                installation_data["url"], installation_id
+            ),
             headers={
-                'Authorization': 'Bearer %s' % get_jwt(github_id=installation_data['id'], github_private_key=installation_data['private_key']),
-                'Accept': 'application/vnd.github.machine-man-preview+json',
+                "Authorization": "Bearer %s"
+                % get_jwt(
+                    github_id=installation_data["id"],
+                    github_private_key=installation_data["private_key"],
+                ),
+                "Accept": "application/vnd.github.machine-man-preview+json",
             },
-            verify=installation_data['verify_ssl']
+            verify=installation_data["verify_ssl"],
         )
         resp.raise_for_status()
         installation_resp = resp.json()
 
         resp = session.get(
-            u'https://{}/api/v3/user/installations'.format(installation_data['url']),
-            params={'access_token': access_token},
-            headers={'Accept': 'application/vnd.github.machine-man-preview+json'},
-            verify=installation_data['verify_ssl']
+            u"https://{}/api/v3/user/installations".format(installation_data["url"]),
+            params={"access_token": access_token},
+            headers={"Accept": "application/vnd.github.machine-man-preview+json"},
+            verify=installation_data["verify_ssl"],
         )
         resp.raise_for_status()
         user_installations_resp = resp.json()
 
         # verify that user actually has access to the installation
-        for installation in user_installations_resp['installations']:
-            if installation['id'] == installation_resp['id']:
+        for installation in user_installations_resp["installations"]:
+            if installation["id"] == installation_resp["id"]:
                 return installation_resp
 
         return None
 
     def build_integration(self, state):
-        identity = state['identity']['data']
-        installation_data = state['installation_data']
-        user = get_user_info(installation_data['url'], identity['access_token'])
+        identity = state["identity"]["data"]
+        installation_data = state["installation_data"]
+        user = get_user_info(installation_data["url"], identity["access_token"])
         installation = self.get_installation_info(
-            installation_data,
-            identity['access_token'],
-            state['installation_id'])
+            installation_data, identity["access_token"], state["installation_id"]
+        )
 
-        domain = urlparse(installation['account']['html_url']).netloc
+        domain = urlparse(installation["account"]["html_url"]).netloc
         integration = {
-            'name': installation['account']['login'],
+            "name": installation["account"]["login"],
             # installation id is not enough to be unique for self-hosted GH
-            'external_id': u'{}:{}'.format(domain, installation['id']),
+            "external_id": u"{}:{}".format(domain, installation["id"]),
             # GitHub identity is associated directly to the application, *not*
             # to the installation itself.
             # app id is not enough to be unique for self-hosted GH
-            'idp_external_id': u'{}:{}'.format(domain, installation['app_id']),
-            'metadata': {
+            "idp_external_id": u"{}:{}".format(domain, installation["app_id"]),
+            "metadata": {
                 # The access token will be populated upon API usage
-                'access_token': None,
-                'expires_at': None,
-                'icon': installation['account']['avatar_url'],
-                'domain_name': installation['account']['html_url'].replace('https://', ''),
-                'account_type': installation['account']['type'],
-                'installation_id': installation['id'],
-                'installation': installation_data
+                "access_token": None,
+                "expires_at": None,
+                "icon": installation["account"]["avatar_url"],
+                "domain_name": installation["account"]["html_url"].replace("https://", ""),
+                "account_type": installation["account"]["type"],
+                "installation_id": installation["id"],
+                "installation": installation_data,
             },
-            'user_identity': {
-                'type': 'github_enterprise',
-                'external_id': user['id'],
-                'scopes': [],  # GitHub apps do not have user scopes
-                'data': {'access_token': identity['access_token']},
+            "user_identity": {
+                "type": "github_enterprise",
+                "external_id": user["id"],
+                "scopes": [],  # GitHub apps do not have user scopes
+                "data": {"access_token": identity["access_token"]},
             },
-            'idp_config': state['oauth_config_information']
+            "idp_config": state["oauth_config_information"],
         }
 
-        if state.get('reinstall_id'):
-            integration['reinstall_id'] = state['reinstall_id']
+        if state.get("reinstall_id"):
+            integration["reinstall_id"] = state["reinstall_id"]
 
         return integration
 
     def setup(self):
         from sentry.plugins import bindings
+
         bindings.add(
-            'integration-repository.provider',
+            "integration-repository.provider",
             GitHubEnterpriseRepositoryProvider,
-            id='integrations:github_enterprise',
+            id="integrations:github_enterprise",
         )
 
 
 class GitHubEnterpriseInstallationRedirect(PipelineView):
     def get_app_url(self, installation_data):
-        url = installation_data.get('url')
-        name = installation_data.get('name')
-        return u'https://{}/github-apps/{}'.format(url, name)
+        url = installation_data.get("url")
+        name = installation_data.get("name")
+        return u"https://{}/github-apps/{}".format(url, name)
 
     def dispatch(self, request, pipeline):
-        installation_data = pipeline.fetch_state(key='installation_data')
-        if 'reinstall_id' in request.GET:
-            pipeline.bind_state('reinstall_id', request.GET['reinstall_id'])
+        installation_data = pipeline.fetch_state(key="installation_data")
+        if "reinstall_id" in request.GET:
+            pipeline.bind_state("reinstall_id", request.GET["reinstall_id"])
 
-        if 'installation_id' in request.GET:
-            pipeline.bind_state('installation_id', request.GET['installation_id'])
+        if "installation_id" in request.GET:
+            pipeline.bind_state("installation_id", request.GET["installation_id"])
             return pipeline.next_step()
 
         return self.redirect(self.get_app_url(installation_data))

--- a/src/sentry/integrations/github_enterprise/repository.py
+++ b/src/sentry/integrations/github_enterprise/repository.py
@@ -7,13 +7,13 @@ from sentry.integrations.exceptions import ApiError, IntegrationError
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 
 
-WEBHOOK_EVENTS = ['push', 'pull_request']
+WEBHOOK_EVENTS = ["push", "pull_request"]
 
 
 class GitHubEnterpriseRepositoryProvider(GitHubRepositoryProvider):
-    name = 'GitHub Enterprise'
-    logger = logging.getLogger('sentry.plugins.github_enterprise')
-    repo_provider = 'github_enterprise'
+    name = "GitHub Enterprise"
+    logger = logging.getLogger("sentry.plugins.github_enterprise")
+    repo_provider = "github_enterprise"
 
     def _validate_repo(self, client, installation, repo):
         try:
@@ -25,21 +25,20 @@ class GitHubEnterpriseRepositoryProvider(GitHubRepositoryProvider):
             # make sure installation has access to this specific repo
             client.get_commits(repo)
         except ApiError as e:
-            raise IntegrationError(u'You must grant Sentry access to {}'.format(repo))
+            raise IntegrationError(u"You must grant Sentry access to {}".format(repo))
 
         return repo_data
 
     def build_repository_config(self, organization, data):
         integration = Integration.objects.get(
-            id=data['integration_id'], provider=self.repo_provider)
+            id=data["integration_id"], provider=self.repo_provider
+        )
 
-        base_url = integration.metadata['domain_name'].split('/')[0]
+        base_url = integration.metadata["domain_name"].split("/")[0]
         return {
-            'name': data['identifier'],
-            'external_id': data['external_id'],
-            'url': u'https://{}/{}'.format(base_url, data['identifier']),
-            'config': {
-                'name': data['identifier'],
-            },
-            'integration_id': data['integration_id']
+            "name": data["identifier"],
+            "external_id": data["external_id"],
+            "url": u"https://{}/{}".format(base_url, data["identifier"]),
+            "config": {"name": data["identifier"]},
+            "integration_id": data["integration_id"],
         }

--- a/src/sentry/integrations/github_enterprise/urls.py
+++ b/src/sentry/integrations/github_enterprise/urls.py
@@ -5,7 +5,4 @@ from django.conf.urls import patterns, url
 from .webhook import GitHubEnterpriseWebhookEndpoint
 
 
-urlpatterns = patterns(
-    '',
-    url(r'^webhook/$', GitHubEnterpriseWebhookEndpoint.as_view()),
-)
+urlpatterns = patterns("", url(r"^webhook/$", GitHubEnterpriseWebhookEndpoint.as_view()))

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -14,10 +14,15 @@ from django.views.generic import View
 from simplejson import JSONDecodeError
 from sentry.models import Integration
 from sentry.utils import json
-from sentry.integrations.github.webhook import InstallationEventWebhook, InstallationRepositoryEventWebhook, PushEventWebhook, PullRequestEventWebhook
+from sentry.integrations.github.webhook import (
+    InstallationEventWebhook,
+    InstallationRepositoryEventWebhook,
+    PushEventWebhook,
+    PullRequestEventWebhook,
+)
 from .repository import GitHubEnterpriseRepositoryProvider
 
-logger = logging.getLogger('sentry.webhooks')
+logger = logging.getLogger("sentry.webhooks")
 
 
 def get_installation_metadata(event, host):
@@ -25,19 +30,20 @@ def get_installation_metadata(event, host):
         return
     try:
         integration = Integration.objects.get(
-            external_id=u'{}:{}'.format(host, event['installation']['id']),
-            provider='github_enterprise')
+            external_id=u"{}:{}".format(host, event["installation"]["id"]),
+            provider="github_enterprise",
+        )
     except Integration.DoesNotExist:
         return
-    return integration.metadata['installation']
+    return integration.metadata["installation"]
 
 
 class GitHubEnterpriseInstallationEventWebhook(InstallationEventWebhook):
-    provider = 'github_enterprise'
+    provider = "github_enterprise"
 
 
 class GitHubEnterpriseInstallationRepositoryEventWebhook(InstallationRepositoryEventWebhook):
-    provider = 'github_enterprise'
+    provider = "github_enterprise"
 
     # https://developer.github.com/v3/activity/events/types/#installationrepositoriesevent
     def _handle(self, event, organization, repo):
@@ -45,34 +51,34 @@ class GitHubEnterpriseInstallationRepositoryEventWebhook(InstallationRepositoryE
 
 
 class GitHubEnterprisePushEventWebhook(PushEventWebhook):
-    provider = 'github_enterprise'
+    provider = "github_enterprise"
 
     # https://developer.github.com/v3/activity/events/types/#pushevent
     def is_anonymous_email(self, email):
-        return email[-25:] == '@users.noreply.github.com'
+        return email[-25:] == "@users.noreply.github.com"
 
     def get_external_id(self, username):
-        return 'github_enterprise:%s' % username
+        return "github_enterprise:%s" % username
 
     def get_idp_external_id(self, integration, host):
-        return u'{}:{}'.format(host, integration.metadata['installation']['id'])
+        return u"{}:{}".format(host, integration.metadata["installation"]["id"])
 
     def should_ignore_commit(self, commit):
-        return GitHubEnterpriseRepositoryProvider.should_ignore_commit(commit['message'])
+        return GitHubEnterpriseRepositoryProvider.should_ignore_commit(commit["message"])
 
 
 class GitHubEnterprisePullRequestEventWebhook(PullRequestEventWebhook):
-    provider = 'github_enterprise'
+    provider = "github_enterprise"
 
     # https://developer.github.com/v3/activity/events/types/#pullrequestevent
     def is_anonymous_email(self, email):
-        return email[-25:] == '@users.noreply.github.com'
+        return email[-25:] == "@users.noreply.github.com"
 
     def get_external_id(self, username):
-        return 'github_enterprise:%s' % username
+        return "github_enterprise:%s" % username
 
     def get_idp_external_id(self, integration, host):
-        return u'{}:{}'.format(host, integration.metadata['installation']['id'])
+        return u"{}:{}".format(host, integration.metadata["installation"]["id"])
 
 
 class GitHubEnterpriseWebhookBase(View):
@@ -81,18 +87,16 @@ class GitHubEnterpriseWebhookBase(View):
         return self._handlers.get(event_type)
 
     def is_valid_signature(self, method, body, secret, signature):
-        if method != 'sha1':
-            raise NotImplementedError('signature method %s is not supported' % (method, ))
+        if method != "sha1":
+            raise NotImplementedError("signature method %s is not supported" % (method,))
         expected = hmac.new(
-            key=secret.encode('utf-8'),
-            msg=body,
-            digestmod=hashlib.sha1,
+            key=secret.encode("utf-8"), msg=body, digestmod=hashlib.sha1
         ).hexdigest()
         return constant_time_compare(expected, signature)
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
-        if request.method != 'POST':
+        if request.method != "POST":
             return HttpResponse(status=405)
 
         return super(GitHubEnterpriseWebhookBase, self).dispatch(request, *args, **kwargs)
@@ -103,69 +107,59 @@ class GitHubEnterpriseWebhookBase(View):
     def get_secret(self, event, host):
         metadata = get_installation_metadata(event, host)
         if metadata:
-            return metadata.get('webhook_secret')
+            return metadata.get("webhook_secret")
         else:
             return None
 
     def handle(self, request):
         body = six.binary_type(request.body)
         if not body:
-            logger.warning(
-                'github_enterprise.webhook.missing-body',
-                extra=self.get_logging_data(),
-            )
+            logger.warning("github_enterprise.webhook.missing-body", extra=self.get_logging_data())
             return HttpResponse(status=400)
 
         try:
-            handler = self.get_handler(request.META['HTTP_X_GITHUB_EVENT'])
+            handler = self.get_handler(request.META["HTTP_X_GITHUB_EVENT"])
         except KeyError:
-            logger.warning(
-                'github_enterprise.webhook.missing-event',
-                extra=self.get_logging_data(),
-            )
+            logger.warning("github_enterprise.webhook.missing-event", extra=self.get_logging_data())
             return HttpResponse(status=400)
 
         if not handler:
             return HttpResponse(status=204)
 
         try:
-            event = json.loads(body.decode('utf-8'))
+            event = json.loads(body.decode("utf-8"))
         except JSONDecodeError:
             logger.warning(
-                'github_enterprise.webhook.invalid-json',
+                "github_enterprise.webhook.invalid-json",
                 extra=self.get_logging_data(),
                 exc_info=True,
             )
             return HttpResponse(status=400)
 
         try:
-            host = request.META['HTTP_X_GITHUB_ENTERPRISE_HOST']
+            host = request.META["HTTP_X_GITHUB_ENTERPRISE_HOST"]
         except KeyError:
-            logger.warning('github_enterprise.webhook.missing-enterprise-host')
+            logger.warning("github_enterprise.webhook.missing-enterprise-host")
             return HttpResponse(status=400)
 
         secret = self.get_secret(event, host)
         if not secret:
-            logger.warning(
-                'github_enterprise.webhook.missing-integration',
-                extra={'host': host}
-            )
+            logger.warning("github_enterprise.webhook.missing-integration", extra={"host": host})
             return HttpResponse(status=400)
 
         try:
             # Attempt to validate the signature. Older versions of
             # GitHub Enterprise do not send the signature so this is an optional step.
-            method, signature = request.META['HTTP_X_HUB_SIGNATURE'].split('=', 1)
+            method, signature = request.META["HTTP_X_HUB_SIGNATURE"].split("=", 1)
             if not self.is_valid_signature(method, body, secret, signature):
                 logger.warning(
-                    'github_enterprise.webhook.invalid-signature',
-                    extra=self.get_logging_data(),
+                    "github_enterprise.webhook.invalid-signature", extra=self.get_logging_data()
                 )
                 return HttpResponse(status=401)
         except (KeyError, IndexError) as e:
             logger.info(
-                'github_enterprise.webhook.missing-signature',
-                extra={'host': host, 'error': six.text_type(e)}
+                "github_enterprise.webhook.missing-signature",
+                extra={"host": host, "error": six.text_type(e)},
             )
         handler()(event, host)
         return HttpResponse(status=204)
@@ -173,15 +167,15 @@ class GitHubEnterpriseWebhookBase(View):
 
 class GitHubEnterpriseWebhookEndpoint(GitHubEnterpriseWebhookBase):
     _handlers = {
-        'push': GitHubEnterprisePushEventWebhook,
-        'pull_request': GitHubEnterprisePullRequestEventWebhook,
-        'installation': GitHubEnterpriseInstallationEventWebhook,
-        'installation_repositories': GitHubEnterpriseInstallationRepositoryEventWebhook,
+        "push": GitHubEnterprisePushEventWebhook,
+        "pull_request": GitHubEnterprisePullRequestEventWebhook,
+        "installation": GitHubEnterpriseInstallationEventWebhook,
+        "installation_repositories": GitHubEnterpriseInstallationRepositoryEventWebhook,
     }
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
-        if request.method != 'POST':
+        if request.method != "POST":
             return HttpResponse(status=405)
 
         return super(GitHubEnterpriseWebhookEndpoint, self).dispatch(request, *args, **kwargs)

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -8,34 +8,30 @@ from sentry.utils.http import absolute_uri
 from six.moves.urllib.parse import quote
 
 
-API_VERSION = u'/api/v4'
+API_VERSION = u"/api/v4"
 
 
 class GitLabApiClientPath(object):
-    oauth_token = u'/oauth/token'
-    commit = u'/projects/{project}/repository/commits/{sha}'
-    commits = u'/projects/{project}/repository/commits'
-    compare = u'/projects/{project}/repository/compare'
-    diff = u'/projects/{project}/repository/commits/{sha}/diff'
-    group = u'/groups/{group}'
-    group_projects = u'/groups/{group}/projects'
-    hooks = u'/hooks'
-    issue = u'/projects/{project}/issues/{issue}'
-    issues = u'/projects/{project}/issues'
-    notes = u'/projects/{project}/issues/{issue_id}/notes'
-    project = u'/projects/{project}'
-    project_issues = u'/projects/{project}/issues'
-    project_hooks = u'/projects/{project}/hooks'
-    project_hook = u'/projects/{project}/hooks/{hook_id}'
-    user = u'/user'
+    oauth_token = u"/oauth/token"
+    commit = u"/projects/{project}/repository/commits/{sha}"
+    commits = u"/projects/{project}/repository/commits"
+    compare = u"/projects/{project}/repository/compare"
+    diff = u"/projects/{project}/repository/commits/{sha}/diff"
+    group = u"/groups/{group}"
+    group_projects = u"/groups/{group}/projects"
+    hooks = u"/hooks"
+    issue = u"/projects/{project}/issues/{issue}"
+    issues = u"/projects/{project}/issues"
+    notes = u"/projects/{project}/issues/{issue_id}/notes"
+    project = u"/projects/{project}"
+    project_issues = u"/projects/{project}/issues"
+    project_hooks = u"/projects/{project}/hooks"
+    project_hook = u"/projects/{project}/hooks/{hook_id}"
+    user = u"/user"
 
     @staticmethod
     def build_api_url(base_url, path):
-        return u'{base_url}{api}{path}'.format(
-            base_url=base_url,
-            api=API_VERSION,
-            path=path,
-        )
+        return u"{base_url}{api}{path}".format(base_url=base_url, api=API_VERSION, path=path)
 
 
 class GitLabSetupClient(ApiClient):
@@ -45,7 +41,7 @@ class GitLabSetupClient(ApiClient):
     needed to build installation metadata
     """
 
-    integration_name = 'gitlab_setup'
+    integration_name = "gitlab_setup"
 
     def __init__(self, base_url, access_token, verify_ssl):
         self.base_url = base_url
@@ -58,29 +54,27 @@ class GitLabSetupClient(ApiClient):
         We need to URL quote because subgroups use `/` in their
         `id` and GitLab requires slugs to be URL encoded.
         """
-        group = quote(group, safe='')
+        group = quote(group, safe="")
         path = GitLabApiClientPath.group.format(group=group)
         return self.get(path)
 
     def request(self, method, path, data=None, params=None):
-        headers = {
-            'Authorization': u'Bearer {}'.format(self.token)
-        }
+        headers = {"Authorization": u"Bearer {}".format(self.token)}
         return self._request(
             method,
             GitLabApiClientPath.build_api_url(self.base_url, path),
             headers=headers,
             data=data,
-            params=params
+            params=params,
         )
 
 
 class GitLabApiClient(ApiClient):
-    integration_name = 'gitlab'
+    integration_name = "gitlab"
 
     def __init__(self, installation):
         self.installation = installation
-        verify_ssl = self.metadata['verify_ssl']
+        verify_ssl = self.metadata["verify_ssl"]
         self.is_refreshing_token = False
         super(GitLabApiClient, self).__init__(verify_ssl)
 
@@ -93,30 +87,17 @@ class GitLabApiClient(ApiClient):
         return self.installation.model.metadata
 
     def request(self, method, path, data=None, params=None):
-        access_token = self.identity.data['access_token']
-        headers = {
-            'Authorization': u'Bearer {}'.format(access_token)
-        }
-        url = GitLabApiClientPath.build_api_url(
-            self.metadata['base_url'],
-            path
-        )
+        access_token = self.identity.data["access_token"]
+        headers = {"Authorization": u"Bearer {}".format(access_token)}
+        url = GitLabApiClientPath.build_api_url(self.metadata["base_url"], path)
         try:
-            return self._request(
-                method,
-                url,
-                headers=headers, data=data, params=params
-            )
+            return self._request(method, url, headers=headers, data=data, params=params)
         except ApiUnauthorized as e:
             if self.is_refreshing_token:
                 raise e
             self.is_refreshing_token = True
             self.refresh_auth()
-            resp = self._request(
-                method,
-                url,
-                headers=headers, data=data, params=params
-            )
+            resp = self._request(method, url, headers=headers, data=data, params=params)
             self.is_refreshing_token = False
             return resp
 
@@ -129,7 +110,7 @@ class GitLabApiClient(ApiClient):
         """
         self.identity.get_provider().refresh_identity(
             self.identity,
-            refresh_token_url='%s%s' % (self.metadata['base_url'], GitLabApiClientPath.oauth_token),
+            refresh_token_url="%s%s" % (self.metadata["base_url"], GitLabApiClientPath.oauth_token),
         )
 
     def get_user(self):
@@ -147,13 +128,8 @@ class GitLabApiClient(ApiClient):
         # simple param returns limited fields for the project.
         # Really useful, because we often don't need most of the project information
         return self.get(
-            GitLabApiClientPath.group_projects.format(
-                group=group,
-            ),
-            params={
-                'search': query,
-                'simple': simple,
-            }
+            GitLabApiClientPath.group_projects.format(group=group),
+            params={"search": query, "simple": simple},
         )
 
     def get_project(self, project_id):
@@ -161,9 +137,7 @@ class GitLabApiClient(ApiClient):
 
         See https://docs.gitlab.com/ee/api/projects.html#get-single-project
         """
-        return self.get(
-            GitLabApiClientPath.project.format(project=project_id)
-        )
+        return self.get(GitLabApiClientPath.project.format(project=project_id))
 
     def get_issue(self, project_id, issue_id):
         """Get an issue
@@ -171,21 +145,16 @@ class GitLabApiClient(ApiClient):
         See https://docs.gitlab.com/ee/api/issues.html#single-issue
         """
         try:
-            return self.get(
-                GitLabApiClientPath.issue.format(project=project_id, issue=issue_id)
-            )
+            return self.get(GitLabApiClientPath.issue.format(project=project_id, issue=issue_id))
         except IndexError:
-            raise ApiError('Issue not found with ID', 404)
+            raise ApiError("Issue not found with ID", 404)
 
     def create_issue(self, project, data):
         """Create an issue
 
         See https://docs.gitlab.com/ee/api/issues.html#new-issue
         """
-        return self.post(
-            GitLabApiClientPath.issues.format(project=project),
-            data=data,
-        )
+        return self.post(GitLabApiClientPath.issues.format(project=project), data=data)
 
     def create_issue_comment(self, project_id, issue_id, data):
         """Create an issue note/comment
@@ -193,8 +162,7 @@ class GitLabApiClient(ApiClient):
         See https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note
         """
         return self.post(
-            GitLabApiClientPath.notes.format(project=project_id, issue_id=issue_id),
-            data=data,
+            GitLabApiClientPath.notes.format(project=project_id, issue_id=issue_id), data=data
         )
 
     def search_project_issues(self, project_id, query, iids=None):
@@ -204,11 +172,7 @@ class GitLabApiClient(ApiClient):
         """
         path = GitLabApiClientPath.project_issues.format(project=project_id)
 
-        return self.get(path, params={
-            'scope': 'all',
-            'search': query,
-            'iids': iids,
-        })
+        return self.get(path, params={"scope": "all", "search": query, "iids": iids})
 
     def create_project_webhook(self, project_id):
         """Create a webhook on a project
@@ -216,18 +180,18 @@ class GitLabApiClient(ApiClient):
         See https://docs.gitlab.com/ee/api/projects.html#add-project-hook
         """
         path = GitLabApiClientPath.project_hooks.format(project=project_id)
-        hook_uri = reverse('sentry-extensions-gitlab-webhook')
+        hook_uri = reverse("sentry-extensions-gitlab-webhook")
         model = self.installation.model
         data = {
-            'url': absolute_uri(hook_uri),
-            'token': u'{}:{}'.format(model.external_id, model.metadata['webhook_secret']),
-            'merge_requests_events': True,
-            'push_events': True,
-            'enable_ssl_verification': model.metadata['verify_ssl'],
+            "url": absolute_uri(hook_uri),
+            "token": u"{}:{}".format(model.external_id, model.metadata["webhook_secret"]),
+            "merge_requests_events": True,
+            "push_events": True,
+            "enable_ssl_verification": model.metadata["verify_ssl"],
         }
         resp = self.post(path, data)
 
-        return resp['id']
+        return resp["id"]
 
     def delete_project_webhook(self, project_id, hook_id):
         """Delete a webhook from a project
@@ -250,10 +214,10 @@ class GitLabApiClient(ApiClient):
         commit = self.get(path)
         if not commit:
             return []
-        end_date = commit['created_at']
+        end_date = commit["created_at"]
 
         path = GitLabApiClientPath.commits.format(project=project_id)
-        return self.get(path, params={'until': end_date})
+        return self.get(path, params={"until": end_date})
 
     def compare_commits(self, project_id, start_sha, end_sha):
         """Compare commits between two shas
@@ -261,15 +225,12 @@ class GitLabApiClient(ApiClient):
         See https://docs.gitlab.com/ee/api/repositories.html#compare-branches-tags-or-commits
         """
         path = GitLabApiClientPath.compare.format(project=project_id)
-        return self.get(path, params={'from': start_sha, 'to': end_sha})
+        return self.get(path, params={"from": start_sha, "to": end_sha})
 
     def get_diff(self, project_id, sha):
         """Get the diff for a commit
 
         See https://docs.gitlab.com/ee/api/commits.html#get-the-diff-of-a-commit
         """
-        path = GitLabApiClientPath.diff.format(
-            project=project_id,
-            sha=sha
-        )
+        path = GitLabApiClientPath.diff.format(project=project_id, sha=sha)
         return self.get(path)

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -13,7 +13,7 @@ from sentry.integrations import (
     IntegrationInstallation,
     IntegrationFeatures,
     IntegrationProvider,
-    IntegrationMetadata
+    IntegrationMetadata,
 )
 from sentry.integrations.exceptions import ApiError, IntegrationError
 from sentry.integrations.repositories import RepositoryMixin
@@ -61,10 +61,10 @@ FEATURES = [
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
     features=FEATURES,
-    author='The Sentry Team',
-    noun=_('Installation'),
-    issue_url='https://github.com/getsentry/sentry/issues/',
-    source_url='https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/gitlab',
+    author="The Sentry Team",
+    noun=_("Installation"),
+    issue_url="https://github.com/getsentry/sentry/issues/",
+    source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/gitlab",
     aspects={},
 )
 
@@ -77,7 +77,7 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
         self.default_identity = None
 
     def get_group_id(self):
-        return self.model.metadata['group_id']
+        return self.model.metadata["group_id"]
 
     def get_client(self):
         if self.default_identity is None:
@@ -89,10 +89,7 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
         # Note: gitlab projects are the same things as repos everywhere else
         group = self.get_group_id()
         resp = self.get_client().search_group_projects(group, query)
-        return [{
-            'identifier': repo['id'],
-            'name': repo['name_with_namespace'],
-        } for repo in resp]
+        return [{"identifier": repo["id"], "name": repo["name_with_namespace"]} for repo in resp]
 
     def search_projects(self, query):
         client = self.get_client()
@@ -111,134 +108,131 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
 
         See https://docs.gitlab.com/ee/api/#data-validation-and-error-reporting
         """
-        if 'message' in data:
-            return data['message']
-        if 'error' in data:
-            return data['error']
+        if "message" in data:
+            return data["message"]
+        if "error" in data:
+            return data["error"]
 
 
 class InstallationForm(forms.Form):
     url = forms.CharField(
-        label=_('GitLab URL'),
-        help_text=_('The base URL for your GitLab instance, including the host and protocol. '
-                    'Do not include group path.'
-                    '<br>'
-                    'If using gitlab.com, enter https://gitlab.com/'),
-        widget=forms.TextInput(
-            attrs={'placeholder': 'https://gitlab.example.com'}
+        label=_("GitLab URL"),
+        help_text=_(
+            "The base URL for your GitLab instance, including the host and protocol. "
+            "Do not include group path."
+            "<br>"
+            "If using gitlab.com, enter https://gitlab.com/"
         ),
+        widget=forms.TextInput(attrs={"placeholder": "https://gitlab.example.com"}),
     )
     group = forms.CharField(
-        label=_('GitLab Group Path'),
-        help_text=_('This can be found in the URL of your group\'s GitLab page. '
-                    '<br>'
-                    'For example, if your group can be found at '
-                    'https://gitlab.com/my-group/my-subgroup, enter `my-group/my-subgroup`.'),
-        widget=forms.TextInput(
-            attrs={'placeholder': _('my-group/my-subgroup')}
-        )
+        label=_("GitLab Group Path"),
+        help_text=_(
+            "This can be found in the URL of your group's GitLab page. "
+            "<br>"
+            "For example, if your group can be found at "
+            "https://gitlab.com/my-group/my-subgroup, enter `my-group/my-subgroup`."
+        ),
+        widget=forms.TextInput(attrs={"placeholder": _("my-group/my-subgroup")}),
     )
     verify_ssl = forms.BooleanField(
-        label=_('Verify SSL'),
-        help_text=_('By default, we verify SSL certificates '
-                    'when delivering payloads to your GitLab instance, '
-                    'and request GitLab to verify SSL when it delivers '
-                    'webhooks to Sentry.'),
+        label=_("Verify SSL"),
+        help_text=_(
+            "By default, we verify SSL certificates "
+            "when delivering payloads to your GitLab instance, "
+            "and request GitLab to verify SSL when it delivers "
+            "webhooks to Sentry."
+        ),
         widget=forms.CheckboxInput(),
         required=False,
-        initial=True
+        initial=True,
     )
     client_id = forms.CharField(
-        label=_('GitLab Application ID'),
+        label=_("GitLab Application ID"),
         widget=forms.TextInput(
-            attrs={'placeholder': _(
-                '5832fc6e14300a0d962240a8144466eef4ee93ef0d218477e55f11cf12fc3737')}
-        )
+            attrs={
+                "placeholder": _("5832fc6e14300a0d962240a8144466eef4ee93ef0d218477e55f11cf12fc3737")
+            }
+        ),
     )
     client_secret = forms.CharField(
-        label=_('GitLab Application Secret'),
-        widget=forms.TextInput(
-            attrs={'placeholder': _('XXXXXXXXXXXXXXXXXXXXXXXXXXX')}
-        )
+        label=_("GitLab Application Secret"),
+        widget=forms.TextInput(attrs={"placeholder": _("XXXXXXXXXXXXXXXXXXXXXXXXXXX")}),
     )
 
     def clean_url(self):
         """Strip off trailing / as they cause invalid URLs downstream"""
-        return self.cleaned_data['url'].rstrip('/')
+        return self.cleaned_data["url"].rstrip("/")
 
 
 class InstallationConfigView(PipelineView):
     def dispatch(self, request, pipeline):
-        if request.method == 'POST':
+        if request.method == "POST":
             form = InstallationForm(request.POST)
             if form.is_valid():
                 form_data = form.cleaned_data
 
-                pipeline.bind_state('installation_data', form_data)
+                pipeline.bind_state("installation_data", form_data)
 
-                pipeline.bind_state('oauth_config_information', {
-                    "access_token_url": u"{}/oauth/token".format(form_data.get('url')),
-                    "authorize_url": u"{}/oauth/authorize".format(form_data.get('url')),
-                    "client_id": form_data.get('client_id'),
-                    "client_secret": form_data.get('client_secret'),
-                    "verify_ssl": form_data.get('verify_ssl')
-                })
+                pipeline.bind_state(
+                    "oauth_config_information",
+                    {
+                        "access_token_url": u"{}/oauth/token".format(form_data.get("url")),
+                        "authorize_url": u"{}/oauth/authorize".format(form_data.get("url")),
+                        "client_id": form_data.get("client_id"),
+                        "client_secret": form_data.get("client_secret"),
+                        "verify_ssl": form_data.get("verify_ssl"),
+                    },
+                )
                 pipeline.get_logger().info(
-                    'gitlab.setup.installation-config-view.success',
+                    "gitlab.setup.installation-config-view.success",
                     extra={
-                        'base_url': form_data.get('url'),
-                        'client_id': form_data.get('client_id'),
-                        'verify_ssl': form_data.get('verify_ssl'),
-                    }
+                        "base_url": form_data.get("url"),
+                        "client_id": form_data.get("client_id"),
+                        "verify_ssl": form_data.get("verify_ssl"),
+                    },
                 )
                 return pipeline.next_step()
         else:
             form = InstallationForm()
 
         return render_to_response(
-            template='sentry/integrations/gitlab-config.html',
-            context={
-                'form': form,
-            },
+            template="sentry/integrations/gitlab-config.html",
+            context={"form": form},
             request=request,
         )
 
 
 class InstallationGuideView(PipelineView):
     def dispatch(self, request, pipeline):
-        if 'completed_installation_guide' in request.GET:
+        if "completed_installation_guide" in request.GET:
             return pipeline.next_step()
         return render_to_response(
-            template='sentry/integrations/gitlab-config.html',
+            template="sentry/integrations/gitlab-config.html",
             context={
-                'next_url': '%s%s' % (absolute_uri('extensions/gitlab/setup/'), '?completed_installation_guide'),
-                'setup_values': [
-                    {'label': 'Name', 'value': 'Sentry'},
-                    {'label': 'Redirect URI', 'value': absolute_uri('/extensions/gitlab/setup/')},
-                    {'label': 'Scopes', 'value': 'api'}
-                ]
+                "next_url": "%s%s"
+                % (absolute_uri("extensions/gitlab/setup/"), "?completed_installation_guide"),
+                "setup_values": [
+                    {"label": "Name", "value": "Sentry"},
+                    {"label": "Redirect URI", "value": absolute_uri("/extensions/gitlab/setup/")},
+                    {"label": "Scopes", "value": "api"},
+                ],
             },
             request=request,
         )
 
 
 class GitlabIntegrationProvider(IntegrationProvider):
-    key = 'gitlab'
-    name = 'GitLab'
+    key = "gitlab"
+    name = "GitLab"
     metadata = metadata
     integration_cls = GitlabIntegration
 
     needs_default_identity = True
 
-    features = frozenset([
-        IntegrationFeatures.ISSUE_BASIC,
-        IntegrationFeatures.COMMITS,
-    ])
+    features = frozenset([IntegrationFeatures.ISSUE_BASIC, IntegrationFeatures.COMMITS])
 
-    setup_dialog_config = {
-        'width': 1030,
-        'height': 1000,
-    }
+    setup_dialog_config = {"width": 1030, "height": 1000}
 
     def _make_identity_pipeline_view(self):
         """
@@ -249,90 +243,90 @@ class GitlabIntegrationProvider(IntegrationProvider):
         """
         identity_pipeline_config = dict(
             oauth_scopes=sorted(GitlabIdentityProvider.oauth_scopes),
-            redirect_url=absolute_uri('/extensions/gitlab/setup/'),
-            **self.pipeline.fetch_state('oauth_config_information')
+            redirect_url=absolute_uri("/extensions/gitlab/setup/"),
+            **self.pipeline.fetch_state("oauth_config_information")
         )
 
         return NestedPipelineView(
-            bind_key='identity',
-            provider_key='gitlab',
+            bind_key="identity",
+            provider_key="gitlab",
             pipeline_cls=IdentityProviderPipeline,
             config=identity_pipeline_config,
         )
 
     def get_group_info(self, access_token, installation_data):
         client = GitLabSetupClient(
-            installation_data['url'],
-            access_token,
-            installation_data['verify_ssl']
+            installation_data["url"], access_token, installation_data["verify_ssl"]
         )
         try:
-            resp = client.get_group(installation_data['group'])
+            resp = client.get_group(installation_data["group"])
             return resp.json
         except ApiError as e:
             self.get_logger().info(
-                'gitlab.installation.get-group-info-failure',
+                "gitlab.installation.get-group-info-failure",
                 extra={
-                    'base_url': installation_data['url'],
-                    'verify_ssl': installation_data['verify_ssl'],
-                    'group': installation_data['group'],
-                    'error_message': e.message,
-                    'error_status': e.code,
-                }
+                    "base_url": installation_data["url"],
+                    "verify_ssl": installation_data["verify_ssl"],
+                    "group": installation_data["group"],
+                    "error_message": e.message,
+                    "error_status": e.code,
+                },
             )
-            raise IntegrationError('The requested GitLab group could not be found.')
+            raise IntegrationError("The requested GitLab group could not be found.")
 
     def get_pipeline_views(self):
-        return [InstallationGuideView(), InstallationConfigView(),
-                lambda: self._make_identity_pipeline_view()]
+        return [
+            InstallationGuideView(),
+            InstallationConfigView(),
+            lambda: self._make_identity_pipeline_view(),
+        ]
 
     def build_integration(self, state):
-        data = state['identity']['data']
+        data = state["identity"]["data"]
         oauth_data = get_oauth_data(data)
-        user = get_user_info(data['access_token'], state['installation_data'])
-        group = self.get_group_info(data['access_token'], state['installation_data'])
+        user = get_user_info(data["access_token"], state["installation_data"])
+        group = self.get_group_info(data["access_token"], state["installation_data"])
         scopes = sorted(GitlabIdentityProvider.oauth_scopes)
-        base_url = state['installation_data']['url']
+        base_url = state["installation_data"]["url"]
 
         hostname = urlparse(base_url).netloc
-        verify_ssl = state['installation_data']['verify_ssl']
+        verify_ssl = state["installation_data"]["verify_ssl"]
 
         # Generate a hash to prevent stray hooks from being accepted
         # use a consistent hash so that reinstalls/shared integrations don't
         # rotate secrets.
-        secret = sha1_text(''.join([hostname, state['installation_data']['client_id']]))
+        secret = sha1_text("".join([hostname, state["installation_data"]["client_id"]]))
 
         integration = {
-            'name': group['full_name'],
+            "name": group["full_name"],
             # Splice the gitlab host and project together to
             # act as unique link between a gitlab instance, group + sentry.
             # This value is embedded then in the webook token that we
             # give to gitlab to allow us to find the integration a hook came
             # from.
-            'external_id': u'{}:{}'.format(hostname, group['id']),
-            'metadata': {
-                'icon': group['avatar_url'],
-                'instance': hostname,
-                'domain_name': u'{}/{}'.format(hostname, group['full_path']),
-                'scopes': scopes,
-                'verify_ssl': verify_ssl,
-                'base_url': base_url,
-                'webhook_secret': secret.hexdigest(),
-                'group_id': group['id'],
+            "external_id": u"{}:{}".format(hostname, group["id"]),
+            "metadata": {
+                "icon": group["avatar_url"],
+                "instance": hostname,
+                "domain_name": u"{}/{}".format(hostname, group["full_path"]),
+                "scopes": scopes,
+                "verify_ssl": verify_ssl,
+                "base_url": base_url,
+                "webhook_secret": secret.hexdigest(),
+                "group_id": group["id"],
             },
-            'user_identity': {
-                'type': 'gitlab',
-                'external_id': u'{}:{}'.format(hostname, user['id']),
-                'scopes': scopes,
-                'data': oauth_data,
+            "user_identity": {
+                "type": "gitlab",
+                "external_id": u"{}:{}".format(hostname, user["id"]),
+                "scopes": scopes,
+                "data": oauth_data,
             },
         }
         return integration
 
     def setup(self):
         from sentry.plugins import bindings
+
         bindings.add(
-            'integration-repository.provider',
-            GitlabRepositoryProvider,
-            id='integrations:gitlab',
+            "integration-repository.provider", GitlabRepositoryProvider, id="integrations:gitlab"
         )

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -7,29 +7,25 @@ from sentry.integrations.exceptions import ApiError, IntegrationError, ApiUnauth
 from sentry.integrations.issues import IssueBasicMixin
 from sentry.utils.http import absolute_uri
 
-ISSUE_EXTERNAL_KEY_FORMAT = re.compile(r'.+:(.+)#(.+)')
+ISSUE_EXTERNAL_KEY_FORMAT = re.compile(r".+:(.+)#(.+)")
 
 
 class GitlabIssueBasic(IssueBasicMixin):
     def make_external_key(self, data):
-        return u'{}:{}'.format(self.model.metadata['domain_name'], data['key'])
+        return u"{}:{}".format(self.model.metadata["domain_name"], data["key"])
 
     def get_issue_url(self, key):
         match = ISSUE_EXTERNAL_KEY_FORMAT.match(key)
         project, issue_id = match.group(1), match.group(2)
-        return u'{}/{}/issues/{}'.format(
-            self.model.metadata['base_url'],
-            project,
-            issue_id,
-        )
+        return u"{}/{}/issues/{}".format(self.model.metadata["base_url"], project, issue_id)
 
     def get_persisted_default_config_fields(self):
-        return ['project']
+        return ["project"]
 
     def get_projects_and_default(self, group, **kwargs):
-        params = kwargs.get('params', {})
+        params = kwargs.get("params", {})
         defaults = self.get_project_defaults(group.project_id)
-        kwargs['repo'] = params.get('project', defaults.get('project'))
+        kwargs["repo"] = params.get("project", defaults.get("project"))
 
         # In GitLab Repositories are called Projects
         default_project, project_choices = self.get_repository_choices(group, **kwargs)
@@ -41,80 +37,72 @@ class GitlabIssueBasic(IssueBasicMixin):
             # default_repo should be the project_id
             project = client.get_project(default_repo)
         except (ApiError, ApiUnauthorized):
-            return ('', '')
-        return (project['id'], project['name_with_namespace'])
+            return ("", "")
+        return (project["id"], project["name_with_namespace"])
 
     def get_create_issue_config(self, group, **kwargs):
         default_project, project_choices = self.get_projects_and_default(group, **kwargs)
-        kwargs['link_referrer'] = 'gitlab_integration'
+        kwargs["link_referrer"] = "gitlab_integration"
         fields = super(GitlabIssueBasic, self).get_create_issue_config(group, **kwargs)
 
         org = group.organization
         autocomplete_url = reverse(
-            'sentry-extensions-gitlab-search', args=[org.slug, self.model.id],
+            "sentry-extensions-gitlab-search", args=[org.slug, self.model.id]
         )
 
         return [
             {
-                'name': 'project',
-                'label': 'GitLab Project',
-                'type': 'select',
-                'url': autocomplete_url,
-                'choices': project_choices,
-                'defaultValue': default_project,
-                'required': True,
+                "name": "project",
+                "label": "GitLab Project",
+                "type": "select",
+                "url": autocomplete_url,
+                "choices": project_choices,
+                "defaultValue": default_project,
+                "required": True,
             }
         ] + fields
 
     def create_issue(self, data, **kwargs):
         client = self.get_client()
 
-        project_id = data.get('project')
+        project_id = data.get("project")
 
         if not project_id:
-            raise IntegrationError('project kwarg must be provided')
+            raise IntegrationError("project kwarg must be provided")
 
         try:
             issue = client.create_issue(
                 project=project_id,
-                data={
-                    'title': data['title'],
-                    'description': data['description'],
-                })
+                data={"title": data["title"], "description": data["description"]},
+            )
             project = client.get_project(project_id)
         except ApiError as e:
             raise IntegrationError(self.message_from_error(e))
 
-        project_and_issue_iid = '%s#%s' % (project['path_with_namespace'], issue['iid'])
+        project_and_issue_iid = "%s#%s" % (project["path_with_namespace"], issue["iid"])
         return {
-            'key': project_and_issue_iid,
-            'title': issue['title'],
-            'description': issue['description'],
-            'url': issue['web_url'],
-            'project': project_id,
-            'metadata': {
-                'display_name': project_and_issue_iid,
-            }
+            "key": project_and_issue_iid,
+            "title": issue["title"],
+            "description": issue["description"],
+            "url": issue["web_url"],
+            "project": project_id,
+            "metadata": {"display_name": project_and_issue_iid},
         }
 
     def after_link_issue(self, external_issue, **kwargs):
-        data = kwargs['data']
-        project_id, issue_id = data.get('externalIssue', '').split('#')
+        data = kwargs["data"]
+        project_id, issue_id = data.get("externalIssue", "").split("#")
         if not (project_id and issue_id):
-            raise IntegrationError('Project and Issue id must be provided')
+            raise IntegrationError("Project and Issue id must be provided")
 
         client = self.get_client()
-        comment = data.get('comment')
+        comment = data.get("comment")
         if not comment:
             return
 
         try:
             client.create_issue_comment(
-                project_id=project_id,
-                issue_id=issue_id,
-                data={
-                    'body': comment,
-                }
+                project_id=project_id, issue_id=issue_id, data={"body": comment}
             )
         except ApiError as e:
             raise IntegrationError(self.message_from_error(e))
@@ -124,53 +112,52 @@ class GitlabIssueBasic(IssueBasicMixin):
 
         org = group.organization
         autocomplete_url = reverse(
-            'sentry-extensions-gitlab-search', args=[org.slug, self.model.id],
+            "sentry-extensions-gitlab-search", args=[org.slug, self.model.id]
         )
 
         return [
             {
-                'name': 'project',
-                'label': 'GitLab Project',
-                'type': 'select',
-                'default': default_project,
-                'choices': project_choices,
-                'url': autocomplete_url,
-                'updatesForm': True,
-                'required': True,
+                "name": "project",
+                "label": "GitLab Project",
+                "type": "select",
+                "default": default_project,
+                "choices": project_choices,
+                "url": autocomplete_url,
+                "updatesForm": True,
+                "required": True,
             },
             {
-                'name': 'externalIssue',
-                'label': 'Issue',
-                'default': '',
-                'type': 'select',
-                'url': autocomplete_url,
-                'required': True,
+                "name": "externalIssue",
+                "label": "Issue",
+                "default": "",
+                "type": "select",
+                "url": autocomplete_url,
+                "required": True,
             },
             {
-                'name': 'comment',
-                'label': 'Comment',
-                'default': u'Sentry issue: [{issue_id}]({url})'.format(
+                "name": "comment",
+                "label": "Comment",
+                "default": u"Sentry issue: [{issue_id}]({url})".format(
                     url=absolute_uri(
-                        group.get_absolute_url(params={'referrer': 'gitlab_integration'})
+                        group.get_absolute_url(params={"referrer": "gitlab_integration"})
                     ),
                     issue_id=group.qualified_short_id,
                 ),
-                'type': 'textarea',
-                'required': False,
-                'help': ('Leave blank if you don\'t want to '
-                         'add a comment to the GitLab issue.'),
-            }
+                "type": "textarea",
+                "required": False,
+                "help": ("Leave blank if you don't want to " "add a comment to the GitLab issue."),
+            },
         ]
 
     def get_issue(self, issue_id, **kwargs):
-        project_id, issue_num = issue_id.split('#')
+        project_id, issue_num = issue_id.split("#")
         client = self.get_client()
 
         if not project_id:
-            raise IntegrationError('project must be provided')
+            raise IntegrationError("project must be provided")
 
         if not issue_num:
-            raise IntegrationError('issue must be provided')
+            raise IntegrationError("issue must be provided")
 
         try:
             issue = client.get_issue(project_id, issue_num)
@@ -178,17 +165,15 @@ class GitlabIssueBasic(IssueBasicMixin):
         except ApiError as e:
             raise IntegrationError(self.message_from_error(e))
 
-        project_and_issue_iid = '%s#%s' % (project['path_with_namespace'], issue['iid'])
+        project_and_issue_iid = "%s#%s" % (project["path_with_namespace"], issue["iid"])
         return {
-            'key': project_and_issue_iid,
-            'title': issue['title'],
-            'description': issue['description'],
-            'url': issue['web_url'],
-            'project': project_id,
-            'metadata': {
-                'display_name': project_and_issue_iid,
-            }
+            "key": project_and_issue_iid,
+            "title": issue["title"],
+            "description": issue["description"],
+            "url": issue["web_url"],
+            "project": project_id,
+            "metadata": {"display_name": project_and_issue_iid},
         }
 
     def get_issue_display_name(self, external_issue):
-        return external_issue.metadata['display_name']
+        return external_issue.metadata["display_name"]

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -7,73 +7,69 @@ from sentry.models import Integration
 
 
 class GitlabRepositoryProvider(providers.IntegrationRepositoryProvider):
-    name = 'Gitlab'
+    name = "Gitlab"
 
     def get_installation(self, integration_id, organization_id):
         if integration_id is None:
-            raise IntegrationError('%s requires an integration id.' % self.name)
+            raise IntegrationError("%s requires an integration id." % self.name)
 
         integration_model = Integration.objects.get(
-            id=integration_id,
-            organizations=organization_id,
-            provider='gitlab',
+            id=integration_id, organizations=organization_id, provider="gitlab"
         )
 
         return integration_model.get_installation(organization_id)
 
     def get_repository_data(self, organization, config):
-        installation = self.get_installation(config.get('installation'), organization.id)
+        installation = self.get_installation(config.get("installation"), organization.id)
         client = installation.get_client()
 
-        repo_id = config['identifier']
-        instance = installation.model.metadata['instance']
+        repo_id = config["identifier"]
+        instance = installation.model.metadata["instance"]
 
         try:
             project = client.get_project(repo_id)
         except Exception as e:
             installation.raise_error(e)
-        config.update({
-            'instance': instance,
-            'path': project['path_with_namespace'],
-            'name': project['name_with_namespace'],
-            'external_id': u'{}:{}'.format(instance, project['id']),
-            'project_id': project['id'],
-            'url': project['web_url'],
-        })
+        config.update(
+            {
+                "instance": instance,
+                "path": project["path_with_namespace"],
+                "name": project["name_with_namespace"],
+                "external_id": u"{}:{}".format(instance, project["id"]),
+                "project_id": project["id"],
+                "url": project["web_url"],
+            }
+        )
         return config
 
     def build_repository_config(self, organization, data):
 
-        installation = self.get_installation(data.get('installation'),
-                                             organization.id)
+        installation = self.get_installation(data.get("installation"), organization.id)
         client = installation.get_client()
         hook_id = None
         try:
-            hook_id = client.create_project_webhook(data['project_id'])
+            hook_id = client.create_project_webhook(data["project_id"])
         except Exception as e:
             installation.raise_error(e)
         return {
-            'name': data['name'],
-            'external_id': data['external_id'],
-            'url': data['url'],
-            'config': {
-                'instance': data['instance'],
-                'path': data['path'],
-                'webhook_id': hook_id,
-                'project_id': data['project_id'],
+            "name": data["name"],
+            "external_id": data["external_id"],
+            "url": data["url"],
+            "config": {
+                "instance": data["instance"],
+                "path": data["path"],
+                "webhook_id": hook_id,
+                "project_id": data["project_id"],
             },
-            'integration_id': data['installation'],
+            "integration_id": data["installation"],
         }
 
     def on_delete_repository(self, repo):
         """Clean up the attached webhook"""
-        installation = self.get_installation(repo.integration_id,
-                                             repo.organization_id)
+        installation = self.get_installation(repo.integration_id, repo.organization_id)
         client = installation.get_client()
         try:
-            client.delete_project_webhook(
-                repo.config['project_id'],
-                repo.config['webhook_id'])
+            client.delete_project_webhook(repo.config["project_id"], repo.config["webhook_id"])
         except ApiError as e:
             if e.code == 404:
                 return
@@ -81,16 +77,15 @@ class GitlabRepositoryProvider(providers.IntegrationRepositoryProvider):
 
     def compare_commits(self, repo, start_sha, end_sha):
         """Fetch the commit list and diffed files between two shas"""
-        installation = self.get_installation(repo.integration_id,
-                                             repo.organization_id)
+        installation = self.get_installation(repo.integration_id, repo.organization_id)
         client = installation.get_client()
         try:
             if start_sha is None:
-                res = client.get_last_commits(repo.config['project_id'], end_sha)
+                res = client.get_last_commits(repo.config["project_id"], end_sha)
                 return self._format_commits(client, repo, res)
             else:
-                res = client.compare_commits(repo.config['project_id'], start_sha, end_sha)
-                return self._format_commits(client, repo, res['commits'])
+                res = client.compare_commits(repo.config["project_id"], start_sha, end_sha)
+                return self._format_commits(client, repo, res["commits"])
         except Exception as e:
             installation.raise_error(e)
 
@@ -99,55 +94,41 @@ class GitlabRepositoryProvider(providers.IntegrationRepositoryProvider):
         """
         return [
             {
-                'id': c['id'],
-                'repository': repo.name,
-                'author_email': c['author_email'],
-                'author_name': c['author_name'],
-                'message': c['title'],
-                'timestamp': self.format_date(c['created_at']),
-                'patch_set': self._get_patchset(client, repo, c['id'])
-            } for c in commit_list
+                "id": c["id"],
+                "repository": repo.name,
+                "author_email": c["author_email"],
+                "author_name": c["author_name"],
+                "message": c["title"],
+                "timestamp": self.format_date(c["created_at"]),
+                "patch_set": self._get_patchset(client, repo, c["id"]),
+            }
+            for c in commit_list
         ]
 
     def _get_patchset(self, client, repo, sha):
         """GitLab commit lists don't come with diffs so we have
         to make additional round trips.
         """
-        diffs = client.get_diff(repo.config['project_id'], sha)
+        diffs = client.get_diff(repo.config["project_id"], sha)
         return self._transform_patchset(diffs)
 
     def _transform_patchset(self, patch_set):
         file_changes = []
         for changed_file in patch_set:
-            if changed_file['new_file']:
-                file_changes.append({
-                    'path': changed_file['new_path'],
-                    'type': 'A',
-                })
-            elif changed_file['deleted_file']:
-                file_changes.append({
-                    'path': changed_file['old_path'],
-                    'type': 'D',
-                })
-            elif changed_file['renamed_file']:
-                file_changes.append({
-                    'path': changed_file['old_path'],
-                    'type': 'D',
-                })
-                file_changes.append({
-                    'path': changed_file['new_path'],
-                    'type': 'A',
-                })
+            if changed_file["new_file"]:
+                file_changes.append({"path": changed_file["new_path"], "type": "A"})
+            elif changed_file["deleted_file"]:
+                file_changes.append({"path": changed_file["old_path"], "type": "D"})
+            elif changed_file["renamed_file"]:
+                file_changes.append({"path": changed_file["old_path"], "type": "D"})
+                file_changes.append({"path": changed_file["new_path"], "type": "A"})
             else:
-                file_changes.append({
-                    'path': changed_file['new_path'],
-                    'type': 'M',
-                })
+                file_changes.append({"path": changed_file["new_path"], "type": "M"})
 
         return file_changes
 
     def pull_request_url(self, repo, pull_request):
-        return u'{}/merge_requests/{}'.format(repo.url, pull_request.key)
+        return u"{}/merge_requests/{}".format(repo.url, pull_request.key)
 
     def repository_external_slug(self, repo):
-        return repo.config['project_id']
+        return repo.config["project_id"]

--- a/src/sentry/integrations/gitlab/search.py
+++ b/src/sentry/integrations/gitlab/search.py
@@ -9,30 +9,27 @@ from sentry.models import Integration
 
 
 class GitlabIssueSearchEndpoint(IntegrationEndpoint):
-
     def get(self, request, organization, integration_id):
         try:
             integration = Integration.objects.get(
-                organizations=organization,
-                id=integration_id,
-                provider='gitlab',
+                organizations=organization, id=integration_id, provider="gitlab"
             )
         except Integration.DoesNotExist:
             return Response(status=404)
 
-        field = request.GET.get('field')
-        query = request.GET.get('query')
+        field = request.GET.get("field")
+        query = request.GET.get("query")
         if field is None:
-            return Response({'detail': 'field is a required parameter'}, status=400)
+            return Response({"detail": "field is a required parameter"}, status=400)
         if query is None:
-            return Response({'detail': 'query is a required parameter'}, status=400)
+            return Response({"detail": "query is a required parameter"}, status=400)
 
         installation = integration.get_installation(organization.id)
 
-        if field == 'externalIssue':
-            project = request.GET.get('project')
+        if field == "externalIssue":
+            project = request.GET.get("project")
             if project is None:
-                return Response({'detail': 'project is a required parameter'}, status=400)
+                return Response({"detail": "project is a required parameter"}, status=400)
             try:
                 iids = [int(query)]
                 query = None
@@ -42,21 +39,28 @@ class GitlabIssueSearchEndpoint(IntegrationEndpoint):
             try:
                 response = installation.search_issues(query=query, project_id=project, iids=iids)
             except ApiError as e:
-                return Response({'detail': six.text_type(e)}, status=400)
+                return Response({"detail": six.text_type(e)}, status=400)
 
-            return Response([{
-                'label': '(#%s) %s' % (i['iid'], i['title']),
-                'value': '%s#%s' % (i['project_id'], i['iid'])
-            } for i in response])
+            return Response(
+                [
+                    {
+                        "label": "(#%s) %s" % (i["iid"], i["title"]),
+                        "value": "%s#%s" % (i["project_id"], i["iid"]),
+                    }
+                    for i in response
+                ]
+            )
 
-        elif field == 'project':
+        elif field == "project":
             try:
                 response = installation.search_projects(query)
             except ApiError as e:
-                return Response({'detail': six.text_type(e)}, status=400)
-            return Response([{
-                'label': project['name_with_namespace'],
-                'value': project['id'],
-            } for project in response])
+                return Response({"detail": six.text_type(e)}, status=400)
+            return Response(
+                [
+                    {"label": project["name_with_namespace"], "value": project["id"]}
+                    for project in response
+                ]
+            )
 
-        return Response({'detail': 'invalid field value'}, status=400)
+        return Response({"detail": "invalid field value"}, status=400)

--- a/src/sentry/integrations/gitlab/urls.py
+++ b/src/sentry/integrations/gitlab/urls.py
@@ -6,15 +6,11 @@ from .webhooks import GitlabWebhookEndpoint
 from .search import GitlabIssueSearchEndpoint
 
 urlpatterns = patterns(
-    '',
+    "",
     url(
-        r'^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$',
+        r"^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$",
         GitlabIssueSearchEndpoint.as_view(),
-        name='sentry-extensions-gitlab-search'
+        name="sentry-extensions-gitlab-search",
     ),
-    url(
-        r'^webhook/$',
-        GitlabWebhookEndpoint.as_view(),
-        name='sentry-extensions-gitlab-webhook'
-    ),
+    url(r"^webhook/$", GitlabWebhookEndpoint.as_view(), name="sentry-extensions-gitlab-webhook"),
 )

--- a/src/sentry/models/distribution.py
+++ b/src/sentry/models/distribution.py
@@ -3,21 +3,20 @@ from __future__ import absolute_import
 from django.db import models
 from django.utils import timezone
 
-from sentry.db.models import Model, BoundedPositiveIntegerField, \
-    FlexibleForeignKey, sane_repr
+from sentry.db.models import Model, BoundedPositiveIntegerField, FlexibleForeignKey, sane_repr
 
 
 class Distribution(Model):
     __core__ = False
 
     organization_id = BoundedPositiveIntegerField(db_index=True)
-    release = FlexibleForeignKey('sentry.Release')
+    release = FlexibleForeignKey("sentry.Release")
     name = models.CharField(max_length=64)
     date_added = models.DateTimeField(default=timezone.now)
 
     class Meta:
-        app_label = 'sentry'
-        db_table = 'sentry_distribution'
-        unique_together = (('release', 'name'), )
+        app_label = "sentry"
+        db_table = "sentry_distribution"
+        unique_together = (("release", "name"),)
 
-    __repr__ = sane_repr('release', 'name')
+    __repr__ = sane_repr("release", "name")

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -71,7 +71,7 @@ def devserver(reload, watchers, workers, experimental_spa, styleguide, prefix, e
             )
 
     uwsgi_overrides = {
-        'http-keepalive': True,
+        "http-keepalive": True,
         # Make sure we reload really quickly for local dev in case it
         # doesn't want to shut down nicely on it's own, NO MERCY
         "worker-reload-mercy": 2,
@@ -109,7 +109,7 @@ def devserver(reload, watchers, workers, experimental_spa, styleguide, prefix, e
         proxy_port = port
         port = port + 1
 
-        uwsgi_overrides['protocol'] = 'http'
+        uwsgi_overrides["protocol"] = "http"
 
         os.environ["SENTRY_WEBPACK_PROXY_PORT"] = "%s" % proxy_port
         os.environ["SENTRY_BACKEND_PORT"] = "%s" % port
@@ -124,14 +124,16 @@ def devserver(reload, watchers, workers, experimental_spa, styleguide, prefix, e
     else:
         # If we are the bare http server, use the http option with uwsgi protocol
         # See https://uwsgi-docs.readthedocs.io/en/latest/HTTP.html
-        uwsgi_overrides.update({
-            # Make sure uWSGI spawns an HTTP server for us as we don't
-            # have a proxy/load-balancer in front in dev mode.
-            'http': '%s:%s' % (host, port),
-            'protocol': 'uwsgi',
-            # This is needed to prevent https://git.io/fj7Lw
-            'uwsgi-socket': None,
-        })
+        uwsgi_overrides.update(
+            {
+                # Make sure uWSGI spawns an HTTP server for us as we don't
+                # have a proxy/load-balancer in front in dev mode.
+                "http": "%s:%s" % (host, port),
+                "protocol": "uwsgi",
+                # This is needed to prevent https://git.io/fj7Lw
+                "uwsgi-socket": None,
+            }
+        )
 
     if workers:
         if settings.CELERY_ALWAYS_EAGER:

--- a/src/sentry/utils/distutils/commands/base.py
+++ b/src/sentry/utils/distutils/commands/base.py
@@ -12,27 +12,31 @@ from distutils.core import Command
 import sentry  # We just need its path via __file__
 
 
-SENTRY_ROOT_PATH = os.path.abspath(os.path.join(sentry.__file__, '..', '..', '..'))
+SENTRY_ROOT_PATH = os.path.abspath(os.path.join(sentry.__file__, "..", "..", ".."))
 
 
-YARN_PATH = os.path.join(SENTRY_ROOT_PATH, 'bin', 'yarn')
+YARN_PATH = os.path.join(SENTRY_ROOT_PATH, "bin", "yarn")
 
 
 class BaseBuildCommand(Command):
     user_options = [
-        ('work-path=', 'w', "The working directory for source files. Defaults to ."),
-        ('build-lib=', 'b', "directory for script runtime modules"),
+        ("work-path=", "w", "The working directory for source files. Defaults to ."),
+        ("build-lib=", "b", "directory for script runtime modules"),
         (
-            'inplace', 'i', "ignore build-lib and put compiled javascript files into the source "
-            + "directory alongside your pure Python modules"
+            "inplace",
+            "i",
+            "ignore build-lib and put compiled javascript files into the source "
+            + "directory alongside your pure Python modules",
         ),
         (
-            'force', 'f', "Force rebuilding of static content. Defaults to rebuilding on version "
-            "change detection."
+            "force",
+            "f",
+            "Force rebuilding of static content. Defaults to rebuilding on version "
+            "change detection.",
         ),
     ]
 
-    boolean_options = ['force']
+    boolean_options = ["force"]
 
     def initialize_options(self):
         self.build_lib = None
@@ -41,7 +45,7 @@ class BaseBuildCommand(Command):
         self.inplace = None
 
     def get_root_path(self):
-        return os.path.abspath(os.path.dirname(sys.modules['__main__'].__file__))
+        return os.path.abspath(os.path.dirname(sys.modules["__main__"].__file__))
 
     def get_dist_paths(self):
         return []
@@ -83,8 +87,8 @@ class BaseBuildCommand(Command):
         #
         # To find the default value of the inplace flag we inspect the
         # sdist and build_ext commands.
-        sdist = self.distribution.get_command_obj('sdist')
-        build_ext = self.get_finalized_command('build_ext')
+        sdist = self.distribution.get_command_obj("sdist")
+        build_ext = self.get_finalized_command("build_ext")
 
         # If we are not decided on in-place we are inplace if either
         # build_ext is inplace or we are invoked through the install
@@ -103,12 +107,12 @@ class BaseBuildCommand(Command):
 
         # In place means build_lib is src.  We also log this.
         if self.inplace:
-            log.debug('in-place js building enabled')
-            self.build_lib = 'src'
+            log.debug("in-place js building enabled")
+            self.build_lib = "src"
         # Otherwise we fetch build_lib from the build command.
         else:
-            self.set_undefined_options('build', ('build_lib', 'build_lib'))
-            log.debug('regular js build: build path is %s' % self.build_lib)
+            self.set_undefined_options("build", ("build_lib", "build_lib"))
+            log.debug("regular js build: build path is %s" % self.build_lib)
 
         if self.work_path is None:
             self.work_path = self.get_root_path()
@@ -122,48 +126,41 @@ class BaseBuildCommand(Command):
     def _setup_git(self):
         work_path = self.work_path
 
-        if os.path.exists(os.path.join(work_path, '.git')):
-            log.info('initializing git submodules')
-            self._run_command(['git', 'submodule', 'init'])
-            self._run_command(['git', 'submodule', 'update'])
+        if os.path.exists(os.path.join(work_path, ".git")):
+            log.info("initializing git submodules")
+            self._run_command(["git", "submodule", "init"])
+            self._run_command(["git", "submodule", "update"])
 
     def _setup_js_deps(self):
         node_version = None
         try:
-            node_version = self._run_command(['node', '--version']).rstrip()
+            node_version = self._run_command(["node", "--version"]).rstrip()
         except OSError:
-            log.fatal(
-                u'Cannot find node executable. Please install node'
-                ' and try again.'
-            )
+            log.fatal(u"Cannot find node executable. Please install node" " and try again.")
             sys.exit(1)
 
         if node_version[2] is not None:
-            log.info(u'using node ({0}))'.format(node_version))
-            self._run_yarn_command(
-                ['install', '--production', '--pure-lockfile', '--quiet']
-            )
+            log.info(u"using node ({0}))".format(node_version))
+            self._run_yarn_command(["install", "--production", "--pure-lockfile", "--quiet"])
 
     def _run_command(self, cmd, env=None):
-        log.debug('running [%s]' % (' '.join(cmd), ))
+        log.debug("running [%s]" % (" ".join(cmd),))
         try:
             return check_output(cmd, cwd=self.work_path, env=env)
         except Exception:
-            log.error('command failed [%s] via [%s]' % (' '.join(cmd), self.work_path, ))
+            log.error("command failed [%s] via [%s]" % (" ".join(cmd), self.work_path))
             raise
 
     def _run_yarn_command(self, cmd, env=None):
-        log.debug(u'yarn path: ({0}))'.format(YARN_PATH))
-        self._run_command(
-            [YARN_PATH] + cmd, env=env
-        )
+        log.debug(u"yarn path: ({0}))".format(YARN_PATH))
+        self._run_command([YARN_PATH] + cmd, env=env)
 
     def update_manifests(self):
         # if we were invoked from sdist, we need to inform sdist about
         # which files we just generated.  Otherwise they will be missing
         # in the manifest.  This adds the files for what webpack generates
         # plus our own assets.json file.
-        sdist = self.distribution.get_command_obj('sdist')
+        sdist = self.distribution.get_command_obj("sdist")
         if not sdist.finalized:
             return
 
@@ -172,7 +169,7 @@ class BaseBuildCommand(Command):
         # Use the underlying file list so that we skip the file-exists
         # check which we do not want here.
         files = sdist.filelist.files
-        base = os.path.abspath('.')
+        base = os.path.abspath(".")
 
         # We need to split off the local parts of the files relative to
         # the current folder.  This will chop off the right path for the
@@ -181,7 +178,7 @@ class BaseBuildCommand(Command):
             for dirname, _, filenames in os.walk(os.path.abspath(path)):
                 for filename in filenames:
                     filename = os.path.join(dirname, filename)
-                    files.append(filename[len(base):].lstrip(os.path.sep))
+                    files.append(filename[len(base) :].lstrip(os.path.sep))
 
         for file in self.get_manifest_additions():
             files.append(file)

--- a/src/sentry/utils/distutils/commands/build_assets.py
+++ b/src/sentry/utils/distutils/commands/build_assets.py
@@ -15,40 +15,41 @@ from .base import BaseBuildCommand
 class BuildAssetsCommand(BaseBuildCommand):
     user_options = BaseBuildCommand.user_options + [
         (
-            'asset-json-path=', None,
-            'Relative path for JSON manifest. Defaults to {dist_name}/assets.json'
+            "asset-json-path=",
+            None,
+            "Relative path for JSON manifest. Defaults to {dist_name}/assets.json",
         ),
         (
-            'inplace', 'i', "ignore build-lib and put compiled javascript files into the source " +
-            "directory alongside your pure Python modules"
+            "inplace",
+            "i",
+            "ignore build-lib and put compiled javascript files into the source "
+            + "directory alongside your pure Python modules",
         ),
         (
-            'force', 'f', "Force rebuilding of static content. Defaults to rebuilding on version "
-            "change detection."
+            "force",
+            "f",
+            "Force rebuilding of static content. Defaults to rebuilding on version "
+            "change detection.",
         ),
     ]
 
-    description = 'build static media assets'
+    description = "build static media assets"
 
     def initialize_options(self):
-        self.asset_json_path = u'{}/assets.json'.format(
-            self.distribution.get_name(),
-        )
+        self.asset_json_path = u"{}/assets.json".format(self.distribution.get_name())
         BaseBuildCommand.initialize_options(self)
 
     def get_dist_paths(self):
-        return [
-            'src/sentry/static/sentry/dist',
-        ]
+        return ["src/sentry/static/sentry/dist"]
 
     def get_manifest_additions(self):
-        return ('src/' + self.asset_json_path, )
+        return ("src/" + self.asset_json_path,)
 
     def _get_package_version(self):
         """
         Attempt to get the most correct current version of Sentry.
         """
-        pkg_path = os.path.join(self.work_path, 'src')
+        pkg_path = os.path.join(self.work_path, "src")
 
         sys.path.insert(0, pkg_path)
         try:
@@ -57,7 +58,7 @@ class BuildAssetsCommand(BaseBuildCommand):
             version = None
             build = None
         else:
-            log.info(u'pulled version information from \'sentry\' module'.format(sentry.__file__))
+            log.info(u"pulled version information from 'sentry' module".format(sentry.__file__))
             version = self.distribution.get_version()
             build = sentry.__build__
         finally:
@@ -71,15 +72,10 @@ class BuildAssetsCommand(BaseBuildCommand):
             except Exception:
                 pass
             else:
-                log.info(u'pulled version information from \'{}\''.format(
-                    json_path,
-                ))
-                version, build = data['version'], data['build']
+                log.info(u"pulled version information from '{}'".format(json_path))
+                version, build = data["version"], data["build"]
 
-        return {
-            'version': version,
-            'build': build,
-        }
+        return {"version": version, "build": build}
 
     def _needs_static(self, version_info):
         json_path = self.get_asset_json_path()
@@ -88,9 +84,9 @@ class BuildAssetsCommand(BaseBuildCommand):
 
         with open(json_path) as fp:
             data = json.load(fp)
-        if data.get('version') != version_info.get('version'):
+        if data.get("version") != version_info.get("version"):
             return True
-        if data.get('build') != version_info.get('build'):
+        if data.get("build") != version_info.get("build"):
             return True
         return False
 
@@ -103,53 +99,49 @@ class BuildAssetsCommand(BaseBuildCommand):
     def _build(self):
         version_info = self._get_package_version()
         log.info(
-            u'building assets for {} v{} (build {})'.format(
+            u"building assets for {} v{} (build {})".format(
                 self.distribution.get_name(),
-                version_info['version'] or 'UNKNOWN',
-                version_info['build'] or 'UNKNOWN',
+                version_info["version"] or "UNKNOWN",
+                version_info["build"] or "UNKNOWN",
             )
         )
-        if not version_info['version'] or not version_info['build']:
-            log.fatal('Could not determine sentry version or build')
+        if not version_info["version"] or not version_info["build"]:
+            log.fatal("Could not determine sentry version or build")
             sys.exit(1)
 
         try:
             self._build_static()
         except Exception:
             traceback.print_exc()
-            log.fatal(
-                'unable to build Sentry\'s static assets!'
-            )
+            log.fatal("unable to build Sentry's static assets!")
             sys.exit(1)
 
-        log.info('writing version manifest')
+        log.info("writing version manifest")
         manifest = self._write_version_file(version_info)
-        log.info(u'recorded manifest\n{}'.format(
-            json.dumps(manifest, indent=2),
-        ))
+        log.info(u"recorded manifest\n{}".format(json.dumps(manifest, indent=2)))
 
     def _build_static(self):
         # By setting NODE_ENV=production, a few things happen
         #   * React optimizes out certain code paths
         #   * Webpack will add version strings to built/referenced assets
         env = dict(os.environ)
-        env['SENTRY_STATIC_DIST_PATH'] = self.sentry_static_dist_path
-        env['NODE_ENV'] = 'production'
-        self._run_yarn_command(['webpack', '--bail'], env=env)
+        env["SENTRY_STATIC_DIST_PATH"] = self.sentry_static_dist_path
+        env["NODE_ENV"] = "production"
+        self._run_yarn_command(["webpack", "--bail"], env=env)
 
     def _write_version_file(self, version_info):
         manifest = {
-            'createdAt': datetime.datetime.utcnow().isoformat() + 'Z',
-            'version': version_info['version'],
-            'build': version_info['build'],
+            "createdAt": datetime.datetime.utcnow().isoformat() + "Z",
+            "version": version_info["version"],
+            "build": version_info["build"],
         }
-        with open(self.get_asset_json_path(), 'w') as fp:
+        with open(self.get_asset_json_path(), "w") as fp:
             json.dump(manifest, fp)
         return manifest
 
     @property
     def sentry_static_dist_path(self):
-        return os.path.abspath(os.path.join(self.build_lib, 'sentry/static/sentry/dist'))
+        return os.path.abspath(os.path.join(self.build_lib, "sentry/static/sentry/dist"))
 
     def get_asset_json_path(self):
         return os.path.abspath(os.path.join(self.build_lib, self.asset_json_path))

--- a/src/sentry/utils/distutils/commands/build_integration_docs.py
+++ b/src/sentry/utils/distutils/commands/build_integration_docs.py
@@ -8,15 +8,16 @@ from .base import BaseBuildCommand
 
 
 class BuildIntegrationDocsCommand(BaseBuildCommand):
-    description = 'build integration docs'
+    description = "build integration docs"
 
     def get_dist_paths(self):
         return [
             # Also see sentry.utils.integrationdocs.DOC_FOLDER
-            os.path.join(self.get_root_path(), 'src', 'sentry', 'integration-docs'),
+            os.path.join(self.get_root_path(), "src", "sentry", "integration-docs")
         ]
 
     def _build(self):
         from sentry.utils.integrationdocs import sync_docs
-        log.info('downloading integration docs')
+
+        log.info("downloading integration docs")
         sync_docs()

--- a/src/sentry/utils/distutils/commands/build_js_sdk_registry.py
+++ b/src/sentry/utils/distutils/commands/build_js_sdk_registry.py
@@ -9,8 +9,10 @@ from distutils import log
 
 import sentry
 
-JS_SDK_REGISTRY_URL = 'https://release-registry.services.sentry.io/sdks/sentry.javascript.browser/versions'
-LOADER_FOLDER = os.path.abspath(os.path.join(os.path.dirname(sentry.__file__), 'loader'))
+JS_SDK_REGISTRY_URL = (
+    "https://release-registry.services.sentry.io/sdks/sentry.javascript.browser/versions"
+)
+LOADER_FOLDER = os.path.abspath(os.path.join(os.path.dirname(sentry.__file__), "loader"))
 
 # We cannot leverage six here, so we need to vendor
 # bits that we need.
@@ -30,32 +32,32 @@ else:
 
 
 def dump_registry(path, data):
-    fn = os.path.join(LOADER_FOLDER, path + '.json')
+    fn = os.path.join(LOADER_FOLDER, path + ".json")
     directory = os.path.dirname(fn)
     try:
         os.makedirs(directory)
     except OSError:
         pass
-    with open(fn, 'wb') as f:
+    with open(fn, "wb") as f:
         json.dump(data, f, indent=2)
-        f.write('\n')
+        f.write("\n")
 
 
 def sync_registry():
-    body = urlopen(JS_SDK_REGISTRY_URL).read().decode('utf-8')
+    body = urlopen(JS_SDK_REGISTRY_URL).read().decode("utf-8")
     data = json.loads(body)
-    dump_registry('_registry', data)
+    dump_registry("_registry", data)
 
 
 from .base import BaseBuildCommand
 
 
 class BuildJsSdkRegistryCommand(BaseBuildCommand):
-    description = 'build js sdk registry'
+    description = "build js sdk registry"
 
     def run(self):
-        log.info('downloading js sdk information from the release registry')
+        log.info("downloading js sdk information from the release registry")
         try:
             sync_registry()
         except BaseException:
-            log.error('error ocurred while trying to fetch js sdk information from the registry')
+            log.error("error ocurred while trying to fetch js sdk information from the registry")

--- a/src/social_auth/backends/github_apps.py
+++ b/src/social_auth/backends/github_apps.py
@@ -4,16 +4,14 @@ from social_auth.backends.github import GithubBackend, GithubAuth
 
 
 class GithubAppsBackend(GithubBackend):
-    name = 'github_apps'
+    name = "github_apps"
 
 
 class GithubAppsAuth(GithubAuth):
     AUTH_BACKEND = GithubAppsBackend
-    SETTINGS_KEY_NAME = 'GITHUB_APPS_APP_ID'
-    SETTINGS_SECRET_NAME = 'GITHUB_APPS_API_SECRET'
+    SETTINGS_KEY_NAME = "GITHUB_APPS_APP_ID"
+    SETTINGS_SECRET_NAME = "GITHUB_APPS_API_SECRET"
     REDIRECT_STATE = False
 
 
-BACKENDS = {
-    'github_apps': GithubAppsAuth,
-}
+BACKENDS = {"github_apps": GithubAppsAuth}

--- a/src/south/introspection_plugins/django_taggit.py
+++ b/src/south/introspection_plugins/django_taggit.py
@@ -5,7 +5,7 @@ South introspection rules for django-taggit
 from django.conf import settings
 from south.modelsinspector import add_ignored_fields
 
-if 'taggit' in settings.INSTALLED_APPS:
+if "taggit" in settings.INSTALLED_APPS:
     try:
         from taggit.managers import TaggableManager
     except ImportError:

--- a/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
@@ -18,7 +18,7 @@ class SentryAppPublishRequestTest(APITestCase):
 
         self.url = reverse("sentry-api-0-sentry-app-publish-request", args=[self.sentry_app.slug])
 
-    @mock.patch('sentry.utils.email.send_mail')
+    @mock.patch("sentry.utils.email.send_mail")
     def test_publish_request(self, send_mail):
         self.login_as(user=self.user)
         response = self.client.post(self.url, format="json")
@@ -31,7 +31,7 @@ class SentryAppPublishRequestTest(APITestCase):
             fail_silently=False,
         )
 
-    @mock.patch('sentry.utils.email.send_mail')
+    @mock.patch("sentry.utils.email.send_mail")
     def test_publish_already_published(self, send_mail):
         self.sentry_app.update(status=SentryAppStatus.PUBLISHED)
         self.login_as(user=self.user)
@@ -40,7 +40,7 @@ class SentryAppPublishRequestTest(APITestCase):
         assert response.data["detail"] == "Cannot publish already published integration"
         send_mail.asssert_not_called()
 
-    @mock.patch('sentry.utils.email.send_mail')
+    @mock.patch("sentry.utils.email.send_mail")
     def test_publish_internal(self, send_mail):
         self.sentry_app.update(status=SentryAppStatus.INTERNAL)
         self.login_as(user=self.user)

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -8,37 +8,33 @@ from sentry.models import Integration
 
 
 class GitHubAppsClientTest(TestCase):
-
-    @mock.patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_save_token(self, get_jwt):
 
         integration = Integration.objects.create(
-            provider='github',
-            name='Github Test Org',
-            external_id='1',
-            metadata={
-                'access_token': None,
-                'expires_at': None,
-            }
+            provider="github",
+            name="Github Test Org",
+            external_id="1",
+            metadata={"access_token": None, "expires_at": None},
         )
 
-        install = integration.get_installation(organization_id='123')
+        install = integration.get_installation(organization_id="123")
         client = install.get_client()
 
         responses.add(
             method=responses.POST,
-            url='https://api.github.com/installations/1/access_tokens',
+            url="https://api.github.com/installations/1/access_tokens",
             body='{"token": "12345token", "expires_at": "2030-01-01T00:00:00Z"}',
             status=200,
-            content_type='application/json',
+            content_type="application/json",
         )
 
         token = client.get_token()
-        assert token == '12345token'
+        assert token == "12345token"
         assert len(responses.calls) == 1
 
         # Second get_token doesn't have to make an API call
         token = client.get_token()
-        assert token == '12345token'
+        assert token == "12345token"
         assert len(responses.calls) == 1

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -10,29 +10,31 @@ from six.moves.urllib.parse import parse_qs, urlencode, urlparse
 from sentry.constants import ObjectStatus
 from sentry.integrations.github import GitHubIntegrationProvider
 from sentry.models import (
-    Identity, IdentityProvider, IdentityStatus, Integration, OrganizationIntegration,
-    Repository, Project
+    Identity,
+    IdentityProvider,
+    IdentityStatus,
+    Integration,
+    OrganizationIntegration,
+    Repository,
+    Project,
 )
 from sentry.plugins import plugins
 from sentry.testutils import IntegrationTestCase
-from tests.sentry.plugins.testutils import (
-    register_mock_plugins,
-    unregister_mock_plugins,
-)
+from tests.sentry.plugins.testutils import register_mock_plugins, unregister_mock_plugins
 
 
 class GitHubIntegrationTest(IntegrationTestCase):
     provider = GitHubIntegrationProvider
-    base_url = 'https://api.github.com'
+    base_url = "https://api.github.com"
 
     def setUp(self):
         super(GitHubIntegrationTest, self).setUp()
 
-        self.installation_id = 'install_1'
-        self.user_id = 'user_1'
-        self.app_id = 'app_1'
-        self.access_token = 'xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx'
-        self.expires_at = '3000-01-01T00:00:00Z'
+        self.installation_id = "install_1"
+        self.user_id = "user_1"
+        self.app_id = "app_1"
+        self.access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+        self.expires_at = "3000-01-01T00:00:00Z"
 
         self._stub_github()
         register_mock_plugins()
@@ -44,138 +46,107 @@ class GitHubIntegrationTest(IntegrationTestCase):
     def _stub_github(self):
         responses.reset()
 
-        sentry.integrations.github.integration.get_jwt = MagicMock(
-            return_value='jwt_token_1',
-        )
-        sentry.integrations.github.client.get_jwt = MagicMock(
-            return_value='jwt_token_1',
+        sentry.integrations.github.integration.get_jwt = MagicMock(return_value="jwt_token_1")
+        sentry.integrations.github.client.get_jwt = MagicMock(return_value="jwt_token_1")
+
+        responses.add(
+            responses.POST,
+            "https://github.com/login/oauth/access_token",
+            json={"access_token": self.access_token},
         )
 
         responses.add(
             responses.POST,
-            'https://github.com/login/oauth/access_token',
-            json={'access_token': self.access_token}
+            self.base_url + "/installations/{}/access_tokens".format(self.installation_id),
+            json={"token": self.access_token, "expires_at": self.expires_at},
         )
 
+        responses.add(responses.GET, self.base_url + "/user", json={"id": self.user_id})
+
         responses.add(
-            responses.POST,
-            self.base_url + '/installations/{}/access_tokens'.format(
-                self.installation_id,
-            ),
+            responses.GET,
+            self.base_url + "/installation/repositories",
             json={
-                'token': self.access_token,
-                'expires_at': self.expires_at,
-            }
+                "repositories": [
+                    {"id": 1296269, "name": "foo", "full_name": "Test-Organization/foo"},
+                    {"id": 9876574, "name": "bar", "full_name": "Test-Organization/bar"},
+                ]
+            },
         )
 
         responses.add(
             responses.GET,
-            self.base_url + '/user',
-            json={'id': self.user_id}
-        )
-
-        responses.add(
-            responses.GET,
-            self.base_url + '/installation/repositories',
+            self.base_url + "/app/installations/{}".format(self.installation_id),
             json={
-                'repositories': [
-                    {
-                        'id': 1296269,
-                        'name': 'foo',
-                        'full_name': 'Test-Organization/foo',
-                    },
-                    {
-                        'id': 9876574,
-                        'name': 'bar',
-                        'full_name': 'Test-Organization/bar',
-                    },
-                ],
-            }
-        )
-
-        responses.add(
-            responses.GET,
-            self.base_url + '/app/installations/{}'.format(
-                self.installation_id,
-            ),
-            json={
-                'id': self.installation_id,
-                'app_id': self.app_id,
-                'account': {
-                    'login': 'Test Organization',
-                    'avatar_url': 'http://example.com/avatar.png',
-                    'html_url': 'https://github.com/Test-Organization',
-                    'type': 'Organization',
+                "id": self.installation_id,
+                "app_id": self.app_id,
+                "account": {
+                    "login": "Test Organization",
+                    "avatar_url": "http://example.com/avatar.png",
+                    "html_url": "https://github.com/Test-Organization",
+                    "type": "Organization",
                 },
-            }
+            },
         )
 
         responses.add(
             responses.GET,
-            self.base_url + '/user/installations',
-            json={
-                'installations': [{'id': self.installation_id}],
-            }
+            self.base_url + "/user/installations",
+            json={"installations": [{"id": self.installation_id}]},
         )
 
-        responses.add(
-            responses.GET,
-            self.base_url + '/repos/Test-Organization/foo/hooks',
-            json=[],
-        )
+        responses.add(responses.GET, self.base_url + "/repos/Test-Organization/foo/hooks", json=[])
 
     def assert_setup_flow(self):
         resp = self.client.get(self.init_path)
         assert resp.status_code == 302
-        redirect = urlparse(resp['Location'])
-        assert redirect.scheme == 'https'
-        assert redirect.netloc == 'github.com'
-        assert redirect.path == '/apps/sentry-test-app'
+        redirect = urlparse(resp["Location"])
+        assert redirect.scheme == "https"
+        assert redirect.netloc == "github.com"
+        assert redirect.path == "/apps/sentry-test-app"
 
         # App installation ID is provided
-        resp = self.client.get(u'{}?{}'.format(
-            self.setup_path,
-            urlencode({'installation_id': self.installation_id})
-        ))
+        resp = self.client.get(
+            u"{}?{}".format(self.setup_path, urlencode({"installation_id": self.installation_id}))
+        )
 
-        redirect = urlparse(resp['Location'])
+        redirect = urlparse(resp["Location"])
 
         assert resp.status_code == 302
-        assert redirect.scheme == 'https'
-        assert redirect.netloc == 'github.com'
-        assert redirect.path == '/login/oauth/authorize'
+        assert redirect.scheme == "https"
+        assert redirect.netloc == "github.com"
+        assert redirect.path == "/login/oauth/authorize"
 
         params = parse_qs(redirect.query)
 
-        assert params['state']
-        assert params['redirect_uri'] == ['http://testserver/extensions/github/setup/']
-        assert params['response_type'] == ['code']
-        assert params['client_id'] == ['github-client-id']
+        assert params["state"]
+        assert params["redirect_uri"] == ["http://testserver/extensions/github/setup/"]
+        assert params["response_type"] == ["code"]
+        assert params["client_id"] == ["github-client-id"]
 
         # Compact list values into singular values, since there's only ever one.
         authorize_params = {k: v[0] for k, v in six.iteritems(params)}
 
-        resp = self.client.get(u'{}?{}'.format(
-            self.setup_path,
-            urlencode({
-                'code': 'oauth-code',
-                'state': authorize_params['state'],
-            })
-        ))
+        resp = self.client.get(
+            u"{}?{}".format(
+                self.setup_path,
+                urlencode({"code": "oauth-code", "state": authorize_params["state"]}),
+            )
+        )
 
         oauth_exchange = responses.calls[0]
         req_params = parse_qs(oauth_exchange.request.body)
 
-        assert req_params['grant_type'] == ['authorization_code']
-        assert req_params['code'] == ['oauth-code']
-        assert req_params['redirect_uri'] == ['http://testserver/extensions/github/setup/']
-        assert req_params['client_id'] == ['github-client-id']
-        assert req_params['client_secret'] == ['github-client-secret']
+        assert req_params["grant_type"] == ["authorization_code"]
+        assert req_params["code"] == ["oauth-code"]
+        assert req_params["redirect_uri"] == ["http://testserver/extensions/github/setup/"]
+        assert req_params["client_id"] == ["github-client-id"]
+        assert req_params["client_secret"] == ["github-client-secret"]
 
         assert oauth_exchange.response.status_code == 200
 
-        auth_header = responses.calls[2].request.headers['Authorization']
-        assert auth_header == 'Bearer jwt_token_1'
+        auth_header = responses.calls[2].request.headers["Authorization"]
+        assert auth_header == "Bearer jwt_token_1"
 
         self.assertDialogSuccess(resp)
         return resp
@@ -184,23 +155,19 @@ class GitHubIntegrationTest(IntegrationTestCase):
     def test_plugin_migration(self):
         accessible_repo = Repository.objects.create(
             organization_id=self.organization.id,
-            name='Test-Organization/foo',
-            url='https://github.com/Test-Organization/foo',
-            provider='github',
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="github",
             external_id=123,
-            config={
-                'name': 'Test-Organization/foo',
-            },
+            config={"name": "Test-Organization/foo"},
         )
 
         inaccessible_repo = Repository.objects.create(
             organization_id=self.organization.id,
-            name='Not-My-Org/other',
-            provider='github',
+            name="Not-My-Org/other",
+            provider="github",
             external_id=321,
-            config={
-                'name': 'Not-My-Org/other',
-            },
+            config={"name": "Not-My-Org/other"},
         )
 
         with self.tasks():
@@ -209,42 +176,34 @@ class GitHubIntegrationTest(IntegrationTestCase):
         integration = Integration.objects.get(provider=self.provider.key)
 
         # Updates the existing Repository to belong to the new Integration
-        assert Repository.objects.get(
-            id=accessible_repo.id,
-        ).integration_id == integration.id
+        assert Repository.objects.get(id=accessible_repo.id).integration_id == integration.id
 
         # Doesn't touch Repositories not accessible by the new Integration
-        assert Repository.objects.get(
-            id=inaccessible_repo.id,
-        ).integration_id is None
+        assert Repository.objects.get(id=inaccessible_repo.id).integration_id is None
 
     @responses.activate
     def test_disables_plugin_when_fully_migrated(self):
-        project = Project.objects.create(
-            organization_id=self.organization.id,
-        )
+        project = Project.objects.create(organization_id=self.organization.id)
 
-        plugin = plugins.get('github')
+        plugin = plugins.get("github")
         plugin.enable(project)
 
         # Accessible to new Integration
         Repository.objects.create(
             organization_id=self.organization.id,
-            name='Test-Organization/foo',
-            url='https://github.com/Test-Organization/foo',
-            provider='github',
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="github",
             external_id=123,
-            config={
-                'name': 'Test-Organization/foo',
-            },
+            config={"name": "Test-Organization/foo"},
         )
 
-        assert 'github' in [p.slug for p in plugins.for_project(project)]
+        assert "github" in [p.slug for p in plugins.for_project(project)]
 
         with self.tasks():
             self.assert_setup_flow()
 
-        assert 'github' not in [p.slug for p in plugins.for_project(project)]
+        assert "github" not in [p.slug for p in plugins.for_project(project)]
 
     @responses.activate
     def test_basic_flow(self):
@@ -254,32 +213,25 @@ class GitHubIntegrationTest(IntegrationTestCase):
         integration = Integration.objects.get(provider=self.provider.key)
 
         assert integration.external_id == self.installation_id
-        assert integration.name == 'Test Organization'
+        assert integration.name == "Test Organization"
         assert integration.metadata == {
-            'access_token': None,
+            "access_token": None,
             # The metadata doesn't get saved with the timezone "Z" character
             # for some reason, so just compare everything but that.
-            'expires_at': None,
-            'icon': 'http://example.com/avatar.png',
-            'domain_name': 'github.com/Test-Organization',
-            'account_type': 'Organization',
+            "expires_at": None,
+            "icon": "http://example.com/avatar.png",
+            "domain_name": "github.com/Test-Organization",
+            "account_type": "Organization",
         }
         oi = OrganizationIntegration.objects.get(
-            integration=integration,
-            organization=self.organization,
+            integration=integration, organization=self.organization
         )
         assert oi.config == {}
 
-        idp = IdentityProvider.objects.get(type='github')
-        identity = Identity.objects.get(
-            idp=idp,
-            user=self.user,
-            external_id=self.user_id,
-        )
+        idp = IdentityProvider.objects.get(type="github")
+        identity = Identity.objects.get(idp=idp, user=self.user, external_id=self.user_id)
         assert identity.status == IdentityStatus.VALID
-        assert identity.data == {
-            'access_token': self.access_token,
-        }
+        assert identity.data == {"access_token": self.access_token}
 
     @responses.activate
     def test_reassign_user(self):
@@ -300,7 +252,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         Identity.objects.get().update(user=user2)
         resp = self.assert_setup_flow()
         assert '"success":false' in resp.content
-        assert 'The provided GitHub account is linked to a different Sentry user' in resp.content
+        assert "The provided GitHub account is linked to a different Sentry user" in resp.content
 
     @responses.activate
     def test_reinstall_flow(self):
@@ -312,64 +264,61 @@ class GitHubIntegrationTest(IntegrationTestCase):
         assert integration.status == ObjectStatus.DISABLED
         assert integration.external_id == self.installation_id
 
-        resp = self.client.get(u'{}?{}'.format(
-            self.init_path,
-            urlencode({'reinstall_id': integration.id})
-        ))
+        resp = self.client.get(
+            u"{}?{}".format(self.init_path, urlencode({"reinstall_id": integration.id}))
+        )
 
         assert resp.status_code == 302
-        redirect = urlparse(resp['Location'])
-        assert redirect.scheme == 'https'
-        assert redirect.netloc == 'github.com'
-        assert redirect.path == '/apps/sentry-test-app'
+        redirect = urlparse(resp["Location"])
+        assert redirect.scheme == "https"
+        assert redirect.netloc == "github.com"
+        assert redirect.path == "/apps/sentry-test-app"
 
         # New Installation
-        self.installation_id = 'install_2'
+        self.installation_id = "install_2"
 
-        resp = self.client.get(u'{}?{}'.format(
-            self.setup_path,
-            urlencode({'installation_id': self.installation_id})
-        ))
+        resp = self.client.get(
+            u"{}?{}".format(self.setup_path, urlencode({"installation_id": self.installation_id}))
+        )
 
-        redirect = urlparse(resp['Location'])
+        redirect = urlparse(resp["Location"])
 
         assert resp.status_code == 302
-        assert redirect.scheme == 'https'
-        assert redirect.netloc == 'github.com'
-        assert redirect.path == '/login/oauth/authorize'
+        assert redirect.scheme == "https"
+        assert redirect.netloc == "github.com"
+        assert redirect.path == "/login/oauth/authorize"
 
         params = parse_qs(redirect.query)
 
-        assert params['state']
-        assert params['redirect_uri'] == ['http://testserver/extensions/github/setup/']
-        assert params['response_type'] == ['code']
-        assert params['client_id'] == ['github-client-id']
+        assert params["state"]
+        assert params["redirect_uri"] == ["http://testserver/extensions/github/setup/"]
+        assert params["response_type"] == ["code"]
+        assert params["client_id"] == ["github-client-id"]
 
         # Compact list values to make the rest of this easier
         authorize_params = {k: v[0] for k, v in six.iteritems(params)}
 
         self._stub_github()
 
-        resp = self.client.get(u'{}?{}'.format(
-            self.setup_path,
-            urlencode({
-                'code': 'oauth-code',
-                'state': authorize_params['state'],
-            })
-        ))
+        resp = self.client.get(
+            u"{}?{}".format(
+                self.setup_path,
+                urlencode({"code": "oauth-code", "state": authorize_params["state"]}),
+            )
+        )
 
         mock_access_token_request = responses.calls[0].request
         req_params = parse_qs(mock_access_token_request.body)
-        assert req_params['grant_type'] == ['authorization_code']
-        assert req_params['code'] == ['oauth-code']
-        assert req_params['redirect_uri'] == ['http://testserver/extensions/github/setup/']
-        assert req_params['client_id'] == ['github-client-id']
-        assert req_params['client_secret'] == ['github-client-secret']
+        assert req_params["grant_type"] == ["authorization_code"]
+        assert req_params["code"] == ["oauth-code"]
+        assert req_params["redirect_uri"] == ["http://testserver/extensions/github/setup/"]
+        assert req_params["client_id"] == ["github-client-id"]
+        assert req_params["client_secret"] == ["github-client-secret"]
 
         assert resp.status_code == 200
 
-        auth_header = responses.calls[2].request.headers['Authorization']
-        assert auth_header == 'Bearer jwt_token_1'
+        auth_header = responses.calls[2].request.headers["Authorization"]
+        assert auth_header == "Bearer jwt_token_1"
 
         integration = Integration.objects.get(provider=self.provider.key)
         assert integration.status == ObjectStatus.VISIBLE
@@ -379,33 +328,29 @@ class GitHubIntegrationTest(IntegrationTestCase):
     def test_disable_plugin_when_fully_migrated(self):
         self._stub_github()
 
-        project = Project.objects.create(
-            organization_id=self.organization.id,
-        )
+        project = Project.objects.create(organization_id=self.organization.id)
 
-        plugin = plugins.get('github')
+        plugin = plugins.get("github")
         plugin.enable(project)
 
         # Accessible to new Integration - mocked in _stub_github
         Repository.objects.create(
             organization_id=self.organization.id,
-            name='Test-Organization/foo',
-            url='https://github.com/Test-Organization/foo',
-            provider='github',
-            external_id='123',
-            config={
-                'name': 'Test-Organization/foo',
-            },
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="github",
+            external_id="123",
+            config={"name": "Test-Organization/foo"},
         )
 
         # Enabled before
-        assert 'github' in [p.slug for p in plugins.for_project(project)]
+        assert "github" in [p.slug for p in plugins.for_project(project)]
 
         with self.tasks():
             self.assert_setup_flow()
 
         # Disabled after Integration installed
-        assert 'github' not in [p.slug for p in plugins.for_project(project)]
+        assert "github" not in [p.slug for p in plugins.for_project(project)]
 
     @responses.activate
     def test_get_repositories_search_param(self):
@@ -414,24 +359,18 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            self.base_url + '/search/repositories?q=org:test%20ex',
+            self.base_url + "/search/repositories?q=org:test%20ex",
             json={
-                'items': [
-                    {
-                        'name': 'example',
-                        'full_name': 'test/example',
-                    },
-                    {
-                        'name': 'exhaust',
-                        'full_name': 'test/exhaust',
-                    },
+                "items": [
+                    {"name": "example", "full_name": "test/example"},
+                    {"name": "exhaust", "full_name": "test/exhaust"},
                 ]
-            }
+            },
         )
         integration = Integration.objects.get(provider=self.provider.key)
         installation = integration.get_installation(self.organization)
-        result = installation.get_repositories('ex')
+        result = installation.get_repositories("ex")
         assert result == [
-            {'identifier': 'test/example', 'name': 'example'},
-            {'identifier': 'test/exhaust', 'name': 'exhaust'}
+            {"identifier": "test/example", "name": "example"},
+            {"identifier": "test/exhaust", "name": "exhaust"},
         ]

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -24,346 +24,322 @@ class GitHubIssueBasicTest(TestCase):
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
         self.model = Integration.objects.create(
-            provider='github',
-            external_id='github_external_id',
-            name='getsentry',
+            provider="github", external_id="github_external_id", name="getsentry"
         )
         self.model.add_organization(self.organization, self.user)
         self.integration = GitHubIntegration(self.model, self.organization.id)
         self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
 
     @responses.activate
-    @patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_get_allowed_assignees(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            'https://api.github.com/installations/github_external_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://api.github.com/installations/github_external_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/sentry/assignees',
-            json=[{'login': 'MeredithAnya'}]
+            "https://api.github.com/repos/getsentry/sentry/assignees",
+            json=[{"login": "MeredithAnya"}],
         )
 
-        repo = 'getsentry/sentry'
+        repo = "getsentry/sentry"
         assert self.integration.get_allowed_assignees(repo) == (
-            ('', 'Unassigned'),
-            ('MeredithAnya', 'MeredithAnya')
+            ("", "Unassigned"),
+            ("MeredithAnya", "MeredithAnya"),
         )
 
         request = responses.calls[0].request
-        assert request.headers['Authorization'] == 'Bearer jwt_token_1'
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
-        assert request.headers['Authorization'] == 'token token_1'
+        assert request.headers["Authorization"] == "token token_1"
 
     @responses.activate
-    @patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_create_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            'https://api.github.com/installations/github_external_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://api.github.com/installations/github_external_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
         responses.add(
             responses.POST,
-            'https://api.github.com/repos/getsentry/sentry/issues',
-            json={'number': 321, 'title': 'hello', 'body': 'This is the description',
-                  'html_url': 'https://github.com/getsentry/sentry/issues/231'}
+            "https://api.github.com/repos/getsentry/sentry/issues",
+            json={
+                "number": 321,
+                "title": "hello",
+                "body": "This is the description",
+                "html_url": "https://github.com/getsentry/sentry/issues/231",
+            },
         )
 
         form_data = {
-            'repo': 'getsentry/sentry',
-            'title': 'hello',
-            'description': 'This is the description',
+            "repo": "getsentry/sentry",
+            "title": "hello",
+            "description": "This is the description",
         }
 
         assert self.integration.create_issue(form_data) == {
-            'key': 321,
-            'description': 'This is the description',
-            'title': 'hello',
-            'url': 'https://github.com/getsentry/sentry/issues/231',
-            'repo': 'getsentry/sentry',
+            "key": 321,
+            "description": "This is the description",
+            "title": "hello",
+            "url": "https://github.com/getsentry/sentry/issues/231",
+            "repo": "getsentry/sentry",
         }
         request = responses.calls[0].request
-        assert request.headers['Authorization'] == 'Bearer jwt_token_1'
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
-        assert request.headers['Authorization'] == 'token token_1'
+        assert request.headers["Authorization"] == "token token_1"
         payload = json.loads(request.body)
-        assert payload == {'body': 'This is the description', 'assignee': None, 'title': 'hello'}
+        assert payload == {"body": "This is the description", "assignee": None, "title": "hello"}
 
     @responses.activate
-    @patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_get_repo_issues(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            'https://api.github.com/installations/github_external_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://api.github.com/installations/github_external_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/sentry/issues',
-            json=[{'number': 321, 'title': 'hello', 'body': 'This is the description'}]
+            "https://api.github.com/repos/getsentry/sentry/issues",
+            json=[{"number": 321, "title": "hello", "body": "This is the description"}],
         )
-        repo = 'getsentry/sentry'
-        assert self.integration.get_repo_issues(repo) == ((321, '#321 hello'),)
+        repo = "getsentry/sentry"
+        assert self.integration.get_repo_issues(repo) == ((321, "#321 hello"),)
 
         request = responses.calls[0].request
-        assert request.headers['Authorization'] == 'Bearer jwt_token_1'
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
-        assert request.headers['Authorization'] == 'token token_1'
+        assert request.headers["Authorization"] == "token token_1"
 
     @responses.activate
-    @patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_link_issue(self, mock_get_jwt):
         issue_id = 321
         responses.add(
             responses.POST,
-            'https://api.github.com/installations/github_external_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://api.github.com/installations/github_external_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/sentry/issues/321',
-            json={'number': issue_id, 'title': 'hello', 'body': 'This is the description',
-                  'html_url': 'https://github.com/getsentry/sentry/issues/231'}
+            "https://api.github.com/repos/getsentry/sentry/issues/321",
+            json={
+                "number": issue_id,
+                "title": "hello",
+                "body": "This is the description",
+                "html_url": "https://github.com/getsentry/sentry/issues/231",
+            },
         )
 
-        data = {
-            'repo': 'getsentry/sentry',
-            'externalIssue': issue_id,
-            'comment': 'hello',
-        }
+        data = {"repo": "getsentry/sentry", "externalIssue": issue_id, "comment": "hello"}
 
         assert self.integration.get_issue(issue_id, data=data) == {
-            'key': issue_id,
-            'description': 'This is the description',
-            'title': 'hello',
-            'url': 'https://github.com/getsentry/sentry/issues/231',
-            'repo': 'getsentry/sentry',
+            "key": issue_id,
+            "description": "This is the description",
+            "title": "hello",
+            "url": "https://github.com/getsentry/sentry/issues/231",
+            "repo": "getsentry/sentry",
         }
         request = responses.calls[0].request
-        assert request.headers['Authorization'] == 'Bearer jwt_token_1'
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
-        assert request.headers['Authorization'] == 'token token_1'
+        assert request.headers["Authorization"] == "token token_1"
 
     @responses.activate
-    @patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_repo_dropdown_choices(self, mock_get_jwt):
         event = self.store_event(
-            data={
-                'event_id': 'a' * 32,
-                'timestamp': self.min_ago,
-            },
-            project_id=self.project.id,
+            data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
         )
 
         responses.add(
             responses.POST,
-            'https://api.github.com/installations/github_external_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://api.github.com/installations/github_external_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/sentry/assignees',
-            json=[{'login': 'MeredithAnya'}]
+            "https://api.github.com/repos/getsentry/sentry/assignees",
+            json=[{"login": "MeredithAnya"}],
         )
 
         responses.add(
             responses.GET,
-            'https://api.github.com/installation/repositories',
-            json={'repositories': [{'full_name': 'getsentry/sentry', 'name': 'sentry'}]}
+            "https://api.github.com/installation/repositories",
+            json={"repositories": [{"full_name": "getsentry/sentry", "name": "sentry"}]},
         )
 
         resp = self.integration.get_create_issue_config(group=event.group)
-        assert resp[0]['choices'] == [(u'getsentry/sentry', u'sentry')]
+        assert resp[0]["choices"] == [(u"getsentry/sentry", u"sentry")]
 
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/hello/assignees',
-            json=[{'login': 'MeredithAnya'}]
+            "https://api.github.com/repos/getsentry/hello/assignees",
+            json=[{"login": "MeredithAnya"}],
         )
 
         # create an issue
-        data = {'params': {'repo': 'getsentry/hello'}}
+        data = {"params": {"repo": "getsentry/hello"}}
         resp = self.integration.get_create_issue_config(group=event.group, **data)
-        assert resp[0]['choices'] == [(u'getsentry/hello', u'hello'),
-                                      (u'getsentry/sentry', u'sentry')]
+        assert resp[0]["choices"] == [
+            (u"getsentry/hello", u"hello"),
+            (u"getsentry/sentry", u"sentry"),
+        ]
         # link an issue
-        data = {'params': {'repo': 'getsentry/hello'}}
+        data = {"params": {"repo": "getsentry/hello"}}
         resp = self.integration.get_link_issue_config(group=event.group, **data)
-        assert resp[0]['choices'] == [(u'getsentry/hello', u'hello'),
-                                      (u'getsentry/sentry', u'sentry')]
+        assert resp[0]["choices"] == [
+            (u"getsentry/hello", u"hello"),
+            (u"getsentry/sentry", u"sentry"),
+        ]
 
     @responses.activate
-    @patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def after_link_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            'https://api.github.com/installations/github_external_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://api.github.com/installations/github_external_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
         responses.add(
             responses.POST,
-            'https://api.github.com/repos/getsentry/sentry/issues/321/comments',
-            json={'body': 'hello'}
+            "https://api.github.com/repos/getsentry/sentry/issues/321/comments",
+            json={"body": "hello"},
         )
 
-        data = {'comment': 'hello'}
+        data = {"comment": "hello"}
         external_issue = ExternalIssue.objects.create(
-            organization_id=self.organization.id,
-            integration_id=self.model.id,
-            key='hello#321',
+            organization_id=self.organization.id, integration_id=self.model.id, key="hello#321"
         )
 
         self.integration.after_link_issue(external_issue, data=data)
 
         request = responses.calls[0].request
-        assert request.headers['Authorization'] == 'Bearer jwt_token_1'
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
-        assert request.headers['Authorization'] == 'token token_1'
+        assert request.headers["Authorization"] == "token token_1"
         payload = json.loads(request.body)
-        assert payload == {'body': 'hello'}
+        assert payload == {"body": "hello"}
 
     @responses.activate
-    @patch('sentry.integrations.github.client.GitHubClientMixin.get_token', return_value='jwt_token_1')
+    @patch(
+        "sentry.integrations.github.client.GitHubClientMixin.get_token", return_value="jwt_token_1"
+    )
     def test_default_repo_link_fields(self, mock_get_jwt):
         responses.add(
             responses.GET,
-            'https://api.github.com/installation/repositories',
-            json={
-                'repositories': [
-                    {'name': 'sentry', 'full_name': 'getsentry/sentry'}
-                ]
-            },
+            "https://api.github.com/installation/repositories",
+            json={"repositories": [{"name": "sentry", "full_name": "getsentry/sentry"}]},
         )
         event = self.store_event(
-            data={
-                'event_id': 'a' * 32,
-                'timestamp': self.min_ago,
-            },
-            project_id=self.project.id,
+            data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
         )
         group = event.group
 
         org_integration = self.integration.org_integration
         org_integration.config = {
-            'project_issue_defaults': {
-                six.text_type(group.project_id): {'repo': 'getsentry/sentry'}
+            "project_issue_defaults": {
+                six.text_type(group.project_id): {"repo": "getsentry/sentry"}
             }
         }
         org_integration.save()
         fields = self.integration.get_link_issue_config(group)
         for field in fields:
-            if field['name'] == 'repo':
+            if field["name"] == "repo":
                 repo_field = field
                 break
-        assert repo_field['default'] == 'getsentry/sentry'
+        assert repo_field["default"] == "getsentry/sentry"
 
     @responses.activate
-    @patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_default_repo_create_fields(self, mock_get_jwt):
         responses.add(
             responses.GET,
-            'https://api.github.com/installation/repositories',
-            json={
-                'repositories': [
-                    {'name': 'sentry', 'full_name': 'getsentry/sentry'}
-                ]
-            },
+            "https://api.github.com/installation/repositories",
+            json={"repositories": [{"name": "sentry", "full_name": "getsentry/sentry"}]},
         )
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/sentry/assignees',
-            json=[{'login': 'MeredithAnya'}]
+            "https://api.github.com/repos/getsentry/sentry/assignees",
+            json=[{"login": "MeredithAnya"}],
         )
         responses.add(
             responses.POST,
-            'https://api.github.com/installations/github_external_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://api.github.com/installations/github_external_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
         event = self.store_event(
-            data={
-                'event_id': 'a' * 32,
-                'timestamp': self.min_ago,
-            },
-            project_id=self.project.id,
+            data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
         )
         group = event.group
         org_integration = self.integration.org_integration
         org_integration.config = {
-            'project_issue_defaults': {
-                six.text_type(group.project_id): {'repo': 'getsentry/sentry'}
+            "project_issue_defaults": {
+                six.text_type(group.project_id): {"repo": "getsentry/sentry"}
             }
         }
         org_integration.save()
         fields = self.integration.get_create_issue_config(group)
         for field in fields:
-            if field['name'] == 'repo':
+            if field["name"] == "repo":
                 repo_field = field
                 break
-        assert repo_field['default'] == 'getsentry/sentry'
+        assert repo_field["default"] == "getsentry/sentry"
 
     @responses.activate
-    @patch('sentry.integrations.github.client.GitHubClientMixin.get_token', return_value='jwt_token_1')
+    @patch(
+        "sentry.integrations.github.client.GitHubClientMixin.get_token", return_value="jwt_token_1"
+    )
     def test_default_repo_link_fields_no_repos(self, mock_get_jwt):
         responses.add(
             responses.GET,
-            'https://api.github.com/installation/repositories',
-            json={
-                'repositories': []
-            },
+            "https://api.github.com/installation/repositories",
+            json={"repositories": []},
         )
         event = self.store_event(
-            data={
-                'event_id': 'a' * 32,
-                'timestamp': self.min_ago,
-            },
-            project_id=self.project.id,
+            data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
         )
         fields = self.integration.get_link_issue_config(event.group)
-        repo_field = [field for field in fields if field['name'] == 'repo'][0]
-        assert repo_field['default'] is ''
-        assert repo_field['choices'] == []
+        repo_field = [field for field in fields if field["name"] == "repo"][0]
+        assert repo_field["default"] is ""
+        assert repo_field["choices"] == []
 
     @responses.activate
-    @patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_default_repo_create_fields_no_repos(self, mock_get_jwt):
         responses.add(
             responses.GET,
-            'https://api.github.com/installation/repositories',
-            json={
-                'repositories': []
-            },
+            "https://api.github.com/installation/repositories",
+            json={"repositories": []},
         )
         responses.add(
             responses.POST,
-            'https://api.github.com/installations/github_external_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://api.github.com/installations/github_external_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
         event = self.store_event(
-            data={
-                'event_id': 'a' * 32,
-                'timestamp': self.min_ago,
-            },
-            project_id=self.project.id,
+            data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
         )
         fields = self.integration.get_create_issue_config(event.group)
-        repo_field = [field for field in fields if field['name'] == 'repo'][0]
-        assignee_field = [field for field in fields if field['name'] == 'assignee'][0]
+        repo_field = [field for field in fields if field["name"] == "repo"][0]
+        assignee_field = [field for field in fields if field["name"] == "assignee"][0]
 
-        assert repo_field['default'] == ''
-        assert repo_field['choices'] == []
-        assert assignee_field['default'] == ''
-        assert assignee_field['choices'] == []
+        assert repo_field["default"] == ""
+        assert repo_field["choices"] == []
+        assert assignee_field["default"] == ""
+        assert assignee_field["choices"] == []

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -14,19 +14,15 @@ from sentry.utils import json
 
 from sentry.integrations.exceptions import IntegrationError
 from sentry.integrations.github.repository import GitHubRepositoryProvider
-from .testutils import (
-    COMPARE_COMMITS_EXAMPLE,
-    GET_LAST_COMMITS_EXAMPLE,
-    GET_COMMIT_EXAMPLE
-)
+from .testutils import COMPARE_COMMITS_EXAMPLE, GET_LAST_COMMITS_EXAMPLE, GET_COMMIT_EXAMPLE
 
 
 def stub_installation_token():
     ten_hours = datetime.datetime.utcnow() + datetime.timedelta(hours=10)
     responses.add(
         responses.POST,
-        'https://api.github.com/installations/654321/access_tokens',
-        json={'token': 'v1.install-token', 'expires_at': ten_hours.strftime('%Y-%m-%dT%H:%M:%SZ')}
+        "https://api.github.com/installations/654321/access_tokens",
+        json={"token": "v1.install-token", "expires_at": ten_hours.strftime("%Y-%m-%dT%H:%M:%SZ")},
     )
 
 
@@ -34,10 +30,7 @@ class GitHubAppsProviderTest(PluginTestCase):
     def setUp(self):
         super(GitHubAppsProviderTest, self).setUp()
         self.organization = self.create_organization()
-        self.integration = Integration.objects.create(
-            provider='github',
-            external_id='654321',
-        )
+        self.integration = Integration.objects.create(provider="github", external_id="654321")
 
     def tearDown(self):
         super(GitHubAppsProviderTest, self).tearDown()
@@ -45,58 +38,53 @@ class GitHubAppsProviderTest(PluginTestCase):
 
     @fixture
     def provider(self):
-        return GitHubRepositoryProvider('integrations:github')
+        return GitHubRepositoryProvider("integrations:github")
 
     @fixture
     def repository(self):
         return Repository.objects.create(
-            name='getsentry/example-repo',
-            provider='integrations:github',
+            name="getsentry/example-repo",
+            provider="integrations:github",
             organization_id=self.organization.id,
             integration_id=self.integration.id,
-            url='https://github.com/getsentry/example-repo',
-            config={'name': 'getsentry/example-repo'},
+            url="https://github.com/getsentry/example-repo",
+            config={"name": "getsentry/example-repo"},
         )
 
     @responses.activate
     def test_build_repository_config(self):
         organization = self.create_organization()
-        integration = Integration.objects.create(
-            provider='github',
-            name='Example GitHub',
-        )
+        integration = Integration.objects.create(provider="github", name="Example GitHub")
         integration.add_organization(organization, self.user)
         data = {
-            'identifier': 'getsentry/example-repo',
-            'external_id': '654321',
-            'integration_id': integration.id,
+            "identifier": "getsentry/example-repo",
+            "external_id": "654321",
+            "integration_id": integration.id,
         }
         data = self.provider.build_repository_config(organization, data)
         assert data == {
-            'config': {
-                'name': 'getsentry/example-repo',
-            },
-            'external_id': '654321',
-            'integration_id': integration.id,
-            'name': 'getsentry/example-repo',
-            'url': 'https://github.com/getsentry/example-repo',
+            "config": {"name": "getsentry/example-repo"},
+            "external_id": "654321",
+            "integration_id": integration.id,
+            "name": "getsentry/example-repo",
+            "url": "https://github.com/getsentry/example-repo",
         }
 
-    @mock.patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_compare_commits_no_start(self, get_jwt):
         stub_installation_token()
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/example-repo/commits?sha=abcdef',
-            json=json.loads(GET_LAST_COMMITS_EXAMPLE)
+            "https://api.github.com/repos/getsentry/example-repo/commits?sha=abcdef",
+            json=json.loads(GET_LAST_COMMITS_EXAMPLE),
         )
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e',
-            json=json.loads(GET_COMMIT_EXAMPLE)
+            "https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            json=json.loads(GET_COMMIT_EXAMPLE),
         )
-        result = self.provider.compare_commits(self.repository, None, 'abcdef')
+        result = self.provider.compare_commits(self.repository, None, "abcdef")
         for commit in result:
             assert_commit_shape(commit)
 
@@ -105,112 +93,123 @@ class GitHubAppsProviderTest(PluginTestCase):
         stub_installation_token()
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/example-repo/commits?sha=abcdef',
-            status=502
+            "https://api.github.com/repos/getsentry/example-repo/commits?sha=abcdef",
+            status=502,
         )
         with pytest.raises(IntegrationError):
-            self.provider.compare_commits(self.repository, None, 'abcdef')
+            self.provider.compare_commits(self.repository, None, "abcdef")
 
-    @mock.patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_compare_commits(self, get_jwt):
         stub_installation_token()
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef',
-            json=json.loads(COMPARE_COMMITS_EXAMPLE)
+            "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef",
+            json=json.loads(COMPARE_COMMITS_EXAMPLE),
         )
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e',
-            json=json.loads(GET_COMMIT_EXAMPLE)
+            "https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            json=json.loads(GET_COMMIT_EXAMPLE),
         )
-        result = self.provider.compare_commits(self.repository, 'xyz123', 'abcdef')
+        result = self.provider.compare_commits(self.repository, "xyz123", "abcdef")
         for commit in result:
             assert_commit_shape(commit)
 
-    @mock.patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_compare_commits_patchset_handling(self, get_jwt):
         stub_installation_token()
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef',
-            json=json.loads(COMPARE_COMMITS_EXAMPLE)
+            "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef",
+            json=json.loads(COMPARE_COMMITS_EXAMPLE),
         )
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e',
-            json=json.loads(GET_COMMIT_EXAMPLE)
+            "https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            json=json.loads(GET_COMMIT_EXAMPLE),
         )
-        result = self.provider.compare_commits(self.repository, 'xyz123', 'abcdef')
+        result = self.provider.compare_commits(self.repository, "xyz123", "abcdef")
 
-        patchset = result[0]['patch_set']
-        assert patchset[0] == {'path': 'file1.txt', 'type': 'M'}
-        assert patchset[1] == {'path': 'added.txt', 'type': 'A'}
-        assert patchset[2] == {'path': 'removed.txt', 'type': 'D'}
-        assert patchset[3] == {'path': 'old_name.txt', 'type': 'D'}
-        assert patchset[4] == {'path': 'renamed.txt', 'type': 'A'}
+        patchset = result[0]["patch_set"]
+        assert patchset[0] == {"path": "file1.txt", "type": "M"}
+        assert patchset[1] == {"path": "added.txt", "type": "A"}
+        assert patchset[2] == {"path": "removed.txt", "type": "D"}
+        assert patchset[3] == {"path": "old_name.txt", "type": "D"}
+        assert patchset[4] == {"path": "renamed.txt", "type": "A"}
 
     @responses.activate
     def test_compare_commits_failure(self):
         stub_installation_token()
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef',
-            status=502
+            "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef",
+            status=502,
         )
         with pytest.raises(IntegrationError):
-            self.provider.compare_commits(self.repository, 'xyz123', 'abcdef')
+            self.provider.compare_commits(self.repository, "xyz123", "abcdef")
 
-    @mock.patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_compare_commits_force_refresh(self, get_jwt):
         stub_installation_token()
         ten_hours = datetime.datetime.utcnow() + datetime.timedelta(hours=10)
         self.integration.metadata = {
-            'access_token': 'old-access-token',
-            'expires_at': ten_hours.replace(microsecond=0).isoformat()
+            "access_token": "old-access-token",
+            "expires_at": ten_hours.replace(microsecond=0).isoformat(),
         }
         self.integration.save()
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef',
+            "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef",
             status=404,
-            body='GitHub returned a 404 Not Found error.'
+            body="GitHub returned a 404 Not Found error.",
         )
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef',
-            json=json.loads(COMPARE_COMMITS_EXAMPLE)
+            "https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef",
+            json=json.loads(COMPARE_COMMITS_EXAMPLE),
         )
         responses.add(
             responses.GET,
-            'https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e',
-            json=json.loads(GET_COMMIT_EXAMPLE)
+            "https://api.github.com/repos/getsentry/example-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            json=json.loads(GET_COMMIT_EXAMPLE),
         )
 
-        result = self.provider.compare_commits(self.repository, 'xyz123', 'abcdef')
+        result = self.provider.compare_commits(self.repository, "xyz123", "abcdef")
         for commit in result:
             assert_commit_shape(commit)
 
         # assert token was refreshed
-        assert Integration.objects.get(
-            id=self.integration.id).metadata['access_token'] == 'v1.install-token'
+        assert (
+            Integration.objects.get(id=self.integration.id).metadata["access_token"]
+            == "v1.install-token"
+        )
 
         # compare_commits gives 400, token was refreshed, and compare_commits gives 200
-        assert responses.calls[0].response.url == u'https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef'
+        assert (
+            responses.calls[0].response.url
+            == u"https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef"
+        )
         assert responses.calls[0].response.status_code == 404
-        assert responses.calls[1].response.url == u'https://api.github.com/installations/654321/access_tokens'
+        assert (
+            responses.calls[1].response.url
+            == u"https://api.github.com/installations/654321/access_tokens"
+        )
         assert responses.calls[1].response.status_code == 200
-        assert responses.calls[2].response.url == u'https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef'
+        assert (
+            responses.calls[2].response.url
+            == u"https://api.github.com/repos/getsentry/example-repo/compare/xyz123...abcdef"
+        )
         assert responses.calls[2].response.status_code == 200
 
     def test_pull_request_url(self):
         pull = PullRequest(key=99)
         result = self.provider.pull_request_url(self.repository, pull)
-        assert result == 'https://github.com/getsentry/example-repo/pull/99'
+        assert result == "https://github.com/getsentry/example-repo/pull/99"
 
     def test_repository_external_slug(self):
         result = self.provider.repository_external_slug(self.repository)
-        assert result == self.repository.config['name']
+        assert result == self.repository.config["name"]

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -4,58 +4,49 @@ import responses
 
 from datetime import datetime, timedelta
 from django.core.urlresolvers import reverse
-from sentry.models import (
-    Integration,
-    Identity,
-    IdentityProvider
-)
+from sentry.models import Integration, Identity, IdentityProvider
 from sentry.testutils import APITestCase
 
 
 class GithubSearchTest(APITestCase):
     # There is another test case that inherits from this
     # one to ensure that github:enterprise behaves as expected.
-    provider = 'github'
-    base_url = 'https://api.github.com'
+    provider = "github"
+    base_url = "https://api.github.com"
 
     def create_integration(self):
         future = datetime.now() + timedelta(hours=1)
         return Integration.objects.create(
             provider=self.provider,
-            name='test',
+            name="test",
             external_id=9999,
             metadata={
-                'domain_name': 'github.com/test',
-                'account_type': 'Organization',
-                'access_token': '123456789',
-                'expires_at': future.replace(microsecond=0).isoformat(),
-            }
+                "domain_name": "github.com/test",
+                "account_type": "Organization",
+                "access_token": "123456789",
+                "expires_at": future.replace(microsecond=0).isoformat(),
+            },
         )
 
     def setUp(self):
         super(GithubSearchTest, self).setUp()
         self.integration = self.create_integration()
         identity = Identity.objects.create(
-            idp=IdentityProvider.objects.create(
-                type=self.provider,
-                config={},
-            ),
+            idp=IdentityProvider.objects.create(type=self.provider, config={}),
             user=self.user,
             external_id=self.user.id,
-            data={
-                'access_token': '123456789',
-            }
+            data={"access_token": "123456789"},
         )
         self.integration.add_organization(self.organization, self.user, identity.id)
         self.installation = self.integration.get_installation(self.organization.id)
 
         self.login_as(self.user)
         self.url = reverse(
-            'sentry-extensions-github-search',
+            "sentry-extensions-github-search",
             kwargs={
-                'organization_slug': self.organization.slug,
-                'integration_id': self.installation.model.id,
-            }
+                "organization_slug": self.organization.slug,
+                "integration_id": self.installation.model.id,
+            },
         )
 
     # Happy Paths
@@ -63,124 +54,82 @@ class GithubSearchTest(APITestCase):
     def test_finds_external_issue_results(self):
         responses.add(
             responses.GET,
-            self.base_url + '/search/issues?q=repo:example%20AEIOU',
+            self.base_url + "/search/issues?q=repo:example%20AEIOU",
             json={
-                'items': [
-                    {'number': 25, 'title': 'AEIOU Error'},
-                    {'number': 45, 'title': 'AEIOU Error'}
+                "items": [
+                    {"number": 25, "title": "AEIOU Error"},
+                    {"number": 45, "title": "AEIOU Error"},
                 ]
-            }
+            },
         )
         resp = self.client.get(
-            self.url,
-            data={
-                'field': 'externalIssue',
-                'query': 'AEIOU',
-                'repo': 'example'
-            }
+            self.url, data={"field": "externalIssue", "query": "AEIOU", "repo": "example"}
         )
 
         assert resp.status_code == 200
         assert resp.data == [
-            {'value': 25, 'label': '#25 AEIOU Error'},
-            {'value': 45, 'label': '#45 AEIOU Error'}
+            {"value": 25, "label": "#25 AEIOU Error"},
+            {"value": 45, "label": "#45 AEIOU Error"},
         ]
 
     @responses.activate
     def test_finds_external_issue_results_with_id(self):
         responses.add(
             responses.GET,
-            self.base_url + '/search/issues?q=repo:example%2025',
-            json={
-                'items': [
-                    {'number': 25, 'title': 'AEIOU Error'},
-                ]
-            }
+            self.base_url + "/search/issues?q=repo:example%2025",
+            json={"items": [{"number": 25, "title": "AEIOU Error"}]},
         )
         resp = self.client.get(
-            self.url,
-            data={
-                'field': 'externalIssue',
-                'query': '25',
-                'repo': 'example'
-            }
+            self.url, data={"field": "externalIssue", "query": "25", "repo": "example"}
         )
 
         assert resp.status_code == 200
-        assert resp.data == [
-            {'value': 25, 'label': '#25 AEIOU Error'},
-        ]
+        assert resp.data == [{"value": 25, "label": "#25 AEIOU Error"}]
 
     @responses.activate
     def test_finds_repo_results(self):
         responses.add(
             responses.GET,
-            self.base_url + '/search/repositories?q=org:test%20ex',
+            self.base_url + "/search/repositories?q=org:test%20ex",
             json={
-                'items': [
-                    {
-                        'name': 'example',
-                        'full_name': 'test/example',
-                    },
-                    {
-                        'name': 'exhaust',
-                        'full_name': 'test/exhaust',
-                    },
+                "items": [
+                    {"name": "example", "full_name": "test/example"},
+                    {"name": "exhaust", "full_name": "test/exhaust"},
                 ]
-            }
+            },
         )
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'repo',
-                'query': 'ex',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "repo", "query": "ex"})
 
         assert resp.status_code == 200
         assert resp.data == [
-            {'value': 'test/example', 'label': 'example'},
-            {'value': 'test/exhaust', 'label': 'exhaust'}
+            {"value": "test/example", "label": "example"},
+            {"value": "test/exhaust", "label": "exhaust"},
         ]
 
     @responses.activate
     def test_repo_search_validation_error(self):
         responses.add(
             responses.GET,
-            self.base_url + '/search/repositories?q=org:test%20nope',
+            self.base_url + "/search/repositories?q=org:test%20nope",
             json={
-                'message': 'Validation Error',
-                'errors': [
-                    {'message': 'Cannot search for that org'}
-                ]
+                "message": "Validation Error",
+                "errors": [{"message": "Cannot search for that org"}],
             },
-            status=422
+            status=422,
         )
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'repo',
-                'query': 'nope',
-                'repo': 'example',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "repo", "query": "nope", "repo": "example"})
         assert resp.status_code == 404
-        assert 'detail' in resp.data
+        assert "detail" in resp.data
 
     @responses.activate
     def test_finds_no_external_issues_results(self):
         responses.add(
             responses.GET,
-            self.base_url + '/search/issues?q=repo:example%20nope',
-            json={'items': []}
+            self.base_url + "/search/issues?q=repo:example%20nope",
+            json={"items": []},
         )
         resp = self.client.get(
-            self.url,
-            data={
-                'field': 'externalIssue',
-                'query': 'nope',
-                'repo': 'example',
-            }
+            self.url, data={"field": "externalIssue", "query": "nope", "repo": "example"}
         )
 
         assert resp.status_code == 200
@@ -189,17 +138,9 @@ class GithubSearchTest(APITestCase):
     @responses.activate
     def test_finds_no_project_results(self):
         responses.add(
-            responses.GET,
-            self.base_url + '/search/repositories?q=org:test%20nope',
-            json={}
+            responses.GET, self.base_url + "/search/repositories?q=org:test%20nope", json={}
         )
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'repo',
-                'query': 'nope',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "repo", "query": "nope"})
 
         assert resp.status_code == 200
         assert resp.data == []
@@ -208,20 +149,15 @@ class GithubSearchTest(APITestCase):
     def test_search_issues_rate_limit(self):
         responses.add(
             responses.GET,
-            self.base_url + '/search/issues?q=repo:example%20ex',
+            self.base_url + "/search/issues?q=repo:example%20ex",
             status=403,
             json={
-                'message': 'API rate limit exceeded',
-                'documentation_url': 'https://developer.github.com/v3/#rate-limiting',
-            }
+                "message": "API rate limit exceeded",
+                "documentation_url": "https://developer.github.com/v3/#rate-limiting",
+            },
         )
         resp = self.client.get(
-            self.url,
-            data={
-                'field': 'externalIssue',
-                'query': 'ex',
-                'repo': 'example',
-            }
+            self.url, data={"field": "externalIssue", "query": "ex", "repo": "example"}
         )
         assert resp.status_code == 429
 
@@ -229,69 +165,39 @@ class GithubSearchTest(APITestCase):
     def test_search_project_rate_limit(self):
         responses.add(
             responses.GET,
-            self.base_url + '/search/repositories?q=org:test%20ex',
+            self.base_url + "/search/repositories?q=org:test%20ex",
             status=403,
             json={
-                'message': 'API rate limit exceeded',
-                'documentation_url': 'https://developer.github.com/v3/#rate-limiting',
-            }
+                "message": "API rate limit exceeded",
+                "documentation_url": "https://developer.github.com/v3/#rate-limiting",
+            },
         )
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'repo',
-                'query': 'ex',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "repo", "query": "ex"})
         assert resp.status_code == 429
 
     # Request Validations
     def test_missing_field(self):
-        resp = self.client.get(
-            self.url,
-            data={
-                'query': 'XYZ',
-            }
-        )
+        resp = self.client.get(self.url, data={"query": "XYZ"})
         assert resp.status_code == 400
 
     def test_missing_query(self):
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'externalIssue',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "externalIssue"})
 
         assert resp.status_code == 400
 
     def test_invalid_field(self):
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'invalid-field',
-                'query': 'nope',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "invalid-field", "query": "nope"})
 
         assert resp.status_code == 400
 
     # Missing Resources
     def test_missing_integration(self):
         url = reverse(
-            'sentry-extensions-gitlab-search',
-            kwargs={
-                'organization_slug': self.organization.slug,
-                'integration_id': '1234567890',
-            }
+            "sentry-extensions-gitlab-search",
+            kwargs={"organization_slug": self.organization.slug, "integration_id": "1234567890"},
         )
         resp = self.client.get(
-            url,
-            data={
-                'field': 'externalIssue',
-                'query': 'search',
-                'repo': 'example',
-            }
+            url, data={"field": "externalIssue", "query": "search", "repo": "example"}
         )
 
         assert resp.status_code == 404
@@ -299,13 +205,7 @@ class GithubSearchTest(APITestCase):
     def test_missing_installation(self):
         # remove organization integration aka "uninstalling" installation
         self.installation.org_integration.delete()
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'repo',
-                'query': 'not-found',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "repo", "query": "not-found"})
 
         assert resp.status_code == 404
 
@@ -313,32 +213,17 @@ class GithubSearchTest(APITestCase):
     @responses.activate
     def test_search_issues_request_fails(self):
         responses.add(
-            responses.GET,
-            self.base_url + '/search/issues?q=repo:example%20ex',
-            status=503
+            responses.GET, self.base_url + "/search/issues?q=repo:example%20ex", status=503
         )
         resp = self.client.get(
-            self.url,
-            data={
-                'field': 'externalIssue',
-                'query': 'ex',
-                'repo': 'example',
-            }
+            self.url, data={"field": "externalIssue", "query": "ex", "repo": "example"}
         )
         assert resp.status_code == 503
 
     @responses.activate
     def test_projects_request_fails(self):
         responses.add(
-            responses.GET,
-            self.base_url + '/search/repositories?q=org:test%20ex',
-            status=503
+            responses.GET, self.base_url + "/search/repositories?q=org:test%20ex", status=503
         )
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'repo',
-                'query': 'ex',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "repo", "query": "ex"})
         assert resp.status_code == 503

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -5,13 +5,7 @@ import six
 
 from datetime import datetime, timedelta
 from django.utils import timezone
-from sentry.models import (
-    Commit,
-    CommitAuthor,
-    GroupLink,
-    Integration,
-    PullRequest,
-    Repository)
+from sentry.models import Commit, CommitAuthor, GroupLink, Integration, PullRequest, Repository
 from sentry.testutils import APITestCase
 from uuid import uuid4
 
@@ -19,7 +13,7 @@ from .testutils import (
     PUSH_EVENT_EXAMPLE_INSTALLATION,
     PULL_REQUEST_OPENED_EVENT_EXAMPLE,
     PULL_REQUEST_EDITED_EVENT_EXAMPLE,
-    PULL_REQUEST_CLOSED_EVENT_EXAMPLE
+    PULL_REQUEST_CLOSED_EVENT_EXAMPLE,
 )
 from sentry import options
 
@@ -29,7 +23,7 @@ from mock import patch
 class WebhookTest(APITestCase):
     def test_get(self):
 
-        url = '/extensions/github/webhook/'
+        url = "/extensions/github/webhook/"
 
         response = self.client.get(url)
 
@@ -37,80 +31,77 @@ class WebhookTest(APITestCase):
 
     def test_unregistered_event(self):
         project = self.project  # force creation
-        url = u'/extensions/github/webhook/'.format(
-            project.organization.id,
-        )
+        url = u"/extensions/github/webhook/".format(project.organization.id)
 
-        secret = 'b3002c3e321d4b7880360d397db2ccfd'
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
 
-        options.set('github-app.webhook-secret', secret)
+        options.set("github-app.webhook-secret", secret)
 
         response = self.client.post(
             path=url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='UnregisteredEvent',
-            HTTP_X_HUB_SIGNATURE='sha1=56a3df597e02adbc17fb617502c70e19d96a6136',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="UnregisteredEvent",
+            HTTP_X_HUB_SIGNATURE="sha1=56a3df597e02adbc17fb617502c70e19d96a6136",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
 
     def test_invalid_signature_event(self):
 
-        url = '/extensions/github/webhook/'
+        url = "/extensions/github/webhook/"
 
-        secret = '2d7565c3537847b789d6995dca8d9f84'
+        secret = "2d7565c3537847b789d6995dca8d9f84"
 
-        options.set('github-app.webhook-secret', secret)
+        options.set("github-app.webhook-secret", secret)
 
         response = self.client.post(
             path=url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='push',
-            HTTP_X_HUB_SIGNATURE='sha1=33521abeaaf9a57c2abf486e0ccd54d23cf36fec',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_HUB_SIGNATURE="sha1=33521abeaaf9a57c2abf486e0ccd54d23cf36fec",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 401
 
 
 class PushEventWebhookTest(APITestCase):
-
-    @patch('sentry.integrations.github.client.get_jwt')
+    @patch("sentry.integrations.github.client.get_jwt")
     def test_simple(self, mock_get_jwt):
         mock_get_jwt.return_value = ""
 
         project = self.project  # force creation
 
-        url = '/extensions/github/webhook/'
+        url = "/extensions/github/webhook/"
 
-        secret = 'b3002c3e321d4b7880360d397db2ccfd'
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
 
-        options.set('github-app.webhook-secret', secret)
+        options.set("github-app.webhook-secret", secret)
         Repository.objects.create(
             organization_id=project.organization.id,
-            external_id='35129377',
-            provider='integrations:github',
-            name='baxterthehacker/public-repo',
+            external_id="35129377",
+            provider="integrations:github",
+            name="baxterthehacker/public-repo",
         )
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
         integration = Integration.objects.create(
             external_id="12345",
-            provider='github',
-            metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
+            provider="github",
+            metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
         )
         integration.add_organization(project.organization, self.user)
 
         response = self.client.post(
             path=url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='push',
-            HTTP_X_HUB_SIGNATURE='sha1=56a3df597e02adbc17fb617502c70e19d96a6136',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_HUB_SIGNATURE="sha1=56a3df597e02adbc17fb617502c70e19d96a6136",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
@@ -118,76 +109,78 @@ class PushEventWebhookTest(APITestCase):
         commit_list = list(
             Commit.objects.filter(
                 # organization_id=project.organization_id,
-            ).select_related('author').order_by('-date_added')
+            )
+            .select_related("author")
+            .order_by("-date_added")
         )
 
         assert len(commit_list) == 2
 
         commit = commit_list[0]
 
-        assert commit.key == '133d60480286590a610a0eb7352ff6e02b9674c4'
-        assert commit.message == u'Update README.md (àgain)'
-        assert commit.author.name == u'bàxterthehacker'
-        assert commit.author.email == 'baxterthehacker@users.noreply.github.com'
+        assert commit.key == "133d60480286590a610a0eb7352ff6e02b9674c4"
+        assert commit.message == u"Update README.md (àgain)"
+        assert commit.author.name == u"bàxterthehacker"
+        assert commit.author.email == "baxterthehacker@users.noreply.github.com"
         assert commit.author.external_id is None
         assert commit.date_added == datetime(2015, 5, 5, 23, 45, 15, tzinfo=timezone.utc)
 
         commit = commit_list[1]
 
-        assert commit.key == '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c'
-        assert commit.message == 'Update README.md'
-        assert commit.author.name == u'bàxterthehacker'
-        assert commit.author.email == 'baxterthehacker@users.noreply.github.com'
+        assert commit.key == "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
+        assert commit.message == "Update README.md"
+        assert commit.author.name == u"bàxterthehacker"
+        assert commit.author.email == "baxterthehacker@users.noreply.github.com"
         assert commit.author.external_id is None
         assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
 
     def test_anonymous_lookup(self):
         project = self.project  # force creation
 
-        url = '/extensions/github/webhook/'
+        url = "/extensions/github/webhook/"
 
-        secret = 'b3002c3e321d4b7880360d397db2ccfd'
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
 
-        options.set('github-app.webhook-secret', secret)
+        options.set("github-app.webhook-secret", secret)
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
         integration = Integration.objects.create(
-            provider='github',
-            external_id='12345',
-            name='octocat',
-            metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
+            provider="github",
+            external_id="12345",
+            name="octocat",
+            metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
         )
         integration.add_organization(project.organization, self.user)
 
         Repository.objects.create(
             organization_id=project.organization.id,
-            external_id='35129377',
-            provider='integrations:github',
-            name='baxterthehacker/public-repo',
+            external_id="35129377",
+            provider="integrations:github",
+            name="baxterthehacker/public-repo",
         )
 
         CommitAuthor.objects.create(
-            external_id='github:baxterthehacker',
+            external_id="github:baxterthehacker",
             organization_id=project.organization_id,
-            email='baxterthehacker@example.com',
-            name=u'bàxterthehacker',
+            email="baxterthehacker@example.com",
+            name=u"bàxterthehacker",
         )
 
         response = self.client.post(
             path=url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='push',
-            HTTP_X_HUB_SIGNATURE='sha1=56a3df597e02adbc17fb617502c70e19d96a6136',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_HUB_SIGNATURE="sha1=56a3df597e02adbc17fb617502c70e19d96a6136",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
 
         commit_list = list(
-            Commit.objects.filter(
-                organization_id=project.organization_id,
-            ).select_related('author').order_by('-date_added')
+            Commit.objects.filter(organization_id=project.organization_id)
+            .select_related("author")
+            .order_by("-date_added")
         )
 
         # should be skipping the #skipsentry commit
@@ -195,87 +188,87 @@ class PushEventWebhookTest(APITestCase):
 
         commit = commit_list[0]
 
-        assert commit.key == '133d60480286590a610a0eb7352ff6e02b9674c4'
-        assert commit.message == u'Update README.md (àgain)'
-        assert commit.author.name == u'bàxterthehacker'
-        assert commit.author.email == 'baxterthehacker@example.com'
+        assert commit.key == "133d60480286590a610a0eb7352ff6e02b9674c4"
+        assert commit.message == u"Update README.md (àgain)"
+        assert commit.author.name == u"bàxterthehacker"
+        assert commit.author.email == "baxterthehacker@example.com"
         assert commit.date_added == datetime(2015, 5, 5, 23, 45, 15, tzinfo=timezone.utc)
 
         commit = commit_list[1]
 
-        assert commit.key == '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c'
-        assert commit.message == 'Update README.md'
-        assert commit.author.name == u'bàxterthehacker'
-        assert commit.author.email == 'baxterthehacker@example.com'
+        assert commit.key == "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
+        assert commit.message == "Update README.md"
+        assert commit.author.name == u"bàxterthehacker"
+        assert commit.author.email == "baxterthehacker@example.com"
         assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
 
-    @patch('sentry.integrations.github.client.get_jwt')
+    @patch("sentry.integrations.github.client.get_jwt")
     def test_multiple_orgs(self, mock_get_jwt):
         mock_get_jwt.return_value = ""
 
         project = self.project  # force creation
 
-        url = '/extensions/github/webhook/'
+        url = "/extensions/github/webhook/"
 
-        secret = 'b3002c3e321d4b7880360d397db2ccfd'
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
 
-        options.set('github-app.webhook-secret', secret)
+        options.set("github-app.webhook-secret", secret)
         Repository.objects.create(
             organization_id=project.organization.id,
-            external_id='35129377',
-            provider='integrations:github',
-            name='baxterthehacker/public-repo',
+            external_id="35129377",
+            provider="integrations:github",
+            name="baxterthehacker/public-repo",
         )
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
         integration = Integration.objects.create(
             external_id="12345",
-            provider='github',
-            metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
+            provider="github",
+            metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
         )
         integration.add_organization(project.organization, self.user)
 
         org2 = self.create_organization()
-        project2 = self.create_project(organization=org2, name='bar')
+        project2 = self.create_project(organization=org2, name="bar")
 
         Repository.objects.create(
             organization_id=project2.organization.id,
-            external_id='77',
-            provider='integrations:github',
-            name='another/repo',
+            external_id="77",
+            provider="integrations:github",
+            name="another/repo",
         )
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
         integration = Integration.objects.create(
             external_id="99",
-            provider='github',
-            metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
+            provider="github",
+            metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
         )
         integration.add_organization(org2, self.user)
 
         response = self.client.post(
             path=url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='push',
-            HTTP_X_HUB_SIGNATURE='sha1=56a3df597e02adbc17fb617502c70e19d96a6136',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_HUB_SIGNATURE="sha1=56a3df597e02adbc17fb617502c70e19d96a6136",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
 
         commit_list = list(
-            Commit.objects.filter(
-                organization_id=project.organization_id,
-            ).select_related('author').order_by('-date_added')
+            Commit.objects.filter(organization_id=project.organization_id)
+            .select_related("author")
+            .order_by("-date_added")
         )
 
         assert len(commit_list) == 2
 
         commit_list = list(
-            Commit.objects.filter(
-                organization_id=org2.id,
-            ).select_related('author').order_by('-date_added')
+            Commit.objects.filter(organization_id=org2.id)
+            .select_related("author")
+            .order_by("-date_added")
         )
         assert len(commit_list) == 0
 
@@ -284,50 +277,52 @@ class PullRequestEventWebhook(APITestCase):
     def test_opened(self):
         project = self.project  # force creation
         group = self.create_group(project=project, short_id=7)
-        url = '/extensions/github/webhook/'
-        secret = 'b3002c3e321d4b7880360d397db2ccfd'
-        options.set('github-app.webhook-secret', secret)
+        url = "/extensions/github/webhook/"
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
+        options.set("github-app.webhook-secret", secret)
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
         integration = Integration.objects.create(
-            provider='github',
-            external_id='12345',
-            name='octocat',
-            metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
+            provider="github",
+            external_id="12345",
+            name="octocat",
+            metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
         )
         integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,
-            external_id='35129377',
-            provider='integrations:github',
-            name='baxterthehacker/public-repo',
+            external_id="35129377",
+            provider="integrations:github",
+            name="baxterthehacker/public-repo",
         )
 
         response = self.client.post(
             path=url,
             data=PULL_REQUEST_OPENED_EVENT_EXAMPLE,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='pull_request',
-            HTTP_X_HUB_SIGNATURE='sha1=bc7ce12fc1058a35bf99355e6fc0e6da72c35de3',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="pull_request",
+            HTTP_X_HUB_SIGNATURE="sha1=bc7ce12fc1058a35bf99355e6fc0e6da72c35de3",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
 
         prs = PullRequest.objects.filter(
-            repository_id=repo.id,
-            organization_id=project.organization.id,
+            repository_id=repo.id, organization_id=project.organization.id
         )
 
         assert len(prs) == 1
 
         pr = prs[0]
 
-        assert pr.key == '1'
-        assert pr.message == u'This is a pretty simple change that we need to pull into master. Fixes BAR-7'
-        assert pr.title == u'Update the README with new information'
-        assert pr.author.name == u'baxterthehacker'
+        assert pr.key == "1"
+        assert (
+            pr.message
+            == u"This is a pretty simple change that we need to pull into master. Fixes BAR-7"
+        )
+        assert pr.title == u"Update the README with new information"
+        assert pr.author.name == u"baxterthehacker"
 
         self.assert_group_link(group, pr)
 
@@ -335,102 +330,99 @@ class PullRequestEventWebhook(APITestCase):
         project = self.project  # force creation
         group = self.create_group(project=project, short_id=7)
 
-        url = '/extensions/github/webhook/'
-        secret = 'b3002c3e321d4b7880360d397db2ccfd'
-        options.set('github-app.webhook-secret', secret)
+        url = "/extensions/github/webhook/"
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
+        options.set("github-app.webhook-secret", secret)
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
         integration = Integration.objects.create(
-            provider='github',
-            external_id='12345',
-            name='octocat',
-            metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
+            provider="github",
+            external_id="12345",
+            name="octocat",
+            metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
         )
         integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,
-            external_id='35129377',
-            provider='integrations:github',
-            name='baxterthehacker/public-repo',
+            external_id="35129377",
+            provider="integrations:github",
+            name="baxterthehacker/public-repo",
         )
 
         pr = PullRequest.objects.create(
-            key='1',
-            repository_id=repo.id,
-            organization_id=project.organization.id,
+            key="1", repository_id=repo.id, organization_id=project.organization.id
         )
 
         response = self.client.post(
             path=url,
             data=PULL_REQUEST_EDITED_EVENT_EXAMPLE,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='pull_request',
-            HTTP_X_HUB_SIGNATURE='sha1=83100642f0cf5d7f6145cf8d04da5d00a09f890f',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="pull_request",
+            HTTP_X_HUB_SIGNATURE="sha1=83100642f0cf5d7f6145cf8d04da5d00a09f890f",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
 
         pr = PullRequest.objects.get(id=pr.id)
 
-        assert pr.key == '1'
-        assert pr.message == u'new edited body. Fixes BAR-7'
-        assert pr.title == u'new edited title'
-        assert pr.author.name == u'baxterthehacker'
+        assert pr.key == "1"
+        assert pr.message == u"new edited body. Fixes BAR-7"
+        assert pr.title == u"new edited title"
+        assert pr.author.name == u"baxterthehacker"
 
         self.assert_group_link(group, pr)
 
     def test_closed(self):
         project = self.project  # force creation
 
-        url = '/extensions/github/webhook/'
+        url = "/extensions/github/webhook/"
 
-        secret = 'b3002c3e321d4b7880360d397db2ccfd'
+        secret = "b3002c3e321d4b7880360d397db2ccfd"
 
-        options.set('github-app.webhook-secret', secret)
+        options.set("github-app.webhook-secret", secret)
 
         future_expires = datetime.now().replace(microsecond=0) + timedelta(minutes=5)
         integration = Integration.objects.create(
-            provider='github',
-            external_id='12345',
-            name='octocat',
-            metadata={'access_token': '1234', 'expires_at': future_expires.isoformat()}
+            provider="github",
+            external_id="12345",
+            name="octocat",
+            metadata={"access_token": "1234", "expires_at": future_expires.isoformat()},
         )
         integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,
-            external_id='35129377',
-            provider='integrations:github',
-            name='baxterthehacker/public-repo',
+            external_id="35129377",
+            provider="integrations:github",
+            name="baxterthehacker/public-repo",
         )
 
         response = self.client.post(
             path=url,
             data=PULL_REQUEST_CLOSED_EVENT_EXAMPLE,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='pull_request',
-            HTTP_X_HUB_SIGNATURE='sha1=49db856f5658b365b73a2fa73a7cffa543f4d3af',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="pull_request",
+            HTTP_X_HUB_SIGNATURE="sha1=49db856f5658b365b73a2fa73a7cffa543f4d3af",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
 
         prs = PullRequest.objects.filter(
-            repository_id=repo.id,
-            organization_id=project.organization.id,
+            repository_id=repo.id, organization_id=project.organization.id
         )
 
         assert len(prs) == 1
 
         pr = prs[0]
 
-        assert pr.key == '1'
-        assert pr.message == u'new closed body'
-        assert pr.title == u'new closed title'
-        assert pr.author.name == u'baxterthehacker'
-        assert pr.merge_commit_sha == '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c'
+        assert pr.key == "1"
+        assert pr.message == u"new closed body"
+        assert pr.title == u"new closed title"
+        assert pr.author.name == u"baxterthehacker"
+        assert pr.merge_commit_sha == "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
 
     def assert_group_link(self, group, pr):
         link = GroupLink.objects.all().first()

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -7,7 +7,11 @@ from six.moves.urllib.parse import parse_qs, urlencode, urlparse
 
 from sentry.integrations.github_enterprise import GitHubEnterpriseIntegrationProvider
 from sentry.models import (
-    Identity, IdentityProvider, IdentityStatus, Integration, OrganizationIntegration,
+    Identity,
+    IdentityProvider,
+    IdentityStatus,
+    Integration,
+    OrganizationIntegration,
 )
 from sentry.testutils import IntegrationTestCase
 
@@ -15,121 +19,110 @@ from sentry.testutils import IntegrationTestCase
 class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
     provider = GitHubEnterpriseIntegrationProvider
     config = {
-        'url': 'https://github.example.org',
-        'id': 2,
-        'name': 'test-app',
-        'client_id': 'client_id',
-        'client_secret': 'client_secret',
-        'webhook_secret': 'webhook_secret',
-        'private_key': 'private_key',
-        'verify_ssl': True,
+        "url": "https://github.example.org",
+        "id": 2,
+        "name": "test-app",
+        "client_id": "client_id",
+        "client_secret": "client_secret",
+        "webhook_secret": "webhook_secret",
+        "private_key": "private_key",
+        "verify_ssl": True,
     }
-    base_url = 'https://github.example.org/api/v3'
+    base_url = "https://github.example.org/api/v3"
 
-    @patch('sentry.integrations.github_enterprise.integration.get_jwt', return_value='jwt_token_1')
-    @patch('sentry.integrations.github.client.get_jwt', return_value='jwt_token_1')
-    def assert_setup_flow(self, get_jwt, _, installation_id='install_id_1',
-                          app_id='app_1', user_id='user_id_1'):
+    @patch("sentry.integrations.github_enterprise.integration.get_jwt", return_value="jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    def assert_setup_flow(
+        self, get_jwt, _, installation_id="install_id_1", app_id="app_1", user_id="user_id_1"
+    ):
         responses.reset()
         resp = self.client.get(self.init_path)
         assert resp.status_code == 200
         resp = self.client.post(self.init_path, data=self.config)
         assert resp.status_code == 302
-        redirect = urlparse(resp['Location'])
-        assert redirect.scheme == 'https'
-        assert redirect.netloc == 'github.example.org'
-        assert redirect.path == '/github-apps/test-app'
+        redirect = urlparse(resp["Location"])
+        assert redirect.scheme == "https"
+        assert redirect.netloc == "github.example.org"
+        assert redirect.path == "/github-apps/test-app"
 
         # App installation ID is provided, mveo thr
-        resp = self.client.get(u'{}?{}'.format(
-            self.setup_path,
-            urlencode({'installation_id': installation_id})
-        ))
+        resp = self.client.get(
+            u"{}?{}".format(self.setup_path, urlencode({"installation_id": installation_id}))
+        )
 
         assert resp.status_code == 302
-        redirect = urlparse(resp['Location'])
-        assert redirect.scheme == 'https'
-        assert redirect.netloc == 'github.example.org'
-        assert redirect.path == '/login/oauth/authorize'
+        redirect = urlparse(resp["Location"])
+        assert redirect.scheme == "https"
+        assert redirect.netloc == "github.example.org"
+        assert redirect.path == "/login/oauth/authorize"
 
         params = parse_qs(redirect.query)
-        assert params['state']
-        assert params['redirect_uri'] == ['http://testserver/extensions/github-enterprise/setup/']
-        assert params['response_type'] == ['code']
-        assert params['client_id'] == ['client_id']
+        assert params["state"]
+        assert params["redirect_uri"] == ["http://testserver/extensions/github-enterprise/setup/"]
+        assert params["response_type"] == ["code"]
+        assert params["client_id"] == ["client_id"]
         # once we've asserted on it, switch to a singular values to make life
         # easier
         authorize_params = {k: v[0] for k, v in six.iteritems(params)}
 
-        access_token = 'xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx'
+        access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
 
         responses.add(
             responses.POST,
-            'https://github.example.org/login/oauth/access_token',
-            json={'access_token': access_token}
+            "https://github.example.org/login/oauth/access_token",
+            json={"access_token": access_token},
         )
 
         responses.add(
             responses.POST,
-            self.base_url + '/installations/{}/access_tokens'.format(
-                installation_id,
-            ),
+            self.base_url + "/installations/{}/access_tokens".format(installation_id),
+            json={"token": access_token, "expires_at": "3000-01-01T00:00:00Z"},
+        )
+
+        responses.add(responses.GET, self.base_url + "/user", json={"id": user_id})
+
+        responses.add(
+            responses.GET,
+            self.base_url + "/app/installations/{}".format(installation_id),
             json={
-                'token': access_token,
-                'expires_at': '3000-01-01T00:00:00Z',
+                "id": installation_id,
+                "app_id": app_id,
+                "account": {
+                    "login": "Test Organization",
+                    "type": "Organization",
+                    "avatar_url": "https://github.example.org/avatar.png",
+                    "html_url": "https://github.example.org/Test-Organization",
+                },
             },
         )
 
         responses.add(
             responses.GET,
-            self.base_url + '/user',
-            json={'id': user_id}
+            self.base_url + "/user/installations",
+            json={"installations": [{"id": installation_id}]},
         )
 
-        responses.add(
-            responses.GET,
-            self.base_url + '/app/installations/{}'.format(installation_id),
-            json={
-                'id': installation_id,
-                'app_id': app_id,
-                'account': {
-                    'login': 'Test Organization',
-                    'type': 'Organization',
-                    'avatar_url': 'https://github.example.org/avatar.png',
-                    'html_url': 'https://github.example.org/Test-Organization',
-                },
-            }
+        resp = self.client.get(
+            u"{}?{}".format(
+                self.setup_path,
+                urlencode({"code": "oauth-code", "state": authorize_params["state"]}),
+            )
         )
-
-        responses.add(
-            responses.GET,
-            self.base_url + '/user/installations',
-            json={
-                'installations': [{'id': installation_id}],
-            }
-        )
-
-        resp = self.client.get(u'{}?{}'.format(
-            self.setup_path,
-            urlencode({
-                'code': 'oauth-code',
-                'state': authorize_params['state'],
-            })
-        ))
 
         mock_access_token_request = responses.calls[0].request
         req_params = parse_qs(mock_access_token_request.body)
-        assert req_params['grant_type'] == ['authorization_code']
-        assert req_params['code'] == ['oauth-code']
-        assert req_params['redirect_uri'] == [
-            'http://testserver/extensions/github-enterprise/setup/']
-        assert req_params['client_id'] == ['client_id']
-        assert req_params['client_secret'] == ['client_secret']
+        assert req_params["grant_type"] == ["authorization_code"]
+        assert req_params["code"] == ["oauth-code"]
+        assert req_params["redirect_uri"] == [
+            "http://testserver/extensions/github-enterprise/setup/"
+        ]
+        assert req_params["client_id"] == ["client_id"]
+        assert req_params["client_secret"] == ["client_secret"]
 
         assert resp.status_code == 200
 
-        auth_header = responses.calls[2].request.headers['Authorization']
-        assert auth_header == 'Bearer jwt_token_1'
+        auth_header = responses.calls[2].request.headers["Authorization"]
+        assert auth_header == "Bearer jwt_token_1"
 
         self.assertDialogSuccess(resp)
 
@@ -139,45 +132,38 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
 
         integration = Integration.objects.get(provider=self.provider.key)
 
-        assert integration.external_id == 'github.example.org:install_id_1'
-        assert integration.name == 'Test Organization'
+        assert integration.external_id == "github.example.org:install_id_1"
+        assert integration.name == "Test Organization"
         assert integration.metadata == {
-            u'access_token': None,
-            u'expires_at': None,
-            u'icon': u'https://github.example.org/avatar.png',
-            u'domain_name': u'github.example.org/Test-Organization',
-            u'account_type': u'Organization',
-            u'installation_id': u'install_id_1',
-            u'installation': {
-                u'client_id': u'client_id',
-                u'client_secret': u'client_secret',
-                u'id': u'2',
-                u'name': u'test-app',
-                u'private_key': u'private_key',
-                u'url': u'github.example.org',
-                u'webhook_secret': u'webhook_secret',
-                u'verify_ssl': True,
-            }
+            u"access_token": None,
+            u"expires_at": None,
+            u"icon": u"https://github.example.org/avatar.png",
+            u"domain_name": u"github.example.org/Test-Organization",
+            u"account_type": u"Organization",
+            u"installation_id": u"install_id_1",
+            u"installation": {
+                u"client_id": u"client_id",
+                u"client_secret": u"client_secret",
+                u"id": u"2",
+                u"name": u"test-app",
+                u"private_key": u"private_key",
+                u"url": u"github.example.org",
+                u"webhook_secret": u"webhook_secret",
+                u"verify_ssl": True,
+            },
         }
         oi = OrganizationIntegration.objects.get(
-            integration=integration,
-            organization=self.organization,
+            integration=integration, organization=self.organization
         )
         assert oi.config == {}
 
-        idp = IdentityProvider.objects.get(type='github_enterprise')
-        identity = Identity.objects.get(
-            idp=idp,
-            user=self.user,
-            external_id='user_id_1',
-        )
+        idp = IdentityProvider.objects.get(type="github_enterprise")
+        identity = Identity.objects.get(idp=idp, user=self.user, external_id="user_id_1")
         assert identity.status == IdentityStatus.VALID
-        assert identity.data == {
-            'access_token': 'xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx'
-        }
+        assert identity.data == {"access_token": "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"}
 
-    @patch('sentry.integrations.github_enterprise.integration.get_jwt', return_value='jwt_token_1')
-    @patch('sentry.integrations.github_enterprise.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github_enterprise.integration.get_jwt", return_value="jwt_token_1")
+    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_repositories_search_param(self, mock_jwtm, _):
         with self.tasks():
@@ -185,24 +171,18 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            self.base_url + '/search/repositories?q=org:test%20ex',
+            self.base_url + "/search/repositories?q=org:test%20ex",
             json={
-                'items': [
-                    {
-                        'name': 'example',
-                        'full_name': 'test/example',
-                    },
-                    {
-                        'name': 'exhaust',
-                        'full_name': 'test/exhaust',
-                    },
+                "items": [
+                    {"name": "example", "full_name": "test/example"},
+                    {"name": "exhaust", "full_name": "test/exhaust"},
                 ]
-            }
+            },
         )
         integration = Integration.objects.get(provider=self.provider.key)
         installation = integration.get_installation(self.organization)
-        result = installation.get_repositories('ex')
+        result = installation.get_repositories("ex")
         assert result == [
-            {'identifier': 'test/example', 'name': 'example'},
-            {'identifier': 'test/exhaust', 'name': 'exhaust'}
+            {"identifier": "test/example", "name": "example"},
+            {"identifier": "test/exhaust", "name": "exhaust"},
         ]

--- a/tests/sentry/integrations/github_enterprise/test_issues.py
+++ b/tests/sentry/integrations/github_enterprise/test_issues.py
@@ -21,171 +21,171 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
         self.user = self.create_user()
         self.organization = self.create_organization(owner=self.user)
         self.model = Integration.objects.create(
-            provider='github_enterprise',
-            external_id='github_external_id',
-            name='getsentry',
+            provider="github_enterprise",
+            external_id="github_external_id",
+            name="getsentry",
             metadata={
-                'domain_name': '35.232.149.196/getsentry',
-                'installation_id': 'installation_id',
-                'installation': {
-                    'id': 2,
-                    'private_key': 'private_key',
-                    'verify_ssl': True}}
+                "domain_name": "35.232.149.196/getsentry",
+                "installation_id": "installation_id",
+                "installation": {"id": 2, "private_key": "private_key", "verify_ssl": True},
+            },
         )
         self.model.add_organization(self.organization, self.user)
         self.integration = GitHubEnterpriseIntegration(self.model, self.organization.id)
 
     @responses.activate
-    @patch('sentry.integrations.github_enterprise.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     def test_get_allowed_assignees(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            'https://35.232.149.196/api/v3/installations/installation_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://35.232.149.196/api/v3/installations/installation_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
         responses.add(
             responses.GET,
-            'https://35.232.149.196/api/v3/repos/getsentry/sentry/assignees',
-            json=[{'login': 'MeredithAnya'}]
+            "https://35.232.149.196/api/v3/repos/getsentry/sentry/assignees",
+            json=[{"login": "MeredithAnya"}],
         )
 
-        repo = 'getsentry/sentry'
+        repo = "getsentry/sentry"
         assert self.integration.get_allowed_assignees(repo) == (
-            ('', 'Unassigned'),
-            ('MeredithAnya', 'MeredithAnya')
+            ("", "Unassigned"),
+            ("MeredithAnya", "MeredithAnya"),
         )
 
         request = responses.calls[0].request
-        assert request.headers['Authorization'] == 'Bearer jwt_token_1'
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
-        assert request.headers['Authorization'] == 'token token_1'
+        assert request.headers["Authorization"] == "token token_1"
 
     @responses.activate
-    @patch('sentry.integrations.github_enterprise.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     def test_create_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            'https://35.232.149.196/api/v3/installations/installation_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://35.232.149.196/api/v3/installations/installation_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
         responses.add(
             responses.POST,
-            'https://35.232.149.196/api/v3/repos/getsentry/sentry/issues',
-            json={'number': 321, 'title': 'hello', 'body': 'This is the description',
-                  'html_url': 'https://35.232.149.196/getsentry/sentry/issues/231'}
+            "https://35.232.149.196/api/v3/repos/getsentry/sentry/issues",
+            json={
+                "number": 321,
+                "title": "hello",
+                "body": "This is the description",
+                "html_url": "https://35.232.149.196/getsentry/sentry/issues/231",
+            },
         )
 
         form_data = {
-            'repo': 'getsentry/sentry',
-            'title': 'hello',
-            'description': 'This is the description',
+            "repo": "getsentry/sentry",
+            "title": "hello",
+            "description": "This is the description",
         }
 
         assert self.integration.create_issue(form_data) == {
-            'key': 321,
-            'description': 'This is the description',
-            'title': 'hello',
-            'url': 'https://35.232.149.196/getsentry/sentry/issues/231',
-            'repo': 'getsentry/sentry',
+            "key": 321,
+            "description": "This is the description",
+            "title": "hello",
+            "url": "https://35.232.149.196/getsentry/sentry/issues/231",
+            "repo": "getsentry/sentry",
         }
         request = responses.calls[0].request
-        assert request.headers['Authorization'] == 'Bearer jwt_token_1'
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
-        assert request.headers['Authorization'] == 'token token_1'
+        assert request.headers["Authorization"] == "token token_1"
         payload = json.loads(request.body)
-        assert payload == {'body': 'This is the description', 'assignee': None, 'title': 'hello'}
+        assert payload == {"body": "This is the description", "assignee": None, "title": "hello"}
 
     @responses.activate
-    @patch('sentry.integrations.github_enterprise.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     def test_get_repo_issues(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            'https://35.232.149.196/api/v3/installations/installation_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://35.232.149.196/api/v3/installations/installation_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
         responses.add(
             responses.GET,
-            'https://35.232.149.196/api/v3/repos/getsentry/sentry/issues',
-            json=[{'number': 321, 'title': 'hello', 'body': 'This is the description'}]
+            "https://35.232.149.196/api/v3/repos/getsentry/sentry/issues",
+            json=[{"number": 321, "title": "hello", "body": "This is the description"}],
         )
-        repo = 'getsentry/sentry'
-        assert self.integration.get_repo_issues(repo) == ((321, '#321 hello'),)
+        repo = "getsentry/sentry"
+        assert self.integration.get_repo_issues(repo) == ((321, "#321 hello"),)
 
         request = responses.calls[0].request
-        assert request.headers['Authorization'] == 'Bearer jwt_token_1'
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
-        assert request.headers['Authorization'] == 'token token_1'
+        assert request.headers["Authorization"] == "token token_1"
 
     @responses.activate
-    @patch('sentry.integrations.github_enterprise.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     def test_link_issue(self, mock_get_jwt):
         issue_id = 321
         responses.add(
             responses.POST,
-            'https://35.232.149.196/api/v3/installations/installation_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://35.232.149.196/api/v3/installations/installation_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
         responses.add(
             responses.GET,
-            'https://35.232.149.196/api/v3/repos/getsentry/sentry/issues/321',
-            json={'number': issue_id, 'title': 'hello', 'body': 'This is the description',
-                  'html_url': 'https://35.232.149.196/getsentry/sentry/issues/231'}
+            "https://35.232.149.196/api/v3/repos/getsentry/sentry/issues/321",
+            json={
+                "number": issue_id,
+                "title": "hello",
+                "body": "This is the description",
+                "html_url": "https://35.232.149.196/getsentry/sentry/issues/231",
+            },
         )
 
-        data = {
-            'repo': 'getsentry/sentry',
-            'externalIssue': issue_id,
-            'comment': 'hello',
-        }
+        data = {"repo": "getsentry/sentry", "externalIssue": issue_id, "comment": "hello"}
 
         assert self.integration.get_issue(issue_id, data=data) == {
-            'key': issue_id,
-            'description': 'This is the description',
-            'title': 'hello',
-            'url': 'https://35.232.149.196/getsentry/sentry/issues/231',
-            'repo': 'getsentry/sentry',
+            "key": issue_id,
+            "description": "This is the description",
+            "title": "hello",
+            "url": "https://35.232.149.196/getsentry/sentry/issues/231",
+            "repo": "getsentry/sentry",
         }
         request = responses.calls[0].request
-        assert request.headers['Authorization'] == 'Bearer jwt_token_1'
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
-        assert request.headers['Authorization'] == 'token token_1'
+        assert request.headers["Authorization"] == "token token_1"
 
     @responses.activate
-    @patch('sentry.integrations.github_enterprise.client.get_jwt', return_value='jwt_token_1')
+    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     def after_link_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
-            'https://35.232.149.196/api/v3/installations/installation_id/access_tokens',
-            json={'token': 'token_1', 'expires_at': '2018-10-11T22:14:10Z'}
+            "https://35.232.149.196/api/v3/installations/installation_id/access_tokens",
+            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
         )
 
         responses.add(
             responses.POST,
-            'https://35.232.149.196/api/v3/repos/getsentry/sentry/issues/321/comments',
-            json={'body': 'hello'}
+            "https://35.232.149.196/api/v3/repos/getsentry/sentry/issues/321/comments",
+            json={"body": "hello"},
         )
 
-        data = {'comment': 'hello'}
+        data = {"comment": "hello"}
         external_issue = ExternalIssue.objects.create(
-            organization_id=self.organization.id,
-            integration_id=self.model.id,
-            key='hello#321',
+            organization_id=self.organization.id, integration_id=self.model.id, key="hello#321"
         )
 
         self.integration.after_link_issue(external_issue, data=data)
 
         request = responses.calls[0].request
-        assert request.headers['Authorization'] == 'Bearer jwt_token_1'
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
-        assert request.headers['Authorization'] == 'token token_1'
+        assert request.headers["Authorization"] == "token token_1"
         payload = json.loads(request.body)
-        assert payload == {'body': 'hello'}
+        assert payload == {"body": "hello"}

--- a/tests/sentry/integrations/github_enterprise/test_search.py
+++ b/tests/sentry/integrations/github_enterprise/test_search.py
@@ -8,24 +8,24 @@ from ..github.test_search import GithubSearchTest
 class GithubEnterpriseSearchTest(GithubSearchTest):
     # Inherit test methods/scenarios from GithubSearchTest
     # and fill out the slots that customize it to use github:enterprise
-    provider = 'github_enterprise'
-    base_url = 'https://github.example.org/api/v3'
+    provider = "github_enterprise"
+    base_url = "https://github.example.org/api/v3"
 
     def create_integration(self):
         future = datetime.now() + timedelta(hours=1)
         return Integration.objects.create(
             provider=self.provider,
-            name='test',
+            name="test",
             external_id=9999,
             metadata={
-                'domain_name': 'github.example.org',
-                'account_type': 'Organization',
-                'access_token': '123456789',
-                'expires_at': future.replace(microsecond=0).isoformat(),
-                'installation': {
-                    'private_key': 'some private key',
-                    'id': 123456,
-                    'verify_ssl': True
-                }
-            }
+                "domain_name": "github.example.org",
+                "account_type": "Organization",
+                "access_token": "123456789",
+                "expires_at": future.replace(microsecond=0).isoformat(),
+                "installation": {
+                    "private_key": "some private key",
+                    "id": 123456,
+                    "verify_ssl": True,
+                },
+            },
         )

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -5,12 +5,7 @@ import six
 
 from datetime import datetime
 from django.utils import timezone
-from sentry.models import (
-    Commit,
-    CommitAuthor,
-    Integration,
-    PullRequest,
-    Repository)
+from sentry.models import Commit, CommitAuthor, Integration, PullRequest, Repository
 from sentry.testutils import APITestCase
 from uuid import uuid4
 
@@ -18,7 +13,7 @@ from .testutils import (
     PUSH_EVENT_EXAMPLE_INSTALLATION,
     PULL_REQUEST_OPENED_EVENT_EXAMPLE,
     PULL_REQUEST_EDITED_EVENT_EXAMPLE,
-    PULL_REQUEST_CLOSED_EVENT_EXAMPLE
+    PULL_REQUEST_CLOSED_EVENT_EXAMPLE,
 )
 
 from mock import patch
@@ -26,7 +21,7 @@ from mock import patch
 
 class WebhookTest(APITestCase):
     def test_get(self):
-        url = '/extensions/github-enterprise/webhook/'
+        url = "/extensions/github-enterprise/webhook/"
 
         response = self.client.get(url)
         assert response.status_code == 405
@@ -34,129 +29,123 @@ class WebhookTest(APITestCase):
     def test_unknown_host_event(self):
         # No integration defined in the database, so event should be rejected
         # because we can't find metadata and secret for it
-        url = '/extensions/github-enterprise/webhook/'
+        url = "/extensions/github-enterprise/webhook/"
 
         response = self.client.post(
             path=url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='push',
-            HTTP_X_GITHUB_ENTERPRISE_HOST='99.99.99.99',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="99.99.99.99",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
         assert response.status_code == 400
 
     def test_unregistered_event(self):
         project = self.project  # force creation
-        url = u'/extensions/github-enterprise/webhook/'.format(
-            project.organization.id,
-        )
+        url = u"/extensions/github-enterprise/webhook/".format(project.organization.id)
 
         response = self.client.post(
             path=url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='UnregisteredEvent',
-            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
-            HTTP_X_HUB_SIGNATURE='sha1=56a3df597e02adbc17fb617502c70e19d96a6136',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="UnregisteredEvent",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_HUB_SIGNATURE="sha1=56a3df597e02adbc17fb617502c70e19d96a6136",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
         assert response.status_code == 204
 
-    @patch('sentry.integrations.github_enterprise.webhook.get_installation_metadata')
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_invalid_signature_event(self, mock_installation):
         mock_installation.return_value = {
-            'url': '35.232.149.196',
-            'id': '2',
-            'name': 'test-app',
-            'webhook_secret': 'b3002c3e321d4b7880360d397db2ccfd',
-            'private_key': 'private_key',
-            'verify_ssl': True,
+            "url": "35.232.149.196",
+            "id": "2",
+            "name": "test-app",
+            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
+            "private_key": "private_key",
+            "verify_ssl": True,
         }
-        url = '/extensions/github-enterprise/webhook/'
+        url = "/extensions/github-enterprise/webhook/"
 
         response = self.client.post(
             path=url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='push',
-            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
-            HTTP_X_HUB_SIGNATURE='sha1=33521abeaaf9a57c2abf486e0ccd54d23cf36fec',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_HUB_SIGNATURE="sha1=33521abeaaf9a57c2abf486e0ccd54d23cf36fec",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
         assert response.status_code == 401
 
-    @patch('sentry.integrations.github_enterprise.webhook.get_installation_metadata')
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_missing_signature_ok(self, mock_installation):
         # Old Github:e doesn't send a signature, so we have to accept that.
         mock_installation.return_value = {
-            'url': '35.232.149.196',
-            'id': '2',
-            'name': 'test-app',
-            'webhook_secret': 'b3002c3e321d4b7880360d397db2ccfd',
-            'private_key': 'private_key',
-            'verify_ssl': True,
+            "url": "35.232.149.196",
+            "id": "2",
+            "name": "test-app",
+            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
+            "private_key": "private_key",
+            "verify_ssl": True,
         }
-        url = '/extensions/github-enterprise/webhook/'
+        url = "/extensions/github-enterprise/webhook/"
 
         response = self.client.post(
             path=url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='push',
-            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
         assert response.status_code == 204
 
 
 class PushEventWebhookTest(APITestCase):
-    @patch('sentry.integrations.github_enterprise.client.get_jwt')
-    @patch('sentry.integrations.github_enterprise.webhook.get_installation_metadata')
+    @patch("sentry.integrations.github_enterprise.client.get_jwt")
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_simple(self, mock_get_installation_metadata, mock_get_jwt):
         mock_get_jwt.return_value = ""
 
         project = self.project  # force creation
 
-        url = '/extensions/github-enterprise/webhook/'
+        url = "/extensions/github-enterprise/webhook/"
         mock_get_installation_metadata.return_value = {
-            'url': '35.232.149.196',
-            'id': '2',
-            'name': 'test-app',
-            'webhook_secret': 'b3002c3e321d4b7880360d397db2ccfd',
-            'private_key': 'private_key',
-            'verify_ssl': True,
+            "url": "35.232.149.196",
+            "id": "2",
+            "name": "test-app",
+            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
+            "private_key": "private_key",
+            "verify_ssl": True,
         }
 
         Repository.objects.create(
             organization_id=project.organization.id,
-            external_id='35129377',
-            provider='integrations:github_enterprise',
-            name='baxterthehacker/public-repo',
+            external_id="35129377",
+            provider="integrations:github_enterprise",
+            name="baxterthehacker/public-repo",
         )
         integration = Integration.objects.create(
             external_id="35.232.149.196:12345",
-            provider='github_enterprise',
+            provider="github_enterprise",
             metadata={
-                'domain_name': '35.232.149.196/baxterthehacker',
-                'installation_id': '12345',
-                'installation': {
-                    'id': '2',
-                    'private_key': 'private_key',
-                    'verify_ssl': True,
-                }
-            }
+                "domain_name": "35.232.149.196/baxterthehacker",
+                "installation_id": "12345",
+                "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
+            },
         )
         integration.add_organization(project.organization, self.user)
 
         response = self.client.post(
             path=url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='push',
-            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
-            HTTP_X_HUB_SIGNATURE='sha1=2a0586cc46490b17441834e1e143ec3d8c1fe032',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_HUB_SIGNATURE="sha1=2a0586cc46490b17441834e1e143ec3d8c1fe032",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
@@ -164,88 +153,86 @@ class PushEventWebhookTest(APITestCase):
         commit_list = list(
             Commit.objects.filter(
                 # organization_id=project.organization_id,
-            ).select_related('author').order_by('-date_added')
+            )
+            .select_related("author")
+            .order_by("-date_added")
         )
 
         assert len(commit_list) == 2
 
         commit = commit_list[0]
 
-        assert commit.key == '133d60480286590a610a0eb7352ff6e02b9674c4'
-        assert commit.message == u'Update README.md (àgain)'
-        assert commit.author.name == u'bàxterthehacker'
-        assert commit.author.email == 'baxterthehacker@users.noreply.github.com'
+        assert commit.key == "133d60480286590a610a0eb7352ff6e02b9674c4"
+        assert commit.message == u"Update README.md (àgain)"
+        assert commit.author.name == u"bàxterthehacker"
+        assert commit.author.email == "baxterthehacker@users.noreply.github.com"
         assert commit.author.external_id is None
         assert commit.date_added == datetime(2015, 5, 5, 23, 45, 15, tzinfo=timezone.utc)
 
         commit = commit_list[1]
 
-        assert commit.key == '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c'
-        assert commit.message == 'Update README.md'
-        assert commit.author.name == u'bàxterthehacker'
-        assert commit.author.email == 'baxterthehacker@users.noreply.github.com'
+        assert commit.key == "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
+        assert commit.message == "Update README.md"
+        assert commit.author.name == u"bàxterthehacker"
+        assert commit.author.email == "baxterthehacker@users.noreply.github.com"
         assert commit.author.external_id is None
         assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
 
-    @patch('sentry.integrations.github_enterprise.webhook.get_installation_metadata')
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_anonymous_lookup(self, mock_get_installation_metadata):
         project = self.project  # force creation
 
-        url = '/extensions/github-enterprise/webhook/'
+        url = "/extensions/github-enterprise/webhook/"
         mock_get_installation_metadata.return_value = {
-            'url': '35.232.149.196',
-            'id': '2',
-            'name': 'test-app',
-            'webhook_secret': 'b3002c3e321d4b7880360d397db2ccfd',
-            'private_key': 'private_key',
-            'verify_ssl': True,
+            "url": "35.232.149.196",
+            "id": "2",
+            "name": "test-app",
+            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
+            "private_key": "private_key",
+            "verify_ssl": True,
         }
 
         integration = Integration.objects.create(
-            provider='github_enterprise',
-            external_id='35.232.149.196:12345',
-            name='octocat',
+            provider="github_enterprise",
+            external_id="35.232.149.196:12345",
+            name="octocat",
             metadata={
-                'domain_name': '35.232.149.196/baxterthehacker',
-                'installation': {
-                    'id': '2',
-                    'private_key': 'private_key',
-                    'verify_ssl': True,
-                }
-            }
+                "domain_name": "35.232.149.196/baxterthehacker",
+                "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
+            },
         )
         integration.add_organization(project.organization, self.user)
 
         Repository.objects.create(
             organization_id=project.organization.id,
-            external_id='35129377',
-            provider='integrations:github_enterprise',
-            name='baxterthehacker/public-repo',
+            external_id="35129377",
+            provider="integrations:github_enterprise",
+            name="baxterthehacker/public-repo",
         )
 
         CommitAuthor.objects.create(
-            external_id='github_enterprise:baxterthehacker',
+            external_id="github_enterprise:baxterthehacker",
             organization_id=project.organization_id,
-            email='baxterthehacker@example.com',
-            name=u'bàxterthehacker',
+            email="baxterthehacker@example.com",
+            name=u"bàxterthehacker",
         )
 
         response = self.client.post(
             path=url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='push',
-            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
-            HTTP_X_HUB_SIGNATURE='sha1=2a0586cc46490b17441834e1e143ec3d8c1fe032',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_HUB_SIGNATURE="sha1=2a0586cc46490b17441834e1e143ec3d8c1fe032",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
 
         commit_list = list(
-            Commit.objects.filter(
-                organization_id=project.organization_id,
-            ).select_related('author').order_by('-date_added')
+            Commit.objects.filter(organization_id=project.organization_id)
+            .select_related("author")
+            .order_by("-date_added")
         )
 
         # should be skipping the #skipsentry commit
@@ -253,293 +240,273 @@ class PushEventWebhookTest(APITestCase):
 
         commit = commit_list[0]
 
-        assert commit.key == '133d60480286590a610a0eb7352ff6e02b9674c4'
-        assert commit.message == u'Update README.md (àgain)'
-        assert commit.author.name == u'bàxterthehacker'
-        assert commit.author.email == 'baxterthehacker@example.com'
+        assert commit.key == "133d60480286590a610a0eb7352ff6e02b9674c4"
+        assert commit.message == u"Update README.md (àgain)"
+        assert commit.author.name == u"bàxterthehacker"
+        assert commit.author.email == "baxterthehacker@example.com"
         assert commit.date_added == datetime(2015, 5, 5, 23, 45, 15, tzinfo=timezone.utc)
 
         commit = commit_list[1]
 
-        assert commit.key == '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c'
-        assert commit.message == 'Update README.md'
-        assert commit.author.name == u'bàxterthehacker'
-        assert commit.author.email == 'baxterthehacker@example.com'
+        assert commit.key == "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
+        assert commit.message == "Update README.md"
+        assert commit.author.name == u"bàxterthehacker"
+        assert commit.author.email == "baxterthehacker@example.com"
         assert commit.date_added == datetime(2015, 5, 5, 23, 40, 15, tzinfo=timezone.utc)
 
-    @patch('sentry.integrations.github_enterprise.client.get_jwt')
-    @patch('sentry.integrations.github_enterprise.webhook.get_installation_metadata')
+    @patch("sentry.integrations.github_enterprise.client.get_jwt")
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_multiple_orgs(self, mock_get_installation_metadata, mock_get_jwt):
         mock_get_jwt.return_value = ""
 
         project = self.project  # force creation
 
-        url = '/extensions/github-enterprise/webhook/'
+        url = "/extensions/github-enterprise/webhook/"
         mock_get_installation_metadata.return_value = {
-            'url': '35.232.149.196',
-            'id': '2',
-            'name': 'test-app',
-            'webhook_secret': 'b3002c3e321d4b7880360d397db2ccfd',
-            'private_key': 'private_key',
-            'verify_ssl': True,
+            "url": "35.232.149.196",
+            "id": "2",
+            "name": "test-app",
+            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
+            "private_key": "private_key",
+            "verify_ssl": True,
         }
 
         Repository.objects.create(
             organization_id=project.organization.id,
-            external_id='35129377',
-            provider='integrations:github_enterprise',
-            name='baxterthehacker/public-repo',
+            external_id="35129377",
+            provider="integrations:github_enterprise",
+            name="baxterthehacker/public-repo",
         )
         integration = Integration.objects.create(
             external_id="35.232.149.196:12345",
-            provider='github_enterprise',
+            provider="github_enterprise",
             metadata={
-                'domain_name': '35.232.149.196/baxterthehacker',
-                'installation_id': '12345',
-                'installation': {
-                    'id': '2',
-                    'private_key': 'private_key',
-                    'verify_ssl': True,
-                }
-            }
+                "domain_name": "35.232.149.196/baxterthehacker",
+                "installation_id": "12345",
+                "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
+            },
         )
         integration.add_organization(project.organization, self.user)
 
         org2 = self.create_organization()
-        project2 = self.create_project(organization=org2, name='bar')
+        project2 = self.create_project(organization=org2, name="bar")
 
         Repository.objects.create(
             organization_id=project2.organization.id,
-            external_id='77',
-            provider='integrations:github_enterprise',
-            name='another/repo',
+            external_id="77",
+            provider="integrations:github_enterprise",
+            name="another/repo",
         )
         integration = Integration.objects.create(
             external_id="35.232.149.196:99",
-            provider='github_enterprise',
+            provider="github_enterprise",
             metadata={
-                'domain_name': '35.232.149.196/another',
-                'installation': {
-                    'installation_id': '99',
-                    'id': '2',
-                    'private_key': 'private_key',
-                    'verify_ssl': True,
-                }
-            }
+                "domain_name": "35.232.149.196/another",
+                "installation": {
+                    "installation_id": "99",
+                    "id": "2",
+                    "private_key": "private_key",
+                    "verify_ssl": True,
+                },
+            },
         )
         integration.add_organization(org2, self.user)
 
         response = self.client.post(
             path=url,
             data=PUSH_EVENT_EXAMPLE_INSTALLATION,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='push',
-            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
-            HTTP_X_HUB_SIGNATURE='sha1=2a0586cc46490b17441834e1e143ec3d8c1fe032',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="push",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_HUB_SIGNATURE="sha1=2a0586cc46490b17441834e1e143ec3d8c1fe032",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
 
         commit_list = list(
-            Commit.objects.filter(
-                organization_id=project.organization_id,
-            ).select_related('author').order_by('-date_added')
+            Commit.objects.filter(organization_id=project.organization_id)
+            .select_related("author")
+            .order_by("-date_added")
         )
 
         assert len(commit_list) == 2
 
         commit_list = list(
-            Commit.objects.filter(
-                organization_id=org2.id,
-            ).select_related('author').order_by('-date_added')
+            Commit.objects.filter(organization_id=org2.id)
+            .select_related("author")
+            .order_by("-date_added")
         )
         assert len(commit_list) == 0
 
 
 class PullRequestEventWebhook(APITestCase):
-    @patch('sentry.integrations.github_enterprise.webhook.get_installation_metadata')
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_opened(self, mock_get_installation_metadata):
         project = self.project  # force creation
 
-        url = '/extensions/github-enterprise/webhook/'
+        url = "/extensions/github-enterprise/webhook/"
         mock_get_installation_metadata.return_value = {
-            'url': '35.232.149.196',
-            'id': '2',
-            'name': 'test-app',
-            'webhook_secret': 'b3002c3e321d4b7880360d397db2ccfd',
-            'private_key': 'private_key',
-            'verify_ssl': True,
+            "url": "35.232.149.196",
+            "id": "2",
+            "name": "test-app",
+            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
+            "private_key": "private_key",
+            "verify_ssl": True,
         }
 
         integration = Integration.objects.create(
-            provider='github_enterprise',
-            external_id='35.232.149.196:234',
-            name='octocat',
+            provider="github_enterprise",
+            external_id="35.232.149.196:234",
+            name="octocat",
             metadata={
-                'domain_name': '35.232.149.196/baxterthehacker',
-                'installation': {
-                    'id': '2',
-                    'private_key': 'private_key',
-                    'verify_ssl': True,
-                }
-            }
+                "domain_name": "35.232.149.196/baxterthehacker",
+                "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
+            },
         )
         integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,
-            external_id='35129377',
-            provider='integrations:github_enterprise',
-            name='baxterthehacker/public-repo',
+            external_id="35129377",
+            provider="integrations:github_enterprise",
+            name="baxterthehacker/public-repo",
         )
 
         response = self.client.post(
             path=url,
             data=PULL_REQUEST_OPENED_EVENT_EXAMPLE,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='pull_request',
-            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
-            HTTP_X_HUB_SIGNATURE='sha1=aa5b11bc52b9fac082cb59f9ee8667cb222c3aff',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="pull_request",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_HUB_SIGNATURE="sha1=aa5b11bc52b9fac082cb59f9ee8667cb222c3aff",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
 
         prs = PullRequest.objects.filter(
-            repository_id=repo.id,
-            organization_id=project.organization.id,
+            repository_id=repo.id, organization_id=project.organization.id
         )
 
         assert len(prs) == 1
 
         pr = prs[0]
 
-        assert pr.key == '1'
-        assert pr.message == u'This is a pretty simple change that we need to pull into master.'
-        assert pr.title == u'Update the README with new information'
-        assert pr.author.name == u'baxterthehacker'
+        assert pr.key == "1"
+        assert pr.message == u"This is a pretty simple change that we need to pull into master."
+        assert pr.title == u"Update the README with new information"
+        assert pr.author.name == u"baxterthehacker"
 
-    @patch('sentry.integrations.github_enterprise.webhook.get_installation_metadata')
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_edited(self, mock_get_installation_metadata):
         project = self.project  # force creation
 
-        url = '/extensions/github-enterprise/webhook/'
+        url = "/extensions/github-enterprise/webhook/"
         mock_get_installation_metadata.return_value = {
-            'url': '35.232.149.196',
-            'id': '2',
-            'name': 'test-app',
-            'webhook_secret': 'b3002c3e321d4b7880360d397db2ccfd',
-            'private_key': 'private_key',
-            'verify_ssl': True,
+            "url": "35.232.149.196",
+            "id": "2",
+            "name": "test-app",
+            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
+            "private_key": "private_key",
+            "verify_ssl": True,
         }
 
         integration = Integration.objects.create(
-            provider='github_enterprise',
-            external_id='35.232.149.196:234',
-            name='octocat',
+            provider="github_enterprise",
+            external_id="35.232.149.196:234",
+            name="octocat",
             metadata={
-                'domain_name': '35.232.149.196/baxterthehacker',
-                'installation': {
-                    'id': '2',
-                    'private_key': 'private_key',
-                    'verify_ssl': True,
-                }
-            }
+                "domain_name": "35.232.149.196/baxterthehacker",
+                "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
+            },
         )
         integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,
-            external_id='35129377',
-            provider='integrations:github_enterprise',
-            name='baxterthehacker/public-repo',
+            external_id="35129377",
+            provider="integrations:github_enterprise",
+            name="baxterthehacker/public-repo",
         )
 
         pr = PullRequest.objects.create(
-            key='1',
-            repository_id=repo.id,
-            organization_id=project.organization.id,
+            key="1", repository_id=repo.id, organization_id=project.organization.id
         )
 
         response = self.client.post(
             path=url,
             data=PULL_REQUEST_EDITED_EVENT_EXAMPLE,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='pull_request',
-            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
-            HTTP_X_HUB_SIGNATURE='sha1=b50a13afd33b514e8e62e603827ea62530f0690e',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="pull_request",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_HUB_SIGNATURE="sha1=b50a13afd33b514e8e62e603827ea62530f0690e",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
 
         pr = PullRequest.objects.get(id=pr.id)
 
-        assert pr.key == '1'
-        assert pr.message == u'new edited body'
-        assert pr.title == u'new edited title'
-        assert pr.author.name == u'baxterthehacker'
+        assert pr.key == "1"
+        assert pr.message == u"new edited body"
+        assert pr.title == u"new edited title"
+        assert pr.author.name == u"baxterthehacker"
 
-    @patch('sentry.integrations.github_enterprise.webhook.get_installation_metadata')
+    @patch("sentry.integrations.github_enterprise.webhook.get_installation_metadata")
     def test_closed(self, mock_get_installation_metadata):
         project = self.project  # force creation
 
-        url = '/extensions/github-enterprise/webhook/'
+        url = "/extensions/github-enterprise/webhook/"
         mock_get_installation_metadata.return_value = {
-            'url': '35.232.149.196',
-            'id': '2',
-            'name': 'test-app',
-            'webhook_secret': 'b3002c3e321d4b7880360d397db2ccfd',
-            'private_key': 'private_key',
-            'verify_ssl': True,
+            "url": "35.232.149.196",
+            "id": "2",
+            "name": "test-app",
+            "webhook_secret": "b3002c3e321d4b7880360d397db2ccfd",
+            "private_key": "private_key",
+            "verify_ssl": True,
         }
 
         integration = Integration.objects.create(
-            provider='github_enterprise',
-            external_id='35.232.149.196:234',
-            name='octocat',
+            provider="github_enterprise",
+            external_id="35.232.149.196:234",
+            name="octocat",
             metadata={
-                'domain_name': '35.232.149.196/baxterthehacker',
-                'installation': {
-                    'id': '2',
-                    'private_key': 'private_key',
-                    'verify_ssl': True,
-                }
-            }
+                "domain_name": "35.232.149.196/baxterthehacker",
+                "installation": {"id": "2", "private_key": "private_key", "verify_ssl": True},
+            },
         )
         integration.add_organization(project.organization, self.user)
 
         repo = Repository.objects.create(
             organization_id=project.organization.id,
-            external_id='35129377',
-            provider='integrations:github_enterprise',
-            name='baxterthehacker/public-repo',
+            external_id="35129377",
+            provider="integrations:github_enterprise",
+            name="baxterthehacker/public-repo",
         )
 
         response = self.client.post(
             path=url,
             data=PULL_REQUEST_CLOSED_EVENT_EXAMPLE,
-            content_type='application/json',
-            HTTP_X_GITHUB_EVENT='pull_request',
-            HTTP_X_GITHUB_ENTERPRISE_HOST='35.232.149.196',
-            HTTP_X_HUB_SIGNATURE='sha1=dff1c803cf1e48c1b9aefe4a17952ea132758806',
-            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4())
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="pull_request",
+            HTTP_X_GITHUB_ENTERPRISE_HOST="35.232.149.196",
+            HTTP_X_HUB_SIGNATURE="sha1=dff1c803cf1e48c1b9aefe4a17952ea132758806",
+            HTTP_X_GITHUB_DELIVERY=six.text_type(uuid4()),
         )
 
         assert response.status_code == 204
 
         prs = PullRequest.objects.filter(
-            repository_id=repo.id,
-            organization_id=project.organization.id,
+            repository_id=repo.id, organization_id=project.organization.id
         )
 
         assert len(prs) == 1
 
         pr = prs[0]
 
-        assert pr.key == '1'
-        assert pr.message == u'new closed body'
-        assert pr.title == u'new closed title'
-        assert pr.author.name == u'baxterthehacker'
-        assert pr.merge_commit_sha == '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c'
+        assert pr.key == "1"
+        assert pr.message == u"new closed body"
+        assert pr.title == u"new closed title"
+        assert pr.author.name == u"baxterthehacker"
+        assert pr.merge_commit_sha == "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -14,15 +14,15 @@ class GitlabRefreshAuthTest(GitLabTestCase):
     def setUp(self):
         super(GitlabRefreshAuthTest, self).setUp()
         self.client = self.installation.get_client()
-        self.request_data = {'id': 'user_id'}
-        self.request_url = 'https://example.gitlab.com/api/v4/user'
-        self.refresh_url = 'https://example.gitlab.com/oauth/token'
+        self.request_data = {"id": "user_id"}
+        self.request_url = "https://example.gitlab.com/api/v4/user"
+        self.refresh_url = "https://example.gitlab.com/oauth/token"
         self.refresh_response = {
-            'access_token': '123432sfh29uhs29347',
-            'token_type': 'bearer',
-            'refresh_token': '29f43sdfsk22fsj929',
-            'created_at': 1536798907,
-            'scope': 'api'
+            "access_token": "123432sfh29uhs29347",
+            "token_type": "bearer",
+            "refresh_token": "29f43sdfsk22fsj929",
+            "created_at": 1536798907,
+            "scope": "api",
         }
         self.original_identity_data = dict(self.client.identity.data)
 
@@ -37,7 +37,7 @@ class GitlabRefreshAuthTest(GitLabTestCase):
             responses.POST,
             self.refresh_url,
             status=200 if success else 401,
-            json=self.refresh_response if success else {}
+            json=self.refresh_response if success else {},
         )
 
     def add_get_user_response(self, success):
@@ -53,9 +53,9 @@ class GitlabRefreshAuthTest(GitLabTestCase):
         assert call.response.status_code == status
 
     def assert_data(self, data, expected_data):
-        assert data['access_token'] == expected_data['access_token']
-        assert data['refresh_token'] == expected_data['refresh_token']
-        assert data['created_at'] == expected_data['created_at']
+        assert data["access_token"] == expected_data["access_token"]
+        assert data["refresh_token"] == expected_data["refresh_token"]
+        assert data["created_at"] == expected_data["created_at"]
 
     def assert_request_failed_refresh(self):
         responses_calls = responses.calls

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -8,8 +8,11 @@ from mock import patch, Mock
 
 from sentry.integrations.gitlab import GitlabIntegrationProvider
 from sentry.models import (
-    Identity, IdentityProvider, IdentityStatus, Integration,
-    OrganizationIntegration
+    Identity,
+    IdentityProvider,
+    IdentityStatus,
+    Integration,
+    OrganizationIntegration,
 )
 from sentry.testutils import IntegrationTestCase
 
@@ -19,133 +22,118 @@ class GitlabIntegrationTest(IntegrationTestCase):
     config = {
         # Trailing slash is intentional to ensure that valid
         # URLs are generated even if the user inputs a trailing /
-        'url': 'https://gitlab.example.com/',
-        'name': 'Test App',
-        'group': 'cool-group',
-        'verify_ssl': True,
-        'client_id': 'client_id',
-        'client_secret': 'client_secret'
+        "url": "https://gitlab.example.com/",
+        "name": "Test App",
+        "group": "cool-group",
+        "verify_ssl": True,
+        "client_id": "client_id",
+        "client_secret": "client_secret",
     }
 
     default_group_id = 4
 
     def setUp(self):
         super(GitlabIntegrationTest, self).setUp()
-        self.init_path_without_guide = '%s%s' % (self.init_path, '?completed_installation_guide')
+        self.init_path_without_guide = "%s%s" % (self.init_path, "?completed_installation_guide")
 
-    def assert_setup_flow(self, user_id='user_id_1'):
+    def assert_setup_flow(self, user_id="user_id_1"):
         resp = self.client.get(self.init_path)
         assert resp.status_code == 200
-        self.assertContains(resp, 'you will need to create a Sentry app in your GitLab instance')
+        self.assertContains(resp, "you will need to create a Sentry app in your GitLab instance")
         resp = self.client.get(self.init_path_without_guide)
         assert resp.status_code == 200
         resp = self.client.post(self.init_path_without_guide, data=self.config)
         assert resp.status_code == 302
-        redirect = urlparse(resp['Location'])
-        assert redirect.scheme == 'https'
-        assert redirect.netloc == 'gitlab.example.com'
-        assert redirect.path == '/oauth/authorize'
+        redirect = urlparse(resp["Location"])
+        assert redirect.scheme == "https"
+        assert redirect.netloc == "gitlab.example.com"
+        assert redirect.path == "/oauth/authorize"
 
         params = parse_qs(redirect.query)
-        assert params['state']
-        assert params['redirect_uri'] == ['http://testserver/extensions/gitlab/setup/']
-        assert params['response_type'] == ['code']
-        assert params['client_id'] == ['client_id']
+        assert params["state"]
+        assert params["redirect_uri"] == ["http://testserver/extensions/gitlab/setup/"]
+        assert params["response_type"] == ["code"]
+        assert params["client_id"] == ["client_id"]
         # once we've asserted on it, switch to a singular values to make life
         # easier
         authorize_params = {k: v[0] for k, v in six.iteritems(params)}
 
-        access_token = 'xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx'
+        access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
 
         responses.add(
             responses.POST,
-            'https://gitlab.example.com/oauth/token',
-            json={'access_token': access_token}
+            "https://gitlab.example.com/oauth/token",
+            json={"access_token": access_token},
         )
+        responses.add(responses.GET, "https://gitlab.example.com/api/v4/user", json={"id": user_id})
         responses.add(
             responses.GET,
-            'https://gitlab.example.com/api/v4/user',
-            json={'id': user_id}
+            "https://gitlab.example.com/api/v4/groups/cool-group",
+            json={
+                "id": self.default_group_id,
+                "full_name": "Cool",
+                "full_path": "cool-group",
+                "web_url": "https://gitlab.example.com/groups/cool-group",
+                "avatar_url": "https://gitlab.example.com/uploads/group/avatar/4/foo.jpg",
+            },
         )
         responses.add(
-            responses.GET,
-            'https://gitlab.example.com/api/v4/groups/cool-group',
-            json={
-                'id': self.default_group_id,
-                'full_name': 'Cool',
-                'full_path': 'cool-group',
-                'web_url': 'https://gitlab.example.com/groups/cool-group',
-                'avatar_url': 'https://gitlab.example.com/uploads/group/avatar/4/foo.jpg',
-            }
-        )
-        responses.add(
-            responses.POST,
-            'https://gitlab.example.com/api/v4/hooks',
-            json={
-                'id': 'webhook-id-1'
-            }
+            responses.POST, "https://gitlab.example.com/api/v4/hooks", json={"id": "webhook-id-1"}
         )
 
-        resp = self.client.get(u'{}?{}'.format(
-            self.setup_path,
-            urlencode({
-                'code': 'oauth-code',
-                'state': authorize_params['state'],
-            })
-        ))
+        resp = self.client.get(
+            u"{}?{}".format(
+                self.setup_path,
+                urlencode({"code": "oauth-code", "state": authorize_params["state"]}),
+            )
+        )
 
         mock_access_token_request = responses.calls[0].request
         req_params = parse_qs(mock_access_token_request.body)
-        assert req_params['grant_type'] == ['authorization_code']
-        assert req_params['code'] == ['oauth-code']
-        assert req_params['redirect_uri'] == [
-            'http://testserver/extensions/gitlab/setup/']
-        assert req_params['client_id'] == ['client_id']
-        assert req_params['client_secret'] == ['client_secret']
+        assert req_params["grant_type"] == ["authorization_code"]
+        assert req_params["code"] == ["oauth-code"]
+        assert req_params["redirect_uri"] == ["http://testserver/extensions/gitlab/setup/"]
+        assert req_params["client_id"] == ["client_id"]
+        assert req_params["client_secret"] == ["client_secret"]
 
         assert resp.status_code == 200
 
         self.assertDialogSuccess(resp)
 
     @responses.activate
-    @patch('sentry.integrations.gitlab.integration.sha1_text')
+    @patch("sentry.integrations.gitlab.integration.sha1_text")
     def test_basic_flow(self, mock_sha):
         sha = Mock()
-        sha.hexdigest.return_value = 'secret-token'
+        sha.hexdigest.return_value = "secret-token"
         mock_sha.return_value = sha
 
         self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)
 
-        assert integration.external_id == 'gitlab.example.com:4'
-        assert integration.name == 'Cool'
+        assert integration.external_id == "gitlab.example.com:4"
+        assert integration.name == "Cool"
         assert integration.metadata == {
-            'instance': 'gitlab.example.com',
-            'scopes': ['api'],
-            'icon': u'https://gitlab.example.com/uploads/group/avatar/4/foo.jpg',
-            'domain_name': u'gitlab.example.com/cool-group',
-            'verify_ssl': True,
-            'base_url': 'https://gitlab.example.com',
-            'webhook_secret': 'secret-token',
-            'group_id': self.default_group_id,
+            "instance": "gitlab.example.com",
+            "scopes": ["api"],
+            "icon": u"https://gitlab.example.com/uploads/group/avatar/4/foo.jpg",
+            "domain_name": u"gitlab.example.com/cool-group",
+            "verify_ssl": True,
+            "base_url": "https://gitlab.example.com",
+            "webhook_secret": "secret-token",
+            "group_id": self.default_group_id,
         }
         oi = OrganizationIntegration.objects.get(
-            integration=integration,
-            organization=self.organization,
+            integration=integration, organization=self.organization
         )
         assert oi.config == {}
 
-        idp = IdentityProvider.objects.get(type='gitlab')
+        idp = IdentityProvider.objects.get(type="gitlab")
         identity = Identity.objects.get(
-            idp=idp,
-            user=self.user,
-            external_id='gitlab.example.com:user_id_1',
+            idp=idp, user=self.user, external_id="gitlab.example.com:user_id_1"
         )
         assert identity.status == IdentityStatus.VALID
-        assert identity.data == {
-            'access_token': 'xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx'
-        }
+        assert identity.data == {"access_token": "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"}
 
     @responses.activate
     def test_setup_missing_group(self):
@@ -155,38 +143,31 @@ class GitlabIntegrationTest(IntegrationTestCase):
         resp = self.client.post(self.init_path_without_guide, data=self.config)
         assert resp.status_code == 302
 
-        redirect = urlparse(resp['Location'])
-        assert redirect.scheme == 'https'
-        assert redirect.netloc == 'gitlab.example.com'
-        assert redirect.path == '/oauth/authorize'
+        redirect = urlparse(resp["Location"])
+        assert redirect.scheme == "https"
+        assert redirect.netloc == "gitlab.example.com"
+        assert redirect.path == "/oauth/authorize"
 
         params = parse_qs(redirect.query)
         authorize_params = {k: v[0] for k, v in six.iteritems(params)}
 
         responses.add(
             responses.POST,
-            'https://gitlab.example.com/oauth/token',
-            json={'access_token': 'access-token-value'}
+            "https://gitlab.example.com/oauth/token",
+            json={"access_token": "access-token-value"},
         )
+        responses.add(responses.GET, "https://gitlab.example.com/api/v4/user", json={"id": 9})
         responses.add(
-            responses.GET,
-            'https://gitlab.example.com/api/v4/user',
-            json={'id': 9}
+            responses.GET, "https://gitlab.example.com/api/v4/groups/cool-group", status=404
         )
-        responses.add(
-            responses.GET,
-            'https://gitlab.example.com/api/v4/groups/cool-group',
-            status=404
+        resp = self.client.get(
+            u"{}?{}".format(
+                self.setup_path,
+                urlencode({"code": "oauth-code", "state": authorize_params["state"]}),
+            )
         )
-        resp = self.client.get(u'{}?{}'.format(
-            self.setup_path,
-            urlencode({
-                'code': 'oauth-code',
-                'state': authorize_params['state'],
-            })
-        ))
         assert resp.status_code == 200
-        self.assertContains(resp, 'GitLab group could not be found')
+        self.assertContains(resp, "GitLab group could not be found")
 
     @responses.activate
     def test_get_group_id(self):

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -15,383 +15,388 @@ from .testutils import GitLabTestCase
 
 
 class GitlabIssuesTest(GitLabTestCase):
-
     def setUp(self):
         super(GitlabIssuesTest, self).setUp()
         min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
         event = self.store_event(
             data={
-                'event_id': 'a' * 32,
-                'message': 'message',
-                'timestamp': min_ago,
-                'stacktrace': copy.deepcopy(DEFAULT_EVENT_DATA['stacktrace']),
+                "event_id": "a" * 32,
+                "message": "message",
+                "timestamp": min_ago,
+                "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
             },
             project_id=self.project.id,
         )
         self.group = event.group
 
     def test_make_external_key(self):
-        project_name = 'getsentry/sentry'
-        issue_iid = '7'
-        external_key = '%s#%s' % (project_name, issue_iid)
-        domain_name = self.installation.model.metadata['domain_name']
-        data = {
-            'key': external_key,
-        }
-        assert self.installation.make_external_key(data) == '%s:%s' % (domain_name, external_key)
+        project_name = "getsentry/sentry"
+        issue_iid = "7"
+        external_key = "%s#%s" % (project_name, issue_iid)
+        domain_name = self.installation.model.metadata["domain_name"]
+        data = {"key": external_key}
+        assert self.installation.make_external_key(data) == "%s:%s" % (domain_name, external_key)
 
     def test_get_issue_url(self):
-        issue_id = 'example.gitlab.com:project/project#7'
-        assert self.installation.get_issue_url(
-            issue_id) == 'https://example.gitlab.com/project/project/issues/7'
+        issue_id = "example.gitlab.com:project/project#7"
+        assert (
+            self.installation.get_issue_url(issue_id)
+            == "https://example.gitlab.com/project/project/issues/7"
+        )
 
     @responses.activate
     def test_get_create_issue_config(self):
         group_description = (
-            u'Sentry Issue: [%s](%s)\n\n'
-            '```\nStacktrace (most recent call first):\n\n'
+            u"Sentry Issue: [%s](%s)\n\n"
+            "```\nStacktrace (most recent call first):\n\n"
             '  File "sentry/models/foo.py", line 29, in build_msg\n'
-            '    string_max_length=self.string_max_length)\n\nmessage\n```'
+            "    string_max_length=self.string_max_length)\n\nmessage\n```"
         ) % (
             self.group.qualified_short_id,
-            absolute_uri(self.group.get_absolute_url(params={'referrer': 'gitlab_integration'})),
+            absolute_uri(self.group.get_absolute_url(params={"referrer": "gitlab_integration"})),
         )
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/groups/%s/projects' % self.installation.model.metadata['group_id'],
+            u"https://example.gitlab.com/api/v4/groups/%s/projects"
+            % self.installation.model.metadata["group_id"],
             json=[
-                {'name_with_namespace': 'getsentry / sentry', 'id': 1},
-                {'name_with_namespace': 'getsentry / hello', 'id': 22},
-            ]
+                {"name_with_namespace": "getsentry / sentry", "id": 1},
+                {"name_with_namespace": "getsentry / hello", "id": 22},
+            ],
         )
         assert self.installation.get_create_issue_config(self.group) == [
             {
-                'url': '/extensions/gitlab/search/baz/%d/' % self.installation.model.id,
-                'name': 'project',
-                'required': True,
-                'type': 'select',
-                'label': 'GitLab Project',
-                'choices': [(1, u'getsentry / sentry'), (22, u'getsentry / hello')],
-                'defaultValue': 1,
+                "url": "/extensions/gitlab/search/baz/%d/" % self.installation.model.id,
+                "name": "project",
+                "required": True,
+                "type": "select",
+                "label": "GitLab Project",
+                "choices": [(1, u"getsentry / sentry"), (22, u"getsentry / hello")],
+                "defaultValue": 1,
             },
             {
-                'name': 'title',
-                'label': 'Title',
-                'default': self.group.get_latest_event().error(),
-                'type': 'string',
-                'required': True,
+                "name": "title",
+                "label": "Title",
+                "default": self.group.get_latest_event().error(),
+                "type": "string",
+                "required": True,
             },
             {
-                'name': 'description',
-                'label': 'Description',
-                'default': group_description,
-                'type': 'textarea',
-                'autosize': True,
-                'maxRows': 10,
-            }
+                "name": "description",
+                "label": "Description",
+                "default": group_description,
+                "type": "textarea",
+                "autosize": True,
+                "maxRows": 10,
+            },
         ]
 
     @responses.activate
     def test_get_link_issue_config(self):
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/groups/%s/projects' % self.installation.model.metadata['group_id'],
+            u"https://example.gitlab.com/api/v4/groups/%s/projects"
+            % self.installation.model.metadata["group_id"],
             json=[
-                {'name_with_namespace': 'getsentry / sentry', 'id': 1},
-                {'name_with_namespace': 'getsentry / hello', 'id': 22},
-            ]
+                {"name_with_namespace": "getsentry / sentry", "id": 1},
+                {"name_with_namespace": "getsentry / hello", "id": 22},
+            ],
         )
-        autocomplete_url = '/extensions/gitlab/search/baz/%d/' % self.installation.model.id
+        autocomplete_url = "/extensions/gitlab/search/baz/%d/" % self.installation.model.id
         assert self.installation.get_link_issue_config(self.group) == [
             {
-                'name': 'project',
-                'label': 'GitLab Project',
-                'type': 'select',
-                'default': 1,
-                'choices': [(1, u'getsentry / sentry'), (22, u'getsentry / hello')],
-                'url': autocomplete_url,
-                'updatesForm': True,
-                'required': True,
+                "name": "project",
+                "label": "GitLab Project",
+                "type": "select",
+                "default": 1,
+                "choices": [(1, u"getsentry / sentry"), (22, u"getsentry / hello")],
+                "url": autocomplete_url,
+                "updatesForm": True,
+                "required": True,
             },
             {
-                'name': 'externalIssue',
-                'label': 'Issue',
-                'default': '',
-                'type': 'select',
-                'url': autocomplete_url,
-                'required': True,
+                "name": "externalIssue",
+                "label": "Issue",
+                "default": "",
+                "type": "select",
+                "url": autocomplete_url,
+                "required": True,
             },
             {
-                'name': 'comment',
-                'label': 'Comment',
-                'default': u'Sentry issue: [{issue_id}]({url})'.format(
+                "name": "comment",
+                "label": "Comment",
+                "default": u"Sentry issue: [{issue_id}]({url})".format(
                     url=absolute_uri(
-                        self.group.get_absolute_url(params={'referrer': 'gitlab_integration'})
+                        self.group.get_absolute_url(params={"referrer": "gitlab_integration"})
                     ),
                     issue_id=self.group.qualified_short_id,
                 ),
-                'type': 'textarea',
-                'required': False,
-                'help': ('Leave blank if you don\'t want to '
-                         'add a comment to the GitLab issue.'),
-            }
+                "type": "textarea",
+                "required": False,
+                "help": ("Leave blank if you don't want to " "add a comment to the GitLab issue."),
+            },
         ]
 
     @responses.activate
     def test_create_issue(self):
-        issue_iid = '1'
-        project_id = '10'
-        project_name = 'getsentry/sentry'
-        key = '%s#%s' % (project_name, issue_iid)
+        issue_iid = "1"
+        project_id = "10"
+        project_name = "getsentry/sentry"
+        key = "%s#%s" % (project_name, issue_iid)
         responses.add(
             responses.POST,
-            u'https://example.gitlab.com/api/v4/projects/%s/issues' % project_id,
-            json={'id': 8, 'iid': issue_iid, 'title': 'hello', 'description': 'This is the description',
-                  'web_url': 'https://example.gitlab.com/%s/issues/%s' % (project_name, issue_iid)}
+            u"https://example.gitlab.com/api/v4/projects/%s/issues" % project_id,
+            json={
+                "id": 8,
+                "iid": issue_iid,
+                "title": "hello",
+                "description": "This is the description",
+                "web_url": "https://example.gitlab.com/%s/issues/%s" % (project_name, issue_iid),
+            },
         )
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/projects/%s' % project_id,
-            json={'path_with_namespace': project_name, 'id': 10}
+            u"https://example.gitlab.com/api/v4/projects/%s" % project_id,
+            json={"path_with_namespace": project_name, "id": 10},
         )
         form_data = {
-            'project': project_id,
-            'title': 'hello',
-            'description': 'This is the description',
+            "project": project_id,
+            "title": "hello",
+            "description": "This is the description",
         }
 
         assert self.installation.create_issue(form_data) == {
-            'key': key,
-            'description': 'This is the description',
-            'title': 'hello',
-            'url': 'https://example.gitlab.com/%s/issues/%s' % (project_name, issue_iid),
-            'project': project_id,
-            'metadata': {
-                'display_name': key,
-            }
+            "key": key,
+            "description": "This is the description",
+            "title": "hello",
+            "url": "https://example.gitlab.com/%s/issues/%s" % (project_name, issue_iid),
+            "project": project_id,
+            "metadata": {"display_name": key},
         }
 
     @responses.activate
     def test_get_issue(self):
-        project_id = '12'
-        project_name = 'getsentry/sentry'
-        issue_iid = '13'
-        key = '%s#%s' % (project_name, issue_iid)
+        project_id = "12"
+        project_name = "getsentry/sentry"
+        issue_iid = "13"
+        key = "%s#%s" % (project_name, issue_iid)
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/projects/%s/issues/%s' % (project_id, issue_iid),
-            json={'id': 18, 'iid': issue_iid, 'title': 'hello', 'description': 'This is the description',
-                  'web_url': 'https://example.gitlab.com/%s/issues/%s' % (project_name, issue_iid)}
+            u"https://example.gitlab.com/api/v4/projects/%s/issues/%s" % (project_id, issue_iid),
+            json={
+                "id": 18,
+                "iid": issue_iid,
+                "title": "hello",
+                "description": "This is the description",
+                "web_url": "https://example.gitlab.com/%s/issues/%s" % (project_name, issue_iid),
+            },
         )
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/projects/%s' % project_id,
-            json={'id': project_id, 'path_with_namespace': project_name}
+            u"https://example.gitlab.com/api/v4/projects/%s" % project_id,
+            json={"id": project_id, "path_with_namespace": project_name},
         )
 
-        assert self.installation.get_issue(issue_id='%s#%s' % (project_id, issue_iid), data={}) == {
-            'key': key,
-            'description': 'This is the description',
-            'title': 'hello',
-            'url': 'https://example.gitlab.com/%s/issues/%s' % (project_name, issue_iid),
-            'project': project_id,
-            'metadata': {
-                'display_name': key,
-            }
+        assert self.installation.get_issue(issue_id="%s#%s" % (project_id, issue_iid), data={}) == {
+            "key": key,
+            "description": "This is the description",
+            "title": "hello",
+            "url": "https://example.gitlab.com/%s/issues/%s" % (project_name, issue_iid),
+            "project": project_id,
+            "metadata": {"display_name": key},
         }
 
     @responses.activate
     def test_create_issue_default_project_in_group_api_call(self):
         group_description = (
-            u'Sentry Issue: [%s](%s)\n\n'
-            '```\nStacktrace (most recent call first):\n\n'
+            u"Sentry Issue: [%s](%s)\n\n"
+            "```\nStacktrace (most recent call first):\n\n"
             '  File "sentry/models/foo.py", line 29, in build_msg\n'
-            '    string_max_length=self.string_max_length)\n\nmessage\n```'
+            "    string_max_length=self.string_max_length)\n\nmessage\n```"
         ) % (
             self.group.qualified_short_id,
-            absolute_uri(self.group.get_absolute_url(params={'referrer': 'gitlab_integration'})),
+            absolute_uri(self.group.get_absolute_url(params={"referrer": "gitlab_integration"})),
         )
         project_id = 10
-        project_name = 'This_is / a_project'
+        project_name = "This_is / a_project"
         org_integration = self.installation.org_integration
-        org_integration.config['project_issue_defaults'] = {
-            six.text_type(self.group.project_id): {'project': project_id}
+        org_integration.config["project_issue_defaults"] = {
+            six.text_type(self.group.project_id): {"project": project_id}
         }
         org_integration.save()
 
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/groups/%s/projects' % self.installation.model.metadata['group_id'],
+            u"https://example.gitlab.com/api/v4/groups/%s/projects"
+            % self.installation.model.metadata["group_id"],
             json=[
-                {'name_with_namespace': 'getsentry / sentry', 'id': 1},
-                {'name_with_namespace': project_name, 'id': project_id},
-                {'name_with_namespace': 'getsentry / hello', 'id': 22},
-            ]
+                {"name_with_namespace": "getsentry / sentry", "id": 1},
+                {"name_with_namespace": project_name, "id": project_id},
+                {"name_with_namespace": "getsentry / hello", "id": 22},
+            ],
         )
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/projects/%s' % project_id,
-            json={'path_with_namespace': project_name, 'id': project_id}
+            u"https://example.gitlab.com/api/v4/projects/%s" % project_id,
+            json={"path_with_namespace": project_name, "id": project_id},
         )
         assert self.installation.get_create_issue_config(self.group) == [
             {
-                'url': '/extensions/gitlab/search/baz/%d/' % self.installation.model.id,
-                'name': 'project',
-                'required': True,
-                'choices': [
-                    (1, u'getsentry / sentry'),
-                    (10, u'This_is / a_project'),
-                    (22, u'getsentry / hello')
+                "url": "/extensions/gitlab/search/baz/%d/" % self.installation.model.id,
+                "name": "project",
+                "required": True,
+                "choices": [
+                    (1, u"getsentry / sentry"),
+                    (10, u"This_is / a_project"),
+                    (22, u"getsentry / hello"),
                 ],
-                'defaultValue': project_id,
-                'type': 'select',
-                'label': 'GitLab Project'
+                "defaultValue": project_id,
+                "type": "select",
+                "label": "GitLab Project",
             },
             {
-                'name': 'title',
-                'label': 'Title',
-                'default': self.group.get_latest_event().error(),
-                'type': 'string',
-                'required': True,
+                "name": "title",
+                "label": "Title",
+                "default": self.group.get_latest_event().error(),
+                "type": "string",
+                "required": True,
             },
             {
-                'name': 'description',
-                'label': 'Description',
-                'default': group_description,
-                'type': 'textarea',
-                'autosize': True,
-                'maxRows': 10,
-            }
+                "name": "description",
+                "label": "Description",
+                "default": group_description,
+                "type": "textarea",
+                "autosize": True,
+                "maxRows": 10,
+            },
         ]
 
     @responses.activate
     def test_create_issue_default_project_not_in_api_call(self):
         group_description = (
-            u'Sentry Issue: [%s](%s)\n\n'
-            '```\nStacktrace (most recent call first):\n\n'
+            u"Sentry Issue: [%s](%s)\n\n"
+            "```\nStacktrace (most recent call first):\n\n"
             '  File "sentry/models/foo.py", line 29, in build_msg\n'
-            '    string_max_length=self.string_max_length)\n\nmessage\n```'
+            "    string_max_length=self.string_max_length)\n\nmessage\n```"
         ) % (
             self.group.qualified_short_id,
-            absolute_uri(self.group.get_absolute_url(params={'referrer': 'gitlab_integration'})),
+            absolute_uri(self.group.get_absolute_url(params={"referrer": "gitlab_integration"})),
         )
         project_id = 10
-        project_name = 'This_is / a_project'
+        project_name = "This_is / a_project"
         org_integration = self.installation.org_integration
-        org_integration.config['project_issue_defaults'] = {
-            six.text_type(self.group.project_id): {'project': project_id}
+        org_integration.config["project_issue_defaults"] = {
+            six.text_type(self.group.project_id): {"project": project_id}
         }
         org_integration.save()
 
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/groups/%s/projects' % self.installation.model.metadata['group_id'],
+            u"https://example.gitlab.com/api/v4/groups/%s/projects"
+            % self.installation.model.metadata["group_id"],
             json=[
-                {'name_with_namespace': 'getsentry / sentry', 'id': 1},
-                {'name_with_namespace': 'getsentry / hello', 'id': 22},
-            ]
+                {"name_with_namespace": "getsentry / sentry", "id": 1},
+                {"name_with_namespace": "getsentry / hello", "id": 22},
+            ],
         )
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/projects/%s' % project_id,
-            json={'name_with_namespace': project_name, 'id': project_id}
+            u"https://example.gitlab.com/api/v4/projects/%s" % project_id,
+            json={"name_with_namespace": project_name, "id": project_id},
         )
         assert self.installation.get_create_issue_config(self.group) == [
             {
-                'url': '/extensions/gitlab/search/baz/%d/' % self.installation.model.id,
-                'name': 'project',
-                'required': True,
-                'choices': [
-                    (10, u'This_is / a_project'),
-                    (1, u'getsentry / sentry'),
-                    (22, u'getsentry / hello')
+                "url": "/extensions/gitlab/search/baz/%d/" % self.installation.model.id,
+                "name": "project",
+                "required": True,
+                "choices": [
+                    (10, u"This_is / a_project"),
+                    (1, u"getsentry / sentry"),
+                    (22, u"getsentry / hello"),
                 ],
-                'defaultValue': project_id,
-                'type': 'select',
-                'label': 'GitLab Project'
+                "defaultValue": project_id,
+                "type": "select",
+                "label": "GitLab Project",
             },
             {
-                'name': 'title',
-                'label': 'Title',
-                'default': self.group.get_latest_event().error(),
-                'type': 'string',
-                'required': True,
+                "name": "title",
+                "label": "Title",
+                "default": self.group.get_latest_event().error(),
+                "type": "string",
+                "required": True,
             },
             {
-                'name': 'description',
-                'label': 'Description',
-                'default': group_description,
-                'type': 'textarea',
-                'autosize': True,
-                'maxRows': 10,
-            }
+                "name": "description",
+                "label": "Description",
+                "default": group_description,
+                "type": "textarea",
+                "autosize": True,
+                "maxRows": 10,
+            },
         ]
 
     @responses.activate
     def test_create_issue_no_projects(self):
         group_description = (
-            u'Sentry Issue: [%s](%s)\n\n'
-            '```\nStacktrace (most recent call first):\n\n'
+            u"Sentry Issue: [%s](%s)\n\n"
+            "```\nStacktrace (most recent call first):\n\n"
             '  File "sentry/models/foo.py", line 29, in build_msg\n'
-            '    string_max_length=self.string_max_length)\n\nmessage\n```'
+            "    string_max_length=self.string_max_length)\n\nmessage\n```"
         ) % (
             self.group.qualified_short_id,
-            absolute_uri(self.group.get_absolute_url(params={'referrer': 'gitlab_integration'})),
+            absolute_uri(self.group.get_absolute_url(params={"referrer": "gitlab_integration"})),
         )
 
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/groups/%s/projects' % self.installation.model.metadata['group_id'],
-            json=[]
+            u"https://example.gitlab.com/api/v4/groups/%s/projects"
+            % self.installation.model.metadata["group_id"],
+            json=[],
         )
         assert self.installation.get_create_issue_config(self.group) == [
             {
-                'url': '/extensions/gitlab/search/baz/%d/' % self.installation.model.id,
-                'name': 'project',
-                'required': True,
-                'choices': [],
-                'defaultValue': '',
-                'type': 'select',
-                'label': 'GitLab Project'
+                "url": "/extensions/gitlab/search/baz/%d/" % self.installation.model.id,
+                "name": "project",
+                "required": True,
+                "choices": [],
+                "defaultValue": "",
+                "type": "select",
+                "label": "GitLab Project",
             },
             {
-                'name': 'title',
-                'label': 'Title',
-                'default': self.group.get_latest_event().error(),
-                'type': 'string',
-                'required': True,
+                "name": "title",
+                "label": "Title",
+                "default": self.group.get_latest_event().error(),
+                "type": "string",
+                "required": True,
             },
             {
-                'name': 'description',
-                'label': 'Description',
-                'default': group_description,
-                'type': 'textarea',
-                'autosize': True,
-                'maxRows': 10,
-            }
+                "name": "description",
+                "label": "Description",
+                "default": group_description,
+                "type": "textarea",
+                "autosize": True,
+                "maxRows": 10,
+            },
         ]
 
     @responses.activate
     def test_after_link_issue(self):
         responses.add(
             responses.POST,
-            u'https://example.gitlab.com/api/v4/projects/2/issues/321/notes',
-            json=[]
+            u"https://example.gitlab.com/api/v4/projects/2/issues/321/notes",
+            json=[],
         )
-        data = {'externalIssue': '2#321', 'comment': 'This is not good.'}
+        data = {"externalIssue": "2#321", "comment": "This is not good."}
         external_issue = ExternalIssue.objects.create(
-            organization_id=self.organization.id,
-            integration_id=self.integration.id,
-            key='2#321',
+            organization_id=self.organization.id, integration_id=self.integration.id, key="2#321"
         )
         self.installation.after_link_issue(external_issue, data=data)
 
     def test_after_link_issue_required_fields(self):
-        data = {'externalIssue': '2#231', 'comment': 'This is not good.'}
+        data = {"externalIssue": "2#231", "comment": "This is not good."}
         external_issue = ExternalIssue.objects.create(
-            organization_id=self.organization.id,
-            integration_id=self.integration.id,
-            key='#',
+            organization_id=self.organization.id, integration_id=self.integration.id, key="#"
         )
         with self.assertRaises(IntegrationError):
             self.installation.after_link_issue(external_issue, data=data)
@@ -400,14 +405,12 @@ class GitlabIssuesTest(GitLabTestCase):
     def test_after_link_issue_failure(self):
         responses.add(
             responses.POST,
-            u'https://example.gitlab.com/api/v4/projects/2/issues/321/notes',
-            status=502
+            u"https://example.gitlab.com/api/v4/projects/2/issues/321/notes",
+            status=502,
         )
-        data = {'externalIssue': '2#321', 'comment': 'This is not good.'}
+        data = {"externalIssue": "2#321", "comment": "This is not good."}
         external_issue = ExternalIssue.objects.create(
-            organization_id=self.organization.id,
-            integration_id=self.integration.id,
-            key='2#321',
+            organization_id=self.organization.id, integration_id=self.integration.id, key="2#321"
         )
         with self.assertRaises(IntegrationError):
             self.installation.after_link_issue(external_issue, data=data)

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -8,68 +8,52 @@ from exam import fixture
 
 from sentry.integrations.exceptions import IntegrationError
 from sentry.integrations.gitlab.repository import GitlabRepositoryProvider
-from sentry.models import (
-    Identity,
-    IdentityProvider,
-    Integration,
-    PullRequest,
-    Repository,
-)
+from sentry.models import Identity, IdentityProvider, Integration, PullRequest, Repository
 from sentry.testutils import IntegrationRepositoryTestCase
 from sentry.testutils.asserts import assert_commit_shape
 from sentry.utils import json
 
-from .testutils import (
-    COMPARE_RESPONSE,
-    COMMIT_LIST_RESPONSE,
-    COMMIT_DIFF_RESPONSE
-)
+from .testutils import COMPARE_RESPONSE, COMMIT_LIST_RESPONSE, COMMIT_DIFF_RESPONSE
 
 
 class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
-    provider_name = 'integrations:gitlab'
+    provider_name = "integrations:gitlab"
 
     def setUp(self):
         super(GitLabRepositoryProviderTest, self).setUp()
         self.integration = Integration.objects.create(
-            provider='gitlab',
-            name='Example GitLab',
-            external_id='example.gitlab.com:getsentry',
+            provider="gitlab",
+            name="Example GitLab",
+            external_id="example.gitlab.com:getsentry",
             metadata={
-                'instance': 'example.gitlab.com',
-                'domain_name': 'example.gitlab.com/getsentry',
-                'verify_ssl': False,
-                'base_url': 'https://example.gitlab.com',
-                'webhook_secret': 'secret-token-value',
-            }
+                "instance": "example.gitlab.com",
+                "domain_name": "example.gitlab.com/getsentry",
+                "verify_ssl": False,
+                "base_url": "https://example.gitlab.com",
+                "webhook_secret": "secret-token-value",
+            },
         )
         identity = Identity.objects.create(
-            idp=IdentityProvider.objects.create(
-                type='gitlab',
-                config={},
-                external_id='1234567890',
-            ),
+            idp=IdentityProvider.objects.create(type="gitlab", config={}, external_id="1234567890"),
             user=self.user,
-            external_id='example.gitlab.com:4',
-            data={
-                'access_token': '1234567890',
-            }
+            external_id="example.gitlab.com:4",
+            data={"access_token": "1234567890"},
         )
         self.integration.add_organization(self.organization, self.user, identity.id)
         self.integration.get_provider().setup()
 
         self.default_repository_config = {
-            'path_with_namespace': 'getsentry/example-repo',
-            'name_with_namespace': 'Get Sentry / Example Repo',
-            'path': 'example-repo',
-            'id': '123',
-            'web_url': 'https://example.gitlab.com/getsentry/projects/example-repo',
+            "path_with_namespace": "getsentry/example-repo",
+            "name_with_namespace": "Get Sentry / Example Repo",
+            "path": "example-repo",
+            "id": "123",
+            "web_url": "https://example.gitlab.com/getsentry/projects/example-repo",
         }
         self.gitlab_id = 123
 
     @fixture
     def provider(self):
-        return GitlabRepositoryProvider('gitlab')
+        return GitlabRepositoryProvider("gitlab")
 
     def tearDown(self):
         super(GitLabRepositoryProviderTest, self).tearDown()
@@ -78,32 +62,32 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
     def add_create_repository_responses(self, repository_config):
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/projects/%s' % self.gitlab_id,
-            json=repository_config
+            u"https://example.gitlab.com/api/v4/projects/%s" % self.gitlab_id,
+            json=repository_config,
         )
         responses.add(
             responses.POST,
-            u'https://example.gitlab.com/api/v4/projects/%s/hooks' % self.gitlab_id,
-            json={'id': 99}
+            u"https://example.gitlab.com/api/v4/projects/%s/hooks" % self.gitlab_id,
+            json={"id": 99},
         )
 
     def assert_repository(self, repository_config, organization_id=None):
-        instance = self.integration.metadata['instance']
+        instance = self.integration.metadata["instance"]
 
-        external_id = u'{}:{}'.format(instance, repository_config['id'])
+        external_id = u"{}:{}".format(instance, repository_config["id"])
         repo = Repository.objects.get(
             organization_id=organization_id or self.organization.id,
             provider=self.provider_name,
-            external_id=external_id
+            external_id=external_id,
         )
-        assert repo.name == repository_config['name_with_namespace']
-        assert repo.url == repository_config['web_url']
+        assert repo.name == repository_config["name_with_namespace"]
+        assert repo.url == repository_config["web_url"]
         assert repo.integration_id == self.integration.id
         assert repo.config == {
-            'instance': instance,
-            'path': repository_config['path_with_namespace'],
-            'project_id': repository_config['id'],
-            'webhook_id': 99,
+            "instance": instance,
+            "path": repository_config["path_with_namespace"],
+            "project_id": repository_config["id"],
+            "webhook_id": 99,
         }
 
     @responses.activate
@@ -116,19 +100,20 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
     def test_create_repository_verify_payload(self):
         def request_callback(request):
             payload = json.loads(request.body)
-            assert 'url' in payload
-            assert payload['push_events']
-            assert payload['merge_requests_events']
-            expected_token = u'{}:{}'.format(self.integration.external_id,
-                                             self.integration.metadata['webhook_secret'])
-            assert payload['token'] == expected_token
+            assert "url" in payload
+            assert payload["push_events"]
+            assert payload["merge_requests_events"]
+            expected_token = u"{}:{}".format(
+                self.integration.external_id, self.integration.metadata["webhook_secret"]
+            )
+            assert payload["token"] == expected_token
 
-            return (201, {}, json.dumps({'id': 99}))
+            return (201, {}, json.dumps({"id": 99}))
 
         responses.add_callback(
             responses.POST,
-            u'https://example.gitlab.com/api/v4/projects/%s/hooks' % self.gitlab_id,
-            callback=request_callback
+            u"https://example.gitlab.com/api/v4/projects/%s/hooks" % self.gitlab_id,
+            callback=request_callback,
         )
         response = self.create_repository(self.default_repository_config, self.integration.id)
         assert response.status_code == 201
@@ -138,30 +123,28 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
     def test_create_repository_request_invalid_url(self):
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/projects/%s' % self.gitlab_id,
+            u"https://example.gitlab.com/api/v4/projects/%s" % self.gitlab_id,
             status=200,
-            json=self.default_repository_config
+            json=self.default_repository_config,
         )
         responses.add(
             responses.POST,
-            u'https://example.gitlab.com/api/v4/projects/%s/hooks' % self.gitlab_id,
+            u"https://example.gitlab.com/api/v4/projects/%s/hooks" % self.gitlab_id,
             status=422,
-            json={'error': 'Invalid url given'}
+            json={"error": "Invalid url given"},
         )
         response = self.create_repository(
-            self.default_repository_config,
-            self.integration.id,
-            add_responses=False)
+            self.default_repository_config, self.integration.id, add_responses=False
+        )
         assert response.status_code == 400
         self.assert_error_message(
-            response,
-            'validation',
-            'Error Communicating with GitLab (HTTP 422): Invalid url given')
+            response, "validation", "Error Communicating with GitLab (HTTP 422): Invalid url given"
+        )
 
     def test_create_repository_data_no_installation_id(self):
         response = self.create_repository(self.default_repository_config, None)
         assert response.status_code == 400
-        self.assert_error_message(response, 'validation', 'requires an integration id')
+        self.assert_error_message(response, "validation", "requires an integration id")
 
     def test_create_repository_data_integration_does_not_exist(self):
         integration_id = self.integration.id
@@ -170,74 +153,70 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         response = self.create_repository(self.default_repository_config, integration_id)
         assert response.status_code == 404
         self.assert_error_message(
-            response,
-            'not found',
-            'Integration matching query does not exist.')
+            response, "not found", "Integration matching query does not exist."
+        )
 
     def test_create_repository_org_given_has_no_installation(self):
         organization = self.create_organization(owner=self.user)
         response = self.create_repository(
-            self.default_repository_config,
-            self.integration.id,
-            organization.slug)
+            self.default_repository_config, self.integration.id, organization.slug
+        )
         assert response.status_code == 404
 
     @responses.activate
     def test_create_repository_get_project_request_fails(self):
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/projects/%s' % self.gitlab_id,
+            u"https://example.gitlab.com/api/v4/projects/%s" % self.gitlab_id,
             status=503,
         )
         response = self.create_repository(
-            self.default_repository_config,
-            self.integration.id,
-            add_responses=False)
+            self.default_repository_config, self.integration.id, add_responses=False
+        )
         assert response.status_code == 503
 
     @responses.activate
     def test_create_repository_integration_create_webhook_failure(self):
         responses.add(
             responses.GET,
-            u'https://example.gitlab.com/api/v4/projects/%s' % self.gitlab_id,
-            json=self.default_repository_config
+            u"https://example.gitlab.com/api/v4/projects/%s" % self.gitlab_id,
+            json=self.default_repository_config,
         )
         responses.add(
             responses.POST,
-            u'https://example.gitlab.com/api/v4/projects/%s/hooks' % self.gitlab_id,
+            u"https://example.gitlab.com/api/v4/projects/%s/hooks" % self.gitlab_id,
             status=503,
         )
-        response = self.create_repository(self.default_repository_config,
-                                          self.integration.id, add_responses=False)
+        response = self.create_repository(
+            self.default_repository_config, self.integration.id, add_responses=False
+        )
         assert response.status_code == 503
 
     @responses.activate
     def test_on_delete_repository_remove_webhook(self):
-        response = self.create_repository(self.default_repository_config,
-                                          self.integration.id)
+        response = self.create_repository(self.default_repository_config, self.integration.id)
         responses.reset()
 
         responses.add(
             responses.DELETE,
-            'https://example.gitlab.com/api/v4/projects/%s/hooks/99' % self.gitlab_id,
-            status=204
+            "https://example.gitlab.com/api/v4/projects/%s/hooks/99" % self.gitlab_id,
+            status=204,
         )
-        repo = Repository.objects.get(pk=response.data['id'])
+        repo = Repository.objects.get(pk=response.data["id"])
         self.provider.on_delete_repository(repo)
         assert len(responses.calls) == 1
 
     @responses.activate
     def test_on_delete_repository_remove_webhook_missing_hook(self):
-        response = self.create_repository(self.default_repository_config,
-                                          self.integration.id)
+        response = self.create_repository(self.default_repository_config, self.integration.id)
         responses.reset()
 
         responses.add(
             responses.DELETE,
-            'https://example.gitlab.com/api/v4/projects/%s/hooks/99' % self.gitlab_id,
-            status=404
+            "https://example.gitlab.com/api/v4/projects/%s/hooks/99" % self.gitlab_id,
+            status=404,
         )
-        repo = Repository.objects.get(pk=response.data['id'])
+        repo = Repository.objects.get(pk=response.data["id"])
         self.provider.on_delete_repository(repo)
         assert len(responses.calls) == 1
 
@@ -245,23 +224,25 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
     def test_compare_commits_start_and_end(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/%s/repository/compare?from=abc&to=xyz' % self.gitlab_id,
-            json=json.loads(COMPARE_RESPONSE)
+            "https://example.gitlab.com/api/v4/projects/%s/repository/compare?from=abc&to=xyz"
+            % self.gitlab_id,
+            json=json.loads(COMPARE_RESPONSE),
         )
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/%s/repository/commits/12d65c8dd2b2676fa3ac47d955accc085a37a9c1/diff' % self.gitlab_id,
-            json=json.loads(COMMIT_DIFF_RESPONSE)
+            "https://example.gitlab.com/api/v4/projects/%s/repository/commits/12d65c8dd2b2676fa3ac47d955accc085a37a9c1/diff"
+            % self.gitlab_id,
+            json=json.loads(COMMIT_DIFF_RESPONSE),
         )
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/%s/repository/commits/8b090c1b79a14f2bd9e8a738f717824ff53aebad/diff' % self.gitlab_id,
-            json=json.loads(COMMIT_DIFF_RESPONSE)
+            "https://example.gitlab.com/api/v4/projects/%s/repository/commits/8b090c1b79a14f2bd9e8a738f717824ff53aebad/diff"
+            % self.gitlab_id,
+            json=json.loads(COMMIT_DIFF_RESPONSE),
         )
-        response = self.create_repository(self.default_repository_config,
-                                          self.integration.id)
-        repo = Repository.objects.get(pk=response.data['id'])
-        commits = self.provider.compare_commits(repo, 'abc', 'xyz')
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        repo = Repository.objects.get(pk=response.data["id"])
+        commits = self.provider.compare_commits(repo, "abc", "xyz")
         assert 2 == len(commits)
         for commit in commits:
             assert_commit_shape(commit)
@@ -270,42 +251,44 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
     def test_compare_commits_start_and_end_gitlab_failure(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/%s/repository/compare?from=abc&to=xyz' % self.gitlab_id,
-            status=502
+            "https://example.gitlab.com/api/v4/projects/%s/repository/compare?from=abc&to=xyz"
+            % self.gitlab_id,
+            status=502,
         )
-        response = self.create_repository(self.default_repository_config,
-                                          self.integration.id)
-        repo = Repository.objects.get(pk=response.data['id'])
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        repo = Repository.objects.get(pk=response.data["id"])
         with pytest.raises(IntegrationError):
-            self.provider.compare_commits(repo, 'abc', 'xyz')
+            self.provider.compare_commits(repo, "abc", "xyz")
 
     @responses.activate
     def test_compare_commits_no_start(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/%s/repository/commits/xyz' % self.gitlab_id,
-            json={'created_at': '2018-09-19T13:14:15Z'}
+            "https://example.gitlab.com/api/v4/projects/%s/repository/commits/xyz" % self.gitlab_id,
+            json={"created_at": "2018-09-19T13:14:15Z"},
         )
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/%s/repository/commits?until=2018-09-19T13:14:15Z' % self.gitlab_id,
-            json=json.loads(COMMIT_LIST_RESPONSE)
+            "https://example.gitlab.com/api/v4/projects/%s/repository/commits?until=2018-09-19T13:14:15Z"
+            % self.gitlab_id,
+            json=json.loads(COMMIT_LIST_RESPONSE),
         )
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/%s/repository/commits/ed899a2f4b50b4370feeea94676502b42383c746/diff' % self.gitlab_id,
-            json=json.loads(COMMIT_DIFF_RESPONSE)
+            "https://example.gitlab.com/api/v4/projects/%s/repository/commits/ed899a2f4b50b4370feeea94676502b42383c746/diff"
+            % self.gitlab_id,
+            json=json.loads(COMMIT_DIFF_RESPONSE),
         )
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/%s/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/diff' % self.gitlab_id,
-            json=json.loads(COMMIT_DIFF_RESPONSE)
+            "https://example.gitlab.com/api/v4/projects/%s/repository/commits/6104942438c14ec7bd21c6cd5bd995272b3faff6/diff"
+            % self.gitlab_id,
+            json=json.loads(COMMIT_DIFF_RESPONSE),
         )
 
-        response = self.create_repository(self.default_repository_config,
-                                          self.integration.id)
-        repo = Repository.objects.get(pk=response.data['id'])
-        commits = self.provider.compare_commits(repo, None, 'xyz')
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        repo = Repository.objects.get(pk=response.data["id"])
+        commits = self.provider.compare_commits(repo, None, "xyz")
         for commit in commits:
             assert_commit_shape(commit)
 
@@ -313,28 +296,27 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
     def test_compare_commits_no_start_gitlab_failure(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/%s/repository/commits/abc' % self.gitlab_id,
-            status=502
+            "https://example.gitlab.com/api/v4/projects/%s/repository/commits/abc" % self.gitlab_id,
+            status=502,
         )
-        response = self.create_repository(self.default_repository_config,
-                                          self.integration.id)
-        repo = Repository.objects.get(pk=response.data['id'])
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        repo = Repository.objects.get(pk=response.data["id"])
         with pytest.raises(IntegrationError):
-            self.provider.compare_commits(repo, None, 'abc')
+            self.provider.compare_commits(repo, None, "abc")
 
     @responses.activate
     def test_pull_request_url(self):
-        response = self.create_repository(self.default_repository_config,
-                                          self.integration.id)
-        repo = Repository.objects.get(pk=response.data['id'])
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        repo = Repository.objects.get(pk=response.data["id"])
         pull = PullRequest(key=99)
         result = self.provider.pull_request_url(repo, pull)
-        assert result == 'https://example.gitlab.com/getsentry/projects/example-repo/merge_requests/99'
+        assert (
+            result == "https://example.gitlab.com/getsentry/projects/example-repo/merge_requests/99"
+        )
 
     @responses.activate
     def test_repository_external_slug(self):
-        response = self.create_repository(self.default_repository_config,
-                                          self.integration.id)
-        repo = Repository.objects.get(pk=response.data['id'])
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        repo = Repository.objects.get(pk=response.data["id"])
         result = self.provider.repository_external_slug(repo)
-        assert result == repo.config['project_id']
+        assert result == repo.config["project_id"]

--- a/tests/sentry/integrations/gitlab/test_search.py
+++ b/tests/sentry/integrations/gitlab/test_search.py
@@ -7,16 +7,16 @@ from .testutils import GitLabTestCase
 
 
 class GitlabSearchTest(GitLabTestCase):
-    provider = 'gitlab'
+    provider = "gitlab"
 
     def setUp(self):
         super(GitlabSearchTest, self).setUp()
         self.url = reverse(
-            'sentry-extensions-gitlab-search',
+            "sentry-extensions-gitlab-search",
             kwargs={
-                'organization_slug': self.organization.slug,
-                'integration_id': self.installation.model.id,
-            }
+                "organization_slug": self.organization.slug,
+                "integration_id": self.installation.model.id,
+            },
         )
 
     # Happy Paths
@@ -24,96 +24,71 @@ class GitlabSearchTest(GitLabTestCase):
     def test_finds_external_issue_results(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/5/issues?scope=all&search=AEIOU',
+            "https://example.gitlab.com/api/v4/projects/5/issues?scope=all&search=AEIOU",
             json=[
-                {'iid': 25, 'title': 'AEIOU Error', 'project_id': '5'},
-                {'iid': 45, 'title': 'AEIOU Error', 'project_id': '5'}
-            ]
+                {"iid": 25, "title": "AEIOU Error", "project_id": "5"},
+                {"iid": 45, "title": "AEIOU Error", "project_id": "5"},
+            ],
         )
         resp = self.client.get(
-            self.url,
-            data={
-                'field': 'externalIssue',
-                'query': 'AEIOU',
-                'project': '5'
-            }
+            self.url, data={"field": "externalIssue", "query": "AEIOU", "project": "5"}
         )
 
         assert resp.status_code == 200
         assert resp.data == [
-            {'value': '5#25', 'label': '(#25) AEIOU Error'},
-            {'value': '5#45', 'label': '(#45) AEIOU Error'}
+            {"value": "5#25", "label": "(#25) AEIOU Error"},
+            {"value": "5#45", "label": "(#45) AEIOU Error"},
         ]
 
     @responses.activate
     def test_finds_external_issue_results_with_iid(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/5/issues?scope=all&search=25',
-            json=[
-                {'iid': 25, 'title': 'AEIOU Error', 'project_id': '5'},
-            ]
+            "https://example.gitlab.com/api/v4/projects/5/issues?scope=all&search=25",
+            json=[{"iid": 25, "title": "AEIOU Error", "project_id": "5"}],
         )
         resp = self.client.get(
-            self.url,
-            data={
-                'field': 'externalIssue',
-                'query': '25',
-                'project': '5'
-            }
+            self.url, data={"field": "externalIssue", "query": "25", "project": "5"}
         )
 
         assert resp.status_code == 200
-        assert resp.data == [
-            {'value': '5#25', 'label': '(#25) AEIOU Error'},
-        ]
+        assert resp.data == [{"value": "5#25", "label": "(#25) AEIOU Error"}]
 
     @responses.activate
     def test_finds_project_results(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/groups/1/projects?query=GetSentry&simple=True',
+            "https://example.gitlab.com/api/v4/groups/1/projects?query=GetSentry&simple=True",
             json=[
                 {
-                    'id': '1',
-                    'name_with_namespace': 'GetSentry / Sentry',
-                    'path_with_namespace': 'getsentry/sentry'
+                    "id": "1",
+                    "name_with_namespace": "GetSentry / Sentry",
+                    "path_with_namespace": "getsentry/sentry",
                 },
                 {
-                    'id': '2',
-                    'name_with_namespace': 'GetSentry2 / Sentry2',
-                    'path_with_namespace': 'getsentry2/sentry2'
+                    "id": "2",
+                    "name_with_namespace": "GetSentry2 / Sentry2",
+                    "path_with_namespace": "getsentry2/sentry2",
                 },
-            ]
+            ],
         )
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'project',
-                'query': 'GetSentry',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "project", "query": "GetSentry"})
 
         assert resp.status_code == 200
         assert resp.data == [
-            {'value': '1', 'label': 'GetSentry / Sentry'},
-            {'value': '2', 'label': 'GetSentry2 / Sentry2'}
+            {"value": "1", "label": "GetSentry / Sentry"},
+            {"value": "2", "label": "GetSentry2 / Sentry2"},
         ]
 
     @responses.activate
     def test_finds_no_external_issues_results(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/5/issues?scope=all&search=XYZ',
-            json=[]
+            "https://example.gitlab.com/api/v4/projects/5/issues?scope=all&search=XYZ",
+            json=[],
         )
         resp = self.client.get(
-            self.url,
-            data={
-                'field': 'externalIssue',
-                'query': 'XYZ',
-                'project': '5',
-            }
+            self.url, data={"field": "externalIssue", "query": "XYZ", "project": "5"}
         )
 
         assert resp.status_code == 200
@@ -123,16 +98,11 @@ class GitlabSearchTest(GitLabTestCase):
     def test_finds_no_external_issues_results_iid(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/5/issues?scope=all&search=11',
-            json=[]
+            "https://example.gitlab.com/api/v4/projects/5/issues?scope=all&search=11",
+            json=[],
         )
         resp = self.client.get(
-            self.url,
-            data={
-                'field': 'externalIssue',
-                'query': '11',
-                'project': '5',
-            }
+            self.url, data={"field": "externalIssue", "query": "11", "project": "5"}
         )
 
         assert resp.status_code == 200
@@ -142,48 +112,26 @@ class GitlabSearchTest(GitLabTestCase):
     def test_finds_no_project_results(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/groups/1/projects?query=GetSentry&simple=True',
-            json=[]
+            "https://example.gitlab.com/api/v4/groups/1/projects?query=GetSentry&simple=True",
+            json=[],
         )
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'project',
-                'query': 'GetSentry',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "project", "query": "GetSentry"})
 
         assert resp.status_code == 200
         assert resp.data == []
 
     # Request Validations
     def test_missing_field(self):
-        resp = self.client.get(
-            self.url,
-            data={
-                'query': 'XYZ',
-            }
-        )
+        resp = self.client.get(self.url, data={"query": "XYZ"})
         assert resp.status_code == 400
 
     def test_missing_query(self):
-        resp = self.client.get(
-            self.url,
-            data={
-                'query': 'GetSentry',
-            }
-        )
+        resp = self.client.get(self.url, data={"query": "GetSentry"})
 
         assert resp.status_code == 400
 
     def test_invalid_field(self):
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'bad-field',
-                'query': 'GetSentry',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "bad-field", "query": "GetSentry"})
 
         assert resp.status_code == 400
 
@@ -191,82 +139,43 @@ class GitlabSearchTest(GitLabTestCase):
     def test_missing_project_with_external_issue_field(self):
         responses.add(
             responses.GET,
-            'https://example.gitlab.com/api/v4/projects/5/issues?scope=all&search=AEIOU',
+            "https://example.gitlab.com/api/v4/projects/5/issues?scope=all&search=AEIOU",
             json=[
-                {'iid': 25, 'title': 'AEIOU Error', 'project_id': '5'},
-                {'iid': 45, 'title': 'AEIOU Error', 'project_id': '5'}
-            ]
+                {"iid": 25, "title": "AEIOU Error", "project_id": "5"},
+                {"iid": 45, "title": "AEIOU Error", "project_id": "5"},
+            ],
         )
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'externalIssue',
-                'query': 'AEIOU',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "externalIssue", "query": "AEIOU"})
 
         assert resp.status_code == 400
 
     # Missing Resources
     def test_missing_integration(self):
         url = reverse(
-            'sentry-extensions-gitlab-search',
-            kwargs={
-                'organization_slug': self.organization.slug,
-                'integration_id': '1234567890',
-            }
+            "sentry-extensions-gitlab-search",
+            kwargs={"organization_slug": self.organization.slug, "integration_id": "1234567890"},
         )
-        resp = self.client.get(
-            url,
-            data={
-                'field': 'project',
-                'query': 'GetSentry',
-            }
-        )
+        resp = self.client.get(url, data={"field": "project", "query": "GetSentry"})
 
         assert resp.status_code == 404
 
     def test_missing_installation(self):
         # remove organization integration aka "uninstalling" installation
         self.installation.org_integration.delete()
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'project',
-                'query': 'GetSentry',
-            }
-        )
+        resp = self.client.get(self.url, data={"field": "project", "query": "GetSentry"})
 
         assert resp.status_code == 404
 
     # Distributed System Issues
     @responses.activate
     def test_search_issues_request_fails(self):
-        responses.add(
-            responses.GET,
-            u'https://example.gitlab.com/api/v4/issues',
-            status=503
-        )
+        responses.add(responses.GET, u"https://example.gitlab.com/api/v4/issues", status=503)
         resp = self.client.get(
-            self.url,
-            data={
-                'field': 'externalIssue',
-                'query': 'GetSentry',
-                'project': '5',
-            }
+            self.url, data={"field": "externalIssue", "query": "GetSentry", "project": "5"}
         )
         assert resp.status_code == 400
 
     def test_projects_request_fails(self):
-        responses.add(
-            responses.GET, u'https://example.gitlab.com/api/v4/projects',
-            status=503
-        )
-        resp = self.client.get(
-            self.url,
-            data={
-                'field': 'project',
-                'query': 'GetSentry',
-            }
-        )
+        responses.add(responses.GET, u"https://example.gitlab.com/api/v4/projects", status=503)
+        resp = self.client.get(self.url, data={"field": "project", "query": "GetSentry"})
         assert resp.status_code == 400

--- a/tests/sentry/integrations/gitlab/testutils.py
+++ b/tests/sentry/integrations/gitlab/testutils.py
@@ -2,63 +2,51 @@ from __future__ import absolute_import
 
 from sentry.testutils import APITestCase
 from time import time
-from sentry.models import (
-    Identity,
-    IdentityProvider,
-    Integration,
-    Repository
-)
+from sentry.models import Identity, IdentityProvider, Integration, Repository
 
 
-EXTERNAL_ID = 'example.gitlab.com:group-x'
-WEBHOOK_SECRET = 'secret-token-value'
-WEBHOOK_TOKEN = u'{}:{}'.format(EXTERNAL_ID, WEBHOOK_SECRET)
+EXTERNAL_ID = "example.gitlab.com:group-x"
+WEBHOOK_SECRET = "secret-token-value"
+WEBHOOK_TOKEN = u"{}:{}".format(EXTERNAL_ID, WEBHOOK_SECRET)
 
 
 class GitLabTestCase(APITestCase):
-    provider = 'gitlab'
+    provider = "gitlab"
 
     def setUp(self):
         self.login_as(self.user)
         self.integration = Integration.objects.create(
             provider=self.provider,
-            name='Example Gitlab',
+            name="Example Gitlab",
             external_id=EXTERNAL_ID,
             metadata={
-                'instance': 'example.gitlab.com',
-                'base_url': 'https://example.gitlab.com',
-                'domain_name': 'example.gitlab.com/group-x',
-                'verify_ssl': False,
-                'webhook_secret': WEBHOOK_SECRET,
-                'group_id': 1,
-            }
+                "instance": "example.gitlab.com",
+                "base_url": "https://example.gitlab.com",
+                "domain_name": "example.gitlab.com/group-x",
+                "verify_ssl": False,
+                "webhook_secret": WEBHOOK_SECRET,
+                "group_id": 1,
+            },
         )
         identity = Identity.objects.create(
-            idp=IdentityProvider.objects.create(
-                type=self.provider,
-                config={},
-            ),
+            idp=IdentityProvider.objects.create(type=self.provider, config={}),
             user=self.user,
-            external_id='gitlab123',
-            data={
-                'access_token': '123456789',
-                'created_at': time(),
-                'refresh_token': '0987654321',
-            }
+            external_id="gitlab123",
+            data={"access_token": "123456789", "created_at": time(), "refresh_token": "0987654321"},
         )
         self.integration.add_organization(self.organization, self.user, identity.id)
         self.installation = self.integration.get_installation(self.organization.id)
 
     def create_repo(self, name, external_id=15, url=None, organization_id=None):
-        instance = self.integration.metadata['instance']
+        instance = self.integration.metadata["instance"]
         organization_id = organization_id or self.organization.id
         return Repository.objects.create(
             organization_id=organization_id,
             name=name,
-            external_id=u'{}:{}'.format(instance, external_id),
+            external_id=u"{}:{}".format(instance, external_id),
             url=url,
-            config={'project_id': external_id},
-            provider='integrations:gitlab',
+            config={"project_id": external_id},
+            provider="integrations:gitlab",
             integration_id=self.integration.id,
         )
 

--- a/tests/snuba/api/endpoints/test_organization_events_distribution.py
+++ b/tests/snuba/api/endpoints/test_organization_events_distribution.py
@@ -7,14 +7,11 @@ from uuid import uuid4
 
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT
 from sentry.testutils import APITestCase, SnubaTestCase
-from sentry.testutils.helpers.datetime import (
-    before_now,
-    iso_format
-)
+from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
 class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
-    feature_list = ('organizations:events-v2', 'organizations:global-views')
+    feature_list = ("organizations:events-v2", "organizations:global-views")
 
     def setUp(self):
         super(OrganizationEventsDistributionEndpointTest, self).setUp()
@@ -24,157 +21,131 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
         self.project = self.create_project()
         self.project2 = self.create_project()
         self.url = reverse(
-            'sentry-api-0-organization-events-distribution',
-            kwargs={
-                'organization_slug': self.project.organization.slug,
-            }
+            "sentry-api-0-organization-events-distribution",
+            kwargs={"organization_slug": self.project.organization.slug},
         )
         self.min_ago_iso = iso_format(self.min_ago)
 
     def test_simple(self):
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'number': 'one'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"number": "one"},
             },
-            project_id=self.project2.id
+            project_id=self.project2.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'number': 'one'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"number": "one"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'number': 'two'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"number": "two"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
 
         with self.feature(self.feature_list):
-            response = self.client.get(self.url, {'key': 'number'}, format='json')
+            response = self.client.get(self.url, {"key": "number"}, format="json")
 
         assert response.status_code == 200, response.content
 
         assert response.data == {
-            'topValues': [
-                {
-                    'count': 2,
-                    'name': 'one',
-                    'value': 'one',
-                },
-                {
-                    'count': 1,
-                    'name': 'two',
-                    'value': 'two',
-                }
+            "topValues": [
+                {"count": 2, "name": "one", "value": "one"},
+                {"count": 1, "name": "two", "value": "two"},
             ],
-            'key': 'number'
+            "key": "number",
         }
 
     def test_with_message_query(self):
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'message': 'how to make fast',
-                'tags': {'color': 'green'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "message": "how to make fast",
+                "tags": {"color": "green"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'message': 'Delet the Data',
-                'tags': {'color': 'red'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "message": "Delet the Data",
+                "tags": {"color": "red"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'message': 'Data the Delet ',
-                'tags': {'color': 'yellow'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "message": "Data the Delet ",
+                "tags": {"color": "yellow"},
             },
-            project_id=self.project2.id
+            project_id=self.project2.id,
         )
 
         with self.feature(self.feature_list):
-            response = self.client.get(
-                self.url, {
-                    'query': 'delet', 'key': 'color'}, format='json')
+            response = self.client.get(self.url, {"query": "delet", "key": "color"}, format="json")
 
         assert response.status_code == 200, response.content
 
         assert response.data == {
-            'topValues': [
-                {
-                    'count': 1,
-                    'name': 'yellow',
-                    'value': 'yellow',
-                },
-                {
-                    'count': 1,
-                    'name': 'red',
-                    'value': 'red',
-                }
+            "topValues": [
+                {"count": 1, "name": "yellow", "value": "yellow"},
+                {"count": 1, "name": "red", "value": "red"},
             ],
-            'key': 'color'
+            "key": "color",
         }
 
     def test_with_condition(self):
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'message': 'how to make fast',
-                'tags': {'color': 'green'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "message": "how to make fast",
+                "tags": {"color": "green"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'message': 'Delet the Data',
-                'tags': {'color': 'red'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "message": "Delet the Data",
+                "tags": {"color": "red"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'message': 'Data the Delet ',
-                'tags': {'color': 'yellow'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "message": "Data the Delet ",
+                "tags": {"color": "yellow"},
             },
-            project_id=self.project2.id
+            project_id=self.project2.id,
         )
 
         with self.feature(self.feature_list):
             response = self.client.get(
-                self.url, {
-                    'query': 'color:yellow', 'key': 'color'}, format='json')
+                self.url, {"query": "color:yellow", "key": "color"}, format="json"
+            )
 
         assert response.status_code == 200, response.content
 
         assert response.data == {
-            'topValues': [
-                {
-                    'count': 1,
-                    'name': 'yellow',
-                    'value': 'yellow',
-                },
-            ],
-            'key': 'color'
+            "topValues": [{"count": 1, "name": "yellow", "value": "yellow"}],
+            "key": "color",
         }
 
     def test_start_end(self):
@@ -184,58 +155,52 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
 
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': iso_format(two_days_ago),
-                'tags': {'color': 'red'},
+                "event_id": uuid4().hex,
+                "timestamp": iso_format(two_days_ago),
+                "tags": {"color": "red"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': iso_format(hour_ago),
-                'tags': {'color': 'red'},
+                "event_id": uuid4().hex,
+                "timestamp": iso_format(hour_ago),
+                "tags": {"color": "red"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': iso_format(two_hours_ago),
-                'tags': {'color': 'red'},
+                "event_id": uuid4().hex,
+                "timestamp": iso_format(two_hours_ago),
+                "tags": {"color": "red"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': iso_format(timezone.now()),
-                'tags': {'color': 'red'},
+                "event_id": uuid4().hex,
+                "timestamp": iso_format(timezone.now()),
+                "tags": {"color": "red"},
             },
-            project_id=self.project2.id
+            project_id=self.project2.id,
         )
 
         with self.feature(self.feature_list):
             response = self.client.get(
                 self.url,
                 {
-                    'start': iso_format(self.day_ago),
-                    'end': iso_format(self.min_ago),
-                    'key': ['color'],
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.min_ago),
+                    "key": ["color"],
                 },
-                format='json'
+                format="json",
             )
 
         assert response.status_code == 200, response.content
         assert response.data == {
-            'topValues': [
-                {
-                    'count': 2,
-                    'name': 'red',
-                    'value': 'red',
-                }
-            ],
-            'key': 'color'
+            "topValues": [{"count": 2, "name": "red", "value": "red"}],
+            "key": "color",
         }
 
     def test_excluded_tag(self):
@@ -243,326 +208,245 @@ class OrganizationEventsDistributionEndpointTest(APITestCase, SnubaTestCase):
         self.user2 = self.create_user()
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': iso_format(self.day_ago),
-                'tags': {'sentry:user': self.user.email},
+                "event_id": uuid4().hex,
+                "timestamp": iso_format(self.day_ago),
+                "tags": {"sentry:user": self.user.email},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': iso_format(self.day_ago),
-                'tags': {'sentry:user': self.user2.email},
+                "event_id": uuid4().hex,
+                "timestamp": iso_format(self.day_ago),
+                "tags": {"sentry:user": self.user2.email},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': iso_format(self.day_ago),
-                'tags': {'sentry:user': self.user2.email},
+                "event_id": uuid4().hex,
+                "timestamp": iso_format(self.day_ago),
+                "tags": {"sentry:user": self.user2.email},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
 
         with self.feature(self.feature_list):
             response = self.client.get(
-                self.url,
-                format='json',
-                data={
-                    'key': 'user',
-                    'project': [self.project.id]
-                },
+                self.url, format="json", data={"key": "user", "project": [self.project.id]}
             )
 
         assert response.status_code == 200, response.content
         assert response.data == {
-            'topValues': [
-                {
-                    'count': 2,
-                    'name': self.user2.email,
-                    'value': self.user2.email,
-                },
-                {
-                    'count': 1,
-                    'name': self.user.email,
-                    'value': self.user.email,
-                }
+            "topValues": [
+                {"count": 2, "name": self.user2.email, "value": self.user2.email},
+                {"count": 1, "name": self.user.email, "value": self.user.email},
             ],
-            'key': 'user'
+            "key": "user",
         }
 
     def test_no_projects(self):
         org = self.create_organization(owner=self.user)
         url = reverse(
-            'sentry-api-0-organization-events-distribution',
-            kwargs={
-                'organization_slug': org.slug,
-            }
+            "sentry-api-0-organization-events-distribution", kwargs={"organization_slug": org.slug}
         )
-        with self.feature('organizations:events-v2'):
-            response = self.client.get(url, {'key': 'color'}, format='json')
+        with self.feature("organizations:events-v2"):
+            response = self.client.get(url, {"key": "color"}, format="json")
         assert response.status_code == 400, response.content
-        assert response.data == {'detail': 'A valid project must be included.'}
+        assert response.data == {"detail": "A valid project must be included."}
 
     def test_no_key_param(self):
-        with self.feature('organizations:events-v2'):
-            response = self.client.get(self.url, {'project': [self.project.id]}, format='json')
+        with self.feature("organizations:events-v2"):
+            response = self.client.get(self.url, {"project": [self.project.id]}, format="json")
         assert response.status_code == 400, response.content
-        assert response.data == {'detail': 'Tag key must be specified.'}
+        assert response.data == {"detail": "Tag key must be specified."}
 
     def test_multiple_projects_without_global_view(self):
-        self.store_event(
-            data={
-                'event_id': uuid4().hex,
-            },
-            project_id=self.project.id
-        )
-        self.store_event(
-            data={
-                'event_id': uuid4().hex,
-            },
-            project_id=self.project2.id
-        )
+        self.store_event(data={"event_id": uuid4().hex}, project_id=self.project.id)
+        self.store_event(data={"event_id": uuid4().hex}, project_id=self.project2.id)
 
-        with self.feature('organizations:events-v2'):
-            response = self.client.get(self.url, {'key': 'color'}, format='json')
+        with self.feature("organizations:events-v2"):
+            response = self.client.get(self.url, {"key": "color"}, format="json")
         assert response.status_code == 400, response.content
-        assert response.data == {'detail': 'You cannot view events from multiple projects.'}
+        assert response.data == {"detail": "You cannot view events from multiple projects."}
 
     def test_project_selected(self):
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'number': 'two'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"number": "two"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'number': 'one'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"number": "one"},
             },
-            project_id=self.project2.id
+            project_id=self.project2.id,
         )
 
         with self.feature(self.feature_list):
             response = self.client.get(
-                self.url,
-                {'key': 'number', 'project': [self.project.id]},
-                format='json'
+                self.url, {"key": "number", "project": [self.project.id]}, format="json"
             )
 
         assert response.status_code == 200, response.content
         assert response.data == {
-            'topValues': [{
-                'name': 'two',
-                'value': 'two',
-                'count': 1,
-            }],
-            'key': 'number'
+            "topValues": [{"name": "two", "value": "two", "count": 1}],
+            "key": "number",
         }
 
     def test_project_key(self):
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'color': 'green'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"color": "green"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'number': 'one'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"number": "one"},
             },
-            project_id=self.project2.id
+            project_id=self.project2.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'color': 'green'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"color": "green"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
-            data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'color': 'red'},
-            },
-            project_id=self.project.id
+            data={"event_id": uuid4().hex, "timestamp": self.min_ago_iso, "tags": {"color": "red"}},
+            project_id=self.project.id,
         )
 
         with self.feature(self.feature_list):
-            response = self.client.get(
-                self.url, {'key': 'project.name'}, format='json')
+            response = self.client.get(self.url, {"key": "project.name"}, format="json")
 
         assert response.status_code == 200, response.content
 
         assert response.data == {
-            'topValues': [
-                {
-                    'count': 3,
-                    'name': self.project.slug,
-                    'value': self.project.slug,
-                },
-                {
-                    'count': 1,
-                    'name': self.project2.slug,
-                    'value': self.project2.slug,
-                }
+            "topValues": [
+                {"count": 3, "name": self.project.slug, "value": self.project.slug},
+                {"count": 1, "name": self.project2.slug, "value": self.project2.slug},
             ],
-            'key': 'project.name'
+            "key": "project.name",
         }
 
     def test_non_tag_key(self):
         user1 = {
-            'id': '1',
-            'ip_address': '127.0.0.1',
-            'email': 'foo@example.com',
-            'username': 'foo',
+            "id": "1",
+            "ip_address": "127.0.0.1",
+            "email": "foo@example.com",
+            "username": "foo",
         }
         user2 = {
-            'id': '2',
-            'ip_address': '127.0.0.2',
-            'email': 'bar@example.com',
-            'username': 'bar',
+            "id": "2",
+            "ip_address": "127.0.0.2",
+            "email": "bar@example.com",
+            "username": "bar",
         }
         self.store_event(
-            data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'user': user1,
-            },
-            project_id=self.project.id
+            data={"event_id": uuid4().hex, "timestamp": self.min_ago_iso, "user": user1},
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'color': 'green'},
-                'user': user2,
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"color": "green"},
+                "user": user2,
             },
-            project_id=self.project2.id
+            project_id=self.project2.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'color': 'green'},
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"color": "green"},
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'color': 'red'},
-                'user': user1,
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"color": "red"},
+                "user": user1,
             },
-            project_id=self.project.id
+            project_id=self.project.id,
         )
 
         with self.feature(self.feature_list):
-            response = self.client.get(
-                self.url, {'key': 'user.email'}, format='json')
+            response = self.client.get(self.url, {"key": "user.email"}, format="json")
 
         assert response.status_code == 200, response.content
 
         assert response.data == {
-            'topValues': [
-                {
-                    'count': 2,
-                    'name': user1['email'],
-                    'value': user1['email'],
-                },
-                {
-                    'count': 1,
-                    'name': user2['email'],
-                    'value': user2['email'],
-                }
+            "topValues": [
+                {"count": 2, "name": user1["email"], "value": user1["email"]},
+                {"count": 1, "name": user2["email"], "value": user2["email"]},
             ],
-            'key': 'user.email'
+            "key": "user.email",
         }
 
     def test_value_limit(self):
         for i in range(0, 12):
             self.store_event(
                 data={
-                    'event_id': uuid4().hex,
-                    'timestamp': self.min_ago_iso,
-                    'tags': {'color': 'color%d' % i}
+                    "event_id": uuid4().hex,
+                    "timestamp": self.min_ago_iso,
+                    "tags": {"color": "color%d" % i},
                 },
-                project_id=self.create_project().id
+                project_id=self.create_project().id,
             )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'color': 'yellow'}
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"color": "yellow"},
             },
-            project_id=self.project2.id
+            project_id=self.project2.id,
         )
         self.store_event(
             data={
-                'event_id': uuid4().hex,
-                'timestamp': self.min_ago_iso,
-                'tags': {'color': 'yellow'}
+                "event_id": uuid4().hex,
+                "timestamp": self.min_ago_iso,
+                "tags": {"color": "yellow"},
             },
-            project_id=self.project2.id
+            project_id=self.project2.id,
         )
         with self.feature(self.feature_list):
-            response = self.client.get(
-                self.url, {'key': 'color'}, format='json')
+            response = self.client.get(self.url, {"key": "color"}, format="json")
 
         assert response.status_code == 200, response.content
-        assert len(response.data['topValues']) == TOP_VALUES_DEFAULT_LIMIT
-        assert response.data['topValues'][0] == {
-            'count': 2,
-            'name': 'yellow',
-            'value': 'yellow',
-        }
+        assert len(response.data["topValues"]) == TOP_VALUES_DEFAULT_LIMIT
+        assert response.data["topValues"][0] == {"count": 2, "name": "yellow", "value": "yellow"}
 
     def test_malformed_query(self):
-        self.store_event(
-            data={
-                'event_id': uuid4().hex,
-            },
-            project_id=self.project.id
-        )
-        self.store_event(
-            data={
-                'event_id': uuid4().hex,
-            },
-            project_id=self.project2.id
-        )
+        self.store_event(data={"event_id": uuid4().hex}, project_id=self.project.id)
+        self.store_event(data={"event_id": uuid4().hex}, project_id=self.project2.id)
 
         with self.feature(self.feature_list):
             response = self.client.get(
-                self.url,
-                format='json',
-                data={
-                    'key': ['color'],
-                    'query': '\n\n\n\n'
-                })
+                self.url, format="json", data={"key": ["color"], "query": "\n\n\n\n"}
+            )
         assert response.status_code == 400, response.content
         assert response.data == {
-            'detail': "Parse error: 'search' (column 1). This is commonly caused by unmatched-parentheses. Enclose any text in double quotes."}
+            "detail": "Parse error: 'search' (column 1). This is commonly caused by unmatched-parentheses. Enclose any text in double quotes."
+        }
 
     def test_invalid_tag(self):
         with self.feature(self.feature_list):
-            response = self.client.get(
-                self.url,
-                data={
-                    'key': ['color;;;']
-                },
-                format='json')
+            response = self.client.get(self.url, data={"key": ["color;;;"]}, format="json")
         assert response.status_code == 400, response.content
-        assert response.data == {'detail': "Tag key color;;; is not valid."}
+        assert response.data == {"detail": "Tag key color;;; is not valid."}

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -448,29 +448,23 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
 
     def test_calculated_limit(self):
 
-        with patch('sentry.tsdb.snuba.snuba') as snuba:
+        with patch("sentry.tsdb.snuba.snuba") as snuba:
             # 24h test
             rollup = 3600
             end = self.now
             start = end + timedelta(days=-1, seconds=rollup)
-            self.db.get_data(TSDBModel.group,
-                             [1, 2, 3, 4, 5], start, end,
-                             rollup=rollup)
-            assert snuba.query.call_args[1]['limit'] == 120
+            self.db.get_data(TSDBModel.group, [1, 2, 3, 4, 5], start, end, rollup=rollup)
+            assert snuba.query.call_args[1]["limit"] == 120
 
             # 14 day test
             rollup = 86400
             start = end + timedelta(days=-14, seconds=rollup)
-            self.db.get_data(TSDBModel.group,
-                             [1, 2, 3, 4, 5], start, end,
-                             rollup=rollup)
-            assert snuba.query.call_args[1]['limit'] == 70
+            self.db.get_data(TSDBModel.group, [1, 2, 3, 4, 5], start, end, rollup=rollup)
+            assert snuba.query.call_args[1]["limit"] == 70
 
             # 1h test
             rollup = 3600
             end = self.now
             start = end + timedelta(hours=-1, seconds=rollup)
-            self.db.get_data(TSDBModel.group,
-                             [1, 2, 3, 4, 5], start, end,
-                             rollup=rollup)
-            assert snuba.query.call_args[1]['limit'] == 5
+            self.db.get_data(TSDBModel.group, [1, 2, 3, 4, 5], start, end, rollup=rollup)
+            assert snuba.query.call_args[1]["limit"] == 5


### PR DESCRIPTION
The file exclude pattern used for black, originally taken from [here](https://github.com/getsentry/sentry/pull/13181), wasn't correct. For example, `src/sentry/utils/distutils/commands/base.py` was being ignored because it has the `dist` substring - we intended on ignoring `dist/` directories.

The one directory we do want to exclude, `south_migrations`, was made more explicit by adding a trailing slash. Everything else has been removed, and the files previously ignored have now been blackened. I changed over to using pre-commit's `types: [python]` file matcher, which also matches python shebang'd stuff.

Also, pre-commit has been bumped and pinned to latest with no apparent breaking/ill effects. In particular, [v1.14.4](https://github.com/pre-commit/pre-commit/releases?after=v1.14.4) comes with a useful `Add a warning on unexpected keys in configuration` - it let me know that `python_version: python3` was noop, so that's been removed.