### PR TITLE
fix(issueDetailsPage/contextSummary): Prefer client_os over os for eventContextSummary

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contextSummary.jsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary.jsx
@@ -61,12 +61,10 @@ class GenericSummary extends React.Component {
 export class OsSummary extends React.Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
-    contextKey: PropTypes.string,
   };
 
   render() {
     const data = this.props.data;
-    const contextKey = this.props.contextKey;
 
     if (objectIsEmpty(data) || !data.name) {
       return <NoSummary title={t('Unknown OS')} />;
@@ -100,9 +98,6 @@ export class OsSummary extends React.Component {
         <span className="context-item-icon" />
         <h3>{data.name}</h3>
         {versionElement}
-        <p>
-          <small>{contextKey === 'client_os' ? 'Clientside' : 'Crashsite'}</small>
-        </p>
       </div>
     );
   }
@@ -272,7 +267,7 @@ class EventContextSummary extends React.Component {
       }
 
       contextCount += 1;
-      return <Component key={key} contextKey={key} data={data} {...props} />;
+      return <Component key={key} data={data} {...props} />;
     });
 
     // Bail out if all contexts are empty or only the user context is set
@@ -291,7 +286,7 @@ class EventContextSummary extends React.Component {
           return null;
         }
         contextCount += 1;
-        return <Component key={keys[0]} contextKey={keys[0]} data={{}} {...props} />;
+        return <Component key={keys[0]} data={{}} {...props} />;
       });
     }
 

--- a/src/sentry/static/sentry/app/components/events/contextSummary.jsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary.jsx
@@ -66,6 +66,7 @@ export class OsSummary extends React.Component {
 
   render() {
     const data = this.props.data;
+    const contextKey = this.props.contextKey;
 
     if (objectIsEmpty(data) || !data.name) {
       return <NoSummary title={t('Unknown OS')} />;
@@ -99,7 +100,9 @@ export class OsSummary extends React.Component {
         <span className="context-item-icon" />
         <h3>{data.name}</h3>
         {versionElement}
-        <p><small>{this.contextKey == "client_os" ? "Clientside" : "Crashsite"}</small></p>
+        <p>
+          <small>{contextKey === 'client_os' ? 'Clientside' : 'Crashsite'}</small>
+        </p>
       </div>
     );
   }
@@ -259,16 +262,12 @@ class EventContextSummary extends React.Component {
       if (contextCount >= MAX_CONTEXTS) {
         return null;
       }
-      let data = {};
-      let key;
-      for(key of keys) {
-        data = evt.contexts[key] || evt[key];
-        if(!objectIsEmpty(data)) {
-          break;
-        }
-      }
 
-      if (objectIsEmpty(data)) {
+      const [key, data] = keys
+        .map(k => [k, evt.contexts[k] || evt[k]])
+        .find(([_k, d]) => !objectIsEmpty(d)) || [null, null];
+
+      if (!key) {
         return null;
       }
 

--- a/src/sentry/static/sentry/app/components/events/contextSummary.jsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary.jsx
@@ -234,12 +234,12 @@ export class GpuSummary extends React.Component {
 const MIN_CONTEXTS = 3;
 const MAX_CONTEXTS = 4;
 const KNOWN_CONTEXTS = [
-  {key: 'user', Component: UserSummary},
-  {key: 'browser', Component: GenericSummary, unknownTitle: t('Unknown Browser')},
-  {key: 'runtime', Component: GenericSummary, unknownTitle: t('Unknown Runtime')},
-  {key: 'os', Component: OsSummary},
-  {key: 'device', Component: DeviceSummary},
-  {key: 'gpu', Component: GpuSummary},
+  {keys: ['user'], Component: UserSummary},
+  {keys: ['browser'], Component: GenericSummary, unknownTitle: t('Unknown Browser')},
+  {keys: ['runtime'], Component: GenericSummary, unknownTitle: t('Unknown Runtime')},
+  {keys: ['client_os', 'os'], Component: OsSummary},
+  {keys: ['device'], Component: DeviceSummary},
+  {keys: ['gpu'], Component: GpuSummary},
 ];
 
 class EventContextSummary extends React.Component {
@@ -253,14 +253,23 @@ class EventContextSummary extends React.Component {
 
     // Add defined contexts in the declared order, until we reach the limit
     // defined by MAX_CONTEXTS.
-    let contexts = KNOWN_CONTEXTS.map(({key, Component, ...props}) => {
+    let contexts = KNOWN_CONTEXTS.map(({keys, Component, ...props}) => {
       if (contextCount >= MAX_CONTEXTS) {
         return null;
       }
-      const data = evt.contexts[key] || evt[key];
+      let data = {};
+      let key;
+      for(key of keys) {
+        data = evt.contexts[key] || evt[key];
+        if(!objectIsEmpty(data)) {
+          break;
+        }
+      }
+
       if (objectIsEmpty(data)) {
         return null;
       }
+
       contextCount += 1;
       return <Component key={key} data={data} {...props} />;
     });
@@ -273,7 +282,7 @@ class EventContextSummary extends React.Component {
     if (contextCount < MIN_CONTEXTS) {
       // Add contents in the declared order until we have at least MIN_CONTEXTS
       // contexts in our list.
-      contexts = KNOWN_CONTEXTS.map(({key, Component, ...props}, index) => {
+      contexts = KNOWN_CONTEXTS.map(({keys, Component, ...props}, index) => {
         if (contexts[index]) {
           return contexts[index];
         }
@@ -281,7 +290,7 @@ class EventContextSummary extends React.Component {
           return null;
         }
         contextCount += 1;
-        return <Component key={key} data={{}} {...props} />;
+        return <Component key={keys[0]} data={{}} {...props} />;
       });
     }
 

--- a/src/sentry/static/sentry/app/components/events/contextSummary.jsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary.jsx
@@ -61,6 +61,7 @@ class GenericSummary extends React.Component {
 export class OsSummary extends React.Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
+    contextKey: PropTypes.string,
   };
 
   render() {
@@ -98,6 +99,7 @@ export class OsSummary extends React.Component {
         <span className="context-item-icon" />
         <h3>{data.name}</h3>
         {versionElement}
+        <p><small>{this.contextKey == "client_os" ? "Clientside" : "Crashsite"}</small></p>
       </div>
     );
   }
@@ -271,7 +273,7 @@ class EventContextSummary extends React.Component {
       }
 
       contextCount += 1;
-      return <Component key={key} data={data} {...props} />;
+      return <Component key={key} contextKey={key} data={data} {...props} />;
     });
 
     // Bail out if all contexts are empty or only the user context is set
@@ -290,7 +292,7 @@ class EventContextSummary extends React.Component {
           return null;
         }
         contextCount += 1;
-        return <Component key={keys[0]} data={{}} {...props} />;
+        return <Component key={keys[0]} contextKey={keys[0]} data={{}} {...props} />;
       });
     }
 

--- a/tests/js/spec/components/events/__snapshots__/contextSummary.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/contextSummary.spec.jsx.snap
@@ -7,6 +7,7 @@ exports[`ContextSummary render() should prefer client_os over os 1`] = `
   className="context-summary"
 >
   <UserSummary
+    contextKey="user"
     data={
       Object {
         "email": "mail@example.org",
@@ -16,6 +17,7 @@ exports[`ContextSummary render() should prefer client_os over os 1`] = `
     key="user"
   />
   <GenericSummary
+    contextKey="browser"
     data={
       Object {
         "name": "Chrome",
@@ -26,6 +28,7 @@ exports[`ContextSummary render() should prefer client_os over os 1`] = `
     unknownTitle="Unknown Browser"
   />
   <GenericSummary
+    contextKey="runtime"
     data={
       Object {
         "name": "Electron",
@@ -37,6 +40,7 @@ exports[`ContextSummary render() should prefer client_os over os 1`] = `
     unknownTitle="Unknown Runtime"
   />
   <OsSummary
+    contextKey="client_os"
     data={
       Object {
         "build": "17E199",
@@ -56,6 +60,7 @@ exports[`ContextSummary render() should render at least three contexts 1`] = `
   className="context-summary"
 >
   <UserSummary
+    contextKey="user"
     data={
       Object {
         "email": "mail@example.org",
@@ -65,11 +70,13 @@ exports[`ContextSummary render() should render at least three contexts 1`] = `
     key="user"
   />
   <GenericSummary
+    contextKey="browser"
     data={Object {}}
     key="browser"
     unknownTitle="Unknown Browser"
   />
   <DeviceSummary
+    contextKey="device"
     data={
       Object {
         "arch": "x86",
@@ -88,6 +95,7 @@ exports[`ContextSummary render() should render client_os too 1`] = `
   className="context-summary"
 >
   <UserSummary
+    contextKey="user"
     data={
       Object {
         "email": "mail@example.org",
@@ -97,6 +105,7 @@ exports[`ContextSummary render() should render client_os too 1`] = `
     key="user"
   />
   <GenericSummary
+    contextKey="browser"
     data={
       Object {
         "name": "Chrome",
@@ -107,6 +116,7 @@ exports[`ContextSummary render() should render client_os too 1`] = `
     unknownTitle="Unknown Browser"
   />
   <GenericSummary
+    contextKey="runtime"
     data={
       Object {
         "name": "Electron",
@@ -118,6 +128,7 @@ exports[`ContextSummary render() should render client_os too 1`] = `
     unknownTitle="Unknown Runtime"
   />
   <OsSummary
+    contextKey="client_os"
     data={
       Object {
         "build": "17E199",
@@ -141,6 +152,7 @@ exports[`ContextSummary render() should render up to four contexts 1`] = `
   className="context-summary"
 >
   <UserSummary
+    contextKey="user"
     data={
       Object {
         "email": "mail@example.org",
@@ -150,6 +162,7 @@ exports[`ContextSummary render() should render up to four contexts 1`] = `
     key="user"
   />
   <GenericSummary
+    contextKey="browser"
     data={
       Object {
         "name": "Chrome",
@@ -160,6 +173,7 @@ exports[`ContextSummary render() should render up to four contexts 1`] = `
     unknownTitle="Unknown Browser"
   />
   <GenericSummary
+    contextKey="runtime"
     data={
       Object {
         "name": "Electron",
@@ -171,6 +185,7 @@ exports[`ContextSummary render() should render up to four contexts 1`] = `
     unknownTitle="Unknown Runtime"
   />
   <OsSummary
+    contextKey="os"
     data={
       Object {
         "build": "17E199",
@@ -190,6 +205,7 @@ exports[`ContextSummary render() should skip a missing user context 1`] = `
   className="context-summary"
 >
   <GenericSummary
+    contextKey="runtime"
     data={
       Object {
         "name": "Electron",
@@ -201,6 +217,7 @@ exports[`ContextSummary render() should skip a missing user context 1`] = `
     unknownTitle="Unknown Runtime"
   />
   <OsSummary
+    contextKey="os"
     data={
       Object {
         "build": "17E199",
@@ -213,6 +230,7 @@ exports[`ContextSummary render() should skip a missing user context 1`] = `
     key="os"
   />
   <DeviceSummary
+    contextKey="device"
     data={
       Object {
         "arch": "x86",
@@ -231,6 +249,7 @@ exports[`ContextSummary render() should skip non-default named contexts 1`] = `
   className="context-summary"
 >
   <UserSummary
+    contextKey="user"
     data={
       Object {
         "email": "mail@example.org",
@@ -240,6 +259,7 @@ exports[`ContextSummary render() should skip non-default named contexts 1`] = `
     key="user"
   />
   <GenericSummary
+    contextKey="runtime"
     data={
       Object {
         "name": "Electron",
@@ -251,6 +271,7 @@ exports[`ContextSummary render() should skip non-default named contexts 1`] = `
     unknownTitle="Unknown Runtime"
   />
   <OsSummary
+    contextKey="os"
     data={
       Object {
         "build": "17E199",
@@ -263,6 +284,7 @@ exports[`ContextSummary render() should skip non-default named contexts 1`] = `
     key="os"
   />
   <DeviceSummary
+    contextKey="device"
     data={
       Object {
         "arch": "x86",
@@ -333,6 +355,11 @@ exports[`OsSummary render() should render the kernel version when no version 1`]
      
     17.5.0
   </p>
+  <p>
+    <small>
+      Crashsite
+    </small>
+  </p>
 </div>
 `;
 
@@ -353,6 +380,11 @@ exports[`OsSummary render() should render the version string 1`] = `
      
     10.13.4
   </p>
+  <p>
+    <small>
+      Crashsite
+    </small>
+  </p>
 </div>
 `;
 
@@ -372,6 +404,11 @@ exports[`OsSummary render() should render unknown when no version 1`] = `
     </strong>
      
     Unknown
+  </p>
+  <p>
+    <small>
+      Crashsite
+    </small>
   </p>
 </div>
 `;

--- a/tests/js/spec/components/events/__snapshots__/contextSummary.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/contextSummary.spec.jsx.snap
@@ -2,6 +2,55 @@
 
 exports[`ContextSummary render() should bail out with empty contexts 1`] = `""`;
 
+exports[`ContextSummary render() should prefer client_os over os 1`] = `
+<div
+  className="context-summary"
+>
+  <UserSummary
+    data={
+      Object {
+        "email": "mail@example.org",
+        "id": "1",
+      }
+    }
+    key="user"
+  />
+  <GenericSummary
+    data={
+      Object {
+        "name": "Chrome",
+        "version": "65.0.3325",
+      }
+    }
+    key="browser"
+    unknownTitle="Unknown Browser"
+  />
+  <GenericSummary
+    data={
+      Object {
+        "name": "Electron",
+        "type": "runtime",
+        "version": "1.7.13",
+      }
+    }
+    key="runtime"
+    unknownTitle="Unknown Runtime"
+  />
+  <OsSummary
+    data={
+      Object {
+        "build": "17E199",
+        "kernel_version": "17.5.0",
+        "name": "Mac OS X",
+        "type": "os",
+        "version": "10.13.4",
+      }
+    }
+    key="client_os"
+  />
+</div>
+`;
+
 exports[`ContextSummary render() should render at least three contexts 1`] = `
 <div
   className="context-summary"
@@ -30,6 +79,55 @@ exports[`ContextSummary render() should render at least three contexts 1`] = `
       }
     }
     key="device"
+  />
+</div>
+`;
+
+exports[`ContextSummary render() should render client_os too 1`] = `
+<div
+  className="context-summary"
+>
+  <UserSummary
+    data={
+      Object {
+        "email": "mail@example.org",
+        "id": "1",
+      }
+    }
+    key="user"
+  />
+  <GenericSummary
+    data={
+      Object {
+        "name": "Chrome",
+        "version": "65.0.3325",
+      }
+    }
+    key="browser"
+    unknownTitle="Unknown Browser"
+  />
+  <GenericSummary
+    data={
+      Object {
+        "name": "Electron",
+        "type": "runtime",
+        "version": "1.7.13",
+      }
+    }
+    key="runtime"
+    unknownTitle="Unknown Runtime"
+  />
+  <OsSummary
+    data={
+      Object {
+        "build": "17E199",
+        "kernel_version": "17.5.0",
+        "name": "Mac OS X",
+        "type": "os",
+        "version": "10.13.4",
+      }
+    }
+    key="client_os"
   />
 </div>
 `;

--- a/tests/js/spec/components/events/__snapshots__/contextSummary.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/contextSummary.spec.jsx.snap
@@ -7,7 +7,6 @@ exports[`ContextSummary render() should prefer client_os over os 1`] = `
   className="context-summary"
 >
   <UserSummary
-    contextKey="user"
     data={
       Object {
         "email": "mail@example.org",
@@ -17,7 +16,6 @@ exports[`ContextSummary render() should prefer client_os over os 1`] = `
     key="user"
   />
   <GenericSummary
-    contextKey="browser"
     data={
       Object {
         "name": "Chrome",
@@ -28,7 +26,6 @@ exports[`ContextSummary render() should prefer client_os over os 1`] = `
     unknownTitle="Unknown Browser"
   />
   <GenericSummary
-    contextKey="runtime"
     data={
       Object {
         "name": "Electron",
@@ -40,7 +37,6 @@ exports[`ContextSummary render() should prefer client_os over os 1`] = `
     unknownTitle="Unknown Runtime"
   />
   <OsSummary
-    contextKey="client_os"
     data={
       Object {
         "build": "17E199",
@@ -60,7 +56,6 @@ exports[`ContextSummary render() should render at least three contexts 1`] = `
   className="context-summary"
 >
   <UserSummary
-    contextKey="user"
     data={
       Object {
         "email": "mail@example.org",
@@ -70,13 +65,11 @@ exports[`ContextSummary render() should render at least three contexts 1`] = `
     key="user"
   />
   <GenericSummary
-    contextKey="browser"
     data={Object {}}
     key="browser"
     unknownTitle="Unknown Browser"
   />
   <DeviceSummary
-    contextKey="device"
     data={
       Object {
         "arch": "x86",
@@ -95,7 +88,6 @@ exports[`ContextSummary render() should render client_os too 1`] = `
   className="context-summary"
 >
   <UserSummary
-    contextKey="user"
     data={
       Object {
         "email": "mail@example.org",
@@ -105,7 +97,6 @@ exports[`ContextSummary render() should render client_os too 1`] = `
     key="user"
   />
   <GenericSummary
-    contextKey="browser"
     data={
       Object {
         "name": "Chrome",
@@ -116,7 +107,6 @@ exports[`ContextSummary render() should render client_os too 1`] = `
     unknownTitle="Unknown Browser"
   />
   <GenericSummary
-    contextKey="runtime"
     data={
       Object {
         "name": "Electron",
@@ -128,7 +118,6 @@ exports[`ContextSummary render() should render client_os too 1`] = `
     unknownTitle="Unknown Runtime"
   />
   <OsSummary
-    contextKey="client_os"
     data={
       Object {
         "build": "17E199",
@@ -152,7 +141,6 @@ exports[`ContextSummary render() should render up to four contexts 1`] = `
   className="context-summary"
 >
   <UserSummary
-    contextKey="user"
     data={
       Object {
         "email": "mail@example.org",
@@ -162,7 +150,6 @@ exports[`ContextSummary render() should render up to four contexts 1`] = `
     key="user"
   />
   <GenericSummary
-    contextKey="browser"
     data={
       Object {
         "name": "Chrome",
@@ -173,7 +160,6 @@ exports[`ContextSummary render() should render up to four contexts 1`] = `
     unknownTitle="Unknown Browser"
   />
   <GenericSummary
-    contextKey="runtime"
     data={
       Object {
         "name": "Electron",
@@ -185,7 +171,6 @@ exports[`ContextSummary render() should render up to four contexts 1`] = `
     unknownTitle="Unknown Runtime"
   />
   <OsSummary
-    contextKey="os"
     data={
       Object {
         "build": "17E199",
@@ -205,7 +190,6 @@ exports[`ContextSummary render() should skip a missing user context 1`] = `
   className="context-summary"
 >
   <GenericSummary
-    contextKey="runtime"
     data={
       Object {
         "name": "Electron",
@@ -217,7 +201,6 @@ exports[`ContextSummary render() should skip a missing user context 1`] = `
     unknownTitle="Unknown Runtime"
   />
   <OsSummary
-    contextKey="os"
     data={
       Object {
         "build": "17E199",
@@ -230,7 +213,6 @@ exports[`ContextSummary render() should skip a missing user context 1`] = `
     key="os"
   />
   <DeviceSummary
-    contextKey="device"
     data={
       Object {
         "arch": "x86",
@@ -249,7 +231,6 @@ exports[`ContextSummary render() should skip non-default named contexts 1`] = `
   className="context-summary"
 >
   <UserSummary
-    contextKey="user"
     data={
       Object {
         "email": "mail@example.org",
@@ -259,7 +240,6 @@ exports[`ContextSummary render() should skip non-default named contexts 1`] = `
     key="user"
   />
   <GenericSummary
-    contextKey="runtime"
     data={
       Object {
         "name": "Electron",
@@ -271,7 +251,6 @@ exports[`ContextSummary render() should skip non-default named contexts 1`] = `
     unknownTitle="Unknown Runtime"
   />
   <OsSummary
-    contextKey="os"
     data={
       Object {
         "build": "17E199",
@@ -284,7 +263,6 @@ exports[`ContextSummary render() should skip non-default named contexts 1`] = `
     key="os"
   />
   <DeviceSummary
-    contextKey="device"
     data={
       Object {
         "arch": "x86",
@@ -355,11 +333,6 @@ exports[`OsSummary render() should render the kernel version when no version 1`]
      
     17.5.0
   </p>
-  <p>
-    <small>
-      Crashsite
-    </small>
-  </p>
 </div>
 `;
 
@@ -380,11 +353,6 @@ exports[`OsSummary render() should render the version string 1`] = `
      
     10.13.4
   </p>
-  <p>
-    <small>
-      Crashsite
-    </small>
-  </p>
 </div>
 `;
 
@@ -404,11 +372,6 @@ exports[`OsSummary render() should render unknown when no version 1`] = `
     </strong>
      
     Unknown
-  </p>
-  <p>
-    <small>
-      Crashsite
-    </small>
   </p>
 </div>
 `;

--- a/tests/js/spec/components/events/contextSummary.spec.jsx
+++ b/tests/js/spec/components/events/contextSummary.spec.jsx
@@ -26,6 +26,14 @@ const CONTEXT_OS = {
   name: 'Mac OS X',
 };
 
+const CONTEXT_OS_SERVER = {
+  kernel_version: '4.3.0',
+  version: '4.3.0',
+  type: 'os',
+  build: '123123123',
+  name: 'Linux',
+};
+
 const CONTEXT_RUNTIME = {
   version: '1.7.13',
   type: 'runtime',
@@ -96,6 +104,37 @@ describe('ContextSummary', function() {
           browser: CONTEXT_BROWSER,
           runtime: CONTEXT_RUNTIME,
           device: CONTEXT_DEVICE, // must be omitted
+        },
+      };
+
+      const wrapper = shallow(<ContextSummary event={event} />);
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should prefer client_os over os', () => {
+      const event = {
+        id: '',
+        user: CONTEXT_USER,
+        contexts: {
+          client_os: CONTEXT_OS,
+          os: CONTEXT_OS_SERVER,
+          browser: CONTEXT_BROWSER,
+          runtime: CONTEXT_RUNTIME,
+        },
+      };
+
+      const wrapper = shallow(<ContextSummary event={event} />);
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render client_os too', () => {
+      const event = {
+        id: '',
+        user: CONTEXT_USER,
+        contexts: {
+          client_os: CONTEXT_OS,
+          browser: CONTEXT_BROWSER,
+          runtime: CONTEXT_RUNTIME,
         },
       };
 


### PR DESCRIPTION
See https://github.com/getsentry/semaphore/pull/229, deploy before that one

--

Follow-up idea: Allow some `{{auto}}`-like marker to let the SDK ask the server for parsing from UA. If you're `platform != javascript` but you want UA-parsing into `contexts.os`, you could:

```
contexts: {
  os: {
    "{{auto}}": true
  }
}
```