### PR TITLE
fix(app-platform): Cannot unset permissions of sentry app

### DIFF
--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -15,7 +15,7 @@ class ApiScopesField(serializers.Field):
     def to_internal_value(self, data):
         valid_scopes = ApiScopes()
 
-        if not data:
+        if data is None:
             return
 
         for scope in data:

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -231,6 +231,29 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         )
         assert response.status_code == 200
 
+    def test_remove_scopes(self):
+        self.login_as(user=self.user)
+        app = self.create_sentry_app(
+            name="SampleApp", organization=self.org, scopes=("event:read",)
+        )
+        assert SentryApp.objects.get(id=app.id).get_scopes() == ["event:read"]
+        url = reverse("sentry-api-0-sentry-app-details", args=[app.slug])
+        # scopes is empty array which should not be treated as none
+        response = self.client.put(url, data={"scopes": ()}, format="json")
+        assert response.status_code == 200
+        assert SentryApp.objects.get(id=app.id).get_scopes() == []
+
+    def test_keep_scope_unchanged(self):
+        self.login_as(user=self.user)
+        app = self.create_sentry_app(
+            name="SampleApp", organization=self.org, scopes=("event:read",)
+        )
+        url = reverse("sentry-api-0-sentry-app-details", args=[app.slug])
+        # scopes is None here
+        response = self.client.put(url, data={}, format="json")
+        assert response.status_code == 200
+        assert SentryApp.objects.get(id=app.id).get_scopes() == ["event:read"]
+
     @patch("sentry.analytics.record")
     def test_bad_schema(self, record):
         self.login_as(user=self.user)


### PR DESCRIPTION
Need to treat `scopes=[]` differently than `scopes=None` so we can unset scopes for a sentry app if they are deselected. If the user doesn't specify `scopes` on the update, we just keep the old value.