### PR TITLE
ref(tests) Use datetime helpers in more places

### DIFF
--- a/src/sentry/testutils/helpers/datetime.py
+++ b/src/sentry/testutils/helpers/datetime.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 __all__ = ["iso_format", "before_now"]
-
-
-from django.utils import timezone
 
 
 def iso_format(date):
@@ -12,4 +9,4 @@ def iso_format(date):
 
 
 def before_now(**kwargs):
-    return timezone.now() - timedelta(**kwargs)
+    return datetime.utcnow() - timedelta(**kwargs)

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import
 
-from datetime import datetime
 from django.utils import timezone
 import pytz
-from mock import patch
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
@@ -53,9 +51,7 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
             self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
             self.browser.snapshot("incidents - details")
 
-    @patch("django.utils.timezone.now")
-    def test_open_create_incident_modal(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+    def test_open_create_incident_modal(self):
         self.store_event(
             data={
                 "event_id": "a" * 32,

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django.utils import timezone
 import pytz
+from mock import patch
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
@@ -51,7 +52,9 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
             self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
             self.browser.snapshot("incidents - details")
 
-    def test_open_create_incident_modal(self):
+    @patch("django.utils.timezone.now")
+    def test_open_create_incident_modal(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
         self.store_event(
             data={
                 "event_id": "a" * 32,

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -1,17 +1,18 @@
 from __future__ import absolute_import
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from django.utils import timezone
 import pytz
 from mock import patch
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.incidents.logic import create_incident
 from sentry.incidents.models import IncidentType
 
 FEATURE_NAME = "organizations:incidents"
 
-event_time = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
+event_time = before_now(days=3).replace(tzinfo=pytz.utc)
 
 
 class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
@@ -59,7 +60,7 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
             data={
                 "event_id": "a" * 32,
                 "message": "oh no",
-                "timestamp": event_time.isoformat()[:19],
+                "timestamp": iso_format(event_time),
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -6,7 +6,6 @@ import pytz
 from datetime import datetime, timedelta
 from django.conf import settings
 from django.utils import timezone
-from mock import patch
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.utils.samples import load_data
@@ -53,14 +52,9 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         self.browser.get(u"/organizations/{}/issues/{}/".format(self.org.slug, groupid))
         self.wait_until_loaded()
 
-    @patch("django.utils.timezone.now")
-    def test_python_event(self, mock_now):
-        # Event needs to be in the past.
-        mock_now.return_value = event_time
+    def test_python_event(self):
         event = self.create_sample_event(platform="python", time=event_time)
 
-        # Move time forward so our event is within range
-        mock_now.return_value = now
         self.visit_issue(event.group.id)
 
         # Wait for tag bars to load

--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+import pytz
+from mock import patch
+
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 
@@ -61,13 +64,16 @@ class OrganizationDiscoverTest(AcceptanceTestCase, SnubaTestCase):
             self.browser.wait_until_not(".is-disabled")
             self.browser.snapshot("discover - query builder")
 
-    def test_run_query(self):
+    @patch("django.utils.timezone.now")
+    def test_run_query(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
         with self.feature("organizations:discover"):
             self.browser.get(self.path)
             self.browser.wait_until_not(".loading")
             self.browser.find_element_by_xpath("//button//span[contains(text(), 'Run')]").click()
             self.browser.wait_until_not(".loading")
             self.browser.snapshot("discover - query results")
+            self.browser.save_screenshot("discover1.png")
 
     def test_save_query_edit(self):
         with self.feature("organizations:discover"):

--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
 
-from datetime import datetime, timedelta
+from datetime import datetime
 import pytz
 from mock import patch
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class OrganizationDiscoverTest(AcceptanceTestCase, SnubaTestCase):
@@ -16,7 +17,7 @@ class OrganizationDiscoverTest(AcceptanceTestCase, SnubaTestCase):
         self.org = self.create_organization(owner=self.user, name="foo")
 
         self.project = self.create_project(organization=self.org, name="Bengal")
-        sec_ago = (datetime.utcnow() - timedelta(seconds=1)).isoformat()[:19]
+        sec_ago = iso_format(before_now(seconds=1))
 
         self.event = self.store_event(
             data={

--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -1,9 +1,5 @@
 from __future__ import absolute_import
 
-from datetime import datetime
-import pytz
-from mock import patch
-
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 
@@ -65,9 +61,7 @@ class OrganizationDiscoverTest(AcceptanceTestCase, SnubaTestCase):
             self.browser.wait_until_not(".is-disabled")
             self.browser.snapshot("discover - query builder")
 
-    @patch("django.utils.timezone.now")
-    def test_run_query(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+    def test_run_query(self):
         with self.feature("organizations:discover"):
             self.browser.get(self.path)
             self.browser.wait_until_not(".loading")

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -7,6 +7,7 @@ from mock import patch
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.utils.samples import load_data
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 FEATURE_NAME = "organizations:events-v2"
@@ -37,7 +38,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_all_events(self, mock_now):
         mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         self.store_event(
             data={
                 "event_id": "a" * 32,
@@ -57,7 +58,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_errors(self, mock_now):
         mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         self.store_event(
             data={
                 "event_id": "a" * 32,
@@ -97,7 +98,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     @patch("django.utils.timezone.now")
     def test_modal_from_all_events(self, mock_now):
         mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
 
         event_data = load_data("python")
         event_data.update(
@@ -139,7 +140,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         event_data = load_data("javascript")
         event_data["fingerprint"] = ["group-1"]
         for id_prefix, offset in event_source:
-            event_time = (timezone.now() - timedelta(minutes=offset)).isoformat()[:19]
+            event_time = iso_format(timezone.now() - timedelta(minutes=offset))
             event_data.update(
                 {
                     "timestamp": event_time,

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+import pytz
+from mock import patch
+
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.utils.samples import load_data
 from sentry.testutils.helpers.datetime import iso_format, before_now
@@ -30,7 +33,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - all events empty state")
 
-    def test_all_events(self):
+    @patch("django.utils.timezone.now")
+    def test_all_events(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
         min_ago = iso_format(before_now(minutes=1))
         self.store_event(
             data={
@@ -48,7 +53,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - all events")
 
-    def test_errors(self):
+    @patch("django.utils.timezone.now")
+    def test_errors(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
         min_ago = iso_format(before_now(minutes=1))
         self.store_event(
             data={
@@ -86,7 +93,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - errors")
 
-    def test_modal_from_all_events(self):
+    @patch("django.utils.timezone.now")
+    def test_modal_from_all_events(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
         min_ago = iso_format(before_now(minutes=1))
 
         event_data = load_data("python")
@@ -120,7 +129,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
             self.browser.snapshot("events-v2 - single error modal")
 
-    def test_modal_from_errors_view(self):
+    @patch("django.utils.timezone.now")
+    def test_modal_from_errors_view(self, mock_now):
+        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
         event_source = (("a", 1), ("b", 39), ("c", 69))
         event_ids = []
         event_data = load_data("javascript")

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -1,10 +1,5 @@
 from __future__ import absolute_import
 
-from datetime import datetime, timedelta
-from django.utils import timezone
-import pytz
-from mock import patch
-
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.utils.samples import load_data
 from sentry.testutils.helpers.datetime import iso_format, before_now
@@ -35,9 +30,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - all events empty state")
 
-    @patch("django.utils.timezone.now")
-    def test_all_events(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+    def test_all_events(self):
         min_ago = iso_format(before_now(minutes=1))
         self.store_event(
             data={
@@ -55,9 +48,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - all events")
 
-    @patch("django.utils.timezone.now")
-    def test_errors(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+    def test_errors(self):
         min_ago = iso_format(before_now(minutes=1))
         self.store_event(
             data={
@@ -95,9 +86,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - errors")
 
-    @patch("django.utils.timezone.now")
-    def test_modal_from_all_events(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+    def test_modal_from_all_events(self):
         min_ago = iso_format(before_now(minutes=1))
 
         event_data = load_data("python")
@@ -131,16 +120,13 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
             self.browser.snapshot("events-v2 - single error modal")
 
-    @patch("django.utils.timezone.now")
-    def test_modal_from_errors_view(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
-
+    def test_modal_from_errors_view(self):
         event_source = (("a", 1), ("b", 39), ("c", 69))
         event_ids = []
         event_data = load_data("javascript")
         event_data["fingerprint"] = ["group-1"]
         for id_prefix, offset in event_source:
-            event_time = iso_format(timezone.now() - timedelta(minutes=offset))
+            event_time = iso_format(before_now(minutes=offset))
             event_data.update(
                 {
                     "timestamp": event_time,

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -2,16 +2,17 @@ from __future__ import absolute_import
 
 import pytz
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from django.utils import timezone
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from tests.acceptance.page_objects.issue_list import IssueListPage
 
 from mock import patch
 
 
-event_time = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
+event_time = before_now(days=3).replace(tzinfo=pytz.utc)
 
 
 class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
@@ -34,7 +35,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
             data={
                 "event_id": "a" * 32,
                 "message": "oh no",
-                "timestamp": event_time.isoformat()[:19],
+                "timestamp": iso_format(event_time),
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,
@@ -43,7 +44,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
             data={
                 "event_id": "b" * 32,
                 "message": "oh snap",
-                "timestamp": event_time.isoformat()[:19],
+                "timestamp": iso_format(event_time),
                 "fingerprint": ["group-2"],
             },
             project_id=self.project.id,

--- a/tests/acceptance/test_project_tags_settings.py
+++ b/tests/acceptance/test_project_tags_settings.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from mock import patch
 import pytz
 
-event_time = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
+event_time = before_now(days=3).replace(tzinfo=pytz.utc)
 
 
 class ProjectTagsSettingsTest(AcceptanceTestCase, SnubaTestCase):
@@ -29,7 +30,7 @@ class ProjectTagsSettingsTest(AcceptanceTestCase, SnubaTestCase):
                 "event_id": "a" * 32,
                 "message": "oh no",
                 "level": "error",
-                "timestamp": event_time.isoformat()[:19],
+                "timestamp": iso_format(event_time),
             },
             project_id=self.project.id,
             assert_no_errors=False,

--- a/tests/acceptance/test_project_tags_settings.py
+++ b/tests/acceptance/test_project_tags_settings.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
-from mock import patch
 import pytz
 
 event_time = before_now(days=3).replace(tzinfo=pytz.utc)
@@ -21,10 +19,7 @@ class ProjectTagsSettingsTest(AcceptanceTestCase, SnubaTestCase):
         self.login_as(self.user)
         self.path = u"/settings/{}/projects/{}/tags/".format(self.org.slug, self.project.slug)
 
-    @patch("django.utils.timezone.now")
-    def test_tags_list(self, mock_now):
-        mock_now.return_value = event_time + timedelta(days=2)
-
+    def test_tags_list(self):
         self.store_event(
             data={
                 "event_id": "a" * 32,

--- a/tests/acceptance/test_shared_issue.py
+++ b/tests/acceptance/test_shared_issue.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
-from datetime import datetime, timedelta
-
 from sentry.testutils import AcceptanceTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.models import GroupShare
 from sentry.utils.samples import load_data
 
@@ -18,7 +17,7 @@ class SharedIssueTest(AcceptanceTestCase):
 
     def test_python_event(self):
         data = load_data(platform="python")
-        data["timestamp"] = (datetime.now() - timedelta(days=1)).isoformat()[:19]
+        data["timestamp"] = iso_format(before_now(days=1))
         event = self.store_event(data=data, project_id=self.project.id)
 
         GroupShare.objects.create(project_id=event.group.project_id, group=event.group)

--- a/tests/sentry/api/endpoints/test_event_attachments.py
+++ b/tests/sentry/api/endpoints/test_event_attachments.py
@@ -2,18 +2,16 @@ from __future__ import absolute_import
 
 import six
 
-from datetime import timedelta
-from django.utils import timezone
-
 from sentry.models import EventAttachment, File
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class EventAttachmentsTest(APITestCase):
     def test_simple(self):
         self.login_as(user=self.user)
 
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         event1 = self.store_event(
             data={"fingerprint": ["group1"], "timestamp": min_ago}, project_id=self.project.id
         )

--- a/tests/sentry/api/endpoints/test_event_committers.py
+++ b/tests/sentry/api/endpoints/test_event_committers.py
@@ -2,12 +2,11 @@ from __future__ import absolute_import
 
 import copy
 
-from datetime import timedelta
-from django.utils import timezone
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 # TODO(dcramer): These tests rely too much on implicit fixtures
 
@@ -19,7 +18,7 @@ class EventCommittersTest(APITestCase):
         project = self.create_project()
 
         release = self.create_release(project, self.user)
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         event = self.store_event(
             data={
                 "fingerprint": ["group1"],
@@ -59,7 +58,7 @@ class EventCommittersTest(APITestCase):
 
         project = self.create_project()
 
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         event = self.store_event(
             data={"fingerprint": ["group1"], "timestamp": min_ago}, project_id=project.id
         )
@@ -84,7 +83,7 @@ class EventCommittersTest(APITestCase):
 
         release = self.create_release(project, self.user)
 
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         event = self.store_event(
             data={
                 "fingerprint": ["group1"],

--- a/tests/sentry/api/endpoints/test_group_events_latest.py
+++ b/tests/sentry/api/endpoints/test_group_events_latest.py
@@ -2,11 +2,9 @@ from __future__ import absolute_import
 
 import six
 
-from datetime import timedelta
-from django.utils import timezone
-
 from sentry.models import Group
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class GroupEventsLatestTest(APITestCase):
@@ -15,8 +13,8 @@ class GroupEventsLatestTest(APITestCase):
         self.login_as(user=self.user)
 
         project = self.create_project()
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
+        two_min_ago = iso_format(before_now(minutes=2))
 
         self.event1 = self.store_event(
             data={"environment": "staging", "fingerprint": ["group_1"], "timestamp": two_min_ago},

--- a/tests/sentry/api/endpoints/test_group_events_oldest.py
+++ b/tests/sentry/api/endpoints/test_group_events_oldest.py
@@ -2,11 +2,9 @@ from __future__ import absolute_import
 
 import six
 
-from datetime import timedelta
-from django.utils import timezone
-
 from sentry.models import Group
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class GroupEventsOldestTest(APITestCase):
@@ -15,8 +13,8 @@ class GroupEventsOldestTest(APITestCase):
         self.login_as(user=self.user)
 
         project = self.create_project()
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
+        two_min_ago = iso_format(before_now(minutes=2))
 
         self.event1 = self.store_event(
             data={"environment": "staging", "fingerprint": ["group_1"], "timestamp": two_min_ago},

--- a/tests/sentry/api/endpoints/test_group_hashes.py
+++ b/tests/sentry/api/endpoints/test_group_hashes.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import
 
 import copy
-from datetime import timedelta
-from django.utils import timezone
 
 from six.moves.urllib.parse import urlencode
 
 from sentry.models import GroupHash
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.eventstream.snuba import SnubaEventStream
 
 
@@ -16,9 +15,8 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
     def test_only_return_latest_event(self):
         self.login_as(user=self.user)
 
-        # remove microseconds and timezone from iso format cause that's what store_event expects
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
+        two_min_ago = iso_format(before_now(minutes=2))
         new_event_id = "b" * 32
 
         old_event = self.store_event(
@@ -55,9 +53,8 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
     def test_return_multiple_hashes(self):
         self.login_as(user=self.user)
 
-        # remove microseconds and timezone from iso format cause that's what store_event expects
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
+        two_min_ago = iso_format(before_now(minutes=2))
 
         event1 = self.store_event(
             data={

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 import six
 import mock
-from datetime import timedelta
-from django.utils import timezone
 import copy
 
 from sentry.integrations.example.integration import ExampleIntegration
@@ -12,16 +10,17 @@ from sentry.models import Activity, ExternalIssue, GroupLink, Integration
 from sentry.testutils import APITestCase
 from sentry.utils.http import absolute_uri
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class GroupIntegrationDetailsTest(APITestCase):
     def setUp(self):
         super(GroupIntegrationDetailsTest, self).setUp()
-        self.min_ago = timezone.now() - timedelta(minutes=1)
+        self.min_ago = before_now(minutes=1)
         self.event = self.store_event(
             data={
                 "event_id": "a" * 32,
-                "timestamp": self.min_ago.isoformat()[:19],
+                "timestamp": iso_format(self.min_ago),
                 "message": "message",
                 "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
             },
@@ -348,7 +347,7 @@ class GroupIntegrationDetailsTest(APITestCase):
         self.login_as(user=self.user)
         org = self.organization
         event = self.store_event(
-            data={"event_id": "a" * 32, "timestamp": self.min_ago.isoformat()[:19]},
+            data={"event_id": "a" * 32, "timestamp": iso_format(self.min_ago)},
             project_id=self.project.id,
         )
         group = event.group

--- a/tests/sentry/api/endpoints/test_project_event_details.py
+++ b/tests/sentry/api/endpoints/test_project_event_details.py
@@ -2,10 +2,9 @@ from __future__ import absolute_import
 
 import six
 
-from datetime import timedelta
-from django.utils import timezone
 from django.core.urlresolvers import reverse
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class ProjectEventDetailsTest(APITestCase):
@@ -14,9 +13,9 @@ class ProjectEventDetailsTest(APITestCase):
         self.login_as(user=self.user)
         project = self.create_project()
 
-        one_min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
-        three_min_ago = (timezone.now() - timedelta(minutes=3)).isoformat()[:19]
+        one_min_ago = iso_format(before_now(minutes=1))
+        two_min_ago = iso_format(before_now(minutes=2))
+        three_min_ago = iso_format(before_now(minutes=3))
 
         self.prev_event = self.store_event(
             data={"timestamp": three_min_ago, "fingerprint": ["group-1"]}, project_id=project.id

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -1,18 +1,18 @@
 from __future__ import absolute_import
-
 import six
 from datetime import timedelta
 from django.utils import timezone
 from uuid import uuid4
 
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.models import EventUser, GroupStatus, UserReport
 
 
 class ProjectUserReportListTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(ProjectUserReportListTest, self).setUp()
-        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        self.min_ago = iso_format(before_now(minutes=1))
         self.environment = self.create_environment(project=self.project, name="production")
         self.event = self.store_event(
             data={
@@ -164,8 +164,8 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(CreateProjectUserReportTest, self).setUp()
-        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        self.hour_ago = (timezone.now() - timedelta(minutes=60)).isoformat()[:19]
+        self.min_ago = iso_format(before_now(minutes=1))
+        self.hour_ago = iso_format(before_now(minutes=60))
 
         self.project = self.create_project()
         self.environment = self.create_environment(project=self.project)

--- a/tests/sentry/api/endpoints/test_shared_group_details.py
+++ b/tests/sentry/api/endpoints/test_shared_group_details.py
@@ -1,10 +1,9 @@
 from __future__ import absolute_import, print_function
 
 import six
-from datetime import timedelta
-from django.utils import timezone
 
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.models import GroupShare
 
 
@@ -12,7 +11,7 @@ class SharedGroupDetailsTest(APITestCase):
     def test_simple(self):
         self.login_as(user=self.user)
 
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         event = self.store_event(data={"timestamp": min_ago}, project_id=self.project.id)
         group = event.group
 

--- a/tests/sentry/api/serializers/test_incident_activity.py
+++ b/tests/sentry/api/serializers/test_incident_activity.py
@@ -13,6 +13,7 @@ from sentry.api.serializers import serialize
 from sentry.incidents.models import IncidentActivityType
 from sentry.incidents.logic import create_incident_activity, create_initial_event_stats_snapshot
 from sentry.testutils import SnubaTestCase, TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class IncidentActivitySerializerTest(TestCase, SnubaTestCase):
@@ -59,7 +60,7 @@ class IncidentActivitySerializerTest(TestCase, SnubaTestCase):
                 data={
                     "event_id": uuid4().hex,
                     "fingerprint": ["group1"],
-                    "timestamp": (timezone.now() - timedelta(seconds=1)).isoformat()[:19],
+                    "timestamp": iso_format(before_now(seconds=1)),
                 },
                 project_id=self.project.id,
             )

--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -1,18 +1,17 @@
 from __future__ import absolute_import
 
 import six
-from datetime import timedelta
-from django.utils import timezone
 
 from sentry.testutils import TestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.eventstore.snuba.backend import SnubaEventStorage
 
 
 class SnubaEventStorageTest(TestCase, SnubaTestCase):
     def setUp(self):
         super(SnubaEventStorageTest, self).setUp()
-        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        self.two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
+        self.min_ago = iso_format(before_now(minutes=1))
+        self.two_min_ago = iso_format(before_now(minutes=2))
         self.project1 = self.create_project()
         self.project2 = self.create_project()
 

--- a/tests/sentry/eventstore/test_base.py
+++ b/tests/sentry/eventstore/test_base.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
-from django.utils import timezone
-
 from sentry import eventstore
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.eventstore.base import EventStorage
 
 
@@ -22,7 +20,7 @@ class EventStorageTest(TestCase):
         """
         Test that bind_nodes populates _node_data
         """
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         self.store_event(
             data={"event_id": "a" * 32, "timestamp": min_ago, "user": {"id": u"user1"}},
             project_id=self.project.id,

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -62,6 +62,7 @@ from sentry.incidents.models import (
 from sentry.models.commit import Commit
 from sentry.models.repository import Repository
 from sentry.testutils import TestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class CreateIncidentTest(TestCase):
@@ -213,7 +214,7 @@ class BaseIncidentsTest(SnubaTestCase):
         data = {
             "event_id": event_id,
             "fingerprint": [fingerprint],
-            "timestamp": timestamp.isoformat()[:19],
+            "timestamp": iso_format(timestamp),
         }
         if user:
             data["user"] = user
@@ -583,7 +584,7 @@ class GetIncidentSuspectCommitsTest(TestCase, BaseIncidentsTest):
         included_commits = set([letter * 40 for letter in ("a", "b", "c", "d")])
         commit_iter = iter(included_commits)
 
-        one_min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        one_min_ago = iso_format(before_now(minutes=1))
         event = self.store_event(
             data={
                 "fingerprint": ["group-1"],

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -1,10 +1,7 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
-
 import six
 from django.core.urlresolvers import reverse
-from django.utils import timezone
 from exam import patcher
 from freezegun import freeze_time
 
@@ -23,6 +20,7 @@ from sentry.incidents.tasks import (
 )
 from sentry.models import Commit, Repository
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.utils.linksign import generate_signed_link
 from sentry.utils.http import absolute_uri
 
@@ -146,7 +144,7 @@ class CalculateIncidentSuspectsTest(TestCase):
         release = self.create_release(project=self.project, version="v12")
         event = self.store_event(
             data={
-                "timestamp": (timezone.now() - timedelta(minutes=1)).isoformat()[:19],
+                "timestamp": iso_format(before_now(minutes=1)),
                 "fingerprint": ["group-1"],
                 "message": "Kaboom!",
                 "platform": "python",

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -1,14 +1,12 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
 import copy
-
-from django.utils import timezone
 
 from sentry.integrations.bitbucket.issues import ISSUE_TYPES, PRIORITIES
 from sentry.models import ExternalIssue, Integration
 from sentry.testutils import APITestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 import json
 import responses
@@ -30,7 +28,7 @@ class BitbucketIssueTest(APITestCase):
                 "subject": self.subject,
             },
         )
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         event = self.store_event(
             data={
                 "event_id": "a" * 32,

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -2,16 +2,15 @@ from __future__ import absolute_import
 
 import responses
 import six
-from datetime import timedelta
 
 from mock import patch
 from exam import fixture
 from django.test import RequestFactory
-from django.utils import timezone
 
 from sentry.integrations.github.integration import GitHubIntegration
 from sentry.models import Integration, ExternalIssue
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.utils import json
 
 
@@ -28,7 +27,7 @@ class GitHubIssueBasicTest(TestCase):
         )
         self.model.add_organization(self.organization, self.user)
         self.integration = GitHubIntegration(self.model, self.organization.id)
-        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        self.min_ago = iso_format(before_now(minutes=1))
 
     @responses.activate
     @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -2,22 +2,20 @@ from __future__ import absolute_import
 
 import responses
 import six
-from datetime import timedelta
 import copy
-
-from django.utils import timezone
 
 from sentry.integrations.exceptions import IntegrationError
 from sentry.models import ExternalIssue
 from sentry.utils.http import absolute_uri
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from .testutils import GitLabTestCase
 
 
 class GitlabIssuesTest(GitLabTestCase):
     def setUp(self):
         super(GitlabIssuesTest, self).setUp()
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         event = self.store_event(
             data={
                 "event_id": "a" * 32,

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -6,10 +6,8 @@ import responses
 import six
 import pytest
 import copy
-from datetime import timedelta
 
 from django.core.urlresolvers import reverse
-from django.utils import timezone
 from exam import fixture
 from mock import Mock
 
@@ -23,6 +21,7 @@ from sentry.models import (
 from sentry.testutils import APITestCase
 from sentry.utils.http import absolute_uri
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 SAMPLE_CREATE_META_RESPONSE = """
@@ -441,7 +440,7 @@ class JiraIntegrationTest(APITestCase):
 
     def setUp(self):
         super(JiraIntegrationTest, self).setUp()
-        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        self.min_ago = iso_format(before_now(minutes=1))
 
     def test_get_create_issue_config(self):
         org = self.organization

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -7,8 +7,6 @@ import six
 from exam import fixture
 from django.test import RequestFactory
 from time import time
-from datetime import timedelta
-from django.utils import timezone
 
 from sentry.integrations.exceptions import IntegrationError
 from sentry.integrations.vsts.integration import VstsIntegration
@@ -21,6 +19,7 @@ from sentry.models import (
     IntegrationExternalProject,
 )
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.utils import json
 
 from .testutils import (
@@ -363,7 +362,7 @@ class VstsIssueFormTest(VstsIssueBase):
                 ]
             },
         )
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         event = self.store_event(
             data={"fingerprint": ["group1"], "timestamp": min_ago}, project_id=self.project.id
         )

--- a/tests/sentry/lang/javascript/test_example.py
+++ b/tests/sentry/lang/javascript/test_example.py
@@ -5,11 +5,10 @@ from __future__ import absolute_import
 import os
 import json
 import responses
-from datetime import timedelta
-from django.utils import timezone
 
 from sentry import eventstore
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 def get_fixture_path(name):
@@ -44,7 +43,7 @@ class ExampleTestCase(TestCase):
         )
         responses.add(responses.GET, "http://example.com/index.html", body="Not Found", status=404)
 
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
 
         data = {
             "timestamp": min_ago,

--- a/tests/sentry/lang/javascript/test_plugin.py
+++ b/tests/sentry/lang/javascript/test_plugin.py
@@ -6,14 +6,13 @@ import pytest
 import os.path
 import responses
 from mock import patch
-from datetime import timedelta
 
 from django.conf import settings
-from django.utils import timezone
 
 from sentry import eventstore
 from sentry.models import File, Release, ReleaseFile
 from sentry.testutils import TestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 BASE64_SOURCEMAP = "data:application/json;base64," + (
@@ -37,7 +36,7 @@ def load_fixture(name):
 class JavascriptIntegrationTest(TestCase, SnubaTestCase):
     def setUp(self):
         super(JavascriptIntegrationTest, self).setUp()
-        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        self.min_ago = iso_format(before_now(minutes=1))
 
     def get_event(self):
         return eventstore.get_events(filter_keys={"project_id": [self.project.id]})[0]

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -16,14 +16,15 @@ from sentry.models import (
     get_group_with_redirect,
 )
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class GroupTest(TestCase):
     def setUp(self):
         super(GroupTest, self).setUp()
-        self.min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        self.two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
-        self.just_over_one_min_ago = (timezone.now() - timedelta(seconds=61)).isoformat()[:19]
+        self.min_ago = iso_format(before_now(minutes=1))
+        self.two_min_ago = iso_format(before_now(minutes=2))
+        self.just_over_one_min_ago = iso_format(before_now(seconds=61))
 
     def test_is_resolved(self):
         group = self.create_group(status=GroupStatus.RESOLVED)

--- a/tests/sentry/plugins/bases/test_issue2.py
+++ b/tests/sentry/plugins/bases/test_issue2.py
@@ -4,14 +4,13 @@ from __future__ import absolute_import
 
 import json
 import mock
-from datetime import timedelta
 
-from django.utils import timezone
 from social_auth.models import UserSocialAuth
 
 from sentry.models import GroupMeta, User
 from sentry.plugins import IssueTrackingPlugin2, plugins
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class TestPluginWithFields(IssueTrackingPlugin2):
@@ -83,7 +82,7 @@ class IssuePlugin2GroupActionTest(TestCase):
         super(IssuePlugin2GroupActionTest, self).setUp()
         self.project = self.create_project()
         self.plugin_instance = plugins.get(slug="issuetrackingplugin2")
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         self.event = self.store_event(
             data={"timestamp": min_ago, "fingerprint": ["group-1"]}, project_id=self.project.id
         )

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -11,6 +11,7 @@ from sentry.models import Group, GroupSnooze, GroupStatus, ProjectOwnership
 from sentry.ownership.grammar import Rule, Matcher, Owner, dump_schema
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.datetime import iso_format
 from sentry.tasks.merge import merge_groups
 from sentry.tasks.post_process import index_event_tags, post_process_group
 
@@ -374,7 +375,7 @@ class PostProcessGroupTest(TestCase):
                 "message": "Foo bar",
                 "exception": {"type": "Foo", "value": "shits on fiah yo"},
                 "level": "error",
-                "timestamp": timezone.now().isoformat()[:19],
+                "timestamp": iso_format(timezone.now()),
             },
             project_id=self.project.id,
             assert_no_errors=False,
@@ -404,11 +405,7 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.tasks.sentry_apps.process_resource_change_bound.delay")
     def test_processes_resource_change_task_not_called_for_non_errors(self, delay):
         event = self.store_event(
-            data={
-                "message": "Foo bar",
-                "level": "info",
-                "timestamp": timezone.now().isoformat()[:19],
-            },
+            data={"message": "Foo bar", "level": "info", "timestamp": iso_format(timezone.now())},
             project_id=self.project.id,
             assert_no_errors=False,
         )
@@ -426,11 +423,7 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.tasks.sentry_apps.process_resource_change_bound.delay")
     def test_processes_resource_change_task_not_called_without_feature_flag(self, delay):
         event = self.store_event(
-            data={
-                "message": "Foo bar",
-                "level": "info",
-                "timestamp": timezone.now().isoformat()[:19],
-            },
+            data={"message": "Foo bar", "level": "info", "timestamp": iso_format(timezone.now())},
             project_id=self.project.id,
             assert_no_errors=False,
         )
@@ -453,7 +446,7 @@ class PostProcessGroupTest(TestCase):
                 "message": "Foo bar",
                 "level": "error",
                 "exception": {"type": "Foo", "value": "shits on fiah yo"},
-                "timestamp": timezone.now().isoformat()[:19],
+                "timestamp": iso_format(timezone.now()),
             },
             project_id=self.project.id,
             assert_no_errors=False,

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -37,7 +37,7 @@ from sentry.tasks.reports import (
 from sentry.testutils.cases import TestCase, SnubaTestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.utils.dates import to_datetime, to_timestamp, floor_to_utc_day
-from sentry.testutils.helpers.datetime import iso_format, before_now
+from sentry.testutils.helpers.datetime import iso_format
 
 from six.moves import xrange
 
@@ -269,8 +269,8 @@ class ReportTestCase(TestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         now = timezone.now()
-        min_ago = iso_format(before_now(minutes=1))
-        two_min_ago = before_now(minutes=2)
+        min_ago = iso_format(now - timedelta(minutes=1))
+        two_min_ago = now - timedelta(minutes=2)
 
         self.store_event(
             data={
@@ -301,9 +301,9 @@ class ReportTestCase(TestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         now = timezone.now()
-        two_days_ago = before_now(days=2)
-        three_days_ago = iso_format(before_now(days=3))
-        seven_days_back = before_now(days=7)
+        two_days_ago = now - timedelta(days=2)
+        three_days_ago = iso_format(now - timedelta(days=3))
+        seven_days_back = now - timedelta(days=7)
 
         event1 = self.store_event(
             data={

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -37,6 +37,7 @@ from sentry.tasks.reports import (
 from sentry.testutils.cases import TestCase, SnubaTestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.utils.dates import to_datetime, to_timestamp, floor_to_utc_day
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 from six.moves import xrange
 
@@ -268,8 +269,8 @@ class ReportTestCase(TestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         now = timezone.now()
-        min_ago = (now - timedelta(minutes=1)).isoformat()[:19]
-        two_min_ago = now - timedelta(minutes=2)
+        min_ago = iso_format(before_now(minutes=1))
+        two_min_ago = before_now(minutes=2)
 
         self.store_event(
             data={
@@ -300,9 +301,9 @@ class ReportTestCase(TestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         now = timezone.now()
-        two_days_ago = now - timedelta(days=2)
-        three_days_ago = (now - timedelta(days=3)).isoformat()[:19]
-        seven_days_back = now - timedelta(days=7)
+        two_days_ago = before_now(days=2)
+        three_days_ago = iso_format(before_now(days=3))
+        seven_days_back = before_now(days=7)
 
         event1 = self.store_event(
             data={

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -4,15 +4,14 @@ import six
 
 from celery import Task
 from collections import namedtuple
-from datetime import timedelta
 from django.core.urlresolvers import reverse
-from django.utils import timezone
 from mock import patch
 
 from sentry.models import Rule, SentryApp, SentryAppInstallation
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.faux import faux
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.utils.http import absolute_uri
 from sentry.receivers.sentry_apps import *  # NOQA
 from sentry.utils import json
@@ -214,7 +213,7 @@ class TestProcessResourceChange(TestCase):
             organization=self.project.organization, slug=sentry_app.slug
         )
 
-        one_min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        one_min_ago = iso_format(before_now(minutes=1))
         event = self.store_event(
             data={
                 "message": "Foo bar",

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -4,11 +4,10 @@ from django.core.urlresolvers import reverse
 from six.moves.urllib.parse import quote
 from uuid import uuid4
 import logging
-from datetime import timedelta
-from django.utils import timezone
 
 from sentry.models import Environment, UserReport
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class ErrorPageEmbedTest(TestCase):
@@ -163,7 +162,7 @@ class ErrorPageEmbedEnvironmentTest(TestCase):
         self.environment.add_project(self.project)
 
     def make_event(self, **kwargs):
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         result = {
             "event_id": "a" * 32,
             "message": "foo",

--- a/tests/sentry/web/frontend/test_group_event_json.py
+++ b/tests/sentry/web/frontend/test_group_event_json.py
@@ -2,11 +2,10 @@ from __future__ import absolute_import
 
 import json
 
-from datetime import timedelta
-from django.utils import timezone
 from exam import fixture
 
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class GroupEventJsonTest(TestCase):
@@ -18,7 +17,7 @@ class GroupEventJsonTest(TestCase):
 
     def test_does_render(self):
         self.login_as(self.user)
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         self.event = self.store_event(
             data={"fingerprint": ["group1"], "timestamp": min_ago}, project_id=self.project.id
         )

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
 from django.core.urlresolvers import reverse
-from django.utils import timezone
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry import options
 
 
@@ -16,7 +15,7 @@ class ProjectEventTest(TestCase):
         self.team = self.create_team(organization=self.org, name="Mariachi Band")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.project = self.create_project(organization=self.org, teams=[self.team])
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         self.event = self.store_event(
             data={"fingerprint": ["group1"], "timestamp": min_ago}, project_id=self.project.id
         )
@@ -45,7 +44,7 @@ class ProjectEventTest(TestCase):
         assert resp.status_code == 404
 
     def test_event_not_found__event_no_group(self):
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
         event = self.store_event(
             data={
                 "type": "transaction",

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -7,12 +7,13 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class GroupEventsTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(GroupEventsTest, self).setUp()
-        self.min_ago = timezone.now() - timedelta(minutes=1)
+        self.min_ago = before_now(minutes=1)
 
     def test_simple(self):
         self.login_as(user=self.user)
@@ -146,7 +147,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             events[name] = self.store_event(
                 data={
                     "fingerprint": ["put-me-in-group1"],
-                    "timestamp": self.min_ago.isoformat()[:19],
+                    "timestamp": iso_format(self.min_ago),
                     "environment": name,
                 },
                 project_id=self.project.id,
@@ -268,7 +269,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_1"],
                 "event_id": "a" * 32,
                 "message": "foo",
-                "timestamp": self.min_ago.isoformat()[:19],
+                "timestamp": iso_format(self.min_ago),
             },
             project_id=self.project.id,
         )
@@ -277,7 +278,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_2"],
                 "event_id": "b" * 32,
                 "message": "group2",
-                "timestamp": self.min_ago.isoformat()[:19],
+                "timestamp": iso_format(self.min_ago),
             },
             project_id=self.project.id,
         )

--- a/tests/snuba/api/endpoints/test_group_events_latest.py
+++ b/tests/snuba/api/endpoints/test_group_events_latest.py
@@ -2,11 +2,9 @@ from __future__ import absolute_import
 
 import six
 
-from datetime import timedelta
-from django.utils import timezone
-
 from sentry.models import Group
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class GroupEventsLatestTest(APITestCase, SnubaTestCase):
@@ -15,8 +13,8 @@ class GroupEventsLatestTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         project = self.create_project()
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
+        two_min_ago = iso_format(before_now(minutes=2))
 
         self.event1 = self.store_event(
             data={

--- a/tests/snuba/api/endpoints/test_group_events_oldest.py
+++ b/tests/snuba/api/endpoints/test_group_events_oldest.py
@@ -2,11 +2,9 @@ from __future__ import absolute_import
 
 import six
 
-from datetime import timedelta
-from django.utils import timezone
-
 from sentry.models import Group
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class GroupEventsOldestTest(APITestCase, SnubaTestCase):
@@ -15,8 +13,8 @@ class GroupEventsOldestTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         project = self.create_project()
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
-        two_min_ago = (timezone.now() - timedelta(minutes=2)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
+        two_min_ago = iso_format(before_now(minutes=2))
 
         self.event1 = self.store_event(
             data={
@@ -27,7 +25,6 @@ class GroupEventsOldestTest(APITestCase, SnubaTestCase):
             },
             project_id=project.id,
         )
-
         self.event2 = self.store_event(
             data={
                 "event_id": "b" * 32,

--- a/tests/snuba/api/endpoints/test_group_tags.py
+++ b/tests/snuba/api/endpoints/test_group_tags.py
@@ -1,20 +1,18 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
-from django.utils import timezone
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class GroupTagsTest(APITestCase, SnubaTestCase):
     def test_multi_env(self):
-        now = timezone.now()
-        min_ago = now - timedelta(minutes=1)
+        min_ago = before_now(minutes=1)
         env = self.create_environment(project=self.project, name="prod")
         env2 = self.create_environment(project=self.project, name="staging")
         self.store_event(
             data={
                 "fingerprint": ["put-me-in-group1"],
-                "timestamp": min_ago.isoformat()[:19],
+                "timestamp": iso_format(min_ago),
                 "environment": env.name,
                 "tags": {"foo": "bar"},
             },
@@ -23,7 +21,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
         event2 = self.store_event(
             data={
                 "fingerprint": ["put-me-in-group1"],
-                "timestamp": min_ago.isoformat()[:19],
+                "timestamp": iso_format(min_ago),
                 "environment": env2.name,
                 "tags": {"biz": "baz"},
             },

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -29,14 +29,15 @@ from sentry.models import (
     UserOptionValue,
 )
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super(GroupSerializerSnubaTest, self).setUp()
-        self.min_ago = timezone.now() - timedelta(minutes=1)
-        self.day_ago = timezone.now() - timedelta(days=1)
-        self.week_ago = timezone.now() - timedelta(days=7)
+        self.min_ago = before_now(minutes=1)
+        self.day_ago = before_now(days=1)
+        self.week_ago = before_now(days=7)
 
     def test_permalink(self):
         group = self.create_group(title="Oh no")
@@ -282,9 +283,9 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         events = []
 
         for event_id, env, user_id, timestamp in [
-            ("a" * 32, environment, 1, self.min_ago.isoformat()[:19]),
-            ("b" * 32, environment, 2, self.min_ago.isoformat()[:19]),
-            ("c" * 32, environment2, 3, self.week_ago.isoformat()[:19]),
+            ("a" * 32, environment, 1, iso_format(self.min_ago)),
+            ("b" * 32, environment, 2, iso_format(self.min_ago)),
+            ("c" * 32, environment2, 3, iso_format(self.week_ago)),
         ]:
             events.append(
                 self.store_event(

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -327,9 +327,9 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         )
         assert result["count"] == "3"
         # result is rounded down to nearest second
-        assert result["lastSeen"] == self.min_ago - timedelta(microseconds=self.min_ago.microsecond)
-        assert result["firstSeen"] == group_env.first_seen
-        assert group_env2.first_seen > group_env.first_seen
+        assert iso_format(result["lastSeen"]) == iso_format(self.min_ago)
+        assert iso_format(result["firstSeen"]) == iso_format(group_env.first_seen)
+        assert iso_format(group_env2.first_seen) > iso_format(group_env.first_seen)
         assert result["userCount"] == 3
 
         # test userCount, count, lastSeen filtering correctly by time
@@ -343,10 +343,8 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
             ),
         )
         assert result["userCount"] == 1
-        assert result["lastSeen"] == self.week_ago - timedelta(
-            microseconds=self.week_ago.microsecond
-        )
-        assert result["firstSeen"] == group_env.first_seen
+        assert iso_format(result["lastSeen"]) == iso_format(self.week_ago)
+        assert iso_format(result["firstSeen"]) == iso_format(group_env.first_seen)
         assert result["count"] == "1"
 
 

--- a/tests/snuba/models/test_group.py
+++ b/tests/snuba/models/test_group.py
@@ -1,16 +1,15 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
-from django.utils import timezone
 from sentry.models import Group
 from sentry.testutils import SnubaTestCase, TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class GroupTestSnuba(TestCase, SnubaTestCase):
     def test_get_oldest_latest_for_environments(self):
         project = self.create_project()
 
-        min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        min_ago = iso_format(before_now(minutes=1))
 
         self.store_event(
             data={

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -21,6 +21,7 @@ from sentry.models import (
 )
 from sentry.search.snuba.backend import SnubaSearchBackend
 from sentry.testutils import SnubaTestCase, TestCase, xfail_if_not_postgres
+from sentry.testutils.helpers.datetime import iso_format
 from sentry.utils.snuba import SENTRY_SNUBA_MAP, SnubaError
 
 
@@ -34,7 +35,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         self.backend = SnubaSearchBackend()
         self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
 
-        event1_timestamp = (self.base_datetime - timedelta(days=21)).isoformat()[:19]
+        event1_timestamp = iso_format(self.base_datetime - timedelta(days=21))
         self.event1 = self.store_event(
             data={
                 "fingerprint": ["put-me-in-group1"],
@@ -54,7 +55,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
                 "message": "group1",
                 "environment": "production",
                 "tags": {"server": "example.com"},
-                "timestamp": self.base_datetime.isoformat()[:19],
+                "timestamp": iso_format(self.base_datetime),
                 "stacktrace": {"frames": [{"module": "group1"}]},
             },
             project_id=self.project.id,
@@ -75,7 +76,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             data={
                 "fingerprint": ["put-me-in-group2"],
                 "event_id": "b" * 32,
-                "timestamp": (self.base_datetime - timedelta(days=20)).isoformat()[:19],
+                "timestamp": iso_format(self.base_datetime - timedelta(days=20)),
                 "message": "bar",
                 "stacktrace": {"frames": [{"module": "group2"}]},
                 "environment": "staging",
@@ -126,7 +127,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             data={
                 "event_id": "a" * 32,
                 "fingerprint": ["put-me-in-groupP2"],
-                "timestamp": (self.base_datetime - timedelta(days=21)).isoformat()[:19],
+                "timestamp": iso_format(self.base_datetime - timedelta(days=21)),
                 "message": "foo",
                 "stacktrace": {"frames": [{"module": "group_p2"}]},
                 "tags": {"server": "example.com"},
@@ -265,7 +266,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             self.store_event(
                 data={
                     "fingerprint": ["put-me-in-group2"],
-                    "timestamp": dt.isoformat()[:19],
+                    "timestamp": iso_format(dt),
                     "stacktrace": {"frames": [{"module": "group2"}]},
                     "environment": "production",
                     "message": "group2",
@@ -387,7 +388,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         self.store_event(
             data={
                 "fingerprint": ["put-me-in-group2"],
-                "timestamp": (self.group2.first_seen + timedelta(days=1)).isoformat()[:19],
+                "timestamp": iso_format(self.group2.first_seen + timedelta(days=1)),
                 "stacktrace": {"frames": [{"module": "group2"}]},
                 "message": "group2",
                 "tags": {"priority": priority},
@@ -405,7 +406,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             self.store_event(
                 data={
                     "fingerprint": ["put-me-in-group1"],
-                    "timestamp": (self.group2.last_seen + timedelta(days=i)).isoformat()[:19],
+                    "timestamp": iso_format(self.group2.last_seen + timedelta(days=i)),
                     "stacktrace": {"frames": [{"module": "group1"}]},
                     "message": "group1",
                     "tags": {"priority": priority},
@@ -415,7 +416,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         self.store_event(
             data={
                 "fingerprint": ["put-me-in-group2"],
-                "timestamp": (self.group2.last_seen + timedelta(days=2)).isoformat()[:19],
+                "timestamp": iso_format(self.group2.last_seen + timedelta(days=2)),
                 "stacktrace": {"frames": [{"module": "group2"}]},
                 "message": "group2",
                 "tags": {"priority": priority},
@@ -493,7 +494,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             self.store_event(
                 data={
                     "fingerprint": ["put-me-in-group2"],
-                    "timestamp": dt.isoformat()[:19],
+                    "timestamp": iso_format(dt),
                     "environment": "production",
                     "message": "group2",
                     "stacktrace": {"frames": [{"module": "group2"}]},
@@ -601,7 +602,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         self.store_event(
             data={
                 "fingerprint": ["put-me-in-group1"],
-                "timestamp": (group1_first_seen + timedelta(days=1)).isoformat()[:19],
+                "timestamp": iso_format(group1_first_seen + timedelta(days=1)),
                 "message": "group1",
                 "stacktrace": {"frames": [{"module": "group1"}]},
                 "environment": "development",
@@ -668,7 +669,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
         self.store_event(
             data={
                 "fingerprint": ["put-me-in-group1"],
-                "timestamp": (self.group1.last_seen + timedelta(days=1)).isoformat()[:19],
+                "timestamp": iso_format(self.group1.last_seen + timedelta(days=1)),
                 "message": "group1",
                 "stacktrace": {"frames": [{"module": "group1"}]},
                 "environment": "development",
@@ -980,7 +981,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
                 data={
                     "event_id": md5("event {}".format(i)).hexdigest(),
                     "fingerprint": ["put-me-in-group{}".format(i)],
-                    "timestamp": (self.base_datetime - timedelta(days=21)).isoformat()[:19],
+                    "timestamp": iso_format(self.base_datetime - timedelta(days=21)),
                     "message": "group {} event".format(i),
                     "stacktrace": {"frames": [{"module": "module {}".format(i)}]},
                     "tags": {"match": "{}".format(i % 2)},
@@ -1230,7 +1231,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
                 "message": "somet[hing]",
                 "environment": "production",
                 "tags": {"server": "example.net"},
-                "timestamp": self.base_datetime.isoformat()[:19],
+                "timestamp": iso_format(self.base_datetime),
                 "stacktrace": {"frames": [{"module": "group1"}]},
             },
             project_id=self.project.id,
@@ -1272,7 +1273,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
                 "message": "something",
                 "environment": "production",
                 "tags": {"server": "example.net"},
-                "timestamp": self.base_datetime.isoformat()[:19],
+                "timestamp": iso_format(self.base_datetime),
                 "stacktrace": {"frames": [{"module": "group1"}]},
             },
             project_id=self.project.id,
@@ -1283,7 +1284,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
                 "event_id": "5" * 32,
                 "message": "something",
                 "environment": "production",
-                "timestamp": self.base_datetime.isoformat()[:19],
+                "timestamp": iso_format(self.base_datetime),
                 "stacktrace": {"frames": [{"module": "group2"}]},
             },
             project_id=self.project.id,
@@ -1309,7 +1310,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
                 "message": "something",
                 "environment": "production",
                 "tags": {"logger": "csp"},
-                "timestamp": self.base_datetime.isoformat()[:19],
+                "timestamp": iso_format(self.base_datetime),
                 "stacktrace": {"frames": [{"module": "group1"}]},
             },
             project_id=self.project.id,
@@ -1320,7 +1321,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
                 "event_id": "5" * 32,
                 "message": "something",
                 "environment": "production",
-                "timestamp": self.base_datetime.isoformat()[:19],
+                "timestamp": iso_format(self.base_datetime),
                 "stacktrace": {"frames": [{"module": "group2"}]},
             },
             project_id=self.project.id,

--- a/tests/snuba/test_snuba.py
+++ b/tests/snuba/test_snuba.py
@@ -8,6 +8,7 @@ import uuid
 from django.utils import timezone
 
 from sentry.testutils import SnubaTestCase, TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.utils import snuba
 
 
@@ -99,7 +100,7 @@ class SnubaTest(TestCase, SnubaTestCase):
 
 class BulkRawQueryTest(TestCase, SnubaTestCase):
     def test_simple(self):
-        one_min_ago = (timezone.now() - timedelta(minutes=1)).isoformat()[:19]
+        one_min_ago = iso_format(before_now(minutes=1))
         event_1 = self.store_event(
             data={"fingerprint": ["group-1"], "message": "hello", "timestamp": one_min_ago},
             project_id=self.project.id,


### PR DESCRIPTION
Use the datetime helpers in tests more extensively. This removes many magic 19s.