### PR TITLE
fix: Fix off by one error in `collect_project_platforms`

### DIFF
--- a/src/sentry/tasks/collect_project_platforms.py
+++ b/src/sentry/tasks/collect_project_platforms.py
@@ -16,7 +16,7 @@ def collect_project_platforms(**kwargs):
     min_project_id = 0
     max_project_id = Project.objects.aggregate(x=Max("id"))["x"] or 0
     step = 1000
-    while min_project_id < max_project_id:
+    while min_project_id <= max_project_id:
         queryset = (
             Group.objects.filter(
                 last_seen__gte=now - timedelta(days=1),


### PR DESCRIPTION
If the max project id is a multiple of 1000 then we'll end up skipping that project. This doesn't
matter much in practice, but caused `CollectProjectPlatformsTest` to become unstable.