### PR TITLE
fix(onboarding): Fix skip onboarding redirect

### DIFF
--- a/src/sentry/static/sentry/app/views/onboarding/welcome.jsx
+++ b/src/sentry/static/sentry/app/views/onboarding/welcome.jsx
@@ -63,7 +63,7 @@ class OnboardingWelcome extends React.Component {
           </Button>
           <SecondaryAction>
             {tct('Not your first Sentry rodeo? [exitLink:Skip this onboarding].', {
-              exitLink: <Button priority="link" onClick={this.skipOnboarding} to="/" />,
+              exitLink: <Button priority="link" onClick={this.skipOnboarding} href="/" />,
             })}
           </SecondaryAction>
         </ActionGroup>


### PR DESCRIPTION
The redirect on "Skip this onboarding" was broken landing on a blank page instead of the issues page.