### PR TITLE
feat(discover2) Add additional pre-canned queries 

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -285,7 +285,6 @@ export type EventViewv1 = {
     query?: string;
   };
   tags: string[];
-  columnWidths: string[];
 };
 
 export type Repository = {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -276,7 +276,6 @@ export type Group = {
 };
 
 export type EventViewv1 = {
-  id: string;
   name: string;
   data: {
     fields: string[];

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.tsx
@@ -21,7 +21,6 @@ export const PIN_ICON = `image://${pinIcon}`;
 export const AGGREGATE_ALIASES = ['last_seen', 'latest_event'] as const;
 
 export const DEFAULT_EVENT_VIEW_V1: Readonly<EventViewv1> = {
-  id: 'all',
   name: t('All Events'),
   data: {
     fields: ['title', 'event.type', 'project', 'user', 'timestamp'],
@@ -34,23 +33,41 @@ export const DEFAULT_EVENT_VIEW_V1: Readonly<EventViewv1> = {
 export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
   DEFAULT_EVENT_VIEW_V1,
   {
-    id: 'errors',
-    name: t('Errors'),
+    name: t('Project Summary'),
     data: {
-      fields: ['title', 'count(id)', 'count_unique(user)', 'project', 'last_seen'],
-      columnNames: ['error', 'events', 'users', 'project', 'last seen'],
-      sort: ['-last_seen', '-title'],
+      fields: ['project', 'count()', 'count_unique(title)'],
+      columnNames: ['project', 'events', 'unique errors'],
+      sort: ['-count'],
       query: 'event.type:error',
     },
     tags: ['error.type', 'project.name'],
   },
   {
-    id: 'csp',
+    name: t('Errors'),
+    data: {
+      fields: ['title', 'count()', 'count_unique(user)', 'project', 'last_seen'],
+      columnNames: ['error', 'events', 'users', 'project', 'last seen'],
+      sort: ['-count', '-title'],
+      query: 'event.type:error',
+    },
+    tags: ['project.name'],
+  },
+  {
+    name: t('Errors by URL'),
+    data: {
+      fields: ['url', 'count()', 'count_unique(title)'],
+      columnNames: ['URL', 'events', 'unique errors'],
+      sort: ['-count'],
+      query: 'event.type:error',
+    },
+    tags: ['error.type', 'project.name', 'url'],
+  },
+  {
     name: t('CSP'),
     data: {
-      fields: ['title', 'count(id)', 'count_unique(user)', 'project', 'last_seen'],
+      fields: ['title', 'count()', 'count_unique(user)', 'project', 'last_seen'],
       columnNames: ['csp', 'events', 'users', 'project', 'last seen'],
-      sort: ['-last_seen', '-title'],
+      sort: ['-count', '-title'],
       query: 'event.type:csp',
     },
     tags: [
@@ -62,22 +79,54 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     ],
   },
   {
-    id: 'transactions',
+    name: t('CSP Report by Directive'),
+    data: {
+      fields: ['effective-directive', 'count()', 'count_unique(title)'],
+      columnNames: ['directive', 'events', 'reports'],
+      sort: ['-count'],
+      query: 'event.type:csp',
+    },
+    tags: ['project.name', 'blocked-uri', 'browser.name', 'os.name'],
+  },
+  {
+    name: t('CSP Report by Blocked URI'),
+    data: {
+      fields: ['blocked-uri', 'count()'],
+      columnNames: ['URI', 'events'],
+      sort: ['-count'],
+      query: 'event.type:csp',
+    },
+    tags: ['project.name', 'blocked-uri', 'browser.name', 'os.name'],
+  },
+  {
+    name: t('CSP Report by User'),
+    data: {
+      fields: ['user', 'count()', 'count_unique(title)'],
+      columnNames: ['User', 'events', 'reports'],
+      sort: ['-count'],
+      query: 'event.type:csp',
+    },
+    tags: ['project.name', 'blocked-uri', 'browser.name', 'os.name'],
+  },
+  {
     name: t('Transactions'),
     data: {
-      fields: ['transaction', 'project', 'count(id)'],
+      fields: ['transaction', 'project', 'count()'],
       columnNames: ['transaction', 'project', 'volume'],
-      sort: ['-transaction'],
+      sort: ['-count'],
       query: 'event.type:transaction',
     },
-    tags: [
-      'event.type',
-      'release',
-      'project.name',
-      'user.email',
-      'user.ip',
-      'environment',
-    ],
+    tags: ['release', 'project.name', 'user.email', 'user.ip', 'environment'],
+  },
+  {
+    name: t('Transactions by User'),
+    data: {
+      fields: ['user', 'count()', 'count_unique(transaction)'],
+      columnNames: ['user', 'events', 'unique transactions'],
+      sort: ['-count'],
+      query: 'event.type:transaction',
+    },
+    tags: ['release', 'project.name', 'user.email', 'user.ip', 'environment'],
   },
 ];
 
@@ -166,7 +215,7 @@ export const FIELD_FORMATTERS: FieldFormatters = {
     ),
   },
   string: {
-    sortField: false,
+    sortField: true,
     renderFunc: (field, data, {organization, location}) => {
       const target = {
         pathname: `/organizations/${organization.slug}/events/`,

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.tsx
@@ -29,7 +29,6 @@ export const DEFAULT_EVENT_VIEW_V1: Readonly<EventViewv1> = {
     sort: ['-timestamp'],
   },
   tags: ['event.type', 'release', 'project.name', 'user.email', 'user.ip', 'environment'],
-  columnWidths: ['3fr', '80px', '1fr', '1fr', '1.5fr'],
 };
 
 export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
@@ -44,7 +43,6 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
       query: 'event.type:error',
     },
     tags: ['error.type', 'project.name'],
-    columnWidths: ['3fr', '70px', '70px', '1fr', '1.5fr'],
   },
   {
     id: 'csp',
@@ -62,7 +60,6 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
       'os.name',
       'effective-directive',
     ],
-    columnWidths: ['3fr', '70px', '70px', '1fr', '1.5fr'],
   },
   {
     id: 'transactions',
@@ -81,7 +78,6 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
       'user.ip',
       'environment',
     ],
-    columnWidths: ['3fr', '1fr', '70px'],
   },
 ];
 

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.tsx
@@ -35,7 +35,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
   {
     name: t('Project Summary'),
     data: {
-      fields: ['project', 'count()', 'count_unique(title)'],
+      fields: ['project', 'count()', 'count_unique(issue.id)'],
       columnNames: ['project', 'events', 'unique errors'],
       sort: ['-count'],
       query: 'event.type:error',
@@ -55,12 +55,22 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
   {
     name: t('Errors by URL'),
     data: {
-      fields: ['url', 'count()', 'count_unique(title)'],
+      fields: ['url', 'count()', 'count_unique(issue.id)'],
       columnNames: ['URL', 'events', 'unique errors'],
       sort: ['-count'],
       query: 'event.type:error',
     },
     tags: ['error.type', 'project.name', 'url'],
+  },
+  {
+    name: t('Errors by User'),
+    data: {
+      fields: ['user', 'count()', 'count_unique(issue.id)'],
+      columnNames: ['User', 'events', 'unique errors'],
+      sort: ['-count'],
+      query: 'event.type:error',
+    },
+    tags: ['user.id', 'project.name', 'url'],
   },
   {
     name: t('CSP'),

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/data.tsx
@@ -138,6 +138,16 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     },
     tags: ['release', 'project.name', 'user.email', 'user.ip', 'environment'],
   },
+  {
+    name: t('Transactions by Region'),
+    data: {
+      fields: ['geo.region', 'count()'],
+      columnNames: ['Region', 'events'],
+      sort: ['-count'],
+      query: 'event.type:transaction',
+    },
+    tags: ['release', 'project.name', 'user.email', 'user.ip'],
+  },
 ];
 
 type EventData = {[key: string]: any};

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/discover2table.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/discover2table.tsx
@@ -211,6 +211,8 @@ class Table extends React.Component<TableProps> {
 
     const lastRowIndex = dataPayload.data.length - 1;
 
+    // TODO add links to the first column even if it isn't one of our
+    // preferred link columns (title, transaction, latest_event)
     const firstCellIndex = 0;
     const lastCellIndex = fields.length - 1;
 

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/discover2table.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/discover2table.tsx
@@ -155,7 +155,7 @@ class Table extends React.Component<TableProps> {
       return null;
     }
 
-    const defaultSort = eventView.getDefaultSort() || eventView.fields[0].snuba_column;
+    const defaultSort = eventView.getDefaultSort() || eventView.fields[0].field;
 
     return eventView.fields.map((field, index) => {
       if (!dataPayload) {
@@ -163,7 +163,7 @@ class Table extends React.Component<TableProps> {
       }
 
       const {meta} = dataPayload;
-      const sortKey = eventView.getSortKey(field.snuba_column, meta);
+      const sortKey = eventView.getSortKey(field.field, meta);
 
       if (sortKey === null) {
         return <PanelHeaderCell key={index}>{field.title}</PanelHeaderCell>;
@@ -196,7 +196,7 @@ class Table extends React.Component<TableProps> {
     }
 
     const {meta} = dataPayload;
-    const fields = eventView.getFieldSnubaCols();
+    const fields = eventView.getFieldNames();
 
     // TODO: deal with this
     // if (fields.length <= 0) {

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/eventView.tsx
@@ -5,7 +5,7 @@ import {EventViewv1} from 'app/types';
 import {DEFAULT_PER_PAGE} from 'app/constants';
 
 import {SPECIAL_FIELDS, FIELD_FORMATTERS} from './data';
-import {MetaType, EventQuery} from './utils';
+import {MetaType, EventQuery, getAggregateAlias} from './utils';
 
 type Descending = {
   kind: 'desc';
@@ -181,8 +181,6 @@ const decodeQuery = (location: Location): string | undefined => {
   return isString(query) ? query.trim() : undefined;
 };
 
-const AGGREGATE_PATTERN = /^([a-z0-9_]+)\(([a-z\._]*)\)$/i;
-
 class EventView {
   fields: Field[];
   sorts: Sort[];
@@ -334,10 +332,7 @@ class EventView {
   };
 
   getSortKey = (fieldname: string, meta: MetaType): string | null => {
-    let column = fieldname;
-    if (fieldname.match(AGGREGATE_PATTERN)) {
-      column = fieldname.replace(AGGREGATE_PATTERN, '$1_$2').toLowerCase();
-    }
+    const column = getAggregateAlias(fieldname);
     if (SPECIAL_FIELDS.hasOwnProperty(column)) {
       return SPECIAL_FIELDS[column as keyof typeof SPECIAL_FIELDS].sortField;
     }

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/index.tsx
@@ -73,7 +73,6 @@ class OrganizationEventsV2 extends React.Component<Props> {
 
     if (typeof name === 'string' && String(name).trim().length > 0) {
       return [t('Events'), String(name).trim()];
-      // return `${} \u2014 ${}`;
     }
 
     return [t('Events')];

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/modalLineGraph.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/modalLineGraph.tsx
@@ -185,7 +185,7 @@ const ModalLineGraph = (props: ModalLineGraphProps) => {
         interval={interval}
         showLoading={true}
         query={queryString}
-        field={eventView.getFieldSnubaCols()}
+        field={eventView.getFieldNames()}
         referenceEvent={referenceEvent}
         includePrevious={false}
       >
@@ -199,7 +199,7 @@ const ModalLineGraph = (props: ModalLineGraphProps) => {
             }}
             onClick={series =>
               handleClick(series, {
-                field: eventView.getFieldSnubaCols(),
+                field: eventView.getFieldNames(),
                 api,
                 organization,
                 currentEvent,

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/utils.tsx
@@ -167,6 +167,7 @@ export function getAggregateAlias(field: string): string {
   }
   return field
     .replace(AGGREGATE_PATTERN, '$1_$2')
+    .replace('.', '_')
     .replace(/_+$/, '')
     .toLowerCase();
 }

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/utils.tsx
@@ -148,13 +148,27 @@ export function getFieldRenderer(
   if (SPECIAL_FIELDS.hasOwnProperty(field)) {
     return SPECIAL_FIELDS[field].renderFunc;
   }
-  // Inflect the field name so it will match the property in the result set.
-  const fieldName = field.replace(/^([^\(]+)\(([a-z\._+]+)\)$/, '$1_$2');
+  const fieldName = getAggregateAlias(field);
   const fieldType = meta[fieldName];
   if (FIELD_FORMATTERS.hasOwnProperty(fieldType)) {
     return partial(FIELD_FORMATTERS[fieldType].renderFunc, fieldName);
   }
   return partial(FIELD_FORMATTERS.string.renderFunc, fieldName);
+}
+
+const AGGREGATE_PATTERN = /^([^\(]+)\(([a-z\._+]*)\)$/;
+
+/**
+ * Get the alias that the API results will have for a given aggregate function name
+ */
+export function getAggregateAlias(field: string): string {
+  if (!field.match(AGGREGATE_PATTERN)) {
+    return field;
+  }
+  return field
+    .replace(AGGREGATE_PATTERN, '$1_$2')
+    .replace(/_+$/, '')
+    .toLowerCase();
 }
 
 /**

--- a/src/sentry/static/sentry/app/views/organizationEventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/organizationEventsV2/utils.tsx
@@ -29,7 +29,7 @@ export type EventQuery = {
  */
 export function hasAggregateField(eventView: EventView): boolean {
   return eventView
-    .getFieldSnubaCols()
+    .getFieldNames()
     .some(
       field =>
         AGGREGATE_ALIASES.includes(field as any) || field.match(/[a-z_]+\([a-z_\.]+\)/)

--- a/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/eventDetails.spec.jsx
@@ -10,7 +10,7 @@ import EventView from 'app/views/organizationEventsV2/eventView';
 describe('OrganizationEventsV2 > EventDetails', function() {
   const allEventsView = EventView.fromEventViewv1(DEFAULT_EVENT_VIEW_V1);
   const errorsView = EventView.fromEventViewv1(
-    ALL_VIEWS.find(view => view.id === 'errors')
+    ALL_VIEWS.find(view => view.name === 'Errors')
   );
 
   beforeEach(function() {

--- a/tests/js/spec/views/organizationEventsV2/index.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/index.spec.jsx
@@ -6,15 +6,15 @@ import {encodeFields} from 'app/views/organizationEventsV2/eventView';
 
 const FIELDS = [
   {
-    snuba_column: 'title',
+    field: 'title',
     title: 'Custom Title',
   },
   {
-    snuba_column: 'timestamp',
+    field: 'timestamp',
     title: 'Custom Time',
   },
   {
-    snuba_column: 'user',
+    field: 'user',
     title: 'Custom User',
   },
 ];

--- a/tests/js/spec/views/organizationEventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/organizationEventsV2/utils.spec.jsx
@@ -1,4 +1,7 @@
-import {getEventTagSearchUrl} from 'app/views/organizationEventsV2/utils';
+import {
+  getAggregateAlias,
+  getEventTagSearchUrl,
+} from 'app/views/organizationEventsV2/utils';
 
 describe('eventTagSearchUrl()', function() {
   let location;
@@ -30,5 +33,23 @@ describe('eventTagSearchUrl()', function() {
       pathname: location.pathname,
       query: {query: 'failure browser:"firefox"'},
     });
+  });
+});
+
+describe('getAggregateAlias', function() {
+  it('no-ops simple fields', function() {
+    expect(getAggregateAlias('field')).toEqual('field');
+    expect(getAggregateAlias('under_field')).toEqual('under_field');
+  });
+
+  it('handles 0 arg functions', function() {
+    expect(getAggregateAlias('count()')).toEqual('count');
+    expect(getAggregateAlias('count_unique()')).toEqual('count_unique');
+  });
+
+  it('handles 1 arg functions', function() {
+    expect(getAggregateAlias('count(id)')).toEqual('count_id');
+    expect(getAggregateAlias('count_unique(user)')).toEqual('count_unique_user');
+    expect(getAggregateAlias('count_unique(issue.id)')).toEqual('count_unique_issue_id');
   });
 });


### PR DESCRIPTION
Add more default discover queries so that we have more than three for the initial preview release.

I have also default the sort to be count descending for all the default views that have a count as that was another request that was easy to do at the same time.

Refs SEN-968
Refs SEN-975