### PR TITLE
feat(workflow): Add availability matches for tag rules

### DIFF
--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -14,6 +14,8 @@ class MatchType(object):
     ENDS_WITH = "ew"
     CONTAINS = "co"
     NOT_CONTAINS = "nc"
+    IS_SET = "is"
+    NOT_SET = "ns"
 
 
 MATCH_CHOICES = OrderedDict(
@@ -24,6 +26,8 @@ MATCH_CHOICES = OrderedDict(
         (MatchType.ENDS_WITH, "ends with"),
         (MatchType.CONTAINS, "contains"),
         (MatchType.NOT_CONTAINS, "does not contain"),
+        (MatchType.IS_SET, "is set"),
+        (MatchType.NOT_SET, "is not set"),
     ]
 )
 
@@ -49,50 +53,69 @@ class TaggedEventCondition(EventCondition):
         match = self.get_option("match")
         value = self.get_option("value")
 
-        if not (key and match and value):
+        if not (key and match):
             return False
 
-        value = value.lower()
         key = key.lower()
 
         tags = (
+            k
+            for gen in (
+                (k.lower() for k, v in event.tags),
+                (tagstore.get_standardized_key(k) for k, v in event.tags),
+            )
+            for k in gen
+        )
+
+        if match == MatchType.IS_SET:
+            return key in tags
+
+        elif match == MatchType.NOT_SET:
+            return key not in tags
+
+        if not value:
+            return False
+
+        value = value.lower()
+
+        values = (
             v.lower()
             for k, v in event.tags
             if k.lower() == key or tagstore.get_standardized_key(k) == key
         )
 
         if match == MatchType.EQUAL:
-            for t_value in tags:
+            for t_value in values:
                 if t_value == value:
                     return True
             return False
 
         elif match == MatchType.NOT_EQUAL:
-            for t_value in tags:
+            for t_value in values:
                 if t_value == value:
                     return False
             return True
 
         elif match == MatchType.STARTS_WITH:
-            for t_value in tags:
+            for t_value in values:
                 if t_value.startswith(value):
                     return True
             return False
 
         elif match == MatchType.ENDS_WITH:
-            for t_value in tags:
+            for t_value in values:
                 if t_value.endswith(value):
                     return True
             return False
 
         elif match == MatchType.CONTAINS:
-            for t_value in tags:
+            for t_value in values:
                 if value in t_value:
                     return True
             return False
 
         elif match == MatchType.NOT_CONTAINS:
-            for t_value in tags:
+            for t_value in values:
                 if value in t_value:
                     return False
             return True

--- a/tests/sentry/rules/conditions/test_tagged_event.py
+++ b/tests/sentry/rules/conditions/test_tagged_event.py
@@ -88,3 +88,20 @@ class TaggedEventConditionTest(RuleTestCase):
             data={"match": MatchType.NOT_CONTAINS, "key": "logger", "value": "bar.foo"}
         )
         self.assertPasses(rule, event)
+
+    def test_is_set(self):
+        event = self.get_event()
+
+        rule = self.get_rule(data={"match": MatchType.IS_SET, "key": "logger"})
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule(data={"match": MatchType.IS_SET, "key": "missing"})
+        self.assertDoesNotPass(rule, event)
+
+    def test_is_not_set(self):
+        event = self.get_event()
+        rule = self.get_rule(data={"match": MatchType.NOT_SET, "key": "logger"})
+        self.assertDoesNotPass(rule, event)
+
+        rule = self.get_rule(data={"match": MatchType.NOT_SET, "key": "missing"})
+        self.assertPasses(rule, event)


### PR DESCRIPTION
This is already supported on the event attributes. The main reasoning behind this is to give more flexibility on the alerting rules.

In our case, we are tagging plenty of events, and just having to add a specific value that we want to whitelist or blacklist causes a pretty big amount of code changes. This will allow us to filter events when we don't really care about the value set on the tag, but just about the tag being set or not.