### PR TITLE
feat(discover2): Add feature-flag for query builder

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -816,6 +816,8 @@ SENTRY_FEATURES = {
     "organizations:create": True,
     # Enable the 'discover' interface.
     "organizations:discover": False,
+    # Enable the Discover v2 query builder
+    "organizations:discover-v2-query-builder": False,
     # Enable attaching arbitrary files to events.
     "organizations:event-attachments": False,
     # Allow organizations to configure custom external symbol sources.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -57,6 +57,7 @@ default_manager.add("organizations:advanced-search", OrganizationFeature)  # NOQ
 default_manager.add("organizations:boolean-search", OrganizationFeature)  # NOQA
 default_manager.add("organizations:api-keys", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover", OrganizationFeature)  # NOQA
+default_manager.add("organizations:discover-v2-query-builder", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:event-attachments", OrganizationFeature)  # NOQA


### PR DESCRIPTION
- Feature flag `organizations:discover-v2-query-builder` defaults to `False` and hides Discover V2 query builder.