### PR TITLE
fix: Update email snapshots

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -56,7 +56,7 @@ redis>=2.10.3,<2.10.6
 requests-oauthlib==0.3.3
 requests[security]>=2.20.0,<2.21.0
 selenium==3.141.0
-semaphore>=0.4.42,<0.5.0
+semaphore>=0.4.43,<0.5.0
 sentry-sdk>=0.11.0
 setproctitle>=1.1.7,<1.2.0
 simplejson>=3.2.0,<3.9.0

--- a/tests/fixtures/emails/alert.txt
+++ b/tests/fixtures/emails/alert.txt
@@ -16,11 +16,11 @@ Tags
 
 * browser = Chrome 28.0.1500
 * browser.name = Chrome
+* client_os.name = Windows 8
 * device = Other
 * environment = prod
 * level = error
 * logger = javascript
-* os.name = Windows 8
 * sentry:user = id:1
 * url = http://example.com/foo
 


### PR DESCRIPTION
The release of a new semaphore version broke the snapshots.