### PR TITLE
fix(grouping): Fix an incorrect message for grouping hints

### DIFF
--- a/src/sentry/grouping/strategies/legacy.py
+++ b/src/sentry/grouping/strategies/legacy.py
@@ -335,23 +335,27 @@ def frame_legacy(frame, event, **meta):
         elif frame.lineno:
             lineno_component.update(values=[frame.lineno])
     else:
+        if context_line_component.contributes:
+            fallback_hint = "is not used if context-line is available"
+        else:
+            fallback_hint = "is not used if module or filename are available"
         if frame.symbol:
             symbol_component.update(
                 contributes=False,
                 values=[frame.symbol],
-                hint="symbol is used only if module or filename are available",
+                hint="symbol " + fallback_hint,
             )
         if func:
             function_component.update(
                 contributes=False,
                 values=[func],
-                hint="function name is used only if module or filename are available",
+                hint="function name " + fallback_hint,
             )
         if frame.lineno:
             lineno_component.update(
                 contributes=False,
                 values=[frame.lineno],
-                hint="line number is used only if module or filename are available",
+                hint="line number " + fallback_hint,
             )
 
     return GroupingComponent(

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-09T18:49:34.560544Z'
+created: '2019-09-03T07:26:05.646111Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,189 +14,189 @@ app:
               u'Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Invoke'
           frame (non app frame)
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Invoke'
           frame (non app frame)
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Routing.EndpointMiddleware'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Invoke'
           frame (non app frame)
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeAsync'
           frame (non app frame)
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeFilterPipelineAsync'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'System.Threading.Tasks.Task Next(State ByRef, Scope ByRef, System.Object ByRef, Boolean ByRef)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Next'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void Rethrow(Microsoft.AspNetCore.Mvc.Filters.ResourceExecutedContext)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Rethrow'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeNextResourceFilter'
           frame (non app frame)
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeInnerFilterAsync'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'System.Threading.Tasks.Task Next(State ByRef, Scope ByRef, System.Object ByRef, Boolean ByRef)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Next'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void Rethrow(Microsoft.AspNetCore.Mvc.Filters.ActionExecutedContext)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Rethrow'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeNextActionFilterAsync'
           frame (non app frame)
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeActionMethodAsync'
           frame (non app frame)
             module*
@@ -209,14 +209,14 @@ app:
               u'Microsoft.Extensions.Internal.ObjectMethodExecutor'
             context-line*
               u'System.Object Execute(System.Object, System.Object[])'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Execute'
           frame*
             module*
               u'(unknown)'
             context-line*
               u'System.Object lambda_method(System.Runtime.CompilerServices.Closure, System.Object, System.Object[])'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'lambda_method'
           frame*
             module*
@@ -225,9 +225,9 @@ app:
               u'C:\\Users\\dvora\\source\\repos\\SentryTest2\\SentryTest2\\Controllers\\ValuesController.cs'
             context-line*
               u'Microsoft.AspNetCore.Mvc.ActionResult`1[System.String] Get(Int32)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Get'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               27
         type*
           u'System.Exception'
@@ -252,189 +252,189 @@ system:
               u'Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Invoke'
           frame*
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Invoke'
           frame*
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Routing.EndpointMiddleware'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Invoke'
           frame*
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeAsync'
           frame*
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeFilterPipelineAsync'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'System.Threading.Tasks.Task Next(State ByRef, Scope ByRef, System.Object ByRef, Boolean ByRef)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Next'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void Rethrow(Microsoft.AspNetCore.Mvc.Filters.ResourceExecutedContext)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Rethrow'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeNextResourceFilter'
           frame*
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeInnerFilterAsync'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'System.Threading.Tasks.Task Next(State ByRef, Scope ByRef, System.Object ByRef, Boolean ByRef)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Next'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void Rethrow(Microsoft.AspNetCore.Mvc.Filters.ActionExecutedContext)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Rethrow'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeNextActionFilterAsync'
           frame*
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeActionMethodAsync'
           frame*
             module*
@@ -447,14 +447,14 @@ system:
               u'Microsoft.Extensions.Internal.ObjectMethodExecutor'
             context-line*
               u'System.Object Execute(System.Object, System.Object[])'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Execute'
           frame*
             module*
               u'(unknown)'
             context-line*
               u'System.Object lambda_method(System.Runtime.CompilerServices.Closure, System.Object, System.Object[])'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'lambda_method'
           frame*
             module*
@@ -463,9 +463,9 @@ system:
               u'C:\\Users\\dvora\\source\\repos\\SentryTest2\\SentryTest2\\Controllers\\ValuesController.cs'
             context-line*
               u'Microsoft.AspNetCore.Mvc.ActionResult`1[System.String] Get(Int32)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Get'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               27
         type*
           u'System.Exception'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:30.960302Z'
+created: '2019-09-03T07:26:05.662941Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'sentry/utils/safe.py'
             context-line*
               u'            result = func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'safe_execute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               31
           frame*
             module*
@@ -27,9 +27,9 @@ app:
               u'sentry/utils/services.py'
             context-line*
               u'                context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'<lambda>'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               91
           frame*
             module*
@@ -38,9 +38,9 @@ app:
               u'getsentry/quotas.py'
             context-line*
               u'        return super(SubscriptionQuota, self).is_rate_limited(project, key=key)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'is_rate_limited'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               136
           frame*
             module*
@@ -49,9 +49,9 @@ app:
               u'sentry/quotas/redis.py'
             context-line*
               u'        rejections = is_rate_limited(client, keys, args)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'is_rate_limited'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               189
           frame*
             module*
@@ -60,9 +60,9 @@ app:
               u'sentry/utils/redis.py'
             context-line*
               u'        return script(keys, args, client)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'call_script'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               239
           frame (non app frame)
             module*
@@ -71,9 +71,9 @@ app:
               u'redis/client.py'
             context-line*
               u'            return client.evalsha(self.sha, len(keys), *args)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'__call__'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               2694
           frame (non app frame)
             module*
@@ -82,9 +82,9 @@ app:
               u'redis/client.py'
             context-line*
               u"        return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'evalsha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1944
           frame (non app frame)
             module*
@@ -93,9 +93,9 @@ app:
               u'redis/client.py'
             context-line*
               u'            return self.parse_response(connection, command_name, **options)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'execute_command'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               579
           frame (non app frame)
             module*
@@ -104,9 +104,9 @@ app:
               u'redis/client.py'
             context-line*
               u'        response = connection.read_response()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'parse_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               585
           frame (non app frame)
             module*
@@ -115,9 +115,9 @@ app:
               u'redis/connection.py'
             context-line*
               u'            response = self._parser.read_response()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'read_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               577
           frame (non app frame)
             module*
@@ -126,9 +126,9 @@ app:
               u'redis/connection.py'
             context-line*
               u'                                      (e.args,))'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'read_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               357
         type*
           u'ConnectionError'
@@ -155,9 +155,9 @@ system:
               u'sentry/utils/safe.py'
             context-line*
               u'            result = func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'safe_execute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               31
           frame*
             module*
@@ -166,9 +166,9 @@ system:
               u'sentry/utils/services.py'
             context-line*
               u'                context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'<lambda>'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               91
           frame*
             module*
@@ -177,9 +177,9 @@ system:
               u'getsentry/quotas.py'
             context-line*
               u'        return super(SubscriptionQuota, self).is_rate_limited(project, key=key)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'is_rate_limited'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               136
           frame*
             module*
@@ -188,9 +188,9 @@ system:
               u'sentry/quotas/redis.py'
             context-line*
               u'        rejections = is_rate_limited(client, keys, args)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'is_rate_limited'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               189
           frame*
             module*
@@ -199,9 +199,9 @@ system:
               u'sentry/utils/redis.py'
             context-line*
               u'        return script(keys, args, client)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'call_script'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               239
           frame*
             module*
@@ -210,9 +210,9 @@ system:
               u'redis/client.py'
             context-line*
               u'            return client.evalsha(self.sha, len(keys), *args)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'__call__'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               2694
           frame*
             module*
@@ -221,9 +221,9 @@ system:
               u'redis/client.py'
             context-line*
               u"        return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'evalsha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1944
           frame*
             module*
@@ -232,9 +232,9 @@ system:
               u'redis/client.py'
             context-line*
               u'            return self.parse_response(connection, command_name, **options)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'execute_command'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               579
           frame*
             module*
@@ -243,9 +243,9 @@ system:
               u'redis/client.py'
             context-line*
               u'        response = connection.read_response()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'parse_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               585
           frame*
             module*
@@ -254,9 +254,9 @@ system:
               u'redis/connection.py'
             context-line*
               u'            response = self._parser.read_response()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'read_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               577
           frame*
             module*
@@ -265,9 +265,9 @@ system:
               u'redis/connection.py'
             context-line*
               u'                                      (e.args,))'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'read_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               357
         type*
           u'ConnectionError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-09T18:49:34.676384Z'
+created: '2019-09-03T07:26:05.772892Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,7 +16,7 @@ app:
               u'./app/components/modals/createTeamModal.jsx'
             context-line*
               u'        onError(err);'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               27
           frame* (frame considered in-app because no frame is in-app)
             module*
@@ -25,9 +25,9 @@ app:
               u'./app/views/settings/components/forms/form.jsx'
             context-line*
               u'    this.model.submitError(error);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'onError'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               125
         type*
           u'TypeError'
@@ -47,7 +47,7 @@ system:
               u'./app/components/modals/createTeamModal.jsx'
             context-line*
               u'        onError(err);'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               27
           frame*
             module*
@@ -56,9 +56,9 @@ system:
               u'./app/views/settings/components/forms/form.jsx'
             context-line*
               u'    this.model.submitError(error);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'onError'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               125
         type*
           u'TypeError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:31.144386Z'
+created: '2019-09-03T07:26:05.860539Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
             u'foo.py'
           context-line*
             u'hello world'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'test'
 --------------------------------------------------------------------------
 system:
@@ -26,5 +26,5 @@ system:
             u'foo.py'
           context-line*
             u'hello world'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'test'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:31.160938Z'
+created: '2019-09-03T07:26:05.877040Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
             u'/foo.py'
           context-line*
             u'hello world'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'test'
 --------------------------------------------------------------------------
 system:
@@ -26,5 +26,5 @@ system:
             u'/foo.py'
           context-line*
             u'hello world'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'test'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:31.170291Z'
+created: '2019-09-03T07:26:05.885617Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
             u'/foo.py'
           context-line*
             u'hello world'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'test'
 --------------------------------------------------------------------------
 system:
@@ -26,5 +26,5 @@ system:
             u'/foo.py'
           context-line*
             u'hello world'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'test'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:31.237122Z'
+created: '2019-09-03T07:26:05.949013Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
     app
       stacktrace
         frame (frame considered in-app because no frame is in-app)
-          function (function name is used only if module or filename are available)
+          function (function name is not used if module or filename are available)
             u'forEach'
 --------------------------------------------------------------------------
 fallback:
@@ -21,5 +21,5 @@ system:
     system
       stacktrace
         frame (native code indicated by filename)
-          function (function name is used only if module or filename are available)
+          function (function name is not used if module or filename are available)
             u'forEach'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:31.312882Z'
+created: '2019-09-03T07:26:06.021857Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,9 +13,9 @@ app:
             u'foo.py'
           context-line*
             u'foo bar'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'bar'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if context-line is available)
             1
 --------------------------------------------------------------------------
 system:
@@ -28,7 +28,7 @@ system:
             u'foo.py'
           context-line*
             u'foo bar'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'bar'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if context-line is available)
             1

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:29.272686Z'
+created: '2019-09-03T07:26:06.199243Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,66 +12,66 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Foo.testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               1
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame (frame considered in-app because no frame is in-app)
             filename (anonymous filename discarded)
               u'<anonymous>'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Array.map'
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Object.callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               19
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Object.aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'
@@ -87,66 +87,66 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Foo.testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               1
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame
             filename (anonymous filename discarded)
               u'<anonymous>'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Array.map'
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Object.callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               19
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Object.aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:29.285780Z'
+created: '2019-09-03T07:26:06.212964Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,23 +12,23 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Anonymous function'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Foo.prototype.testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame* (frame considered in-app because no frame is in-app)
             filename*
@@ -40,9 +40,9 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame* (frame considered in-app because no frame is in-app)
             filename*
@@ -52,30 +52,30 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Anonymous function'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               17
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'
@@ -91,23 +91,23 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Anonymous function'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Foo.prototype.testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame*
             filename*
@@ -119,9 +119,9 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame*
             filename*
@@ -131,30 +131,30 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Anonymous function'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               17
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-10T13:21:29.445249Z'
+created: '2019-09-03T07:26:06.226196Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,63 +12,63 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               1
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test/<'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               19
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'
@@ -84,63 +84,63 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               1
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test/<'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               19
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:44:33.382733Z'
+created: '2019-09-03T07:26:06.239864Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -55,7 +55,7 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (anonymous filename discarded)
               u'<anonymous>'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Array.map'
           frame* (frame considered in-app because no frame is in-app)
             module*
@@ -148,7 +148,7 @@ system:
           frame
             filename (anonymous filename discarded)
               u'<anonymous>'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Array.map'
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:44:33.421886Z'
+created: '2019-09-03T07:26:06.280118Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -35,7 +35,7 @@ app:
             lineno (function takes precedence)
               38
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
           frame* (frame considered in-app because no frame is in-app)
             module*
@@ -47,7 +47,7 @@ app:
             lineno (function takes precedence)
               32
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'map'
           frame* (frame considered in-app because no frame is in-app)
             module*
@@ -75,7 +75,7 @@ app:
             lineno (function takes precedence)
               19
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
           frame* (frame considered in-app because no frame is in-app)
             module*
@@ -123,7 +123,7 @@ system:
             lineno (function takes precedence)
               38
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
           frame*
             module*
@@ -135,7 +135,7 @@ system:
             lineno (function takes precedence)
               32
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'map'
           frame*
             module*
@@ -163,7 +163,7 @@ system:
             lineno (function takes precedence)
               19
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:29.310096Z'
+created: '2019-09-03T07:26:06.293821Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,63 +12,63 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'map'
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               19
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'
@@ -84,63 +84,63 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'map'
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               19
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T21:58:32.681533Z'
+created: '2019-09-03T07:26:06.319660Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/core-js/modules/_microtask.js'
             context-line*
               u'        fn();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'M'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               18
           frame (non app frame)
             module*
@@ -27,9 +27,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise.js'
             context-line*
               u"    while (chain.length > i) run(chain[i++]); // variable length - can't use forEach"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fn'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               92
           frame (non app frame)
             module*
@@ -38,9 +38,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise.js'
             context-line*
               u'            result = handler(value); // may throw'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'run'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               75
           frame (non app frame)
             module*
@@ -49,9 +49,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'        asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_next'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame (non app frame)
             module*
@@ -60,9 +60,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'    var info = gen[key](arg);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'asyncGeneratorStep'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               3
           frame (non app frame)
             module*
@@ -71,9 +71,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'        return this._invoke(method, arg);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'key'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               114
           frame (non app frame)
             module*
@@ -82,9 +82,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'        var record = tryCatch(innerFn, self, context);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'this'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               288
           frame (non app frame)
             module*
@@ -93,9 +93,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'      return { type: "normal", arg: fn.call(obj, arg) };'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'tryCatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               62
           frame*
             module*
@@ -104,9 +104,9 @@ app:
               u'./app/components/lazyLoad.jsx'
             context-line*
               u'      this.setState({'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fn'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               100
           frame (non app frame)
             module*
@@ -175,9 +175,9 @@ app:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    this.fetchData();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'X'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               42
           frame*
             module*
@@ -186,9 +186,9 @@ app:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'this'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               96
           frame*
             module*
@@ -197,9 +197,9 @@ app:
               u'./app/api.jsx'
             context-line*
               u'    const preservedError = new Error();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fetchGroupEventAndMarkSeen'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               276
         type*
           u'NotFoundError'
@@ -219,9 +219,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/core-js/modules/_microtask.js'
             context-line*
               u'        fn();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'M'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               18
           frame*
             module*
@@ -230,9 +230,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise.js'
             context-line*
               u"    while (chain.length > i) run(chain[i++]); // variable length - can't use forEach"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fn'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               92
           frame*
             module*
@@ -241,9 +241,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise.js'
             context-line*
               u'            result = handler(value); // may throw'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'run'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               75
           frame*
             module*
@@ -252,9 +252,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'        asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_next'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame*
             module*
@@ -263,9 +263,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'    var info = gen[key](arg);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'asyncGeneratorStep'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               3
           frame*
             module*
@@ -274,9 +274,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'        return this._invoke(method, arg);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'key'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               114
           frame*
             module*
@@ -285,9 +285,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'        var record = tryCatch(innerFn, self, context);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'this'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               288
           frame*
             module*
@@ -296,9 +296,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'      return { type: "normal", arg: fn.call(obj, arg) };'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'tryCatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               62
           frame*
             module*
@@ -307,9 +307,9 @@ system:
               u'./app/components/lazyLoad.jsx'
             context-line*
               u'      this.setState({'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fn'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               100
           frame*
             module*
@@ -378,9 +378,9 @@ system:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    this.fetchData();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'X'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               42
           frame*
             module*
@@ -389,9 +389,9 @@ system:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'this'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               96
           frame*
             module*
@@ -400,9 +400,9 @@ system:
               u'./app/api.jsx'
             context-line*
               u'    const preservedError = new Error();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fetchGroupEventAndMarkSeen'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               276
         type*
           u'NotFoundError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T21:58:32.702883Z'
+created: '2019-09-03T07:26:06.363401Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
       exception*
         stacktrace*
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'promiseReactionJob'
           frame (non app frame)
             module*
@@ -19,9 +19,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'        asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_next'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame (non app frame)
             module*
@@ -30,9 +30,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'    var info = gen[key](arg);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'asyncGeneratorStep'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               3
           frame (non app frame)
             module*
@@ -41,9 +41,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'        var record = tryCatch(innerFn, self, context);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'key'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               288
           frame (non app frame)
             module*
@@ -52,9 +52,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'      return { type: "normal", arg: fn.call(obj, arg) };'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'tryCatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               62
           frame*
             module*
@@ -63,9 +63,9 @@ app:
               u'./app/components/lazyLoad.jsx'
             context-line*
               u'      this.setState({'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'call'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               100
           frame (non app frame)
             module*
@@ -134,9 +134,9 @@ app:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    this.fetchData();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'q'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               42
           frame*
             module*
@@ -145,9 +145,9 @@ app:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fetchData'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               96
           frame*
             module*
@@ -156,9 +156,9 @@ app:
               u'./app/api.jsx'
             context-line*
               u'    const preservedError = new Error();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fetchGroupEventAndMarkSeen'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               276
         type*
           u'NotFoundError'
@@ -172,7 +172,7 @@ system:
       exception*
         stacktrace*
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'promiseReactionJob'
           frame*
             module*
@@ -181,9 +181,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'        asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_next'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame*
             module*
@@ -192,9 +192,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'    var info = gen[key](arg);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'asyncGeneratorStep'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               3
           frame*
             module*
@@ -203,9 +203,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'        var record = tryCatch(innerFn, self, context);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'key'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               288
           frame*
             module*
@@ -214,9 +214,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'      return { type: "normal", arg: fn.call(obj, arg) };'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'tryCatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               62
           frame*
             module*
@@ -225,9 +225,9 @@ system:
               u'./app/components/lazyLoad.jsx'
             context-line*
               u'      this.setState({'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'call'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               100
           frame*
             module*
@@ -296,9 +296,9 @@ system:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    this.fetchData();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'q'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               42
           frame*
             module*
@@ -307,9 +307,9 @@ system:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fetchData'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               96
           frame*
             module*
@@ -318,9 +318,9 @@ system:
               u'./app/api.jsx'
             context-line*
               u'    const preservedError = new Error();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fetchGroupEventAndMarkSeen'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               276
         type*
           u'NotFoundError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-09T18:49:35.041211Z'
+created: '2019-09-03T07:26:06.405461Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,448 +14,448 @@ app:
               u'/server.php'
             context-line*
               u"require_once __DIR__.'/public/index.php';"
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               21
           frame*
             filename*
               u'/public/index.php'
             context-line*
               u'    $request = Illuminate\\Http\\Request::capture()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'require_once'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               55
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php'
             context-line*
               u'            $response = $this->sendRequestThroughRouter($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Kernel::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               116
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php'
             context-line*
               u'                    ->then($this->dispatchToRouter());'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Kernel::sendRequestThroughRouter'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               151
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'        return $pipeline($this->passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::then'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               104
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\CheckForMaintenanceMode::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               62
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ValidatePostSize.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\ValidatePostSize::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               27
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               21
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               21
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/fideloper/proxy/src/TrustProxies.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Fideloper\\Proxy\\TrustProxies::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               57
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                return $destination($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               30
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php'
             context-line*
               u'            return $this->router->dispatch($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Kernel::Illuminate\\Foundation\\Http\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               176
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'        return $this->dispatchToRoute($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               612
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'        return $this->runRoute($request, $this->findRoute($request));'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::dispatchToRoute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               623
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'            $this->runRouteWithinStack($route, $request)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::runRoute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               657
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'                        });'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::runRouteWithinStack'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               682
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'        return $pipeline($this->passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::then'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               104
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php'
             context-line*
               u'        return $this->encrypt($next($this->decrypt($request)));'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Cookie\\Middleware\\EncryptCookies::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               66
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php'
             context-line*
               u'        $response = $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               37
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php'
             context-line*
               u'            $response = $next($request), $session'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Session\\Middleware\\StartSession::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               59
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/View/Middleware/ShareErrorsFromSession.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\View\\Middleware\\ShareErrorsFromSession::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               49
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php'
             context-line*
               u'            return tap($next($request), function ($response) use ($request) {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\VerifyCsrfToken::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               75
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Middleware/SubstituteBindings.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Middleware\\SubstituteBindings::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               41
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                return $destination($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               30
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'                                $request, $route->run()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               680
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Route.php'
             context-line*
               u'            return $this->runCallable();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Route::run'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               179
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Route.php'
             context-line*
               u"            $this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Route::runCallable'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               205
           frame*
             filename*
               u'/routes/web.php'
             context-line*
               u"    throw new Exception('LARAVEL TEST');"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\RouteFileRegistrar::{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               22
         type*
           u'Exception'
@@ -473,448 +473,448 @@ system:
               u'/server.php'
             context-line*
               u"require_once __DIR__.'/public/index.php';"
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               21
           frame*
             filename*
               u'/public/index.php'
             context-line*
               u'    $request = Illuminate\\Http\\Request::capture()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'require_once'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               55
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php'
             context-line*
               u'            $response = $this->sendRequestThroughRouter($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Kernel::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               116
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php'
             context-line*
               u'                    ->then($this->dispatchToRouter());'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Kernel::sendRequestThroughRouter'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               151
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'        return $pipeline($this->passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::then'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               104
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\CheckForMaintenanceMode::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               62
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ValidatePostSize.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\ValidatePostSize::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               27
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               21
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               21
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/fideloper/proxy/src/TrustProxies.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Fideloper\\Proxy\\TrustProxies::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               57
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                return $destination($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               30
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php'
             context-line*
               u'            return $this->router->dispatch($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Kernel::Illuminate\\Foundation\\Http\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               176
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'        return $this->dispatchToRoute($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               612
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'        return $this->runRoute($request, $this->findRoute($request));'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::dispatchToRoute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               623
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'            $this->runRouteWithinStack($route, $request)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::runRoute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               657
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'                        });'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::runRouteWithinStack'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               682
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'        return $pipeline($this->passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::then'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               104
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php'
             context-line*
               u'        return $this->encrypt($next($this->decrypt($request)));'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Cookie\\Middleware\\EncryptCookies::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               66
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php'
             context-line*
               u'        $response = $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               37
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php'
             context-line*
               u'            $response = $next($request), $session'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Session\\Middleware\\StartSession::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               59
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/View/Middleware/ShareErrorsFromSession.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\View\\Middleware\\ShareErrorsFromSession::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               49
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php'
             context-line*
               u'            return tap($next($request), function ($response) use ($request) {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\VerifyCsrfToken::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               75
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Middleware/SubstituteBindings.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Middleware\\SubstituteBindings::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               41
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                return $destination($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               30
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'                                $request, $route->run()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               680
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Route.php'
             context-line*
               u'            return $this->runCallable();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Route::run'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               179
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Route.php'
             context-line*
               u"            $this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Route::runCallable'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               205
           frame*
             filename*
               u'/routes/web.php'
             context-line*
               u"    throw new Exception('LARAVEL TEST');"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\RouteFileRegistrar::{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               22
         type*
           u'Exception'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:31.547922Z'
+created: '2019-09-03T07:26:06.580929Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/packages/hub/dist/hub.js'
             context-line*
               u'     */'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.Object.<anonymous>.Hub.withScope'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               171
           frame*
             module*
@@ -36,9 +36,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'        return fn.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.mockConstructor [as captureException]'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               150
           frame (non app frame)
             module*
@@ -47,9 +47,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'          })();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.<anonymous>'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               446
           frame (non app frame)
             module*
@@ -58,9 +58,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'                return specificMockImpl.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'finalReturnValue'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               437
           frame (non app frame)
             module*
@@ -69,9 +69,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'        return original.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.<anonymous>'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               806
           frame*
             module*
@@ -80,9 +80,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/packages/hub/src/hub.ts'
             context-line*
               u'    if (maxBreadcrumbs <= 0) {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.Object.<anonymous>.Hub.captureException'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               255
           frame*
             module*
@@ -91,9 +91,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/packages/hub/dist/hub.js'
             context-line*
               u'     * @returns Scope, the new cloned scope'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.Object.<anonymous>.Hub.invokeClient'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               91
           frame*
             module*
@@ -102,9 +102,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/packages/core/src/baseclient.ts'
             context-line*
               u'    promisedEvent'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'NodeClient.Object.<anonymous>.BaseClient.captureException'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               110
           frame*
             module*
@@ -133,9 +133,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/packages/hub/dist/hub.js'
             context-line*
               u'     */'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.Object.<anonymous>.Hub.withScope'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               171
           frame*
             module*
@@ -153,9 +153,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'        return fn.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.mockConstructor [as captureException]'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               150
           frame*
             module*
@@ -164,9 +164,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'          })();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.<anonymous>'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               446
           frame*
             module*
@@ -175,9 +175,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'                return specificMockImpl.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'finalReturnValue'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               437
           frame*
             module*
@@ -186,9 +186,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'        return original.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.<anonymous>'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               806
           frame*
             module*
@@ -197,9 +197,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/packages/hub/src/hub.ts'
             context-line*
               u'    if (maxBreadcrumbs <= 0) {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.Object.<anonymous>.Hub.captureException'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               255
           frame*
             module*
@@ -208,9 +208,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/packages/hub/dist/hub.js'
             context-line*
               u'     * @returns Scope, the new cloned scope'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.Object.<anonymous>.Hub.invokeClient'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               91
           frame*
             module*
@@ -219,9 +219,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/packages/core/src/baseclient.ts'
             context-line*
               u'    promisedEvent'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'NodeClient.Object.<anonymous>.BaseClient.captureException'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               110
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-06-05T11:45:13.045473Z'
+created: '2019-09-03T07:26:06.609215Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'django/core/handlers/base.py'
             context-line*
               u'                    response = wrapped_callback(request, *callback_args, **callback_kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'get_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               112
           frame (non app frame)
             module*
@@ -27,9 +27,9 @@ app:
               u'django/views/generic/base.py'
             context-line*
               u'            return self.dispatch(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               69
           frame (non app frame)
             module*
@@ -38,9 +38,9 @@ app:
               u'django/utils/decorators.py'
             context-line*
               u'            return bound_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_wrapper'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               29
           frame (non app frame)
             module*
@@ -49,9 +49,9 @@ app:
               u'django/views/decorators/csrf.py'
             context-line*
               u'        return view_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'wrapped_view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               57
           frame (non app frame)
             module*
@@ -60,9 +60,9 @@ app:
               u'django/utils/decorators.py'
             context-line*
               u'                return func(self, *args2, **kwargs2)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'bound_func'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -71,9 +71,9 @@ app:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'        return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               37
           frame (non app frame)
             module*
@@ -82,9 +82,9 @@ app:
               u'django/views/generic/base.py'
             context-line*
               u'        return handler(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               87
           frame*
             module*
@@ -93,9 +93,9 @@ app:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'            hook.handle(request)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'post'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               127
           frame*
             module*
@@ -104,9 +104,9 @@ app:
               u'sentry_plugins/heroku/plugin.py'
             context-line*
               u"        email = request.POST['user']"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               17
           frame (non app frame)
             module*
@@ -115,9 +115,9 @@ app:
               u'django/utils/datastructures.py'
             context-line*
               u'            raise MultiValueDictKeyError(repr(key))'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'__getitem__'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               301
         type*
           u'MultiValueDictKeyError'
@@ -137,9 +137,9 @@ system:
               u'django/core/handlers/base.py'
             context-line*
               u'                    response = wrapped_callback(request, *callback_args, **callback_kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'get_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               112
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -148,9 +148,9 @@ system:
               u'django/views/generic/base.py'
             context-line*
               u'            return self.dispatch(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               69
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -159,9 +159,9 @@ system:
               u'django/utils/decorators.py'
             context-line*
               u'            return bound_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_wrapper'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               29
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -170,9 +170,9 @@ system:
               u'django/views/decorators/csrf.py'
             context-line*
               u'        return view_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'wrapped_view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               57
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -181,9 +181,9 @@ system:
               u'django/utils/decorators.py'
             context-line*
               u'                return func(self, *args2, **kwargs2)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'bound_func'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -192,9 +192,9 @@ system:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'        return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               37
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -203,9 +203,9 @@ system:
               u'django/views/generic/base.py'
             context-line*
               u'        return handler(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               87
           frame*
             module*
@@ -214,9 +214,9 @@ system:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'            hook.handle(request)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'post'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               127
           frame*
             module*
@@ -225,9 +225,9 @@ system:
               u'sentry_plugins/heroku/plugin.py'
             context-line*
               u"        email = request.POST['user']"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               17
           frame*
             module*
@@ -236,9 +236,9 @@ system:
               u'django/utils/datastructures.py'
             context-line*
               u'            raise MultiValueDictKeyError(repr(key))'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'__getitem__'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               301
         type*
           u'MultiValueDictKeyError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-06-05T11:45:13.065061Z'
+created: '2019-09-03T07:26:06.628432Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'django/core/handlers/base.py'
             context-line*
               u'                    response = wrapped_callback(request, *callback_args, **callback_kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'get_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               112
           frame (non app frame)
             module*
@@ -27,9 +27,9 @@ app:
               u'django/views/generic/base.py'
             context-line*
               u'            return self.dispatch(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               69
           frame (non app frame)
             module*
@@ -38,9 +38,9 @@ app:
               u'django/utils/decorators.py'
             context-line*
               u'            return bound_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_wrapper'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               29
           frame (non app frame)
             module*
@@ -49,9 +49,9 @@ app:
               u'django/views/decorators/csrf.py'
             context-line*
               u'        return view_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'wrapped_view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               57
           frame (non app frame)
             module*
@@ -60,9 +60,9 @@ app:
               u'django/utils/decorators.py'
             context-line*
               u'                return func(self, *args2, **kwargs2)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'bound_func'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -71,9 +71,9 @@ app:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'        return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               37
           frame (non app frame)
             module*
@@ -82,9 +82,9 @@ app:
               u'django/views/generic/base.py'
             context-line*
               u'        return handler(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               87
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -93,9 +93,9 @@ app:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'            hook.handle(request)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'post'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               127
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -104,9 +104,9 @@ app:
               u'sentry_plugins/heroku/plugin.py'
             context-line*
               u"        email = request.POST['user']"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               17
           frame (non app frame)
             module*
@@ -115,9 +115,9 @@ app:
               u'django/utils/datastructures.py'
             context-line*
               u'            raise MultiValueDictKeyError(repr(key))'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'__getitem__'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               301
         type*
           u'MultiValueDictKeyError'
@@ -137,9 +137,9 @@ system:
               u'django/core/handlers/base.py'
             context-line*
               u'                    response = wrapped_callback(request, *callback_args, **callback_kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'get_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               112
           frame*
             module*
@@ -148,9 +148,9 @@ system:
               u'django/views/generic/base.py'
             context-line*
               u'            return self.dispatch(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               69
           frame*
             module*
@@ -159,9 +159,9 @@ system:
               u'django/utils/decorators.py'
             context-line*
               u'            return bound_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_wrapper'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               29
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -170,9 +170,9 @@ system:
               u'django/views/decorators/csrf.py'
             context-line*
               u'        return view_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'wrapped_view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               57
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -181,9 +181,9 @@ system:
               u'django/utils/decorators.py'
             context-line*
               u'                return func(self, *args2, **kwargs2)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'bound_func'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -192,9 +192,9 @@ system:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'        return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               37
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -203,9 +203,9 @@ system:
               u'django/views/generic/base.py'
             context-line*
               u'        return handler(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               87
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -214,9 +214,9 @@ system:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'            hook.handle(request)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'post'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               127
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -225,9 +225,9 @@ system:
               u'sentry_plugins/heroku/plugin.py'
             context-line*
               u"        email = request.POST['user']"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               17
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -236,9 +236,9 @@ system:
               u'django/utils/datastructures.py'
             context-line*
               u'            raise MultiValueDictKeyError(repr(key))'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'__getitem__'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               301
         type*
           u'MultiValueDictKeyError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:31.566737Z'
+created: '2019-09-03T07:26:06.639222Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'sentry/utils/safe.py'
             context-line*
               u'                result = func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'safe_execute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               29
           frame*
             module*
@@ -27,9 +27,9 @@ app:
               u'sentry/integrations/slack/notify_action.py'
             context-line*
               u'            resp.raise_for_status()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'send_notification'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               119
           frame (non app frame)
             module*
@@ -38,9 +38,9 @@ app:
               u'requests/models.py'
             context-line*
               u'            raise HTTPError(http_error_msg, response=self)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'raise_for_status'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               940
         type*
           u'HTTPError'
@@ -67,9 +67,9 @@ system:
               u'sentry/utils/safe.py'
             context-line*
               u'                result = func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'safe_execute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               29
           frame*
             module*
@@ -78,9 +78,9 @@ system:
               u'sentry/integrations/slack/notify_action.py'
             context-line*
               u'            resp.raise_for_status()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'send_notification'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               119
           frame*
             module*
@@ -89,9 +89,9 @@ system:
               u'requests/models.py'
             context-line*
               u'            raise HTTPError(http_error_msg, response=self)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'raise_for_status'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               940
         type*
           u'HTTPError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-09T18:49:35.213236Z'
+created: '2019-09-03T07:26:06.668409Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'    return this.flushedQueue();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'value'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               119
           frame (non app frame)
             module*
@@ -27,9 +27,9 @@ app:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'      this._inCall--;'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'flushedQueue'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               318
           frame (non app frame)
             module*
@@ -38,9 +38,9 @@ app:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'    return this.flushedQueue();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_inCall'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               119
           frame (non app frame)
             module*
@@ -49,9 +49,9 @@ app:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'    this._lastFlush = new Date().getTime();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'flushedQueue'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               357
           frame (non app frame)
             module*
@@ -60,9 +60,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'      _receiveRootNodeIDEvent(index, eventTopLevelType, i);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_lastFlush'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1160
           frame (non app frame)
             module*
@@ -71,9 +71,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  batchedUpdates(function() {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_receiveRootNodeIDEvent'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1095
           frame (non app frame)
             module*
@@ -82,9 +82,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'    return _batchedUpdates(fn, bookkeeping);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'batchedUpdates'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1054
           frame (non app frame)
             module*
@@ -93,9 +93,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'        return fn(a);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_batchedUpdates'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               5928
           frame (non app frame)
             module*
@@ -104,9 +104,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'      (forEachAccumulated(events, executeDispatchesAndReleaseTopLevel),'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fn'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1113
           frame (non app frame)
             module*
@@ -115,12 +115,12 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  Array.isArray(arr) ? arr.forEach(cb, scope) : arr && cb.call(scope, arr);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'forEachAccumulated'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               219
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'[native code] forEach'
           frame (non app frame)
             module*
@@ -129,9 +129,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'        executeDispatch(e, !1, dispatchListeners, dispatchInstances);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'D'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               235
           frame (non app frame)
             module*
@@ -140,9 +140,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError('
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'executeDispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               181
           frame (non app frame)
             module*
@@ -151,9 +151,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'    ReactErrorUtils.invokeGuardedCallback.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'invokeGuardedCallbackAndCatchFirstError'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               54
           frame (non app frame)
             module*
@@ -162,9 +162,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'    invokeGuardedCallback.apply(ReactErrorUtils, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'apply'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               41
           frame (non app frame)
             module*
@@ -173,9 +173,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  var funcArgs = Array.prototype.slice.call(arguments, 3);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'apply'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               28
           frame (non app frame)
             module*
@@ -184,9 +184,9 @@ app:
               u'node_modules/react-native/Libraries/Components/Touchable/Touchable.js'
             context-line*
               u'  touchableHandleResponderRelease: function(e) {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'arguments'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               430
           frame (non app frame)
             module*
@@ -195,9 +195,9 @@ app:
               u'node_modules/react-native/Libraries/Components/Touchable/Touchable.js'
             context-line*
               u'      this._performSideEffectsForTransition(curState, nextState, signal, e);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_receiveSignal'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               662
           frame (non app frame)
             module*
@@ -206,9 +206,9 @@ app:
               u'node_modules/react-native/Libraries/Components/Touchable/Touchable.js'
             context-line*
               u'        this.touchableHandlePress(e);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_performSideEffectsForTransition'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               744
           frame (non app frame)
             module*
@@ -217,9 +217,9 @@ app:
               u'node_modules/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android.js'
             context-line*
               u'    this.props.onPress && this.props.onPress(e);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'this'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               175
           frame*
             module*
@@ -228,9 +228,9 @@ app:
               u'App.js'
             context-line*
               u'        <Button'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'onPress'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               143
           frame*
             module*
@@ -239,9 +239,9 @@ app:
               u'App.js'
             context-line*
               u'        <Button'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Button'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               115
         type*
           u'TypeError'
@@ -261,9 +261,9 @@ system:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'    return this.flushedQueue();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'value'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               119
           frame*
             module*
@@ -272,9 +272,9 @@ system:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'      this._inCall--;'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'flushedQueue'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               318
           frame*
             module*
@@ -283,9 +283,9 @@ system:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'    return this.flushedQueue();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_inCall'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               119
           frame*
             module*
@@ -294,9 +294,9 @@ system:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'    this._lastFlush = new Date().getTime();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'flushedQueue'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               357
           frame*
             module*
@@ -305,9 +305,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'      _receiveRootNodeIDEvent(index, eventTopLevelType, i);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_lastFlush'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1160
           frame*
             module*
@@ -316,9 +316,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  batchedUpdates(function() {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_receiveRootNodeIDEvent'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1095
           frame*
             module*
@@ -327,9 +327,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'    return _batchedUpdates(fn, bookkeeping);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'batchedUpdates'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1054
           frame*
             module*
@@ -338,9 +338,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'        return fn(a);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_batchedUpdates'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               5928
           frame*
             module*
@@ -349,9 +349,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'      (forEachAccumulated(events, executeDispatchesAndReleaseTopLevel),'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fn'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1113
           frame*
             module*
@@ -360,12 +360,12 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  Array.isArray(arr) ? arr.forEach(cb, scope) : arr && cb.call(scope, arr);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'forEachAccumulated'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               219
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'[native code] forEach'
           frame*
             module*
@@ -374,9 +374,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'        executeDispatch(e, !1, dispatchListeners, dispatchInstances);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'D'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               235
           frame*
             module*
@@ -385,9 +385,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError('
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'executeDispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               181
           frame*
             module*
@@ -396,9 +396,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'    ReactErrorUtils.invokeGuardedCallback.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'invokeGuardedCallbackAndCatchFirstError'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               54
           frame*
             module*
@@ -407,9 +407,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'    invokeGuardedCallback.apply(ReactErrorUtils, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'apply'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               41
           frame*
             module*
@@ -418,9 +418,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  var funcArgs = Array.prototype.slice.call(arguments, 3);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'apply'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               28
           frame*
             module*
@@ -429,9 +429,9 @@ system:
               u'node_modules/react-native/Libraries/Components/Touchable/Touchable.js'
             context-line*
               u'  touchableHandleResponderRelease: function(e) {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'arguments'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               430
           frame*
             module*
@@ -440,9 +440,9 @@ system:
               u'node_modules/react-native/Libraries/Components/Touchable/Touchable.js'
             context-line*
               u'      this._performSideEffectsForTransition(curState, nextState, signal, e);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_receiveSignal'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               662
           frame*
             module*
@@ -451,9 +451,9 @@ system:
               u'node_modules/react-native/Libraries/Components/Touchable/Touchable.js'
             context-line*
               u'        this.touchableHandlePress(e);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_performSideEffectsForTransition'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               744
           frame*
             module*
@@ -462,9 +462,9 @@ system:
               u'node_modules/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android.js'
             context-line*
               u'    this.props.onPress && this.props.onPress(e);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'this'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               175
           frame*
             module*
@@ -473,9 +473,9 @@ system:
               u'App.js'
             context-line*
               u'        <Button'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'onPress'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               143
           frame*
             module*
@@ -484,9 +484,9 @@ system:
               u'App.js'
             context-line*
               u'        <Button'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Button'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               115
         type*
           u'TypeError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:31.625402Z'
+created: '2019-09-03T07:26:06.707090Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,7 +12,7 @@ app:
           filename (ignored because filename is a URL)
             u'foo'
           context-line (discarded because from URL origin)
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             1
 --------------------------------------------------------------------------
 fallback:
@@ -27,5 +27,5 @@ system:
           filename (ignored because filename is a URL)
             u'foo'
           context-line (discarded because from URL origin)
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             1

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:31.633429Z'
+created: '2019-09-03T07:26:06.715819Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
             u'foo'
           context-line*
             u'<HTML>'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if context-line is available)
             1
 --------------------------------------------------------------------------
 system:
@@ -26,5 +26,5 @@ system:
             u'foo'
           context-line*
             u'<HTML>'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if context-line is available)
             1

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:31.641600Z'
+created: '2019-09-03T07:26:06.724471Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,7 +12,7 @@ app:
           filename (ignored because filename is a URL)
             u'/index.js'
           context-line (discarded because from URL origin)
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             20
 --------------------------------------------------------------------------
 fallback:
@@ -27,5 +27,5 @@ system:
           filename (ignored because filename is a URL)
             u'/index.js'
           context-line (discarded because from URL origin)
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             20

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:31.667889Z'
+created: '2019-09-03T07:26:06.795984Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,16 +14,16 @@ app:
         frame (frame considered in-app because no frame is in-app)
           filename (ignored because filename is a URL)
             u'/C:/Users/redacted/AppData/Local/redacted/app-2.4.1/resources/app.asar/dojo/dojo.js'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if module or filename are available)
             u'c'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             1188
         frame (frame considered in-app because no frame is in-app)
           filename (ignored because filename is a URL)
             u'/C:/Users/redacted/AppData/Local/redacted/app-2.4.1/resources/app.asar/dojo/dojo.js'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if module or filename are available)
             u'Object._createDocumentViewModel'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             1184
 --------------------------------------------------------------------------
 fallback:
@@ -40,14 +40,14 @@ system:
         frame
           filename (ignored because filename is a URL)
             u'/C:/Users/redacted/AppData/Local/redacted/app-2.4.1/resources/app.asar/dojo/dojo.js'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if module or filename are available)
             u'c'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             1188
         frame
           filename (ignored because filename is a URL)
             u'/C:/Users/redacted/AppData/Local/redacted/app-2.4.1/resources/app.asar/dojo/dojo.js'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if module or filename are available)
             u'Object._createDocumentViewModel'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             1184

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:36.853169Z'
+created: '2019-09-03T07:26:07.084393Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,10 +10,10 @@ app:
       exception*
         stacktrace*
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'__pthread_start'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'__pthread_body'
           frame (non app frame)
             filename*
@@ -552,10 +552,10 @@ system:
       exception*
         stacktrace*
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'__pthread_start'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'__pthread_body'
           frame*
             filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-09T18:49:35.432802Z'
+created: '2019-09-03T07:26:07.106321Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,189 +14,189 @@ app:
               u'Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Invoke'
           frame (non app frame)
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Invoke'
           frame (non app frame)
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Routing.EndpointMiddleware'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Invoke'
           frame (non app frame)
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeAsync'
           frame (non app frame)
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeFilterPipelineAsync'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'System.Threading.Tasks.Task Next(State ByRef, Scope ByRef, System.Object ByRef, Boolean ByRef)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Next'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void Rethrow(Microsoft.AspNetCore.Mvc.Filters.ResourceExecutedContext)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Rethrow'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeNextResourceFilter'
           frame (non app frame)
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeInnerFilterAsync'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'System.Threading.Tasks.Task Next(State ByRef, Scope ByRef, System.Object ByRef, Boolean ByRef)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Next'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void Rethrow(Microsoft.AspNetCore.Mvc.Filters.ActionExecutedContext)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Rethrow'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeNextActionFilterAsync'
           frame (non app frame)
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame (non app frame)
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame (non app frame)
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeActionMethodAsync'
           frame (non app frame)
             module*
@@ -209,14 +209,14 @@ app:
               u'Microsoft.Extensions.Internal.ObjectMethodExecutor'
             context-line*
               u'System.Object Execute(System.Object, System.Object[])'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Execute'
           frame*
             module*
               u'(unknown)'
             context-line*
               u'System.Object lambda_method(System.Runtime.CompilerServices.Closure, System.Object, System.Object[])'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'lambda_method'
           frame*
             module*
@@ -225,9 +225,9 @@ app:
               u'C:\\Users\\dvora\\source\\repos\\SentryTest2\\SentryTest2\\Controllers\\ValuesController.cs'
             context-line*
               u'Microsoft.AspNetCore.Mvc.ActionResult`1[System.String] Get(Int32)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Get'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               27
         type*
           u'System.Exception'
@@ -252,189 +252,189 @@ system:
               u'Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Invoke'
           frame*
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Invoke'
           frame*
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Routing.EndpointMiddleware'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Invoke'
           frame*
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeAsync'
           frame*
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeFilterPipelineAsync'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'System.Threading.Tasks.Task Next(State ByRef, Scope ByRef, System.Object ByRef, Boolean ByRef)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Next'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void Rethrow(Microsoft.AspNetCore.Mvc.Filters.ResourceExecutedContext)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Rethrow'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeNextResourceFilter'
           frame*
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeInnerFilterAsync'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'System.Threading.Tasks.Task Next(State ByRef, Scope ByRef, System.Object ByRef, Boolean ByRef)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Next'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void Rethrow(Microsoft.AspNetCore.Mvc.Filters.ActionExecutedContext)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Rethrow'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeNextActionFilterAsync'
           frame*
             module*
               u'System.Runtime.CompilerServices.TaskAwaiter'
             context-line*
               u'Void HandleNonSuccessAndDebuggerNotification(System.Threading.Tasks.Task)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'HandleNonSuccessAndDebuggerNotification'
           frame*
             module*
               u'System.Runtime.ExceptionServices.ExceptionDispatchInfo'
             context-line*
               u'Void Throw()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Throw'
           frame*
             module*
               u'Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker'
             context-line*
               u'Void MoveNext()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'InvokeActionMethodAsync'
           frame*
             module*
@@ -447,14 +447,14 @@ system:
               u'Microsoft.Extensions.Internal.ObjectMethodExecutor'
             context-line*
               u'System.Object Execute(System.Object, System.Object[])'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Execute'
           frame*
             module*
               u'(unknown)'
             context-line*
               u'System.Object lambda_method(System.Runtime.CompilerServices.Closure, System.Object, System.Object[])'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'lambda_method'
           frame*
             module*
@@ -463,9 +463,9 @@ system:
               u'C:\\Users\\dvora\\source\\repos\\SentryTest2\\SentryTest2\\Controllers\\ValuesController.cs'
             context-line*
               u'Microsoft.AspNetCore.Mvc.ActionResult`1[System.String] Get(Int32)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Get'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               27
         type*
           u'System.Exception'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:36.889789Z'
+created: '2019-09-03T07:26:07.121298Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'sentry/utils/safe.py'
             context-line*
               u'            result = func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'safe_execute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               31
           frame*
             module*
@@ -27,9 +27,9 @@ app:
               u'sentry/utils/services.py'
             context-line*
               u'                context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'<lambda>'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               91
           frame*
             module*
@@ -38,9 +38,9 @@ app:
               u'getsentry/quotas.py'
             context-line*
               u'        return super(SubscriptionQuota, self).is_rate_limited(project, key=key)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'is_rate_limited'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               136
           frame*
             module*
@@ -49,9 +49,9 @@ app:
               u'sentry/quotas/redis.py'
             context-line*
               u'        rejections = is_rate_limited(client, keys, args)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'is_rate_limited'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               189
           frame*
             module*
@@ -60,9 +60,9 @@ app:
               u'sentry/utils/redis.py'
             context-line*
               u'        return script(keys, args, client)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'call_script'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               239
           frame (non app frame)
             module*
@@ -71,9 +71,9 @@ app:
               u'redis/client.py'
             context-line*
               u'            return client.evalsha(self.sha, len(keys), *args)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'__call__'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               2694
           frame (non app frame)
             module*
@@ -82,9 +82,9 @@ app:
               u'redis/client.py'
             context-line*
               u"        return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'evalsha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1944
           frame (non app frame)
             module*
@@ -93,9 +93,9 @@ app:
               u'redis/client.py'
             context-line*
               u'            return self.parse_response(connection, command_name, **options)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'execute_command'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               579
           frame (non app frame)
             module*
@@ -104,9 +104,9 @@ app:
               u'redis/client.py'
             context-line*
               u'        response = connection.read_response()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'parse_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               585
           frame (non app frame)
             module*
@@ -115,9 +115,9 @@ app:
               u'redis/connection.py'
             context-line*
               u'            response = self._parser.read_response()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'read_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               577
           frame (non app frame)
             module*
@@ -126,9 +126,9 @@ app:
               u'redis/connection.py'
             context-line*
               u'                                      (e.args,))'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'read_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               357
         type*
           u'ConnectionError'
@@ -155,9 +155,9 @@ system:
               u'sentry/utils/safe.py'
             context-line*
               u'            result = func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'safe_execute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               31
           frame*
             module*
@@ -166,9 +166,9 @@ system:
               u'sentry/utils/services.py'
             context-line*
               u'                context[key] = (lambda f: lambda *a, **k: getattr(self, f)(*a, **k))(key)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'<lambda>'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               91
           frame*
             module*
@@ -177,9 +177,9 @@ system:
               u'getsentry/quotas.py'
             context-line*
               u'        return super(SubscriptionQuota, self).is_rate_limited(project, key=key)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'is_rate_limited'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               136
           frame*
             module*
@@ -188,9 +188,9 @@ system:
               u'sentry/quotas/redis.py'
             context-line*
               u'        rejections = is_rate_limited(client, keys, args)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'is_rate_limited'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               189
           frame*
             module*
@@ -199,9 +199,9 @@ system:
               u'sentry/utils/redis.py'
             context-line*
               u'        return script(keys, args, client)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'call_script'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               239
           frame*
             module*
@@ -210,9 +210,9 @@ system:
               u'redis/client.py'
             context-line*
               u'            return client.evalsha(self.sha, len(keys), *args)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'__call__'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               2694
           frame*
             module*
@@ -221,9 +221,9 @@ system:
               u'redis/client.py'
             context-line*
               u"        return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'evalsha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1944
           frame*
             module*
@@ -232,9 +232,9 @@ system:
               u'redis/client.py'
             context-line*
               u'            return self.parse_response(connection, command_name, **options)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'execute_command'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               579
           frame*
             module*
@@ -243,9 +243,9 @@ system:
               u'redis/client.py'
             context-line*
               u'        response = connection.read_response()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'parse_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               585
           frame*
             module*
@@ -254,9 +254,9 @@ system:
               u'redis/connection.py'
             context-line*
               u'            response = self._parser.read_response()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'read_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               577
           frame*
             module*
@@ -265,9 +265,9 @@ system:
               u'redis/connection.py'
             context-line*
               u'                                      (e.args,))'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'read_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               357
         type*
           u'ConnectionError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-09T18:49:35.541296Z'
+created: '2019-09-03T07:26:07.224005Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,7 +16,7 @@ app:
               u'./app/components/modals/createTeamModal.jsx'
             context-line*
               u'        onError(err);'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               27
           frame* (frame considered in-app because no frame is in-app)
             module*
@@ -25,9 +25,9 @@ app:
               u'./app/views/settings/components/forms/form.jsx'
             context-line*
               u'    this.model.submitError(error);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'onError'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               125
         type*
           u'TypeError'
@@ -47,7 +47,7 @@ system:
               u'./app/components/modals/createTeamModal.jsx'
             context-line*
               u'        onError(err);'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               27
           frame*
             module*
@@ -56,9 +56,9 @@ system:
               u'./app/views/settings/components/forms/form.jsx'
             context-line*
               u'    this.model.submitError(error);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'onError'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               125
         type*
           u'TypeError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:37.076435Z'
+created: '2019-09-03T07:26:07.287141Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
             u'foo.py'
           context-line*
             u'hello world'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'test'
 --------------------------------------------------------------------------
 system:
@@ -26,5 +26,5 @@ system:
             u'foo.py'
           context-line*
             u'hello world'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'test'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:37.091971Z'
+created: '2019-09-03T07:26:07.303194Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
             u'/foo.py'
           context-line*
             u'hello world'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'test'
 --------------------------------------------------------------------------
 system:
@@ -26,5 +26,5 @@ system:
             u'/foo.py'
           context-line*
             u'hello world'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'test'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:37.099518Z'
+created: '2019-09-03T07:26:07.311985Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
             u'/foo.py'
           context-line*
             u'hello world'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'test'
 --------------------------------------------------------------------------
 system:
@@ -26,5 +26,5 @@ system:
             u'/foo.py'
           context-line*
             u'hello world'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'test'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:37.171612Z'
+created: '2019-09-03T07:26:07.375364Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
     app
       stacktrace
         frame (frame considered in-app because no frame is in-app)
-          function (function name is used only if module or filename are available)
+          function (function name is not used if module or filename are available)
             u'forEach'
 --------------------------------------------------------------------------
 fallback:
@@ -21,5 +21,5 @@ system:
     system
       stacktrace
         frame (native code indicated by filename)
-          function (function name is used only if module or filename are available)
+          function (function name is not used if module or filename are available)
             u'forEach'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:37.246976Z'
+created: '2019-09-03T07:26:07.449753Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,9 +13,9 @@ app:
             u'foo.py'
           context-line*
             u'foo bar'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'bar'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if context-line is available)
             1
 --------------------------------------------------------------------------
 system:
@@ -28,7 +28,7 @@ system:
             u'foo.py'
           context-line*
             u'foo bar'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if context-line is available)
             u'bar'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if context-line is available)
             1

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:30.287453Z'
+created: '2019-09-03T07:26:07.618200Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,66 +12,66 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Foo.testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               1
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame (frame considered in-app because no frame is in-app)
             filename (anonymous filename discarded)
               u'<anonymous>'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Array.map'
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Object.callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               19
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Object.aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'
@@ -87,66 +87,66 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Foo.testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               1
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame
             filename (anonymous filename discarded)
               u'<anonymous>'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Array.map'
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Object.callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               19
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Object.aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:30.299340Z'
+created: '2019-09-03T07:26:07.631524Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,23 +12,23 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Anonymous function'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Foo.prototype.testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame* (frame considered in-app because no frame is in-app)
             filename*
@@ -40,9 +40,9 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame* (frame considered in-app because no frame is in-app)
             filename*
@@ -52,30 +52,30 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Anonymous function'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               17
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'
@@ -91,23 +91,23 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Anonymous function'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Foo.prototype.testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame*
             filename*
@@ -119,9 +119,9 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame*
             filename*
@@ -131,30 +131,30 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Anonymous function'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               17
           frame
             filename (ignored because filename is a URL)
               u'/Home/Desktop/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-10T13:21:30.528503Z'
+created: '2019-09-03T07:26:07.644295Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,63 +12,63 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               1
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test/<'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               19
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'
@@ -84,63 +84,63 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               1
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test/<'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               19
           frame
             filename (ignored because filename is a URL)
               u'/private/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:44:34.467623Z'
+created: '2019-09-03T07:26:07.657855Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -55,7 +55,7 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (anonymous filename discarded)
               u'<anonymous>'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Array.map'
           frame* (frame considered in-app because no frame is in-app)
             module*
@@ -148,7 +148,7 @@ system:
           frame
             filename (anonymous filename discarded)
               u'<anonymous>'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Array.map'
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:44:34.505161Z'
+created: '2019-09-03T07:26:07.698717Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -35,7 +35,7 @@ app:
             lineno (function takes precedence)
               38
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
           frame* (frame considered in-app because no frame is in-app)
             module*
@@ -47,7 +47,7 @@ app:
             lineno (function takes precedence)
               32
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'map'
           frame* (frame considered in-app because no frame is in-app)
             module*
@@ -75,7 +75,7 @@ app:
             lineno (function takes precedence)
               19
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
           frame* (frame considered in-app because no frame is in-app)
             module*
@@ -123,7 +123,7 @@ system:
             lineno (function takes precedence)
               38
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
           frame*
             module*
@@ -135,7 +135,7 @@ system:
             lineno (function takes precedence)
               32
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'map'
           frame*
             module*
@@ -163,7 +163,7 @@ system:
             lineno (function takes precedence)
               19
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T19:13:30.322788Z'
+created: '2019-09-03T07:26:07.711906Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,63 +12,63 @@ app:
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'map'
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               19
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
           frame (frame considered in-app because no frame is in-app)
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'
@@ -84,63 +84,63 @@ system:
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               49
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'testMethod'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               43
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               38
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'eval'
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'test'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               32
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'map'
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               33
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callback'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               24
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'callAnotherThing'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               19
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
           frame
             filename (ignored because filename is a URL)
               u'/tmp/test.html'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'aha'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if module or filename are available)
               18
         type*
           u'Error'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T21:58:33.806947Z'
+created: '2019-09-03T07:26:07.737231Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/core-js/modules/_microtask.js'
             context-line*
               u'        fn();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'M'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               18
           frame (non app frame)
             module*
@@ -27,9 +27,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise.js'
             context-line*
               u"    while (chain.length > i) run(chain[i++]); // variable length - can't use forEach"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fn'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               92
           frame (non app frame)
             module*
@@ -38,9 +38,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise.js'
             context-line*
               u'            result = handler(value); // may throw'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'run'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               75
           frame (non app frame)
             module*
@@ -49,9 +49,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'        asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_next'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame (non app frame)
             module*
@@ -60,9 +60,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'    var info = gen[key](arg);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'asyncGeneratorStep'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               3
           frame (non app frame)
             module*
@@ -71,9 +71,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'        return this._invoke(method, arg);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'key'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               114
           frame (non app frame)
             module*
@@ -82,9 +82,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'        var record = tryCatch(innerFn, self, context);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'this'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               288
           frame (non app frame)
             module*
@@ -93,9 +93,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'      return { type: "normal", arg: fn.call(obj, arg) };'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'tryCatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               62
           frame*
             module*
@@ -104,9 +104,9 @@ app:
               u'./app/components/lazyLoad.jsx'
             context-line*
               u'      this.setState({'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fn'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               100
           frame (non app frame)
             module*
@@ -175,9 +175,9 @@ app:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    this.fetchData();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'X'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               42
           frame*
             module*
@@ -186,9 +186,9 @@ app:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'this'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               96
           frame*
             module*
@@ -197,9 +197,9 @@ app:
               u'./app/api.jsx'
             context-line*
               u'    const preservedError = new Error();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fetchGroupEventAndMarkSeen'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               276
         type*
           u'NotFoundError'
@@ -219,9 +219,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/core-js/modules/_microtask.js'
             context-line*
               u'        fn();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'M'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               18
           frame*
             module*
@@ -230,9 +230,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise.js'
             context-line*
               u"    while (chain.length > i) run(chain[i++]); // variable length - can't use forEach"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fn'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               92
           frame*
             module*
@@ -241,9 +241,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/core-js/modules/es6.promise.js'
             context-line*
               u'            result = handler(value); // may throw'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'run'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               75
           frame*
             module*
@@ -252,9 +252,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'        asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_next'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame*
             module*
@@ -263,9 +263,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'    var info = gen[key](arg);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'asyncGeneratorStep'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               3
           frame*
             module*
@@ -274,9 +274,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'        return this._invoke(method, arg);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'key'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               114
           frame*
             module*
@@ -285,9 +285,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'        var record = tryCatch(innerFn, self, context);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'this'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               288
           frame*
             module*
@@ -296,9 +296,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'      return { type: "normal", arg: fn.call(obj, arg) };'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'tryCatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               62
           frame*
             module*
@@ -307,9 +307,9 @@ system:
               u'./app/components/lazyLoad.jsx'
             context-line*
               u'      this.setState({'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fn'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               100
           frame*
             module*
@@ -378,9 +378,9 @@ system:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    this.fetchData();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'X'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               42
           frame*
             module*
@@ -389,9 +389,9 @@ system:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'this'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               96
           frame*
             module*
@@ -400,9 +400,9 @@ system:
               u'./app/api.jsx'
             context-line*
               u'    const preservedError = new Error();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fetchGroupEventAndMarkSeen'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               276
         type*
           u'NotFoundError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T21:58:33.873193Z'
+created: '2019-09-03T07:26:07.759670Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
       exception*
         stacktrace*
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'promiseReactionJob'
           frame (non app frame)
             module*
@@ -19,9 +19,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'        asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_next'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame (non app frame)
             module*
@@ -30,9 +30,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'    var info = gen[key](arg);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'asyncGeneratorStep'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               3
           frame (non app frame)
             module*
@@ -41,9 +41,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'        var record = tryCatch(innerFn, self, context);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'key'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               288
           frame (non app frame)
             module*
@@ -52,9 +52,9 @@ app:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'      return { type: "normal", arg: fn.call(obj, arg) };'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'tryCatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               62
           frame*
             module*
@@ -63,9 +63,9 @@ app:
               u'./app/components/lazyLoad.jsx'
             context-line*
               u'      this.setState({'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'call'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               100
           frame (non app frame)
             module*
@@ -134,9 +134,9 @@ app:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    this.fetchData();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'q'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               42
           frame*
             module*
@@ -145,9 +145,9 @@ app:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fetchData'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               96
           frame*
             module*
@@ -156,9 +156,9 @@ app:
               u'./app/api.jsx'
             context-line*
               u'    const preservedError = new Error();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fetchGroupEventAndMarkSeen'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               276
         type*
           u'NotFoundError'
@@ -172,7 +172,7 @@ system:
       exception*
         stacktrace*
           frame (native code indicated by filename)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'promiseReactionJob'
           frame*
             module*
@@ -181,9 +181,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'        asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_next'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame*
             module*
@@ -192,9 +192,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/@babel/runtime/helpers/asyncToGenerator.js'
             context-line*
               u'    var info = gen[key](arg);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'asyncGeneratorStep'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               3
           frame*
             module*
@@ -203,9 +203,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'        var record = tryCatch(innerFn, self, context);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'key'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               288
           frame*
             module*
@@ -214,9 +214,9 @@ system:
               u'/usr/src/getsentry/src/sentry/node_modules/regenerator-runtime/runtime.js'
             context-line*
               u'      return { type: "normal", arg: fn.call(obj, arg) };'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'tryCatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               62
           frame*
             module*
@@ -225,9 +225,9 @@ system:
               u'./app/components/lazyLoad.jsx'
             context-line*
               u'      this.setState({'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'call'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               100
           frame*
             module*
@@ -296,9 +296,9 @@ system:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    this.fetchData();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'q'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               42
           frame*
             module*
@@ -307,9 +307,9 @@ system:
               u'./app/views/groupDetails/shared/groupEventDetails.jsx'
             context-line*
               u'    fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fetchData'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               96
           frame*
             module*
@@ -318,9 +318,9 @@ system:
               u'./app/api.jsx'
             context-line*
               u'    const preservedError = new Error();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fetchGroupEventAndMarkSeen'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               276
         type*
           u'NotFoundError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-09T18:49:35.887760Z'
+created: '2019-09-03T07:26:07.801071Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,448 +14,448 @@ app:
               u'/server.php'
             context-line*
               u"require_once __DIR__.'/public/index.php';"
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               21
           frame*
             filename*
               u'/public/index.php'
             context-line*
               u'    $request = Illuminate\\Http\\Request::capture()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'require_once'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               55
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php'
             context-line*
               u'            $response = $this->sendRequestThroughRouter($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Kernel::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               116
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php'
             context-line*
               u'                    ->then($this->dispatchToRouter());'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Kernel::sendRequestThroughRouter'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               151
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'        return $pipeline($this->passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::then'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               104
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\CheckForMaintenanceMode::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               62
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ValidatePostSize.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\ValidatePostSize::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               27
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               21
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               21
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/fideloper/proxy/src/TrustProxies.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Fideloper\\Proxy\\TrustProxies::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               57
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                return $destination($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               30
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php'
             context-line*
               u'            return $this->router->dispatch($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Kernel::Illuminate\\Foundation\\Http\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               176
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'        return $this->dispatchToRoute($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               612
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'        return $this->runRoute($request, $this->findRoute($request));'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::dispatchToRoute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               623
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'            $this->runRouteWithinStack($route, $request)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::runRoute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               657
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'                        });'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::runRouteWithinStack'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               682
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'        return $pipeline($this->passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::then'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               104
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php'
             context-line*
               u'        return $this->encrypt($next($this->decrypt($request)));'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Cookie\\Middleware\\EncryptCookies::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               66
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php'
             context-line*
               u'        $response = $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               37
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php'
             context-line*
               u'            $response = $next($request), $session'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Session\\Middleware\\StartSession::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               59
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/View/Middleware/ShareErrorsFromSession.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\View\\Middleware\\ShareErrorsFromSession::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               49
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php'
             context-line*
               u'            return tap($next($request), function ($response) use ($request) {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\VerifyCsrfToken::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               75
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Middleware/SubstituteBindings.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Middleware\\SubstituteBindings::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               41
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                return $destination($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               30
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'                                $request, $route->run()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               680
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Route.php'
             context-line*
               u'            return $this->runCallable();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Route::run'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               179
           frame (non app frame)
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Route.php'
             context-line*
               u"            $this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Route::runCallable'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               205
           frame*
             filename*
               u'/routes/web.php'
             context-line*
               u"    throw new Exception('LARAVEL TEST');"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\RouteFileRegistrar::{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               22
         type*
           u'Exception'
@@ -473,448 +473,448 @@ system:
               u'/server.php'
             context-line*
               u"require_once __DIR__.'/public/index.php';"
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               21
           frame*
             filename*
               u'/public/index.php'
             context-line*
               u'    $request = Illuminate\\Http\\Request::capture()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'require_once'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               55
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php'
             context-line*
               u'            $response = $this->sendRequestThroughRouter($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Kernel::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               116
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php'
             context-line*
               u'                    ->then($this->dispatchToRouter());'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Kernel::sendRequestThroughRouter'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               151
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'        return $pipeline($this->passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::then'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               104
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/CheckForMaintenanceMode.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\CheckForMaintenanceMode::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               62
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ValidatePostSize.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\ValidatePostSize::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               27
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               21
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\TransformsRequest::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               21
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/fideloper/proxy/src/TrustProxies.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Fideloper\\Proxy\\TrustProxies::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               57
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                return $destination($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               30
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php'
             context-line*
               u'            return $this->router->dispatch($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Kernel::Illuminate\\Foundation\\Http\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               176
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'        return $this->dispatchToRoute($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               612
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'        return $this->runRoute($request, $this->findRoute($request));'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::dispatchToRoute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               623
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'            $this->runRouteWithinStack($route, $request)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::runRoute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               657
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'                        });'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::runRouteWithinStack'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               682
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'        return $pipeline($this->passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::then'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               104
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php'
             context-line*
               u'        return $this->encrypt($next($this->decrypt($request)));'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Cookie\\Middleware\\EncryptCookies::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               66
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php'
             context-line*
               u'        $response = $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               37
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php'
             context-line*
               u'            $response = $next($request), $session'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Session\\Middleware\\StartSession::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               59
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/View/Middleware/ShareErrorsFromSession.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\View\\Middleware\\ShareErrorsFromSession::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               49
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php'
             context-line*
               u'            return tap($next($request), function ($response) use ($request) {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Foundation\\Http\\Middleware\\VerifyCsrfToken::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               75
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                    return $callable($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               53
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php'
             context-line*
               u'                                ? $pipe->{$this->method}(...$parameters)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               163
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Middleware/SubstituteBindings.php'
             context-line*
               u'        return $next($request);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Middleware\\SubstituteBindings::handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               41
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Pipeline.php'
             context-line*
               u'                return $destination($passable);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Pipeline::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               30
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Router.php'
             context-line*
               u'                                $request, $route->run()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Router::Illuminate\\Routing\\{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               680
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Route.php'
             context-line*
               u'            return $this->runCallable();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Route::run'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               179
           frame*
             filename*
               u'/vendor/laravel/framework/src/Illuminate/Routing/Route.php'
             context-line*
               u"            $this->parametersWithoutNulls(), new ReflectionFunction($this->action['uses'])"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\Route::runCallable'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               205
           frame*
             filename*
               u'/routes/web.php'
             context-line*
               u"    throw new Exception('LARAVEL TEST');"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Illuminate\\Routing\\RouteFileRegistrar::{closure}'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               22
         type*
           u'Exception'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-11T09:56:04.447818Z'
+created: '2019-09-03T07:26:07.864619Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
       exception (ignored because hash matches system variant)
         stacktrace
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated(unsigned long,unsigned short,_GUID const &,_GUID const &,_GUID const &,HKL__ *,unsigned long)'
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent(char const *,char const *,char const *)'
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()'
         type*
           u'log_demo'
@@ -30,13 +30,13 @@ system:
       exception*
         stacktrace
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated(unsigned long,unsigned short,_GUID const &,_GUID const &,_GUID const &,HKL__ *,unsigned long)'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent(char const *,char const *,char const *)'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()'
         type*
           u'log_demo'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-16T11:55:54.205797Z'
+created: '2019-09-03T07:26:07.881126Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
       exception (ignored because hash matches system variant)
         stacktrace
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated(unsigned long,unsigned short,_GUID const &,_GUID const &,_GUID const &,HKL__ *,unsigned long)'
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent(char const *,char const *,char const *)'
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()'
         type*
           u'log_demo'
@@ -30,13 +30,13 @@ system:
       exception*
         stacktrace
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated(unsigned long,unsigned short,_GUID const &,_GUID const &,_GUID const &,HKL__ *,unsigned long)'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent(char const *,char const *,char const *)'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()'
         type*
           u'log_demo'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-20T23:12:41.265357Z'
+created: '2019-09-03T07:26:07.915869Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,46 +10,46 @@ app:
       exception (ignored because hash matches system variant)
         stacktrace
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'_main'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start_internal'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'___rust_maybe_catch_panic'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::panicking::try::do_call'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log_demo::main'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log::__private_api_log'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'<sentry::integrations::log::Logger as log::Log>::log'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'sentry::hub::Hub::with_active'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'sentry::hub::Hub::with'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'sentry::hub::Hub::with_active::{{closure}}'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'<unknown>'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'<redacted>'
         type*
           u'log_demo'
@@ -63,46 +63,46 @@ system:
       exception*
         stacktrace
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'_main'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start_internal'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'___rust_maybe_catch_panic'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::panicking::try::do_call'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log_demo::main'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log::__private_api_log'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'<sentry::integrations::log::Logger as log::Log>::log'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'sentry::hub::Hub::with_active'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'sentry::hub::Hub::with'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'sentry::hub::Hub::with_active::{{closure}}'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'<unknown>'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'<redacted>'
         type*
           u'log_demo'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-16T18:21:47.044949Z'
+created: '2019-09-03T07:26:07.932400Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,13 +10,13 @@ app:
       exception (ignored because hash matches system variant)
         stacktrace
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated(unsigned long,unsigned short,_GUID const &,_GUID const &,_GUID const &,HKL__ *,unsigned long)'
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent(char const *,char const *,char const *)'
           frame (frame considered in-app because no frame is in-app)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()'
         type*
           u'log_demo'
@@ -30,13 +30,13 @@ system:
       exception*
         stacktrace
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated(unsigned long,unsigned short,_GUID const &,_GUID const &,_GUID const &,HKL__ *,unsigned long)'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'Scaleform::GFx::AS3::IMEManager::DispatchEvent(char const *,char const *,char const *)'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'<lambda_5db80dab47756d3e72c2dcd38b80b1dd>::operator()'
         type*
           u'log_demo'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:37.450972Z'
+created: '2019-09-03T07:26:07.963390Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/packages/hub/dist/hub.js'
             context-line*
               u'     */'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.Object.<anonymous>.Hub.withScope'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               171
           frame*
             module*
@@ -36,9 +36,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'        return fn.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.mockConstructor [as captureException]'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               150
           frame (non app frame)
             module*
@@ -47,9 +47,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'          })();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.<anonymous>'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               446
           frame (non app frame)
             module*
@@ -58,9 +58,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'                return specificMockImpl.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'finalReturnValue'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               437
           frame (non app frame)
             module*
@@ -69,9 +69,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'        return original.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.<anonymous>'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               806
           frame*
             module*
@@ -80,9 +80,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/packages/hub/src/hub.ts'
             context-line*
               u'    if (maxBreadcrumbs <= 0) {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.Object.<anonymous>.Hub.captureException'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               255
           frame*
             module*
@@ -91,9 +91,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/packages/hub/dist/hub.js'
             context-line*
               u'     * @returns Scope, the new cloned scope'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.Object.<anonymous>.Hub.invokeClient'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               91
           frame*
             module*
@@ -102,9 +102,9 @@ app:
               u'/home/travis/build/getsentry/sentry-javascript/packages/core/src/baseclient.ts'
             context-line*
               u'    promisedEvent'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'NodeClient.Object.<anonymous>.BaseClient.captureException'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               110
           frame*
             module*
@@ -133,9 +133,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/packages/hub/dist/hub.js'
             context-line*
               u'     */'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.Object.<anonymous>.Hub.withScope'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               171
           frame*
             module*
@@ -153,9 +153,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'        return fn.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.mockConstructor [as captureException]'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               150
           frame*
             module*
@@ -164,9 +164,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'          })();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.<anonymous>'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               446
           frame*
             module*
@@ -175,9 +175,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'                return specificMockImpl.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'finalReturnValue'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               437
           frame*
             module*
@@ -186,9 +186,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/node_modules/jest-mock/build/index.js'
             context-line*
               u'        return original.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.<anonymous>'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               806
           frame*
             module*
@@ -197,9 +197,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/packages/hub/src/hub.ts'
             context-line*
               u'    if (maxBreadcrumbs <= 0) {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.Object.<anonymous>.Hub.captureException'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               255
           frame*
             module*
@@ -208,9 +208,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/packages/hub/dist/hub.js'
             context-line*
               u'     * @returns Scope, the new cloned scope'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Hub.Object.<anonymous>.Hub.invokeClient'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               91
           frame*
             module*
@@ -219,9 +219,9 @@ system:
               u'/home/travis/build/getsentry/sentry-javascript/packages/core/src/baseclient.ts'
             context-line*
               u'    promisedEvent'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'NodeClient.Object.<anonymous>.BaseClient.captureException'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               110
           frame*
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-06-05T11:45:14.369523Z'
+created: '2019-09-03T07:26:07.991355Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'django/core/handlers/base.py'
             context-line*
               u'                    response = wrapped_callback(request, *callback_args, **callback_kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'get_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               112
           frame (non app frame)
             module*
@@ -27,9 +27,9 @@ app:
               u'django/views/generic/base.py'
             context-line*
               u'            return self.dispatch(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               69
           frame (non app frame)
             module*
@@ -38,9 +38,9 @@ app:
               u'django/utils/decorators.py'
             context-line*
               u'            return bound_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_wrapper'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               29
           frame (non app frame)
             module*
@@ -49,9 +49,9 @@ app:
               u'django/views/decorators/csrf.py'
             context-line*
               u'        return view_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'wrapped_view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               57
           frame (non app frame)
             module*
@@ -60,9 +60,9 @@ app:
               u'django/utils/decorators.py'
             context-line*
               u'                return func(self, *args2, **kwargs2)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'bound_func'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -71,9 +71,9 @@ app:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'        return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               37
           frame (non app frame)
             module*
@@ -82,9 +82,9 @@ app:
               u'django/views/generic/base.py'
             context-line*
               u'        return handler(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               87
           frame*
             module*
@@ -93,9 +93,9 @@ app:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'            hook.handle(request)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'post'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               127
           frame*
             module*
@@ -104,9 +104,9 @@ app:
               u'sentry_plugins/heroku/plugin.py'
             context-line*
               u"        email = request.POST['user']"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               17
           frame (non app frame)
             module*
@@ -115,9 +115,9 @@ app:
               u'django/utils/datastructures.py'
             context-line*
               u'            raise MultiValueDictKeyError(repr(key))'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'__getitem__'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               301
         type*
           u'MultiValueDictKeyError'
@@ -137,9 +137,9 @@ system:
               u'django/core/handlers/base.py'
             context-line*
               u'                    response = wrapped_callback(request, *callback_args, **callback_kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'get_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               112
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -148,9 +148,9 @@ system:
               u'django/views/generic/base.py'
             context-line*
               u'            return self.dispatch(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               69
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -159,9 +159,9 @@ system:
               u'django/utils/decorators.py'
             context-line*
               u'            return bound_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_wrapper'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               29
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -170,9 +170,9 @@ system:
               u'django/views/decorators/csrf.py'
             context-line*
               u'        return view_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'wrapped_view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               57
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -181,9 +181,9 @@ system:
               u'django/utils/decorators.py'
             context-line*
               u'                return func(self, *args2, **kwargs2)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'bound_func'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -192,9 +192,9 @@ system:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'        return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               37
           frame (ignored by grouping enhancement rule (path:**/release_webhook.py v-group))
             module*
@@ -203,9 +203,9 @@ system:
               u'django/views/generic/base.py'
             context-line*
               u'        return handler(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               87
           frame*
             module*
@@ -214,9 +214,9 @@ system:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'            hook.handle(request)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'post'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               127
           frame*
             module*
@@ -225,9 +225,9 @@ system:
               u'sentry_plugins/heroku/plugin.py'
             context-line*
               u"        email = request.POST['user']"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               17
           frame*
             module*
@@ -236,9 +236,9 @@ system:
               u'django/utils/datastructures.py'
             context-line*
               u'            raise MultiValueDictKeyError(repr(key))'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'__getitem__'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               301
         type*
           u'MultiValueDictKeyError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-06-05T11:45:14.388605Z'
+created: '2019-09-03T07:26:08.010099Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'django/core/handlers/base.py'
             context-line*
               u'                    response = wrapped_callback(request, *callback_args, **callback_kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'get_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               112
           frame (non app frame)
             module*
@@ -27,9 +27,9 @@ app:
               u'django/views/generic/base.py'
             context-line*
               u'            return self.dispatch(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               69
           frame (non app frame)
             module*
@@ -38,9 +38,9 @@ app:
               u'django/utils/decorators.py'
             context-line*
               u'            return bound_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_wrapper'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               29
           frame (non app frame)
             module*
@@ -49,9 +49,9 @@ app:
               u'django/views/decorators/csrf.py'
             context-line*
               u'        return view_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'wrapped_view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               57
           frame (non app frame)
             module*
@@ -60,9 +60,9 @@ app:
               u'django/utils/decorators.py'
             context-line*
               u'                return func(self, *args2, **kwargs2)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'bound_func'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -71,9 +71,9 @@ app:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'        return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               37
           frame (non app frame)
             module*
@@ -82,9 +82,9 @@ app:
               u'django/views/generic/base.py'
             context-line*
               u'        return handler(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               87
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -93,9 +93,9 @@ app:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'            hook.handle(request)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'post'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               127
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -104,9 +104,9 @@ app:
               u'sentry_plugins/heroku/plugin.py'
             context-line*
               u"        email = request.POST['user']"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               17
           frame (non app frame)
             module*
@@ -115,9 +115,9 @@ app:
               u'django/utils/datastructures.py'
             context-line*
               u'            raise MultiValueDictKeyError(repr(key))'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'__getitem__'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               301
         type*
           u'MultiValueDictKeyError'
@@ -137,9 +137,9 @@ system:
               u'django/core/handlers/base.py'
             context-line*
               u'                    response = wrapped_callback(request, *callback_args, **callback_kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'get_response'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               112
           frame*
             module*
@@ -148,9 +148,9 @@ system:
               u'django/views/generic/base.py'
             context-line*
               u'            return self.dispatch(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               69
           frame*
             module*
@@ -159,9 +159,9 @@ system:
               u'django/utils/decorators.py'
             context-line*
               u'            return bound_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_wrapper'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               29
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -170,9 +170,9 @@ system:
               u'django/views/decorators/csrf.py'
             context-line*
               u'        return view_func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'wrapped_view'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               57
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -181,9 +181,9 @@ system:
               u'django/utils/decorators.py'
             context-line*
               u'                return func(self, *args2, **kwargs2)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'bound_func'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               25
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -192,9 +192,9 @@ system:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'        return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               37
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -203,9 +203,9 @@ system:
               u'django/views/generic/base.py'
             context-line*
               u'        return handler(request, *args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'dispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               87
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -214,9 +214,9 @@ system:
               u'sentry/web/frontend/release_webhook.py'
             context-line*
               u'            hook.handle(request)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'post'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               127
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -225,9 +225,9 @@ system:
               u'sentry_plugins/heroku/plugin.py'
             context-line*
               u"        email = request.POST['user']"
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'handle'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               17
           frame (ignored by grouping enhancement rule (function:wrapped_view ^-group -group))
             module*
@@ -236,9 +236,9 @@ system:
               u'django/utils/datastructures.py'
             context-line*
               u'            raise MultiValueDictKeyError(repr(key))'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'__getitem__'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               301
         type*
           u'MultiValueDictKeyError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:37.467604Z'
+created: '2019-09-03T07:26:08.021024Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'sentry/utils/safe.py'
             context-line*
               u'                result = func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'safe_execute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               29
           frame*
             module*
@@ -27,9 +27,9 @@ app:
               u'sentry/integrations/slack/notify_action.py'
             context-line*
               u'            resp.raise_for_status()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'send_notification'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               119
           frame (non app frame)
             module*
@@ -38,9 +38,9 @@ app:
               u'requests/models.py'
             context-line*
               u'            raise HTTPError(http_error_msg, response=self)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'raise_for_status'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               940
         type*
           u'HTTPError'
@@ -67,9 +67,9 @@ system:
               u'sentry/utils/safe.py'
             context-line*
               u'                result = func(*args, **kwargs)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'safe_execute'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               29
           frame*
             module*
@@ -78,9 +78,9 @@ system:
               u'sentry/integrations/slack/notify_action.py'
             context-line*
               u'            resp.raise_for_status()'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'send_notification'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               119
           frame*
             module*
@@ -89,9 +89,9 @@ system:
               u'requests/models.py'
             context-line*
               u'            raise HTTPError(http_error_msg, response=self)'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'raise_for_status'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               940
         type*
           u'HTTPError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-09T18:49:36.002678Z'
+created: '2019-09-03T07:26:08.049873Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,9 +16,9 @@ app:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'    return this.flushedQueue();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'value'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               119
           frame (non app frame)
             module*
@@ -27,9 +27,9 @@ app:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'      this._inCall--;'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'flushedQueue'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               318
           frame (non app frame)
             module*
@@ -38,9 +38,9 @@ app:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'    return this.flushedQueue();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_inCall'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               119
           frame (non app frame)
             module*
@@ -49,9 +49,9 @@ app:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'    this._lastFlush = new Date().getTime();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'flushedQueue'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               357
           frame (non app frame)
             module*
@@ -60,9 +60,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'      _receiveRootNodeIDEvent(index, eventTopLevelType, i);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_lastFlush'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1160
           frame (non app frame)
             module*
@@ -71,9 +71,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  batchedUpdates(function() {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_receiveRootNodeIDEvent'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1095
           frame (non app frame)
             module*
@@ -82,9 +82,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'    return _batchedUpdates(fn, bookkeeping);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'batchedUpdates'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1054
           frame (non app frame)
             module*
@@ -93,9 +93,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'        return fn(a);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_batchedUpdates'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               5928
           frame (non app frame)
             module*
@@ -104,9 +104,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'      (forEachAccumulated(events, executeDispatchesAndReleaseTopLevel),'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fn'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1113
           frame (non app frame)
             module*
@@ -115,12 +115,12 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  Array.isArray(arr) ? arr.forEach(cb, scope) : arr && cb.call(scope, arr);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'forEachAccumulated'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               219
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'[native code] forEach'
           frame (non app frame)
             module*
@@ -129,9 +129,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'        executeDispatch(e, !1, dispatchListeners, dispatchInstances);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'D'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               235
           frame (non app frame)
             module*
@@ -140,9 +140,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError('
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'executeDispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               181
           frame (non app frame)
             module*
@@ -151,9 +151,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'    ReactErrorUtils.invokeGuardedCallback.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'invokeGuardedCallbackAndCatchFirstError'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               54
           frame (non app frame)
             module*
@@ -162,9 +162,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'    invokeGuardedCallback.apply(ReactErrorUtils, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'apply'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               41
           frame (non app frame)
             module*
@@ -173,9 +173,9 @@ app:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  var funcArgs = Array.prototype.slice.call(arguments, 3);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'apply'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               28
           frame (non app frame)
             module*
@@ -184,9 +184,9 @@ app:
               u'node_modules/react-native/Libraries/Components/Touchable/Touchable.js'
             context-line*
               u'  touchableHandleResponderRelease: function(e) {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'arguments'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               430
           frame (non app frame)
             module*
@@ -195,9 +195,9 @@ app:
               u'node_modules/react-native/Libraries/Components/Touchable/Touchable.js'
             context-line*
               u'      this._performSideEffectsForTransition(curState, nextState, signal, e);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_receiveSignal'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               662
           frame (non app frame)
             module*
@@ -206,9 +206,9 @@ app:
               u'node_modules/react-native/Libraries/Components/Touchable/Touchable.js'
             context-line*
               u'        this.touchableHandlePress(e);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_performSideEffectsForTransition'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               744
           frame (non app frame)
             module*
@@ -217,9 +217,9 @@ app:
               u'node_modules/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android.js'
             context-line*
               u'    this.props.onPress && this.props.onPress(e);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'this'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               175
           frame*
             module*
@@ -228,9 +228,9 @@ app:
               u'App.js'
             context-line*
               u'        <Button'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'onPress'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               143
           frame*
             module*
@@ -239,9 +239,9 @@ app:
               u'App.js'
             context-line*
               u'        <Button'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Button'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               115
         type*
           u'TypeError'
@@ -261,9 +261,9 @@ system:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'    return this.flushedQueue();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'value'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               119
           frame*
             module*
@@ -272,9 +272,9 @@ system:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'      this._inCall--;'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'flushedQueue'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               318
           frame*
             module*
@@ -283,9 +283,9 @@ system:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'    return this.flushedQueue();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_inCall'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               119
           frame*
             module*
@@ -294,9 +294,9 @@ system:
               u'node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js'
             context-line*
               u'    this._lastFlush = new Date().getTime();'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'flushedQueue'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               357
           frame*
             module*
@@ -305,9 +305,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'      _receiveRootNodeIDEvent(index, eventTopLevelType, i);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_lastFlush'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1160
           frame*
             module*
@@ -316,9 +316,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  batchedUpdates(function() {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_receiveRootNodeIDEvent'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1095
           frame*
             module*
@@ -327,9 +327,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'    return _batchedUpdates(fn, bookkeeping);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'batchedUpdates'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1054
           frame*
             module*
@@ -338,9 +338,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'        return fn(a);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_batchedUpdates'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               5928
           frame*
             module*
@@ -349,9 +349,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'      (forEachAccumulated(events, executeDispatchesAndReleaseTopLevel),'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'fn'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               1113
           frame*
             module*
@@ -360,12 +360,12 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  Array.isArray(arr) ? arr.forEach(cb, scope) : arr && cb.call(scope, arr);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'forEachAccumulated'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               219
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'[native code] forEach'
           frame*
             module*
@@ -374,9 +374,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'        executeDispatch(e, !1, dispatchListeners, dispatchInstances);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'D'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               235
           frame*
             module*
@@ -385,9 +385,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  ReactErrorUtils.invokeGuardedCallbackAndCatchFirstError('
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'executeDispatch'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               181
           frame*
             module*
@@ -396,9 +396,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'    ReactErrorUtils.invokeGuardedCallback.apply(this, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'invokeGuardedCallbackAndCatchFirstError'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               54
           frame*
             module*
@@ -407,9 +407,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'    invokeGuardedCallback.apply(ReactErrorUtils, arguments);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'apply'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               41
           frame*
             module*
@@ -418,9 +418,9 @@ system:
               u'node_modules/react-native/Libraries/Renderer/ReactNativeRenderer-prod.js'
             context-line*
               u'  var funcArgs = Array.prototype.slice.call(arguments, 3);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'apply'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               28
           frame*
             module*
@@ -429,9 +429,9 @@ system:
               u'node_modules/react-native/Libraries/Components/Touchable/Touchable.js'
             context-line*
               u'  touchableHandleResponderRelease: function(e) {'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'arguments'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               430
           frame*
             module*
@@ -440,9 +440,9 @@ system:
               u'node_modules/react-native/Libraries/Components/Touchable/Touchable.js'
             context-line*
               u'      this._performSideEffectsForTransition(curState, nextState, signal, e);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_receiveSignal'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               662
           frame*
             module*
@@ -451,9 +451,9 @@ system:
               u'node_modules/react-native/Libraries/Components/Touchable/Touchable.js'
             context-line*
               u'        this.touchableHandlePress(e);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'_performSideEffectsForTransition'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               744
           frame*
             module*
@@ -462,9 +462,9 @@ system:
               u'node_modules/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.android.js'
             context-line*
               u'    this.props.onPress && this.props.onPress(e);'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'this'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               175
           frame*
             module*
@@ -473,9 +473,9 @@ system:
               u'App.js'
             context-line*
               u'        <Button'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'onPress'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               143
           frame*
             module*
@@ -484,9 +484,9 @@ system:
               u'App.js'
             context-line*
               u'        <Button'
-            function (function name is used only if module or filename are available)
+            function (function name is not used if context-line is available)
               u'Button'
-            lineno (line number is used only if module or filename are available)
+            lineno (line number is not used if context-line is available)
               115
         type*
           u'TypeError'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:37.522544Z'
+created: '2019-09-03T07:26:08.088010Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,7 +12,7 @@ app:
           filename (ignored because filename is a URL)
             u'foo'
           context-line (discarded because from URL origin)
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             1
 --------------------------------------------------------------------------
 fallback:
@@ -27,5 +27,5 @@ system:
           filename (ignored because filename is a URL)
             u'foo'
           context-line (discarded because from URL origin)
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             1

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:37.530570Z'
+created: '2019-09-03T07:26:08.097043Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,7 +13,7 @@ app:
             u'foo'
           context-line*
             u'<HTML>'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if context-line is available)
             1
 --------------------------------------------------------------------------
 system:
@@ -26,5 +26,5 @@ system:
             u'foo'
           context-line*
             u'<HTML>'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if context-line is available)
             1

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:37.538762Z'
+created: '2019-09-03T07:26:08.106341Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,7 +12,7 @@ app:
           filename (ignored because filename is a URL)
             u'/index.js'
           context-line (discarded because from URL origin)
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             20
 --------------------------------------------------------------------------
 fallback:
@@ -27,5 +27,5 @@ system:
           filename (ignored because filename is a URL)
             u'/index.js'
           context-line (discarded because from URL origin)
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             20

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-07-09T12:12:23.637309Z'
+created: '2019-09-03T07:26:08.155900Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,25 +10,25 @@ app:
       exception (ignored because hash matches system variant)
         stacktrace
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'_main'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start_internal'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'___rust_maybe_catch_panic'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::panicking::try::do_call'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame (marked in-app by grouping enhancement rule (function:log_demo::* +app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log_demo::main'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log::__private_api_log'
         type*
           u'log_demo'
@@ -42,25 +42,25 @@ system:
       exception*
         stacktrace
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'_main'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start_internal'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'___rust_maybe_catch_panic'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::panicking::try::do_call'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame (marked in-app by grouping enhancement rule (function:log_demo::* +app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log_demo::main'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log::__private_api_log'
         type*
           u'log_demo'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:37.563211Z'
+created: '2019-09-03T07:26:08.181598Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,16 +14,16 @@ app:
         frame (frame considered in-app because no frame is in-app)
           filename (ignored because filename is a URL)
             u'/C:/Users/redacted/AppData/Local/redacted/app-2.4.1/resources/app.asar/dojo/dojo.js'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if module or filename are available)
             u'c'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             1188
         frame (frame considered in-app because no frame is in-app)
           filename (ignored because filename is a URL)
             u'/C:/Users/redacted/AppData/Local/redacted/app-2.4.1/resources/app.asar/dojo/dojo.js'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if module or filename are available)
             u'Object._createDocumentViewModel'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             1184
 --------------------------------------------------------------------------
 fallback:
@@ -40,14 +40,14 @@ system:
         frame
           filename (ignored because filename is a URL)
             u'/C:/Users/redacted/AppData/Local/redacted/app-2.4.1/resources/app.asar/dojo/dojo.js'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if module or filename are available)
             u'c'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             1188
         frame
           filename (ignored because filename is a URL)
             u'/C:/Users/redacted/AppData/Local/redacted/app-2.4.1/resources/app.asar/dojo/dojo.js'
-          function (function name is used only if module or filename are available)
+          function (function name is not used if module or filename are available)
             u'Object._createDocumentViewModel'
-          lineno (line number is used only if module or filename are available)
+          lineno (line number is not used if module or filename are available)
             1184

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-06-05T11:45:14.554934Z'
+created: '2019-09-03T07:26:08.229703Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,25 +10,25 @@ app:
       exception (ignored because hash matches system variant)
         stacktrace
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'_main'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start_internal'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'___rust_maybe_catch_panic'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::panicking::try::do_call'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame (marked in-app by grouping enhancement rule (family:native function:log_demo::* +app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log_demo::main'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log::__private_api_log'
         type*
           u'log_demo'
@@ -42,25 +42,25 @@ system:
       exception*
         stacktrace
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'_main'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start_internal'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'___rust_maybe_catch_panic'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::panicking::try::do_call'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame (marked in-app by grouping enhancement rule (family:native function:log_demo::* +app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log_demo::main'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log::__private_api_log'
         type*
           u'log_demo'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-06-05T11:45:14.605221Z'
+created: '2019-09-03T07:26:08.279303Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,25 +10,25 @@ app:
       exception (ignored because hash matches system variant)
         stacktrace
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'_main'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start_internal'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'___rust_maybe_catch_panic'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::panicking::try::do_call'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame (marked in-app by grouping enhancement rule (family:native function:log_demo::* +app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log_demo::main'
           frame (non app frame)
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log::__private_api_log'
         type*
           u'log_demo'
@@ -42,25 +42,25 @@ system:
       exception*
         stacktrace
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'_main'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start_internal'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'___rust_maybe_catch_panic'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::panicking::try::do_call'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame (marked in-app by grouping enhancement rule (family:native function:log_demo::* +app))
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log_demo::main'
           frame
-            function (function name is used only if module or filename are available)
+            function (function name is not used if module or filename are available)
               u'log::__private_api_log'
         type*
           u'log_demo'


### PR DESCRIPTION
This fixes an incorrect grouping hint when context lines are available and extra information is ignored on the legacy grouping algorithm.