### PR TITLE
feat(discover2) Auto-link first column in results.

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -831,13 +831,21 @@ def get_reference_event_conditions(snuba_args, reference_event):
     """
     conditions = []
 
+    tags = {}
+    if "tags.key" in reference_event and "tags.value" in reference_event:
+        tags = dict(zip(reference_event["tags.key"], reference_event["tags.value"]))
+
     # If we were given an project/event to use build additional
     # conditions using that event and the non-aggregated columns
     # we received in the querystring. This lets us find the oldest/newest.
     # This only handles simple fields on the snuba_data dict.
     for field in snuba_args.get("groupby", []):
         prop = get_snuba_column_name(field)
-        value = reference_event.get(prop, None)
+        if prop.startswith("tags["):
+            value = tags.get(field, None)
+        else:
+            value = reference_event.get(prop, None)
         if value:
             conditions.append([prop, "=", value])
+
     return conditions

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -4,7 +4,7 @@ import {isString, pick} from 'lodash';
 import {EventViewv1} from 'app/types';
 import {DEFAULT_PER_PAGE} from 'app/constants';
 
-import {SPECIAL_FIELDS, FIELD_FORMATTERS} from './data';
+import {AUTOLINK_FIELDS, SPECIAL_FIELDS, FIELD_FORMATTERS} from './data';
 import {MetaType, EventQuery, getAggregateAlias} from './utils';
 
 type Descending = {
@@ -224,36 +224,45 @@ class EventView {
     });
   }
 
-  generateQueryStringObject = (): Query => {
+  generateQueryStringObject(): Query {
     return {
       field: encodeFields(this.fields),
       sort: encodeSorts(this.sorts),
       tag: this.tags,
       query: this.query,
     };
-  };
+  }
 
-  isValid = (): boolean => {
+  isValid(): boolean {
     return this.fields.length > 0;
-  };
+  }
 
-  getFieldTitles = () => {
+  getFieldTitles(): string[] {
     return this.fields.map(field => {
       return field.title;
     });
-  };
+  }
 
-  getFieldNames = () => {
+  getFieldNames(): string[] {
     return this.fields.map(field => {
       return field.field;
     });
-  };
+  }
 
-  numOfColumns = (): number => {
+  hasAutolinkField(): boolean {
+    // If the field set contains no autolink fields,
+    // and the current field is not a special field,
+    // then it should be forced into a link.
+    return this.fields.some(field => {
+      return AUTOLINK_FIELDS.includes(field.field);
+    });
+  }
+
+  numOfColumns(): number {
     return this.fields.length;
-  };
+  }
 
-  getQuery = (inputQuery: string | string[] | null | undefined): string => {
+  getQuery(inputQuery: string | string[] | null | undefined): string {
     const queryParts: Array<string> = [];
 
     if (this.query) {
@@ -277,10 +286,10 @@ class EventView {
     }
 
     return queryParts.join(' ');
-  };
+  }
 
   // Takes an EventView instance and converts it into the format required for the events API
-  getEventsAPIPayload = (location: Location): EventQuery => {
+  getEventsAPIPayload(location: Location): EventQuery {
     const query = location.query || {};
 
     type LocationQuery = {
@@ -321,17 +330,17 @@ class EventView {
     }
 
     return eventQuery;
-  };
+  }
 
-  getDefaultSort = (): string | undefined => {
+  getDefaultSort(): string | undefined {
     if (this.sorts.length <= 0) {
       return void 0;
     }
 
     return encodeSort(this.sorts[0]);
-  };
+  }
 
-  getSortKey = (fieldname: string, meta: MetaType): string | null => {
+  getSortKey(fieldname: string, meta: MetaType): string | null {
     const column = getAggregateAlias(fieldname);
     if (SPECIAL_FIELDS.hasOwnProperty(column)) {
       return SPECIAL_FIELDS[column as keyof typeof SPECIAL_FIELDS].sortField;
@@ -344,7 +353,7 @@ class EventView {
     }
 
     return null;
-  };
+  }
 }
 
 export default EventView;

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -249,10 +249,10 @@ class EventView {
     });
   }
 
+  /**
+   * Check if the field set contains no automatically linked fields
+   */
   hasAutolinkField(): boolean {
-    // If the field set contains no autolink fields,
-    // and the current field is not a special field,
-    // then it should be forced into a link.
     return this.fields.some(field => {
       return AUTOLINK_FIELDS.includes(field.field);
     });

--- a/src/sentry/static/sentry/app/views/eventsV2/table.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table.tsx
@@ -44,6 +44,9 @@ type State = {
   dataPayload: DataPayload | null | undefined;
 };
 
+/**
+ * Container element that fetches events and handles pagination
+ */
 class Table extends React.PureComponent<Props, State> {
   state: State = {
     eventView: EventView.fromLocation(this.props.location),
@@ -137,6 +140,9 @@ type TableViewProps = {
   location: Location;
 };
 
+/**
+ * Renders the table headers and rows for the result set.
+ */
 class TableView extends React.Component<TableViewProps> {
   renderLoading = () => {
     return (
@@ -208,11 +214,8 @@ class TableView extends React.Component<TableViewProps> {
     //     </PanelGridInfo>
     //   );
     // }
-
     const lastRowIndex = dataPayload.data.length - 1;
-
-    // TODO add links to the first column even if it isn't one of our
-    // preferred link columns (title, transaction, latest_event)
+    const hasLinkField = eventView.hasAutolinkField();
     const firstCellIndex = 0;
     const lastCellIndex = fields.length - 1;
 
@@ -221,8 +224,9 @@ class TableView extends React.Component<TableViewProps> {
         <React.Fragment key={rowIndex}>
           {fields.map((field, columnIndex) => {
             const key = `${field}.${columnIndex}`;
+            const forceLinkField = !hasLinkField && columnIndex === 0;
 
-            const fieldRenderer = getFieldRenderer(field, meta);
+            const fieldRenderer = getFieldRenderer(field, meta, forceLinkField);
             return (
               <PanelItemCell
                 hideBottomBorder={rowIndex === lastRowIndex}

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -140,6 +140,7 @@ export type MetaType = {
  *
  * @param {String} field name
  * @param {object} metadata mapping.
+ * @param {boolean} Whether or not to coerce a field into a link.
  * @returns {Function}
  */
 export function getFieldRenderer(

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -6,6 +6,7 @@ import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {
   AGGREGATE_ALIASES,
   SPECIAL_FIELDS,
+  LINK_FORMATTERS,
   FIELD_FORMATTERS,
   FieldTypes,
   FieldFormatterRenderFunctionPartial,
@@ -143,13 +144,21 @@ export type MetaType = {
  */
 export function getFieldRenderer(
   field: string,
-  meta: MetaType
+  meta: MetaType,
+  forceLink: boolean
 ): FieldFormatterRenderFunctionPartial {
   if (SPECIAL_FIELDS.hasOwnProperty(field)) {
     return SPECIAL_FIELDS[field].renderFunc;
   }
   const fieldName = getAggregateAlias(field);
   const fieldType = meta[fieldName];
+
+  // If the current field is being coerced to a link
+  // use a different formatter set based on the type.
+  if (forceLink && LINK_FORMATTERS.hasOwnProperty(fieldType)) {
+    return partial(LINK_FORMATTERS[fieldType], fieldName);
+  }
+
   if (FIELD_FORMATTERS.hasOwnProperty(fieldType)) {
     return partial(FIELD_FORMATTERS[fieldType].renderFunc, fieldName);
   }

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -1,4 +1,11 @@
-import {getAggregateAlias, getEventTagSearchUrl} from 'app/views/eventsV2/utils';
+import {mount} from 'enzyme';
+
+import {initializeOrg} from 'app-test/helpers/initializeOrg';
+import {
+  getFieldRenderer,
+  getAggregateAlias,
+  getEventTagSearchUrl,
+} from 'app/views/eventsV2/utils';
 
 describe('eventTagSearchUrl()', function() {
   let location;
@@ -48,5 +55,188 @@ describe('getAggregateAlias', function() {
     expect(getAggregateAlias('count(id)')).toEqual('count_id');
     expect(getAggregateAlias('count_unique(user)')).toEqual('count_unique_user');
     expect(getAggregateAlias('count_unique(issue.id)')).toEqual('count_unique_issue_id');
+  });
+});
+
+describe('getFieldRenderer', function() {
+  let location, context, project, organization, data;
+  beforeEach(function() {
+    context = initializeOrg({
+      project: TestStubs.Project(),
+    });
+    organization = context.organization;
+    project = context.project;
+
+    location = {
+      pathname: '/events',
+      query: {},
+    };
+    data = {
+      title: 'ValueError: something bad',
+      transaction: 'api.do_things',
+      boolValue: 1,
+      numeric: 1.23,
+      createdAt: new Date(2019, 9, 3, 12, 13, 14),
+      url: '/example',
+      latest_event: 'deadbeef',
+      'project.name': project.slug,
+    };
+  });
+
+  it('can render string fields', function() {
+    const renderer = getFieldRenderer('url', {url: 'string'});
+    expect(renderer).toBeInstanceOf(Function);
+    const wrapper = mount(renderer(data, {location, organization}));
+    const link = wrapper.find('QueryLink');
+    expect(link).toHaveLength(1);
+    expect(link.props().to).toEqual({
+      pathname: location.pathname,
+      query: {query: 'url:/example'},
+    });
+    expect(link.text()).toEqual(data.url);
+  });
+
+  it('can render boolean fields', function() {
+    const renderer = getFieldRenderer('boolValue', {boolValue: 'boolean'});
+    expect(renderer).toBeInstanceOf(Function);
+    const wrapper = mount(renderer(data, {location, organization}));
+    const link = wrapper.find('QueryLink');
+    expect(link).toHaveLength(1);
+    expect(link.props().to).toEqual({
+      pathname: location.pathname,
+      query: {query: 'boolValue:1'},
+    });
+  });
+
+  it('can render integer fields', function() {
+    const renderer = getFieldRenderer('numeric', {numeric: 'integer'});
+    expect(renderer).toBeInstanceOf(Function);
+    const wrapper = mount(renderer(data, {location, organization}));
+
+    const value = wrapper.find('Count');
+    expect(value).toHaveLength(1);
+    expect(value.props().value).toEqual(data.numeric);
+  });
+
+  it('can render date fields', function() {
+    const renderer = getFieldRenderer('createdAt', {createdAt: 'date'});
+    expect(renderer).toBeInstanceOf(Function);
+    const wrapper = mount(renderer(data, {location, organization}));
+
+    const value = wrapper.find('StyledDateTime');
+    expect(value).toHaveLength(1);
+    expect(value.props().date).toEqual(data.createdAt);
+  });
+
+  it('can render null date fields', function() {
+    const renderer = getFieldRenderer('nope', {nope: 'date'});
+    expect(renderer).toBeInstanceOf(Function);
+    const wrapper = mount(renderer(data, {location, organization}));
+
+    const value = wrapper.find('StyledDateTime');
+    expect(value).toHaveLength(0);
+    expect(wrapper.text()).toEqual('n/a');
+  });
+
+  it('can render transaction as a link', function() {
+    const renderer = getFieldRenderer('transaction', {transaction: 'string'});
+    expect(renderer).toBeInstanceOf(Function);
+    const wrapper = mount(renderer(data, {location, organization}));
+
+    const value = wrapper.find('OverflowLink');
+    expect(value).toHaveLength(1);
+    expect(value.props().to).toEqual({
+      pathname: location.pathname,
+      query: {
+        eventSlug: `${project.slug}:deadbeef`,
+      },
+    });
+    expect(value.text()).toEqual(data.transaction);
+  });
+
+  it('can render title as a link', function() {
+    const renderer = getFieldRenderer('title', {title: 'string'});
+    expect(renderer).toBeInstanceOf(Function);
+    const wrapper = mount(renderer(data, {location, organization}));
+
+    const value = wrapper.find('OverflowLink');
+    expect(value).toHaveLength(1);
+    expect(value.props().to).toEqual({
+      pathname: location.pathname,
+      query: {
+        eventSlug: `${project.slug}:deadbeef`,
+      },
+    });
+    expect(value.text()).toEqual(data.title);
+  });
+
+  it('can render project as an avatar', function() {
+    const renderer = getFieldRenderer('project', {'project.name': 'string'});
+    expect(renderer).toBeInstanceOf(Function);
+    const wrapper = mount(
+      renderer(data, {location, organization}),
+      context.routerContext
+    );
+
+    const value = wrapper.find('ProjectBadge');
+    expect(value).toHaveLength(1);
+    expect(value.props().project).toEqual(project);
+  });
+
+  it('can coerce string field to a link', function() {
+    const renderer = getFieldRenderer('url', {url: 'string'}, true);
+    expect(renderer).toBeInstanceOf(Function);
+    const wrapper = mount(
+      renderer(data, {location, organization}),
+      context.routerContext
+    );
+
+    // No basic link should be present.
+    expect(wrapper.find('QueryLink')).toHaveLength(0);
+
+    const link = wrapper.find('OverflowLink');
+    expect(link.props().to).toEqual({
+      pathname: location.pathname,
+      query: {
+        eventSlug: `${project.slug}:deadbeef`,
+      },
+    });
+    expect(link.text()).toEqual('/example');
+  });
+
+  it('can coerce number field to a link', function() {
+    const renderer = getFieldRenderer('numeric', {numeric: 'number'}, true);
+    expect(renderer).toBeInstanceOf(Function);
+    const wrapper = mount(
+      renderer(data, {location, organization}),
+      context.routerContext
+    );
+
+    const link = wrapper.find('OverflowLink');
+    expect(link.props().to).toEqual({
+      pathname: location.pathname,
+      query: {
+        eventSlug: `${project.slug}:deadbeef`,
+      },
+    });
+    expect(link.find('Count').props().value).toEqual(data.numeric);
+  });
+
+  it('can coerce date field to a link', function() {
+    const renderer = getFieldRenderer('createdAt', {createdAt: 'date'}, true);
+    expect(renderer).toBeInstanceOf(Function);
+    const wrapper = mount(
+      renderer(data, {location, organization}),
+      context.routerContext
+    );
+
+    const link = wrapper.find('OverflowLink');
+    expect(link.props().to).toEqual({
+      pathname: location.pathname,
+      query: {
+        eventSlug: `${project.slug}:deadbeef`,
+      },
+    });
+    expect(link.find('StyledDateTime').props().date).toEqual(data.createdAt);
   });
 });


### PR DESCRIPTION
If the query set does not contain a transaction or title field then we need wrap the first column in a link so that the modal view can be accessed. One of our pre-baked views includes grouping by the URL tag. Because of this I've extended the reference condition generation to work with tags.

Refs SEN-1013