### PR TITLE
fix(ui): Fix Pill component creating bad links for tags with spaces

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventTags.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.tsx
@@ -42,7 +42,10 @@ class EventTags extends React.Component<EventTagsProps> {
         query.project = tag.value;
         break;
       default:
-        query.query = `${query.query} ${tag.key}:${tag.value}`;
+        query.query =
+          tag.value.indexOf(' ') > -1
+            ? `${query.query} ${tag.key}:"${tag.value}"`
+            : `${query.query} ${tag.key}:${tag.value}`;
     }
 
     const locationSearch = `?${queryString.stringify(query)}`;


### PR DESCRIPTION
Discovered on production that tags with spaces in them (e.g. `Mac OS X`, `Chrome 76.0.3809`) was broken and needed to be encapsulated with double-quotes.

Prettier forced the weird inline on me. Not sure why it always conks out on ternary operators.