### PR TITLE
feat(discover2) Add reflux store and actions for discover queries

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/discoverSavedQueries.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/discoverSavedQueries.tsx
@@ -1,0 +1,84 @@
+import {Client} from 'app/api';
+
+import DiscoverSavedQueryActions from 'app/actions/discoverSavedQueryActions';
+import {t} from 'app/locale';
+import {addErrorMessage} from 'app/actionCreators/indicator';
+import {SavedQuery, Query} from 'app/views/discover/types';
+
+export function fetchSavedQueries(api: Client, orgId: string): Promise<SavedQuery[]> {
+  DiscoverSavedQueryActions.startFetchSavedQueries();
+
+  const promise = api.requestPromise(`/organizations/${orgId}/discover/saved/`, {
+    method: 'GET',
+  });
+  promise
+    .then(resp => {
+      DiscoverSavedQueryActions.fetchSavedQueriesSuccess(resp);
+    })
+    .catch(() => {
+      DiscoverSavedQueryActions.fetchSavedQueriesError();
+      addErrorMessage(t('Unable to load saved queries'));
+    });
+  return promise;
+}
+
+export function createSavedQuery(
+  api: Client,
+  orgId: string,
+  query: Query
+): Promise<SavedQuery> {
+  const promise = api.requestPromise(`/organizations/${orgId}/discover/saved/`, {
+    method: 'POST',
+    data: query,
+  });
+  promise
+    .then(resp => {
+      DiscoverSavedQueryActions.createSavedQuerySuccess(resp);
+    })
+    .catch(() => {
+      addErrorMessage(t('Unable to create your saved query'));
+    });
+  return promise;
+}
+
+export function updateSavedQuery(
+  api: Client,
+  orgId: string,
+  query: SavedQuery
+): Promise<SavedQuery> {
+  const promise = api.requestPromise(
+    `/organizations/${orgId}/discover/saved/${query.id}/`,
+    {
+      method: 'PUT',
+      data: query,
+    }
+  );
+  promise
+    .then(resp => {
+      DiscoverSavedQueryActions.updateSavedQuerySuccess(resp);
+    })
+    .catch(() => {
+      addErrorMessage(t('Unable to update your saved query'));
+    });
+  return promise;
+}
+
+export function deleteSavedQuery(
+  api: Client,
+  orgId: string,
+  queryId: string
+): Promise<null> {
+  const promise = api.requestPromise(
+    `/organizations/${orgId}/discover/saved/${queryId}/`,
+    {method: 'DELETE'}
+  );
+  promise
+    .then(() => {
+      DiscoverSavedQueryActions.deleteSavedQuerySuccess(queryId);
+    })
+    .catch(() => {
+      addErrorMessage(t('Unable to delete the saved query'));
+    });
+
+  return promise;
+}

--- a/src/sentry/static/sentry/app/actions/discoverSavedQueryActions.tsx
+++ b/src/sentry/static/sentry/app/actions/discoverSavedQueryActions.tsx
@@ -1,0 +1,11 @@
+import Reflux from 'reflux';
+
+export default Reflux.createActions([
+  'resetSavedQueries',
+  'startFetchSavedQueries',
+  'fetchSavedQueriesSuccess',
+  'fetchSavedQueriesError',
+  'createSavedQuerySuccess',
+  'deleteSavedQuerySuccess',
+  'updateSavedQuerySuccess',
+]);

--- a/src/sentry/static/sentry/app/stores/discoverSavedQueriesStore.tsx
+++ b/src/sentry/static/sentry/app/stores/discoverSavedQueriesStore.tsx
@@ -1,0 +1,112 @@
+import Reflux from 'reflux';
+
+import {SavedQuery} from 'app/views/discover/types';
+import DiscoverSavedQueryActions from 'app/actions/discoverSavedQueryActions';
+
+type SavedQueryState = {
+  savedQueries: SavedQuery[];
+  hasError: boolean;
+  isLoading: boolean;
+};
+
+const DiscoverSavedQueriesStore = Reflux.createStore({
+  init() {
+    const {
+      resetSavedQueries,
+      startFetchSavedQueries,
+      fetchSavedQueriesSuccess,
+      fetchSavedQueriesError,
+      createSavedQuerySuccess,
+      deleteSavedQuerySuccess,
+      updateSavedQuerySuccess,
+    } = DiscoverSavedQueryActions;
+
+    this.listenTo(resetSavedQueries, this.onReset);
+    this.listenTo(startFetchSavedQueries, this.onStartFetchSavedQueries);
+    this.listenTo(fetchSavedQueriesSuccess, this.fetchSavedQueriesSuccess);
+    this.listenTo(fetchSavedQueriesError, this.fetchSavedQueriesError);
+    this.listenTo(createSavedQuerySuccess, this.createSavedQuerySuccess);
+    this.listenTo(updateSavedQuerySuccess, this.updateSavedQuerySuccess);
+    this.listenTo(deleteSavedQuerySuccess, this.deleteSavedQuerySuccess);
+
+    this.reset();
+  },
+  get(): SavedQueryState {
+    return this.state;
+  },
+
+  reset(): void {
+    this.state = {
+      savedQueries: [],
+      hasError: false,
+      isLoading: true,
+    } as SavedQueryState;
+  },
+
+  onReset(): void {
+    this.reset();
+    this.trigger(this.state);
+  },
+
+  onStartFetchSavedQueries(): void {
+    this.state = {
+      ...this.state,
+      isLoading: true,
+    };
+    this.trigger(this.state);
+  },
+
+  fetchSavedQueriesSuccess(data: SavedQuery[]): void {
+    this.state = {
+      ...this.state,
+      savedQueries: data,
+      isLoading: false,
+      hasError: false,
+    };
+    this.trigger(this.state);
+  },
+
+  fetchSavedQueriesError(): void {
+    this.state = {
+      ...this.state,
+      savedQueries: [],
+      isLoading: false,
+      hasError: true,
+    };
+    this.trigger(this.state);
+  },
+
+  createSavedQuerySuccess(query): void {
+    this.state = {
+      ...this.state,
+      savedQueries: [...this.state.savedQueries, query],
+    };
+    this.trigger(this.state);
+  },
+
+  updateSavedQuerySuccess(query): void {
+    let savedQueries;
+    const index = this.state.savedQueries.findIndex(item => item.id === query.id);
+    if (index > -1) {
+      savedQueries = [...this.state.savedQueries].splice(index, 1, query);
+    } else {
+      savedQueries = [...this.state.savedQueries, query];
+    }
+    this.state = {
+      ...this.state,
+      savedQueries,
+    };
+    this.trigger(this.state);
+  },
+
+  deleteSavedQuerySuccess(id): void {
+    const savedQueries = [...this.state.savedQueries.filter(query => query.id !== id)];
+    this.state = {
+      ...this.state,
+      savedQueries,
+    };
+    this.trigger(this.state);
+  },
+});
+
+export default DiscoverSavedQueriesStore;

--- a/tests/js/spec/stores/discoverSavedQueriesStore.spec.jsx
+++ b/tests/js/spec/stores/discoverSavedQueriesStore.spec.jsx
@@ -1,0 +1,159 @@
+import DiscoverSavedQueriesStore from 'app/stores/discoverSavedQueriesStore';
+import {
+  fetchSavedQueries,
+  createSavedQuery,
+  updateSavedQuery,
+  deleteSavedQuery,
+} from 'app/actionCreators/discoverSavedQueries';
+import {Client} from 'app/api';
+
+describe('DiscoverSavedQueriesStore', function() {
+  let api;
+  const now = '2019-09-03T12:13:14';
+
+  beforeAll(function() {
+    api = new Client();
+    DiscoverSavedQueriesStore.reset();
+  });
+
+  beforeEach(function() {
+    Client.addMockResponse({
+      url: '/organizations/org-1/discover/saved/',
+      body: [
+        {
+          id: '1',
+          name: 'first query',
+          fields: ['title', 'count()'],
+          dateCreated: now,
+          dateUpdated: now,
+          createdBy: '1',
+        },
+        {
+          id: '2',
+          name: 'second query',
+          fields: ['transaction', 'count()'],
+          dateCreated: now,
+          dateUpdated: now,
+          createdBy: '1',
+        },
+      ],
+    });
+    Client.addMockResponse({
+      url: '/organizations/org-1/discover/saved/1/',
+      method: 'DELETE',
+    });
+  });
+
+  afterEach(async function() {
+    Client.clearMockResponses();
+    DiscoverSavedQueriesStore.reset();
+    await tick();
+  });
+
+  it('has default state', function() {
+    expect(DiscoverSavedQueriesStore.get()).toEqual({
+      hasError: false,
+      isLoading: true,
+      savedQueries: [],
+    });
+  });
+
+  it('fetching queries updates the store', async function() {
+    fetchSavedQueries(api, 'org-1');
+    await tick();
+
+    const state = DiscoverSavedQueriesStore.get();
+    expect(state.isLoading).toEqual(false);
+    expect(state.hasError).toEqual(false);
+    expect(state.savedQueries).toHaveLength(2);
+  });
+
+  it('fetching queries updates the store on error', async function() {
+    Client.clearMockResponses();
+    Client.addMockResponse({
+      url: '/organizations/org-1/discover/saved/',
+      method: 'GET',
+      statusCode: 500,
+    });
+    fetchSavedQueries(api, 'org-1');
+    await tick();
+
+    const state = DiscoverSavedQueriesStore.get();
+    expect(state.isLoading).toEqual(false);
+    expect(state.hasError).toEqual(true);
+    expect(state.savedQueries).toHaveLength(0);
+  });
+
+  it('updating a query updates the store', async function() {
+    Client.addMockResponse({
+      url: '/organizations/org-1/discover/saved/1/',
+      method: 'PUT',
+      body: {
+        id: '2',
+        name: 'best query',
+        dateCreated: now,
+        dateUpdated: now,
+        createdBy: '2',
+      },
+    });
+    fetchSavedQueries(api, 'org-1');
+    await tick();
+
+    const query = {
+      id: '2',
+      name: 'best query',
+      fields: ['title', 'count()'],
+    };
+    updateSavedQuery(api, 'org-1', query);
+    await tick();
+
+    const state = DiscoverSavedQueriesStore.get();
+    expect(state.isLoading).toEqual(false);
+    expect(state.hasError).toEqual(false);
+    expect(state.savedQueries).toHaveLength(2);
+    expect(state.savedQueries[0].dateCreated).toEqual(now);
+  });
+
+  it('creating a query updates the store', async function() {
+    Client.addMockResponse({
+      url: '/organizations/org-1/discover/saved/',
+      method: 'POST',
+      body: {
+        id: '2',
+        name: 'best query',
+        fields: ['title', 'count()'],
+        dateCreated: now,
+        dateUpdated: now,
+        createdBy: '2',
+      },
+    });
+
+    fetchSavedQueries(api, 'org-1');
+    await tick();
+
+    const query = {
+      name: 'best query',
+      fields: ['title', 'count()'],
+    };
+    createSavedQuery(api, 'org-1', query);
+    await tick();
+
+    const state = DiscoverSavedQueriesStore.get();
+    expect(state.isLoading).toEqual(false);
+    expect(state.hasError).toEqual(false);
+    expect(state.savedQueries).toHaveLength(3);
+  });
+
+  it('deleting a query updates the store', async function() {
+    fetchSavedQueries(api, 'org-1');
+    await tick();
+
+    deleteSavedQuery(api, 'org-1', '1');
+    await tick();
+
+    const state = DiscoverSavedQueriesStore.get();
+    expect(state.isLoading).toEqual(false);
+    expect(state.hasError).toEqual(false);
+    expect(state.savedQueries).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Add a Reflux store and some basic actionCreators for discover queries. We'll be using discover queries in the sidebar and a few different page elements which is why I'm adding a new store for them.

Refs SEN-996