### PR TITLE
fix(github) Don't KeyError on None

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -56,7 +56,7 @@ class Webhook(object):
                 "github.missing-integration",
                 extra={
                     "action": event.get("action"),
-                    "repository": event.get("repository")["full_name"],
+                    "repository": event.get("repository", {}).get("full_name", None),
                     "external_id": six.text_type(external_id),
                 },
             )


### PR DESCRIPTION
Not all github events have `repository` payloads. For example installation `added` events don't.

Fixes SENTRY-CEV