### PR TITLE
fix(integrations) Handle 400 response codes in integration repo list

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import {migrateRepository, addRepository} from 'app/actionCreators/integrations';
+import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
@@ -80,7 +81,7 @@ export default class IntegrationRepos extends AsyncComponent {
       success: data => {
         this.setState({integrationRepos: data, dropdownBusy: false});
       },
-      error: error => {
+      error: () => {
         this.setState({dropdownBusy: false});
       },
     });
@@ -173,6 +174,23 @@ export default class IntegrationRepos extends AsyncComponent {
         )}
       </DropdownAutoComplete>
     );
+  }
+
+  renderError(error) {
+    const badRequest = Object.values(this.state.errors).find(
+      resp => resp && resp.status === 400
+    );
+    if (badRequest) {
+      return (
+        <Alert type="error" icon="icon-circle-exclamation">
+          {t(
+            'We were unable to fetch repositories for this integration. Try again later, or reconnect this integration.'
+          )}
+        </Alert>
+      );
+    }
+
+    return super.renderError(error);
   }
 
   renderBody() {

--- a/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationRepos.spec.jsx
@@ -13,6 +13,28 @@ describe('IntegrationRepos', function() {
   const integration = TestStubs.GitHubIntegration();
   const routerContext = TestStubs.routerContext();
 
+  describe('Getting repositories', function() {
+    it('handles broken integrations', function() {
+      Client.addMockResponse({
+        url: `/organizations/${org.slug}/integrations/1/repos/`,
+        statusCode: 400,
+        body: {detail: 'Invalid grant'},
+      });
+      Client.addMockResponse({
+        url: `/organizations/${org.slug}/repos/`,
+        method: 'GET',
+        body: [],
+      });
+
+      const wrapper = mount(
+        <IntegrationRepos integration={integration} />,
+        routerContext
+      );
+      expect(wrapper.find('PanelBody')).toHaveLength(0);
+      expect(wrapper.find('Alert')).toHaveLength(1);
+    });
+  });
+
   describe('Adding repositories', function() {
     it('can save successfully', async function() {
       const addRepo = Client.addMockResponse({


### PR DESCRIPTION
An integration's repository list can fail with an IntegrationError if the access token has expired and cannot be renewed. Instead of showing a user-feedback dialog we can handle that situation more gracefully and let the user know they may need to reconnect their integration.

Fixes SENTRY-1FKR
Refs ISSUE-578