### PR TITLE
fix(discover2) Handle API errors better

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table.tsx
@@ -6,6 +6,7 @@ import styled from 'react-emotion';
 
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
+import Alert from 'app/components/alert';
 import {Client} from 'app/api';
 import {Organization} from 'app/types';
 import Pagination from 'app/components/pagination';
@@ -39,7 +40,7 @@ type Props = {
 type State = {
   eventView: EventView;
   loading: boolean;
-  hasError: boolean;
+  error: null | string;
   pageLinks: null | string;
   dataPayload: DataPayload | null | undefined;
 };
@@ -51,7 +52,7 @@ class Table extends React.PureComponent<Props, State> {
   state: State = {
     eventView: EventView.fromLocation(this.props.location),
     loading: true,
-    hasError: false,
+    error: null,
     pageLinks: null,
     dataPayload: null,
   };
@@ -99,15 +100,16 @@ class Table extends React.PureComponent<Props, State> {
         this.setState(prevState => {
           return {
             loading: false,
-            hasError: false,
+            error: null,
             pageLinks: jqxhr ? jqxhr.getResponseHeader('Link') : prevState.pageLinks,
             dataPayload,
           };
         });
       },
-      error: _err => {
+      error: err => {
         this.setState({
-          hasError: true,
+          loading: false,
+          error: err.responseJSON.detail,
         });
       },
     });
@@ -115,7 +117,7 @@ class Table extends React.PureComponent<Props, State> {
 
   render() {
     const {organization, location} = this.props;
-    const {pageLinks, eventView, loading, dataPayload} = this.state;
+    const {pageLinks, eventView, loading, dataPayload, error} = this.state;
 
     return (
       <Container>
@@ -125,6 +127,7 @@ class Table extends React.PureComponent<Props, State> {
           dataPayload={dataPayload}
           isLoading={loading}
           location={location}
+          error={error}
         />
         <Pagination pageLinks={pageLinks} />
       </Container>
@@ -137,6 +140,7 @@ type TableViewProps = {
   eventView: EventView;
   isLoading: boolean;
   dataPayload: DataPayload | null | undefined;
+  error: string | null;
   location: Location;
 };
 
@@ -203,17 +207,6 @@ class TableView extends React.Component<TableViewProps> {
 
     const {meta} = dataPayload;
     const fields = eventView.getFieldNames();
-
-    // TODO: deal with this
-    // if (fields.length <= 0) {
-    //   return (
-    //     <PanelGridInfo numOfCols={1}>
-    //       <EmptyStateWarning>
-    //         <p>{t('No field column selected')}</p>
-    //       </EmptyStateWarning>
-    //     </PanelGridInfo>
-    //   );
-    // }
     const lastRowIndex = dataPayload.data.length - 1;
     const hasLinkField = eventView.hasAutolinkField();
     const firstCellIndex = 0;
@@ -245,22 +238,36 @@ class TableView extends React.Component<TableViewProps> {
     });
   };
 
-  renderTable = () => {
+  renderTable() {
     return (
       <React.Fragment>
         {this.renderHeader()}
         {this.renderContent()}
       </React.Fragment>
     );
-  };
+  }
+
+  renderError() {
+    const {error, eventView} = this.props;
+    return (
+      <React.Fragment>
+        <Alert type="error" icon="icon-circle-exclamation">
+          {error}
+        </Alert>
+        <PanelGrid numOfCols={eventView.numOfColumns()}>{this.renderHeader()}</PanelGrid>
+      </React.Fragment>
+    );
+  }
 
   render() {
-    const {isLoading, eventView} = this.props;
+    const {isLoading, error, eventView} = this.props;
 
     if (isLoading) {
       return this.renderLoading();
     }
-
+    if (error) {
+      return this.renderError();
+    }
     return (
       <PanelGrid numOfCols={eventView.numOfColumns()}>{this.renderTable()}</PanelGrid>
     );


### PR DESCRIPTION
Render errors from the eventsv2 APIs in an alert. This lets users know they've made a mistake and what that mistake is as the API gives useful errors in expected scenarios.

![Screen Shot 2019-09-04 at 4 38 06 PM](https://user-images.githubusercontent.com/24086/64289592-7fbe4080-cf32-11e9-825f-04d539a6ad41.png)


Refs SEN-720