### PR TITLE
fix(search) Handle status filters better

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -12,7 +12,12 @@ from sentry.api.event_search import (
     SearchVisitor,
 )
 from sentry.constants import STATUS_CHOICES
-from sentry.search.utils import parse_actor_value, parse_user_value, parse_release
+from sentry.search.utils import (
+    parse_actor_value,
+    parse_user_value,
+    parse_release,
+    parse_status_value,
+)
 
 
 class IssueSearchVisitor(SearchVisitor):
@@ -92,12 +97,20 @@ def convert_release_value(value, projects, user, environments):
     return parse_release(value, projects, environments)
 
 
+def convert_status_value(value, projects, user, environments):
+    try:
+        return parse_status_value(value)
+    except ValueError:
+        raise InvalidSearchQuery(u"invalid status value of '{}'".format(value))
+
+
 value_converters = {
     "assigned_to": convert_actor_value,
     "bookmarked_by": convert_user_value,
     "subscribed_by": convert_user_value,
     "first_release": convert_release_value,
     "release": convert_release_value,
+    "status": convert_status_value,
 }
 
 

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -31,6 +31,14 @@ def get_user_tag(projects, key, value):
     return euser.tag_value
 
 
+def parse_status_value(value):
+    if value in STATUS_CHOICES:
+        return STATUS_CHOICES[value]
+    if value in STATUS_CHOICES.values():
+        return value
+    raise ValueError("Invalid status value")
+
+
 def parse_datetime_range(value):
     try:
         flag, count, interval = value[0], int(value[1:-1]), value[-1]

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -129,6 +129,23 @@ class ConvertQueryValuesTest(TestCase):
         assert filters[0].value.raw_value == search_val.raw_value
 
 
+class ConvertStatusValueTest(TestCase):
+    def test_valid(self):
+        for status_string, status_val in STATUS_CHOICES.items():
+            filters = [SearchFilter(SearchKey("status"), "=", SearchValue(status_string))]
+            result = convert_query_values(filters, [self.project], self.user, None)
+            assert result[0].value.raw_value == status_val
+
+            filters = [SearchFilter(SearchKey("status"), "=", SearchValue(status_val))]
+            result = convert_query_values(filters, [self.project], self.user, None)
+            assert result[0].value.raw_value == status_val
+
+    def test_invalid(self):
+        filters = [SearchFilter(SearchKey("status"), "=", SearchValue("wrong"))]
+        with self.assertRaises(ValueError):
+            convert_query_values(filters, [self.project], self.user, None)
+
+
 class ConvertActorValueTest(TestCase):
     def test_user(self):
         assert convert_actor_value("me", [self.project], self.user, None) == convert_user_value(

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -142,7 +142,7 @@ class ConvertStatusValueTest(TestCase):
 
     def test_invalid(self):
         filters = [SearchFilter(SearchKey("status"), "=", SearchValue("wrong"))]
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InvalidSearchQuery, expected_regex="invalid status value"):
             convert_query_values(filters, [self.project], self.user, None)
 
 


### PR DESCRIPTION
Searching issues by status shouldn't explode when the user uses the values they get from the API results.

This makes `status:unresolved` work in issue search.

Fixes SENTRY-CMJ