### PR TITLE
fix(ui): Remove z-index from `<SmartSearchBar>` [SEN-1017]

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -1081,7 +1081,6 @@ const Container = styled('div')`
 
   position: relative;
 
-  z-index: ${p => p.theme.zIndex.dropdown};
   display: flex;
 
   .show-sidebar & {


### PR DESCRIPTION
This will inevitably break something, but I have manually tested issues list, events, eventsv2, and it seems to be fine.

This is needed so we don't have to add extra CSS for `<SelectControl>` dropdown that overlaps `<SmartSearchBar>` in Incident Rules.

Fixes SEN-1017