### PR TITLE
feat: Added beta tags to grouping for early adopters

### DIFF
--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -156,6 +156,7 @@ class StrategyConfiguration(object):
     strategies = {}
     delegates = {}
     changelog = None
+    hidden = False
 
     def __init__(self, enhancements=None, **extra):
         if enhancements is None:
@@ -189,6 +190,7 @@ class StrategyConfiguration(object):
             "strategies": sorted(self.strategies),
             "changelog": self.changelog,
             "delegates": sorted(x.id for x in self.delegates.values()),
+            "hidden": self.hidden,
             "latest": projectoptions.lookup_well_known_key("sentry:grouping_config").get_default(
                 epoch=projectoptions.LATEST_EPOCH
             )
@@ -196,7 +198,7 @@ class StrategyConfiguration(object):
         }
 
 
-def create_strategy_configuration(id, strategies=None, delegates=None, changelog=None):
+def create_strategy_configuration(id, strategies=None, delegates=None, changelog=None, hidden=False):
     class NewStrategyConfiguration(StrategyConfiguration):
         pass
 
@@ -204,6 +206,7 @@ def create_strategy_configuration(id, strategies=None, delegates=None, changelog
     NewStrategyConfiguration.config_class = id.split(":", 1)[0]
     NewStrategyConfiguration.strategies = {}
     NewStrategyConfiguration.delegates = {}
+    NewStrategyConfiguration.hidden = hidden
 
     for strategy_id in strategies or {}:
         strategy = lookup_strategy(strategy_id)

--- a/src/sentry/grouping/strategies/configurations.py
+++ b/src/sentry/grouping/strategies/configurations.py
@@ -67,6 +67,7 @@ register_strategy_config(
         * New grouping strategy optimized for native and javascript
         * Not compatible with the old legacy grouping
     """,
+    hidden=True,
 )
 
 register_strategy_config(
@@ -87,6 +88,7 @@ register_strategy_config(
         * messages are now preprocessed to increase change of grouping together
         * exceptions without stacktraces are now grouped by a trimmed message
     """,
+    hidden=True,
 )
 
 register_strategy_config(
@@ -134,4 +136,5 @@ register_strategy_config(
         * Uses `newstyle:2019-04-05` for native platforms
         * Uses `legacy:2019-03-12` for all other platforms
     """,
+    hidden=True,
 )

--- a/src/sentry/static/sentry/app/components/events/eventEntries.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.jsx
@@ -216,7 +216,11 @@ class EventEntries extends React.Component {
           <EventSdkUpdates event={event} />
         )}
         {!isShare && features.has('grouping-info') && (
-          <EventGroupingInfo projectId={project.slug} event={event} />
+          <EventGroupingInfo
+            projectId={project.slug}
+            event={event}
+            showSelector={features.has('set-grouping-config')}
+          />
         )}
       </div>
     );

--- a/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
@@ -15,9 +15,9 @@ import KeyValueList from 'app/components/events/interfaces/keyValueList';
 
 import withOrganization from 'app/utils/withOrganization';
 
-const GroupingConfigItem = styled(({hidden: _hidden, active: _active, ...props}) => (
-  <code {...props} />
-))`
+export const GroupingConfigItem = styled(
+  ({hidden: _hidden, active: _active, ...props}) => <code {...props} />
+)`
   ${p => (p.hidden ? 'opacity: 0.5;' : '')}
   ${p => (p.active ? 'font-weight: bold;' : '')}
 `;

--- a/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
@@ -23,7 +23,9 @@ const GroupVariantList = styled('ul')`
   line-height: 18px;
 `;
 
-const GroupVariantListItem = styled(({contributes: _contributes, ...props}) => <li {...props} />)`
+const GroupVariantListItem = styled(({contributes: _contributes, ...props}) => (
+  <li {...props} />
+))`
   padding: 15px 0 20px 0;
   margin-top: 15px;
   ${p => (p.contributes ? '' : 'color:' + p.theme.gray6)};
@@ -52,7 +54,9 @@ const GroupingComponentListItem = styled('li')`
   margin: 2px 0 1px 13px;
 `;
 
-const GroupingComponentWrapper = styled(({contributes: _contributes, ...props}) => <div {...props} />)`
+const GroupingComponentWrapper = styled(({contributes: _contributes, ...props}) => (
+  <div {...props} />
+))`
   ${p => (p.contributes ? '' : 'color:' + p.theme.gray6)};
 `;
 

--- a/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
@@ -23,8 +23,7 @@ const GroupVariantList = styled('ul')`
   line-height: 18px;
 `;
 
-// eslint-disable-next-line no-unused-vars
-const GroupVariantListItem = styled(({contributes, ...props}) => <li {...props} />)`
+const GroupVariantListItem = styled(({contributes: _contributes, ...props}) => <li {...props} />)`
   padding: 15px 0 20px 0;
   margin-top: 15px;
   ${p => (p.contributes ? '' : 'color:' + p.theme.gray6)};
@@ -53,8 +52,7 @@ const GroupingComponentListItem = styled('li')`
   margin: 2px 0 1px 13px;
 `;
 
-// eslint-disable-next-line no-unused-vars
-const GroupingComponentWrapper = styled(({contributes, ...props}) => <div {...props} />)`
+const GroupingComponentWrapper = styled(({contributes: _contributes, ...props}) => <div {...props} />)`
   ${p => (p.contributes ? '' : 'color:' + p.theme.gray6)};
 `;
 

--- a/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
@@ -15,6 +15,13 @@ import KeyValueList from 'app/components/events/interfaces/keyValueList';
 
 import withOrganization from 'app/utils/withOrganization';
 
+const GroupingConfigItem = styled(({hidden: _hidden, active: _active, ...props}) => (
+  <code {...props} />
+))`
+  ${p => (p.hidden ? 'opacity: 0.5;' : '')}
+  ${p => (p.active ? 'font-weight: bold;' : '')}
+`;
+
 const GroupVariantList = styled('ul')`
   padding: 0;
   margin: 0;
@@ -222,7 +229,7 @@ class GroupingConfigSelect extends AsyncComponent {
     props.value = configId;
 
     function renderIdLabel(id) {
-      return <code>{eventConfigId === id ? <strong>{id}</strong> : id}</code>;
+      return <GroupingConfigItem active={eventConfigId === id}>{id}</GroupingConfigItem>;
     }
 
     return (

--- a/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
@@ -264,7 +264,7 @@ class EventGroupingInfo extends AsyncComponent {
     organization: SentryTypes.Organization.isRequired,
     projectId: PropTypes.string.isRequired,
     event: SentryTypes.Event.isRequired,
-    showSelector: PropTypes.object,
+    showSelector: PropTypes.bool,
   };
 
   getEndpoints() {

--- a/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo.jsx
@@ -6,6 +6,7 @@ import AsyncComponent from 'app/components/asyncComponent';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 import DropdownButton from 'app/components/dropdownButton';
 import Tooltip from 'app/components/tooltip';
+import BetaTag from 'app/components/betaTag';
 
 import EventDataSection from 'app/components/events/eventDataSection';
 import SentryTypes from 'app/sentryTypes';
@@ -22,6 +23,7 @@ const GroupVariantList = styled('ul')`
   line-height: 18px;
 `;
 
+// eslint-disable-next-line no-unused-vars
 const GroupVariantListItem = styled(({contributes, ...props}) => <li {...props} />)`
   padding: 15px 0 20px 0;
   margin-top: 15px;
@@ -51,6 +53,7 @@ const GroupingComponentListItem = styled('li')`
   margin: 2px 0 1px 13px;
 `;
 
+// eslint-disable-next-line no-unused-vars
 const GroupingComponentWrapper = styled(({contributes, ...props}) => <div {...props} />)`
   ${p => (p.contributes ? '' : 'color:' + p.theme.gray6)};
 `;
@@ -225,12 +228,14 @@ class GroupingConfigSelect extends AsyncComponent {
         {...props}
         alignMenu="left"
         selectedItem={configId}
-        items={this.state.data.map(item => {
-          return {
-            value: item.id,
-            label: renderIdLabel(item.id),
-          };
-        })}
+        items={this.state.data
+          .filter(item => !item.hidden || item.id === eventConfigId)
+          .map(item => {
+            return {
+              value: item.id,
+              label: renderIdLabel(item.id),
+            };
+          })}
       >
         {({isOpen}) => (
           <Tooltip title="Click here to experiment with other grouping configs">
@@ -250,6 +255,7 @@ class EventGroupingInfo extends AsyncComponent {
     organization: SentryTypes.Organization.isRequired,
     projectId: PropTypes.string.isRequired,
     event: SentryTypes.Event.isRequired,
+    showSelector: PropTypes.object,
   };
 
   getEndpoints() {
@@ -325,19 +331,21 @@ class EventGroupingInfo extends AsyncComponent {
     return (
       <GroupVariantList>
         <div style={{float: 'right'}}>
-          <GroupingConfigSelect
-            name="groupingConfig"
-            eventConfigId={eventConfigId}
-            configId={configId}
-            onSelect={selection => {
-              this.setState(
-                {
-                  configOverride: selection.value,
-                },
-                () => this.reloadData()
-              );
-            }}
-          />
+          {this.props.showSelector && (
+            <GroupingConfigSelect
+              name="groupingConfig"
+              eventConfigId={eventConfigId}
+              configId={configId}
+              onSelect={selection => {
+                this.setState(
+                  {
+                    configOverride: selection.value,
+                  },
+                  () => this.reloadData()
+                );
+              }}
+            />
+          )}
         </div>
         {variants.map(variant => (
           <GroupVariant variant={variant} key={variant.key} />
@@ -356,7 +364,7 @@ class EventGroupingInfo extends AsyncComponent {
       >
         <div className="box-header">
           <a className="pull-right grouping-info-toggle" onClick={this.toggle}>
-            {isOpen ? t('Hide Details') : t('Show Details')}
+            {isOpen ? t('Hide Details') : t('Show Details')} <BetaTag />
           </a>
           <h3>
             {t('Event Grouping Information')}

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -11,6 +11,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import platforms from 'app/data/platforms';
 import slugify from 'app/utils/slugify';
 import space from 'app/styles/space';
+import GroupingConfigItem from 'app/components/events/groupingInfo';
 
 // Export route to make these forms searchable by label/help
 export const route = '/settings/:orgId/projects/:projectId/';
@@ -139,9 +140,9 @@ export const fields = {
       return groupingConfigs.map(({id, hidden}) => {
         return [
           id.toString(),
-          <code key={id} style={{opacity: hidden ? '0.5' : 1.0}}>
+          <GroupingConfigItem key={id} hidden={hidden}>
             {id}
-          </code>,
+          </GroupingConfigItem>,
         ];
       });
     },

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -11,7 +11,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import platforms from 'app/data/platforms';
 import slugify from 'app/utils/slugify';
 import space from 'app/styles/space';
-import GroupingConfigItem from 'app/components/events/groupingInfo';
+import {GroupingConfigItem} from 'app/components/events/groupingInfo';
 
 // Export route to make these forms searchable by label/help
 export const route = '/settings/:orgId/projects/:projectId/';

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -136,7 +136,14 @@ export const fields = {
       );
     },
     choices: ({groupingConfigs}) => {
-      return groupingConfigs.map(({id}) => [id.toString(), <code key={id}>{id}</code>]);
+      return groupingConfigs.map(({id, hidden}) => {
+        return [
+          id.toString(),
+          <code key={id} style={{opacity: hidden ? '0.5' : 1.0}}>
+            {id}
+          </code>,
+        ];
+      });
     },
     help: t('Sets the grouping algorithm to be used for new events.'),
     visible: ({features}) => features.has('set-grouping-config'),
@@ -206,9 +213,7 @@ export const fields = {
         </pre>
       </React.Fragment>
     ),
-    validate: ({id, form}) => {
-      return [];
-    },
+    validate: () => [],
     visible: ({features}) =>
       features.has('set-grouping-config') || features.has('tweak-grouping-config'),
   },

--- a/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.jsx
@@ -33,7 +33,7 @@ class JsonForm extends React.Component {
     /**
      * Panel title if `forms` is not defined
      */
-    title: PropTypes.string,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
 
     access: PropTypes.object,
     features: PropTypes.object,
@@ -152,7 +152,7 @@ class FormPanel extends React.Component {
     /**
      * Panel title
      */
-    title: PropTypes.string,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     /**
      * List of fields to render
      */

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -26,6 +26,7 @@ import ProjectsStore from 'app/stores/projectsStore';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import TextField from 'app/views/settings/components/forms/textField';
+import BetaTag from 'app/components/betaTag';
 import handleXhrErrorResponse from 'app/utils/handleXhrErrorResponse';
 import recreateRoute from 'app/utils/recreateRoute';
 
@@ -117,21 +118,20 @@ class ProjectGeneralSettings extends AsyncView {
       }
     });
 
-    if (Object.keys(newData).length === 0) {
-      return null;
-    }
+    const noUpdates = Object.keys(newData).length === 0;
 
     return (
       <Field
         label={t('Upgrade Grouping Strategy')}
         help={tct(
-          'This project uses an old grouping strategy and an update is possible.[linebreak]Doing so will cause new events to group differently.',
+          'If the project uses an old grouping strategy an update is possible.[linebreak]Doing so will cause new events to group differently.',
           {
             linebreak: <br />,
           }
         )}
       >
         <Confirm
+          disabled={noUpdates}
           onConfirm={() => {
             addLoadingMessage(t('Changing grouping...'));
             this.api
@@ -171,6 +171,8 @@ class ProjectGeneralSettings extends AsyncView {
         >
           <div>
             <Button
+              disabled={noUpdates}
+              title={noUpdates ? t('You are already on the latest version') : null}
               className="ref-upgrade-grouping-strategy"
               type="button"
               priority="primary"
@@ -287,7 +289,7 @@ class ProjectGeneralSettings extends AsyncView {
                   <Form
                     hideFooter
                     onFieldChange={this.handleTransferFieldChange}
-                    onSubmit={(data, onSuccess, onError, e) => {
+                    onSubmit={(_data, _onSuccess, _onError, e) => {
                       e.stopPropagation();
                       confirm();
                     }}
@@ -384,7 +386,11 @@ class ProjectGeneralSettings extends AsyncView {
             jsonFormProps.features.has('tweak-grouping-config')) && (
             <JsonForm
               {...jsonFormProps}
-              title={t('Grouping Settings')}
+              title={
+                <>
+                  {t('Grouping Settings')} <BetaTag />
+                </>
+              }
               fields={[
                 fields.groupingConfig,
                 fields.groupingEnhancementsBase,
@@ -469,7 +475,7 @@ class ProjectGeneralSettings extends AsyncView {
 
 const ProjectGeneralSettingsContainer = createReactClass({
   mixins: [Reflux.listenTo(ProjectsStore, 'onProjectsUpdate')],
-  onProjectsUpdate(projects) {
+  onProjectsUpdate(_projects) {
     if (!this.changedSlug) {
       return;
     }

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -387,9 +387,9 @@ class ProjectGeneralSettings extends AsyncView {
             <JsonForm
               {...jsonFormProps}
               title={
-                <>
+                <React.Fragment>
                   {t('Grouping Settings')} <BetaTag />
-                </>
+                </React.Fragment>
               }
               fields={[
                 fields.groupingConfig,
@@ -398,7 +398,7 @@ class ProjectGeneralSettings extends AsyncView {
                 fields.fingerprintingRules,
               ]}
               renderHeader={() => (
-                <>
+                <React.Fragment>
                   <PanelAlert type="warning">
                     <TextBlock noMargin>
                       {t(
@@ -408,7 +408,7 @@ class ProjectGeneralSettings extends AsyncView {
                   </PanelAlert>
                   {jsonFormProps.features.has('tweak-grouping-config') &&
                     this.renderUpgradeGrouping()}
-                </>
+                </React.Fragment>
               )}
             />
           )}


### PR DESCRIPTION
This changes grouping so we can unlock it for early adopters.

Below event view:

<img width="805" alt="Screenshot 2019-09-05 at 14 56 51" src="https://user-images.githubusercontent.com/7396/64345846-557f8800-cff1-11e9-966b-b50cf0cd65e2.png">

Settings view:

<img width="910" alt="Screenshot 2019-09-05 at 14 57 07" src="https://user-images.githubusercontent.com/7396/64345847-557f8800-cff1-11e9-8810-a5890a60435b.png">
