### PR TITLE
feat(app-platform): keep user on integration page when saving a new integration

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -102,10 +102,14 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
     return events.map(e => e.split('.').shift());
   }
 
-  handleSubmitSuccess = data => {
+  handleSubmitSuccess = (data: SentryApp) => {
+    const {app} = this.state;
     const {orgId} = this.props.params;
-    addSuccessMessage(t(`${data.name} successfully saved.`));
-    browserHistory.push(`/settings/${orgId}/developer-settings/`);
+    const verb = app ? 'saved' : 'created';
+    const baseUrl = `/settings/${orgId}/developer-settings/`;
+    const url = app ? baseUrl : `${baseUrl}${data.slug}/`;
+    addSuccessMessage(t(`%s successfully ${verb}.`, data.name));
+    browserHistory.push(url);
   };
 
   handleSubmitError = err => {

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -105,10 +105,13 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
   handleSubmitSuccess = (data: SentryApp) => {
     const {app} = this.state;
     const {orgId} = this.props.params;
-    const verb = app ? 'saved' : 'created';
     const baseUrl = `/settings/${orgId}/developer-settings/`;
     const url = app ? baseUrl : `${baseUrl}${data.slug}/`;
-    addSuccessMessage(t(`%s successfully ${verb}.`, data.name));
+    if (app) {
+      addSuccessMessage(t('%s successfully saved.', data.name));
+    } else {
+      addSuccessMessage(t('%s successfully created.', data.name));
+    }
     browserHistory.push(url);
   };
 

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -52,7 +52,7 @@ class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
 
         self.browser.wait_until(".ref-success")
 
-        assert self.browser.find_element_by_link_text("Tesla")
+        assert self.browser.find_element_by_xpath("//button//span[contains(text(), 'New Token')]")
 
 
 class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -37,7 +37,7 @@ class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
 
         self.browser.wait_until(".ref-success")
 
-        assert self.browser.find_element_by_link_text("Tesla")
+        assert self.browser.find_element_by_xpath("//div[contains(text(), 'Client ID')]")
 
     def test_create_new_internal_integration(self):
         self.load_page(self.org_developer_settings_path)


### PR DESCRIPTION
It is confusing for users who create integrations to end up back at the developer settings page because we don't show the client id/secret and any tokens in the initial view. If we keep the user on the page for that integration after creating it, then that information will be right there immediately.