### PR TITLE
ref(2fa): Clean up accept invite w/ 2fa flow

### DIFF
--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -1,14 +1,40 @@
 from __future__ import absolute_import
 
+from six.moves.urllib.parse import urlencode, parse_qsl
 from django.utils.crypto import constant_time_compare
 from django.core.urlresolvers import reverse
-from sentry.utils import metrics
 
+from sentry.utils import metrics
 from sentry.models import AuditLogEntryEvent, Authenticator, OrganizationMember
 from sentry.signals import member_joined
 
-PENDING_INVITE = "pending-invite"
+INVITE_COOKIE = "pending-invite"
 COOKIE_MAX_AGE = 60 * 60 * 24 * 7  # 7 days
+
+
+def add_invite_cookie(request, response, member_id, token):
+    url = reverse("sentry-accept-invite", args=[member_id, token])
+    response.set_cookie(
+        INVITE_COOKIE,
+        urlencode({"memberId": member_id, "token": token, "url": url}),
+        max_age=COOKIE_MAX_AGE,
+    )
+
+
+def remove_invite_cookie(request, response):
+    if INVITE_COOKIE in request.COOKIES:
+        response.delete_cookie(INVITE_COOKIE)
+
+
+def get_invite_cookie(request):
+    if INVITE_COOKIE not in request.COOKIES:
+        return None
+
+    # memberId should be coerced back to an integer
+    invite_data = dict(parse_qsl(request.COOKIES.get(INVITE_COOKIE)))
+    invite_data["memberId"] = int(invite_data["memberId"])
+
+    return invite_data
 
 
 class ApiInviteHelper(object):
@@ -18,7 +44,7 @@ class ApiInviteHelper(object):
         self.member_id = member_id
         self.token = token
         self.logger = logger
-        self.om = self.get_organization_member()
+        self.om = self.organization_member
 
     def handle_success(self):
         member_joined.send_robust(
@@ -32,7 +58,8 @@ class ApiInviteHelper(object):
                 extra={"organization_id": self.om.organization.id, "user_id": self.request.user.id},
             )
 
-    def get_organization_member(self):
+    @property
+    def organization_member(self):
         return OrganizationMember.objects.select_related("organization").get(pk=self.member_id)
 
     @property
@@ -41,6 +68,8 @@ class ApiInviteHelper(object):
 
     @property
     def valid_token(self):
+        if self.token is None:
+            return False
         if self.om.token_expired:
             return False
         return constant_time_compare(self.om.token or self.om.legacy_token, self.token)
@@ -73,33 +102,27 @@ class ApiInviteHelper(object):
             and not self.needs_2fa
         )
 
-    def accept_invite(self):
+    def accept_invite(self, user=None):
         om = self.om
+
+        if user is None:
+            user = self.request.user
 
         if self.member_already_exists:
             self.handle_member_already_exists()
             om.delete()
         else:
-            om.set_user(self.request.user)
+            om.set_user(user)
             om.save()
 
             self.instance.create_audit_entry(
                 self.request,
                 organization=om.organization,
                 target_object=om.id,
-                target_user=self.request.user,
+                target_user=user,
                 event=AuditLogEntryEvent.MEMBER_ACCEPT,
                 data=om.get_audit_log_data(),
             )
 
             self.handle_success()
             metrics.incr("organization.invite-accepted", sample_rate=1.0)
-
-    def add_invite_cookie(self, request, response, member_id, token):
-        url = reverse("sentry-accept-invite", args=[member_id, token])
-        response.set_cookie(PENDING_INVITE, url, max_age=COOKIE_MAX_AGE)
-
-    def remove_invite_cookie(self, response):
-        if PENDING_INVITE in self.request.COOKIES:
-            response.delete_cookie(PENDING_INVITE)
-        return response

--- a/src/sentry/static/sentry/app/actionCreators/organizations.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organizations.jsx
@@ -70,44 +70,47 @@ export function updateOrganization(org) {
   OrganizationsActions.update(org);
 }
 
-export function fetchOrganizationByMember(memberId, {addOrg, fetchOrgDetails}) {
+export async function fetchOrganizationByMember(memberId, {addOrg, fetchOrgDetails}) {
   const api = new Client();
-  const request = api.requestPromise(`/organizations/?query=member_id:${memberId}`);
+  const data = await api.requestPromise(`/organizations/?query=member_id:${memberId}`);
 
-  request.then(data => {
-    if (data.length) {
-      if (addOrg) {
-        // add org to SwitchOrganization dropdown
-        OrganizationsStore.add(data[0]);
-      }
+  if (!data.length) {
+    return null;
+  }
 
-      if (fetchOrgDetails) {
-        // load SidebarDropdown with org details including `access`
-        fetchOrganizationDetails(data[0].slug, {setActive: true, loadProjects: true});
-      }
-    }
-  });
+  const org = data[0];
 
-  return request;
+  if (addOrg) {
+    // add org to SwitchOrganization dropdown
+    OrganizationsStore.add(org);
+  }
+
+  if (fetchOrgDetails) {
+    // load SidebarDropdown with org details including `access`
+    await fetchOrganizationDetails(org.slug, {setActive: true, loadProjects: true});
+  }
+
+  return org;
 }
 
-export function fetchOrganizationDetails(orgId, {setActive, loadProjects, loadTeam}) {
+export async function fetchOrganizationDetails(
+  orgId,
+  {setActive, loadProjects, loadTeam}
+) {
   const api = new Client();
-  const request = api.requestPromise(`/organizations/${orgId}/`);
+  const data = await api.requestPromise(`/organizations/${orgId}/`);
 
-  request.then(data => {
-    if (setActive) {
-      setActiveOrganization(data);
-    }
+  if (setActive) {
+    setActiveOrganization(data);
+  }
 
-    if (loadTeam) {
-      TeamStore.loadInitialData(data.teams);
-    }
+  if (loadTeam) {
+    TeamStore.loadInitialData(data.teams);
+  }
 
-    if (loadProjects) {
-      ProjectsStore.loadInitialData(data.projects || []);
-    }
-  });
+  if (loadProjects) {
+    ProjectsStore.loadInitialData(data.projects || []);
+  }
 
-  return request;
+  return data;
 }

--- a/src/sentry/static/sentry/app/utils/getPendingInvite.tsx
+++ b/src/sentry/static/sentry/app/utils/getPendingInvite.tsx
@@ -1,0 +1,18 @@
+import Cookies from 'js-cookie';
+import queryString from 'query-string';
+
+type PendingInvite = {
+  memberId: number;
+  token: string;
+  url: string;
+};
+
+export default function getPendingInvite(): PendingInvite | null {
+  const data = Cookies.get('pending-invite');
+
+  if (!data) {
+    return null;
+  }
+
+  return queryString.parse(data) as any;
+}

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
@@ -1,34 +1,28 @@
-/**
- * Renders necessary forms in order to enroll user in 2fa
- */
 import {withRouter} from 'react-router';
 import React from 'react';
-import Cookies from 'js-cookie';
 
+import {PanelItem} from 'app/components/panels';
 import {
   addErrorMessage,
   addMessage,
   addSuccessMessage,
 } from 'app/actionCreators/indicator';
-import {t} from 'app/locale';
 import {openRecoveryOptions} from 'app/actionCreators/modal';
 import {fetchOrganizationByMember} from 'app/actionCreators/organizations';
+import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import CircleIndicator from 'app/components/circleIndicator';
+import Field from 'app/views/settings/components/forms/field';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
-import Field from 'app/views/settings/components/forms/field';
-import {PanelItem} from 'app/components/panels';
 import Qrcode from 'app/components/qrcode';
 import RemoveConfirm from 'app/views/settings/account/accountSecurity/components/removeConfirm';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
-import U2fsign from 'app/components/u2f/u2fsign';
 import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
-
-const ENDPOINT = '/users/me/authenticators/';
-const PENDING_INVITE = 'pending-invite';
+import U2fsign from 'app/components/u2f/u2fsign';
+import getPendingInvite from 'app/utils/getPendingInvite';
 
 /**
  * Retrieve additional form fields (or modify ones) based on 2fa method
@@ -120,65 +114,52 @@ const getFields = ({authenticator, hasSentCode, onSmsReset, onSmsSubmit, onU2fTa
   return null;
 };
 
+/**
+ * Renders necessary forms in order to enroll user in 2fa
+ */
 class AccountSecurityEnroll extends AsyncView {
-  constructor(...args) {
-    super(...args);
-    this._form = {};
-  }
+  _form = {};
 
   getTitle() {
     return t('Security');
   }
 
+  get authenticatorEndpoint() {
+    return `/users/me/authenticators/${this.props.params.authId}/`;
+  }
+
+  get enrollEndpoint() {
+    return `${this.authenticatorEndpoint}enroll/`;
+  }
+
   getEndpoints() {
-    return [
-      [
-        'authenticator',
-        `${ENDPOINT}${this.props.params.authId}/enroll/`,
-        {},
-        {
-          allowError: err => {
-            const alreadyEnrolled =
-              err &&
-              err.status === 400 &&
-              err.responseJSON &&
-              err.responseJSON.details === 'Already enrolled';
+    const errorHandler = err => {
+      const alreadyEnrolled =
+        err &&
+        err.status === 400 &&
+        err.responseJSON &&
+        err.responseJSON.details === 'Already enrolled';
 
-            if (alreadyEnrolled) {
-              this.props.router.push('/settings/account/security/');
-              addErrorMessage(t('Already enrolled'));
-              return true;
-            }
-            return false;
-          },
-        },
-      ],
-    ];
+      if (alreadyEnrolled) {
+        this.props.router.push('/settings/account/security/');
+        addErrorMessage(t('Already enrolled'));
+      }
+
+      // Allow the endpoint to fail if the user is already enrolled
+      return alreadyEnrolled;
+    };
+
+    return [['authenticator', this.enrollEndpoint, {}, {allowError: errorHandler}]];
   }
 
-  componentWillMount() {
-    super.componentWillMount();
-    // If 2FA is required, a pending organization invite
-    // can be accepted once the user enrolls in 2FA
-    let invite = Cookies.get(PENDING_INVITE);
-
-    if (invite) {
-      invite = invite.split('/');
-      this.invite = {
-        memberId: invite[2],
-        token: invite[3],
-      };
-    }
+  componentDidMount() {
+    this.pendingInvitation = getPendingInvite();
   }
 
-  loadOrganizationContext = () => {
-    if (this.invite && this.invite.memberId) {
-      fetchOrganizationByMember(this.invite.memberId, {
-        addOrg: true,
-        fetchOrgDetails: true,
-      });
-    }
-  };
+  get authenticatorName() {
+    const {authenticator} = this.state;
+    return (authenticator && authenticator.name) || 'Authenticator';
+  }
 
   handleFieldChange = (name, value) => {
     // This should not be used for rendering, that's why it's not in state
@@ -186,17 +167,10 @@ class AccountSecurityEnroll extends AsyncView {
   };
 
   // This resets state so that user can re-enter their phone number again
-  handleSmsReset = () => {
-    this.setState(
-      {
-        hasSentCode: false,
-      },
-      this.remountComponent
-    );
-  };
+  handleSmsReset = () => this.setState({hasSentCode: false}, this.remountComponent);
 
-  // Handles
-  handleSmsSubmit = dataModel => {
+  // Handles SMS authenticators
+  handleSmsSubmit = async () => {
     const {authenticator, hasSentCode} = this.state;
 
     // Don't submit if empty
@@ -210,152 +184,123 @@ class AccountSecurityEnroll extends AsyncView {
       // Otherwise API will think that we are on verification step (e.g. after submitting phone)
       otp: hasSentCode ? this._form.otp || '' : undefined,
       secret: authenticator.secret,
-      ...this.invite,
     };
 
     // Only show loading when submitting OTP
-    this.setState({
-      loading: hasSentCode,
-    });
+    this.setState({loading: hasSentCode});
 
     if (!hasSentCode) {
       addMessage(t('Sending code to %s...', data.phone));
     }
 
-    this.api
-      .requestPromise(`${ENDPOINT}${this.props.params.authId}/enroll/`, {
-        data,
-      })
-      .then(
-        () => {
-          if (!hasSentCode) {
-            // Just successfully finished sending OTP to user
-            this.setState({
-              hasSentCode: true,
-              loading: false,
-              // authenticator: data,
-            });
-            addMessage(t('Sent code to %s', data.phone));
-          } else {
-            // OTP was accepted and SMS was added as a 2fa method
-            this.loadOrganizationContext();
-            this.props.router.push('/settings/account/security/');
-            openRecoveryOptions({
-              authenticatorName: authenticator.name,
-            });
-          }
-        },
-        error => {
-          this._form = {};
-          const isSmsInterface = authenticator.id === 'sms';
+    try {
+      await this.api.requestPromise(this.enrollEndpoint, {data});
+    } catch (error) {
+      this._form = {};
+      const isSmsInterface = authenticator.id === 'sms';
 
-          this.setState({
-            hasSentCode: !isSmsInterface,
-          });
+      this.setState({
+        hasSentCode: !isSmsInterface,
+      });
 
-          // Re-mount because we want to fetch a fresh secret
-          this.remountComponent();
+      // Re-mount because we want to fetch a fresh secret
+      this.remountComponent();
 
-          const errorMessage = this.state.hasSentCode
-            ? t('Incorrect OTP')
-            : t('Error sending SMS');
-          addErrorMessage(errorMessage);
-        }
+      addErrorMessage(
+        this.state.hasSentCode ? t('Incorrect OTP') : t('Error sending SMS')
       );
+
+      return;
+    }
+
+    if (!hasSentCode) {
+      // Just successfully finished sending OTP to user
+      this.setState({hasSentCode: true, loading: false});
+      addMessage(t('Sent code to %s', data.phone));
+    } else {
+      // OTP was accepted and SMS was added as a 2fa method
+      this.handleEnrollSuccess();
+    }
   };
 
   // Handle u2f device tap
-  handleU2fTap = data => {
-    return this.api
-      .requestPromise(`${ENDPOINT}${this.props.params.authId}/enroll/`, {
-        data: {
-          ...data,
-          ...this._form,
-          ...this.invite,
-        },
-      })
+  handleU2fTap = data =>
+    this.api
+      .requestPromise(this.enrollEndpoint, {data: {...data, ...this._form}})
       .then(this.handleEnrollSuccess, this.handleEnrollError);
-  };
 
   // Currently only TOTP uses this
-  handleSubmit = dataModel => {
-    const {authenticator} = this.state;
-
+  handleTotpSubmit = dataModel => {
     const data = {
       ...this._form,
       ...(dataModel || {}),
-      secret: authenticator.secret,
-      ...this.invite,
+      secret: this.state.authenticator.secret,
     };
 
-    this.setState({
-      loading: true,
-    });
+    this.setState({loading: true});
+
     this.api
-      .requestPromise(`${ENDPOINT}${this.props.params.authId}/enroll/`, {
-        method: 'POST',
-        data,
-      })
+      .requestPromise(this.enrollEndpoint, {method: 'POST', data})
       .then(this.handleEnrollSuccess, this.handleEnrollError);
   };
 
   // Handler when we successfully add a 2fa device
-  handleEnrollSuccess = () => {
-    this.loadOrganizationContext();
-    const authenticatorName =
-      (this.state.authenticator && this.state.authenticator.name) || 'Authenticator';
-    this.props.router.push('/settings/account/security');
-    openRecoveryOptions({
-      authenticatorName,
-    });
+  handleEnrollSuccess = async () => {
+    let next = '/settings/account/security';
+
+    // If we're pending approval of an invite, the user will have just joined
+    // the organization when completing 2fa enrollment. We should reload the
+    // organization context in that case to assign them to the org.
+    if (this.pendingInvitation) {
+      const org = await fetchOrganizationByMember(this.pendingInvitation.memberId, {
+        addOrg: true,
+        fetchOrgDetails: true,
+      });
+
+      next = `/organizations/${org.slug}/`;
+    }
+
+    this.props.router.push(next);
+    openRecoveryOptions({authenticatorName: this.authenticatorName});
   };
 
   // Handler when we failed to add a 2fa device
   handleEnrollError = () => {
-    const authenticatorName =
-      (this.state.authenticator && this.state.authenticator.name) || 'Authenticator';
     this.setState({loading: false});
-    addErrorMessage(t('Error adding %s authenticator', authenticatorName));
+    addErrorMessage(t('Error adding %s authenticator', this.authenticatorName));
   };
 
   // Removes an authenticator
-  handleRemove = () => {
+  handleRemove = async () => {
     const {authenticator} = this.state;
 
     if (!authenticator || !authenticator.authId) {
       return;
     }
 
-    // `authenticator.authId` is NOT the same as `props.params.authId`
-    // This is for backwards compatbility with API endpoint
-    this.api
-      .requestPromise(`${ENDPOINT}${authenticator.authId}/`, {
-        method: 'DELETE',
-      })
-      .then(
-        () => {
-          this.props.router.push('/settings/account/security/');
-          addSuccessMessage(t('Authenticator has been removed'));
-        },
-        () => {
-          // Error deleting authenticator
-          addErrorMessage(t('Error removing authenticator'));
-        }
-      );
+    // `authenticator.authId` is NOT the same as `props.params.authId` This is
+    // for backwards compatbility with API endpoint
+    try {
+      await this.api.requestPromise(this.authenticatorEndpoint, {method: 'DELETE'});
+    } catch (err) {
+      addErrorMessage(t('Error removing authenticator'));
+      return;
+    }
+
+    this.props.router.push('/settings/account/security/');
+    addSuccessMessage(t('Authenticator has been removed'));
   };
 
   renderBody() {
-    const {authenticator} = this.state;
+    const {authenticator, hasSentCode} = this.state;
 
     if (!authenticator) {
       return null;
     }
 
-    const endpoint = `${ENDPOINT}${this.props.params.authId}/`;
-
     const fields = getFields({
       authenticator,
-      hasSentCode: this.state.hasSentCode,
+      hasSentCode,
       onSmsReset: this.handleSmsReset,
       onSmsSubmit: this.handleSmsSubmit,
       onU2fTap: this.handleU2fTap,
@@ -373,7 +318,7 @@ class AccountSecurityEnroll extends AsyncView {
       : {};
 
     return (
-      <div>
+      <React.Fragment>
         <SettingsPageHeader
           title={
             <React.Fragment>
@@ -397,15 +342,15 @@ class AccountSecurityEnroll extends AsyncView {
           <Form
             apiMethod="POST"
             onFieldChange={this.handleFieldChange}
-            apiEndpoint={endpoint}
-            onSubmit={this.handleSubmit}
+            apiEndpoint={this.authenticatorEndpoint}
+            onSubmit={this.handleTotpSubmit}
             initialData={{...defaultValues, ...authenticator}}
             hideFooter
           >
             <JsonForm forms={[{title: 'Configuration', fields}]} />
           </Form>
         )}
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
@@ -261,21 +261,17 @@ class AccountSecurityEnroll extends AsyncView {
 
   // Handler when we successfully add a 2fa device
   async handleEnrollSuccess() {
-    let next = '/settings/account/security/';
-
     // If we're pending approval of an invite, the user will have just joined
     // the organization when completing 2fa enrollment. We should reload the
     // organization context in that case to assign them to the org.
     if (this.pendingInvitation) {
-      const org = await fetchOrganizationByMember(this.pendingInvitation.memberId, {
+      await fetchOrganizationByMember(this.pendingInvitation.memberId, {
         addOrg: true,
         fetchOrgDetails: true,
       });
-
-      next = `/organizations/${org.slug}/`;
     }
 
-    this.props.router.push(next);
+    this.props.router.push('/settings/account/security/');
     openRecoveryOptions({authenticatorName: this.authenticatorName});
   }
 

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.jsx
@@ -246,7 +246,7 @@ class AccountSecurityEnroll extends AsyncView {
 
   // Handler when we successfully add a 2fa device
   handleEnrollSuccess = async () => {
-    let next = '/settings/account/security';
+    let next = '/settings/account/security/';
 
     // If we're pending approval of an invite, the user will have just joined
     // the organization when completing 2fa enrollment. We should reload the

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityWrapper.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityWrapper.jsx
@@ -17,32 +17,24 @@ class AccountSecurityWrapper extends AsyncComponent {
       return;
     }
 
-    this.setState(
-      {
-        loading: true,
-      },
-      () =>
-        this.api
-          .requestPromise(`${ENDPOINT}${auth.authId}/`, {
-            method: 'DELETE',
-          })
-          .then(this.remountComponent, () => {
-            this.setState({loading: false});
-            addErrorMessage(t('Error disabling', auth.name));
-          })
-    );
+    this.setState({loading: true});
+
+    this.api
+      .requestPromise(`${ENDPOINT}${auth.authId}/`, {method: 'DELETE'})
+      .then(this.remountComponent, () => {
+        this.setState({loading: false});
+        addErrorMessage(t('Error disabling', auth.name));
+      });
   };
 
   handleRegenerateBackupCodes = () => {
-    this.setState({loading: true}, () =>
-      this.api
-        .requestPromise(`${ENDPOINT}${this.props.params.authId}/`, {
-          method: 'PUT',
-        })
-        .then(this.remountComponent, () =>
-          this.addError(t('Error regenerating backup codes'))
-        )
-    );
+    this.setState({loading: true});
+
+    this.api
+      .requestPromise(`${ENDPOINT}${this.props.params.authId}/`, {method: 'PUT'})
+      .then(this.remountComponent, () =>
+        this.addError(t('Error regenerating backup codes'))
+      );
   };
 
   renderBody() {
@@ -54,9 +46,9 @@ class AccountSecurityWrapper extends AsyncComponent {
     const orgsRequire2fa = organizations.filter(org => org.require2FA);
     const deleteDisabled = orgsRequire2fa.length > 0 && countEnrolled === 1;
 
-    // This happens when you switch between children views
-    // And the next child view is lazy loaded, it can potentially be `null`
-    // while the code split package is being fetched
+    // This happens when you switch between children views and the next child
+    // view is lazy loaded, it can potentially be `null` while the code split
+    // package is being fetched
     if (this.props.children === null) {
       return null;
     }

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/removeConfirm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/removeConfirm.jsx
@@ -5,24 +5,17 @@ import ConfirmHeader from 'app/views/settings/account/accountSecurity/components
 import Confirm from 'app/components/confirm';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 
-class RemoveConfirm extends React.Component {
-  render() {
-    return (
-      <Confirm
-        message={
-          <React.Fragment>
-            <ConfirmHeader>{t('Do you want to remove this method?')}</ConfirmHeader>
-            <TextBlock>
-              {t(
-                'Removing the last authentication method will disable two-factor authentication completely.'
-              )}
-            </TextBlock>
-          </React.Fragment>
-        }
-        {...this.props}
-      />
-    );
-  }
-}
+const message = (
+  <React.Fragment>
+    <ConfirmHeader>{t('Do you want to remove this method?')}</ConfirmHeader>
+    <TextBlock>
+      {t(
+        'Removing the last authentication method will disable two-factor authentication completely.'
+      )}
+    </TextBlock>
+  </React.Fragment>
+);
+
+const RemoveConfirm = props => <Confirm {...props} message={message} />;
 
 export default RemoveConfirm;

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/twoFactorRequired.jsx
@@ -3,38 +3,22 @@ import styled from 'react-emotion';
 
 import {tct} from 'app/locale';
 import Alert from 'app/components/alert';
-import AsyncComponent from 'app/components/asyncComponent';
-import Cookies from 'js-cookie';
 import ExternalLink from 'app/components/links/externalLink';
 import space from 'app/styles/space';
+import getPendingInvite from 'app/utils/getPendingInvite';
 
-const PENDING_INVITE = 'pending-invite';
-
-class TwoFactorRequired extends AsyncComponent {
-  getEndpoints() {
-    return [];
-  }
-
-  renderBody() {
-    const pendingInvite = Cookies.get(PENDING_INVITE);
-
-    if (!pendingInvite) {
-      return null;
-    }
-
-    return (
-      <StyledAlert data-test-id="require-2fa" type="error" icon="icon-circle-exclamation">
-        {tct(
-          'You have been invited to an organization that requires [link:two-factor authentication].' +
-            ' Setup two-factor authentication below to join your organization.',
-          {
-            link: <ExternalLink href="https://docs.sentry.io/accounts/require-2fa/" />,
-          }
-        )}
-      </StyledAlert>
-    );
-  }
-}
+const TwoFactorRequired = () =>
+  !getPendingInvite() ? null : (
+    <StyledAlert data-test-id="require-2fa" type="error" icon="icon-circle-exclamation">
+      {tct(
+        'You have been invited to an organization that requires [link:two-factor authentication].' +
+          ' Setup two-factor authentication below to join your organization.',
+        {
+          link: <ExternalLink href="https://docs.sentry.io/accounts/require-2fa/" />,
+        }
+      )}
+    </StyledAlert>
+  );
 
 const StyledAlert = styled(Alert)`
   margin: ${space(3)} 0;

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/index.jsx
@@ -1,6 +1,3 @@
-/**
- * Lists 2fa devices + password change form
- */
 import {Box, Flex} from 'grid-emotion';
 import React from 'react';
 import styled from 'react-emotion';
@@ -23,6 +20,9 @@ import RemoveConfirm from 'app/views/settings/account/accountSecurity/components
 import PasswordForm from 'app/views/settings/account/passwordForm';
 import recreateRoute from 'app/utils/recreateRoute';
 
+/**
+ * Lists 2fa devices + password change form
+ */
 class AccountSecurity extends AsyncView {
   static PropTypes = {
     authenticators: PropTypes.arrayOf(PropTypes.object).isRequired,
@@ -162,9 +162,11 @@ class AccountSecurity extends AsyncView {
                             onConfirm={() => onDisable(auth)}
                             disabled={deleteDisabled}
                           >
-                            <Button css={{marginLeft: 6}} size="small">
-                              <span className="icon icon-trash" />
-                            </Button>
+                            <Button
+                              css={{marginLeft: 6}}
+                              size="small"
+                              icon="icon-trash"
+                            />
                           </RemoveConfirm>
                         </Tooltip>
                       )}

--- a/tests/js/spec/views/accountSecurity.spec.jsx
+++ b/tests/js/spec/views/accountSecurity.spec.jsx
@@ -59,7 +59,7 @@ describe('AccountSecurity', function() {
     ).toBe('Info');
 
     // Remove button
-    expect(wrapper.find('Button .icon-trash')).toHaveLength(1);
+    expect(wrapper.find('Button[icon="icon-trash"]')).toHaveLength(1);
     expect(wrapper.find('CircleIndicator').prop('enabled')).toBe(true);
 
     expect(wrapper.find('TwoFactorRequired')).toHaveLength(0);
@@ -92,7 +92,7 @@ describe('AccountSecurity', function() {
     expect(wrapper.find('CircleIndicator').prop('enabled')).toBe(true);
 
     // This will open confirm modal
-    wrapper.find('Button .icon-trash').simulate('click');
+    wrapper.find('Button[icon="icon-trash"]').simulate('click');
     // Confirm
     wrapper
       .find('Modal Button')
@@ -160,7 +160,7 @@ describe('AccountSecurity', function() {
 
     // This will open confirm modal
     wrapper
-      .find('Button .icon-trash')
+      .find('Button[icon="icon-trash"]')
       .first()
       .simulate('click');
 
@@ -206,7 +206,7 @@ describe('AccountSecurity', function() {
     expect(wrapper.find('Tooltip').prop('title')).toContain('test 1 and test 2');
 
     // This will open confirm modal
-    wrapper.find('Button .icon-trash').simulate('click');
+    wrapper.find('Button[icon="icon-trash"]').simulate('click');
     // Confirm
     expect(wrapper.find('Modal Button')).toHaveLength(0);
     expect(deleteMock).not.toHaveBeenCalled();

--- a/tests/js/spec/views/twoFactorRequired.spec.jsx
+++ b/tests/js/spec/views/twoFactorRequired.spec.jsx
@@ -7,7 +7,7 @@ import AccountSecurityWrapper from 'app/views/settings/account/accountSecurity/a
 
 const ENDPOINT = '/users/me/authenticators/';
 const ORG_ENDPOINT = '/organizations/';
-const PENDING_INVITE = 'pending-invite';
+const INVITE_COOKIE = 'pending-invite';
 
 describe('TwoFactorRequired', function() {
   beforeEach(function() {
@@ -67,7 +67,12 @@ describe('TwoFactorRequired', function() {
   });
 
   it('does not render when 2FA is enrolled and has pendingInvite cookie', function() {
-    Cookies.set(PENDING_INVITE, '/accept/5/abcde/');
+    const cookieData = {
+      memberId: 5,
+      token: 'abcde',
+      url: '/accept/5/abcde/',
+    };
+    Cookies.set(INVITE_COOKIE, cookieData);
     MockApiClient.addMockResponse({
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Totp({isEnrolled: true})],
@@ -85,11 +90,11 @@ describe('TwoFactorRequired', function() {
     );
     expect(wrapper.find('TwoFactorRequired')).toHaveLength(0);
     expect(wrapper.find('StyledAlert[data-test-id="require-2fa"]')).toHaveLength(0);
-    Cookies.remove(PENDING_INVITE);
+    Cookies.remove(INVITE_COOKIE);
   });
 
   it('renders when 2FA is disabled and has pendingInvite cookie', function() {
-    Cookies.set(PENDING_INVITE, '/accept/5/abcde/');
+    Cookies.set(INVITE_COOKIE, '/accept/5/abcde/');
     MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
       body: TestStubs.Organizations({require2FA: true}),
@@ -103,6 +108,6 @@ describe('TwoFactorRequired', function() {
     );
     expect(wrapper.find('TwoFactorRequired')).toHaveLength(1);
     expect(wrapper.find('StyledAlert[data-test-id="require-2fa"]')).toHaveLength(1);
-    Cookies.remove(PENDING_INVITE);
+    Cookies.remove(INVITE_COOKIE);
   });
 });


### PR DESCRIPTION
This includes a few changes in preparation to make the accept invite flow consistent between SSO and 2fa setup:

 * the memberId and token are no longer passed as hidden form properties back to enroll endpoint to handle invite acceptance. Instead we'll read directly from the pending-invite cookie to retrieve these values. Security is not a concern here as the same token MUST be present in the cookie.

 * The enroll endpoint is simplified:

   1. There is no need for the `else` in the try except block containing the enroll code (since we will return if we reach the except block)

   2. Invite acceptance is simplified.

 * The pending invite cookie creation / removal methods have been moved to module level helper methods on the invite_helper module.

 * A user may now be specified in accept_invite.

 * The fetchOrganizationDetails and fetchOrganizationByMember action creators have been converted to async methods, making it possible to access the response data from both.

 * a getPendingInvite helper utility has been added.

 * The accountSecurityEnroll view has had various cleanups applied:

   - authenticatorEndpoint and enrollEndpoint have been made getter methods on the component.

   - This component no longer parse the cookie for token and member ID, and instead retrieves the pending invite data using the getPendingInvite helper.

   - Various cases where the setState callback was used to make api requests after the `loading` state was set have been refactored to just asynchronously continue to the API request, there is no need to ensure the loading state is set before making and API request.

   - Promises converted to using async await

 * After invite acceptance the accountSecurityEnroll view will now redirect to the organizations default page.