### PR TITLE
ref(app-platform): Refactor consolidateScopes file into functions & update usages

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.jsx
@@ -15,7 +15,7 @@ import HookStore from 'app/stores/hookStore';
 import marked, {singleLineRenderer} from 'app/utils/marked';
 import InlineSvg from 'app/components/inlineSvg';
 import Tag from 'app/views/settings/components/tag';
-import ConsolidatedScopes from 'app/utils/consolidatedScopes';
+import {toPermissions} from 'app/utils/consolidatedScopes';
 import CircleIndicator from 'app/components/circleIndicator';
 
 const defaultFeatureGateComponents = {
@@ -62,7 +62,7 @@ export default class SentryAppDetailsModal extends AsyncComponent {
   }
 
   get permissions() {
-    return new ConsolidatedScopes(this.props.sentryApp.scopes).toPermissions();
+    return toPermissions(this.props.sentryApp.scopes);
   }
 
   onInstall() {

--- a/src/sentry/static/sentry/app/utils/consolidatedScopes.jsx
+++ b/src/sentry/static/sentry/app/utils/consolidatedScopes.jsx
@@ -1,4 +1,4 @@
-import {pull, groupBy} from 'lodash';
+import {invertBy, groupBy, pick} from 'lodash';
 
 const PERMISSION_LEVELS = {
   read: 0,
@@ -15,123 +15,105 @@ const HUMAN_RESOURCE_NAMES = {
   member: 'Member',
 };
 
+const DEFAULT_RESOURCE_PERMISSIONS = {
+  Project: 'no-access',
+  Team: 'no-access',
+  Release: 'no-access',
+  Event: 'no-access',
+  Organization: 'no-access',
+  Member: 'no-access',
+};
+
 const PROJECT_RELEASES = 'project:releases';
 
-export default class ConsolidatedScopes {
-  constructor(scopes) {
-    this.scopes = scopes;
-  }
+/**
+ * Numerical value of the scope where Admin is higher than Write,
+ * which is higher than Read. Used to sort scopes by access.
+ */
+const permissionLevel = scope => {
+  const permission = scope.split(':')[1];
+  return PERMISSION_LEVELS[permission];
+};
 
-  /**
-   * Convert into a list of Permissions, grouped by resource.
-   *
-   * This is used in the new/edit Sentry App form. That page displays permissions
-   * in a per-Resource manner, meaning one row for Project, one for Organization, etc.
-   *
-   * This exposes scopes in a way that works for that UI.
-   *
-   * Example:
-   *    {
-   *      'Project': 'read',
-   *      'Organization': 'write',
-   *      'Team': 'no-access',
-   *      ...
-   *    }
-   */
-  toResourcePermissions() {
-    const scopes = [...this.scopes];
-    const permissions = this.defaultResourcePermissions;
+const compareScopes = (a, b) => {
+  return permissionLevel(a) - permissionLevel(b);
+};
 
-    // The scope for releases is `project:releases`, but instead of displaying
-    // it as a permission of Project, we want to separate it out into its own
-    // row for Releases.
-    if (scopes.includes(PROJECT_RELEASES)) {
-      permissions.Release = 'admin';
-      pull(scopes, PROJECT_RELEASES); // remove project:releases
-    }
-
-    this.topScopes(scopes).forEach(scope => {
-      const [resource, permission] = scope.split(':');
-      permissions[HUMAN_RESOURCE_NAMES[resource]] = permission;
-    });
-
-    return permissions;
-  }
-
-  /**
-   * Convert into a list of Permissions, grouped by access and including a
-   * list of resources per access level.
-   *
-   * This is used in the Permissions Modal when installing an App. It displays
-   * scopes in a per-Permission way, meaning one row for Read, one for Write,
-   * and one for Admin.
-   *
-   * This exposes scopes in a way that works for that UI.
-   *
-   * Example:
-   *    {
-   *      read:  ['Project', 'Organization'],
-   *      write: ['Member'],
-   *      admin: ['Release']
-   *    }
-   */
-  toPermissions() {
-    const scopes = [...this.scopes];
-    const permissions = {read: [], write: [], admin: []};
-
-    // The scope for releases is `project:releases`, but instead of displaying
-    // it as a permission of Project, we want to separate it out into its own
-    // row for Releases.
-    if (scopes.includes(PROJECT_RELEASES)) {
-      permissions.admin.push('Release');
-      pull(scopes, PROJECT_RELEASES); // remove project:releases
-    }
-
-    this.topScopes(scopes).forEach(scope => {
-      const [resource, permission] = scope.split(':');
-      permissions[permission].push(HUMAN_RESOURCE_NAMES[resource]);
-    });
-
-    return permissions;
-  }
-
-  /**
-   * Return the most permissive scope for each resource.
-   *
-   * Example:
-   *    Given the full list of scopes:
-   *      ['project:read', 'project:write', 'team:read', 'team:write', 'team:admin']
-   *
-   *    this would return:
-   *      ['project:write', 'team:admin']
-   */
-  topScopes(scopeList) {
-    return Object.values(groupBy(scopeList, scope => scope.split(':')[0]))
-      .map(scopes => scopes.sort(this.compareScopes))
-      .map(scopes => scopes.pop());
-  }
-
-  compareScopes = (a, b) => {
-    return this.permissionLevel(a) - this.permissionLevel(b);
-  };
-
-  /**
-   * Numerical value of the scope where Admin is higher than Write,
-   * which is higher than Read. Used to sort scopes by access.
-   */
-  permissionLevel = scope => {
-    const permission = scope.split(':')[1];
-    return PERMISSION_LEVELS[permission];
-  };
-
-  get defaultResourcePermissions() {
-    return {
-      Project: 'no-access',
-      Team: 'no-access',
-      Release: 'no-access',
-      Event: 'no-access',
-      Organization: 'no-access',
-      Member: 'no-access',
-    };
-  }
+/**
+ * Return the most permissive scope for each resource.
+ *
+ * Example:
+ *    Given the full list of scopes:
+ *      ['project:read', 'project:write', 'team:read', 'team:write', 'team:admin']
+ *
+ *    this would return:
+ *      ['project:write', 'team:admin']
+ */
+function topScopes(scopeList) {
+  return Object.values(groupBy(scopeList, scope => scope.split(':')[0]))
+    .map(scopes => scopes.sort(compareScopes))
+    .map(scopes => scopes.pop());
 }
+
+/**
+ * Convert into a list of Permissions, grouped by resource.
+ *
+ * This is used in the new/edit Sentry App form. That page displays permissions
+ * in a per-Resource manner, meaning one row for Project, one for Organization, etc.
+ *
+ * This exposes scopes in a way that works for that UI.
+ *
+ * Example:
+ *    {
+ *      'Project': 'read',
+ *      'Organization': 'write',
+ *      'Team': 'no-access',
+ *      ...
+ *    }
+ */
+function toResourcePermissions(scopes) {
+  const permissions = {...DEFAULT_RESOURCE_PERMISSIONS};
+  let filteredScopes = [...scopes];
+  // The scope for releases is `project:releases`, but instead of displaying
+  // it as a permission of Project, we want to separate it out into its own
+  // row for Releases.
+  if (scopes.includes(PROJECT_RELEASES)) {
+    permissions.Release = 'admin';
+    filteredScopes = scopes.filter(scope => scope !== PROJECT_RELEASES); // remove project:releases
+  }
+
+  topScopes(filteredScopes).forEach(scope => {
+    const [resource, permission] = scope.split(':');
+    permissions[HUMAN_RESOURCE_NAMES[resource]] = permission;
+  });
+
+  return permissions;
+}
+
+/**
+ * Convert into a list of Permissions, grouped by access and including a
+ * list of resources per access level.
+ *
+ * This is used in the Permissions Modal when installing an App. It displays
+ * scopes in a per-Permission way, meaning one row for Read, one for Write,
+ * and one for Admin.
+ *
+ * This exposes scopes in a way that works for that UI.
+ *
+ * Example:
+ *    {
+ *      read:  ['Project', 'Organization'],
+ *      write: ['Member'],
+ *      admin: ['Release']
+ *    }
+ */
+function toPermissions(scopes) {
+  const defaultPermissions = {read: [], write: [], admin: []};
+  const resourcePermissions = toResourcePermissions(scopes);
+
+  // Filter out the 'no-access' permissions
+  const permissions = pick(invertBy(resourcePermissions), ['read', 'write', 'admin']);
+  return {...defaultPermissions, ...permissions};
+}
+
+export {toPermissions, toResourcePermissions};

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import ConsolidatedScopes from 'app/utils/consolidatedScopes';
+import {toResourcePermissions} from 'app/utils/consolidatedScopes';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
 import PermissionSelection from 'app/views/settings/organizationDeveloperSettings/permissionSelection';
@@ -57,7 +57,7 @@ export default class PermissionsObserver extends React.Component<Props, State> {
    *
    */
   scopeListToPermissionState() {
-    return new ConsolidatedScopes(this.props.scopes).toResourcePermissions();
+    return toResourcePermissions(this.props.scopes);
   }
 
   onPermissionChange = permissions => {

--- a/tests/js/spec/utils/consolidatedScopes.spec.jsx
+++ b/tests/js/spec/utils/consolidatedScopes.spec.jsx
@@ -1,19 +1,14 @@
-import ConsolidatedScopes from 'app/utils/consolidatedScopes';
+import {toPermissions, toResourcePermissions} from 'app/utils/consolidatedScopes';
 
 describe('ConsolidatedScopes', () => {
   let scopes;
 
   beforeEach(() => {
-    scopes = new ConsolidatedScopes([
-      'event:read',
-      'event:admin',
-      'project:releases',
-      'org:read',
-    ]);
+    scopes = ['event:read', 'event:admin', 'project:releases', 'org:read'];
   });
 
   it('exposes scopes, grouped for each resource', () => {
-    expect(scopes.toResourcePermissions()).toEqual(
+    expect(toResourcePermissions(scopes)).toEqual(
       expect.objectContaining({
         Event: 'admin',
         Release: 'admin',
@@ -23,7 +18,7 @@ describe('ConsolidatedScopes', () => {
   });
 
   it('exposes scopes, grouped by access level', () => {
-    expect(scopes.toPermissions()).toEqual({
+    expect(toPermissions(scopes)).toEqual({
       admin: expect.arrayContaining(['Event', 'Release']),
       read: ['Organization'],
       write: [],


### PR DESCRIPTION
Refactor the `ConsolidatedScopes` class into separate util functions to reduce complexity.
Export `toPermissions` and `toResourcePermissions` functions instead of the class

Fixes API-249