### PR TITLE
fix(gitlab) Don't 500 requests that are missing a token

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -163,6 +163,7 @@ class GitlabWebhookEndpoint(View):
         return super(GitlabWebhookEndpoint, self).dispatch(request, *args, **kwargs)
 
     def post(self, request):
+        token = "<unknown>"
         try:
             # Munge the token to extract the integration external_id.
             # gitlab hook payloads don't give us enough unique context


### PR DESCRIPTION
Initialize `token` so that when it isn't present our logging doesn't fail.

Fixes SENTRY-CEY