### PR TITLE
feat(app-platform): remove author input for internal integrations

### DIFF
--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -66,7 +66,7 @@ class URLField(serializers.URLField):
 
 class SentryAppSerializer(Serializer):
     name = serializers.CharField()
-    author = serializers.CharField()
+    author = serializers.CharField(required=False, allow_null=True)
     scopes = ApiScopesField(allow_null=True)
     status = serializers.CharField(required=False, allow_null=True)
     events = EventListField(required=False, allow_null=True)
@@ -135,5 +135,9 @@ class SentryAppSerializer(Serializer):
                     )
             else:
                 raise ValidationError({"webhookUrl": "webhookUrl required for public integrations"})
+
+        # validate author for public integrations
+        if not get_current_value("isInternal") and not get_current_value("author"):
+            raise ValidationError({"author": "author required for public integrations"})
 
         return attrs

--- a/src/sentry/mediators/sentry_apps/internal_creator.py
+++ b/src/sentry/mediators/sentry_apps/internal_creator.py
@@ -16,7 +16,6 @@ from sentry.mediators.sentry_app_installation_tokens import (
 
 class InternalCreator(Mediator):
     name = Param(six.string_types)
-    author = Param(six.string_types)
     organization = Param("sentry.models.Organization")
     scopes = Param(Iterable, default=lambda self: [])
     events = Param(Iterable, default=lambda self: [])
@@ -29,6 +28,8 @@ class InternalCreator(Mediator):
     user = Param("sentry.models.User")
 
     def call(self):
+        # SentryAppCreator expects an author so just set it to the org name
+        self.kwargs["author"] = self.organization.name
         self.sentry_app = SentryAppCreator.run(**self.kwargs)
         self.sentry_app.status = SentryAppStatus.INTERNAL
         self.sentry_app.verify_install = False

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.jsx
@@ -108,7 +108,7 @@ const getInternalFormFields = () => {
    ***/
 
   const internalFormFields = getPublicFormFields().filter(
-    formField => !['redirectUrl', 'verifyInstall'].includes(formField.name)
+    formField => !['redirectUrl', 'verifyInstall', 'author'].includes(formField.name)
   );
   const webhookField = internalFormFields.find(field => field.name === 'webhookUrl');
   webhookField.required = false;

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -45,8 +45,6 @@ class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
         self.browser.click('[aria-label="New Internal Integration"]')
 
         self.browser.element('input[name="name"]').send_keys("Tesla")
-        self.browser.element('input[name="author"]').send_keys("Elon Musk")
-        self.browser.element('input[name="webhookUrl"]').send_keys("https://example.com/webhook")
 
         self.browser.click('[aria-label="Save Changes"]')
 

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -422,6 +422,20 @@ class PostSentryAppsTest(SentryAppsTest):
         # Below line will fail once we stop assigning api_token on the sentry_app_installation
         assert sentry_app_installation_token.api_token == sentry_app_installation.api_token
 
+    def test_no_author_public_integration(self):
+        self.login_as(user=self.user)
+        response = self._post(author=None)
+
+        assert response.status_code == 400
+        assert response.data == {"author": ["author required for public integrations"]}
+
+    def test_no_author_internal_integration(self):
+        self.create_project(organization=self.org)
+        self.login_as(user=self.user)
+        response = self._post(isInternal=True, author=None)
+
+        assert response.status_code == 201
+
     def _post(self, **kwargs):
         body = {
             "name": "MyApp",


### PR DESCRIPTION
We really don't need to get the author of an internal integration so this PR removes it.