### PR TITLE
fix(ui) Use better pattern when looking for aggregates

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -21,6 +21,8 @@ export type EventQuery = {
   per_page?: number;
 };
 
+const AGGREGATE_PATTERN = /^([^\(]+)\(([a-z\._+]*)\)$/;
+
 /**
  * Takes a view and determines if there are any aggregate fields in it.
  *
@@ -32,8 +34,7 @@ export function hasAggregateField(eventView: EventView): boolean {
   return eventView
     .getFieldNames()
     .some(
-      field =>
-        AGGREGATE_ALIASES.includes(field as any) || field.match(/[a-z_]+\([a-z_\.]+\)/)
+      field => AGGREGATE_ALIASES.includes(field as any) || field.match(AGGREGATE_PATTERN)
     );
 }
 
@@ -165,8 +166,6 @@ export function getFieldRenderer(
   }
   return partial(FIELD_FORMATTERS.string.renderFunc, fieldName);
 }
-
-const AGGREGATE_PATTERN = /^([^\(]+)\(([a-z\._+]*)\)$/;
 
 /**
  * Get the alias that the API results will have for a given aggregate function name


### PR DESCRIPTION
The `count()` aggregate doesn't require any fields. Use the same pattern we use elsewhere to ensure aggregates are detected the same.