### PR TITLE
feat(discover2) Show saved queries in a sidebar hover menu

### DIFF
--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -13,11 +13,18 @@ from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
 class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
     permission_classes = (DiscoverSavedQueryPermission,)
 
+    def has_feature(self, organization, request):
+        return features.has(
+            "organizations:discover", organization, actor=request.user
+        ) or features.has(
+            "organizations:discover-v2-query-builder", organization, actor=request.user
+        )
+
     def get(self, request, organization):
         """
         List saved queries for organization
         """
-        if not features.has("organizations:discover", organization, actor=request.user):
+        if not self.has_feature(organization, request):
             return self.respond(status=404)
 
         saved_queries = list(
@@ -33,7 +40,7 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         """
         Create a saved query
         """
-        if not features.has("organizations:discover", organization, actor=request.user):
+        if not self.has_feature(organization, request):
             return self.respond(status=404)
 
         serializer = DiscoverSavedQuerySerializer(

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -13,11 +13,18 @@ from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
 class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
     permission_classes = (DiscoverSavedQueryPermission,)
 
+    def has_feature(self, organization, request):
+        return features.has(
+            "organizations:discover", organization, actor=request.user
+        ) or features.has(
+            "organizations:discover-v2-query-builder", organization, actor=request.user
+        )
+
     def get(self, request, organization, query_id):
         """
         Get a saved query
         """
-        if not features.has("organizations:discover", organization, actor=request.user):
+        if not self.has_feature(organization, request):
             return self.respond(status=404)
 
         try:
@@ -31,7 +38,7 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
         """
         Modify a saved query
         """
-        if not features.has("organizations:discover", organization, actor=request.user):
+        if not self.has_feature(organization, request):
             return self.respond(status=404)
 
         try:
@@ -58,7 +65,7 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
         """
         Delete a saved query
         """
-        if not features.has("organizations:discover", organization, actor=request.user):
+        if not self.has_feature(organization, request):
             return self.respond(status=404)
 
         try:

--- a/src/sentry/static/sentry/app/actionCreators/discoverSavedQueries.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/discoverSavedQueries.tsx
@@ -15,9 +15,13 @@ export function fetchSavedQueries(api: Client, orgId: string): Promise<SavedQuer
     .then(resp => {
       DiscoverSavedQueryActions.fetchSavedQueriesSuccess(resp);
     })
-    .catch(() => {
-      DiscoverSavedQueryActions.fetchSavedQueriesError();
-      addErrorMessage(t('Unable to load saved queries'));
+    .catch(err => {
+      if (err.status === 404) {
+        DiscoverSavedQueryActions.fetchSavedQueriesSuccess([]);
+      } else {
+        DiscoverSavedQueryActions.fetchSavedQueriesError();
+        addErrorMessage(t('Unable to load saved queries'));
+      }
     });
   return promise;
 }

--- a/src/sentry/static/sentry/app/actionCreators/discoverSavedQueries.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/discoverSavedQueries.tsx
@@ -15,13 +15,9 @@ export function fetchSavedQueries(api: Client, orgId: string): Promise<SavedQuer
     .then(resp => {
       DiscoverSavedQueryActions.fetchSavedQueriesSuccess(resp);
     })
-    .catch(err => {
-      if (err.status === 404) {
-        DiscoverSavedQueryActions.fetchSavedQueriesSuccess([]);
-      } else {
-        DiscoverSavedQueryActions.fetchSavedQueriesError();
-        addErrorMessage(t('Unable to load saved queries'));
-      }
+    .catch(() => {
+      DiscoverSavedQueryActions.fetchSavedQueriesError();
+      addErrorMessage(t('Unable to load saved queries'));
     });
   return promise;
 }

--- a/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import styled from 'react-emotion';
+
+import {Client} from 'app/api';
+import Feature from 'app/components/acl/feature';
+import {fetchSavedQueries} from 'app/actionCreators/discoverSavedQueries';
+import Link from 'app/components/links/link';
+import {Organization} from 'app/types';
+import {SavedQuery} from 'app/views/discover/types';
+import EventView from 'app/views/eventsV2/eventView';
+
+import space from 'app/styles/space';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
+import withApi from 'app/utils/withApi';
+import withDiscoverSavedQueries from 'app/utils/withDiscoverSavedQueries';
+
+import SidebarItem from './sidebarItem';
+
+type Props = {
+  id: string;
+  to: string;
+  icon: React.ReactNode;
+  label: string;
+  orientation: 'top' | 'left';
+  collapsed: boolean;
+  hasPanel: boolean;
+  onClick: (event: React.MouseEvent<HTMLElement>) => void;
+
+  api: Client;
+  organization: Organization;
+  savedQueries: SavedQuery[];
+};
+
+type State = {
+  isOpen: boolean;
+};
+
+class Discover2Item extends React.Component<Props, State> {
+  state = {
+    isOpen: false,
+  };
+
+  componentDidMount() {
+    const {api, organization} = this.props;
+    fetchSavedQueries(api, organization.slug);
+  }
+
+  handleEnter = () => {
+    this.setState({isOpen: true});
+  };
+
+  handleLeave = () => {
+    this.setState({isOpen: false});
+  };
+
+  renderSavedQueries() {
+    const {savedQueries, organization} = this.props;
+    if (!savedQueries || savedQueries.length === 0) {
+      return <span>No saved queries</span>;
+    }
+    return savedQueries.map(item => {
+      const target = {
+        pathname: `/organizations/${organization.slug}/eventsv2/`,
+        query: EventView.fromSavedQuery(item).generateQueryStringObject(),
+      };
+      return (
+        <MenuItem to={target} key={item.id}>
+          {item.name}
+        </MenuItem>
+      );
+    });
+  }
+
+  render() {
+    const {organization, savedQueries: _, ...sidebarItemProps} = this.props;
+    const {isOpen} = this.state;
+
+    const sidebarItem = <SidebarItem {...sidebarItemProps} />;
+    return (
+      <Feature
+        features={['discover-v2-query-builder']}
+        organization={organization}
+        renderDisabled={() => sidebarItem}
+      >
+        <div onMouseLeave={this.handleLeave} onMouseEnter={this.handleEnter}>
+          {sidebarItem}
+          <Hitbox isOpen={isOpen}>
+            <Menu>{this.renderSavedQueries()}</Menu>
+          </Hitbox>
+        </div>
+      </Feature>
+    );
+  }
+}
+
+export default withApi(withDiscoverSavedQueries(Discover2Item));
+
+type HitboxCustomProps = {
+  isOpen: boolean;
+};
+type HitboxProps = Omit<React.HTMLProps<HTMLDivElement>, keyof HitboxCustomProps> &
+  HitboxCustomProps;
+
+const Hitbox = styled('div')<HitboxProps>`
+  display: ${p => (p.isOpen ? 'block' : 'none')};
+  position: absolute;
+  right: -330px;
+  width: 350px;
+  height: 200px;
+  padding-left: 20px;
+  transform: translateY(-30px);
+`;
+
+const Menu = styled('div')`
+  height: 100%;
+  background: ${p => p.theme.gray4};
+  border-radius: 0 ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0;
+  border: 1px solid ${p => p.theme.sidebar.background};
+`;
+
+const MenuItem = styled(Link)`
+  display: block;
+  padding: ${space(1)} ${space(2)};
+  color: ${p => p.theme.sidebar.color};
+  border-bottom: 1px solid ${p => p.theme.gray3};
+  &:focus,
+  &:hover {
+    color: ${p => p.theme.gray1};
+  }
+  ${overflowEllipsis};
+`;

--- a/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
@@ -5,6 +5,7 @@ import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
 import {fetchSavedQueries} from 'app/actionCreators/discoverSavedQueries';
 import Link from 'app/components/links/link';
+import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {SavedQuery} from 'app/views/discover/types';
 import EventView from 'app/views/eventsV2/eventView';
@@ -16,16 +17,7 @@ import withDiscoverSavedQueries from 'app/utils/withDiscoverSavedQueries';
 
 import SidebarItem from './sidebarItem';
 
-type Props = {
-  id: string;
-  to: string;
-  icon: React.ReactNode;
-  label: string;
-  orientation: 'top' | 'left';
-  collapsed: boolean;
-  hasPanel: boolean;
-  onClick: (event: React.MouseEvent<HTMLElement>) => void;
-
+type Props = React.ComponentProps<SidebarItem> & {
   api: Client;
   organization: Organization;
   savedQueries: SavedQuery[];
@@ -64,7 +56,7 @@ class Discover2Item extends React.Component<Props, State> {
         query: EventView.fromSavedQuery(item).generateQueryStringObject(),
       };
       return (
-        <MenuItem to={target} key={item.id}>
+        <MenuItem aria-role="menuitem" to={target} key={item.id}>
           {item.name}
         </MenuItem>
       );
@@ -74,6 +66,15 @@ class Discover2Item extends React.Component<Props, State> {
   render() {
     const {organization, savedQueries: _, ...sidebarItemProps} = this.props;
     const {isOpen} = this.state;
+    const navProps = {
+      'aria-label': t('Discover Saved Queries'),
+      'aria-haspopup': true,
+      onMouseLeave: this.handleLeave,
+      onMouseEnter: this.handleEnter,
+    };
+    if (isOpen) {
+      navProps['aria-expanded'] = 'true';
+    }
 
     const sidebarItem = <SidebarItem {...sidebarItemProps} />;
     return (
@@ -82,12 +83,12 @@ class Discover2Item extends React.Component<Props, State> {
         organization={organization}
         renderDisabled={() => sidebarItem}
       >
-        <div onMouseLeave={this.handleLeave} onMouseEnter={this.handleEnter}>
+        <nav {...navProps}>
           {sidebarItem}
           <Hitbox isOpen={isOpen}>
-            <Menu>{this.renderSavedQueries()}</Menu>
+            <Menu aria-role="menu">{this.renderSavedQueries()}</Menu>
           </Hitbox>
-        </div>
+        </nav>
       </Feature>
     );
   }
@@ -107,7 +108,7 @@ const Hitbox = styled('div')<HitboxProps>`
   right: -330px;
   width: 350px;
   height: 200px;
-  padding-left: 20px;
+  padding-left: ${space(3)};
   transform: translateY(-30px);
 `;
 

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -27,6 +27,7 @@ import OnboardingStatus from './onboardingStatus';
 import SidebarDropdown from './sidebarDropdown';
 import SidebarHelp from './help';
 import SidebarItem from './sidebarItem';
+import Discover2Item from './discover2Item';
 
 class Sidebar extends React.Component {
   static propTypes = {
@@ -282,8 +283,9 @@ class Sidebar extends React.Component {
                   </Feature>
 
                   <Feature features={['events-v2']} organization={organization}>
-                    <SidebarItem
+                    <Discover2Item
                       {...sidebarItemProps}
+                      organization={organization}
                       onClick={(_id, evt) =>
                         this.navigateWithGlobalSelection(
                           `/organizations/${organization.slug}/eventsv2/`,

--- a/src/sentry/static/sentry/app/views/discover/types.tsx
+++ b/src/sentry/static/sentry/app/views/discover/types.tsx
@@ -7,6 +7,7 @@ export type Query = {
   fields: string[];
   aggregations: Aggregation[];
   conditions?: Condition[];
+  query?: string;
   orderby?: string;
   limit?: number;
   range?: string;

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -1,5 +1,5 @@
 import {Location, Query} from 'history';
-import {isString, pick} from 'lodash';
+import {isString, cloneDeep, pick} from 'lodash';
 
 import {EventViewv1} from 'app/types';
 import {SavedQuery} from 'app/views/discover/types';
@@ -171,8 +171,8 @@ const queryStringFromSavedQuery = (saved: SavedQuery): string => {
   }
   if (saved.conditions) {
     const conditions = saved.conditions.map(item => {
-      const [field, , value] = item;
-      let operator = item[1];
+      const [field, op, value] = item;
+      let operator = op;
       // TODO handle all the other operator types
       if (operator === '=') {
         operator = '';
@@ -284,7 +284,8 @@ class EventView {
         output[field] = this[field];
       }
     }
-    return output;
+
+    return cloneDeep(output);
   }
 
   isValid(): boolean {

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -2,6 +2,7 @@ import {Location, Query} from 'history';
 import {isString, pick} from 'lodash';
 
 import {EventViewv1} from 'app/types';
+import {SavedQuery} from 'app/views/discover/types';
 import {DEFAULT_PER_PAGE} from 'app/constants';
 
 import {AUTOLINK_FIELDS, SPECIAL_FIELDS, FIELD_FORMATTERS} from './data';
@@ -140,30 +141,93 @@ const decodeQuery = (location: Location): string | undefined => {
   return isString(query) ? query.trim() : undefined;
 };
 
+const decodeProjects = (location: Location): number[] => {
+  if (!location.query || !location.query.project) {
+    return [];
+  }
+
+  const value = location.query.project;
+  return Array.isArray(value) ? value.map(i => parseInt(i, 10)) : [parseInt(value, 10)];
+};
+
+const decodeScalar = (
+  value: string[] | string | undefined | null
+): string | undefined => {
+  if (!value) {
+    return void 0;
+  }
+  const unwrapped =
+    Array.isArray(value) && value.length > 0
+      ? value[0]
+      : isString(value)
+      ? value
+      : void 0;
+  return isString(unwrapped) ? unwrapped : void 0;
+};
+
+const queryStringFromSavedQuery = (saved: SavedQuery): string => {
+  if (saved.query) {
+    return saved.query;
+  }
+  if (saved.conditions) {
+    const conditions = saved.conditions.map(item => {
+      const [field, , value] = item;
+      let operator = item[1];
+      // TODO handle all the other operator types
+      if (operator === '=') {
+        operator = '';
+      }
+      return field + ':' + operator + value;
+    });
+    return conditions.join(' ');
+  }
+  return '';
+};
+
 class EventView {
+  name: string | undefined;
   fields: Field[];
   sorts: Sort[];
   tags: string[];
   query: string | undefined;
+  project: number[];
+  range: string | undefined;
+  start: string | undefined;
+  end: string | undefined;
 
   constructor(props: {
+    name: string | undefined;
     fields: Field[];
     sorts: Sort[];
     tags: string[];
     query?: string | undefined;
+    project: number[];
+    range: string | undefined;
+    start: string | undefined;
+    end: string | undefined;
   }) {
+    this.name = props.name;
     this.fields = props.fields;
     this.sorts = props.sorts;
     this.tags = props.tags;
     this.query = props.query;
+    this.project = props.project;
+    this.range = props.range;
+    this.start = props.start;
+    this.end = props.end;
   }
 
   static fromLocation(location: Location): EventView {
     return new EventView({
+      name: decodeScalar(location.query.name),
       fields: decodeFields(location),
       sorts: decodeSorts(location),
       tags: decodeTags(location),
       query: decodeQuery(location),
+      project: decodeProjects(location),
+      start: decodeScalar(location.query.start),
+      end: decodeScalar(location.query.end),
+      range: decodeScalar(location.query.range),
     });
   }
 
@@ -177,20 +241,50 @@ class EventView {
 
     return new EventView({
       fields,
+      name: eventViewV1.name,
       sorts: fromSorts(eventViewV1.data.sort),
       tags: eventViewV1.tags,
       query: eventViewV1.data.query,
+      project: [],
+      range: undefined,
+      start: undefined,
+      end: undefined,
+    });
+  }
+
+  static fromSavedQuery(saved: SavedQuery): EventView {
+    const fields = saved.fields.map(field => {
+      return {field, title: field};
+    });
+
+    return new EventView({
+      fields,
+      name: saved.name,
+      query: queryStringFromSavedQuery(saved),
+      project: saved.projects,
+      start: saved.start,
+      end: saved.end,
+      range: saved.range,
+      sorts: [],
+      tags: [],
     });
   }
 
   generateQueryStringObject(): Query {
-    return {
+    const output = {
       field: this.fields.map(item => item.field),
       alias: this.fields.map(item => item.title),
       sort: encodeSorts(this.sorts),
       tag: this.tags,
       query: this.query,
     };
+    const conditionalFields = ['name', 'project', 'start', 'end', 'range'];
+    for (const field of conditionalFields) {
+      if (this[field] && this[field].length) {
+        output[field] = this[field];
+      }
+    }
+    return output;
   }
 
   isValid(): boolean {

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -44,21 +44,17 @@ class EventsV2 extends React.Component<Props> {
 
     const list = ALL_VIEWS.map((eventViewv1, index) => {
       const eventView = EventView.fromEventViewv1(eventViewv1);
-
-      const name = eventViewv1.name;
-
       const to = {
         pathname: location.pathname,
         query: {
           ...location.query,
-          name,
           ...eventView.generateQueryStringObject(),
         },
       };
 
       return (
         <LinkContainer key={index}>
-          <Link to={to}>{name}</Link>
+          <Link to={to}>{eventView.name}</Link>
         </LinkContainer>
       );
     });

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -8,7 +8,7 @@ from sentry.utils.samples import load_data
 from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
-FEATURE_NAME = "organizations:events-v2"
+FEATURE_NAMES = ("organizations:events-v2", "organizations:discover-v2-query-builder")
 
 all_view = "field=title&field=event.type&field=project&field=user&field=timestamp&alias=title&alias=type&alias=project&alias=user&alias=time&name=All+Events&sort=-timestamp&tag=event.type&tag=release&tag=project.name&tag=user.email&tag=user.ip&tag=environment"
 error_view = "field=title&alias=error&field=count%28id%29&alias=events&field=count_unique%28user%29&alias=users&field=project&alias=project&field=last_seen&alias=last+seen&name=Errors&query=event.type%3Aerror&sort=-last_seen&sort=-title&tag=error.type&tag=project.name"
@@ -31,7 +31,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         self.browser.wait_until_not('[data-test-id="loading-placeholder"]')
 
     def test_all_events_empty(self):
-        with self.feature(FEATURE_NAME):
+        with self.feature(FEATURE_NAMES):
             self.browser.get(self.path + "?" + all_view)
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - all events empty state")
@@ -51,7 +51,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             assert_no_errors=False,
         )
 
-        with self.feature(FEATURE_NAME):
+        with self.feature(FEATURE_NAMES):
             self.browser.get(self.path + "?" + all_view)
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - all events")
@@ -91,7 +91,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             assert_no_errors=False,
         )
 
-        with self.feature(FEATURE_NAME):
+        with self.feature(FEATURE_NAMES):
             self.browser.get(self.path + "?" + error_view)
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - errors")
@@ -114,7 +114,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             data=event_data, project_id=self.project.id, assert_no_errors=False
         )
 
-        with self.feature(FEATURE_NAME):
+        with self.feature(FEATURE_NAMES):
             # Get the list page.
             self.browser.get(self.path + "?" + all_view)
             self.wait_until_loaded()
@@ -152,8 +152,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             event = self.store_event(data=event_data, project_id=self.project.id)
             event_ids.append(event.event_id)
 
-        with self.feature(FEATURE_NAME):
-
+        with self.feature(FEATURE_NAMES):
             # Get the list page
             self.browser.get(self.path + "?" + error_view + "&statsPeriod=24h")
             self.wait_until_loaded()

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -33,6 +33,10 @@ describe('Sidebar', function() {
       url: '/broadcasts/',
       method: 'PUT',
     });
+    apiMocks.savedQueries = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/discover/saved/`,
+      body: [],
+    });
   });
 
   it('renders', function() {

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -1,5 +1,64 @@
 import EventView from 'app/views/eventsV2/eventView';
 
+describe('EventView.fromSavedQuery()', function() {
+  it('maps basic properties', function() {
+    const saved = {
+      name: 'best query',
+      fields: ['count()', 'id'],
+      range: '14d',
+      start: '',
+      end: '',
+    };
+    const eventView = EventView.fromSavedQuery(saved);
+    expect(eventView.fields).toEqual([
+      {field: 'count()', title: 'count()'},
+      {field: 'id', title: 'id'},
+    ]);
+    expect(eventView.name).toEqual(saved.name);
+    expect(eventView.range).toEqual('14d');
+    expect(eventView.start).toEqual('');
+    expect(eventView.end).toEqual('');
+  });
+
+  it('maps equality conditions', function() {
+    const saved = {
+      fields: ['count()', 'id'],
+      conditions: [['event.type', '=', 'error']],
+    };
+    const eventView = EventView.fromSavedQuery(saved);
+    expect(eventView.query).toEqual('event.type:error');
+  });
+});
+
+describe('EventView.generateQueryStringObject()', function() {
+  it('skips empty values', function() {
+    const eventView = new EventView({
+      fields: ['id', 'title'],
+      tags: [],
+      sorts: [],
+      project: [],
+      range: '',
+      start: null,
+      end: undefined,
+    });
+    const query = eventView.generateQueryStringObject();
+    expect(query.range).toBeUndefined();
+    expect(query.start).toBeUndefined();
+    expect(query.end).toBeUndefined();
+    expect(query.project).toBeUndefined();
+  });
+
+  it('encodes fields', function() {
+    const eventView = new EventView({
+      fields: [{field: 'id', title: 'ID'}, {field: 'title', title: 'Event'}],
+      tags: [],
+      sorts: [],
+    });
+    const query = eventView.generateQueryStringObject();
+    expect(query.field).toEqual(['["id","ID"]', '["title","Event"]']);
+  });
+});
+
 describe('EventView.getEventsAPIPayload()', function() {
   it('appends any additional conditions defined for view', function() {
     const eventView = new EventView({

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -48,14 +48,31 @@ describe('EventView.generateQueryStringObject()', function() {
     expect(query.project).toBeUndefined();
   });
 
-  it('encodes fields', function() {
+  it('encodes fields and alias', function() {
     const eventView = new EventView({
       fields: [{field: 'id', title: 'ID'}, {field: 'title', title: 'Event'}],
       tags: [],
       sorts: [],
     });
     const query = eventView.generateQueryStringObject();
-    expect(query.field).toEqual(['["id","ID"]', '["title","Event"]']);
+    expect(query.field).toEqual(['id', 'title']);
+    expect(query.alias).toEqual(['ID', 'Event']);
+  });
+
+  it('returns a copy of data preventing mutation', function() {
+    const eventView = new EventView({
+      fields: [{field: 'id', title: 'ID'}, {field: 'title', title: 'Event'}],
+      tags: [],
+      sorts: [],
+    });
+    const query = eventView.generateQueryStringObject();
+    query.field.push('newthing');
+    query.alias.push('new thing');
+
+    // Getting the query again should return the original values.
+    const secondQuery = eventView.generateQueryStringObject();
+    expect(secondQuery.field).toEqual(['id', 'title']);
+    expect(secondQuery.alias).toEqual(['ID', 'Event']);
   });
 });
 

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -26,8 +26,10 @@ class DiscoverSavedQueryBase(APITestCase, SnubaTestCase):
 
 
 class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
+    feature_name = "organizations:discover"
+
     def test_get(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
             response = self.client.get(url)
 
@@ -40,7 +42,7 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
         assert response.data[0]["limit"] == 10
 
     def test_post(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
             response = self.client.post(
                 url,
@@ -63,7 +65,7 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
         assert not hasattr(response.data, "end")
 
     def test_post_invalid_projects(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
             response = self.client.post(
                 url,
@@ -81,7 +83,7 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
         assert response.status_code == 403, response.content
 
     def test_post_cannot_use_version_two_fields(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
             response = self.client.post(
                 url,
@@ -102,8 +104,10 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
 
 
 class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
+    feature_name = "organizations:discover-v2-query-builder"
+
     def test_post_invalid_conditions(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
             response = self.client.post(
                 url,
@@ -120,7 +124,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
         assert "cannot use the conditions attribute(s)" in response.content
 
     def test_post_require_selected_fields(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
             response = self.client.post(
                 url,
@@ -136,7 +140,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
         assert "include at least one field" in response.content
 
     def test_post_fieldnames_length_mismatch(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
             response = self.client.post(
                 url,
@@ -153,7 +157,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
         assert "equal number of field names and fields" in response.content
 
     def test_post_success(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
             response = self.client.post(
                 url,
@@ -177,7 +181,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
         assert data["query"] == "event.type:error browser.name:Firefox"
 
     def test_post_success_no_fieldnames(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
             response = self.client.post(
                 url,

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -8,6 +8,8 @@ from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryProject
 
 
 class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
+    feature_name = "organizations:discover"
+
     def setUp(self):
         super(DiscoverSavedQueryDetailTest, self).setUp()
         self.login_as(user=self.user)
@@ -35,7 +37,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
         self.query_id_without_access = invalid.id
 
     def test_get(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse(
                 "sentry-api-0-discover-saved-query-detail", args=[self.org.slug, self.query_id]
             )
@@ -49,7 +51,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
         assert response.data["limit"] == 10
 
     def test_get_org_without_access(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse(
                 "sentry-api-0-discover-saved-query-detail",
                 args=[self.org_without_access.slug, self.query_id],
@@ -59,7 +61,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
         assert response.status_code == 403, response.content
 
     def test_put(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse(
                 "sentry-api-0-discover-saved-query-detail", args=[self.org.slug, self.query_id]
             )
@@ -86,7 +88,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
         assert response.data["limit"] == 20
 
     def test_put_query_without_access(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse(
                 "sentry-api-0-discover-saved-query-detail",
                 args=[self.org.slug, self.query_id_without_access],
@@ -99,7 +101,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
             assert response.status_code == 404
 
     def test_put_org_without_access(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse(
                 "sentry-api-0-discover-saved-query-detail",
                 args=[self.org_without_access.slug, self.query_id],
@@ -111,7 +113,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
         assert response.status_code == 403, response.content
 
     def test_delete(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse(
                 "sentry-api-0-discover-saved-query-detail", args=[self.org.slug, self.query_id]
             )
@@ -123,7 +125,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
             assert self.client.get(url).status_code == 404
 
     def test_delete_removes_projects(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse(
                 "sentry-api-0-discover-saved-query-detail", args=[self.org.slug, self.query_id]
             )
@@ -137,7 +139,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
         assert projects == []
 
     def test_delete_query_without_access(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse(
                 "sentry-api-0-discover-saved-query-detail",
                 args=[self.org.slug, self.query_id_without_access],
@@ -148,7 +150,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
             assert response.status_code == 404
 
     def test_delete_org_without_access(self):
-        with self.feature("organizations:discover"):
+        with self.feature(self.feature_name):
             url = reverse(
                 "sentry-api-0-discover-saved-query-detail",
                 args=[self.org_without_access.slug, self.query_id],
@@ -156,3 +158,11 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
             response = self.client.delete(url)
 
         assert response.status_code == 403, response.content
+
+
+class DiscoverSavedQueryV2DetailTest(APITestCase, SnubaTestCase):
+    """
+    Ensure that all the scenarios work with the discover2 feature flag.
+    """
+
+    feature_name = "organizations:discover-v2-query-builder"


### PR DESCRIPTION
Preload an organizations saved discover queries and display them in the sidebar on hover. This will enable users to quickly jump to a saved query of their choice.

In the future we'll be adding clientside search and management controls to edit/delete queries, and improve on the styling.

![Screen Shot 2019-09-06 at 2 45 37 PM](https://user-images.githubusercontent.com/24086/64452799-19156000-d0b5-11e9-93d3-bcb6d2bb14a4.png)


Refs SEN-953