### PR TITLE
feat(api): Move query subscription creation and other subscription related things to `snuba` app

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -7,7 +7,8 @@ from enum import Enum
 from rest_framework import serializers
 
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
-from sentry.incidents.models import AlertRule, AlertRuleAggregations, AlertRuleThresholdType
+from sentry.incidents.models import AlertRule, AlertRuleThresholdType
+from sentry.snuba.models import QueryAggregations
 from sentry.incidents.logic import (
     AlertRuleNameAlreadyUsedError,
     create_alert_rule,
@@ -57,21 +58,21 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
 
     def validate_aggregation(self, aggregation):
         try:
-            return AlertRuleAggregations(aggregation)
+            return QueryAggregations(aggregation)
         except ValueError:
             raise serializers.ValidationError(
                 "Invalid aggregation, valid values are %s"
-                % [item.value for item in AlertRuleAggregations]
+                % [item.value for item in QueryAggregations]
             )
 
     def validate_aggregations(self, aggregations):
         # TODO: Remove this once FE transitions
         try:
-            return [AlertRuleAggregations(agg) for agg in aggregations]
+            return [QueryAggregations(agg) for agg in aggregations]
         except ValueError:
             raise serializers.ValidationError(
                 "Invalid aggregation, valid values are %s"
-                % [item.value for item in AlertRuleAggregations]
+                % [item.value for item in QueryAggregations]
             )
 
     def validate(self, attrs):

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -8,6 +8,7 @@ from enum import Enum
 from sentry.db.models import FlexibleForeignKey, Model, UUIDField
 from sentry.db.models import ArrayField, sane_repr
 from sentry.db.models.manager import BaseManager
+from sentry.snuba.models import QueryAggregations
 from sentry.utils.retries import TimedRetryPolicy
 
 
@@ -232,16 +233,6 @@ class AlertRuleThresholdType(Enum):
     BELOW = 1
 
 
-class AlertRuleAggregations(Enum):
-    TOTAL = 0
-    UNIQUE_USERS = 1
-
-
-# TODO: This should probably live in the snuba app.
-class SnubaDatasets(Enum):
-    EVENTS = "events"
-
-
 class AlertRuleManager(BaseManager):
     """
     A manager that excludes all rows that are pending deletion.
@@ -291,7 +282,7 @@ class AlertRule(Model):
     dataset = models.TextField()
     query = models.TextField()
     # TODO: Remove this default after we migrate
-    aggregation = models.IntegerField(default=AlertRuleAggregations.TOTAL.value)
+    aggregation = models.IntegerField(default=QueryAggregations.TOTAL.value)
     time_window = models.IntegerField()
     resolution = models.IntegerField()
     threshold_type = models.SmallIntegerField()

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -1,9 +1,20 @@
 from __future__ import absolute_import
 
+from enum import Enum
+
 from django.db import models
 from django.utils import timezone
 
 from sentry.db.models import ArrayField, FlexibleForeignKey, Model
+
+
+class QueryAggregations(Enum):
+    TOTAL = 0
+    UNIQUE_USERS = 1
+
+
+class QueryDatasets(Enum):
+    EVENTS = "events"
 
 
 class QuerySubscription(Model):

--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -1,0 +1,129 @@
+from __future__ import absolute_import
+
+import json
+
+from django.db import transaction
+
+from sentry.api.event_search import get_snuba_query_args
+from sentry.snuba.models import QueryAggregations, QueryDatasets, QuerySubscription
+from sentry.utils.snuba import _snuba_pool, SnubaError
+
+query_aggregation_to_snuba = {
+    QueryAggregations.TOTAL: ("count()", "", "count"),
+    QueryAggregations.UNIQUE_USERS: ("uniq", "tags[sentry:user]", "unique_users"),
+}
+
+
+def create_snuba_subscription(
+    project, subscription_type, dataset, query, aggregation, time_window, resolution
+):
+    """
+    Creates a subscription to a snuba query.
+
+    :param project: The project we're applying the query to
+    :param subscription_type: Text identifier for the subscription type this is. Used
+    to identify the registered callback associated with this subscription.
+    :param dataset: The snuba dataset to query and aggregate over
+    :param query: An event search query that we can parse and convert into a
+    set of Snuba conditions
+    :param aggregation: An aggregation to calculate over the time window
+    :param time_window: The time window to aggregate over
+    :param resolution: How often to receive updates/bucket size
+    :return: The QuerySubscription representing the subscription
+    """
+    # TODO: Move this call to snuba into a task. This lets us successfully create a
+    # subscription in postgres and rollback as needed without having to create/delete
+    # from Snuba
+    subscription_id = _create_in_snuba(
+        project, dataset, query, aggregation, time_window, resolution
+    )
+
+    return QuerySubscription.objects.create(
+        project=project,
+        type=subscription_type,
+        subscription_id=subscription_id,
+        dataset=dataset.value,
+        query=query,
+        aggregation=aggregation.value,
+        time_window=time_window,
+        resolution=resolution,
+    )
+
+
+def update_snuba_subscription(subscription, query, aggregation, time_window, resolution):
+    """
+    Updates a subscription to a snuba query.
+
+    :param query: An event search query that we can parse and convert into a
+    set of Snuba conditions
+    :param aggregation: An aggregation to calculate over the time window
+    :param time_window: The time window to aggregate over
+    :param resolution: How often to receive updates/bucket size
+    :return: The QuerySubscription representing the subscription
+    """
+    # TODO: Move this call to snuba into a task. This lets us successfully update a
+    # subscription in postgres and rollback as needed without having to create/delete
+    # from snuba
+    _delete_from_snuba(subscription)
+    subscription_id = _create_in_snuba(
+        subscription.project,
+        QueryDatasets(subscription.dataset),
+        query,
+        aggregation,
+        time_window,
+        resolution,
+    )
+    subscription.update(
+        subscription_id=subscription_id,
+        query=query,
+        aggregation=aggregation.value,
+        time_window=time_window,
+        resolution=resolution,
+    )
+    return subscription
+
+
+def delete_snuba_subscription(subscription):
+    """
+    Deletes a subscription to a snuba query.
+    :param subscription_id: The uuid of the subscription to delete
+    :return:
+    """
+    with transaction.atomic():
+        subscription.delete()
+        # TODO: Move this call to snuba into a task. This lets us successfully delete a
+        # subscription in postgres and rollback as needed without having to create/delete
+        # from snuba
+        _delete_from_snuba(subscription)
+
+
+def _create_in_snuba(project, dataset, query, aggregation, time_window, resolution):
+    response = _snuba_pool.urlopen(
+        "POST",
+        "/subscriptions",
+        body=json.dumps(
+            {
+                "project_id": project.id,
+                "dataset": dataset.value,
+                # We only care about conditions here. Filter keys only matter for
+                # filtering to project and groups. Projects are handled with an
+                # explicit param, and groups can't be queried here.
+                "conditions": get_snuba_query_args(query)["conditions"],
+                "aggregates": [query_aggregation_to_snuba[aggregation]],
+                "time_window": time_window,
+                "resolution": resolution,
+            }
+        ),
+        retries=False,
+    )
+    if response.status != 202:
+        raise SnubaError("HTTP %s response from Snuba!" % response.status)
+    return json.loads(response.data)["subscription_id"]
+
+
+def _delete_from_snuba(subscription):
+    response = _snuba_pool.urlopen(
+        "DELETE", "/subscriptions/%s" % subscription.subscription_id, retries=False
+    )
+    if response.status != 202:
+        raise SnubaError("HTTP %s response from Snuba!" % response.status)

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -6,7 +6,8 @@ import six
 
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import create_alert_rule
-from sentry.incidents.models import AlertRuleAggregations, AlertRuleThresholdType
+from sentry.incidents.models import AlertRuleThresholdType
+from sentry.snuba.models import QueryAggregations
 from sentry.testutils import TestCase
 
 
@@ -17,7 +18,7 @@ class IncidentSerializerTest(TestCase):
             "hello",
             AlertRuleThresholdType.ABOVE,
             "level:error",
-            AlertRuleAggregations.TOTAL,
+            QueryAggregations.TOTAL,
             10,
             1000,
             400,

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -11,7 +11,8 @@ from freezegun import freeze_time
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.incident import DetailedIncidentSerializer
 from sentry.incidents.logic import create_alert_rule, subscribe_to_incident
-from sentry.incidents.models import AlertRuleAggregations, AlertRuleThresholdType, IncidentGroup
+from sentry.incidents.models import AlertRuleThresholdType, IncidentGroup
+from sentry.snuba.models import QueryAggregations
 from sentry.testutils import TestCase
 
 
@@ -71,7 +72,7 @@ class DetailedIncidentSerializerTest(TestCase):
             "hi",
             AlertRuleThresholdType.ABOVE,
             "test query",
-            AlertRuleAggregations.TOTAL,
+            QueryAggregations.TOTAL,
             10,
             1000,
             400,

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -4,7 +4,8 @@ from exam import fixture
 
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import create_alert_rule
-from sentry.incidents.models import AlertRule, AlertRuleAggregations, AlertRuleThresholdType
+from sentry.incidents.models import AlertRule, AlertRuleThresholdType
+from sentry.snuba.models import QueryAggregations
 from sentry.testutils import APITestCase
 
 
@@ -30,7 +31,7 @@ class AlertRuleDetailsBase(object):
             "hello",
             AlertRuleThresholdType.ABOVE,
             "level:error",
-            AlertRuleAggregations.TOTAL,
+            QueryAggregations.TOTAL,
             10,
             1000,
             400,

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -5,7 +5,8 @@ from freezegun import freeze_time
 
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import create_alert_rule
-from sentry.incidents.models import AlertRule, AlertRuleAggregations, AlertRuleThresholdType
+from sentry.incidents.models import AlertRule, AlertRuleThresholdType
+from sentry.snuba.models import QueryAggregations
 from sentry.testutils import APITestCase
 
 
@@ -34,7 +35,7 @@ class AlertRuleListEndpointTest(APITestCase):
             "hello",
             AlertRuleThresholdType.ABOVE,
             "level:error",
-            AlertRuleAggregations.TOTAL,
+            QueryAggregations.TOTAL,
             10,
             1000,
             400,

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 from exam import fixture
 
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer
-from sentry.incidents.models import AlertRule, AlertRuleAggregations, AlertRuleThresholdType
+from sentry.incidents.models import AlertRule, AlertRuleThresholdType
+from sentry.snuba.models import QueryAggregations
 from sentry.testutils import TestCase
 
 
@@ -65,8 +66,7 @@ class TestAlertRuleSerializer(TestCase):
 
     def test_aggregation(self):
         invalid_values = [
-            "Invalid aggregation, valid values are %s"
-            % [item.value for item in AlertRuleAggregations]
+            "Invalid aggregation, valid values are %s" % [item.value for item in QueryAggregations]
         ]
         self.run_fail_validation_test(
             {"aggregation": "a"}, {"aggregation": ["A valid integer is required."]}
@@ -88,7 +88,7 @@ class TestAlertRuleSerializer(TestCase):
         self._run_changed_fields_test(alert_rule, {"name": "a name"}, {"name": "a name"})
         self._run_changed_fields_test(alert_rule, {"aggregation": 0}, {})
         self._run_changed_fields_test(
-            alert_rule, {"aggregation": 1}, {"aggregation": AlertRuleAggregations.UNIQUE_USERS}
+            alert_rule, {"aggregation": 1}, {"aggregation": QueryAggregations.UNIQUE_USERS}
         )
         self._run_changed_fields_test(alert_rule, {"threshold_type": 0}, {})
         self._run_changed_fields_test(

--- a/tests/sentry/snuba/test_subscriptions.py
+++ b/tests/sentry/snuba/test_subscriptions.py
@@ -1,0 +1,71 @@
+from __future__ import absolute_import
+
+from sentry.snuba.models import QueryAggregations, QueryDatasets, QuerySubscription
+from sentry.snuba.subscriptions import (
+    create_snuba_subscription,
+    delete_snuba_subscription,
+    update_snuba_subscription,
+)
+from sentry.testutils import TestCase
+
+
+class CreateSnubaSubscriptionTest(TestCase):
+    def test(self):
+        type = "something"
+        dataset = QueryDatasets.EVENTS
+        query = "level:error"
+        aggregation = QueryAggregations.TOTAL
+        time_window = 10
+        resolution = 1
+        subscription = create_snuba_subscription(
+            self.project, type, dataset, query, aggregation, time_window, resolution
+        )
+        assert subscription.project == self.project
+        assert subscription.type == type
+        assert subscription.subscription_id != ""
+        assert subscription.dataset == dataset.value
+        assert subscription.query == query
+        assert subscription.aggregation == aggregation.value
+        assert subscription.time_window == time_window
+        assert subscription.resolution == resolution
+
+
+class UpdateSnubaSubscriptionTest(TestCase):
+    def test(self):
+        subscription = create_snuba_subscription(
+            self.project,
+            "something",
+            QueryDatasets.EVENTS,
+            "level:error",
+            QueryAggregations.TOTAL,
+            10,
+            1,
+        )
+
+        query = "level:warning"
+        aggregation = QueryAggregations.UNIQUE_USERS
+        time_window = 20
+        resolution = 2
+        old_subscription_id = subscription.subscription_id
+        update_snuba_subscription(subscription, query, aggregation, time_window, resolution)
+        assert subscription.subscription_id != old_subscription_id
+        assert subscription.query == query
+        assert subscription.aggregation == aggregation.value
+        assert subscription.time_window == time_window
+        assert subscription.resolution == resolution
+
+
+class DeleteSnubaSubscriptionTest(TestCase):
+    def test(self):
+        subscription = create_snuba_subscription(
+            self.project,
+            "something",
+            QueryDatasets.EVENTS,
+            "level:error",
+            QueryAggregations.TOTAL,
+            10,
+            1,
+        )
+        subscription_id = subscription.id
+        delete_snuba_subscription(subscription)
+        assert not QuerySubscription.objects.filter(id=subscription_id).exists()


### PR DESCRIPTION
This pr moves query subscriptions and other things related to them into the `snuba` app. These
things aren't the responsibility of incidents, so it makes sense to have this separation.

We also change the way we handle transactions and rolling back. Previously we'd try to handle
rolling back the transaction and removing any created subscriptions from Snuba in the `incidents`
project. This was starting to get complicated, so we'll now handle this in `snuba` instead. In a
follow up PR I'll move the actual calls to snuba into tasks, so that we can handle the creation of
everything in Postgres, and then once we're committed we can then fire off the creations to Snuba
if everything looks good. This simplifies how we handle transactions a lot, and we can perform
checks inside the tasks to make sure that the subscription is in the correct state.

We'll also handle multiple subscriptions per alert rule in a later pr.