### PR TITLE
feat(transactions): Add custom scope tag for organization in frontend

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
+import * as Sentry from '@sentry/browser';
 
 import {fetchOrganizationEnvironments} from 'app/actionCreators/environments';
 import {openSudo} from 'app/actionCreators/modal';
@@ -96,7 +97,7 @@ const OrganizationContext = createReactClass({
     this.setState(this.getInitialState(), this.fetchData);
   },
 
-  onProjectCreation(project) {
+  onProjectCreation() {
     // If a new project was created, we need to re-fetch the
     // org details endpoint, which will propagate re-rendering
     // for the entire component tree
@@ -134,6 +135,11 @@ const OrganizationContext = createReactClass({
         });
 
         setActiveOrganization(data);
+
+        // Configure scope to have organization tag
+        Sentry.configureScope(scope => {
+          scope.setTag('organization', data.id);
+        });
 
         TeamStore.loadInitialData(data.teams);
         ProjectsStore.loadInitialData(data.projects);


### PR DESCRIPTION
Add organization as a custom tag so it can be searched and filtered in the events v2 interface. This will be helpful in eventually understanding what enterprise organizations are doing inside of sentry.

![image](https://user-images.githubusercontent.com/9372512/64457382-5115a680-d0a7-11e9-916e-60d36003b41f.png)
`organization` can be seen on the right

Refs SEN-1001