### PR TITLE
fix(transactions): fix bug where zero ms spans are displayed as very long

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -239,7 +239,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         return {
           warning: t('The start and end timestamps are equal'),
           left: bounds.start,
-          width: bounds.width,
+          width: 0.00001,
           isSpanVisibleInView: bounds.isSpanVisibleInView,
         };
       }


### PR DESCRIPTION
There are some good suggestions for displaying them differently, but to start let's just display them as something very short.