### PR TITLE
fix(discover2) Don't use json objects in query string

### DIFF
--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -10,8 +10,8 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 FEATURE_NAME = "organizations:events-v2"
 
-all_view = 'field=%5B"title"%2C"title"%5D&field=%5B"event.type"%2C"type"%5D&field=%5B"project"%2C"project"%5D&field=%5B"user"%2C"user"%5D&field=%5B"timestamp"%2C"time"%5D&name=All+Events&sort=-timestamp&tag=event.type&tag=release&tag=project.name&tag=user.email&tag=user.ip&tag=environment'
-error_view = 'field=%5B"title"%2C"error"%5D&field=%5B"count%28id%29"%2C"events"%5D&field=%5B"count_unique%28user%29"%2C"users"%5D&field=%5B"project"%2C"project"%5D&field=%5B"last_seen"%2C"last+seen"%5D&name=Errors&query=event.type%3Aerror&sort=-last_seen&sort=-title&tag=error.type&tag=project.name'
+all_view = "field=title&field=event.type&field=project&field=user&field=timestamp&alias=title&alias=type&alias=project&alias=user&alias=time&name=All+Events&sort=-timestamp&tag=event.type&tag=release&tag=project.name&tag=user.email&tag=user.ip&tag=environment"
+error_view = "field=title&alias=error&field=count%28id%29&alias=events&field=count_unique%28user%29&alias=users&field=project&alias=project&field=last_seen&alias=last+seen&name=Errors&query=event.type%3Aerror&sort=-last_seen&sort=-title&tag=error.type&tag=project.name"
 
 
 class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):

--- a/tests/js/spec/views/eventsV2/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/index.spec.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {mount} from 'enzyme';
 
 import {EventsV2} from 'app/views/eventsV2';
-import {encodeFields} from 'app/views/eventsV2/eventView';
 
 const FIELDS = [
   {
@@ -20,7 +19,10 @@ const FIELDS = [
 ];
 
 const generateFields = () => {
-  return encodeFields(FIELDS);
+  return {
+    alias: FIELDS.map(i => i.title),
+    field: FIELDS.map(i => i.field),
+  };
 };
 
 describe('EventsV2', function() {
@@ -89,7 +91,7 @@ describe('EventsV2', function() {
     const wrapper = mount(
       <EventsV2
         organization={TestStubs.Organization({features, projects: [TestStubs.Project()]})}
-        location={{query: {field: generateFields()}}}
+        location={{query: {...generateFields()}}}
         router={{}}
       />,
       TestStubs.routerContext()
@@ -103,7 +105,7 @@ describe('EventsV2', function() {
     const wrapper = mount(
       <EventsV2
         organization={TestStubs.Organization({features})}
-        location={{query: {field: generateFields()}}}
+        location={{query: {...generateFields()}}}
         router={{}}
       />,
       TestStubs.routerContext()
@@ -117,7 +119,7 @@ describe('EventsV2', function() {
     const wrapper = mount(
       <EventsV2
         organization={TestStubs.Organization({features, projects: [TestStubs.Project()]})}
-        location={{query: {field: generateFields(), sort: ['-timestamp']}}}
+        location={{query: {...generateFields(), sort: ['-timestamp']}}}
         router={{}}
       />,
       TestStubs.routerContext()
@@ -141,7 +143,7 @@ describe('EventsV2', function() {
 
     // Sort link should reverse.
     expect(timestamp.props().to.query).toEqual({
-      field: generateFields(),
+      ...generateFields(),
       sort: 'timestamp',
     });
 
@@ -149,7 +151,7 @@ describe('EventsV2', function() {
 
     // User link should be descending.
     expect(userlink.props().to.query).toEqual({
-      field: generateFields(),
+      ...generateFields(),
       sort: '-user.id',
     });
   });
@@ -158,7 +160,7 @@ describe('EventsV2', function() {
     const wrapper = mount(
       <EventsV2
         organization={TestStubs.Organization({features, projects: [TestStubs.Project()]})}
-        location={{query: {field: generateFields()}}}
+        location={{query: {...generateFields()}}}
         router={{}}
       />,
       TestStubs.routerContext()
@@ -167,7 +169,7 @@ describe('EventsV2', function() {
     const link = wrapper.find(`Table Link[aria-label="${eventTitle}"]`).first();
     expect(link.props().to.query).toEqual({
       eventSlug: 'project-slug:deadbeef',
-      field: generateFields(),
+      ...generateFields(),
     });
   });
 


### PR DESCRIPTION
Using JSON objects in the query string creates problems when links are shared as slack and many email clients will convert " into a smart quote causing broken links. While this isn't a great long term solution it does make less fragile links in the short term.

Refs SEN-1023