### PR TITLE
Fix/update api token scopes

### DIFF
--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 import six
 
 from collections import Iterable
+from django.utils import timezone
+from django.db.models import Q
 
 from sentry import analytics
 from sentry.coreapi import APIError
@@ -10,7 +12,7 @@ from sentry.constants import SentryAppStatus
 from sentry.mediators import Mediator, Param
 from sentry.mediators import service_hooks
 from sentry.mediators.param import if_param
-from sentry.models import SentryAppComponent, ServiceHook, SentryAppInstallation
+from sentry.models import SentryAppComponent, ServiceHook, SentryAppInstallation, ApiToken
 from sentry.models.sentryapp import REQUIRED_EVENT_PERMISSIONS
 
 
@@ -68,6 +70,14 @@ class Updater(Mediator):
         ):
             raise APIError("Cannot update permissions on a published integration.")
         self.sentry_app.scope_list = self.scopes
+        # update the scopes of active tokens tokens
+        tokens = ApiToken.objects.filter(
+            Q(expires_at__isnull=True) | Q(expires_at__gt=timezone.now()),
+            application=self.sentry_app.application,
+        )
+        for token in tokens:
+            token.scope_list = self.scopes
+            token.save()
 
     @if_param("events")
     def _update_events(self):

--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -71,13 +71,10 @@ class Updater(Mediator):
             raise APIError("Cannot update permissions on a published integration.")
         self.sentry_app.scope_list = self.scopes
         # update the scopes of active tokens tokens
-        tokens = ApiToken.objects.filter(
+        ApiToken.objects.filter(
             Q(expires_at__isnull=True) | Q(expires_at__gt=timezone.now()),
             application=self.sentry_app.application,
-        )
-        for token in tokens:
-            token.scope_list = self.scopes
-            token.save()
+        ).update(scope_list=list(self.scopes))
 
     @if_param("events")
     def _update_events(self):

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import
 
+from datetime import timedelta
+from django.utils import timezone
+
 from sentry.coreapi import APIError
 from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Updater
 from sentry.mediators.service_hooks.creator import expand_events
-from sentry.models import SentryAppComponent, ServiceHook
+from sentry.models import SentryAppComponent, ServiceHook, ApiToken
 from sentry.testutils import TestCase
 
 
@@ -25,10 +28,44 @@ class TestUpdater(TestCase):
         self.updater.call()
         assert self.sentry_app.name == "A New Thing"
 
+    def test_update_scopes_internal_integration(self):
+        self.create_project(organization=self.org)
+        sentry_app = self.create_internal_integration(
+            scopes=("project:read",), organization=self.org
+        )
+        updater = Updater(sentry_app=sentry_app, user=self.user)
+        updater.scopes = ("project:read", "project:write")
+        updater.call()
+        assert sentry_app.get_scopes() == ["project:read", "project:write"]
+        assert ApiToken.objects.get(application=sentry_app.application).get_scopes() == [
+            "project:read",
+            "project:write",
+        ]
+
     def test_updates_unpublished_app_scopes(self):
+        # create both expired token and not expired token
+        ApiToken.objects.create(
+            application=self.sentry_app.application,
+            user=self.sentry_app.proxy_user,
+            scopes=self.sentry_app.scopes,
+            scope_list=self.sentry_app.scope_list,
+            expires_at=(timezone.now() + timedelta(hours=1)),
+        )
+        ApiToken.objects.create(
+            application=self.sentry_app.application,
+            user=self.sentry_app.proxy_user,
+            scopes=self.sentry_app.scopes,
+            scope_list=self.sentry_app.scope_list,
+            expires_at=(timezone.now() - timedelta(hours=1)),
+        )
         self.updater.scopes = ("project:read", "project:write")
         self.updater.call()
         assert self.sentry_app.get_scopes() == ["project:read", "project:write"]
+        tokens = ApiToken.objects.filter(application=self.sentry_app.application).order_by(
+            "expires_at"
+        )
+        assert tokens[0].get_scopes() == ["project:read"]
+        assert tokens[1].get_scopes() == ["project:read", "project:write"]
 
     def test_doesnt_update_published_app_scopes(self):
         sentry_app = self.create_sentry_app(

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -43,7 +43,7 @@ class TestUpdater(TestCase):
         ]
 
     def test_updates_unpublished_app_scopes(self):
-        # create both expired token and not expired token
+        # create both expired token and not expired tokens
         ApiToken.objects.create(
             application=self.sentry_app.application,
             user=self.sentry_app.proxy_user,


### PR DESCRIPTION
This PR updates the scopes of active API tokens attached to an application when the scopes of that application are updated. Note that we prevent updating the scopes of published applications so this only matters for internal and unpublished integrations.