### PR TITLE
fix(discover2) Hide related events when it fails

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.tsx
@@ -378,7 +378,7 @@ export default class AsyncComponent<
     return <LoadingIndicator />;
   }
 
-  renderError(error, disableLog = false, disableReport = false) {
+  renderError(error, disableLog = false, disableReport = false): React.ReactNode {
     // 401s are captured by SudoModal, but may be passed back to AsyncComponent if they close the modal without identifying
     const unauthorizedErrors = Object.values(this.state.errors).find(
       resp => resp && resp.status === 401

--- a/src/sentry/static/sentry/app/views/eventsV2/relatedEvents.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/relatedEvents.tsx
@@ -36,8 +36,11 @@ class RelatedEvents extends AsyncComponent<Props> {
     projects: PropTypes.arrayOf(SentryTypes.Project),
   };
 
+  hasGlobalViews(): boolean {
+    return this.props.organization.features.includes('global-views');
+  }
+
   getEndpoints(): Array<[string, string, {query: EventQuery}]> {
-    // TODO what happens when global-views feature is not on the org?
     const {event, organization} = this.props;
     const eventsUrl = `/organizations/${organization.slug}/eventsv2/`;
     const trace = event.tags.find(tag => tag.key === 'trace');
@@ -68,6 +71,15 @@ class RelatedEvents extends AsyncComponent<Props> {
 
   renderLoading() {
     return <Placeholder height="120px" bottomGutter={2} />;
+  }
+
+  renderError(error) {
+    // Hide the related events if the user doesn't have global-views
+    if (!this.hasGlobalViews()) {
+      return <span />;
+    }
+
+    return super.renderError(error);
   }
 
   renderBody() {

--- a/src/sentry/static/sentry/app/views/eventsV2/relatedEvents.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/relatedEvents.tsx
@@ -76,7 +76,7 @@ class RelatedEvents extends AsyncComponent<Props> {
   renderError(error) {
     // Hide the related events if the user doesn't have global-views
     if (!this.hasGlobalViews()) {
-      return <span />;
+      return null;
     }
 
     return super.renderError(error);

--- a/tests/js/spec/stores/discoverSavedQueriesStore.spec.jsx
+++ b/tests/js/spec/stores/discoverSavedQueriesStore.spec.jsx
@@ -136,6 +136,7 @@ describe('DiscoverSavedQueriesStore', function() {
     };
     createSavedQuery(api, 'org-1', query);
     await tick();
+    await tick();
 
     const state = DiscoverSavedQueriesStore.get();
     expect(state.isLoading).toEqual(false);


### PR DESCRIPTION
Related events can fail to load if the account doesn't have global-views. When that request fails and the account is missing global-views we can hide the panel entirely.

Fixes SEN-1018