### PR TITLE
feat(ui): Add option to "Include Future Projects" for Incident Rules [SEN-992]

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectIncidentRules/ruleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectIncidentRules/ruleForm.tsx
@@ -492,6 +492,13 @@ class RuleForm extends React.Component<Props, State> {
                             placeholder: t('My Incident Rule Name'),
                             required: true,
                           },
+                          {
+                            name: 'includeFutureProjects',
+                            type: 'boolean',
+                            label: t('Include Future Projects'),
+                            help: t('Apply this rule to all future projects as well'),
+                            required: false,
+                          },
                         ],
                       },
                     ]}


### PR DESCRIPTION
This adds a switch to "Include Future Projects", but it currently does nothing because backend does not support it.

Fixes SEN-992