### PR TITLE
Revert "fix(user-feedback): Fix user feedback page hostname (#14429)"

### DIFF
--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -12,7 +12,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
-from sentry import eventstore, options as sentry_options
+from sentry import eventstore
 from sentry.models import Event, ProjectKey, ProjectOption, UserReport
 from sentry.web.helpers import render_to_response
 from sentry.signals import user_feedback_received
@@ -208,9 +208,7 @@ class ErrorPageEmbedView(View):
         )
 
         context = {
-            "endpoint": mark_safe(
-                "*/" + json.dumps(sentry_options.get("system.url-prefix")) + ";/*"
-            ),
+            "endpoint": mark_safe("*/" + json.dumps(request.build_absolute_uri()) + ";/*"),
             "template": mark_safe("*/" + json.dumps(template) + ";/*"),
             "strings": json.dumps_htmlsafe(
                 {


### PR DESCRIPTION
This reverts commit ae07f117d364b6e8c1e5ee1ab8cf6507dd94a00d.

>seems like user-feedback requests are going to sentry.io and not the relevant endpoint (e.g. `sentry.io/api/embed-error-page`)