### PR TITLE
chore: pre-commit managed flake8 + flake8 updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,12 @@ exclude: >
         ^src/sentry/data/
     )
 repos:
--   repo: local
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.8
     hooks:
     - id: flake8
-      name: flake8
-      entry: flake8
-      language: python
-      files: \.py$
+      types: [python]
+      language_version: 'python2.7'
       log_file: '.artifacts/flake8.pycodestyle.log'
 -   repo: https://github.com/ambv/black
     rev: 19.3b0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     rev: 3.7.8
     hooks:
     - id: flake8
+      additional_dependencies: [sentry-flake8]
       types: [python]
       language_version: 'python2.7'
       log_file: '.artifacts/flake8.pycodestyle.log'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
       types: [python]
       language_version: 'python2.7'
       log_file: '.artifacts/flake8.pycodestyle.log'
+      exclude: (south_migrations/|^src/south/|^examples/)
 -   repo: https://github.com/ambv/black
     rev: 19.3b0
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,9 +124,10 @@ matrix:
       install:
         - python setup.py install_egg_info
         - SENTRY_LIGHT_BUILD=1 pip install -U -e ".[dev,tests,optional]"
-        # temporarily place python3.6 on path so it's possible for pre-commit to install black
-        - pyenv global
-        - pyenv global 3.7.4 2.7.15
+        # temporarily place python3.6+ on path so it's possible for pre-commit to install black
+        # TODO: put in travis cache
+        - pyenv install 3.6.3
+        - pyenv global 3.6.3 system
         - make setup-git
         - pyenv global system
         - find "$NODE_DIR" -type d -empty -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,8 @@ matrix:
         - python setup.py install_egg_info
         - SENTRY_LIGHT_BUILD=1 pip install -U -e ".[dev,tests,optional]"
         # temporarily place python3.6 on path so it's possible for pre-commit to install black
-        - pyenv global 3.6.7 2.7.15
+        - pyenv global
+        - pyenv global 3.7.4 2.7.15
         - make setup-git
         - pyenv global system
         - find "$NODE_DIR" -type d -empty -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,10 @@ matrix:
       install:
         - python setup.py install_egg_info
         - SENTRY_LIGHT_BUILD=1 pip install -U -e ".[dev,tests,optional]"
+        # temporarily place python3.6 on path so it's possible for pre-commit to install black
+        - pyenv global 3.6.7 2.7.15
+        - make setup-git
+        - pyenv global system
         - find "$NODE_DIR" -type d -empty -delete
         - nvm install
         - ./bin/yarn install --pure-lockfile

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,7 +53,7 @@
     "editor.formatOnSave": false
   },
 
-  "python.linting.pylintEnabled": false,
+  "python.linting.enabled": true,
   "python.linting.flake8Enabled": true,
   // https://github.com/DonJayamanne/pythonVSCode/issues/992
   "python.pythonPath": "${workspaceFolder}/.venv/bin/python",
@@ -64,8 +64,5 @@
   "python.testing.nosetestsEnabled": false,
   "editor.tabSize": 4,
   "restructuredtext.confPath": "",
-  "python.linting.enabled": true,
-  "python.linting.flake8Path": "${workspaceFolder}/.venv/bin/flake8",
-  "python.linting.pep8Path": "${workspaceFolder}/.venv/bin/pep8",
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest"
 }

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ lint: lint-python lint-js
 
 lint-python:
 	@echo "--> Linting python"
-	bash -eo pipefail -c "flake8 | tee .artifacts/flake8.pycodestyle.log"
+	pre-commit run flake8 -a
 	@echo ""
 
 review-python-snapshots:

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ travis-noop:
 	@echo "nothing to do here."
 
 .PHONY: travis-test-lint
-travis-test-lint: lint-python lint-js
+travis-test-lint: setup-git lint-python lint-js
 
 .PHONY: travis-test-postgres travis-test-acceptance travis-test-snuba travis-test-symbolicator travis-test-js travis-test-cli travis-test-dist travis-test-riak
 travis-test-postgres: test-python

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ travis-noop:
 	@echo "nothing to do here."
 
 .PHONY: travis-test-lint
-travis-test-lint: setup-git lint-python lint-js
+travis-test-lint: lint-python lint-js
 
 .PHONY: travis-test-postgres travis-test-acceptance travis-test-snuba travis-test-symbolicator travis-test-js travis-test-cli travis-test-dist travis-test-riak
 travis-test-postgres: test-python

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
 Babel
 docker>=3.7.0,<3.8.0
 isort>=4.3.4,<4.4.0
-pycodestyle>=2.3.1,<2.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,5 @@
 Babel
-
-# Dependency of flake8
-# https://github.com/jaraco/configparser/issues/27
-# https://github.com/jaraco/configparser/issues/30
-configparser!=3.5.2,!=3.5.3,!=3.7.0
 docker>=3.7.0,<3.8.0
-flake8>=3.5.0,<3.6.0
 isort>=4.3.4,<4.4.0
 pycodestyle>=2.3.1,<2.4.0
 sentry-flake8>=0.1.0,<0.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,3 @@ Babel
 docker>=3.7.0,<3.8.0
 isort>=4.3.4,<4.4.0
 pycodestyle>=2.3.1,<2.4.0
-sentry-flake8>=0.1.0,<0.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,18 +18,6 @@ exclude = .venv/.git,*/south_migrations/*,node_modules/*,src/sentry/static/sentr
 [bdist_wheel]
 python-tag = py27
 
-[pep8]
-max-line-length = 100
-# W690 is wrong (e.g. it causes functools.reduce to be imported, which is not compat with Python 3)
-# E700 isnt that important
-# E701 isnt that important
-# E711 could be incorrect
-# E712 could be incorrect
-# E721 says "always use isinstance" which is not the same as type()
-ignore = W690,E701,E70,E711,E721
-aggressive = 1
-exclude = */south_migrations/*
-
 [coverage:run]
 omit =
     src/sentry/south_migrations/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ markers =
 # W605 false positive until python3.8: https://github.com/PyCQA/pycodestyle/issues/755
 ignore = F999,E203,E501,E128,E124,E402,W503,W504,W605,E731,C901,B007,B306,B009,B010
 max-line-length = 100
-# TODO: mirror this in pre-commit exclude flavor regex
 exclude = .venv/.git,*/south_migrations/*,node_modules/*,src/sentry/static/sentry/vendor/*,docs/*,src/south/*,examples/*
 
 [bdist_wheel]

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,8 @@ markers =
 
 [flake8]
 # E203 false positive, see https://github.com/PyCQA/pycodestyle/issues/373
-ignore = F999,E203,E501,E128,E124,E402,W503,E731,C901,B007,B306,B009,B010
+# W605 false positive until python3.8: https://github.com/PyCQA/pycodestyle/issues/755
+ignore = F999,E203,E501,E128,E124,E402,W503,W605,E731,C901,B007,B306,B009,B010
 max-line-length = 100
 # TODO: mirror this in pre-commit exclude flavor regex
 exclude = .venv/.git,*/south_migrations/*,node_modules/*,src/sentry/static/sentry/vendor/*,docs/*,src/south/*,examples/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,12 @@ markers =
 # E203 false positive, see https://github.com/PyCQA/pycodestyle/issues/373
 # W605 false positive until python3.8: https://github.com/PyCQA/pycodestyle/issues/755
 ignore = F999,E203,E501,E128,E124,E402,W503,W504,W605,E731,C901,B007,B306,B009,B010
-max-line-length = 100
 exclude = .venv/.git,*/south_migrations/*,node_modules/*,src/sentry/static/sentry/vendor/*,docs/*,src/south/*,examples/*
+
+# XXX: E501 is ignored, which disables line length checking.
+# Currently, the black formatter doesn't wrap long strings: https://github.com/psf/black/issues/182#issuecomment-385325274
+# We already have a lot of E501's - these are lines black didn't wrap.
+# But rather than append # noqa: E501 to all of them, we just ignore E501 for now.
 
 [bdist_wheel]
 python-tag = py27

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ markers =
 [flake8]
 # E203 false positive, see https://github.com/PyCQA/pycodestyle/issues/373
 # W605 false positive until python3.8: https://github.com/PyCQA/pycodestyle/issues/755
-ignore = F999,E203,E501,E128,E124,E402,W503,W605,E731,C901,B007,B306,B009,B010
+ignore = F999,E203,E501,E128,E124,E402,W503,W504,W605,E731,C901,B007,B306,B009,B010
 max-line-length = 100
 # TODO: mirror this in pre-commit exclude flavor regex
 exclude = .venv/.git,*/south_migrations/*,node_modules/*,src/sentry/static/sentry/vendor/*,docs/*,src/south/*,examples/*

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -285,7 +285,7 @@ class OrganizationSerializer(serializers.Serializer):
 
         # check if fields changed
         for f, v in six.iteritems(org_tracked_field):
-            if f is not "flag_field":
+            if f != "flag_field":
                 if org.has_changed(f):
                     old_val = org.old_value(f)
                     changed_data[f] = u"from {} to {}".format(old_val, v)

--- a/src/sentry/api/validators/monitor.py
+++ b/src/sentry/api/validators/monitor.py
@@ -64,7 +64,6 @@ class CronJobValidator(serializers.Serializer):
             return attrs
 
         if schedule_type == ScheduleType.INTERVAL:
-            # type: [int count, str unit name]
             if not isinstance(value, list):
                 raise ValidationError("Invalid value for schedule_type")
             if not isinstance(value[0], int):
@@ -72,7 +71,6 @@ class CronJobValidator(serializers.Serializer):
             if value[1] not in INTERVAL_NAMES:
                 raise ValidationError("Invalid value for schedule unit name (index 1)")
         elif schedule_type == ScheduleType.CRONTAB:
-            # type: str schedule
             if not isinstance(value, six.string_types):
                 raise ValidationError("Invalid value for schedule_type")
             value = value.strip()

--- a/src/sentry/db/models/fields/bounded.py
+++ b/src/sentry/db/models/fields/bounded.py
@@ -69,7 +69,7 @@ if settings.SENTRY_USE_BIG_INTS:
             if "postgres" in engine:
                 return "bigserial"
             else:
-                raise NotImplemented
+                raise NotImplementedError
 
         def get_related_db_type(self, connection):
             return BoundedBigIntegerField().db_type(connection)

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -54,7 +54,7 @@ class OAuth2Provider(Provider):
         """
         try:
             prop = getattr(self, u"oauth_{}".format(parameter_name))
-            if prop is not "":
+            if prop != "":
                 return prop
         except AttributeError:
             pass

--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -307,7 +307,6 @@ def run_formatter(cmd, file_list, prompt_on_changes=True):
 
 def run(file_list=None, format=True, lint=True, js=True, py=True,
         less=True, yarn=True, test=False, parseable=False):
-    # pep8.py uses sys.argv to find setup.cfg
     old_sysargv = sys.argv
 
     try:

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -162,7 +162,7 @@ class RavenIntegrationTest(TransactionTestCase):
         for _request in requests:
             self.send_event(*_request)
 
-        assert request.call_count is 1
+        assert request.call_count == 1
         assert Group.objects.count() == 1
         group = Group.objects.get()
         assert group.data["title"] == "foo"

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -315,7 +315,7 @@ class GitHubIssueBasicTest(TestCase):
         )
         fields = self.integration.get_link_issue_config(event.group)
         repo_field = [field for field in fields if field["name"] == "repo"][0]
-        assert repo_field["default"] is ""
+        assert repo_field["default"] == ""
         assert repo_field["choices"] == []
 
     @responses.activate

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -130,7 +130,7 @@ class MailPluginTest(TestCase):
         with self.options({"system.url-prefix": "http://example.com"}):
             self.plugin.notify(notification)
 
-        assert _send_mail.call_count is 1
+        assert _send_mail.call_count == 1
         args, kwargs = _send_mail.call_args
         self.assertEquals(kwargs.get("project"), self.project)
         self.assertEquals(kwargs.get("reference"), group)
@@ -169,7 +169,7 @@ class MailPluginTest(TestCase):
         with self.options({"system.url-prefix": "http://example.com"}):
             self.plugin.notify(notification)
 
-        assert _send_mail.call_count is 1
+        assert _send_mail.call_count == 1
         args, kwargs = _send_mail.call_args
         assert kwargs.get("subject") == u"BAR-2 - hello world"
 
@@ -260,7 +260,7 @@ class MailPluginTest(TestCase):
         with self.tasks():
             self.plugin.notify_digest(project, digest)
 
-        assert notify.call_count is 0
+        assert notify.call_count == 0
         assert len(mail.outbox) == 1
 
         message = mail.outbox[0]
@@ -273,8 +273,8 @@ class MailPluginTest(TestCase):
         rule = project.rule_set.all()[0]
         digest = build_digest(project, (event_to_record(self.event, (rule,)),))
         self.plugin.notify_digest(project, digest)
-        assert send_async.call_count is 1
-        assert notify.call_count is 1
+        assert send_async.call_count == 1
+        assert notify.call_count == 1
 
     @mock.patch(
         "sentry.models.ProjectOption.objects.get_value",

--- a/tests/sentry/rules/actions/test_notify_event.py
+++ b/tests/sentry/rules/actions/test_notify_event.py
@@ -19,6 +19,6 @@ class NotifyEventActionTest(RuleTestCase):
 
         results = list(rule.after(event=event, state=self.get_state()))
 
-        assert len(results) is 1
-        assert plugin.should_notify.call_count is 1
+        assert len(results) == 1
+        assert plugin.should_notify.call_count == 1
         assert results[0].callback is plugin.rule_notify

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -24,8 +24,8 @@ class NotifyEventServiceActionTest(RuleTestCase):
 
             results = list(rule.after(event=event, state=self.get_state()))
 
-        assert len(results) is 1
-        assert plugin.should_notify.call_count is 1
+        assert len(results) == 1
+        assert plugin.should_notify.call_count == 1
         assert results[0].callback is plugin.rule_notify
 
     def test_applies_correctly_for_sentry_apps(self):
@@ -39,5 +39,5 @@ class NotifyEventServiceActionTest(RuleTestCase):
 
         results = list(rule.after(event=event, state=self.get_state()))
 
-        assert len(results) is 1
+        assert len(results) == 1
         assert results[0].callback is notify_sentry_app

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -219,7 +219,7 @@ def test_threaded_executor():
         queue_full_future.result()  # will not block if completed
 
     initial_waiting.set()  # let the task finish
-    assert initial_future.result(timeout=1) is 1
+    assert initial_future.result(timeout=1) == 1
     assert initial_future.done()
 
     assert high_priority_ready.wait(timeout=1)  # this should be the next task to execute
@@ -227,12 +227,12 @@ def test_threaded_executor():
     assert not low_priority_future.running()
 
     high_priority_waiting.set()  # let the task finish
-    assert high_priority_future.result(timeout=1) is 3
+    assert high_priority_future.result(timeout=1) == 3
     assert high_priority_future.done()
 
     assert low_priority_ready.wait(timeout=1)  # this should be the next task to execute
     assert low_priority_future.running()
 
     low_priority_waiting.set()  # let the task finish
-    assert low_priority_future.result(timeout=1) is 2
+    assert low_priority_future.result(timeout=1) == 2
     assert low_priority_future.done()

--- a/tests/sentry/web/frontend/test_release_webhook.py
+++ b/tests/sentry/web/frontend/test_release_webhook.py
@@ -72,7 +72,7 @@ class ReleaseWebhookTest(TestCase):
         mock_plugin_get.assert_called_once_with("dummy")
         MockPlugin.get_release_hook.assert_called_once_with()
         MockReleaseHook.assert_called_once_with(self.project)
-        assert MockReleaseHook.return_value.handle.call_count is 1
+        assert MockReleaseHook.return_value.handle.call_count == 1
 
     @patch("sentry.plugins.plugins.get")
     def test_disabled_plugin(self, mock_plugin_get):


### PR DESCRIPTION
Moving flake8 to be installed/managed via pre-commit. Took the opportunity to also bump to latest stable (all configparser version woes seem to be gone too) and refactor or ignore some new linting errors. Wasn't bad at all.