### PR TITLE
fix(app-platform): Fix 404 link to docs

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.jsx
@@ -120,7 +120,7 @@ class OrganizationDeveloperSettings extends AsyncView {
     return (
       <div>
         <SettingsPageHeader title={t('Developer Settings')} />
-        <AlertLink to="https://docs.sentry.io/workflow/integrations/integration-platform/">
+        <AlertLink href="https://docs.sentry.io/workflow/integrations/integration-platform/">
           {t(
             'Have questions about the Integration Platform? Learn more about it in our docs.'
           )}

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -124,62 +124,53 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
             </Wrapper>
           </SettingsPageHeading>
           <AlertLink
+            href="https://docs.sentry.io/workflow/integrations/integration-platform/"
             priority="warning"
-            to="https://docs.sentry.io/workflow/integrations/integration-platform/"
           >
             <StyledLink
+              href="https://docs.sentry.io/workflow/integrations/integration-platform/"
               priority="warning"
-              to="https://docs.sentry.io/workflow/integrations/integration-platform/"
             >
               <Link
                 className="css-1925ci1-StyledLink e1fthm6j0"
+                href="https://docs.sentry.io/workflow/integrations/integration-platform/"
                 priority="warning"
-                to="https://docs.sentry.io/workflow/integrations/integration-platform/"
               >
-                <Link
+                <a
                   className="css-1925ci1-StyledLink e1fthm6j0"
-                  onlyActiveOnIndex={false}
+                  href="https://docs.sentry.io/workflow/integrations/integration-platform/"
                   priority="warning"
-                  style={Object {}}
-                  to="https://docs.sentry.io/workflow/integrations/integration-platform/"
                 >
-                  <a
-                    className="css-1925ci1-StyledLink e1fthm6j0"
-                    onClick={[Function]}
-                    priority="warning"
-                    style={Object {}}
+                  <AlertLinkText>
+                    <div
+                      className="css-19z7wog-AlertLinkText e1fthm6j1"
+                    >
+                      Have questions about the Integration Platform? Learn more about it in our docs.
+                    </div>
+                  </AlertLinkText>
+                  <InlineSvg
+                    size="1em"
+                    src="icon-chevron-right"
                   >
-                    <AlertLinkText>
-                      <div
-                        className="css-19z7wog-AlertLinkText e1fthm6j1"
-                      >
-                        Have questions about the Integration Platform? Learn more about it in our docs.
-                      </div>
-                    </AlertLinkText>
-                    <InlineSvg
+                    <ForwardRef
+                      className="css-qmmkxg-InlineSvg enyz4ql0"
                       size="1em"
                       src="icon-chevron-right"
                     >
-                      <ForwardRef
+                      <svg
                         className="css-qmmkxg-InlineSvg enyz4ql0"
-                        size="1em"
-                        src="icon-chevron-right"
+                        height="1em"
+                        viewBox={Object {}}
+                        width="1em"
                       >
-                        <svg
-                          className="css-qmmkxg-InlineSvg enyz4ql0"
-                          height="1em"
-                          viewBox={Object {}}
-                          width="1em"
-                        >
-                          <use
-                            href="#test"
-                            xlinkHref="#test"
-                          />
-                        </svg>
-                      </ForwardRef>
-                    </InlineSvg>
-                  </a>
-                </Link>
+                        <use
+                          href="#test"
+                          xlinkHref="#test"
+                        />
+                      </svg>
+                    </ForwardRef>
+                  </InlineSvg>
+                </a>
               </Link>
             </StyledLink>
           </AlertLink>


### PR DESCRIPTION
Previously the link to the docs was broken, change the `to` prop on the link to `href` since it's an external link to the docs site 

Fixes https://getsentry.atlassian.net/browse/API-473