### PR TITLE
feat: Flip sampling defaults to false

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -881,7 +881,7 @@ SENTRY_FEATURES = {
     # Enable functionality for rate-limiting events on projects.
     "projects:rate-limits": True,
     # Enable functionality for sampling of events on projects.
-    "projects:sample-events": True,
+    "projects:sample-events": False,
     # Enable functionality to trigger service hooks upon event ingestion.
     "projects:servicehooks": False,
     # Use Kafka (instead of Celery) for ingestion pipeline.
@@ -934,7 +934,7 @@ SENTRY_CELERYBEAT_MONITORS = {
 }
 
 # Only store a portion of all messages per unique group.
-SENTRY_SAMPLE_DATA = True
+SENTRY_SAMPLE_DATA = False
 
 # The following values control the sampling rates
 SENTRY_SAMPLE_RATES = (

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -76,22 +76,23 @@ class EventManagerTest(TestCase):
 
     @mock.patch("sentry.event_manager.should_sample")
     def test_does_not_save_event_when_sampled(self, should_sample):
-        should_sample.return_value = True
-        event_id = "a" * 32
+        with self.feature("projects:sample-events"):
+            should_sample.return_value = True
+            event_id = "a" * 32
 
-        manager = EventManager(make_event(event_id=event_id))
-        manager.save(1)
+            manager = EventManager(make_event(event_id=event_id))
+            manager.save(1)
 
-        # This is a brand new event, so it is actually saved.
-        assert Event.objects.filter(event_id=event_id).exists()
+            # This is a brand new event, so it is actually saved.
+            assert Event.objects.filter(event_id=event_id).exists()
 
-        event_id = "b" * 32
+            event_id = "b" * 32
 
-        manager = EventManager(make_event(event_id=event_id))
-        manager.save(1)
+            manager = EventManager(make_event(event_id=event_id))
+            manager.save(1)
 
-        # This second is a dupe, so should be sampled
-        assert not Event.objects.filter(event_id=event_id).exists()
+            # This second is a dupe, so should be sampled
+            assert not Event.objects.filter(event_id=event_id).exists()
 
     def test_ephemral_interfaces_removed_on_save(self):
         manager = EventManager(make_event(platform="python"))


### PR DESCRIPTION
This only affects open source users as "projects:sample-events"
should already always be false for all SaaS users on sentry.io.

We should follow up by removing all of the associated sampling code.