### PR TITLE
ref(frontend): Mutate the org store items instance on add

### DIFF
--- a/src/sentry/static/sentry/app/stores/organizationsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationsStore.jsx
@@ -55,7 +55,7 @@ const OrganizationsStore = Reflux.createStore({
       }
     });
     if (!match) {
-      this.items.push(item);
+      this.items = [...this.items, item];
     }
     this.trigger(this.items);
   },


### PR DESCRIPTION
Components listening on add will not easily be able to compare the passed organization array without recreating the array instance.

This PR is primarily good hygiene and doesn't fix anything in particular.