### PR TITLE
fix(frontend): Allow withLatestContext to override null organization

### DIFF
--- a/src/sentry/static/sentry/app/utils/withLatestContext.tsx
+++ b/src/sentry/static/sentry/app/utils/withLatestContext.tsx
@@ -15,6 +15,7 @@ const withLatestContext = <P extends object>(WrappedComponent: React.ComponentTy
     createReactClass({
       displayName: `withLatestContext(${getDisplayName(WrappedComponent)})`,
       propTypes: {
+        organization: SentryTypes.Organization,
         organizations: PropTypes.arrayOf(SentryTypes.Organization),
       },
       mixins: [Reflux.connect(LatestContextStore, 'latestContext')],
@@ -46,10 +47,10 @@ const withLatestContext = <P extends object>(WrappedComponent: React.ComponentTy
         return (
           <WrappedComponent
             organizations={organizations as Organization[]}
-            organization={latestOrganization as Organization}
             project={project as Project}
             lastRoute={lastRoute as string}
             {...this.props as P}
+            organization={(this.props.organization || latestOrganization) as Organization}
           />
         );
       },


### PR DESCRIPTION
When using the `withLatestContext` HoC you may pass the organization prop to override the current organization object retrieved from the latest context store. However in some cases, the passed organization may be null (specifically when it is passed to the HoC wrapped sidebar from the OrganizationContext, which will *not* have the latest context).

This change allows the latest organization to be used when the overrided organization prop is falsy.

In the future we should attempt to simplify the LatestContext, OrganizationContext, and OrganizationStore.