### PR TITLE
ref(ui): Change accept org invite SSO text to "Join"

### DIFF
--- a/src/sentry/static/sentry/app/views/acceptOrganizationInvite.tsx
+++ b/src/sentry/static/sentry/app/views/acceptOrganizationInvite.tsx
@@ -112,7 +112,7 @@ class AcceptOrganizationInvite extends AsyncView<AsyncView['props'], State> {
               priority="primary"
               href={this.makeNextUrl(`/auth/login/${inviteDetails.orgSlug}/`)}
             >
-              {t('Login with %s', inviteDetails.ssoProvider)}
+              {t('Join with %s', inviteDetails.ssoProvider)}
             </Button>
           ) : (
             <Button


### PR DESCRIPTION
This makes it a bit more clear between the login link on the right labeled "Login with existing account"