### PR TITLE
fix(grouping): Properly trim MSVC anonymous namespaces

### DIFF
--- a/tests/sentry/grouping/grouping_inputs/native-windows-anon-namespace.json
+++ b/tests/sentry/grouping/grouping_inputs/native-windows-anon-namespace.json
@@ -1,0 +1,60 @@
+{
+  "event_id": "f79bf3f80cb444e0a2eda68ad7c95d93",
+  "platform": "native",
+  "fingerprint": [
+    "{{ default }}"
+  ],
+  "exception": {
+    "values": [
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "__scrt_common_main_seh",
+              "filename": "exe_common.inl",
+              "lineno": 288,
+              "in_app": false,
+              "instruction_addr": "0xeb2d91"
+            },
+            {
+              "function": "invoke_main",
+              "filename": "exe_common.inl",
+              "lineno": 78,
+              "in_app": false,
+              "instruction_addr": "0xeb2dac"
+            },
+            {
+              "function": "main",
+              "filename": "main.cpp",
+              "lineno": 35,
+              "in_app": false,
+              "instruction_addr": "0xeb2a4d"
+            },
+            {
+              "function": "`anonymous namespace'::start",
+              "filename": "main.cpp",
+              "in_app": false,
+              "instruction_addr": "0xeb2a4d",
+              "lineno": 28
+            },
+            {
+              "function": "?A0xc3a0617d::crash",
+              "filename": "main.cpp",
+              "in_app": false,
+              "instruction_addr": "0xeb2a4d",
+              "lineno": 24
+            }
+          ]
+        },
+        "type": "EXCEPTION_ACCESS_VIOLATION_WRITE",
+        "value": "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE",
+        "mechanism": {
+          "synthetic": true,
+          "type": "minidump",
+          "handled": false
+        },
+        "thread_id": 3804
+      }
+    ]
+  }
+}

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/native_windows_anon_namespace.pysnap
@@ -1,0 +1,72 @@
+---
+created: '2019-09-10T09:51:01.536615Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: None
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            filename*
+              u'exe_common.inl'
+            function*
+              u'__scrt_common_main_seh'
+          frame (non app frame)
+            filename*
+              u'exe_common.inl'
+            function*
+              u'invoke_main'
+          frame (non app frame)
+            filename*
+              u'main.cpp'
+            function*
+              u'main'
+          frame (non app frame)
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::start"
+          frame (non app frame)
+            filename*
+              u'main.cpp'
+            function*
+              u'?A0xc3a0617d::crash'
+        type (ignored because exception is synthetic)
+          u'EXCEPTION_ACCESS_VIOLATION_WRITE'
+--------------------------------------------------------------------------
+system:
+  hash: '6fc07910e6c6a6d4051f823aed855991'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              u'exe_common.inl'
+            function*
+              u'__scrt_common_main_seh'
+          frame*
+            filename*
+              u'exe_common.inl'
+            function*
+              u'invoke_main'
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u'main'
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::start"
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u'?A0xc3a0617d::crash'
+        type (ignored because exception is synthetic)
+          u'EXCEPTION_ACCESS_VIOLATION_WRITE'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_windows_anon_namespace.pysnap
@@ -1,0 +1,96 @@
+---
+created: '2019-09-10T09:51:02.717347Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: None
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame* (frame considered in-app because no frame is in-app)
+            filename*
+              u'exe_common.inl'
+            function*
+              u'__scrt_common_main_seh'
+            lineno (function takes precedence)
+              288
+          frame* (frame considered in-app because no frame is in-app)
+            filename*
+              u'exe_common.inl'
+            function*
+              u'invoke_main'
+            lineno (function takes precedence)
+              78
+          frame* (frame considered in-app because no frame is in-app)
+            filename*
+              u'main.cpp'
+            function*
+              u'main'
+            lineno (function takes precedence)
+              35
+          frame* (frame considered in-app because no frame is in-app)
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::start"
+            lineno (function takes precedence)
+              28
+          frame* (frame considered in-app because no frame is in-app)
+            filename*
+              u'main.cpp'
+            function*
+              u'?A0xc3a0617d::crash'
+            lineno (function takes precedence)
+              24
+        type*
+          u'EXCEPTION_ACCESS_VIOLATION_WRITE'
+        value (stacktrace and type take precedence)
+          u'Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE'
+--------------------------------------------------------------------------
+system:
+  hash: 'f133068802b8a7f6162e0c7d8fc6b984'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              u'exe_common.inl'
+            function*
+              u'__scrt_common_main_seh'
+            lineno (function takes precedence)
+              288
+          frame*
+            filename*
+              u'exe_common.inl'
+            function*
+              u'invoke_main'
+            lineno (function takes precedence)
+              78
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u'main'
+            lineno (function takes precedence)
+              35
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::start"
+            lineno (function takes precedence)
+              28
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u'?A0xc3a0617d::crash'
+            lineno (function takes precedence)
+              24
+        type*
+          u'EXCEPTION_ACCESS_VIOLATION_WRITE'
+        value (stacktrace and type take precedence)
+          u'Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_windows_anon_namespace.pysnap
@@ -1,0 +1,72 @@
+---
+created: '2019-09-10T09:51:03.965040Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: None
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            filename*
+              u'exe_common.inl'
+            function*
+              u'__scrt_common_main_seh'
+          frame (non app frame)
+            filename*
+              u'exe_common.inl'
+            function*
+              u'invoke_main'
+          frame (non app frame)
+            filename*
+              u'main.cpp'
+            function*
+              u'main'
+          frame (non app frame)
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::start"
+          frame (non app frame)
+            filename*
+              u'main.cpp'
+            function*
+              u'?A0xc3a0617d::crash'
+        type (ignored because exception is synthetic)
+          u'EXCEPTION_ACCESS_VIOLATION_WRITE'
+--------------------------------------------------------------------------
+system:
+  hash: '6fc07910e6c6a6d4051f823aed855991'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              u'exe_common.inl'
+            function*
+              u'__scrt_common_main_seh'
+          frame*
+            filename*
+              u'exe_common.inl'
+            function*
+              u'invoke_main'
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u'main'
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::start"
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u'?A0xc3a0617d::crash'
+        type (ignored because exception is synthetic)
+          u'EXCEPTION_ACCESS_VIOLATION_WRITE'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/native_windows_anon_namespace.pysnap
@@ -1,0 +1,76 @@
+---
+created: '2019-09-10T09:49:13.787660Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: None
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            filename*
+              u'exe_common.inl'
+            function*
+              u'__scrt_common_main_seh'
+          frame (non app frame)
+            filename*
+              u'exe_common.inl'
+            function*
+              u'invoke_main'
+          frame (non app frame)
+            filename*
+              u'main.cpp'
+            function*
+              u'main'
+          frame (non app frame)
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::start"
+          frame (non app frame)
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::crash"
+        type (ignored because exception is synthetic)
+          u'EXCEPTION_ACCESS_VIOLATION_WRITE'
+        value*
+          u'Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE'
+--------------------------------------------------------------------------
+system:
+  hash: '15d397771f229af8dc42783542f81dd4'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              u'exe_common.inl'
+            function*
+              u'__scrt_common_main_seh'
+          frame*
+            filename*
+              u'exe_common.inl'
+            function*
+              u'invoke_main'
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u'main'
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::start"
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::crash"
+        type (ignored because exception is synthetic)
+          u'EXCEPTION_ACCESS_VIOLATION_WRITE'
+        value (ignored because stacktrace takes precedence)
+          u'Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_windows_anon_namespace.pysnap
@@ -1,0 +1,76 @@
+---
+created: '2019-09-10T09:49:14.992868Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: None
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            filename*
+              u'exe_common.inl'
+            function*
+              u'__scrt_common_main_seh'
+          frame (non app frame)
+            filename*
+              u'exe_common.inl'
+            function*
+              u'invoke_main'
+          frame (non app frame)
+            filename*
+              u'main.cpp'
+            function*
+              u'main'
+          frame (non app frame)
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::start"
+          frame (non app frame)
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::crash"
+        type (ignored because exception is synthetic)
+          u'EXCEPTION_ACCESS_VIOLATION_WRITE'
+        value*
+          u'Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE'
+--------------------------------------------------------------------------
+system:
+  hash: '15d397771f229af8dc42783542f81dd4'
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              u'exe_common.inl'
+            function*
+              u'__scrt_common_main_seh'
+          frame*
+            filename*
+              u'exe_common.inl'
+            function*
+              u'invoke_main'
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u'main'
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::start"
+          frame*
+            filename*
+              u'main.cpp'
+            function*
+              u"`anonymous namespace'::crash"
+        type (ignored because exception is synthetic)
+          u'EXCEPTION_ACCESS_VIOLATION_WRITE'
+        value (ignored because stacktrace takes precedence)
+          u'Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE'


### PR DESCRIPTION
This fixes two upcoming issues with grouping of anonymous namespaces on Windows:

1. Previously, we were always demangling with `msvc-demangler`. This always generated a return value, which was stripped by the function trimming logic. Symbolic is now switching over to demangled names which do not contain a return value, which causes the trimming logic incorrectly detects ``` `anonymous namespace' ``` as a return value:

<img width="579" alt="Screenshot 2019-09-10 at 11 20 54" src="https://user-images.githubusercontent.com/1433023/64604390-5aae4f80-d3c2-11e9-857c-eb1507378e6f.png">

This is now fixed by replacing this with a uniquode sequence in **all grouping versions**. Since this is a change that affects all customers, they would otherwise be broken for everyone who does not (or cannot) upgrade.

2. In PDB inline frames, anonymous namespaces are serialized as `?A0xdeadbeef`. This is ugly to read, and inconsistent with regular functions. Since inline frames are a new feature but we should avoid false positives, these identifiers are only normalized for newstyle grouping that also processes lambda functions. This results in:

<img width="647" alt="Screenshot 2019-09-10 at 11 56 11" src="https://user-images.githubusercontent.com/1433023/64604798-13748e80-d3c3-11e9-9670-e11f2fdcf5a4.png">
