### PR TITLE
fix: Fix broken acceptance tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,9 +107,15 @@ base_acceptance: &acceptance_default
     - ./bin/yarn install --pure-lockfile
     - python setup.py install_egg_info
     - pip install -U -e ".[dev,tests,optional]"
+    - dpkg -s google-chrome-stable
+#    - |
+#      CHROME_MAJOR_VERSION="$(dpkg -s google-chrome-stable | sed -nr 's/Version: ([0-9]+).*/\1/p')"
+#    - echo $CHROME_MAJOR_VERSION
+    - CHROME_MAJOR_VERSION=76
     - |
-      CHROME_MAJOR_VERSION="$(dpkg -s google-chrome-stable | sed -nr 's/Version: ([0-9]+).*/\1/p')"
-      wget -N "https://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION})/chromedriver_linux64.zip" -P ~/
+      CHROME_CURRENT_VERSION="$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION})"
+    - echo $CHROME_CURRENT_VERSION
+    - wget -N "https://chromedriver.storage.googleapis.com/${CHROME_CURRENT_VERSION}/chromedriver_linux64.zip" -P ~/
     - unzip ~/chromedriver_linux64.zip -d ~/
     - rm ~/chromedriver_linux64.zip
     - sudo install -m755 ~/chromedriver /usr/local/bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,15 +107,9 @@ base_acceptance: &acceptance_default
     - ./bin/yarn install --pure-lockfile
     - python setup.py install_egg_info
     - pip install -U -e ".[dev,tests,optional]"
-    - dpkg -s google-chrome-stable
-#    - |
-#      CHROME_MAJOR_VERSION="$(dpkg -s google-chrome-stable | sed -nr 's/Version: ([0-9]+).*/\1/p')"
-#    - echo $CHROME_MAJOR_VERSION
-    - CHROME_MAJOR_VERSION=76
     - |
-      CHROME_CURRENT_VERSION="$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION})"
-    - echo $CHROME_CURRENT_VERSION
-    - wget -N "https://chromedriver.storage.googleapis.com/${CHROME_CURRENT_VERSION}/chromedriver_linux64.zip" -P ~/
+      CHROME_MAJOR_VERSION="$(dpkg -s google-chrome-stable | sed -nr 's/Version: ([0-9]+).*/\1/p')"
+      wget -N "https://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION})/chromedriver_linux64.zip" -P ~/
     - unzip ~/chromedriver_linux64.zip -d ~/
     - rm ~/chromedriver_linux64.zip
     - sudo install -m755 ~/chromedriver /usr/local/bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,9 +107,6 @@ base_acceptance: &acceptance_default
     - ./bin/yarn install --pure-lockfile
     - python setup.py install_egg_info
     - pip install -U -e ".[dev,tests,optional]"
-#    - |
-#      CHROME_MAJOR_VERSION="$(dpkg -s google-chrome-stable | sed -nr 's/Version: ([0-9]+).*/\1/p')"
-#      wget -N "https://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION})/chromedriver_linux64.zip" -P ~/
     - wget -N "https://chromedriver.storage.googleapis.com/2.33/chromedriver_linux64.zip" -P ~/
     - unzip ~/chromedriver_linux64.zip -d ~/
     - rm ~/chromedriver_linux64.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,9 +107,10 @@ base_acceptance: &acceptance_default
     - ./bin/yarn install --pure-lockfile
     - python setup.py install_egg_info
     - pip install -U -e ".[dev,tests,optional]"
-    - |
-      CHROME_MAJOR_VERSION="$(dpkg -s google-chrome-stable | sed -nr 's/Version: ([0-9]+).*/\1/p')"
-      wget -N "https://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION})/chromedriver_linux64.zip" -P ~/
+#    - |
+#      CHROME_MAJOR_VERSION="$(dpkg -s google-chrome-stable | sed -nr 's/Version: ([0-9]+).*/\1/p')"
+#      wget -N "https://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION})/chromedriver_linux64.zip" -P ~/
+    - wget -N "https://chromedriver.storage.googleapis.com/2.33/chromedriver_linux64.zip" -P ~/
     - unzip ~/chromedriver_linux64.zip -d ~/
     - rm ~/chromedriver_linux64.zip
     - sudo install -m755 ~/chromedriver /usr/local/bin/


### PR DESCRIPTION
Chromedriver looks like it no longer stores the the actual file under `LATEST_RELEASE_<version>`,
but just returns the specific version number from that url. We can use that specific version number
to retrieve the file though, so doing that instead.