### PR TITLE
ci(travis): bump to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-dist: trusty
-group: deprecated-2017Q4
+dist: xenial
 language: python
 python: 2.7
 

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -306,6 +306,10 @@ def browser(request, percy, live_server):
     headless = not request.config.getoption("no_headless")
     if driver_type == "chrome":
         options = webdriver.ChromeOptions()
+        # TODO: Temporarily adding this to work around chromedriver issues. We should
+        # remove this once a new version of chromedriver is released and we test that
+        # acceptance tests work ok.
+        options.add_experimental_option("w3c", False)
         options.add_argument("no-sandbox")
         options.add_argument("disable-gpu")
         options.add_argument(u"window-size={}".format(window_size))


### PR DESCRIPTION
Bumps travis to use Xenial.

Also, appears to have solved https://github.com/getsentry/sentry/pull/14653 as in the Xenial boxes have the recent chrome installed correctly.