### PR TITLE
ref(sso): Handle invite acceptance during SSO

### DIFF
--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -18,7 +18,7 @@ class AcceptOrganizationInvite(Endpoint):
         return Response(status=status.HTTP_400_BAD_REQUEST, data={"details": "Invalid invite code"})
 
     def get_helper(self, request, member_id, token):
-        return ApiInviteHelper(instance=self, request=request, member_id=member_id, token=token)
+        return ApiInviteHelper(request=request, member_id=member_id, instance=self, token=token)
 
     def get(self, request, member_id, token):
         try:
@@ -55,9 +55,16 @@ class AcceptOrganizationInvite(Endpoint):
 
         # Allow users to register an account when accepting an invite
         if not helper.user_authenticated:
-            url = reverse("sentry-accept-invite", args=[member_id, token])
-            auth.initiate_login(self.request, next_url=url)
             request.session["can_register"] = True
+
+            # When SSO is required do *not* set a next_url to return to accept
+            # invite. The invite will be accepted after SSO is completed.
+            url = (
+                reverse("sentry-accept-invite", args=[member_id, token])
+                if not auth_provider
+                else "/"
+            )
+            auth.initiate_login(self.request, next_url=url)
 
         # If the org has SSO setup, we'll store the invite cookie to later
         # associate the org member after authentication. We can avoid needing

--- a/src/sentry/utils/audit.py
+++ b/src/sentry/utils/audit.py
@@ -13,7 +13,7 @@ from sentry.models import (
 
 
 def create_audit_entry(request, transaction_id=None, logger=None, **kwargs):
-    user = request.user if request.user.is_authenticated() else None
+    user = kwargs.pop("actor", request.user if request.user.is_authenticated() else None)
     api_key = (
         request.auth if hasattr(request, "auth") and isinstance(request.auth, ApiKey) else None
     )

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -1,35 +1,68 @@
 from __future__ import absolute_import
 
-import mock
+from six.moves.urllib.parse import urlencode
+from django.test import RequestFactory
+from django.contrib.auth.models import AnonymousUser
 
 from sentry.models import AuthProvider, OrganizationMember
 from sentry.testutils import TestCase
 from sentry.auth.helper import handle_new_user
 
 
-class HandleNewuserTest(TestCase):
-    @mock.patch("sentry.auth.helper.handle_new_membership")
-    def test_simple(self, mock_handle_new_membership):
-        provider = AuthProvider.objects.create(organization=self.organization, provider="dummy")
+class HandleNewUserTest(TestCase):
+    def test_simple(self):
+        request = RequestFactory().post("/auth/sso/")
+        request.user = AnonymousUser()
 
+        provider = AuthProvider.objects.create(organization=self.organization, provider="dummy")
         identity = {"id": "1234", "email": "test@example.com", "name": "Morty"}
 
-        auth_identity = handle_new_user(provider, self.organization, None, identity)
+        auth_identity = handle_new_user(provider, self.organization, request, identity)
 
-        assert mock_handle_new_membership.called
         assert auth_identity.user.email == identity["email"]
-
-    @mock.patch("sentry.auth.helper.handle_new_membership")
-    def test_associated_member_invite(self, mock_handle_new_membership):
-        provider = AuthProvider.objects.create(organization=self.organization, provider="dummy")
-
-        identity = {"id": "1234", "email": "test@example.com", "name": "Morty"}
-
-        OrganizationMember.objects.create(organization=self.organization, email=identity["email"])
-
-        auth_identity = handle_new_user(provider, self.organization, None, identity)
-
-        assert not mock_handle_new_membership.called
         assert OrganizationMember.objects.filter(
             organization=self.organization, user=auth_identity.user
         ).exists()
+
+    def test_associated_existing_member_invite_by_email(self):
+        request = RequestFactory().post("/auth/sso/")
+        request.user = AnonymousUser()
+
+        provider = AuthProvider.objects.create(organization=self.organization, provider="dummy")
+        identity = {"id": "1234", "email": "test@example.com", "name": "Morty"}
+
+        member = OrganizationMember.objects.create(
+            organization=self.organization, email=identity["email"]
+        )
+
+        auth_identity = handle_new_user(provider, self.organization, request, identity)
+
+        assigned_member = OrganizationMember.objects.get(
+            organization=self.organization, user=auth_identity.user
+        )
+
+        assert assigned_member.id == member.id
+
+    def test_associate_pending_invite(self):
+        provider = AuthProvider.objects.create(organization=self.organization, provider="dummy")
+        identity = {"id": "1234", "email": "test@example.com", "name": "Morty"}
+
+        # The org member invite should have a non matching email, but the
+        # member id and token will match from the cookie, allowing association
+        member = OrganizationMember.objects.create(
+            organization=self.organization, email="different.email@example.com", token="abc"
+        )
+
+        request = RequestFactory().post("/auth/sso/")
+        request.user = AnonymousUser()
+        request.COOKIES["pending-invite"] = urlencode(
+            {"memberId": member.id, "token": member.token, "url": ""}
+        )
+
+        auth_identity = handle_new_user(provider, self.organization, request, identity)
+
+        assigned_member = OrganizationMember.objects.get(
+            organization=self.organization, user=auth_identity.user
+        )
+
+        assert assigned_member.id == member.id


### PR DESCRIPTION
* SSO will now accept pending invites while going through the accept invite flow
 * Pending invites are now looked up using the InviteHelper
 * After SSO acceptance it will *not* redirect back to the accept invite page

Refs: [GROW-459](https://getsentry.atlassian.net/browse/GROW-459)