### PR TITLE
feat(api): Change alert rule creation to be at the org level(SEN-989)

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -12,7 +12,8 @@ class AlertRuleSerializer(Serializer):
         return {
             "id": six.text_type(obj.id),
             "name": obj.name,
-            "projectId": six.text_type(obj.project_id),
+            # TODO: Remove this once we've migrated to org level
+            "projectId": six.text_type(obj.query_subscriptions.first().project_id),
             "status": obj.status,
             "thresholdType": obj.threshold_type,
             "dataset": obj.dataset,

--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -25,7 +25,7 @@ class OrganizationDeletionTask(ModelDeletionTask):
             ExternalIssue,
             PromptsActivity,
         )
-        from sentry.incidents.models import Incident
+        from sentry.incidents.models import AlertRule, Incident
         from sentry.discover.models import DiscoverSavedQuery
 
         # Team must come first
@@ -51,6 +51,7 @@ class OrganizationDeletionTask(ModelDeletionTask):
             ExternalIssue,
             PromptsActivity,
             Incident,
+            AlertRule,
         )
         relations.extend([ModelRelation(m, {"organization_id": instance.id}) for m in model_list])
 

--- a/src/sentry/deletions/defaults/project.py
+++ b/src/sentry/deletions/defaults/project.py
@@ -6,8 +6,9 @@ from ..base import BulkModelDeletionTask, ModelDeletionTask, ModelRelation
 class ProjectDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
         from sentry import models
-        from sentry.incidents.models import IncidentProject, AlertRule
         from sentry.discover.models import DiscoverSavedQueryProject
+        from sentry.incidents.models import IncidentProject
+        from sentry.snuba.models import QuerySubscription
 
         relations = [
             # ProjectKey gets revoked immediately, in bulk
@@ -39,7 +40,7 @@ class ProjectDeletionTask(ModelDeletionTask):
             models.UserReport,
             DiscoverSavedQueryProject,
             IncidentProject,
-            AlertRule,
+            QuerySubscription,
         )
 
         relations.extend(

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -20,7 +20,9 @@ class ProjectAlertRuleEndpoint(ProjectEndpoint):
             raise PermissionDenied
 
         try:
-            kwargs["alert_rule"] = AlertRule.objects.get(project=project, id=alert_rule_id)
+            kwargs["alert_rule"] = AlertRule.objects.get(
+                query_subscriptions__project=project, id=alert_rule_id
+            )
         except AlertRule.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -22,7 +22,10 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
 
     def put(self, request, project, alert_rule):
         serializer = DrfAlertRuleSerializer(
-            context={"project": project}, instance=alert_rule, data=request.data, partial=True
+            context={"organization": project.organization, "project": project},
+            instance=alert_rule,
+            data=request.data,
+            partial=True,
         )
 
         if serializer.is_valid():

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -36,7 +36,9 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
         if not features.has("organizations:incidents", project.organization, actor=request.user):
             raise ResourceDoesNotExist
 
-        serializer = AlertRuleSerializer(context={"project": project}, data=request.data)
+        serializer = AlertRuleSerializer(
+            context={"organization": project.organization, "project": project}, data=request.data
+        )
 
         if serializer.is_valid():
             alert_rule = serializer.save()

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -84,7 +84,11 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             if "aggregation" not in validated_data:
                 raise serializers.ValidationError("aggregation is required")
 
-            return create_alert_rule(project=self.context["project"], **validated_data)
+            return create_alert_rule(
+                organization=self.context["organization"],
+                projects=[self.context["project"]],
+                **validated_data
+            )
         except AlertRuleNameAlreadyUsedError:
             raise serializers.ValidationError("This name is already in use for this project")
 
@@ -93,8 +97,6 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             # Remove any fields that haven't actually changed
             if isinstance(value, Enum):
                 value = value.value
-            elif field_name == "aggregations":
-                value = [item.value for item in value]
             if getattr(instance, field_name) == value:
                 validated_data.pop(field_name)
         return validated_data

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -251,7 +251,7 @@ class AlertRuleManager(BaseManager):
         )
 
     def fetch_for_project(self, project):
-        return self.filter(project=project)
+        return self.filter(query_subscriptions__project=project)
 
 
 class AlertRuleQuerySubscription(Model):
@@ -291,12 +291,6 @@ class AlertRule(Model):
     threshold_period = models.IntegerField()
     date_modified = models.DateTimeField(default=timezone.now)
     date_added = models.DateTimeField(default=timezone.now)
-    # These will be removed after we've made these columns nullable. Moving to
-    # QuerySubscription
-    subscription_id = models.UUIDField(db_index=True, null=True)
-    aggregations = ArrayField(of=models.IntegerField)
-    query_subscription = FlexibleForeignKey("sentry.QuerySubscription", unique=True, null=True)
-    project = FlexibleForeignKey("sentry.Project", db_index=False, db_constraint=False, null=True)
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -44,7 +44,7 @@ class SubscriptionProcessor(object):
     def __init__(self, subscription):
         self.subscription = subscription
         try:
-            self.alert_rule = AlertRule.objects.get(query_subscription=subscription)
+            self.alert_rule = AlertRule.objects.get(query_subscriptions=subscription)
         except AlertRule.DoesNotExist:
             return
 
@@ -137,7 +137,7 @@ class SubscriptionProcessor(object):
         if self.alert_triggers >= self.alert_rule.threshold_period:
             detected_at = to_datetime(self.last_update)
             self.active_incident = create_incident(
-                self.alert_rule.project.organization,
+                self.alert_rule.organization,
                 IncidentType.ALERT_TRIGGERED,
                 # TODO: Include more info in name?
                 self.alert_rule.name,
@@ -146,7 +146,7 @@ class SubscriptionProcessor(object):
                 query=self.subscription.query,
                 date_started=detected_at,
                 date_detected=detected_at,
-                projects=[self.alert_rule.project],
+                projects=[self.subscription.project],
             )
             # TODO: We should create an audit log, and maybe something that keeps
             # all of the details available for showing on the incident. Might be a json

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -5,7 +5,7 @@ from enum import Enum
 from django.db import models
 from django.utils import timezone
 
-from sentry.db.models import ArrayField, FlexibleForeignKey, Model
+from sentry.db.models import FlexibleForeignKey, Model
 
 
 class QueryAggregations(Enum):
@@ -27,7 +27,6 @@ class QuerySubscription(Model):
     query = models.TextField()
     # TODO: Remove this default after we migrate
     aggregation = models.IntegerField(default=0)
-    aggregations = ArrayField(of=models.IntegerField, null=True)
     time_window = models.IntegerField()
     resolution = models.IntegerField()
     date_added = models.DateTimeField(default=timezone.now)

--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -14,6 +14,34 @@ query_aggregation_to_snuba = {
 }
 
 
+def bulk_create_snuba_subscriptions(
+    projects, subscription_type, dataset, query, aggregation, time_window, resolution
+):
+    """
+    Creates a subscription to a snuba query.
+
+    :param projects: The projects we're applying the query to
+    :param subscription_type: Text identifier for the subscription type this is. Used
+    to identify the registered callback associated with this subscription.
+    :param dataset: The snuba dataset to query and aggregate over
+    :param query: An event search query that we can parse and convert into a
+    set of Snuba conditions
+    :param aggregation: An aggregation to calculate over the time window
+    :param time_window: The time window to aggregate over
+    :param resolution: How often to receive updates/bucket size
+    :return: A list of QuerySubscriptions
+    """
+    subscriptions = []
+    # TODO: Batch this up properly once we move to tasks.
+    for project in projects:
+        subscriptions.append(
+            create_snuba_subscription(
+                project, subscription_type, dataset, query, aggregation, time_window, resolution
+            )
+        )
+    return subscriptions
+
+
 def create_snuba_subscription(
     project, subscription_type, dataset, query, aggregation, time_window, resolution
 ):

--- a/src/sentry/south_migrations/0503_alert_rules_empty_drop_cols.py
+++ b/src/sentry/south_migrations/0503_alert_rules_empty_drop_cols.py
@@ -1,0 +1,5182 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    # Flag to indicate if this migration is too risky
+    # to run online and needs to be coordinated for offline
+    is_dangerous = False
+
+    def forwards(self, orm):
+        # Empty migration to fix the state after we remove columns from AlertRules and
+        # QuerySubscription. We need to remove the fields from Django first, and then
+        # the db, so we'll need a separate migration afterwards to actually drop the
+        # columns from Postgres.
+        pass
+
+    def backwards(self, orm):
+        pass
+
+    models = {
+        "sentry.activity": {
+            "Meta": {"unique_together": "()", "object_name": "Activity", "index_together": "()"},
+            "data": ("sentry.db.models.fields.gzippeddict.GzippedDictField", [], {"null": "True"}),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "type": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "null": "True"},
+            ),
+        },
+        "sentry.alertrule": {
+            "Meta": {
+                "unique_together": "(('organization', 'name'),)",
+                "object_name": "AlertRule",
+                "index_together": "()",
+            },
+            "aggregation": ("django.db.models.fields.IntegerField", [], {"default": "0"}),
+            "alert_threshold": ("django.db.models.fields.IntegerField", [], {}),
+            "dataset": ("django.db.models.fields.TextField", [], {}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_modified": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.TextField", [], {}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']", "null": "True", "db_index": "False"},
+            ),
+            "query": ("django.db.models.fields.TextField", [], {}),
+            "query_subscriptions": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'query_subscriptions'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.AlertRuleQuerySubscription']",
+                    "to": "orm['sentry.QuerySubscription']",
+                },
+            ),
+            "resolution": ("django.db.models.fields.IntegerField", [], {}),
+            "resolve_threshold": ("django.db.models.fields.IntegerField", [], {}),
+            "status": ("django.db.models.fields.SmallIntegerField", [], {"default": "0"}),
+            "threshold_period": ("django.db.models.fields.IntegerField", [], {}),
+            "threshold_type": ("django.db.models.fields.SmallIntegerField", [], {}),
+            "time_window": ("django.db.models.fields.IntegerField", [], {}),
+        },
+        "sentry.alertrulequerysubscription": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "AlertRuleQuerySubscription",
+                "index_together": "()",
+            },
+            "alert_rule": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.AlertRule']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "query_subscription": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.QuerySubscription']", "unique": "True"},
+            ),
+        },
+        "sentry.apiapplication": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "ApiApplication",
+                "index_together": "()",
+            },
+            "allowed_origins": (
+                "django.db.models.fields.TextField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "client_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {
+                    "default": "'ef21e417748a4753ac423110d11682645ec754857ef740d883c9646279c1a074'",
+                    "unique": "True",
+                    "max_length": "64",
+                },
+            ),
+            "client_secret": (
+                "sentry.db.models.fields.encrypted.EncryptedTextField",
+                [],
+                {"default": "'2c61b84102b2415c91a49e59e25591f51865f641d3de40ab88136068cae3f9d1'"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "homepage_url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "'Promoted Glowworm'", "max_length": "64", "blank": "True"},
+            ),
+            "owner": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+            "privacy_url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True"},
+            ),
+            "redirect_uris": ("django.db.models.fields.TextField", [], {}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "terms_url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True"},
+            ),
+        },
+        "sentry.apiauthorization": {
+            "Meta": {
+                "unique_together": "(('user', 'application'),)",
+                "object_name": "ApiAuthorization",
+                "index_together": "()",
+            },
+            "application": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ApiApplication']", "null": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "scope_list": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "scopes": ("django.db.models.fields.BigIntegerField", [], {"default": "None"}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.apigrant": {
+            "Meta": {"unique_together": "()", "object_name": "ApiGrant", "index_together": "()"},
+            "application": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ApiApplication']"},
+            ),
+            "code": (
+                "django.db.models.fields.CharField",
+                [],
+                {
+                    "default": "'61cb7f41c89f448880a80dce1667b243'",
+                    "max_length": "64",
+                    "db_index": "True",
+                },
+            ),
+            "expires_at": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime(2019, 9, 11, 0, 0)", "db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "redirect_uri": ("django.db.models.fields.CharField", [], {"max_length": "255"}),
+            "scope_list": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "scopes": ("django.db.models.fields.BigIntegerField", [], {"default": "None"}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.apikey": {
+            "Meta": {"unique_together": "()", "object_name": "ApiKey", "index_together": "()"},
+            "allowed_origins": (
+                "django.db.models.fields.TextField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "32"},
+            ),
+            "label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "'Default'", "max_length": "64", "blank": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'key_set'", "to": "orm['sentry.Organization']"},
+            ),
+            "scope_list": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "scopes": ("django.db.models.fields.BigIntegerField", [], {"default": "None"}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+        },
+        "sentry.apitoken": {
+            "Meta": {"unique_together": "()", "object_name": "ApiToken", "index_together": "()"},
+            "application": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ApiApplication']", "null": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "expires_at": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime(2019, 10, 11, 0, 0)", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "refresh_token": (
+                "django.db.models.fields.CharField",
+                [],
+                {
+                    "default": "'71487e8785df4efa93d5a867453388264657d1b87f864c5686cc19d9ad097ce8'",
+                    "max_length": "64",
+                    "unique": "True",
+                    "null": "True",
+                },
+            ),
+            "scope_list": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "scopes": ("django.db.models.fields.BigIntegerField", [], {"default": "None"}),
+            "token": (
+                "django.db.models.fields.CharField",
+                [],
+                {
+                    "default": "'b062f91c8f1d488f928a69b7fa31cf390938b09b83cb47ae8b6a3f9ad33f6fe3'",
+                    "unique": "True",
+                    "max_length": "64",
+                },
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.assistantactivity": {
+            "Meta": {
+                "unique_together": "(('user', 'guide_id'),)",
+                "object_name": "AssistantActivity",
+                "db_table": "'sentry_assistant_activity'",
+                "index_together": "()",
+            },
+            "dismissed_ts": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "guide_id": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "useful": (
+                "django.db.models.fields.NullBooleanField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+            "viewed_ts": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+        },
+        "sentry.auditlogentry": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "AuditLogEntry",
+                "index_together": "()",
+            },
+            "actor": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "blank": "True",
+                    "related_name": "u'audit_actors'",
+                    "null": "True",
+                    "to": "orm['sentry.User']",
+                },
+            ),
+            "actor_key": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ApiKey']", "null": "True", "blank": "True"},
+            ),
+            "actor_label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True", "blank": "True"},
+            ),
+            "data": ("sentry.db.models.fields.gzippeddict.GzippedDictField", [], {}),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "event": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ip_address": (
+                "django.db.models.fields.GenericIPAddressField",
+                [],
+                {"max_length": "39", "null": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "target_object": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "target_user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "blank": "True",
+                    "related_name": "u'audit_targets'",
+                    "null": "True",
+                    "to": "orm['sentry.User']",
+                },
+            ),
+        },
+        "sentry.authenticator": {
+            "Meta": {
+                "unique_together": "(('user', 'type'),)",
+                "object_name": "Authenticator",
+                "db_table": "'auth_authenticator'",
+                "index_together": "()",
+            },
+            "config": ("sentry.db.models.fields.encrypted.EncryptedPickledObjectField", [], {}),
+            "created_at": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": ("sentry.db.models.fields.bounded.BoundedAutoField", [], {"primary_key": "True"}),
+            "last_used_at": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "type": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.authidentity": {
+            "Meta": {
+                "unique_together": "(('auth_provider', 'ident'), ('auth_provider', 'user'))",
+                "object_name": "AuthIdentity",
+                "index_together": "()",
+            },
+            "auth_provider": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.AuthProvider']"},
+            ),
+            "data": ("sentry.db.models.fields.encrypted.EncryptedJsonField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "last_synced": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "last_verified": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.authprovider": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "AuthProvider",
+                "index_together": "()",
+            },
+            "config": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "default_global_access": (
+                "django.db.models.fields.BooleanField",
+                [],
+                {"default": "True"},
+            ),
+            "default_role": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "50"},
+            ),
+            "default_teams": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {"to": "orm['sentry.Team']", "symmetrical": "False", "blank": "True"},
+            ),
+            "flags": ("django.db.models.fields.BigIntegerField", [], {"default": "0"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_sync": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']", "unique": "True"},
+            ),
+            "provider": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "sync_time": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+        },
+        "sentry.broadcast": {
+            "Meta": {"unique_together": "()", "object_name": "Broadcast", "index_together": "()"},
+            "cta": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "256", "null": "True", "blank": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_expires": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {
+                    "default": "datetime.datetime(2019, 9, 18, 0, 0)",
+                    "null": "True",
+                    "blank": "True",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_active": (
+                "django.db.models.fields.BooleanField",
+                [],
+                {"default": "True", "db_index": "True"},
+            ),
+            "link": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True", "blank": "True"},
+            ),
+            "message": ("django.db.models.fields.CharField", [], {"max_length": "256"}),
+            "title": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "upstream_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True", "blank": "True"},
+            ),
+        },
+        "sentry.broadcastseen": {
+            "Meta": {
+                "unique_together": "(('broadcast', 'user'),)",
+                "object_name": "BroadcastSeen",
+                "index_together": "()",
+            },
+            "broadcast": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Broadcast']"},
+            ),
+            "date_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.commit": {
+            "Meta": {
+                "unique_together": "(('repository_id', 'key'),)",
+                "object_name": "Commit",
+                "index_together": "(('repository_id', 'date_added'),)",
+            },
+            "author": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.CommitAuthor']", "null": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "message": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "repository_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {},
+            ),
+        },
+        "sentry.commitauthor": {
+            "Meta": {
+                "unique_together": "(('organization_id', 'email'), ('organization_id', 'external_id'))",
+                "object_name": "CommitAuthor",
+                "index_together": "()",
+            },
+            "email": ("django.db.models.fields.EmailField", [], {"max_length": "75"}),
+            "external_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "164", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "128", "null": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+        },
+        "sentry.commitfilechange": {
+            "Meta": {
+                "unique_together": "(('commit', 'filename'),)",
+                "object_name": "CommitFileChange",
+                "index_together": "()",
+            },
+            "commit": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Commit']"},
+            ),
+            "filename": ("django.db.models.fields.CharField", [], {"max_length": "255"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "type": ("django.db.models.fields.CharField", [], {"max_length": "1"}),
+        },
+        "sentry.counter": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "Counter",
+                "db_table": "'sentry_projectcounter'",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "unique": "True"},
+            ),
+            "value": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.dashboard": {
+            "Meta": {
+                "unique_together": "(('organization', 'title'),)",
+                "object_name": "Dashboard",
+                "index_together": "()",
+            },
+            "created_by": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "title": ("django.db.models.fields.CharField", [], {"max_length": "255"}),
+        },
+        "sentry.deletedorganization": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "DeletedOrganization",
+                "index_together": "()",
+            },
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "actor_key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True"},
+            ),
+            "actor_label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "date_created": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "date_deleted": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ip_address": (
+                "django.db.models.fields.GenericIPAddressField",
+                [],
+                {"max_length": "39", "null": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "64", "null": "True"}),
+            "reason": ("django.db.models.fields.TextField", [], {"null": "True", "blank": "True"}),
+            "slug": ("django.db.models.fields.CharField", [], {"max_length": "50", "null": "True"}),
+        },
+        "sentry.deletedproject": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "DeletedProject",
+                "index_together": "()",
+            },
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "actor_key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True"},
+            ),
+            "actor_label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "date_created": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "date_deleted": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ip_address": (
+                "django.db.models.fields.GenericIPAddressField",
+                [],
+                {"max_length": "39", "null": "True"},
+            ),
+            "name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "200", "null": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "organization_name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "organization_slug": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "50", "null": "True"},
+            ),
+            "platform": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "reason": ("django.db.models.fields.TextField", [], {"null": "True", "blank": "True"}),
+            "slug": ("django.db.models.fields.CharField", [], {"max_length": "50", "null": "True"}),
+        },
+        "sentry.deletedteam": {
+            "Meta": {"unique_together": "()", "object_name": "DeletedTeam", "index_together": "()"},
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "actor_key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True"},
+            ),
+            "actor_label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "date_created": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "date_deleted": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ip_address": (
+                "django.db.models.fields.GenericIPAddressField",
+                [],
+                {"max_length": "39", "null": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "64", "null": "True"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "organization_name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "organization_slug": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "50", "null": "True"},
+            ),
+            "reason": ("django.db.models.fields.TextField", [], {"null": "True", "blank": "True"}),
+            "slug": ("django.db.models.fields.CharField", [], {"max_length": "50", "null": "True"}),
+        },
+        "sentry.deploy": {
+            "Meta": {"unique_together": "()", "object_name": "Deploy", "index_together": "()"},
+            "date_finished": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_started": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "environment_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True", "blank": "True"},
+            ),
+            "notified": (
+                "django.db.models.fields.NullBooleanField",
+                [],
+                {"default": "False", "null": "True", "db_index": "True", "blank": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+            "url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True", "blank": "True"},
+            ),
+        },
+        "sentry.discoversavedquery": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "DiscoverSavedQuery",
+                "index_together": "()",
+            },
+            "created_by": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "null": "True", "on_delete": "models.SET_NULL"},
+            ),
+            "date_created": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"auto_now_add": "True", "blank": "True"},
+            ),
+            "date_updated": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"auto_now": "True", "blank": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "255"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "projects": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "to": "orm['sentry.Project']",
+                    "through": "orm['sentry.DiscoverSavedQueryProject']",
+                    "symmetrical": "False",
+                },
+            ),
+            "query": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+        },
+        "sentry.discoversavedqueryproject": {
+            "Meta": {
+                "unique_together": "(('project', 'discover_saved_query'),)",
+                "object_name": "DiscoverSavedQueryProject",
+                "index_together": "()",
+            },
+            "discover_saved_query": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.DiscoverSavedQuery']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.distribution": {
+            "Meta": {
+                "unique_together": "(('release', 'name'),)",
+                "object_name": "Distribution",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+        },
+        "sentry.email": {
+            "Meta": {"unique_together": "()", "object_name": "Email", "index_together": "()"},
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "email": (
+                "sentry.db.models.fields.citext.CIEmailField",
+                [],
+                {"unique": "True", "max_length": "75"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+        },
+        "sentry.environment": {
+            "Meta": {
+                "unique_together": "(('organization_id', 'name'),)",
+                "object_name": "Environment",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "projects": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "to": "orm['sentry.Project']",
+                    "through": "orm['sentry.EnvironmentProject']",
+                    "symmetrical": "False",
+                },
+            ),
+        },
+        "sentry.environmentproject": {
+            "Meta": {
+                "unique_together": "(('project', 'environment'),)",
+                "object_name": "EnvironmentProject",
+                "index_together": "()",
+            },
+            "environment": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Environment']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_hidden": (
+                "django.db.models.fields.NullBooleanField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.event": {
+            "Meta": {
+                "unique_together": "(('project_id', 'event_id'),)",
+                "object_name": "Event",
+                "db_table": "'sentry_message'",
+                "index_together": "(('group_id', 'datetime'),)",
+            },
+            "data": (
+                "sentry.db.models.fields.node.NodeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "event_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True", "db_column": "'message_id'"},
+            ),
+            "group_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "message": ("django.db.models.fields.TextField", [], {}),
+            "platform": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "time_spent": (
+                "sentry.db.models.fields.bounded.BoundedIntegerField",
+                [],
+                {"null": "True"},
+            ),
+        },
+        "sentry.eventattachment": {
+            "Meta": {
+                "unique_together": "(('project_id', 'event_id', 'file'),)",
+                "object_name": "EventAttachment",
+                "index_together": "(('project_id', 'date_added'),)",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "event_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "db_index": "True"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.File']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.TextField", [], {}),
+            "project_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.eventprocessingissue": {
+            "Meta": {
+                "unique_together": "(('raw_event', 'processing_issue'),)",
+                "object_name": "EventProcessingIssue",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "processing_issue": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ProcessingIssue']"},
+            ),
+            "raw_event": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.RawEvent']"},
+            ),
+        },
+        "sentry.eventtag": {
+            "Meta": {
+                "unique_together": "(('event_id', 'key_id', 'value_id'),)",
+                "object_name": "EventTag",
+                "index_together": "(('group_id', 'key_id', 'value_id'),)",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "event_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "group_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "project_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "value_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.eventuser": {
+            "Meta": {
+                "unique_together": "(('project_id', 'ident'), ('project_id', 'hash'))",
+                "object_name": "EventUser",
+                "index_together": "(('project_id', 'email'), ('project_id', 'username'), ('project_id', 'ip_address'))",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "email": (
+                "django.db.models.fields.EmailField",
+                [],
+                {"max_length": "75", "null": "True"},
+            ),
+            "hash": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "128", "null": "True"},
+            ),
+            "ip_address": (
+                "django.db.models.fields.GenericIPAddressField",
+                [],
+                {"max_length": "39", "null": "True"},
+            ),
+            "name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "128", "null": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "username": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "128", "null": "True"},
+            ),
+        },
+        "sentry.externalissue": {
+            "Meta": {
+                "unique_together": "(('organization_id', 'integration_id', 'key'),)",
+                "object_name": "ExternalIssue",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "description": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "integration_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "metadata": ("sentry.db.models.fields.jsonfield.JSONField", [], {"null": "True"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {},
+            ),
+            "title": ("django.db.models.fields.TextField", [], {"null": "True"}),
+        },
+        "sentry.featureadoption": {
+            "Meta": {
+                "unique_together": "(('organization', 'feature_id'),)",
+                "object_name": "FeatureAdoption",
+                "index_together": "()",
+            },
+            "applicable": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "complete": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_completed": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "feature_id": ("django.db.models.fields.PositiveIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+        },
+        "sentry.file": {
+            "Meta": {"unique_together": "()", "object_name": "File", "index_together": "()"},
+            "blob": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'legacy_blob'", "null": "True", "to": "orm['sentry.FileBlob']"},
+            ),
+            "blobs": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "to": "orm['sentry.FileBlob']",
+                    "through": "orm['sentry.FileBlobIndex']",
+                    "symmetrical": "False",
+                },
+            ),
+            "checksum": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "40", "null": "True", "db_index": "True"},
+            ),
+            "headers": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.TextField", [], {}),
+            "path": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "size": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "timestamp": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "type": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+        },
+        "sentry.fileblob": {
+            "Meta": {"unique_together": "()", "object_name": "FileBlob", "index_together": "()"},
+            "checksum": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "40"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "path": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "size": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "timestamp": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+        },
+        "sentry.fileblobindex": {
+            "Meta": {
+                "unique_together": "(('file', 'blob', 'offset'),)",
+                "object_name": "FileBlobIndex",
+                "index_together": "()",
+            },
+            "blob": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.FileBlob']"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.File']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "offset": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+        },
+        "sentry.fileblobowner": {
+            "Meta": {
+                "unique_together": "(('blob', 'organization'),)",
+                "object_name": "FileBlobOwner",
+                "index_together": "()",
+            },
+            "blob": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.FileBlob']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+        },
+        "sentry.group": {
+            "Meta": {
+                "unique_together": "(('project', 'short_id'),)",
+                "object_name": "Group",
+                "db_table": "'sentry_groupedmessage'",
+                "index_together": "(('project', 'first_release'),)",
+            },
+            "active_at": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "culprit": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "200", "null": "True", "db_column": "'view'", "blank": "True"},
+            ),
+            "data": (
+                "sentry.db.models.fields.gzippeddict.GzippedDictField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "first_release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']", "null": "True", "on_delete": "models.PROTECT"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_public": (
+                "django.db.models.fields.NullBooleanField",
+                [],
+                {"default": "False", "null": "True", "blank": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "level": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "40", "db_index": "True", "blank": "True"},
+            ),
+            "logger": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "''", "max_length": "64", "db_index": "True", "blank": "True"},
+            ),
+            "message": ("django.db.models.fields.TextField", [], {}),
+            "num_comments": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+            "platform": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "resolved_at": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "score": ("sentry.db.models.fields.bounded.BoundedIntegerField", [], {"default": "0"}),
+            "short_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "time_spent_count": (
+                "sentry.db.models.fields.bounded.BoundedIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "time_spent_total": (
+                "sentry.db.models.fields.bounded.BoundedIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "times_seen": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "1", "db_index": "True"},
+            ),
+        },
+        "sentry.groupassignee": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "GroupAssignee",
+                "db_table": "'sentry_groupasignee'",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'assignee_set'", "unique": "True", "to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'assignee_set'", "to": "orm['sentry.Project']"},
+            ),
+            "team": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "related_name": "u'sentry_assignee_set'",
+                    "null": "True",
+                    "to": "orm['sentry.Team']",
+                },
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "related_name": "u'sentry_assignee_set'",
+                    "null": "True",
+                    "to": "orm['sentry.User']",
+                },
+            ),
+        },
+        "sentry.groupbookmark": {
+            "Meta": {
+                "unique_together": "(('project', 'user', 'group'),)",
+                "object_name": "GroupBookmark",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'bookmark_set'", "to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'bookmark_set'", "to": "orm['sentry.Project']"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'sentry_bookmark_set'", "to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.groupcommitresolution": {
+            "Meta": {
+                "unique_together": "(('group_id', 'commit_id'),)",
+                "object_name": "GroupCommitResolution",
+                "index_together": "()",
+            },
+            "commit_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "group_id": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+        },
+        "sentry.groupemailthread": {
+            "Meta": {
+                "unique_together": "(('email', 'group'), ('email', 'msgid'))",
+                "object_name": "GroupEmailThread",
+                "index_together": "()",
+            },
+            "date": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "email": ("django.db.models.fields.EmailField", [], {"max_length": "75"}),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'groupemail_set'", "to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "msgid": ("django.db.models.fields.CharField", [], {"max_length": "100"}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'groupemail_set'", "to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.groupenvironment": {
+            "Meta": {
+                "unique_together": "(('group', 'environment'),)",
+                "object_name": "GroupEnvironment",
+                "index_together": "(('environment', 'first_release'),)",
+            },
+            "environment": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Environment']"},
+            ),
+            "first_release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']", "null": "True", "on_delete": "models.DO_NOTHING"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True", "db_index": "True"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+        },
+        "sentry.grouphash": {
+            "Meta": {
+                "unique_together": "(('project', 'hash'),)",
+                "object_name": "GroupHash",
+                "index_together": "()",
+            },
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "null": "True"},
+            ),
+            "group_tombstone_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "hash": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "null": "True"},
+            ),
+            "state": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+        },
+        "sentry.grouplink": {
+            "Meta": {
+                "unique_together": "(('group_id', 'linked_type', 'linked_id'),)",
+                "object_name": "GroupLink",
+                "index_together": "()",
+            },
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "group_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "linked_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "linked_type": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "1"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "relationship": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "2"},
+            ),
+        },
+        "sentry.groupmeta": {
+            "Meta": {
+                "unique_together": "(('group', 'key'),)",
+                "object_name": "GroupMeta",
+                "index_together": "()",
+            },
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "value": ("django.db.models.fields.TextField", [], {}),
+        },
+        "sentry.groupredirect": {
+            "Meta": {
+                "unique_together": "(('organization_id', 'previous_short_id', 'previous_project_slug'),)",
+                "object_name": "GroupRedirect",
+                "index_together": "()",
+            },
+            "group_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "previous_group_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"unique": "True"},
+            ),
+            "previous_project_slug": (
+                "django.db.models.fields.SlugField",
+                [],
+                {"max_length": "50", "null": "True"},
+            ),
+            "previous_short_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+        },
+        "sentry.grouprelease": {
+            "Meta": {
+                "unique_together": "(('group_id', 'release_id', 'environment'),)",
+                "object_name": "GroupRelease",
+                "index_together": "()",
+            },
+            "environment": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "''", "max_length": "64"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "group_id": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "release_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+        },
+        "sentry.groupresolution": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "GroupResolution",
+                "index_together": "()",
+            },
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "unique": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "type": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+        },
+        "sentry.grouprulestatus": {
+            "Meta": {
+                "unique_together": "(('rule', 'group'),)",
+                "object_name": "GroupRuleStatus",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_active": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "rule": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Rule']"},
+            ),
+            "status": ("django.db.models.fields.PositiveSmallIntegerField", [], {"default": "0"}),
+        },
+        "sentry.groupseen": {
+            "Meta": {
+                "unique_together": "(('user', 'group'),)",
+                "object_name": "GroupSeen",
+                "index_together": "()",
+            },
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "db_index": "False"},
+            ),
+        },
+        "sentry.groupshare": {
+            "Meta": {"unique_together": "()", "object_name": "GroupShare", "index_together": "()"},
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "unique": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "null": "True"},
+            ),
+            "uuid": (
+                "django.db.models.fields.CharField",
+                [],
+                {
+                    "default": "'ccf5fcbd8f2d42718691e3e77feb629c'",
+                    "unique": "True",
+                    "max_length": "32",
+                },
+            ),
+        },
+        "sentry.groupsnooze": {
+            "Meta": {"unique_together": "()", "object_name": "GroupSnooze", "index_together": "()"},
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "count": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "unique": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "state": ("sentry.db.models.fields.jsonfield.JSONField", [], {"null": "True"}),
+            "until": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "user_count": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "user_window": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "window": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+        },
+        "sentry.groupsubscription": {
+            "Meta": {
+                "unique_together": "(('group', 'user'),)",
+                "object_name": "GroupSubscription",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'subscription_set'", "to": "orm['sentry.Group']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_active": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'subscription_set'", "to": "orm['sentry.Project']"},
+            ),
+            "reason": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.grouptagkey": {
+            "Meta": {
+                "unique_together": "(('project_id', 'group_id', 'key'),)",
+                "object_name": "GroupTagKey",
+                "index_together": "()",
+            },
+            "group_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "values_seen": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.grouptagvalue": {
+            "Meta": {
+                "unique_together": "(('group_id', 'key', 'value'),)",
+                "object_name": "GroupTagValue",
+                "db_table": "'sentry_messagefiltervalue'",
+                "index_together": "(('project_id', 'key', 'value', 'last_seen'),)",
+            },
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True", "db_index": "True"},
+            ),
+            "group_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True", "db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "times_seen": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "value": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
+        },
+        "sentry.grouptombstone": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "GroupTombstone",
+                "index_together": "()",
+            },
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "culprit": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "200", "null": "True", "blank": "True"},
+            ),
+            "data": (
+                "sentry.db.models.fields.gzippeddict.GzippedDictField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "level": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "40", "blank": "True"},
+            ),
+            "message": ("django.db.models.fields.TextField", [], {}),
+            "previous_group_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"unique": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.identity": {
+            "Meta": {
+                "unique_together": "(('idp', 'external_id'), ('idp', 'user'))",
+                "object_name": "Identity",
+                "index_together": "()",
+            },
+            "data": ("sentry.db.models.fields.encrypted.EncryptedJsonField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_verified": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "external_id": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "idp": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.IdentityProvider']"},
+            ),
+            "scopes": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.identityprovider": {
+            "Meta": {
+                "unique_together": "(('type', 'external_id'),)",
+                "object_name": "IdentityProvider",
+                "index_together": "()",
+            },
+            "config": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "external_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "type": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+        },
+        "sentry.incident": {
+            "Meta": {
+                "unique_together": "(('organization', 'identifier'),)",
+                "object_name": "Incident",
+                "index_together": "()",
+            },
+            "alert_rule": (
+                "django.db.models.fields.related.ForeignKey",
+                [],
+                {"to": "orm['sentry.AlertRule']", "null": "True", "on_delete": "models.SET_NULL"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_closed": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "date_detected": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_started": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "detection_uuid": (
+                "sentry.db.models.fields.uuid.UUIDField",
+                [],
+                {"max_length": "32", "null": "True", "db_index": "True"},
+            ),
+            "groups": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'incidents'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.IncidentGroup']",
+                    "to": "orm['sentry.Group']",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "identifier": ("django.db.models.fields.IntegerField", [], {}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "projects": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'incidents'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.IncidentProject']",
+                    "to": "orm['sentry.Project']",
+                },
+            ),
+            "query": ("django.db.models.fields.TextField", [], {}),
+            "status": ("django.db.models.fields.PositiveSmallIntegerField", [], {"default": "1"}),
+            "title": ("django.db.models.fields.TextField", [], {}),
+            "type": ("django.db.models.fields.PositiveSmallIntegerField", [], {"default": "1"}),
+        },
+        "sentry.incidentactivity": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "IncidentActivity",
+                "index_together": "()",
+            },
+            "comment": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "event_stats_snapshot": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.TimeSeriesSnapshot']", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Incident']"},
+            ),
+            "previous_value": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "type": ("django.db.models.fields.IntegerField", [], {}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "null": "True"},
+            ),
+            "value": ("django.db.models.fields.TextField", [], {"null": "True"}),
+        },
+        "sentry.incidentgroup": {
+            "Meta": {
+                "unique_together": "(('group', 'incident'),)",
+                "object_name": "IncidentGroup",
+                "index_together": "()",
+            },
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "db_index": "False"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Incident']"},
+            ),
+        },
+        "sentry.incidentproject": {
+            "Meta": {
+                "unique_together": "(('project', 'incident'),)",
+                "object_name": "IncidentProject",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Incident']"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "db_index": "False"},
+            ),
+        },
+        "sentry.incidentseen": {
+            "Meta": {
+                "unique_together": "(('user', 'incident'),)",
+                "object_name": "IncidentSeen",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Incident']"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "db_index": "False"},
+            ),
+        },
+        "sentry.incidentsnapshot": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "IncidentSnapshot",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "event_stats_snapshot": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.TimeSeriesSnapshot']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "django.db.models.fields.related.OneToOneField",
+                [],
+                {"to": "orm['sentry.Incident']", "unique": "True"},
+            ),
+            "total_events": ("django.db.models.fields.IntegerField", [], {}),
+            "unique_users": ("django.db.models.fields.IntegerField", [], {}),
+        },
+        "sentry.incidentsubscription": {
+            "Meta": {
+                "unique_together": "(('incident', 'user'),)",
+                "object_name": "IncidentSubscription",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Incident']", "db_index": "False"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.incidentsuspectcommit": {
+            "Meta": {
+                "unique_together": "(('incident', 'commit'),)",
+                "object_name": "IncidentSuspectCommit",
+                "index_together": "()",
+            },
+            "commit": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Commit']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "incident": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Incident']", "db_index": "False"},
+            ),
+            "order": ("django.db.models.fields.SmallIntegerField", [], {}),
+        },
+        "sentry.integration": {
+            "Meta": {
+                "unique_together": "(('provider', 'external_id'),)",
+                "object_name": "Integration",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "external_id": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "metadata": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
+            "organizations": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'integrations'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.OrganizationIntegration']",
+                    "to": "orm['sentry.Organization']",
+                },
+            ),
+            "projects": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'integrations'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.ProjectIntegration']",
+                    "to": "orm['sentry.Project']",
+                },
+            ),
+            "provider": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+        },
+        "sentry.integrationexternalproject": {
+            "Meta": {
+                "unique_together": "(('organization_integration_id', 'external_id'),)",
+                "object_name": "IntegrationExternalProject",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "external_id": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "organization_integration_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "resolved_status": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "unresolved_status": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+        },
+        "sentry.integrationfeature": {
+            "Meta": {
+                "unique_together": "(('sentry_app', 'feature'),)",
+                "object_name": "IntegrationFeature",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "feature": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "sentry_app": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.SentryApp']"},
+            ),
+            "user_description": ("django.db.models.fields.TextField", [], {"null": "True"}),
+        },
+        "sentry.latestrelease": {
+            "Meta": {
+                "unique_together": "(('repository_id', 'environment_id'),)",
+                "object_name": "LatestRelease",
+                "index_together": "()",
+            },
+            "commit_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "deploy_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "environment_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "release_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "repository_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.lostpasswordhash": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "LostPasswordHash",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "hash": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "unique": "True"},
+            ),
+        },
+        "sentry.monitor": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "Monitor",
+                "index_together": "(('type', 'next_checkin'),)",
+            },
+            "config": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "guid": (
+                "sentry.db.models.fields.uuid.UUIDField",
+                [],
+                {"auto_add": "'uuid:uuid4'", "unique": "True", "max_length": "32"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_checkin": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "next_checkin": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "type": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.monitorcheckin": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "MonitorCheckIn",
+                "index_together": "()",
+            },
+            "config": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_updated": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "duration": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "guid": (
+                "sentry.db.models.fields.uuid.UUIDField",
+                [],
+                {"auto_add": "'uuid:uuid4'", "unique": "True", "max_length": "32"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "location": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.MonitorLocation']", "null": "True"},
+            ),
+            "monitor": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Monitor']"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.monitorlocation": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "MonitorLocation",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "guid": (
+                "sentry.db.models.fields.uuid.UUIDField",
+                [],
+                {"auto_add": "'uuid:uuid4'", "unique": "True", "max_length": "32"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+        },
+        "sentry.option": {
+            "Meta": {"unique_together": "()", "object_name": "Option", "index_together": "()"},
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "64"},
+            ),
+            "last_updated": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "value": ("sentry.db.models.fields.encrypted.EncryptedPickledObjectField", [], {}),
+        },
+        "sentry.organization": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "Organization",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "default_role": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "'member'", "max_length": "32"},
+            ),
+            "flags": ("django.db.models.fields.BigIntegerField", [], {"default": "1"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "members": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'org_memberships'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.OrganizationMember']",
+                    "to": "orm['sentry.User']",
+                },
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "slug": (
+                "django.db.models.fields.SlugField",
+                [],
+                {"unique": "True", "max_length": "50"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.organizationaccessrequest": {
+            "Meta": {
+                "unique_together": "(('team', 'member'),)",
+                "object_name": "OrganizationAccessRequest",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "member": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.OrganizationMember']"},
+            ),
+            "team": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Team']"},
+            ),
+        },
+        "sentry.organizationavatar": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "OrganizationAvatar",
+                "index_together": "()",
+            },
+            "avatar_type": (
+                "django.db.models.fields.PositiveSmallIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "to": "orm['sentry.File']",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "32", "db_index": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'avatar'", "unique": "True", "to": "orm['sentry.Organization']"},
+            ),
+        },
+        "sentry.organizationintegration": {
+            "Meta": {
+                "unique_together": "(('organization', 'integration'),)",
+                "object_name": "OrganizationIntegration",
+                "index_together": "()",
+            },
+            "config": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "default_auth_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "integration": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Integration']"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.organizationmember": {
+            "Meta": {
+                "unique_together": "(('organization', 'user'), ('organization', 'email'))",
+                "object_name": "OrganizationMember",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "email": (
+                "django.db.models.fields.EmailField",
+                [],
+                {"max_length": "75", "null": "True", "blank": "True"},
+            ),
+            "flags": ("django.db.models.fields.BigIntegerField", [], {"default": "0"}),
+            "has_global_access": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'member_set'", "to": "orm['sentry.Organization']"},
+            ),
+            "role": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "'member'", "max_length": "32"},
+            ),
+            "teams": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "to": "orm['sentry.Team']",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.OrganizationMemberTeam']",
+                    "blank": "True",
+                },
+            ),
+            "token": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "unique": "True", "null": "True", "blank": "True"},
+            ),
+            "token_expires_at": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "None", "null": "True"},
+            ),
+            "type": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "50", "blank": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "blank": "True",
+                    "related_name": "u'sentry_orgmember_set'",
+                    "null": "True",
+                    "to": "orm['sentry.User']",
+                },
+            ),
+        },
+        "sentry.organizationmemberteam": {
+            "Meta": {
+                "unique_together": "(('team', 'organizationmember'),)",
+                "object_name": "OrganizationMemberTeam",
+                "db_table": "'sentry_organizationmember_teams'",
+                "index_together": "()",
+            },
+            "id": ("sentry.db.models.fields.bounded.BoundedAutoField", [], {"primary_key": "True"}),
+            "is_active": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "organizationmember": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.OrganizationMember']"},
+            ),
+            "team": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Team']"},
+            ),
+        },
+        "sentry.organizationonboardingtask": {
+            "Meta": {
+                "unique_together": "(('organization', 'task'),)",
+                "object_name": "OrganizationOnboardingTask",
+                "index_together": "()",
+            },
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_completed": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "status": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "task": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "null": "True"},
+            ),
+        },
+        "sentry.organizationoption": {
+            "Meta": {
+                "unique_together": "(('organization', 'key'),)",
+                "object_name": "OrganizationOption",
+                "db_table": "'sentry_organizationoptions'",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "value": ("sentry.db.models.fields.encrypted.EncryptedPickledObjectField", [], {}),
+        },
+        "sentry.platformexternalissue": {
+            "Meta": {
+                "unique_together": "(('group_id', 'service_type'),)",
+                "object_name": "PlatformExternalIssue",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "display_name": ("django.db.models.fields.TextField", [], {}),
+            "group_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "service_type": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "web_url": ("django.db.models.fields.URLField", [], {"max_length": "200"}),
+        },
+        "sentry.processingissue": {
+            "Meta": {
+                "unique_together": "(('project', 'checksum', 'type'),)",
+                "object_name": "ProcessingIssue",
+                "index_together": "()",
+            },
+            "checksum": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "40", "db_index": "True"},
+            ),
+            "data": ("sentry.db.models.fields.gzippeddict.GzippedDictField", [], {}),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "type": ("django.db.models.fields.CharField", [], {"max_length": "30"}),
+        },
+        "sentry.project": {
+            "Meta": {
+                "unique_together": "(('organization', 'slug'),)",
+                "object_name": "Project",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "first_event": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "flags": (
+                "django.db.models.fields.BigIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+            "forced_color": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "6", "null": "True", "blank": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "platform": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "public": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "slug": ("django.db.models.fields.SlugField", [], {"max_length": "50", "null": "True"}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "teams": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'teams'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.ProjectTeam']",
+                    "to": "orm['sentry.Team']",
+                },
+            ),
+        },
+        "sentry.projectavatar": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "ProjectAvatar",
+                "index_together": "()",
+            },
+            "avatar_type": (
+                "django.db.models.fields.PositiveSmallIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "to": "orm['sentry.File']",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "32", "db_index": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'avatar'", "unique": "True", "to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.projectbookmark": {
+            "Meta": {
+                "unique_together": "(('project', 'user'),)",
+                "object_name": "ProjectBookmark",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "null": "True", "blank": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.projectdebugfile": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "ProjectDebugFile",
+                "db_table": "'sentry_projectdsymfile'",
+                "index_together": "(('project', 'debug_id'), ('project', 'code_id'))",
+            },
+            "code_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "cpu_name": ("django.db.models.fields.CharField", [], {"max_length": "40"}),
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"null": "True"}),
+            "debug_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "db_column": "'uuid'"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.File']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "object_name": ("django.db.models.fields.TextField", [], {}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "null": "True"},
+            ),
+        },
+        "sentry.projectintegration": {
+            "Meta": {
+                "unique_together": "(('project', 'integration'),)",
+                "object_name": "ProjectIntegration",
+                "index_together": "()",
+            },
+            "config": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "integration": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Integration']"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.projectkey": {
+            "Meta": {"unique_together": "()", "object_name": "ProjectKey", "index_together": "()"},
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True", "blank": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'key_set'", "to": "orm['sentry.Project']"},
+            ),
+            "public_key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "unique": "True", "null": "True"},
+            ),
+            "rate_limit_count": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "rate_limit_window": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "roles": ("django.db.models.fields.BigIntegerField", [], {"default": "1"}),
+            "secret_key": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "unique": "True", "null": "True"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+        },
+        "sentry.projectoption": {
+            "Meta": {
+                "unique_together": "(('project', 'key'),)",
+                "object_name": "ProjectOption",
+                "db_table": "'sentry_projectoptions'",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "value": ("sentry.db.models.fields.encrypted.EncryptedPickledObjectField", [], {}),
+        },
+        "sentry.projectownership": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "ProjectOwnership",
+                "index_together": "()",
+            },
+            "auto_assignment": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "date_created": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "fallthrough": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_active": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "last_updated": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "unique": "True"},
+            ),
+            "raw": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "schema": ("sentry.db.models.fields.jsonfield.JSONField", [], {"null": "True"}),
+        },
+        "sentry.projectplatform": {
+            "Meta": {
+                "unique_together": "(('project_id', 'platform'),)",
+                "object_name": "ProjectPlatform",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "platform": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "project_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.projectredirect": {
+            "Meta": {
+                "unique_together": "(('organization', 'redirect_slug'),)",
+                "object_name": "ProjectRedirect",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "redirect_slug": ("django.db.models.fields.SlugField", [], {"max_length": "50"}),
+        },
+        "sentry.projectteam": {
+            "Meta": {
+                "unique_together": "(('project', 'team'),)",
+                "object_name": "ProjectTeam",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "team": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Team']"},
+            ),
+        },
+        "sentry.promptsactivity": {
+            "Meta": {
+                "unique_together": "(('user', 'feature', 'organization_id', 'project_id'),)",
+                "object_name": "PromptsActivity",
+                "index_together": "()",
+            },
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "feature": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.pullrequest": {
+            "Meta": {
+                "unique_together": "(('repository_id', 'key'),)",
+                "object_name": "PullRequest",
+                "db_table": "'sentry_pull_request'",
+                "index_together": "(('repository_id', 'date_added'), ('organization_id', 'merge_commit_sha'))",
+            },
+            "author": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.CommitAuthor']", "null": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "merge_commit_sha": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "message": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "repository_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {},
+            ),
+            "title": ("django.db.models.fields.TextField", [], {"null": "True"}),
+        },
+        "sentry.pullrequestcommit": {
+            "Meta": {
+                "unique_together": "(('pull_request', 'commit'),)",
+                "object_name": "PullRequestCommit",
+                "db_table": "'sentry_pullrequest_commit'",
+                "index_together": "()",
+            },
+            "commit": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Commit']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "pull_request": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.PullRequest']"},
+            ),
+        },
+        "sentry.querysubscription": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "QuerySubscription",
+                "index_together": "()",
+            },
+            "aggregation": ("django.db.models.fields.IntegerField", [], {"default": "0"}),
+            "dataset": ("django.db.models.fields.TextField", [], {}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "query": ("django.db.models.fields.TextField", [], {}),
+            "resolution": ("django.db.models.fields.IntegerField", [], {}),
+            "subscription_id": ("django.db.models.fields.TextField", [], {"unique": "True"}),
+            "time_window": ("django.db.models.fields.IntegerField", [], {}),
+            "type": ("django.db.models.fields.TextField", [], {}),
+        },
+        "sentry.rawevent": {
+            "Meta": {
+                "unique_together": "(('project', 'event_id'),)",
+                "object_name": "RawEvent",
+                "index_together": "()",
+            },
+            "data": (
+                "sentry.db.models.fields.node.NodeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "event_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.recentsearch": {
+            "Meta": {
+                "unique_together": "(('user', 'organization', 'type', 'query_hash'),)",
+                "object_name": "RecentSearch",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "query": ("django.db.models.fields.TextField", [], {}),
+            "query_hash": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "type": ("django.db.models.fields.PositiveSmallIntegerField", [], {}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "db_index": "False"},
+            ),
+        },
+        "sentry.relay": {
+            "Meta": {"unique_together": "()", "object_name": "Relay", "index_together": "()"},
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_internal": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "public_key": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
+            "relay_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "64"},
+            ),
+        },
+        "sentry.release": {
+            "Meta": {
+                "unique_together": "(('organization', 'version'),)",
+                "object_name": "Release",
+                "index_together": "()",
+            },
+            "authors": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "commit_count": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_released": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "date_started": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_commit_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "last_deploy_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "new_groups": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "owner": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "to": "orm['sentry.User']",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                    "blank": "True",
+                },
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "projects": (
+                "django.db.models.fields.related.ManyToManyField",
+                [],
+                {
+                    "related_name": "u'releases'",
+                    "symmetrical": "False",
+                    "through": "orm['sentry.ReleaseProject']",
+                    "to": "orm['sentry.Project']",
+                },
+            ),
+            "ref": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "250", "null": "True", "blank": "True"},
+            ),
+            "total_deploys": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+            "url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True", "blank": "True"},
+            ),
+            "version": ("django.db.models.fields.CharField", [], {"max_length": "250"}),
+        },
+        "sentry.releasecommit": {
+            "Meta": {
+                "unique_together": "(('release', 'commit'), ('release', 'order'))",
+                "object_name": "ReleaseCommit",
+                "index_together": "()",
+            },
+            "commit": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Commit']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "order": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+        },
+        "sentry.releaseenvironment": {
+            "Meta": {
+                "unique_together": "(('organization', 'release', 'environment'),)",
+                "object_name": "ReleaseEnvironment",
+                "db_table": "'sentry_environmentrelease'",
+                "index_together": "()",
+            },
+            "environment": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Environment']"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+        },
+        "sentry.releasefile": {
+            "Meta": {
+                "unique_together": "(('release', 'ident'),)",
+                "object_name": "ReleaseFile",
+                "index_together": "(('release', 'name'),)",
+            },
+            "dist": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Distribution']", "null": "True"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.File']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": ("django.db.models.fields.CharField", [], {"max_length": "40"}),
+            "name": ("django.db.models.fields.TextField", [], {}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+        },
+        "sentry.releaseheadcommit": {
+            "Meta": {
+                "unique_together": "(('repository_id', 'release'),)",
+                "object_name": "ReleaseHeadCommit",
+                "index_together": "()",
+            },
+            "commit": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Commit']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+            "repository_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {},
+            ),
+        },
+        "sentry.releaseproject": {
+            "Meta": {
+                "unique_together": "(('project', 'release'),)",
+                "object_name": "ReleaseProject",
+                "db_table": "'sentry_release_project'",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "new_groups": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+        },
+        "sentry.releaseprojectenvironment": {
+            "Meta": {
+                "unique_together": "(('project', 'release', 'environment'),)",
+                "object_name": "ReleaseProjectEnvironment",
+                "index_together": "()",
+            },
+            "environment": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Environment']"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "last_deploy_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "new_issues_count": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "release": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Release']"},
+            ),
+        },
+        "sentry.repository": {
+            "Meta": {
+                "unique_together": "(('organization_id', 'name'), ('organization_id', 'provider', 'external_id'))",
+                "object_name": "Repository",
+                "index_together": "()",
+            },
+            "config": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "external_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "integration_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "provider": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "url": ("django.db.models.fields.URLField", [], {"max_length": "200", "null": "True"}),
+        },
+        "sentry.reprocessingreport": {
+            "Meta": {
+                "unique_together": "(('project', 'event_id'),)",
+                "object_name": "ReprocessingReport",
+                "index_together": "()",
+            },
+            "datetime": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "event_id": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.rule": {
+            "Meta": {"unique_together": "()", "object_name": "Rule", "index_together": "()"},
+            "data": ("sentry.db.models.fields.gzippeddict.GzippedDictField", [], {}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "environment_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "label": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+        },
+        "sentry.savedsearch": {
+            "Meta": {
+                "unique_together": "(('project', 'name'), ('organization', 'owner', 'type'))",
+                "object_name": "SavedSearch",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_default": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "is_global": (
+                "django.db.models.fields.NullBooleanField",
+                [],
+                {"default": "False", "null": "True", "db_index": "True", "blank": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']", "null": "True"},
+            ),
+            "owner": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']", "null": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "null": "True"},
+            ),
+            "query": ("django.db.models.fields.TextField", [], {}),
+            "type": (
+                "django.db.models.fields.PositiveSmallIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+        },
+        "sentry.savedsearchuserdefault": {
+            "Meta": {
+                "unique_together": "(('project', 'user'),)",
+                "object_name": "SavedSearchUserDefault",
+                "db_table": "'sentry_savedsearch_userdefault'",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+            "savedsearch": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.SavedSearch']"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.scheduleddeletion": {
+            "Meta": {
+                "unique_together": "(('app_label', 'model_name', 'object_id'),)",
+                "object_name": "ScheduledDeletion",
+                "index_together": "()",
+            },
+            "aborted": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "app_label": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_scheduled": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime(2019, 10, 11, 0, 0)"},
+            ),
+            "guid": (
+                "django.db.models.fields.CharField",
+                [],
+                {
+                    "default": "'9084afb08a684cada7c3ae19e4923e99'",
+                    "unique": "True",
+                    "max_length": "32",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "in_progress": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "model_name": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "object_id": ("sentry.db.models.fields.bounded.BoundedBigIntegerField", [], {}),
+        },
+        "sentry.scheduledjob": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "ScheduledJob",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_scheduled": ("django.db.models.fields.DateTimeField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "payload": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+        },
+        "sentry.sentryapp": {
+            "Meta": {"unique_together": "()", "object_name": "SentryApp", "index_together": "()"},
+            "application": (
+                "django.db.models.fields.related.OneToOneField",
+                [],
+                {
+                    "related_name": "u'sentry_app'",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                    "to": "orm['sentry.ApiApplication']",
+                },
+            ),
+            "author": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_deleted": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "date_updated": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "events": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_alertable": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "name": ("django.db.models.fields.TextField", [], {}),
+            "overview": ("django.db.models.fields.TextField", [], {"null": "True"}),
+            "owner": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'owned_sentry_apps'", "to": "orm['sentry.Organization']"},
+            ),
+            "proxy_user": (
+                "django.db.models.fields.related.OneToOneField",
+                [],
+                {
+                    "related_name": "u'sentry_app'",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                    "to": "orm['sentry.User']",
+                },
+            ),
+            "redirect_url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True"},
+            ),
+            "schema": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "scope_list": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "scopes": ("django.db.models.fields.BigIntegerField", [], {"default": "None"}),
+            "slug": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "64"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "uuid": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "'1137b838-ae5d-4246-9fbb-9930cad16e46'", "max_length": "64"},
+            ),
+            "verify_install": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "webhook_url": (
+                "django.db.models.fields.URLField",
+                [],
+                {"max_length": "200", "null": "True"},
+            ),
+        },
+        "sentry.sentryappavatar": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "SentryAppAvatar",
+                "index_together": "()",
+            },
+            "avatar_type": (
+                "django.db.models.fields.PositiveSmallIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "to": "orm['sentry.File']",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "32", "db_index": "True"},
+            ),
+            "sentry_app": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'avatar'", "unique": "True", "to": "orm['sentry.SentryApp']"},
+            ),
+        },
+        "sentry.sentryappcomponent": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "SentryAppComponent",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "schema": (
+                "sentry.db.models.fields.encrypted.EncryptedJsonField",
+                [],
+                {"default": "{}"},
+            ),
+            "sentry_app": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'components'", "to": "orm['sentry.SentryApp']"},
+            ),
+            "type": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "uuid": (
+                "sentry.db.models.fields.uuid.UUIDField",
+                [],
+                {"auto_add": "'uuid:uuid4'", "unique": "True", "max_length": "32"},
+            ),
+        },
+        "sentry.sentryappinstallation": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "SentryAppInstallation",
+                "index_together": "()",
+            },
+            "api_grant": (
+                "django.db.models.fields.related.OneToOneField",
+                [],
+                {
+                    "related_name": "u'sentry_app_installation'",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                    "to": "orm['sentry.ApiGrant']",
+                },
+            ),
+            "api_token": (
+                "django.db.models.fields.related.OneToOneField",
+                [],
+                {
+                    "related_name": "u'sentry_app_installation'",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                    "to": "orm['sentry.ApiToken']",
+                },
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "date_deleted": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "date_updated": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'sentry_app_installations'", "to": "orm['sentry.Organization']"},
+            ),
+            "sentry_app": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'installations'", "to": "orm['sentry.SentryApp']"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "uuid": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "'9bdf5009-23d5-43e3-b891-f9ee2ce01e97'", "max_length": "64"},
+            ),
+        },
+        "sentry.sentryappinstallationtoken": {
+            "Meta": {
+                "unique_together": "(('sentry_app_installation', 'api_token'),)",
+                "object_name": "SentryAppInstallationToken",
+                "index_together": "()",
+            },
+            "api_token": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ApiToken']"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "sentry_app_installation": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.SentryAppInstallation']"},
+            ),
+        },
+        "sentry.servicehook": {
+            "Meta": {"unique_together": "()", "object_name": "ServiceHook", "index_together": "()"},
+            "actor_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "application": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ApiApplication']", "null": "True"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "events": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"django.db.models.fields.TextField", [], {})},
+            ),
+            "guid": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "32", "unique": "True", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "organization_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "secret": (
+                "sentry.db.models.fields.encrypted.EncryptedTextField",
+                [],
+                {"default": "'acdb9101b13e4504accf16a6bda125439d33402dc11d43ad874b5d3eb7c65ec9'"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0", "db_index": "True"},
+            ),
+            "url": ("django.db.models.fields.URLField", [], {"max_length": "512"}),
+            "version": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.servicehookproject": {
+            "Meta": {
+                "unique_together": "(('service_hook', 'project_id'),)",
+                "object_name": "ServiceHookProject",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "service_hook": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.ServiceHook']"},
+            ),
+        },
+        "sentry.tagkey": {
+            "Meta": {
+                "unique_together": "(('project_id', 'key'),)",
+                "object_name": "TagKey",
+                "db_table": "'sentry_filterkey'",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "label": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "64", "null": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"db_index": "True"},
+            ),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "values_seen": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.tagvalue": {
+            "Meta": {
+                "unique_together": "(('project_id', 'key', 'value'),)",
+                "object_name": "TagValue",
+                "db_table": "'sentry_filtervalue'",
+                "index_together": "(('project_id', 'key', 'last_seen'),)",
+            },
+            "data": (
+                "sentry.db.models.fields.gzippeddict.GzippedDictField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True", "db_index": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True", "db_index": "True"},
+            ),
+            "project_id": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"null": "True", "db_index": "True"},
+            ),
+            "times_seen": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "value": ("django.db.models.fields.CharField", [], {"max_length": "200"}),
+        },
+        "sentry.team": {
+            "Meta": {
+                "unique_together": "(('organization', 'slug'),)",
+                "object_name": "Team",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']"},
+            ),
+            "slug": ("django.db.models.fields.SlugField", [], {"max_length": "50"}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+        },
+        "sentry.teamavatar": {
+            "Meta": {"unique_together": "()", "object_name": "TeamAvatar", "index_together": "()"},
+            "avatar_type": (
+                "django.db.models.fields.PositiveSmallIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "to": "orm['sentry.File']",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "32", "db_index": "True"},
+            ),
+            "team": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'avatar'", "unique": "True", "to": "orm['sentry.Team']"},
+            ),
+        },
+        "sentry.timeseriessnapshot": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "TimeSeriesSnapshot",
+                "index_together": "()",
+            },
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "end": ("django.db.models.fields.DateTimeField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "period": ("django.db.models.fields.IntegerField", [], {}),
+            "start": ("django.db.models.fields.DateTimeField", [], {}),
+            "values": (
+                "sentry.db.models.fields.array.ArrayField",
+                [],
+                {"of": (u"sentry.db.models.fields.array.ArrayField", [], {"null": "True"})},
+            ),
+        },
+        "sentry.user": {
+            "Meta": {
+                "unique_together": "()",
+                "object_name": "User",
+                "db_table": "'auth_user'",
+                "index_together": "()",
+            },
+            "date_joined": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "email": (
+                "django.db.models.fields.EmailField",
+                [],
+                {"max_length": "75", "blank": "True"},
+            ),
+            "flags": (
+                "django.db.models.fields.BigIntegerField",
+                [],
+                {"default": "0", "null": "True"},
+            ),
+            "id": ("sentry.db.models.fields.bounded.BoundedAutoField", [], {"primary_key": "True"}),
+            "is_active": ("django.db.models.fields.BooleanField", [], {"default": "True"}),
+            "is_managed": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "is_password_expired": (
+                "django.db.models.fields.BooleanField",
+                [],
+                {"default": "False"},
+            ),
+            "is_sentry_app": (
+                "django.db.models.fields.NullBooleanField",
+                [],
+                {"default": "None", "null": "True", "blank": "True"},
+            ),
+            "is_staff": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "is_superuser": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "last_active": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "null": "True"},
+            ),
+            "last_login": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"null": "True", "blank": "True"},
+            ),
+            "last_password_change": ("django.db.models.fields.DateTimeField", [], {"null": "True"}),
+            "name": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "200", "db_column": "'first_name'", "blank": "True"},
+            ),
+            "password": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "session_nonce": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "12", "null": "True"},
+            ),
+            "username": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "128"},
+            ),
+        },
+        "sentry.useravatar": {
+            "Meta": {"unique_together": "()", "object_name": "UserAvatar", "index_together": "()"},
+            "avatar_type": (
+                "django.db.models.fields.PositiveSmallIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "file": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {
+                    "to": "orm['sentry.File']",
+                    "unique": "True",
+                    "null": "True",
+                    "on_delete": "models.SET_NULL",
+                },
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ident": (
+                "django.db.models.fields.CharField",
+                [],
+                {"unique": "True", "max_length": "32", "db_index": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'avatar'", "unique": "True", "to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.useremail": {
+            "Meta": {
+                "unique_together": "(('user', 'email'),)",
+                "object_name": "UserEmail",
+                "index_together": "()",
+            },
+            "date_hash_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "email": ("django.db.models.fields.EmailField", [], {"max_length": "75"}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "is_verified": ("django.db.models.fields.BooleanField", [], {"default": "False"}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"related_name": "u'emails'", "to": "orm['sentry.User']"},
+            ),
+            "validation_hash": (
+                "django.db.models.fields.CharField",
+                [],
+                {"default": "u'0iXnsTdUVbGXq649AYzgEV9IZg5WStoq'", "max_length": "32"},
+            ),
+        },
+        "sentry.userip": {
+            "Meta": {
+                "unique_together": "(('user', 'ip_address'),)",
+                "object_name": "UserIP",
+                "index_together": "()",
+            },
+            "country_code": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "16", "null": "True"},
+            ),
+            "first_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "ip_address": (
+                "django.db.models.fields.GenericIPAddressField",
+                [],
+                {"max_length": "39"},
+            ),
+            "last_seen": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "region_code": (
+                "django.db.models.fields.CharField",
+                [],
+                {"max_length": "16", "null": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.useroption": {
+            "Meta": {
+                "unique_together": "(('user', 'project', 'key'), ('user', 'organization', 'key'))",
+                "object_name": "UserOption",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "key": ("django.db.models.fields.CharField", [], {"max_length": "64"}),
+            "organization": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Organization']", "null": "True"},
+            ),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']", "null": "True"},
+            ),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+            "value": ("sentry.db.models.fields.encrypted.EncryptedPickledObjectField", [], {}),
+        },
+        "sentry.userpermission": {
+            "Meta": {
+                "unique_together": "(('user', 'permission'),)",
+                "object_name": "UserPermission",
+                "index_together": "()",
+            },
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "permission": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "user": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.User']"},
+            ),
+        },
+        "sentry.userreport": {
+            "Meta": {
+                "unique_together": "(('project', 'event_id'),)",
+                "object_name": "UserReport",
+                "index_together": "(('project', 'event_id'), ('project', 'date_added'))",
+            },
+            "comments": ("django.db.models.fields.TextField", [], {}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now", "db_index": "True"},
+            ),
+            "email": ("django.db.models.fields.EmailField", [], {"max_length": "75"}),
+            "environment": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Environment']", "null": "True"},
+            ),
+            "event_id": ("django.db.models.fields.CharField", [], {"max_length": "32"}),
+            "event_user_id": (
+                "sentry.db.models.fields.bounded.BoundedBigIntegerField",
+                [],
+                {"null": "True"},
+            ),
+            "group": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Group']", "null": "True"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "128"}),
+            "project": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Project']"},
+            ),
+        },
+        "sentry.widget": {
+            "Meta": {
+                "unique_together": "(('dashboard', 'order'), ('dashboard', 'title'))",
+                "object_name": "Widget",
+                "index_together": "()",
+            },
+            "dashboard": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Dashboard']"},
+            ),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "display_options": (
+                "sentry.db.models.fields.jsonfield.JSONField",
+                [],
+                {"default": "{}"},
+            ),
+            "display_type": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "order": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "title": ("django.db.models.fields.CharField", [], {"max_length": "255"}),
+        },
+        "sentry.widgetdatasource": {
+            "Meta": {
+                "unique_together": "(('widget', 'name'), ('widget', 'order'))",
+                "object_name": "WidgetDataSource",
+                "index_together": "()",
+            },
+            "data": ("sentry.db.models.fields.jsonfield.JSONField", [], {"default": "{}"}),
+            "date_added": (
+                "django.db.models.fields.DateTimeField",
+                [],
+                {"default": "datetime.datetime.now"},
+            ),
+            "id": (
+                "sentry.db.models.fields.bounded.BoundedBigAutoField",
+                [],
+                {"primary_key": "True"},
+            ),
+            "name": ("django.db.models.fields.CharField", [], {"max_length": "255"}),
+            "order": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "status": (
+                "sentry.db.models.fields.bounded.BoundedPositiveIntegerField",
+                [],
+                {"default": "0"},
+            ),
+            "type": ("sentry.db.models.fields.bounded.BoundedPositiveIntegerField", [], {}),
+            "widget": (
+                "sentry.db.models.fields.foreignkey.FlexibleForeignKey",
+                [],
+                {"to": "orm['sentry.Widget']"},
+            ),
+        },
+    }
+
+    complete_apps = ["sentry"]

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -11,10 +11,11 @@ from sentry.snuba.models import QueryAggregations
 from sentry.testutils import TestCase
 
 
-class IncidentSerializerTest(TestCase):
+class AlertRuleSerializerTest(TestCase):
     def test_simple(self):
         alert_rule = create_alert_rule(
-            self.project,
+            self.organization,
+            [self.project],
             "hello",
             AlertRuleThresholdType.ABOVE,
             "level:error",
@@ -27,7 +28,9 @@ class IncidentSerializerTest(TestCase):
         result = serialize(alert_rule)
 
         assert result["id"] == six.text_type(alert_rule.id)
-        assert result["projectId"] == six.text_type(alert_rule.project_id)
+        assert result["projectId"] == six.text_type(
+            alert_rule.query_subscriptions.first().project_id
+        )
         assert result["name"] == alert_rule.name
         assert result["thresholdType"] == alert_rule.threshold_type
         assert result["dataset"] == alert_rule.dataset

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -68,7 +68,8 @@ class DetailedIncidentSerializerTest(TestCase):
     def test_alert_rule(self):
         incident = self.create_incident()
         alert_rule = create_alert_rule(
-            self.project,
+            self.organization,
+            [self.project],
             "hi",
             AlertRuleThresholdType.ABOVE,
             "test query",

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -27,7 +27,8 @@ class AlertRuleDetailsBase(object):
     @fixture
     def alert_rule(self):
         return create_alert_rule(
-            self.project,
+            self.organization,
+            [self.project],
             "hello",
             AlertRuleThresholdType.ABOVE,
             "level:error",
@@ -109,12 +110,14 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
                 aggregation=self.alert_rule.aggregation,
             )
 
+        existing_sub = self.alert_rule.query_subscriptions.first()
+
         # Alert rule should be exactly the same
         assert resp.data == serialize(self.alert_rule)
         # If the aggregation changed we'd have a new subscription, validate that
         # it hasn't changed explicitly
-        updated_alert_rule = AlertRule.objects.get(id=self.alert_rule.id)
-        assert updated_alert_rule.subscription_id == self.alert_rule.subscription_id
+        updated_sub = AlertRule.objects.get(id=self.alert_rule.id).query_subscriptions.first()
+        assert updated_sub.subscription_id == existing_sub.subscription_id
 
 
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -31,7 +31,8 @@ class AlertRuleListEndpointTest(APITestCase):
     def test_simple(self):
         self.create_team(organization=self.organization, members=[self.user])
         alert_rule = create_alert_rule(
-            self.project,
+            self.organization,
+            [self.project],
             "hello",
             AlertRuleThresholdType.ABOVE,
             "level:error",

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -25,12 +25,17 @@ class TestAlertRuleSerializer(TestCase):
     def run_fail_validation_test(self, params, errors):
         base_params = self.valid_params.copy()
         base_params.update(params)
-        serializer = AlertRuleSerializer(context={"project": self.project}, data=base_params)
+        serializer = AlertRuleSerializer(
+            context={"organization": self.project.organization, "project": self.project},
+            data=base_params,
+        )
         assert not serializer.is_valid()
         assert serializer.errors == errors
 
     def test_validation_no_params(self):
-        serializer = AlertRuleSerializer(context={"project": self.project}, data={})
+        serializer = AlertRuleSerializer(
+            context={"organization": self.project.organization, "project": self.project}, data={}
+        )
         assert not serializer.is_valid()
         field_is_required = ["This field is required."]
         assert serializer.errors == {
@@ -75,7 +80,10 @@ class TestAlertRuleSerializer(TestCase):
 
     def _run_changed_fields_test(self, alert_rule, params, expected):
         serializer = AlertRuleSerializer(
-            context={"project": self.project}, instance=alert_rule, data=params, partial=True
+            context={"organization": self.project.organization, "project": self.project},
+            instance=alert_rule,
+            data=params,
+            partial=True,
         )
         serializer.is_valid()
         assert (

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -77,7 +77,8 @@ class CreateIncidentTest(TestCase):
         other_group = self.create_group(project=other_project)
         self.record_event.reset_mock()
         alert_rule = create_alert_rule(
-            self.project,
+            self.organization,
+            [self.project],
             "hello",
             AlertRuleThresholdType.ABOVE,
             "level:error",
@@ -760,7 +761,8 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         resolve_threshold = 400
         threshold_period = 1
         alert_rule = create_alert_rule(
-            self.project,
+            self.organization,
+            [self.project],
             name,
             threshold_type,
             query,
@@ -770,7 +772,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             resolve_threshold,
             threshold_period,
         )
-        assert alert_rule.project == self.project
+        assert alert_rule.query_subscriptions.get().project == self.project
         assert alert_rule.name == name
         assert alert_rule.status == AlertRuleStatus.PENDING.value
         assert alert_rule.query_subscriptions.all().count() == 1
@@ -787,7 +789,8 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
     def test_invalid_query(self):
         with self.assertRaises(InvalidSearchQuery):
             create_alert_rule(
-                self.project,
+                self.organization,
+                [self.project],
                 "hi",
                 AlertRuleThresholdType.ABOVE,
                 "has:",
@@ -801,7 +804,8 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
     def test_existing_name(self):
         name = "uh oh"
         create_alert_rule(
-            self.project,
+            self.organization,
+            [self.project],
             name,
             AlertRuleThresholdType.ABOVE,
             "level:error",
@@ -813,7 +817,8 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         )
         with self.assertRaises(AlertRuleNameAlreadyUsedError):
             create_alert_rule(
-                self.project,
+                self.organization,
+                [self.project],
                 name,
                 AlertRuleThresholdType.ABOVE,
                 "level:error",
@@ -829,7 +834,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
     @fixture
     def alert_rule(self):
         return create_alert_rule(
-            self.project,
+            self.organization,
+            [self.project],
             "hello",
             AlertRuleThresholdType.ABOVE,
             "level:error",
@@ -882,7 +888,8 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
     def test_name_used(self):
         used_name = "uh oh"
         create_alert_rule(
-            self.project,
+            self.organization,
+            [self.project],
             used_name,
             AlertRuleThresholdType.ABOVE,
             "level:error",
@@ -904,7 +911,8 @@ class DeleteAlertRuleTest(TestCase, BaseIncidentsTest):
     @fixture
     def alert_rule(self):
         return create_alert_rule(
-            self.project,
+            self.organization,
+            [self.project],
             "hello",
             AlertRuleThresholdType.ABOVE,
             "level:error",

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -13,7 +13,7 @@ from sentry.incidents.logic import create_alert_rule
 from sentry.snuba.subscriptions import query_aggregation_to_snuba
 from sentry.incidents.models import AlertRuleThresholdType, Incident, IncidentStatus, IncidentType
 from sentry.incidents.tasks import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
-from sentry.snuba.models import QueryAggregations, QueryDatasets, QuerySubscription
+from sentry.snuba.models import QueryAggregations
 from sentry.snuba.query_subscription_consumer import QuerySubscriptionConsumer, subscriber_registry
 
 from sentry.testutils import TestCase
@@ -36,22 +36,13 @@ class HandleSnubaQueryUpdateTest(TestCase):
 
     @fixture
     def subscription(self):
-        subscription = QuerySubscription.objects.create(
-            project=self.project,
-            type=INCIDENTS_SNUBA_SUBSCRIPTION_TYPE,
-            subscription_id="some_id",
-            dataset=QueryDatasets.EVENTS.value,
-            query="",
-            aggregation=QueryAggregations.TOTAL.value,
-            time_window=1,
-            resolution=1,
-        )
-        return subscription
+        return self.rule.query_subscriptions.get()
 
     @fixture
     def rule(self):
         rule = create_alert_rule(
-            self.project,
+            self.organization,
+            [self.project],
             "some rule",
             AlertRuleThresholdType.ABOVE,
             query="",
@@ -61,7 +52,6 @@ class HandleSnubaQueryUpdateTest(TestCase):
             resolve_threshold=10,
             threshold_period=1,
         )
-        rule.update(query_subscription=self.subscription)
         return rule
 
     @fixture

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -90,7 +90,7 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
             subscription_id=self.subscription_id,
             dataset="something",
             query="hello",
-            aggregations=0,
+            aggregation=0,
             time_window=1,
             resolution=1,
         )
@@ -122,7 +122,7 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
             subscription_id=self.subscription_id,
             dataset="something",
             query="hello",
-            aggregations=0,
+            aggregation=0,
             time_window=1,
             resolution=1,
         )


### PR DESCRIPTION
Change alert rule creation to be at the org level, and allow mutiple projects to be subscribed to
an alert rule. Add `bulk_create_snuba_subscriptions` so that we can create all the subscriptions
efficiently. Currently doesn't batch but we'll add this in a future pr.

Update the alert rule write serializer to also accept an organization. We'll change it to accept
projects as params later, for now still passing as context.

Remove deprecated columns from:
- AlertRule
  - subscription_id (handled in snuba QuerySubscription now)
   - aggregations (moved to singular column)
   - query_subscription (replaced my m2m table)
   - project (replaced by QuerySubscription)
- QuerySubscription
  - aggregations (replaced by singular column)

Will delete these from the database in a later pr, we need to drop the columns from Django first.