### PR TITLE
ref(ts): Improve HoC typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@sentry/integrations": "5.6.0-beta.4",
     "@types/classnames": "^2.2.0",
     "@types/clipboard": "^2.0.1",
+    "@types/create-react-class": "^15.6.2",
     "@types/echarts": "^4.1.10",
     "@types/jest": "^24.0.17",
     "@types/jquery": "^2.0.53",

--- a/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
@@ -26,7 +26,7 @@ import withDiscoverSavedQueries from 'app/utils/withDiscoverSavedQueries';
 
 import SidebarItem from './sidebarItem';
 
-type Props = React.ComponentProps<SidebarItem> & {
+type Props = {
   api: Client;
   organization: Organization;
   savedQueries: SavedQuery[];

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -202,6 +202,7 @@ export type Plugin = {};
 export type GlobalSelection = {
   projects: number[];
   environments: string[];
+  forceUrlSync?: boolean;
   datetime: {
     start: string;
     end: string;

--- a/src/sentry/static/sentry/app/utils/withApi.tsx
+++ b/src/sentry/static/sentry/app/utils/withApi.tsx
@@ -3,17 +3,25 @@ import React from 'react';
 import {Client} from 'app/api';
 import getDisplayName from 'app/utils/getDisplayName';
 
+type InjectedApiProps = {
+  api: Client;
+};
+
+type WrappedProps<P> = Omit<P, keyof InjectedApiProps> & Partial<InjectedApiProps>;
+
 /**
- * HoC that provides "api" client when mounted, and clears API requests when component is unmounted
+ * HoC that provides "api" client when mounted, and clears API requests when
+ * component is unmounted
  */
-const withApi = <P extends object>(WrappedComponent: React.ComponentType<P>) => {
-  return class extends React.Component<Omit<P, 'api'>> {
+const withApi = <P extends InjectedApiProps>(WrappedComponent: React.ComponentType<P>) =>
+  class extends React.Component<WrappedProps<P>> {
     static displayName = `withApi(${getDisplayName(WrappedComponent)})`;
 
-    constructor(props) {
+    constructor(props: WrappedProps<P>) {
       super(props);
       this.api = new Client();
     }
+
     componentWillUnmount() {
       this.api.clear();
     }
@@ -24,6 +32,5 @@ const withApi = <P extends object>(WrappedComponent: React.ComponentType<P>) => 
       return <WrappedComponent api={this.api} {...this.props as P} />;
     }
   };
-};
 
 export default withApi;

--- a/src/sentry/static/sentry/app/utils/withConfig.tsx
+++ b/src/sentry/static/sentry/app/utils/withConfig.tsx
@@ -1,31 +1,43 @@
 import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
+
+import {Config} from 'app/types';
 import getDisplayName from 'app/utils/getDisplayName';
 import ConfigStore from 'app/stores/configStore';
+
+type InjectedConfigProps = {
+  config: Config;
+};
+
+type State = {
+  config: Config;
+};
 
 /**
  * Higher order component that passes the config object to the wrapped component
  */
-const withConfig = <P extends object>(WrappedComponent: React.ComponentType<P>) =>
-  createReactClass({
+const withConfig = <P extends InjectedConfigProps>(
+  WrappedComponent: React.ComponentType<P>
+) =>
+  createReactClass<
+    Omit<P, keyof InjectedConfigProps> & Partial<InjectedConfigProps>,
+    State
+  >({
     displayName: `withConfig(${getDisplayName(WrappedComponent)})`,
     mixins: [Reflux.listenTo(ConfigStore, 'onUpdate')],
+
     getInitialState() {
-      return {
-        config: ConfigStore.getConfig(),
-      };
+      return {config: ConfigStore.getConfig()};
     },
 
     onUpdate() {
-      this.setState({
-        config: ConfigStore.getConfig(),
-      });
+      this.setState({config: ConfigStore.getConfig()});
     },
 
     render() {
       return (
-        <WrappedComponent config={this.state.config as object} {...this.props as P} />
+        <WrappedComponent config={this.state.config as Config} {...this.props as P} />
       );
     },
   });

--- a/src/sentry/static/sentry/app/utils/withDiscoverSavedQueries.tsx
+++ b/src/sentry/static/sentry/app/utils/withDiscoverSavedQueries.tsx
@@ -6,7 +6,11 @@ import DiscoverSavedQueriesStore from 'app/stores/discoverSavedQueriesStore';
 import getDisplayName from 'app/utils/getDisplayName';
 import {SavedQuery} from 'app/views/discover/types';
 
-type Props = {
+type InjectedDiscoverSavedQueriesProps = {
+  savedQueries: SavedQuery[];
+};
+
+type State = {
   savedQueries: SavedQuery[];
 };
 
@@ -14,10 +18,14 @@ type Props = {
  * Higher order component that uses DiscoverSavedQueryStor and provides the
  * saved queries for the current organization
  */
-const withDiscoverSavedQueries = <P extends Props>(
+const withDiscoverSavedQueries = <P extends InjectedDiscoverSavedQueriesProps>(
   WrappedComponent: React.ComponentType<P>
 ) =>
-  createReactClass({
+  createReactClass<
+    Omit<P, keyof InjectedDiscoverSavedQueriesProps> &
+      Partial<InjectedDiscoverSavedQueriesProps>,
+    State
+  >({
     displayName: `withDiscoverSavedQuery(${getDisplayName(WrappedComponent)})`,
     mixins: [Reflux.listenTo(DiscoverSavedQueriesStore, 'onUpdate')],
 
@@ -45,10 +53,7 @@ const withDiscoverSavedQueries = <P extends Props>(
 
     render() {
       return (
-        <WrappedComponent
-          savedQueries={this.state.savedQueries as SavedQuery[]}
-          {...this.props as P}
-        />
+        <WrappedComponent savedQueries={this.state.savedQueries} {...this.props as P} />
       );
     },
   });

--- a/src/sentry/static/sentry/app/utils/withGlobalSelection.tsx
+++ b/src/sentry/static/sentry/app/utils/withGlobalSelection.tsx
@@ -6,16 +6,29 @@ import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import getDisplayName from 'app/utils/getDisplayName';
 import {GlobalSelection} from 'app/types';
 
+type InjectedGlobalSelectionProps = {
+  forceUrlSync?: boolean;
+  selection: GlobalSelection;
+};
+
+type State = {
+  selection: GlobalSelection;
+};
+
 /**
  * Higher order component that uses GlobalSelectionStore and provides the
  * active project
  */
-const withGlobalSelection = <P extends object>(
+const withGlobalSelection = <P extends InjectedGlobalSelectionProps>(
   WrappedComponent: React.ComponentType<P>
 ) =>
-  createReactClass({
+  createReactClass<
+    Omit<P, keyof InjectedGlobalSelectionProps> & Partial<InjectedGlobalSelectionProps>,
+    State
+  >({
     displayName: `withGlobalSelection(${getDisplayName(WrappedComponent)})`,
     mixins: [Reflux.listenTo(GlobalSelectionStore, 'onUpdate')],
+
     getInitialState() {
       return {
         selection: GlobalSelectionStore.get(),
@@ -34,9 +47,7 @@ const withGlobalSelection = <P extends object>(
       const selection = GlobalSelectionStore.get();
 
       if (this.state.selection !== selection) {
-        this.setState({
-          selection,
-        });
+        this.setState({selection});
       }
     },
 
@@ -44,7 +55,7 @@ const withGlobalSelection = <P extends object>(
       const {forceUrlSync, ...selection} = this.state.selection;
       return (
         <WrappedComponent
-          forceUrlSync={forceUrlSync as boolean}
+          forceUrlSync={!!forceUrlSync}
           selection={selection as GlobalSelection}
           {...this.props as P}
         />

--- a/src/sentry/static/sentry/app/utils/withLatestContext.tsx
+++ b/src/sentry/static/sentry/app/utils/withLatestContext.tsx
@@ -10,13 +10,36 @@ import getDisplayName from 'app/utils/getDisplayName';
 import withOrganizations from 'app/utils/withOrganizations';
 import {Project, Organization} from 'app/types';
 
-const withLatestContext = <P extends object>(WrappedComponent: React.ComponentType<P>) =>
+type InjectedLatestContextProps = {
+  organizations?: Organization[];
+  organization?: Organization;
+  project?: Project;
+  lastRoute?: string;
+};
+
+type WithPluginProps = {
+  organization?: Organization;
+  organizations: Organization[];
+};
+
+type State = {
+  latestContext: Omit<InjectedLatestContextProps, 'organizations'>;
+};
+
+const withLatestContext = <P extends InjectedLatestContextProps>(
+  WrappedComponent: React.ComponentType<P>
+) =>
   withOrganizations(
-    createReactClass({
+    createReactClass<
+      Omit<P, keyof InjectedLatestContextProps> &
+        Partial<InjectedLatestContextProps> &
+        WithPluginProps,
+      State
+    >({
       displayName: `withLatestContext(${getDisplayName(WrappedComponent)})`,
       propTypes: {
         organization: SentryTypes.Organization,
-        organizations: PropTypes.arrayOf(SentryTypes.Organization),
+        organizations: PropTypes.arrayOf(SentryTypes.Organization).isRequired,
       },
       mixins: [Reflux.connect(LatestContextStore, 'latestContext')],
 

--- a/src/sentry/static/sentry/app/utils/withOrganization.tsx
+++ b/src/sentry/static/sentry/app/utils/withOrganization.tsx
@@ -4,8 +4,16 @@ import SentryTypes from 'app/sentryTypes';
 import getDisplayName from 'app/utils/getDisplayName';
 import {Organization} from 'app/types';
 
-const withOrganization = <P extends object>(WrappedComponent: React.ComponentType<P>) =>
-  class extends React.Component<Omit<P, 'organization'>> {
+type InjectedOrganizationProps = {
+  organization: Organization;
+};
+
+const withOrganization = <P extends InjectedOrganizationProps>(
+  WrappedComponent: React.ComponentType<P>
+) =>
+  class extends React.Component<
+    Omit<P, keyof InjectedOrganizationProps> & Partial<InjectedOrganizationProps>
+  > {
     static displayName = `withOrganization(${getDisplayName(WrappedComponent)})`;
     static contextTypes = {
       organization: SentryTypes.Organization,

--- a/src/sentry/static/sentry/app/utils/withOrganizations.tsx
+++ b/src/sentry/static/sentry/app/utils/withOrganizations.tsx
@@ -6,8 +6,22 @@ import getDisplayName from 'app/utils/getDisplayName';
 import OrganizationsStore from 'app/stores/organizationsStore';
 import {Organization} from 'app/types';
 
-const withOrganizations = <P extends object>(WrappedComponent: React.ComponentType<P>) =>
-  createReactClass({
+type InjectedOrganizationsProps = {
+  organizationsLoading?: boolean;
+  organizations: Organization[];
+};
+
+type State = {
+  organizations: Organization[];
+};
+
+const withOrganizations = <P extends InjectedOrganizationsProps>(
+  WrappedComponent: React.ComponentType<P>
+) =>
+  createReactClass<
+    Omit<P, keyof InjectedOrganizationsProps> & Partial<InjectedOrganizationsProps>,
+    State
+  >({
     displayName: `withOrganizations(${getDisplayName(WrappedComponent)})`,
     mixins: [Reflux.connect(OrganizationsStore, 'organizations')],
 

--- a/src/sentry/static/sentry/app/utils/withPlugins.tsx
+++ b/src/sentry/static/sentry/app/utils/withPlugins.tsx
@@ -3,28 +3,37 @@ import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 
 import {defined} from 'app/utils';
+import {Organization, Project, Plugin} from 'app/types';
 import {fetchPlugins} from 'app/actionCreators/plugins';
 import getDisplayName from 'app/utils/getDisplayName';
 import PluginsStore from 'app/stores/pluginsStore';
 import SentryTypes from 'app/sentryTypes';
-
 import withOrganization from 'app/utils/withOrganization';
 import withProject from 'app/utils/withProject';
-import {Plugin} from 'app/types';
+
+type WithPluginProps = {
+  organization: Organization;
+  project: Project;
+};
+
+type InjectedPluginProps = {
+  plugins: Plugin[];
+};
 
 /**
  * Higher order component that fetches list of plugins and
  * passes PluginsStore to component as `plugins`
  */
-
-const withPlugins = <P extends object>(WrappedComponent: React.ComponentType<P>) =>
+const withPlugins = <P extends InjectedPluginProps>(
+  WrappedComponent: React.ComponentType<P>
+) =>
   withOrganization(
     withProject(
-      createReactClass({
+      createReactClass<Omit<P, keyof InjectedPluginProps> & WithPluginProps, {}>({
         displayName: `withPlugins(${getDisplayName(WrappedComponent)})`,
         propTypes: {
-          organization: SentryTypes.Organization,
-          project: SentryTypes.Project,
+          organization: SentryTypes.Organization.isRequired,
+          project: SentryTypes.Project.isRequired,
         },
         mixins: [Reflux.connect(PluginsStore, 'store')],
 

--- a/src/sentry/static/sentry/app/utils/withProject.tsx
+++ b/src/sentry/static/sentry/app/utils/withProject.tsx
@@ -4,11 +4,19 @@ import SentryTypes from 'app/sentryTypes';
 import getDisplayName from 'app/utils/getDisplayName';
 import {Project} from 'app/types';
 
+type InjectedProjectProps = {
+  project: Project;
+};
+
 /**
  * Currently wraps component with project from context
  */
-const withProject = <P extends object>(WrappedComponent: React.ComponentType<P>) =>
-  class extends React.Component<Omit<P, 'project'>> {
+const withProject = <P extends InjectedProjectProps>(
+  WrappedComponent: React.ComponentType<P>
+) =>
+  class extends React.Component<
+    Omit<P, keyof InjectedProjectProps> & Partial<InjectedProjectProps>
+  > {
     static displayName = `withProject(${getDisplayName(WrappedComponent)})`;
     static contextTypes = {
       project: SentryTypes.Project,

--- a/src/sentry/static/sentry/app/utils/withProjects.tsx
+++ b/src/sentry/static/sentry/app/utils/withProjects.tsx
@@ -7,15 +7,24 @@ import ProjectsStore from 'app/stores/projectsStore';
 import SentryTypes from 'app/sentryTypes';
 import {Project} from 'app/types';
 
-/**
- * Higher order component that uses ProjectsStore and provides a list of projects
- */
-type Props = {
+type InjectedProjectsProps = {
   projects: Project[];
 };
 
-const withProjects = <P extends Props>(WrappedComponent: React.ComponentType<P>) =>
-  createReactClass({
+type State = {
+  projects: Project[];
+};
+
+/**
+ * Higher order component that uses ProjectsStore and provides a list of projects
+ */
+const withProjects = <P extends InjectedProjectsProps>(
+  WrappedComponent: React.ComponentType<P>
+) =>
+  createReactClass<
+    Omit<P, keyof InjectedProjectsProps> & Partial<InjectedProjectsProps>,
+    State
+  >({
     displayName: `withProjects(${getDisplayName(WrappedComponent)})`,
     propTypes: {
       organization: SentryTypes.Organization,
@@ -24,13 +33,13 @@ const withProjects = <P extends Props>(WrappedComponent: React.ComponentType<P>)
     mixins: [Reflux.listenTo(ProjectsStore, 'onProjectUpdate')],
     getInitialState() {
       return {
-        projects: ProjectsStore.getAll(),
+        projects: ProjectsStore.getAll() as Project[],
       };
     },
 
     onProjectUpdate() {
       this.setState({
-        projects: ProjectsStore.getAll(),
+        projects: ProjectsStore.getAll() as Project[],
       });
     },
     render() {

--- a/src/sentry/static/sentry/app/utils/withSavedSearches.tsx
+++ b/src/sentry/static/sentry/app/utils/withSavedSearches.tsx
@@ -6,14 +6,30 @@ import SavedSearchesStore from 'app/stores/savedSearchesStore';
 import getDisplayName from 'app/utils/getDisplayName';
 import {SavedSearch} from 'app/types';
 
+type InjectedSavedSearchesProps = {
+  savedSearches: SavedSearch[];
+  savedSearchLoading: boolean;
+  savedSearch: SavedSearch | null;
+};
+
+type State = {
+  SavedSearchs: SavedSearch;
+  isLoading: boolean;
+};
+
 /**
  * Currently wraps component with organization from context
  */
-
-const withSavedSearches = <P extends object>(WrappedComponent: React.ComponentType<P>) =>
-  createReactClass({
+const withSavedSearches = <P extends InjectedSavedSearchesProps>(
+  WrappedComponent: React.ComponentType<P>
+) =>
+  createReactClass<
+    Omit<P, keyof InjectedSavedSearchesProps> & Partial<InjectedSavedSearchesProps>,
+    State
+  >({
     displayName: `withSavedSearches(${getDisplayName(WrappedComponent)})`,
     mixins: [Reflux.listenTo(SavedSearchesStore, 'onUpdate')],
+
     getInitialState() {
       return SavedSearchesStore.get();
     },
@@ -55,5 +71,4 @@ const withSavedSearches = <P extends object>(WrappedComponent: React.ComponentTy
       );
     },
   });
-
 export default withSavedSearches;

--- a/src/sentry/static/sentry/app/utils/withSentryAppComponents.tsx
+++ b/src/sentry/static/sentry/app/utils/withSentryAppComponents.tsx
@@ -5,18 +5,29 @@ import createReactClass from 'create-react-class';
 import getDisplayName from 'app/utils/getDisplayName';
 import SentryAppComponentsStore from 'app/stores/sentryAppComponentsStore';
 
+// TODO(ts): Update when component type is defined
+type Component = {};
+
+type InjectedAppComponentsProps = {
+  components: Component[];
+};
+
+type State = {
+  components: Component[];
+};
+
 type Options = {
   componentType?: 'stacktrace-link';
 };
 
-// TODO(ts): Update when component type is defined
-type Component = {};
-
-const withSentryAppComponents = <P extends object>(
+const withSentryAppComponents = <P extends InjectedAppComponentsProps>(
   WrappedComponent: React.ComponentType<P>,
   {componentType}: Options = {}
 ) =>
-  createReactClass({
+  createReactClass<
+    Omit<P, keyof InjectedAppComponentsProps> & Partial<InjectedAppComponentsProps>,
+    State
+  >({
     displayName: `withSentryAppComponents(${getDisplayName(WrappedComponent)})`,
     mixins: [Reflux.connect(SentryAppComponentsStore, 'components')],
 

--- a/src/sentry/static/sentry/app/utils/withTeams.tsx
+++ b/src/sentry/static/sentry/app/utils/withTeams.tsx
@@ -2,21 +2,28 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 
-import getDisplayName from 'app/utils/getDisplayName';
-import SentryTypes from 'app/sentryTypes';
-import TeamStore from 'app/stores/teamStore';
 import {Team} from 'app/types';
+import getDisplayName from 'app/utils/getDisplayName';
+import TeamStore from 'app/stores/teamStore';
+
+type InjectedTeamsProps = {
+  teams: Team[];
+};
+
+type State = {
+  teams: Team[];
+};
 
 /**
  * Higher order component that uses TeamStore and provides a list of teams
  */
-const withTeams = <P extends object>(WrappedComponent: React.ComponentType<P>) =>
-  createReactClass({
+const withTeams = <P extends InjectedTeamsProps>(
+  WrappedComponent: React.ComponentType<P>
+) =>
+  createReactClass<Omit<P, keyof InjectedTeamsProps>, State>({
     displayName: `withTeams(${getDisplayName(WrappedComponent)})`,
-    propTypes: {
-      organization: SentryTypes.Organization,
-    },
     mixins: [Reflux.listenTo(TeamStore, 'onTeamUpdate')],
+
     getInitialState() {
       return {
         teams: TeamStore.getAll(),
@@ -32,5 +39,4 @@ const withTeams = <P extends object>(WrappedComponent: React.ComponentType<P>) =
       return <WrappedComponent {...this.props as P} teams={this.state.teams as Team[]} />;
     },
   });
-
 export default withTeams;

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails.tsx
@@ -10,7 +10,6 @@ import SentryTypes from 'app/sentryTypes';
 import AsyncComponent from 'app/components/asyncComponent';
 import ModalDialog from 'app/components/modalDialog';
 import NotFound from 'app/components/errors/notFound';
-import withApi from 'app/utils/withApi';
 import theme from 'app/utils/theme';
 import space from 'app/styles/space';
 import {Organization, Event} from 'app/types';
@@ -127,4 +126,4 @@ class EventDetails extends AsyncComponent<Props, State & AsyncComponent['state']
   }
 }
 
-export default withApi(EventDetails);
+export default EventDetails;

--- a/src/sentry/static/sentry/app/views/eventsV2/modalLineGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/modalLineGraph.tsx
@@ -20,7 +20,7 @@ import {Panel} from 'app/components/panels';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import theme from 'app/utils/theme';
-import {Event, Organization} from 'app/types';
+import {Event, Organization, GlobalSelection} from 'app/types';
 
 import {MODAL_QUERY_KEYS, PIN_ICON} from './data';
 import EventView from './eventView';
@@ -136,8 +136,7 @@ type ModalLineGraphProps = {
   location: Location;
   currentEvent: Event;
   eventView: EventView;
-  // TODO(ts): adjust
-  selection: any;
+  selection: GlobalSelection;
 };
 
 /**
@@ -180,8 +179,9 @@ const ModalLineGraph = (props: ModalLineGraphProps) => {
         period={selection.datetime.period}
         project={selection.projects}
         environment={selection.environments}
-        start={selection.datetime.start}
-        end={selection.datetime.end}
+        // TODO(ts): adjust. Expects date, got strings
+        start={selection.datetime.start as any}
+        end={selection.datetime.end as any}
         interval={interval}
         showLoading={true}
         query={queryString}

--- a/src/sentry/static/sentry/app/views/eventsV2/relatedEvents.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/relatedEvents.tsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import {omit} from 'lodash';
 import {Location} from 'history';
 
-import {Organization, EventViewv1, Event, Project} from 'app/types';
+import {Organization, Event, Project} from 'app/types';
 import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -23,7 +23,6 @@ import {EventQuery} from './utils';
 type Props = {
   location: Location;
   organization: Organization;
-  view: EventViewv1;
   event: Event;
   projects: Array<Project>;
 };

--- a/src/sentry/static/sentry/app/views/incidents/details/relatedIssues/index.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/details/relatedIssues/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import {Client} from 'app/api';
+import {Organization} from 'app/types';
 import {Panel, PanelBody, PanelItem} from 'app/components/panels';
 import {t} from 'app/locale';
 import EventOrGroupExtraDetails from 'app/components/eventOrGroupExtraDetails';
@@ -21,6 +22,7 @@ type Props = {
   className?: string;
   incident?: Incident;
   params: Params;
+  organization: Organization;
 };
 
 class RelatedIssues extends React.Component<Props> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2061,6 +2061,13 @@
   resolved "https://registry.yarnpkg.com/@types/clipboard/-/clipboard-2.0.1.tgz#75a74086c293d75b12bc93ff13bc7797fef05a40"
   integrity sha512-gJJX9Jjdt3bIAePQRRjYWG20dIhAgEqonguyHxXuqALxsoDsDLimihqrSg8fXgVTJ4KZCzkfglKtwsh/8dLfbA==
 
+"@types/create-react-class@^15.6.2":
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/@types/create-react-class/-/create-react-class-15.6.2.tgz#0e1b89153be31ded959359c2b827cceaa9d18cf6"
+  integrity sha512-jeDUr85ld9dTUmrb0VEX1P4dGDPZocWXjeW/+jFJpdCqpCcs0Hdrv3awZqjkEsRaB/IEDe+v0ARYgBqNoDORFQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/echarts@^4.1.10":
   version "4.1.10"
   resolved "https://registry.yarnpkg.com/@types/echarts/-/echarts-4.1.10.tgz#ee71911eb8b1717c7c12c0bd81fc83db872f4d3b"


### PR DESCRIPTION
Proptypes are now properly passed through all HoC components.

This fixed a few minor bugs that this exposed.