### PR TITLE
feat(ui) Add extra extra small button size

### DIFF
--- a/docs-ui/components/button.stories.js
+++ b/docs-ui/components/button.stories.js
@@ -73,6 +73,10 @@ storiesOf('UI|Buttons', module)
           </Item>
 
           <Item>
+            <Button size="xxsmall">Extra Extra Small</Button>
+          </Item>
+
+          <Item>
             <Button size="xsmall">Extra Small</Button>
           </Item>
 
@@ -113,6 +117,24 @@ storiesOf('UI|Buttons', module)
             </Item>
             <Item>
               <Button size="micro" icon="icon-trash" />
+            </Item>
+            <Item>
+              <Button size="zero" icon="icon-trash" />
+            </Item>
+            <Item>
+              <Button size="xxsmall" icon="icon-trash" />
+            </Item>
+            <Item>
+              <Button size="xsmall" icon="icon-trash" />
+            </Item>
+            <Item>
+              <Button size="small" icon="icon-trash" />
+            </Item>
+            <Item>
+              <Button icon="icon-trash" />
+            </Item>
+            <Item>
+              <Button size="large" icon="icon-trash" />
             </Item>
           </div>
         </Section>

--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -18,7 +18,7 @@ type ButtonElement = HTMLButtonElement & HTMLAnchorElement & any;
 
 type Props = {
   priority?: 'default' | 'primary' | 'danger' | 'link' | 'success';
-  size?: 'zero' | 'micro' | 'small' | 'xsmall' | 'large';
+  size?: 'zero' | 'micro' | 'small' | 'xsmall' | 'xxsmall' | 'large';
   align?: 'center' | 'left' | 'right';
   disabled?: boolean;
   busy?: boolean;
@@ -40,7 +40,7 @@ type Url = ButtonProps['to'] | ButtonProps['href'];
 class Button extends React.Component<ButtonProps, {}> {
   static propTypes: any = {
     priority: PropTypes.oneOf(['default', 'primary', 'danger', 'link', 'success']),
-    size: PropTypes.oneOf(['zero', 'micro', 'small', 'xsmall', 'large']),
+    size: PropTypes.oneOf(['zero', 'micro', 'small', 'xxsmall', 'xsmall', 'large']),
     disabled: PropTypes.bool,
     busy: PropTypes.bool,
     /**
@@ -192,6 +192,7 @@ const getFontSize = ({size, theme}: StyledButtonProps) => {
   switch (size) {
     case 'micro':
     case 'xsmall':
+    case 'xxsmall':
     case 'small':
       return theme.fontSizeSmall;
     case 'large':
@@ -314,6 +315,8 @@ const getLabelPadding = ({size, priority, borderless}: StyledButtonProps) => {
     case 'micro':
     case 'zero':
       return '0';
+    case 'xxsmall':
+      return borderless ? '2px 4px' : '4px 6px';
     case 'xsmall':
       return borderless ? '4px 6px' : '6px 10px';
     case 'small':


### PR DESCRIPTION
The discover sidebar designs call for a button that has less padding than the current xsmall button, but more than micro. This button size acould be useful in the issue saved search as well where we're currently using a borderless zero size button which feels a bit too big.

![Screen Shot 2019-09-12 at 12 06 19 PM](https://user-images.githubusercontent.com/24086/64801613-dfca6d80-d556-11e9-8aa4-c5b5a0544888.png)


Refs SEN-952