### PR TITLE
fix: Re-enable w3c in chromedriver for acceptance tests

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -216,15 +216,22 @@ class Browser(object):
         max_age=None,
         secure=None,
     ):
+        domain = domain or self.domain
+        # Recent changes to Chrome no longer allow us to explicitly set a cookie domain
+        # to be localhost. If no domain is specified, the cookie will be created on
+        # the host of the current url that the browser has visited.
+        if domain == "localhost":
+            domain = None
         cookie = {
             "name": name,
             "value": value,
             "expires": expires,
             "path": path,
-            "domain": domain or self.domain,
             "max-age": max_age,
             "secure": secure,
         }
+        if domain:
+            cookie["domain"] = domain
 
         # XXX(dcramer): the cookie store must be initialized via a URL
         if not self._has_initialized_cookie_store:
@@ -306,10 +313,6 @@ def browser(request, percy, live_server):
     headless = not request.config.getoption("no_headless")
     if driver_type == "chrome":
         options = webdriver.ChromeOptions()
-        # TODO: Temporarily adding this to work around chromedriver issues. We should
-        # remove this once a new version of chromedriver is released and we test that
-        # acceptance tests work ok.
-        options.add_experimental_option("w3c", False)
         options.add_argument("no-sandbox")
         options.add_argument("disable-gpu")
         options.add_argument(u"window-size={}".format(window_size))


### PR DESCRIPTION
We temporarily disabled w3c in chromedriver to keep the acceptance tests running, but this is a bad
practice in general and the option will be removed at some point. The issues we had with setting
cookies turned out to be caused by trying to set a cookie domain to localhost explicitly. Chrome
used to be lenient about this, but Chrome 77 has started to reject creating a domain cookie for
localhost since it doesn't fit domain naming conventions.

Not specifying the domain allows the cookie to be created as expected, so going ahead with this
whenever we attempt to set a cookie for localhost.

https://groups.google.com/d/msg/chromedriver-users/eXfoSDZoWbM/faaj9xmaAAAJ