### PR TITLE
Fix: Fix flakey symbolicator tests

### DIFF
--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -52,6 +52,7 @@ REAL_RESOLVING_EVENT_DATA = {
             }
         ]
     },
+    "timestamp": iso_format(before_now(seconds=1)),
 }
 
 


### PR DESCRIPTION
@lynnagara fixed `test_debug_id_resolving` earlier, but other tests are still unstable. This should
hopefully fix the remainder.