### PR TITLE
fix(bug): Link url paramater's have 'undefined'

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventTags.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.tsx
@@ -42,10 +42,11 @@ class EventTags extends React.Component<EventTagsProps> {
         query.project = tag.value;
         break;
       default:
+        const origQuery = query.query ? query.query + ' ' : '';
         query.query =
           tag.value.indexOf(' ') > -1
-            ? `${query.query} ${tag.key}:"${tag.value}"`
-            : `${query.query} ${tag.key}:${tag.value}`;
+            ? `${origQuery}${tag.key}:"${tag.value}"`
+            : `${origQuery}${tag.key}:${tag.value}`;
     }
 
     const locationSearch = `?${queryString.stringify(query)}`;


### PR DESCRIPTION
This fixes the eventTags pill on the the issue details page. If query.query was undefined or null, it would be inserted into the url. Not anymore.