### PR TITLE
feat(discover2) Expand the scope of reference conditions

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -8,7 +8,6 @@ from sentry.api.event_search import (
     get_snuba_query_args,
     resolve_field_list,
     InvalidSearchQuery,
-    find_reference_event,
     get_reference_event_conditions,
 )
 from sentry.models.project import Project
@@ -52,9 +51,8 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
         reference_event_id = request.GET.get("referenceEvent")
         if reference_event_id:
-            reference_event = find_reference_event(snuba_args, reference_event_id)
             snuba_args["conditions"] = get_reference_event_conditions(
-                snuba_args, reference_event.snuba_data
+                snuba_args, reference_event_id
             )
 
         # TODO(lb): remove once boolean search is fully functional

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -38,7 +38,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
 
         # We return the requested event if we find a match regardless of whether
         # it occurred within the range specified
-        event = eventstore.get_event_by_id(project.id, event_id, eventstore.full_columns)
+        event = eventstore.get_event_by_id(project.id, event_id)
 
         if event is None:
             return Response({"detail": "Event not found"}, status=404)
@@ -46,9 +46,8 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         # Scope the pagination related event ids to the current event
         # This ensure that if a field list/groupby conditions were provided
         # that we constrain related events to the query + current event values
-        snuba_args["conditions"].extend(
-            get_reference_event_conditions(snuba_args, event.snuba_data)
-        )
+        event_slug = u"{}:{}".format(project.slug, event_id)
+        snuba_args["conditions"].extend(get_reference_event_conditions(snuba_args, event_slug))
         next_event = eventstore.get_next_event_id(
             event, conditions=snuba_args["conditions"], filter_keys=snuba_args["filter_keys"]
         )

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -840,7 +840,7 @@ def get_reference_event_conditions(snuba_args, event_slug):
         if field.startswith("tags["):
             has_tags = True
         else:
-            columns.append(eventstore.Columns.member_for_value(field))
+            columns.append(eventstore.Columns(field))
 
     if has_tags:
         columns.extend([eventstore.Columns.TAGS_KEY, eventstore.Columns.TAGS_VALUE])

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -803,7 +803,7 @@ def resolve_field_list(fields, snuba_args):
     }
 
 
-def find_reference_event(snuba_args, reference_event_slug):
+def find_reference_event(snuba_args, reference_event_slug, fields):
     try:
         project_slug, event_id = reference_event_slug.split(":")
     except ValueError:
@@ -814,14 +814,17 @@ def find_reference_event(snuba_args, reference_event_slug):
         )
     except Project.DoesNotExist:
         raise InvalidSearchQuery("Invalid reference event")
-    reference_event = eventstore.get_event_by_id(project.id, event_id, eventstore.full_columns)
+    reference_event = eventstore.get_event_by_id(project.id, event_id, fields)
     if not reference_event:
         raise InvalidSearchQuery("Invalid reference event")
 
-    return reference_event
+    return reference_event.snuba_data
 
 
-def get_reference_event_conditions(snuba_args, reference_event):
+TAG_KEY_RE = re.compile(r"^tags\[(.*)\]$")
+
+
+def get_reference_event_conditions(snuba_args, event_slug):
     """
     Returns a list of additional conditions/filter_keys to
     scope a query by the groupby fields using values from the reference event
@@ -829,23 +832,35 @@ def get_reference_event_conditions(snuba_args, reference_event):
     This is a key part of pagination in the event details modal and
     summary graph navigation.
     """
-    conditions = []
-
-    tags = {}
-    if "tags.key" in reference_event and "tags.value" in reference_event:
-        tags = dict(zip(reference_event["tags.key"], reference_event["tags.value"]))
-
-    # If we were given an project/event to use build additional
-    # conditions using that event and the non-aggregated columns
-    # we received in the querystring. This lets us find the oldest/newest.
-    # This only handles simple fields on the snuba_data dict.
-    for field in snuba_args.get("groupby", []):
-        prop = get_snuba_column_name(field)
-        if prop.startswith("tags["):
-            value = tags.get(field, None)
+    field_names = [get_snuba_column_name(field) for field in snuba_args.get("groupby", [])]
+    # translate the field names into enum columns
+    columns = []
+    has_tags = False
+    for field in field_names:
+        if field.startswith("tags["):
+            has_tags = True
         else:
-            value = reference_event.get(prop, None)
+            columns.append(eventstore.Columns.member_for_value(field))
+
+    if has_tags:
+        columns.extend([eventstore.Columns.TAGS_KEY, eventstore.Columns.TAGS_VALUE])
+
+    # Fetch the reference event ensuring the fields in the groupby
+    # clause are present.
+    event_data = find_reference_event(snuba_args, event_slug, columns)
+
+    conditions = []
+    tags = {}
+    if "tags.key" in event_data and "tags.value" in event_data:
+        tags = dict(zip(event_data["tags.key"], event_data["tags.value"]))
+
+    for field in field_names:
+        match = TAG_KEY_RE.match(field)
+        if match:
+            value = tags.get(match.group(1), None)
+        else:
+            value = event_data.get(field, None)
         if value:
-            conditions.append([prop, "=", value])
+            conditions.append([field, "=", value])
 
     return conditions

--- a/src/sentry/eventstore/__init__.py
+++ b/src/sentry/eventstore/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from sentry.utils.services import LazyServiceWrapper
 
-from .base import EventStorage  # NOQA
+from .base import EventStorage, Columns  # NOQA
 
 backend = LazyServiceWrapper(
     EventStorage, "sentry.eventstore.snuba.SnubaEventStorage", {}, metrics_path="eventstore"

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -65,19 +65,6 @@ class Columns(Enum):
     CONTEXTS_KEY = "contexts.key"
     CONTEXTS_VALUE = "contexts.value"
 
-    @classmethod
-    def member_for_value(self, value):
-        """
-        Find a member in the enum by value.
-
-        This is useful when translating end user fields into
-        eventstore compatible enums
-        """
-        for member in self:
-            if member.value == value:
-                return member
-        raise ValueError(u"Unknown column member {}".format(value))
-
 
 class EventStorage(Service):
     __all__ = (

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -7,6 +7,7 @@ from sentry.utils.services import Service
 
 
 class Columns(Enum):
+    # TODO add all the other columns.
     EVENT_ID = "event_id"
     GROUP_ID = "group_id"
     PROJECT_ID = "project_id"
@@ -24,6 +25,58 @@ class Columns(Enum):
     USER_ID = "user_id"
     USERNAME = "username"
     TRANSACTION = "transaction"
+    USER_ID = "user_id"
+    USER_EMAIL = "email"
+    USER_USERNAME = "username"
+    USER_IP = "ip_address"
+    SDK_NAME = "sdk_name"
+    SDK_VERSION = "sdk_version"
+    HTTP_METHOD = "http_method"
+    HTTP_REFERER = "http_referer"
+    HTTP_URL = "http_url"
+    OS_BUILD = "os_build"
+    OS_KERNEL_VERSION = "os_kernel_version"
+    DEVICE_NAME = "device_name"
+    DEVICE_BRAND = "device_brand"
+    DEVICE_LOCALE = "device_locale"
+    DEVICE_UUID = "device_uuid"
+    DEVICE_ARCH = "device_arch"
+    DEVICE_BATTERY_LEVEL = "device_battery_level"
+    DEVICE_ORIENTATION = "device_orientation"
+    DEVICE_SIMULATOR = "device_simulator"
+    DEVICE_ONLINE = "device_online"
+    DEVICE_CHARGING = "device_charging"
+    GEO_COUNTRY_CODE = "geo_country_code"
+    GEO_REGION = "geo_region"
+    GEO_CITY = "geo_city"
+    ERROR_TYPE = "exception_stacks.type"
+    ERROR_VALUE = "exception_stacks.value"
+    ERROR_MECHANISM = "exception_stacks.mechanism_type"
+    ERROR_HANDLED = "exception_stacks.mechanism_handled"
+    STACK_ABS_PATH = "exception_frames.abs_path"
+    STACK_FILENAME = "exception_frames.filename"
+    STACK_PACKAGE = "exception_frames.package"
+    STACK_MODULE = "exception_frames.module"
+    STACK_FUNCTION = "exception_frames.function"
+    STACK_IN_APP = "exception_frames.in_app"
+    STACK_COLNO = "exception_frames.colno"
+    STACK_LINENO = "exception_frames.lineno"
+    STACK_STACK_LEVEL = "exception_frames.stack_level"
+    CONTEXTS_KEY = "contexts.key"
+    CONTEXTS_VALUE = "contexts.value"
+
+    @classmethod
+    def member_for_value(self, value):
+        """
+        Find a member in the enum by value.
+
+        This is useful when translating end user fields into
+        eventstore compatible enums
+        """
+        for member in self:
+            if member.value == value:
+                return member
+        raise ValueError(u"Unknown column member {}".format(value))
 
 
 class EventStorage(Service):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -14,6 +14,7 @@ from sentry.api.event_search import (
     event_search_grammar,
     get_snuba_query_args,
     resolve_field_list,
+    get_reference_event_conditions,
     parse_search_query,
     InvalidSearchQuery,
     SearchBoolean,
@@ -22,7 +23,9 @@ from sentry.api.event_search import (
     SearchValue,
     SearchVisitor,
 )
-from sentry.testutils import TestCase
+from sentry.utils.samples import load_data
+from sentry.testutils import TestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
 class ParseSearchQueryTest(unittest.TestCase):
@@ -1231,3 +1234,165 @@ class ResolveFieldListTest(unittest.TestCase):
             ["argMax(project_id, timestamp)", "", "projectid"],
         ]
         assert result["groupby"] == []
+
+
+class GetReferenceEventConditionsTest(SnubaTestCase, TestCase):
+    def setUp(self):
+        super(GetReferenceEventConditionsTest, self).setUp()
+
+        self.conditions = {"filter_keys": {"project_id": [self.project.id]}}
+
+    def test_bad_slug_format(self):
+        with pytest.raises(InvalidSearchQuery):
+            get_reference_event_conditions(self.conditions, "lol")
+
+    def test_unknown_project(self):
+        event = self.store_event(
+            data={"message": "oh no!", "timestamp": iso_format(before_now(seconds=1))},
+            project_id=self.project.id,
+        )
+        self.conditions["filter_keys"]["project_id"] = [-1]
+        with pytest.raises(InvalidSearchQuery):
+            get_reference_event_conditions(self.conditions, "nope:{}".format(event.event_id))
+
+    def test_unknown_event(self):
+        with pytest.raises(InvalidSearchQuery):
+            slug = "{}:deadbeef".format(self.project.slug)
+            get_reference_event_conditions(self.conditions, slug)
+
+    def test_no_fields(self):
+        event = self.store_event(
+            data={
+                "message": "oh no!",
+                "transaction": "/issues/{issue_id}",
+                "timestamp": iso_format(before_now(seconds=1)),
+            },
+            project_id=self.project.id,
+        )
+        self.conditions["groupby"] = []
+        slug = "{}:{}".format(self.project.slug, event.event_id)
+        result = get_reference_event_conditions(self.conditions, slug)
+        assert len(result) == 0
+
+    def test_basic_fields(self):
+        event = self.store_event(
+            data={
+                "message": "oh no!",
+                "transaction": "/issues/{issue_id}",
+                "timestamp": iso_format(before_now(seconds=1)),
+            },
+            project_id=self.project.id,
+        )
+        self.conditions["groupby"] = ["message", "transaction", "unknown-field"]
+        slug = "{}:{}".format(self.project.slug, event.event_id)
+        result = get_reference_event_conditions(self.conditions, slug)
+        assert result == [
+            ["message", "=", "oh no! /issues/{issue_id}"],
+            ["transaction", "=", "/issues/{issue_id}"],
+        ]
+
+    def test_geo_field(self):
+        event = self.store_event(
+            data={
+                "message": "oh no!",
+                "transaction": "/issues/{issue_id}",
+                "user": {
+                    "id": 1,
+                    "geo": {"country_code": "US", "region": "CA", "city": "San Francisco"},
+                },
+                "timestamp": iso_format(before_now(seconds=1)),
+            },
+            project_id=self.project.id,
+        )
+        self.conditions["groupby"] = ["geo.city", "geo.region", "geo.country_code"]
+        slug = "{}:{}".format(self.project.slug, event.event_id)
+        result = get_reference_event_conditions(self.conditions, slug)
+        assert result == [
+            ["geo_city", "=", "San Francisco"],
+            ["geo_region", "=", "CA"],
+            ["geo_country_code", "=", "US"],
+        ]
+
+    def test_sdk_field(self):
+        event = self.store_event(
+            data={
+                "message": "oh no!",
+                "transaction": "/issues/{issue_id}",
+                "sdk": {"name": "sentry-python", "version": "5.0.12"},
+                "timestamp": iso_format(before_now(seconds=1)),
+            },
+            project_id=self.project.id,
+        )
+        self.conditions["groupby"] = ["sdk.version", "sdk.name"]
+        slug = "{}:{}".format(self.project.slug, event.event_id)
+        result = get_reference_event_conditions(self.conditions, slug)
+        assert result == [["sdk_version", "=", "5.0.12"], ["sdk_name", "=", "sentry-python"]]
+
+    def test_error_field(self):
+        data = load_data("php")
+        data["timestamp"] = iso_format(before_now(seconds=1))
+        event = self.store_event(data=data, project_id=self.project.id)
+        self.conditions["groupby"] = ["error.value", "error.type", "error.handled"]
+        slug = "{}:{}".format(self.project.slug, event.event_id)
+        result = get_reference_event_conditions(self.conditions, slug)
+        assert result == [
+            ["exception_stacks.value", "=", ["This is a test exception sent from the Raven CLI."]],
+            ["exception_stacks.type", "=", ["Exception"]],
+            ["exception_stacks.mechanism_handled", "=", [None]],
+        ]
+
+    def test_stack_field(self):
+        data = load_data("php")
+        data["timestamp"] = iso_format(before_now(seconds=1))
+        event = self.store_event(data=data, project_id=self.project.id)
+        self.conditions["groupby"] = ["stack.filename", "stack.function"]
+        slug = "{}:{}".format(self.project.slug, event.event_id)
+        result = get_reference_event_conditions(self.conditions, slug)
+        assert result == [
+            [
+                "exception_frames.filename",
+                "=",
+                [
+                    "/Users/example/Development/raven-php/bin/raven",
+                    "/Users/example/Development/raven-php/bin/raven",
+                    "/Users/example/Development/raven-php/bin/raven",
+                    "/Users/example/Development/raven-php/bin/raven",
+                ],
+            ],
+            ["exception_frames.function", "=", ["null", "main", "cmd_test", "raven_cli_test"]],
+        ]
+
+    def test_tag_value(self):
+        event = self.store_event(
+            data={
+                "message": "oh no!",
+                "timestamp": iso_format(before_now(seconds=1)),
+                "tags": {"customer_id": 1, "color": "red"},
+            },
+            project_id=self.project.id,
+        )
+        self.conditions["groupby"] = ["nope", "color", "customer_id"]
+        slug = "{}:{}".format(self.project.slug, event.event_id)
+        result = get_reference_event_conditions(self.conditions, slug)
+        assert result == [["tags[color]", "=", "red"], ["tags[customer_id]", "=", "1"]]
+
+    def test_context_value(self):
+        event = self.store_event(
+            data={
+                "message": "oh no!",
+                "timestamp": iso_format(before_now(seconds=1)),
+                "contexts": {
+                    "os": {"version": "10.14.6", "type": "os", "name": "Mac OS X"},
+                    "browser": {"type": "browser", "name": "Firefox", "version": "69"},
+                    "gpu": {"type": "gpu", "name": "nvidia 8600", "vendor": "nvidia"},
+                },
+            },
+            project_id=self.project.id,
+        )
+        self.conditions["groupby"] = ["gpu.name", "browser.name"]
+        slug = "{}:{}".format(self.project.slug, event.event_id)
+        result = get_reference_event_conditions(self.conditions, slug)
+        assert result == [
+            ["tags[gpu.name]", "=", "nvidia 8600"],
+            ["tags[browser.name]", "=", "Firefox"],
+        ]


### PR DESCRIPTION
Reference conditions can now be generated for any concrete table in the event schema. I have not added duration fields as those are not yet shipped.

I've had to greatly expand the Columns enum but I've not modified the column family attributes as we generally don't need to fetch all these columns.

The generated conditions for list fields are very restrictive right now and will generally result in not many events being matched. We might change how these conditions are generated in the future.

Refs SEN-929