### PR TITLE
chore: dependency cleanup

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,13 +1,10 @@
 BeautifulSoup>=3.2.1
 boto3>=1.4.1,<1.4.6
-botocore<1.5.71
 celery>=3.1.8,<3.1.19
 cffi>=1.11.5,<2.0
 click>=5.0,<7.0
 confluent-kafka==0.11.5
-# 'cryptography>=1.3,<1.4
 croniter>=0.3.26,<0.4.0
-cssutils>=0.9.9,<0.10.0
 django-crispy-forms>=1.4.0,<1.5.0
 django-jsonfield>=0.9.13,<0.9.14
 django-picklefield>=0.3.0,<1.1.0
@@ -15,19 +12,12 @@ django-sudo>=2.1.0,<3.0.0
 Django>=1.8,<1.9
 djangorestframework==3.0.5
 email-reply-parser>=0.2.0,<0.3.0
-enum34>=1.1.6,<1.2.0
 exam>=0.5.1
-functools32>=3.2.3,<3.3
-futures>=3.2.0,<4.0.0
-# broken on python3
 hiredis>=0.1.0,<0.2.0
 honcho>=1.0.0,<1.1.0
-ipaddress>=1.0.16,<1.1.0
 jsonschema==2.6.0
 kombu==3.0.35
 loremipsum>=1.0.5,<1.1.0
-lxml>=3.4.1
-# for vsts repo
 mistune>0.7,<0.9
 mmh3>=2.3.1,<2.4
 mock==2.0.0
@@ -52,7 +42,6 @@ qrcode>=5.2.2,<6.0.0
 querystring_parser>=1.2.3,<2.0.0
 rb>=1.7.0,<2.0.0
 redis-py-cluster==1.3.4
-redis>=2.10.3,<2.10.6
 requests-oauthlib==0.3.3
 requests[security]>=2.20.0,<2.21.0
 selenium==3.141.0
@@ -68,7 +57,5 @@ structlog==16.1.0
 symbolic>=6.1.4,<7.0.0
 toronado>=0.0.11,<0.1.0
 ua-parser>=0.6.1,<0.8.0
-# for bitbucket client
 unidiff>=0.5.4
-urllib3==1.24.2
 uwsgi>2.0.0,<2.1.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,10 +1,12 @@
 BeautifulSoup>=3.2.1
 boto3>=1.4.1,<1.4.6
+botocore<1.5.71
 celery>=3.1.8,<3.1.19
 cffi>=1.11.5,<2.0
 click>=5.0,<7.0
 confluent-kafka==0.11.5
 croniter>=0.3.26,<0.4.0
+cssutils==1.0.2
 django-crispy-forms>=1.4.0,<1.5.0
 django-jsonfield>=0.9.13,<0.9.14
 django-picklefield>=0.3.0,<1.1.0
@@ -27,6 +29,7 @@ ipaddress>=1.0.16,<1.1.0
 jsonschema==2.6.0
 kombu==3.0.35
 loremipsum>=1.0.5,<1.1.0
+lxml>=3.4.1
 mistune>0.7,<0.9
 mmh3>=2.3.1,<2.4
 mock==2.0.0
@@ -51,6 +54,7 @@ qrcode>=5.2.2,<6.0.0
 querystring_parser>=1.2.3,<2.0.0
 rb>=1.7.0,<2.0.0
 redis-py-cluster==1.3.4
+redis>=2.10.3,<2.10.6
 requests-oauthlib==0.3.3
 requests[security]>=2.20.0,<2.21.0
 selenium==3.141.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -46,12 +46,10 @@ requests[security]>=2.20.0,<2.21.0
 selenium==3.141.0
 semaphore>=0.4.44,<0.5.0
 sentry-sdk>=0.11.0
-setproctitle>=1.1.7,<1.2.0
 simplejson>=3.2.0,<3.9.0
 six>=1.10.0,<1.11.0
 sqlparse>=0.1.16,<0.2.0
 statsd>=3.1.0,<3.2.0
-strict-rfc3339>=0.7
 structlog==16.1.0
 symbolic>=6.1.4,<7.0.0
 toronado>=0.0.11,<0.1.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -12,8 +12,18 @@ django-sudo>=2.1.0,<3.0.0
 Django>=1.8,<1.9
 djangorestframework==3.0.5
 email-reply-parser>=0.2.0,<0.3.0
+
+# TODO: Remove once we no longer support Python 2.7
+enum34>=1.1.6,<1.2.0
+
 exam>=0.5.1
+
+# TODO: Remove once we no longer support Python 2.7
+functools32>=3.2.3,<3.3
+futures>=3.2.0,<4.0.0
+
 hiredis>=0.1.0,<0.2.0
+ipaddress>=1.0.16,<1.1.0
 jsonschema==2.6.0
 kombu==3.0.35
 loremipsum>=1.0.5,<1.1.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -14,7 +14,6 @@ djangorestframework==3.0.5
 email-reply-parser>=0.2.0,<0.3.0
 exam>=0.5.1
 hiredis>=0.1.0,<0.2.0
-honcho>=1.0.0,<1.1.0
 jsonschema==2.6.0
 kombu==3.0.35
 loremipsum>=1.0.5,<1.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ Babel
 configparser!=3.5.2,!=3.5.3,!=3.7.0
 docker>=3.7.0,<3.8.0
 flake8>=3.5.0,<3.6.0
+honcho>=1.0.0,<1.1.0
 isort>=4.3.4,<4.4.0
 pycodestyle>=2.3.1,<2.4.0
 sentry-flake8>=0.1.0,<0.2.0


### PR DESCRIPTION
Wanted to try cleaning up the `requirements` texts.

For every top level entry in `pipdeptree --reverse`, that is also specified in requirements*.txt and is not exclusively pulled in by sentry, is worth taking a look at.

These are:

	urllib3
    redis
    pycodestyle
	botocore
    lxml
    ipaddress
    futures
    functools32
	enum34
    cssutils
    six

At first, i'm just going to remove all of these and see what happens, even though we explicitly import some of them. Here's the before and after `pip freeze` diff:

```diff
12c12
< botocore==1.5.70
---
> botocore==1.5.95
26c26
< cssutils==0.9.10
---
> cssutils==1.0.2
118c118
< redis==2.10.5
---
> redis==3.3.8
141c141
< urllib3==1.24.2
---
> urllib3==1.24.3
```

Some remarks:

- urllib3, botocore should IMO be left to requests and boto3 to bump, respectively, so this is good, even if we do explictly import them in some places
- cssutils needs to be bumped to 1.0.2 anyways if we want to switch to python3: https://bitbucket.org/cthedot/cssutils/issues/52/bad-octal-escape-blows-up-on-python-35b3
- mainly concerned about the huge redis jump.

