### PR TITLE
feat(api): Add org level details to the alert rules serializer, and add `DetailedAlertRuleSerializer` (SEN-989)

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from collections import defaultdict
+
 import six
 
 from sentry.api.serializers import Serializer, register
@@ -12,6 +14,7 @@ class AlertRuleSerializer(Serializer):
         return {
             "id": six.text_type(obj.id),
             "name": obj.name,
+            "organizationId": six.text_type(obj.organization_id),
             # TODO: Remove this once we've migrated to org level
             "projectId": six.text_type(obj.query_subscriptions.first().project_id),
             "status": obj.status,
@@ -28,3 +31,21 @@ class AlertRuleSerializer(Serializer):
             "dateModified": obj.date_modified,
             "dateAdded": obj.date_added,
         }
+
+
+class DetailedAlertRuleSerializer(AlertRuleSerializer):
+    def get_attrs(self, item_list, user, **kwargs):
+        alert_rule_projects = AlertRule.objects.filter(
+            id__in=[item.id for item in item_list]
+        ).values_list("id", "query_subscriptions__project__slug")
+        alert_rules = {item.id: item for item in item_list}
+        result = defaultdict(dict)
+        for alert_rule_id, project_slug in alert_rule_projects:
+            rule_result = result[alert_rules[alert_rule_id]].setdefault("projects", [])
+            rule_result.append(project_slug)
+        return result
+
+    def serialize(self, obj, attrs, user):
+        data = super(DetailedAlertRuleSerializer, self).serialize(obj, attrs, user)
+        data["projects"] = sorted(attrs["projects"])
+        return data

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.alert_rule import AlertRuleSerializer
+from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
 from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.logic import AlreadyDeletedError, delete_alert_rule
@@ -17,7 +17,7 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         ``````````````````
         :auth: required
         """
-        data = serialize(alert_rule, request.user, AlertRuleSerializer())
+        data = serialize(alert_rule, request.user, DetailedAlertRuleSerializer())
         return Response(data)
 
     def put(self, request, organization, alert_rule):

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -5,29 +5,17 @@ from __future__ import absolute_import
 import six
 
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
 from sentry.incidents.logic import create_alert_rule
 from sentry.incidents.models import AlertRuleThresholdType
 from sentry.snuba.models import QueryAggregations
 from sentry.testutils import TestCase
 
 
-class AlertRuleSerializerTest(TestCase):
-    def test_simple(self):
-        alert_rule = create_alert_rule(
-            self.organization,
-            [self.project],
-            "hello",
-            AlertRuleThresholdType.ABOVE,
-            "level:error",
-            QueryAggregations.TOTAL,
-            10,
-            1000,
-            400,
-            1,
-        )
-        result = serialize(alert_rule)
-
+class BaseAlertRuleSerializerTest(object):
+    def assert_alert_rule_serialized(self, alert_rule, result):
         assert result["id"] == six.text_type(alert_rule.id)
+        assert result["organizationId"] == six.text_type(alert_rule.organization_id)
         assert result["projectId"] == six.text_type(
             alert_rule.query_subscriptions.first().project_id
         )
@@ -43,3 +31,41 @@ class AlertRuleSerializerTest(TestCase):
         assert result["thresholdPeriod"] == alert_rule.threshold_period
         assert result["dateModified"] == alert_rule.date_modified
         assert result["dateAdded"] == alert_rule.date_added
+
+
+class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
+    def test_simple(self):
+        alert_rule = create_alert_rule(
+            self.organization,
+            [self.project],
+            "hello",
+            AlertRuleThresholdType.ABOVE,
+            "level:error",
+            QueryAggregations.TOTAL,
+            10,
+            1000,
+            400,
+            1,
+        )
+        result = serialize(alert_rule)
+        self.assert_alert_rule_serialized(alert_rule, result)
+
+
+class DetailedAlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
+    def test_simple(self):
+        projects = [self.project, self.create_project()]
+        alert_rule = create_alert_rule(
+            self.organization,
+            projects,
+            "hello",
+            AlertRuleThresholdType.ABOVE,
+            "level:error",
+            QueryAggregations.TOTAL,
+            10,
+            1000,
+            400,
+            1,
+        )
+        result = serialize(alert_rule, serializer=DetailedAlertRuleSerializer())
+        self.assert_alert_rule_serialized(alert_rule, result)
+        assert result["projects"] == [p.slug for p in projects]

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from exam import fixture
 
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
 from sentry.incidents.logic import create_alert_rule
 from sentry.incidents.models import AlertRule, AlertRuleThresholdType
 from sentry.snuba.models import QueryAggregations
@@ -73,7 +74,7 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase, APITestCase):
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(self.organization.slug, self.alert_rule.id)
 
-        assert resp.data == serialize(self.alert_rule)
+        assert resp.data == serialize(self.alert_rule, serializer=DetailedAlertRuleSerializer())
 
 
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):


### PR DESCRIPTION
This adds `organizationId` to the alert rules model serializer, and adds
`DetailedAlertRuleSerializer` which includes all related project slugs for the rule.