### PR TITLE
fix(grouping): Ignore hex hashes in exception messages

### DIFF
--- a/src/sentry/grouping/strategies/message.py
+++ b/src/sentry/grouping/strategies/message.py
@@ -78,6 +78,9 @@ _irrelevant_re = re.compile(
             ([-\+][\d]{2}[0-5][\d]|(?:UT|GMT|(?:E|C|M|P)(?:ST|DT)|[A-IK-Z]))
         )
     ) |
+    (?P<hex>
+        \b0[xX][0-9a-fA-F]+\b
+    ) |
     (?P<float>
         -\d+\.\d+\b |
         \b\d+\.\d+\b

--- a/tests/sentry/grouping/grouping_inputs/javascript-exception-fallback-to-message-whistles.json
+++ b/tests/sentry/grouping/grouping_inputs/javascript-exception-fallback-to-message-whistles.json
@@ -10,7 +10,7 @@
   "exception": {
     "values": [
       {
-        "value": "Wed Apr 17 22:31:45 2019: foobar.bazblafasel@example.invalid logged in (error 42) time spent 1234.33 --- correlation id 88ee7c66-29a9-4a4a-bc26-c72d76c5de14, checksum da39a3ee5e6b4b0d3255bfef95601890afd80709 (md5 d41d8cd98f00b204e9800998ecf8427e); payload timestamp 2019-04-17T20:29:05Z (submitted from 127.0.0.1 via 2001:0db8:85a3:0000:0000:8a2e:0370:7334 via ::1)",
+        "value": "Wed Apr 17 22:31:45 2019: foobar.bazblafasel@example.invalid logged in (error 42) time spent 1234.33 --- correlation id 88ee7c66-29a9-4a4a-bc26-c72d76c5de14, checksum da39a3ee5e6b4b0d3255bfef95601890afd80709 (md5 d41d8cd98f00b204e9800998ecf8427e); payload timestamp 2019-04-17T20:29:05Z (submitted from 127.0.0.1 via 2001:0db8:85a3:0000:0000:8a2e:0370:7334 via ::1) at offset 0xfeedbeef",
         "type": "Error"
       }
     ]

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-18T14:29:06.978161Z'
+created: '2019-09-16T13:19:05.835883Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,14 +11,14 @@ app:
         type*
           u'Error'
         value*
-          u'Wed Apr 17 22:31:45 2019: foobar.bazblafasel@example.invalid logged in (error 42) time spent 1234.33 --- correlation id 88ee7c66-29a9-4a4a-bc26-c72d76c5de14, checksum da39a3ee5e6b4b0d3255bfef95601890afd80709 (md5 d41d8cd98f00b204e9800998ecf8427e); payload timestamp 2019-04-17T20:29:05Z (submitted from 127.0.0.1 via 2001:0db8:85a3:0000:0000:8a2e:0370:7334 via ::1)'
+          u'Wed Apr 17 22:31:45 2019: foobar.bazblafasel@example.invalid logged in (error 42) time spent 1234.33 --- correlation id 88ee7c66-29a9-4a4a-bc26-c72d76c5de14, checksum da39a3ee5e6b4b0d3255bfef95601890afd80709 (md5 d41d8cd98f00b204e9800998ecf8427e); payload timestamp 2019-04-17T20:29:05Z (submitted from 127.0.0.1 via 2001:0db8:85a3:0000:0000:8a2e:0370:7334 via ::1) at offset 0xfeedbeef'
 --------------------------------------------------------------------------
 system:
-  hash: '9db349ff5ca081a615d14b00c6da9027'
+  hash: '6de7447e45ffb49fd4fa5728aebdd488'
   component:
     system*
       exception*
         type*
           u'Error'
         value*
-          u'Wed Apr 17 22:31:45 2019: foobar.bazblafasel@example.invalid logged in (error 42) time spent 1234.33 --- correlation id 88ee7c66-29a9-4a4a-bc26-c72d76c5de14, checksum da39a3ee5e6b4b0d3255bfef95601890afd80709 (md5 d41d8cd98f00b204e9800998ecf8427e); payload timestamp 2019-04-17T20:29:05Z (submitted from 127.0.0.1 via 2001:0db8:85a3:0000:0000:8a2e:0370:7334 via ::1)'
+          u'Wed Apr 17 22:31:45 2019: foobar.bazblafasel@example.invalid logged in (error 42) time spent 1234.33 --- correlation id 88ee7c66-29a9-4a4a-bc26-c72d76c5de14, checksum da39a3ee5e6b4b0d3255bfef95601890afd80709 (md5 d41d8cd98f00b204e9800998ecf8427e); payload timestamp 2019-04-17T20:29:05Z (submitted from 127.0.0.1 via 2001:0db8:85a3:0000:0000:8a2e:0370:7334 via ::1) at offset 0xfeedbeef'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-18T14:29:08.052541Z'
+created: '2019-09-16T13:19:07.466034Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,14 +11,14 @@ app:
         type*
           u'Error'
         value*
-          u'Wed Apr 17 22:31:45 2019: foobar.bazblafasel@example.invalid logged in (error 42) time spent 1234.33 --- correlation id 88ee7c66-29a9-4a4a-bc26-c72d76c5de14, checksum da39a3ee5e6b4b0d3255bfef95601890afd80709 (md5 d41d8cd98f00b204e9800998ecf8427e); payload timestamp 2019-04-17T20:29:05Z (submitted from 127.0.0.1 via 2001:0db8:85a3:0000:0000:8a2e:0370:7334 via ::1)'
+          u'Wed Apr 17 22:31:45 2019: foobar.bazblafasel@example.invalid logged in (error 42) time spent 1234.33 --- correlation id 88ee7c66-29a9-4a4a-bc26-c72d76c5de14, checksum da39a3ee5e6b4b0d3255bfef95601890afd80709 (md5 d41d8cd98f00b204e9800998ecf8427e); payload timestamp 2019-04-17T20:29:05Z (submitted from 127.0.0.1 via 2001:0db8:85a3:0000:0000:8a2e:0370:7334 via ::1) at offset 0xfeedbeef'
 --------------------------------------------------------------------------
 system:
-  hash: '9db349ff5ca081a615d14b00c6da9027'
+  hash: '6de7447e45ffb49fd4fa5728aebdd488'
   component:
     system*
       exception*
         type*
           u'Error'
         value*
-          u'Wed Apr 17 22:31:45 2019: foobar.bazblafasel@example.invalid logged in (error 42) time spent 1234.33 --- correlation id 88ee7c66-29a9-4a4a-bc26-c72d76c5de14, checksum da39a3ee5e6b4b0d3255bfef95601890afd80709 (md5 d41d8cd98f00b204e9800998ecf8427e); payload timestamp 2019-04-17T20:29:05Z (submitted from 127.0.0.1 via 2001:0db8:85a3:0000:0000:8a2e:0370:7334 via ::1)'
+          u'Wed Apr 17 22:31:45 2019: foobar.bazblafasel@example.invalid logged in (error 42) time spent 1234.33 --- correlation id 88ee7c66-29a9-4a4a-bc26-c72d76c5de14, checksum da39a3ee5e6b4b0d3255bfef95601890afd80709 (md5 d41d8cd98f00b204e9800998ecf8427e); payload timestamp 2019-04-17T20:29:05Z (submitted from 127.0.0.1 via 2001:0db8:85a3:0000:0000:8a2e:0370:7334 via ::1) at offset 0xfeedbeef'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-18T14:29:10.019528Z'
+created: '2019-09-16T13:22:22.844249Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,14 +11,14 @@ app:
         type*
           u'Error'
         value* (stripped common values)
-          u'<date>: <email> logged in (error <int>) time spent <float> --- correlation id <uuid>, checksum <sha1> (md5 <md5>); payload timestamp <date> (submitted from <ip> via <ip> via <ip>)'
+          u'<date>: <email> logged in (error <int>) time spent <float> --- correlation id <uuid>, checksum <sha1> (md5 <md5>); payload timestamp <date> (submitted from <ip> via <ip> via <ip>) at offset <hex>'
 --------------------------------------------------------------------------
 system:
-  hash: '0bbe78766de9b3b64a5cc115018bec46'
+  hash: 'b8e2a347e75266ca7bb565e2b3c0722e'
   component:
     system*
       exception*
         type*
           u'Error'
         value* (stripped common values)
-          u'<date>: <email> logged in (error <int>) time spent <float> --- correlation id <uuid>, checksum <sha1> (md5 <md5>); payload timestamp <date> (submitted from <ip> via <ip> via <ip>)'
+          u'<date>: <email> logged in (error <int>) time spent <float> --- correlation id <uuid>, checksum <sha1> (md5 <md5>); payload timestamp <date> (submitted from <ip> via <ip> via <ip>) at offset <hex>'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T07:29:42.514078Z'
+created: '2019-09-16T13:22:24.055225Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -11,14 +11,14 @@ app:
         type*
           u'Error'
         value* (stripped common values)
-          u'<date>: <email> logged in (error <int>) time spent <float> --- correlation id <uuid>, checksum <sha1> (md5 <md5>); payload timestamp <date> (submitted from <ip> via <ip> via <ip>)'
+          u'<date>: <email> logged in (error <int>) time spent <float> --- correlation id <uuid>, checksum <sha1> (md5 <md5>); payload timestamp <date> (submitted from <ip> via <ip> via <ip>) at offset <hex>'
 --------------------------------------------------------------------------
 system:
-  hash: '0bbe78766de9b3b64a5cc115018bec46'
+  hash: 'b8e2a347e75266ca7bb565e2b3c0722e'
   component:
     system*
       exception*
         type*
           u'Error'
         value* (stripped common values)
-          u'<date>: <email> logged in (error <int>) time spent <float> --- correlation id <uuid>, checksum <sha1> (md5 <md5>); payload timestamp <date> (submitted from <ip> via <ip> via <ip>)'
+          u'<date>: <email> logged in (error <int>) time spent <float> --- correlation id <uuid>, checksum <sha1> (md5 <md5>); payload timestamp <date> (submitted from <ip> via <ip> via <ip>) at offset <hex>'


### PR DESCRIPTION
Fixes a case where hex values would group events into unique issues.