### PR TITLE
fix(ui): Adds locked project id to the URL on issue details page if it does not exist.

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -9,6 +9,7 @@ import SentryTypes from 'app/sentryTypes';
 import EventOrGroupTitle from 'app/components/eventOrGroupTitle';
 import Tooltip from 'app/components/tooltip';
 import {getMessage, getLocation} from 'app/utils/events';
+import GlobalSelectionLink from 'app/components/globalSelectionLink';
 
 /**
  * Displays an event or group/issue title (i.e. in Stream)
@@ -51,7 +52,10 @@ class EventOrGroupHeader extends React.Component {
           this.props.query ? `?query=${window.encodeURIComponent(this.props.query)}` : ''
         }`,
       };
-      Wrapper = Link;
+      if (!this.props.location.search.includes("project=")) {
+        props.to.search += "&project=all";
+      }
+      Wrapper = GlobalSelectionLink;
     } else {
       Wrapper = 'span';
     }

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {withRouter, browserHistory} from 'react-router';
+import {withRouter} from 'react-router';
 import styled, {css} from 'react-emotion';
 import classNames from 'classnames';
 import {capitalize} from 'lodash';
@@ -44,7 +44,7 @@ class EventOrGroupHeader extends React.Component {
     const basePath = `/organizations/${orgId}/issues/`;
 
     if (includeLink) {
-      const locationWithProject = {...this.props.location}
+      const locationWithProject = {...this.props.location};
       const query =
         locationWithProject.query.project !== undefined
           ? {

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {withRouter, Link} from 'react-router';
+import {withRouter} from 'react-router';
 import styled, {css} from 'react-emotion';
 import classNames from 'classnames';
 import {capitalize} from 'lodash';
@@ -52,9 +52,6 @@ class EventOrGroupHeader extends React.Component {
           this.props.query ? `?query=${window.encodeURIComponent(this.props.query)}` : ''
         }`,
       };
-      if (!this.props.location.search.includes("project=")) {
-        props.to.search += "&project=all";
-      }
       Wrapper = GlobalSelectionLink;
     } else {
       Wrapper = 'span';

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {withRouter} from 'react-router';
+import {withRouter, browserHistory} from 'react-router';
 import styled, {css} from 'react-emotion';
 import classNames from 'classnames';
 import {capitalize} from 'lodash';
@@ -44,14 +44,21 @@ class EventOrGroupHeader extends React.Component {
     const basePath = `/organizations/${orgId}/issues/`;
 
     if (includeLink) {
+      const locationWithProject = {...browserHistory.getCurrentLocation()};
+      const query =
+        locationWithProject.query.project !== undefined
+          ? {
+              query: this.props.query,
+            }
+          : {query: this.props.query, _allp: 1};
+
       props.to = {
         pathname: `${basePath}${isEvent ? groupID : id}/${
           isEvent ? `events/${data.id}/` : ''
         }`,
-        search: `${
-          this.props.query ? `?query=${window.encodeURIComponent(this.props.query)}` : ''
-        }`,
+        query,
       };
+
       Wrapper = GlobalSelectionLink;
     } else {
       Wrapper = 'span';

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.jsx
@@ -44,13 +44,13 @@ class EventOrGroupHeader extends React.Component {
     const basePath = `/organizations/${orgId}/issues/`;
 
     if (includeLink) {
-      const locationWithProject = {...browserHistory.getCurrentLocation()};
+      const locationWithProject = {...this.props.location}
       const query =
         locationWithProject.query.project !== undefined
           ? {
               query: this.props.query,
             }
-          : {query: this.props.query, _allp: 1};
+          : {query: this.props.query, _allp: 1}; //This appends _allp to the URL parameters if they have no project selected ("all" projects included in results). This is so that when we enter the issue details page and lock them to a project, we can properly take them back to the issue list page with no project selected (and not the locked project selected)
 
       props.to = {
         pathname: `${basePath}${isEvent ? groupID : id}/${

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -465,8 +465,8 @@ class GlobalSelectionHeader extends React.Component {
   };
 
   getBackButton = () => {
-    const { organization, location } = this.props;
-    const backLocation = {...location}
+    const {organization, location} = this.props;
+    const backLocation = {...location};
     return (
       <BackButtonWrapper>
         <Tooltip title={t('Back to Issues Stream')} position="bottom">

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -465,7 +465,8 @@ class GlobalSelectionHeader extends React.Component {
   };
 
   getBackButton = () => {
-    const {organization, location} = this.props;
+    const { organization, location } = this.props;
+    const backLocation = {...location}
     return (
       <BackButtonWrapper>
         <Tooltip title={t('Back to Issues Stream')} position="bottom">

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -466,7 +466,6 @@ class GlobalSelectionHeader extends React.Component {
 
   getBackButton = () => {
     const {organization, location} = this.props;
-    const backLocation = {...location};
     return (
       <BackButtonWrapper>
         <Tooltip title={t('Back to Issues Stream')} position="bottom">

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -127,14 +127,18 @@ const GroupDetails = createReactClass({
             Sentry.captureException(new Error('Project not found'));
           });
         } else {
-          const locationWithProject = {...browserHistory.getCurrentLocation()};
+          const locationWithProject = {...this.props.location};
           if (
             locationWithProject.query.project === undefined &&
             locationWithProject.query._allp === undefined
           ) {
+            //We use _allp as a temporary measure to know they came from the issue list page with no project selected (all projects included in filter).
+            //If it is not defined, we add the locked project id to the URL (this is becayse uf someone navigates directly to an issue on single-project priveledges, then goes back - they were getting assigned to the first project).
+            //If it is defined, we do not so that our back button will bring us to the issue list page with no project selected instead of the locked proejct.
             locationWithProject.query.project = project.id;
-            browserHistory.replace(locationWithProject);
           }
+          delete locationWithProject.query._allp; //We delete _allp from the URL to keep the hack a bit cleaner, but this is not an ideal solution and will ultimately be replaced with something smarter.
+          browserHistory.replace(locationWithProject);
         }
 
         this.setState({

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -128,9 +128,6 @@ const GroupDetails = createReactClass({
           });
         } else {
           const location_with_project = { ...browserHistory.getCurrentLocation() };
-          console.log(location_with_project)
-          console.log(location_with_project.query)
-          console.log(location_with_project.project)
           if (!location_with_project.query.project) {
             Object.assign(location_with_project.query, {project: project.id});
             browserHistory.replace(location_with_project);

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -127,9 +127,14 @@ const GroupDetails = createReactClass({
             Sentry.captureException(new Error('Project not found'));
           });
         } else {
-          const location_with_project = {...browserHistory.getCurrentLocation()};
-          Object.assign(location_with_project.query, {project: project.id});
-          browserHistory.replace(location_with_project);
+          const location_with_project = { ...browserHistory.getCurrentLocation() };
+          console.log(location_with_project)
+          console.log(location_with_project.query)
+          console.log(location_with_project.project)
+          if (!location_with_project.query.project) {
+            Object.assign(location_with_project.query, {project: project.id});
+            browserHistory.replace(location_with_project);
+          }
         }
 
         this.setState({

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -128,8 +128,6 @@ const GroupDetails = createReactClass({
           });
         } else {
           const locationWithProject = {...browserHistory.getCurrentLocation()};
-          console.log('query: ', locationWithProject.query);
-          console.log('_allp: ', locationWithProject.query._allp);
           if (
             locationWithProject.query.project === undefined &&
             locationWithProject.query._allp === undefined

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -126,6 +126,10 @@ const GroupDetails = createReactClass({
           Sentry.withScope(scope => {
             Sentry.captureException(new Error('Project not found'));
           });
+        } else {
+          const location_with_project = {...browserHistory.getCurrentLocation()};
+          Object.assign(location_with_project.query, {project: project.id});
+          browserHistory.replace(location_with_project);
         }
 
         this.setState({

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -123,7 +123,7 @@ const GroupDetails = createReactClass({
         const project = this.props.project || ProjectsStore.getById(data.project.id);
 
         if (!project) {
-          Sentry.withScope(scope => { 
+          Sentry.withScope(scope => {
             Sentry.captureException(new Error('Project not found'));
           });
         } else {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -127,7 +127,7 @@ const GroupDetails = createReactClass({
             Sentry.captureException(new Error('Project not found'));
           });
         } else {
-          const location_with_project = { ...browserHistory.getCurrentLocation() };
+          const location_with_project = {...browserHistory.getCurrentLocation()};
           if (!location_with_project.query.project) {
             Object.assign(location_with_project.query, {project: project.id});
             browserHistory.replace(location_with_project);

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -128,7 +128,12 @@ const GroupDetails = createReactClass({
           });
         } else {
           const locationWithProject = {...browserHistory.getCurrentLocation()};
-          if (!locationWithProject.query.project) {
+          console.log('query: ', locationWithProject.query);
+          console.log('_allp: ', locationWithProject.query._allp);
+          if (
+            locationWithProject.query.project === undefined &&
+            locationWithProject.query._allp === undefined
+          ) {
             locationWithProject.query.project = project.id;
             browserHistory.replace(locationWithProject);
           }

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -133,8 +133,8 @@ const GroupDetails = createReactClass({
             locationWithProject.query._allp === undefined
           ) {
             //We use _allp as a temporary measure to know they came from the issue list page with no project selected (all projects included in filter).
-            //If it is not defined, we add the locked project id to the URL (this is becayse uf someone navigates directly to an issue on single-project priveledges, then goes back - they were getting assigned to the first project).
-            //If it is defined, we do not so that our back button will bring us to the issue list page with no project selected instead of the locked proejct.
+            //If it is not defined, we add the locked project id to the URL (this is because if someone navigates directly to an issue on single-project priveleges, then goes back - they were getting assigned to the first project).
+            //If it is defined, we do not so that our back button will bring us to the issue list page with no project selected instead of the locked project.
             locationWithProject.query.project = project.id;
           }
           delete locationWithProject.query._allp; //We delete _allp from the URL to keep the hack a bit cleaner, but this is not an ideal solution and will ultimately be replaced with something smarter.

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.jsx
@@ -123,14 +123,14 @@ const GroupDetails = createReactClass({
         const project = this.props.project || ProjectsStore.getById(data.project.id);
 
         if (!project) {
-          Sentry.withScope(scope => {
+          Sentry.withScope(scope => { 
             Sentry.captureException(new Error('Project not found'));
           });
         } else {
-          const location_with_project = {...browserHistory.getCurrentLocation()};
-          if (!location_with_project.query.project) {
-            Object.assign(location_with_project.query, {project: project.id});
-            browserHistory.replace(location_with_project);
+          const locationWithProject = {...browserHistory.getCurrentLocation()};
+          if (!locationWithProject.query.project) {
+            locationWithProject.query.project = project.id;
+            browserHistory.replace(locationWithProject);
           }
         }
 

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -768,7 +768,10 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                       Array [
                                         Object {
                                           "pathname": "/organizations/org-slug/issues/271/",
-                                          "search": "",
+                                          "query": Object {
+                                            "_allp": 1,
+                                            "query": undefined,
+                                          },
                                         },
                                       ],
                                       Array [
@@ -782,7 +785,10 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                       Array [
                                         Object {
                                           "pathname": "/organizations/org-slug/issues/271/",
-                                          "search": "",
+                                          "query": Object {
+                                            "_allp": 1,
+                                            "query": undefined,
+                                          },
                                         },
                                       ],
                                       Array [
@@ -853,7 +859,10 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                       to={
                                         Object {
                                           "pathname": "/organizations/org-slug/issues/271/",
-                                          "search": "",
+                                          "query": Object {
+                                            "_allp": 1,
+                                            "query": undefined,
+                                          },
                                         }
                                       }
                                     >
@@ -868,7 +877,10 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                         to={
                                           Object {
                                             "pathname": "/organizations/org-slug/issues/271/",
-                                            "search": "",
+                                            "query": Object {
+                                              "_allp": 1,
+                                              "query": undefined,
+                                            },
                                           }
                                         }
                                       >
@@ -967,7 +979,10 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                                     Array [
                                                       Object {
                                                         "pathname": "/organizations/org-slug/issues/271/",
-                                                        "search": "",
+                                                        "query": Object {
+                                                          "_allp": 1,
+                                                          "query": undefined,
+                                                        },
                                                       },
                                                     ],
                                                     Array [
@@ -981,7 +996,10 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                                     Array [
                                                       Object {
                                                         "pathname": "/organizations/org-slug/issues/271/",
-                                                        "search": "",
+                                                        "query": Object {
+                                                          "_allp": 1,
+                                                          "query": undefined,
+                                                        },
                                                       },
                                                     ],
                                                     Array [
@@ -1166,7 +1184,10 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                       Array [
                                         Object {
                                           "pathname": "/organizations/org-slug/issues/271/",
-                                          "search": "",
+                                          "query": Object {
+                                            "_allp": 1,
+                                            "query": undefined,
+                                          },
                                         },
                                       ],
                                       Array [
@@ -1180,7 +1201,10 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                       Array [
                                         Object {
                                           "pathname": "/organizations/org-slug/issues/271/",
-                                          "search": "",
+                                          "query": Object {
+                                            "_allp": 1,
+                                            "query": undefined,
+                                          },
                                         },
                                       ],
                                       Array [

--- a/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
+++ b/tests/js/spec/views/organizationGroupDetails/__snapshots__/groupSimilar.spec.jsx.snap
@@ -843,9 +843,8 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                     className="css-10b3zgy-Title-truncateStyles eex8od0"
                                     size="normal"
                                   >
-                                    <Link
+                                    <GlobalSelectionLink
                                       data-test-id="resolved-issue"
-                                      onlyActiveOnIndex={false}
                                       style={
                                         Object {
                                           "textDecoration": "line-through",
@@ -858,172 +857,180 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                         }
                                       }
                                     >
-                                      <a
+                                      <Link
                                         data-test-id="resolved-issue"
-                                        onClick={[Function]}
+                                        onlyActiveOnIndex={false}
                                         style={
                                           Object {
                                             "textDecoration": "line-through",
                                           }
                                         }
+                                        to={
+                                          Object {
+                                            "pathname": "/organizations/org-slug/issues/271/",
+                                            "search": "",
+                                          }
+                                        }
                                       >
-                                        <GroupLevel
-                                          level="error"
+                                        <a
+                                          data-test-id="resolved-issue"
+                                          onClick={[Function]}
+                                          style={
+                                            Object {
+                                              "textDecoration": "line-through",
+                                            }
+                                          }
                                         >
-                                          <div
-                                            className="css-1oawdkn-GroupLevel eex8od5"
+                                          <GroupLevel
+                                            level="error"
                                           >
-                                            <Tooltip
-                                              containerDisplayMode="inline-block"
-                                              position="top"
-                                              title="Error level: Error"
+                                            <div
+                                              className="css-1oawdkn-GroupLevel eex8od5"
                                             >
-                                              <Manager>
-                                                <Reference>
-                                                  <InnerReference
-                                                    setReferenceNode={[Function]}
-                                                  >
-                                                    <span
-                                                      aria-describedby="tooltip-123456"
-                                                      onBlur={[Function]}
-                                                      onFocus={[Function]}
-                                                      onMouseEnter={[Function]}
-                                                      onMouseLeave={[Function]}
-                                                    />
-                                                  </InnerReference>
-                                                </Reference>
-                                              </Manager>
-                                            </Tooltip>
-                                          </div>
-                                        </GroupLevel>
-                                        <EventOrGroupTitle
-                                          data={
-                                            Object {
-                                              "annotations": Array [],
-                                              "assignedTo": null,
-                                              "count": "90",
-                                              "culprit": "length(app/views/groupSimilar/groupSimilarView)",
-                                              "firstSeen": "2017-07-10T18:32:43Z",
-                                              "hasSeen": false,
-                                              "id": "271",
-                                              "isBookmarked": false,
-                                              "isPublic": false,
-                                              "isSubscribed": true,
-                                              "lastSeen": "2017-07-24T23:41:44Z",
-                                              "level": "error",
-                                              "logger": "javascript",
-                                              "metadata": Object {
-                                                "type": "TypeError",
-                                                "value": "Cannot read property 'length' of undefined",
-                                              },
-                                              "numComments": 0,
-                                              "permalink": "http://localhost:8000/sentry/project-slug/issues/271/",
-                                              "project": Object {
-                                                "id": "123",
-                                                "name": "Internal",
-                                                "slug": "project-slug",
-                                              },
-                                              "shareId": "312e323731",
-                                              "shortId": "INTERNAL-4G",
-                                              "status": "resolved",
-                                              "statusDetails": Object {},
-                                              "subscriptionDetails": null,
-                                              "title": "TypeError: Cannot read property 'length' of undefined",
-                                              "type": "error",
-                                              "userCount": 3,
+                                              <Tooltip
+                                                containerDisplayMode="inline-block"
+                                                position="top"
+                                                title="Error level: Error"
+                                              >
+                                                <Manager>
+                                                  <Reference>
+                                                    <InnerReference
+                                                      setReferenceNode={[Function]}
+                                                    >
+                                                      <span
+                                                        aria-describedby="tooltip-123456"
+                                                        onBlur={[Function]}
+                                                        onFocus={[Function]}
+                                                        onMouseEnter={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                      />
+                                                    </InnerReference>
+                                                  </Reference>
+                                                </Manager>
+                                              </Tooltip>
+                                            </div>
+                                          </GroupLevel>
+                                          <EventOrGroupTitle
+                                            data={
+                                              Object {
+                                                "annotations": Array [],
+                                                "assignedTo": null,
+                                                "count": "90",
+                                                "culprit": "length(app/views/groupSimilar/groupSimilarView)",
+                                                "firstSeen": "2017-07-10T18:32:43Z",
+                                                "hasSeen": false,
+                                                "id": "271",
+                                                "isBookmarked": false,
+                                                "isPublic": false,
+                                                "isSubscribed": true,
+                                                "lastSeen": "2017-07-24T23:41:44Z",
+                                                "level": "error",
+                                                "logger": "javascript",
+                                                "metadata": Object {
+                                                  "type": "TypeError",
+                                                  "value": "Cannot read property 'length' of undefined",
+                                                },
+                                                "numComments": 0,
+                                                "permalink": "http://localhost:8000/sentry/project-slug/issues/271/",
+                                                "project": Object {
+                                                  "id": "123",
+                                                  "name": "Internal",
+                                                  "slug": "project-slug",
+                                                },
+                                                "shareId": "312e323731",
+                                                "shortId": "INTERNAL-4G",
+                                                "status": "resolved",
+                                                "statusDetails": Object {},
+                                                "subscriptionDetails": null,
+                                                "title": "TypeError: Cannot read property 'length' of undefined",
+                                                "type": "error",
+                                                "userCount": 3,
+                                              }
                                             }
-                                          }
-                                          includeLink={true}
-                                          location={
-                                            Object {
-                                              "query": Object {},
-                                            }
-                                          }
-                                          params={
-                                            Object {
-                                              "groupId": "group-id",
-                                              "orgId": "org-slug",
-                                              "projectId": "project-slug",
-                                            }
-                                          }
-                                          router={
-                                            Object {
-                                              "createHref": [MockFunction] {
-                                                "calls": Array [
-                                                  Array [
-                                                    Object {
-                                                      "pathname": "/organizations/org-slug/issues/271/",
-                                                      "search": "",
-                                                    },
-                                                  ],
-                                                  Array [
-                                                    Object {
-                                                      "pathname": "/organizations/org-slug/issues/",
-                                                      "query": Object {
-                                                        "query": "logger:javascript",
-                                                      },
-                                                    },
-                                                  ],
-                                                  Array [
-                                                    Object {
-                                                      "pathname": "/organizations/org-slug/issues/271/",
-                                                      "search": "",
-                                                    },
-                                                  ],
-                                                  Array [
-                                                    Object {
-                                                      "pathname": "/organizations/org-slug/issues/",
-                                                      "query": Object {
-                                                        "query": "logger:javascript",
-                                                      },
-                                                    },
-                                                  ],
-                                                ],
-                                                "results": Array [
-                                                  Object {
-                                                    "type": "return",
-                                                    "value": undefined,
-                                                  },
-                                                  Object {
-                                                    "type": "return",
-                                                    "value": undefined,
-                                                  },
-                                                  Object {
-                                                    "type": "return",
-                                                    "value": undefined,
-                                                  },
-                                                  Object {
-                                                    "type": "return",
-                                                    "value": undefined,
-                                                  },
-                                                ],
-                                              },
-                                              "go": [MockFunction],
-                                              "goBack": [MockFunction],
-                                              "goForward": [MockFunction],
-                                              "isActive": [MockFunction],
-                                              "listen": [MockFunction],
-                                              "location": Object {
+                                            includeLink={true}
+                                            location={
+                                              Object {
                                                 "query": Object {},
-                                              },
-                                              "params": Object {
+                                              }
+                                            }
+                                            params={
+                                              Object {
                                                 "groupId": "group-id",
                                                 "orgId": "org-slug",
                                                 "projectId": "project-slug",
-                                              },
-                                              "push": [MockFunction],
-                                              "replace": [MockFunction],
-                                              "setRouteLeaveHook": [MockFunction],
+                                              }
                                             }
-                                          }
-                                          size="normal"
-                                          style={
-                                            Object {
-                                              "fontWeight": 600,
+                                            router={
+                                              Object {
+                                                "createHref": [MockFunction] {
+                                                  "calls": Array [
+                                                    Array [
+                                                      Object {
+                                                        "pathname": "/organizations/org-slug/issues/271/",
+                                                        "search": "",
+                                                      },
+                                                    ],
+                                                    Array [
+                                                      Object {
+                                                        "pathname": "/organizations/org-slug/issues/",
+                                                        "query": Object {
+                                                          "query": "logger:javascript",
+                                                        },
+                                                      },
+                                                    ],
+                                                    Array [
+                                                      Object {
+                                                        "pathname": "/organizations/org-slug/issues/271/",
+                                                        "search": "",
+                                                      },
+                                                    ],
+                                                    Array [
+                                                      Object {
+                                                        "pathname": "/organizations/org-slug/issues/",
+                                                        "query": Object {
+                                                          "query": "logger:javascript",
+                                                        },
+                                                      },
+                                                    ],
+                                                  ],
+                                                  "results": Array [
+                                                    Object {
+                                                      "type": "return",
+                                                      "value": undefined,
+                                                    },
+                                                    Object {
+                                                      "type": "return",
+                                                      "value": undefined,
+                                                    },
+                                                    Object {
+                                                      "type": "return",
+                                                      "value": undefined,
+                                                    },
+                                                    Object {
+                                                      "type": "return",
+                                                      "value": undefined,
+                                                    },
+                                                  ],
+                                                },
+                                                "go": [MockFunction],
+                                                "goBack": [MockFunction],
+                                                "goForward": [MockFunction],
+                                                "isActive": [MockFunction],
+                                                "listen": [MockFunction],
+                                                "location": Object {
+                                                  "query": Object {},
+                                                },
+                                                "params": Object {
+                                                  "groupId": "group-id",
+                                                  "orgId": "org-slug",
+                                                  "projectId": "project-slug",
+                                                },
+                                                "push": [MockFunction],
+                                                "replace": [MockFunction],
+                                                "setRouteLeaveHook": [MockFunction],
+                                              }
                                             }
-                                          }
-                                        >
-                                          <span
+                                            size="normal"
                                             style={
                                               Object {
                                                 "fontWeight": 600,
@@ -1033,22 +1040,30 @@ exports[`Issues Similar View renders with mocked data 1`] = `
                                             <span
                                               style={
                                                 Object {
-                                                  "marginRight": 10,
+                                                  "fontWeight": 600,
                                                 }
                                               }
                                             >
-                                              TypeError
+                                              <span
+                                                style={
+                                                  Object {
+                                                    "marginRight": 10,
+                                                  }
+                                                }
+                                              >
+                                                TypeError
+                                              </span>
+                                              <em
+                                                title="length(app/views/groupSimilar/groupSimilarView)"
+                                              >
+                                                length(app/views/groupSimilar/groupSimilarView)
+                                              </em>
+                                              <br />
                                             </span>
-                                            <em
-                                              title="length(app/views/groupSimilar/groupSimilarView)"
-                                            >
-                                              length(app/views/groupSimilar/groupSimilarView)
-                                            </em>
-                                            <br />
-                                          </span>
-                                        </EventOrGroupTitle>
-                                      </a>
-                                    </Link>
+                                          </EventOrGroupTitle>
+                                        </a>
+                                      </Link>
+                                    </GlobalSelectionLink>
                                   </div>
                                 </Title>
                                 <Message

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -58,7 +58,7 @@ class NotifyEventServiceActionTest(RuleTestCase):
 
             results = list(rule.after(event=event, state=self.get_state()))
 
-        assert len(results) is 2
-        assert plugin.should_notify.call_count is 1
+        assert len(results) == 2
+        assert plugin.should_notify.call_count == 1
         assert results[0].callback is notify_sentry_app
         assert results[1].callback is plugin.rule_notify


### PR DESCRIPTION
Adds the project parameter to the URL (based on the project we autoselect and lock a user to) when browsing to an issue that does not have it.

Drawback: When browsing to an issue from the issue list page, with no project filter (i.e. all projects 'selectedl'), the filter gets added and going back can feel like a poor user experience. Will look into solving this later - Billy recommended pushing this fix in the meantime, though.

Fixes SEN-1024