### PR TITLE
test: Refactor digest tests to use store_event instead of create_event

### DIFF
--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -1,8 +1,5 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
-from django.utils import timezone
-
 from sentry.api.fields.actor import Actor
 from sentry.digests.notifications import build_digest, event_to_record
 from sentry.digests.utilities import (
@@ -14,7 +11,8 @@ from sentry.digests.utilities import (
 )
 from sentry.models import OrganizationMemberTeam, ProjectOwnership, Team, User
 from sentry.ownership.grammar import Rule, Owner, Matcher, dump_schema
-from sentry.testutils import TestCase
+from sentry.testutils import SnubaTestCase, TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 def sort_records(records):
@@ -25,25 +23,50 @@ def sort_records(records):
     return sorted(records, key=lambda r: r.value.event.datetime, reverse=True)
 
 
-class UtilitiesHelpersTestCase(TestCase):
+class UtilitiesHelpersTestCase(TestCase, SnubaTestCase):
+    def create_event(self, project_id):
+        return (
+            self.store_event(
+                data={"timestamp": iso_format(before_now(minutes=1))}, project_id=project_id
+            ),
+        )
+
     def test_get_event_from_groups_in_digest(self):
         project = self.create_project()
         rule = project.rule_set.all()[0]
-        same_group = self.create_group(project=project)
 
         events = [
-            self.create_event(group=same_group),
-            self.create_event(group=same_group),
-            self.create_event(group=self.create_group(project=project)),
-            self.create_event(group=self.create_group(project=project)),
-            self.create_event(group=self.create_group(project=project)),
-            self.create_event(group=self.create_group(project=project)),
+            self.store_event(
+                data={"fingerprint": ["group1"], "timestamp": iso_format(before_now(minutes=1))},
+                project_id=project.id,
+            ),
+            self.store_event(
+                data={"fingerprint": ["group1"], "timestamp": iso_format(before_now(minutes=1))},
+                project_id=project.id,
+            ),
+            self.store_event(
+                data={"fingerprint": ["group2"], "timestamp": iso_format(before_now(minutes=1))},
+                project_id=project.id,
+            ),
+            self.store_event(
+                data={"fingerprint": ["group3"], "timestamp": iso_format(before_now(minutes=1))},
+                project_id=project.id,
+            ),
+            self.store_event(
+                data={"fingerprint": ["group4"], "timestamp": iso_format(before_now(minutes=1))},
+                project_id=project.id,
+            ),
+            self.store_event(
+                data={"fingerprint": ["group5"], "timestamp": iso_format(before_now(minutes=1))},
+                project_id=project.id,
+            ),
         ]
+
         digest = build_digest(
             project, sort_records([event_to_record(event, (rule,)) for event in events])
         )
 
-        events.pop(0)  # remove event with same group
+        events.pop(1)  # remove event with same group
         assert get_event_from_groups_in_digest(digest) == set(events)
 
     def test_team_actors_to_user_ids(self):
@@ -92,12 +115,22 @@ class UtilitiesHelpersTestCase(TestCase):
         self.create_member(user=user4, organization=self.organization, teams=[])
 
         team1_events = set(
-            [self.create_event(), self.create_event(), self.create_event(), self.create_event()]
+            [
+                self.create_event(self.project.id),
+                self.create_event(self.project.id),
+                self.create_event(self.project.id),
+                self.create_event(self.project.id),
+            ]
         )
         team2_events = set(
-            [self.create_event(), self.create_event(), self.create_event(), self.create_event()]
+            [
+                self.create_event(self.project.id),
+                self.create_event(self.project.id),
+                self.create_event(self.project.id),
+                self.create_event(self.project.id),
+            ]
         )
-        user4_events = set([self.create_event(), self.create_event()])
+        user4_events = set([self.create_event(self.project.id), self.create_event(self.project.id)])
         events_by_actor = {
             Actor(team1.id, Team): team1_events,
             Actor(team2.id, Team): team2_events,
@@ -113,8 +146,9 @@ class UtilitiesHelpersTestCase(TestCase):
         assert convert_actors_to_users(events_by_actor, user_by_events.keys()) == user_by_events
 
 
-class GetPersonalizedDigestsTestCase(TestCase):
+class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
     def setUp(self):
+        super(GetPersonalizedDigestsTestCase, self).setUp()
         self.user1 = self.create_user()
         self.user2 = self.create_user()
         self.user3 = self.create_user()
@@ -136,23 +170,31 @@ class GetPersonalizedDigestsTestCase(TestCase):
         self.create_member(user=self.user4, organization=self.organization, teams=[self.team3])
         self.create_member(user=self.user5, organization=self.organization, teams=[self.team3])
 
-        start_time = timezone.now()
-
-        self.team1_events = self.create_events(
-            start_time, self.project, ["hello.py", "goodbye.py", "hola.py", "adios.py"]
+        self.team1_events = self.create_events_from_filenames(
+            self.project, ["hello.py", "goodbye.py", "hola.py", "adios.py"]
         )
-        self.team2_events = self.create_events(
-            start_time, self.project, ["old.cbl", "retro.cbl", "cool.cbl", "gem.cbl"]
+        self.team2_events = self.create_events_from_filenames(
+            self.project, ["old.cbl", "retro.cbl", "cool.cbl", "gem.cbl"]
         )
 
         self.user4_events = [
-            self.create_event(
-                group=self.create_group(project=self.project),
-                data=self.create_event_data("foo.bar", "helloworld.org"),
+            self.store_event(
+                data={
+                    "stacktrace": {"frames": [{"lineno": 1, "filename": "foo.bar"}]},
+                    "request": {"url": "helloworld.org"},
+                    "timestamp": iso_format(before_now(minutes=1)),
+                    "fingerprint": ["user4group1"],
+                },
+                project_id=self.project.id,
             ),
-            self.create_event(
-                group=self.create_group(project=self.project),
-                data=self.create_event_data("bar.foo", "helloworld.org"),
+            self.store_event(
+                data={
+                    "stacktrace": {"frames": [{"lineno": 1, "filename": "bar.foo"}]},
+                    "request": {"url": "helloworld.org"},
+                    "timestamp": iso_format(before_now(minutes=1)),
+                    "fingerprint": ["user4group2"],
+                },
+                project_id=self.project.id,
             ),
         ]
         self.team1_matcher = Matcher("path", "*.py")
@@ -174,39 +216,15 @@ class GetPersonalizedDigestsTestCase(TestCase):
             fallthrough=True,
         )
 
-    def create_event_data(self, filename, url="http://example.com"):
-        data = {
-            "tags": [("level", "error")],
-            "stacktrace": {"frames": [{"lineno": 1, "filename": filename}]},
-            "request": {"url": url},
-        }
-        return data
-
-    def create_events(self, start_time, project, filenames=None, urls=None):
+    def create_events_from_filenames(self, project, filenames=None):
         events = []
-        for index, label in enumerate(filenames or urls):
-            group = self.create_group(
-                project=project,
-                first_seen=start_time - timedelta(days=index + 1),
-                last_seen=start_time - timedelta(hours=index + 1),
-                message="group%d" % index,
-            )
-            if filenames is not None:
-                event = self.create_event(
-                    group=group,
-                    message=group.message,
-                    datetime=group.last_seen,
-                    project=project,
-                    data=self.create_event_data(filename=label),
-                )
-            else:
-                event = self.create_event(
-                    group=group,
-                    message=group.message,
-                    datetime=group.last_seen,
-                    project=project,
-                    data=self.create_event_data("foo.bar", url=label),
-                )
+        for index, label in enumerate(filenames):
+            event_data = {
+                "stacktrace": {"frames": [{"filename": label}]},
+                "fingerprint": [label],
+                "timestamp": iso_format(before_now(minutes=1)),
+            }
+            event = self.store_event(data=event_data, project_id=project.id, assert_no_errors=False)
             events.append(event)
         return events
 
@@ -257,8 +275,8 @@ class GetPersonalizedDigestsTestCase(TestCase):
         rule = project.rule_set.all()[0]
         records = [
             event_to_record(event, (rule,))
-            for event in self.create_events(
-                timezone.now(), project, ["hello.py", "goodbye.py", "hola.py", "adios.py"]
+            for event in self.create_events_from_filenames(
+                project, ["hello.py", "goodbye.py", "hola.py", "adios.py"]
             )
         ]
         digest = build_digest(project, sort_records(records))
@@ -269,8 +287,8 @@ class GetPersonalizedDigestsTestCase(TestCase):
 
     def test_only_everyone(self):
         rule = self.project.rule_set.all()[0]
-        events = self.create_events(
-            timezone.now(), self.project, ["hello.moz", "goodbye.moz", "hola.moz", "adios.moz"]
+        events = self.create_events_from_filenames(
+            self.project, ["hello.moz", "goodbye.moz", "hola.moz", "adios.moz"]
         )
         records = [event_to_record(event, (rule,)) for event in events]
         digest = build_digest(self.project, sort_records(records))
@@ -285,8 +303,8 @@ class GetPersonalizedDigestsTestCase(TestCase):
 
     def test_everyone_with_owners(self):
         rule = self.project.rule_set.all()[0]
-        events = self.create_events(
-            timezone.now(), self.project, ["hello.moz", "goodbye.moz", "hola.moz", "adios.moz"]
+        events = self.create_events_from_filenames(
+            self.project, ["hello.moz", "goodbye.moz", "hola.moz", "adios.moz"]
         )
         records = [event_to_record(event, (rule,)) for event in events + self.team1_events]
         digest = build_digest(self.project, sort_records(records))

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -37,7 +37,7 @@ class UtilitiesHelpersTestCase(TestCase, SnubaTestCase):
 
         events = [
             self.store_event(
-                data={"fingerprint": ["group1"], "timestamp": iso_format(before_now(minutes=1))},
+                data={"fingerprint": ["group1"], "timestamp": iso_format(before_now(minutes=2))},
                 project_id=project.id,
             ),
             self.store_event(
@@ -66,7 +66,7 @@ class UtilitiesHelpersTestCase(TestCase, SnubaTestCase):
             project, sort_records([event_to_record(event, (rule,)) for event in events])
         )
 
-        events.pop(1)  # remove event with same group
+        events.pop(0)  # remove event with same group
         assert get_event_from_groups_in_digest(digest) == set(events)
 
     def test_team_actors_to_user_ids(self):


### PR DESCRIPTION
Will be needed later when we refactor event ingestion to process
all duplicate events.