### PR TITLE
feat(discover2): Store discover state as an LZ string

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "less-loader": "^4.1.0",
     "lodash": "^4.17.11",
     "lodash-webpack-plugin": "^0.11.5",
+    "lz-string": "^1.4.4",
     "marked": "0.6.2",
     "mini-css-extract-plugin": "^v0.5.0",
     "mobx": "^3.2.2",

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -1,5 +1,5 @@
 import {Location, Query} from 'history';
-import {isString, pick, get, isPlainObject} from 'lodash';
+import {isString, cloneDeep, pick, get, isPlainObject} from 'lodash';
 
 import {EventViewv1} from 'app/types';
 import {SavedQuery} from 'app/views/discover/types';
@@ -265,7 +265,7 @@ class EventView {
       }
     }
 
-    return output;
+    return cloneDeep(output);
   }
 
   isValid(): boolean {
@@ -323,7 +323,6 @@ class EventView {
     return queryParts.join(' ');
   }
 
-  // Takes an EventView instance and converts it into the format required for the events API
   getEventsAPIPayload(location: Location): EventQuery {
     const query = location.query || {};
 
@@ -335,7 +334,6 @@ class EventView {
       utc?: string;
       statsPeriod?: string;
       cursor?: string;
-      sort?: string;
     };
 
     const picked = pick<LocationQuery>(query || {}, [
@@ -346,16 +344,16 @@ class EventView {
       'utc',
       'statsPeriod',
       'cursor',
-      'sort',
     ]);
 
     const fieldNames = this.getFieldNames();
 
     const defaultSort = fieldNames.length > 0 ? [fieldNames[0]] : undefined;
+    const encodedSorts = encodeSorts(this.sorts);
 
     const eventQuery: EventQuery = Object.assign(picked, {
       field: [...new Set(fieldNames)],
-      sort: picked.sort ? picked.sort : defaultSort,
+      sort: encodedSorts.length > 0 ? encodedSorts : defaultSort,
       per_page: DEFAULT_PER_PAGE,
       query: this.getQuery(query.query),
     });

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -346,6 +346,7 @@ class EventView {
       cursor?: string;
     };
 
+    // note: these query strings are set by another component
     const picked = pick<LocationQuery>(query || {}, [
       'project',
       'environment',

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -66,14 +66,14 @@ const parseStringArray = (maybe: any): string[] => {
 };
 
 const intoDiscoverState = (location: Location): DiscoverState => {
-  const name = getFirstQueryString(location.query, 'name', '');
-
   try {
     const maybeState: string = getFirstQueryString(location.query, 'state', '{}');
     const result = JSON.parse(decompressString(maybeState));
 
+    const maybeName = get(result, 'name', '');
+
     return {
-      name,
+      name: isString(maybeName) ? maybeName : '',
       fields: parseStringArray(get(result, 'fields', [])),
       aliases: parseStringArray(get(result, 'aliases', [])),
       sorts: parseStringArray(get(result, 'sorts', [])),
@@ -81,7 +81,7 @@ const intoDiscoverState = (location: Location): DiscoverState => {
     };
   } catch (_err) {
     return {
-      name,
+      name: '',
       fields: [],
       aliases: [],
       sorts: [],

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -6,7 +6,14 @@ import {SavedQuery} from 'app/views/discover/types';
 import {DEFAULT_PER_PAGE} from 'app/constants';
 
 import {AUTOLINK_FIELDS, SPECIAL_FIELDS, FIELD_FORMATTERS} from './data';
-import {MetaType, EventQuery, getAggregateAlias, getFirstQueryString} from './utils';
+import {
+  MetaType,
+  EventQuery,
+  getAggregateAlias,
+  getFirstQueryString,
+  compressString,
+  decompressString,
+} from './utils';
 
 type Descending = {
   kind: 'desc';
@@ -60,7 +67,7 @@ const parseStringArray = (maybe: any): string[] => {
 const intoDiscoverState = (location: Location): DiscoverState => {
   try {
     const maybeState: string = getFirstQueryString(location.query, 'state', '{}');
-    const result = JSON.parse(maybeState);
+    const result = JSON.parse(decompressString(maybeState));
 
     return {
       fields: parseFields(get(result, 'fields', [])),
@@ -254,7 +261,7 @@ class EventView {
     };
 
     const output = {
-      state: JSON.stringify(state),
+      state: compressString(JSON.stringify(state)),
       query: this.query,
     };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -62,11 +62,7 @@ class EventsV2 extends React.Component<Props> {
     return <LinkList>{list}</LinkList>;
   }
 
-  getEventViewName = (): Array<string> => {
-    const {location} = this.props;
-
-    const name = getFirstQueryString(location.query, 'name');
-
+  getEventViewName = (name: string): Array<string> => {
     if (typeof name === 'string' && String(name).trim().length > 0) {
       return [t('Events'), String(name).trim()];
     }
@@ -80,12 +76,12 @@ class EventsV2 extends React.Component<Props> {
 
     const eventView = EventView.fromLocation(location);
 
-    const hasQuery = location.query.state || location.query.eventSlug;
+    const hasQuery = eventView.isValid() || location.query.eventSlug;
 
-    const documentTitle = this.getEventViewName()
+    const documentTitle = this.getEventViewName(eventView.name)
       .reverse()
       .join(' - ');
-    const pageTitle = this.getEventViewName().join(' \u2014 ');
+    const pageTitle = this.getEventViewName(eventView.name).join(' \u2014 ');
 
     return (
       <Feature features={['events-v2']} organization={organization} renderDisabled>

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -81,7 +81,7 @@ class EventsV2 extends React.Component<Props> {
     const eventView = EventView.fromLocation(location);
 
     const hasQuery =
-      location.query.field || location.query.eventSlug || location.query.view;
+      location.query.state || location.query.eventSlug || location.query.view;
 
     const documentTitle = this.getEventViewName()
       .reverse()

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -80,8 +80,7 @@ class EventsV2 extends React.Component<Props> {
 
     const eventView = EventView.fromLocation(location);
 
-    const hasQuery =
-      location.query.state || location.query.eventSlug || location.query.view;
+    const hasQuery = location.query.state || location.query.eventSlug;
 
     const documentTitle = this.getEventViewName()
       .reverse()

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -1,5 +1,6 @@
 import {partial, pick} from 'lodash';
 import {Location, Query} from 'history';
+import LZString from 'lz-string';
 
 import {Client} from 'app/api';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
@@ -204,3 +205,16 @@ export function getFirstQueryString(
 
   return defaultValue;
 }
+
+export const compressString = (string: string): string =>
+  LZString.compressToBase64(string)
+    .replace(/\+/g, '-') // Convert '+' to '-'
+    .replace(/\//g, '_') // Convert '/' to '_'
+    .replace(/=+$/, ''); // Remove ending '='
+
+export const decompressString = (string: string): string =>
+  LZString.decompressFromBase64(
+    string
+      .replace(/-/g, '+') // Convert '-' to '+'
+      .replace(/_/g, '/') // Convert '_' to '/'
+  );

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -1,5 +1,5 @@
 import {partial, pick} from 'lodash';
-import {Location} from 'history';
+import {Location, Query} from 'history';
 
 import {Client} from 'app/api';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
@@ -186,10 +186,10 @@ export function getAggregateAlias(field: string): string {
  * @param name      name of the query string field
  */
 export function getFirstQueryString(
-  query: {[key: string]: string | string[] | null | undefined},
+  query: Query,
   name: string,
-  defaultValue?: string
-): string | undefined {
+  defaultValue: string = ''
+): string {
   const needle = query[name];
 
   if (typeof needle === 'string') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9192,6 +9192,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"


### PR DESCRIPTION
## TODO

- [ ] update tests
- [ ] remove stats generation commit
- [x] improve interop with saved queries

-----

The following are the resulting character savings between the new resulting query string in comparison to the original: 

```
query: All Events - savings of 30 characters
query: Project Summary - savings of -20 characters
query: Errors - savings of 6 characters
query: Errors by URL - savings of -25 characters
query: Errors by User - savings of -16 characters
query: CSP - savings of 18 characters
query: CSP Report by Directive - savings of -14 characters
query: CSP Report by Blocked URI - savings of -34 characters
query: CSP Report by User - savings of -20 characters
query: Transactions - savings of -11 characters
query: Transactions by User - savings of -5 characters
query: Transactions by Region - savings of -36 characters
```



-----

Closes SEN-1036