### PR TITLE
chore(filters): Add known google translate error to browser extension filter

### DIFF
--- a/src/sentry/message_filters.py
+++ b/src/sentry/message_filters.py
@@ -244,6 +244,9 @@ _EXTENSION_EXC_VALUES = re.compile(
                 "plugin.setSuspendState is not a function",
                 # lastpass
                 "should_do_lastpass_here",
+                # google translate
+                # see https://medium.com/@amir.harel/a-b-target-classname-indexof-is-not-a-function-at-least-not-mine-8e52f7be64ca
+                "a[b].target.className.indexOf is not a function",
             )
         )
     ),


### PR DESCRIPTION
By request from a customer. See https://medium.com/@amir.harel/a-b-target-classname-indexof-is-not-a-function-at-least-not-mine-8e52f7be64ca.

My only concern is that it's too generic. The `a[b]` bit helps make it a little more specific, but still, I wonder about false positives. Thoughts?