### PR TITLE
feat(debug_files): Feature flag external symbol servers separately

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -208,10 +208,14 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
 
         organization = self.context["project"].organization
         request = self.context["request"]
-        has_sources = features.has("organizations:symbol-sources", organization, actor=request.user)
+        has_sources = features.has(
+            "organizations:custom-symbol-sources", organization, actor=request.user
+        )
 
         if not has_sources:
-            raise serializers.ValidationError("Organization is not allowed to set symbol sources")
+            raise serializers.ValidationError(
+                "Organization is not allowed to set custom symbol sources"
+            )
 
         try:
             sources = parse_sources(sources_json.strip())

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -820,8 +820,10 @@ SENTRY_FEATURES = {
     "organizations:discover-v2-query-builder": False,
     # Enable attaching arbitrary files to events.
     "organizations:event-attachments": False,
-    # Allow organizations to configure custom external symbol sources.
+    # Allow organizations to configure built-in symbol sources.
     "organizations:symbol-sources": True,
+    # Allow organizations to configure custom external symbol sources.
+    "organizations:custom-symbol-sources": True,
     # Enable the events stream interface.
     "organizations:events": False,
     # Enable events v2 instead of the events stream

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -62,6 +62,7 @@ default_manager.add("organizations:events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:event-attachments", OrganizationFeature)  # NOQA
 default_manager.add("organizations:symbol-sources", OrganizationFeature)  # NOQA
+default_manager.add("organizations:custom-symbol-sources", OrganizationFeature)  # NOQA
 default_manager.add("organizations:global-views", OrganizationFeature)  # NOQA
 default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-issue-basic", OrganizationFeature)  # NOQA

--- a/src/sentry/static/sentry/app/data/forms/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectDebugFiles.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 
 import {t} from 'app/locale';
 import {openDebugFileSourceModal} from 'app/actionCreators/modal';
+import Feature from 'app/components/acl/feature';
+import FeatureDisabled from 'app/components/acl/featureDisabled';
 import {DEBUG_SOURCE_TYPES} from 'app/data/debugFileSources';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 
@@ -48,7 +50,24 @@ export const fields = {
     name: 'symbolSources',
     type: 'rich_list',
     label: t('Custom Repositories'),
-    help: t('Configures custom repositories containing debug files.'),
+    /* eslint-disable-next-line react/prop-types */
+    help: ({organization}) => (
+      <Feature
+        features={['organizations:custom-symbol-sources']}
+        hookName="custom-symbol-sources"
+        organization={organization}
+        renderDisabled={p => (
+          <FeatureDisabled
+            features={p.features}
+            message={t('Custom repositories are disabled.')}
+            featureName={t('custom repositories')}
+          />
+        )}
+      >
+        {t('Configures custom repositories containing debug files.')}
+      </Feature>
+    ),
+    disabled: ({features}) => !features.has('custom-symbol-sources'),
     formatMessageValue: false,
     addButtonText: t('Add Repository'),
     addDropdown: {

--- a/src/sentry/static/sentry/app/stores/hookStore.jsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.jsx
@@ -61,6 +61,7 @@ const validHookNames = new Set([
   'feature-disabled:discover-page',
   'feature-disabled:discover-sidebar-item',
   'feature-disabled:project-selector-checkbox',
+  'feature-disabled:custom-symbol-sources',
 ]);
 
 /**

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/index.jsx
@@ -60,7 +60,7 @@ class Field extends React.Component {
     /**
      * Help or description of the field
      */
-    help: PropTypes.oneOfType([PropTypes.node, PropTypes.element]),
+    help: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.func]),
 
     /**
      * Should Control be inline with Label
@@ -126,6 +126,8 @@ class Field extends React.Component {
       return null;
     }
 
+    const helpElement = typeof help === 'function' ? help(this.props) : help;
+
     const controlProps = {
       className: controlClassName,
       inline,
@@ -133,6 +135,7 @@ class Field extends React.Component {
       disabled: isDisabled,
       disabledReason,
       flexibleControlStateSize,
+      help: helpElement,
     };
 
     // See comments in prop types
@@ -154,16 +157,16 @@ class Field extends React.Component {
         hasControlState={!flexibleControlStateSize}
         style={style}
       >
-        {(label || help) && (
+        {(label || helpElement) && (
           <FieldDescription inline={inline} htmlFor={id}>
             {label && (
               <FieldLabel disabled={isDisabled}>
                 {label} {required && <FieldRequiredBadge />}
               </FieldLabel>
             )}
-            {help && (
+            {helpElement && (
               <FieldHelp stacked={stacked} inline={inline}>
-                {help}
+                {helpElement}
               </FieldHelp>
             )}
           </FieldDescription>

--- a/src/sentry/static/sentry/app/views/settings/components/forms/richListField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/richListField.jsx
@@ -57,6 +57,11 @@ class RichList extends React.PureComponent {
     ...RichListProps,
 
     /**
+     * Disables all controls in the rich list.
+     */
+    disabled: PropTypes.bool,
+
+    /**
      * The list of items to render.
      */
     value: PropTypes.array.isRequired,
@@ -70,8 +75,10 @@ class RichList extends React.PureComponent {
   };
 
   triggerChange = items => {
-    this.props.onChange(items, {});
-    this.props.onBlur(items, {});
+    if (!this.props.disabled) {
+      this.props.onChange(items, {});
+      this.props.onBlur(items, {});
+    }
   };
 
   addItem = data => {
@@ -92,41 +99,57 @@ class RichList extends React.PureComponent {
   };
 
   onSelectDropdownItem = item => {
-    this.props.onAddItem(item, this.addItem);
+    if (!this.props.disabled) {
+      this.props.onAddItem(item, this.addItem);
+    }
   };
 
   onEditItem = (item, index) => {
-    this.props.onEditItem(item, data => this.updateItem(data, index));
+    if (!this.props.disabled) {
+      this.props.onEditItem(item, data => this.updateItem(data, index));
+    }
   };
 
   onRemoveItem = (item, index) => {
-    this.props.onRemoveItem(item, () => this.removeItem(index));
+    if (!this.props.disabled) {
+      this.props.onRemoveItem(item, () => this.removeItem(index));
+    }
   };
 
   renderItem = (item, index) => {
+    const {disabled} = this.props;
+
     const removeIcon = (onClick = null) => (
-      <ItemButton onClick={onClick} size="micro" icon="icon-trash" borderless />
+      <ItemButton
+        onClick={onClick}
+        disabled={disabled}
+        size="micro"
+        icon="icon-trash"
+        borderless
+      />
     );
 
-    const removeConfirm = this.props.removeConfirm ? (
-      <Confirm
-        priority="danger"
-        confirmText={t('Remove')}
-        {...this.props.removeConfirm}
-        onConfirm={() => this.onRemoveItem(item, index)}
-      >
-        {removeIcon()}
-      </Confirm>
-    ) : (
-      removeIcon(() => this.onRemoveItem(item, index))
-    );
+    const removeConfirm =
+      this.props.removeConfirm && !disabled ? (
+        <Confirm
+          priority="danger"
+          confirmText={t('Remove')}
+          {...this.props.removeConfirm}
+          onConfirm={() => this.onRemoveItem(item, index)}
+        >
+          {removeIcon()}
+        </Confirm>
+      ) : (
+        removeIcon(() => this.onRemoveItem(item, index))
+      );
 
     return (
-      <Item key={index}>
+      <Item disabled={disabled} key={index}>
         {this.props.renderItem(item)}
         {this.props.onEditItem && (
           <ItemButton
             onClick={() => this.onEditItem(item, index)}
+            disabled={disabled}
             icon="icon-settings"
             size="micro"
             borderless
@@ -138,14 +161,22 @@ class RichList extends React.PureComponent {
   };
 
   renderDropdown = () => {
+    const {disabled} = this.props;
+
     return (
       <DropdownAutoComplete
         {...this.props.addDropdown}
+        disabled={disabled}
         alignMenu="left"
         onSelect={this.onSelectDropdownItem}
       >
         {({isOpen}) => (
-          <DropdownButton icon="icon-circle-add" isOpen={isOpen} size="small">
+          <DropdownButton
+            disabled={disabled}
+            icon="icon-circle-add"
+            isOpen={isOpen}
+            size="small"
+          >
             {this.props.addButtonText}
           </DropdownButton>
         )}
@@ -203,13 +234,14 @@ const Item = styled('li')`
   border: 1px solid ${p => p.theme.button.default.border};
   border-radius: ${p => p.theme.button.borderRadius};
   color: ${p => p.theme.button.default.color};
-  cursor: default;
+  cursor: ${p => (p.disabled ? 'not-allowed' : 'default')};
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 600;
   line-height: ${p => p.theme.fontSizeSmall};
   text-transform: none;
   margin: 0 10px 5px 0;
   white-space: nowrap;
+  opacity: ${p => (p.disabled ? 0.65 : null)};
   padding: 8px 12px;
   /* match adjacent elements */
   height: 30px;
@@ -219,6 +251,6 @@ const ItemButton = styled(Button)`
   margin-left: 10px;
   color: ${p => p.theme.gray2};
   &:hover {
-    color: ${p => p.theme.button.default.color};
+    color: ${p => (p.disabled ? p.theme.gray2 : p.theme.button.default.color)};
   }
 `;

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles.jsx
@@ -220,6 +220,7 @@ class ProjectDebugSymbols extends AsyncComponent {
     const access = new Set(organization.access);
 
     const fieldProps = {
+      organization,
       builtinSymbolSources: this.state.builtinSymbolSources,
     };
 

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -28,5 +28,6 @@ class OrganizationSerializerTest(TestCase):
                 "sso-basic",
                 "sentry10",
                 "symbol-sources",
+                "custom-symbol-sources",
             ]
         )

--- a/tests/sentry/lang/native/test_symbolicator.py
+++ b/tests/sentry/lang/native/test_symbolicator.py
@@ -1,0 +1,104 @@
+from __future__ import absolute_import
+
+import pytest
+
+from sentry.lang.native.symbolicator import get_sources_for_project
+from sentry.testutils.helpers import Feature
+
+
+CUSTOM_SOURCE_CONFIG = """
+[{
+    "type": "http",
+    "id": "custom",
+    "layout": {"type": "symstore"},
+    "url": "https://msdl.microsoft.com/download/symbols/"
+}]
+"""
+
+
+@pytest.mark.django_db
+def test_sources_no_feature(default_project):
+    features = {"organizations:symbol-sources": False, "organizations:custom-symbol-sources": False}
+
+    with Feature(features):
+        sources = get_sources_for_project(default_project)
+
+    assert len(sources) == 1
+    assert sources[0]["type"] == "sentry"
+    assert sources[0]["id"] == "sentry:project"
+
+
+@pytest.mark.django_db
+def test_sources_builtin(default_project):
+    features = {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": False}
+
+    default_project.update_option("sentry:builtin_symbol_sources", ["microsoft"])
+
+    with Feature(features):
+        sources = get_sources_for_project(default_project)
+
+    # XXX: The order matters here! Project is always first, then builtin sources
+    source_ids = map(lambda s: s["id"], sources)
+    assert source_ids == ["sentry:project", "sentry:microsoft"]
+
+
+# Test that a builtin source that is not declared in SENTRY_BUILTIN_SOURCES does
+# not lead to an error. It should simply be ignored.
+@pytest.mark.django_db
+def test_sources_builtin_unknown(default_project):
+    features = {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": False}
+
+    default_project.update_option("sentry:builtin_symbol_sources", ["invalid"])
+
+    with Feature(features):
+        sources = get_sources_for_project(default_project)
+
+    source_ids = map(lambda s: s["id"], sources)
+    assert source_ids == ["sentry:project"]
+
+
+# Test that previously saved builtin sources are not returned if the feature for
+# builtin sources is missing at query time.
+@pytest.mark.django_db
+def test_sources_builtin_disabled(default_project):
+    features = {"organizations:symbol-sources": False, "organizations:custom-symbol-sources": False}
+
+    default_project.update_option("sentry:builtin_symbol_sources", ["microsoft"])
+
+    with Feature(features):
+        sources = get_sources_for_project(default_project)
+
+    source_ids = map(lambda s: s["id"], sources)
+    assert source_ids == ["sentry:project"]
+
+
+@pytest.mark.django_db
+def test_sources_custom(default_project):
+    features = {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": True}
+
+    # Remove builtin sources explicitly to avoid defaults
+    default_project.update_option("sentry:builtin_symbol_sources", [])
+    default_project.update_option("sentry:symbol_sources", CUSTOM_SOURCE_CONFIG)
+
+    with Feature(features):
+        sources = get_sources_for_project(default_project)
+
+    # XXX: The order matters here! Project is always first, then custom sources
+    source_ids = map(lambda s: s["id"], sources)
+    assert source_ids == ["sentry:project", "custom"]
+
+
+# Test that previously saved custom sources are not returned if the feature for
+# custom sources is missing at query time.
+@pytest.mark.django_db
+def test_sources_custom_disabled(default_project):
+    features = {"organizations:symbol-sources": True, "organizations:custom-symbol-sources": False}
+
+    default_project.update_option("sentry:builtin_symbol_sources", [])
+    default_project.update_option("sentry:symbol_sources", CUSTOM_SOURCE_CONFIG)
+
+    with Feature(features):
+        sources = get_sources_for_project(default_project)
+
+    source_ids = map(lambda s: s["id"], sources)
+    assert source_ids == ["sentry:project"]


### PR DESCRIPTION
This PR splits the existing feature flag for symbol servers into two:

 - `organizations:symbol-sources` (existing): Controls whether symbol servers are active at all. Completely hides the configuration UI and disables both built-in and external symbol servers.
- `organizations:custom-symbol-sources` (new): Controls whether users can configure custom HTTP, S3 or GCS sources. This requires `symbol-sources` to be active.

Both features are enabled by default. If the latter feature is disabled, it leads to:
 - Updates to custom symbol servers project settings are rejected
 - The symbolicator code skips all custom symbol servers, even if configured. This allows to leave custom servers in settings, while disabling them using the feature flag.
 - The UI is disabled and renders our standard note. It is hookable in getsentry:

<img width="1180" alt="Screenshot 2019-09-17 at 11 18 35" src="https://user-images.githubusercontent.com/1433023/65029819-b20e6b80-d93e-11e9-856c-b8dec19e01c1.png">

When unfolded, it looks like this:

<img width="1182" alt="Screenshot 2019-09-17 at 11 19 19" src="https://user-images.githubusercontent.com/1433023/65029836-b89ce300-d93e-11e9-9a99-bd7af41aa965.png">
