### PR TITLE
feat: Enable new grouping

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -831,7 +831,7 @@ SENTRY_FEATURES = {
     # Turns on grouping info.
     "organizations:grouping-info": False,
     # Lets organizations upgrade grouping configs and tweak them
-    "organizations:tweak-grouping-config": False,
+    "organizations:tweak-grouping-config": True,
     # Lets organizations manage grouping configs
     "organizations:set-grouping-config": False,
     # Enable incidents feature

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from sentry.projectoptions import register
 
 # latest epoch
-LATEST_EPOCH = 2
+LATEST_EPOCH = 3
 
 # grouping related configs
 #
@@ -13,13 +13,21 @@ LATEST_EPOCH = 2
 #
 # TODO: we might instead want to fall back to the latest of the project's
 # epoch instead.
-DEFAULT_GROUPING_CONFIG = "legacy:2019-03-12"
-register(key="sentry:grouping_config", epoch_defaults={1: DEFAULT_GROUPING_CONFIG})
+LEGACY_GROUPING_CONFIG = "legacy:2019-03-12"
+DEFAULT_GROUPING_CONFIG = "newstyle:2019-05-08"
+register(key="sentry:grouping_config", epoch_defaults={
+    1: LEGACY_GROUPING_CONFIG,
+    3: DEFAULT_GROUPING_CONFIG,
+})
 
 # Grouping enhancements defaults
-DEFAULT_GROUPING_ENHANCEMENTS_BASE = "legacy:2019-03-12"
+LEGACY_GROUPING_ENHANCEMENTS_BASE = "legacy:2019-03-12"
+DEFAULT_GROUPING_ENHANCEMENTS_BASE = "common:2019-03-23"
 register(
-    key="sentry:grouping_enhancements_base", epoch_defaults={1: DEFAULT_GROUPING_ENHANCEMENTS_BASE}
+    key="sentry:grouping_enhancements_base", epoch_defaults={
+        1: LEGACY_GROUPING_ENHANCEMENTS_BASE,
+        3: DEFAULT_GROUPING_ENHANCEMENTS_BASE,
+    }
 )
 register(key="sentry:grouping_enhancements", default=u"")
 

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -28,5 +28,6 @@ class OrganizationSerializerTest(TestCase):
                 "sso-basic",
                 "sentry10",
                 "symbol-sources",
+                "tweak-grouping-config",
             ]
         )

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:30.926320Z'
+created: '2019-09-17T14:11:44.692676Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,7 +15,7 @@ app:
           frame*
             function*
               u'__pthread_body'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'thread.rs'
             function*
@@ -25,17 +25,17 @@ app:
               u'boxed.rs'
             function* (isolated function)
               u'<F as alloc::boxed::FnBox<T>>::call_box'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
             function*
               u'std::thread::Builder::spawn_unchecked::{{closure}}'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panic.rs'
             function*
               u'std::panic::catch_unwind'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panicking.rs'
             function*
@@ -45,7 +45,7 @@ app:
               u'lib.rs'
             function*
               u'___rust_maybe_catch_panic'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panicking.rs'
             function*
@@ -55,12 +55,12 @@ app:
               u'panic.rs'
             function* (isolated function)
               u'<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
             function*
               u'std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'backtrace.rs'
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-07T10:03:31.534504Z'
+created: '2019-09-17T14:11:48.273375Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,19 +12,19 @@ app:
           frame*
             function*
               u'_main'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::rt::lang_start'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::rt::lang_start_internal'
           frame*
             function*
               u'___rust_maybe_catch_panic'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::panicking::try::do_call'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::rt::lang_start::{{closure}}'
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-09-03T07:26:07.084393Z'
+created: '2019-09-17T14:11:51.796827Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,7 +15,7 @@ app:
           frame
             function (function name is not used if module or filename are available)
               u'__pthread_body'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'thread.rs'
             function*
@@ -29,21 +29,21 @@ app:
               u'<F as alloc::boxed::FnBox<A>>::call_box'
             lineno (function takes precedence)
               673
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
             function*
               u'std::thread::Builder::spawn_unchecked::{{closure}}'
             lineno (function takes precedence)
               476
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panic.rs'
             function*
               u'std::panic::catch_unwind'
             lineno (function takes precedence)
               398
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panicking.rs'
             function*
@@ -57,7 +57,7 @@ app:
               u'___rust_maybe_catch_panic'
             lineno (function takes precedence)
               102
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panicking.rs'
             function*
@@ -71,14 +71,14 @@ app:
               u'<std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once'
             lineno (function takes precedence)
               319
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
             function*
               u'std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}'
             lineno (function takes precedence)
               477
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'backtrace.rs'
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-09-03T07:26:07.915869Z'
+created: '2019-09-17T14:11:55.451365Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,19 +12,19 @@ app:
           frame
             function (function name is not used if module or filename are available)
               u'_main'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function (function name is not used if module or filename are available)
               u'std::rt::lang_start'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function (function name is not used if module or filename are available)
               u'std::rt::lang_start_internal'
           frame
             function (function name is not used if module or filename are available)
               u'___rust_maybe_catch_panic'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function (function name is not used if module or filename are available)
               u'std::panicking::try::do_call'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function (function name is not used if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame
@@ -65,19 +65,19 @@ system:
           frame
             function (function name is not used if module or filename are available)
               u'_main'
-          frame
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function (function name is not used if module or filename are available)
               u'std::rt::lang_start'
-          frame
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function (function name is not used if module or filename are available)
               u'std::rt::lang_start_internal'
           frame
             function (function name is not used if module or filename are available)
               u'___rust_maybe_catch_panic'
-          frame
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function (function name is not used if module or filename are available)
               u'std::panicking::try::do_call'
-          frame
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function (function name is not used if module or filename are available)
               u'std::rt::lang_start::{{closure}}'
           frame

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-16T14:31:51.433316Z'
+created: '2019-09-17T14:11:59.100387Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,7 +15,7 @@ app:
           frame*
             function*
               u'__pthread_body'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'thread.rs'
             function*
@@ -25,17 +25,17 @@ app:
               u'boxed.rs'
             function* (isolated function)
               u'<F as alloc::boxed::FnBox<T>>::call_box'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
             function*
               u'std::thread::Builder::spawn_unchecked::{{closure}}'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panic.rs'
             function*
               u'std::panic::catch_unwind'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panicking.rs'
             function*
@@ -45,7 +45,7 @@ app:
               u'lib.rs'
             function*
               u'___rust_maybe_catch_panic'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panicking.rs'
             function*
@@ -55,12 +55,12 @@ app:
               u'panic.rs'
             function* (isolated function)
               u'<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
             function*
               u'std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'backtrace.rs'
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-21T00:08:18.476445Z'
+created: '2019-09-17T14:12:02.733078Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,19 +12,19 @@ app:
           frame*
             function*
               u'_main'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::rt::lang_start'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::rt::lang_start_internal'
           frame*
             function*
               u'___rust_maybe_catch_panic'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::panicking::try::do_call'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::rt::lang_start::{{closure}}'
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-26T19:30:17.379327Z'
+created: '2019-09-17T14:12:05.781800Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,7 +15,7 @@ app:
           frame*
             function*
               u'__pthread_body'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'thread.rs'
             function*
@@ -25,17 +25,17 @@ app:
               u'boxed.rs'
             function*
               u'<F as alloc::boxed::FnBox<T>>::call_box'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
             function*
               u'std::thread::Builder::spawn_unchecked::{{closure}}'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panic.rs'
             function*
               u'std::panic::catch_unwind'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panicking.rs'
             function*
@@ -45,7 +45,7 @@ app:
               u'lib.rs'
             function*
               u'___rust_maybe_catch_panic'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panicking.rs'
             function*
@@ -55,12 +55,12 @@ app:
               u'panic.rs'
             function*
               u'<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
             function*
               u'std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'backtrace.rs'
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-04-17T20:02:28.820942Z'
+created: '2019-09-17T14:12:08.728073Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,19 +12,19 @@ app:
           frame*
             function*
               u'_main'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::rt::lang_start'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::rt::lang_start_internal'
           frame*
             function*
               u'___rust_maybe_catch_panic'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::panicking::try::do_call'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::rt::lang_start::{{closure}}'
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T07:29:41.964392Z'
+created: '2019-09-17T14:12:11.861540Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,7 +15,7 @@ app:
           frame*
             function*
               u'__pthread_body'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'thread.rs'
             function*
@@ -25,17 +25,17 @@ app:
               u'boxed.rs'
             function*
               u'<F as alloc::boxed::FnBox<T>>::call_box'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
             function*
               u'std::thread::Builder::spawn_unchecked::{{closure}}'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panic.rs'
             function*
               u'std::panic::catch_unwind'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panicking.rs'
             function*
@@ -45,7 +45,7 @@ app:
               u'lib.rs'
             function*
               u'___rust_maybe_catch_panic'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panicking.rs'
             function*
@@ -55,12 +55,12 @@ app:
               u'panic.rs'
             function*
               u'<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
             function*
               u'std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'backtrace.rs'
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-08T07:29:42.652574Z'
+created: '2019-09-17T14:12:15.305004Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -12,19 +12,19 @@ app:
           frame*
             function*
               u'_main'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::rt::lang_start'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::rt::lang_start_internal'
           frame*
             function*
               u'___rust_maybe_catch_panic'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::panicking::try::do_call'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             function*
               u'std::rt::lang_start::{{closure}}'
           frame*


### PR DESCRIPTION
This adds a new epoch for grouping that enables the new newstyle grouping
by default and the new enhancers.  This only affects new projects.

Additionally the tweaking of grouping configs is enabled by default.

Note to reviewers; because some tests run against the latest enhancers the output of the snapshots changes. This is intentional as I did not want to have the tests run against an old enhancer config. We can revisit this later, but this is more in line with what people will experience.