### PR TITLE
fix(discover2) Make empty state consistent with filled state

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
@@ -89,7 +89,11 @@ class Discover2Item extends React.Component<Props, State> {
   renderSavedQueries({inputValue, getItemProps, highlightedIndex}) {
     const {savedQueries} = this.props;
     if (!savedQueries || savedQueries.length === 0) {
-      return <span>No saved queries</span>;
+      return (
+        <MenuItem role="menuitem" disabled={true}>
+          No saved queries
+        </MenuItem>
+      );
     }
     const lowerInputValue = inputValue.toLowerCase();
     return savedQueries
@@ -221,7 +225,8 @@ const Menu = styled('div')`
 `;
 
 type MenuItemProps = {
-  active: boolean;
+  active?: boolean;
+  disabled?: boolean;
 };
 const MenuItem = styled('span')<MenuItemProps>`
   display: flex;
@@ -235,9 +240,9 @@ const MenuItem = styled('span')<MenuItemProps>`
   border-bottom: 1px solid ${p => p.theme.borderLight};
   &:focus,
   &:hover {
-    background: ${p => p.theme.offWhiteLight};
-    color: ${p => p.theme.gray3};
-    cursor: pointer;
+    background: ${p => (p.disabled ? p.theme.offWhite : p.theme.offWhiteLight)};
+    color: ${p => (p.disabled ? p.theme.gray2 : p.theme.gray3)};
+    cursor: ${p => (p.disabled ? 'normal' : 'pointer')};
   }
 `;
 


### PR DESCRIPTION
Make the empty sidebar state item look like the populated one.

![Screen Shot 2019-09-17 at 1 10 03 PM](https://user-images.githubusercontent.com/24086/65063716-d07b6380-d94c-11e9-9b2b-0c67f14da7ad.png)


Fixes SEN-1039