### PR TITLE
fix(discover2) Don't send duplicate query strings

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -318,7 +318,7 @@ class EventView {
   }
 
   getQuery(inputQuery: string | string[] | null | undefined): string {
-    const queryParts: Array<string> = [];
+    const queryParts: string[] = [];
 
     if (this.query) {
       queryParts.push(this.query);
@@ -329,13 +329,13 @@ class EventView {
       // e.g. query=hello&query=world
       if (Array.isArray(inputQuery)) {
         inputQuery.forEach(query => {
-          if (typeof query === 'string') {
+          if (typeof query === 'string' && !queryParts.includes(query)) {
             queryParts.push(query);
           }
         });
       }
 
-      if (typeof inputQuery === 'string') {
+      if (typeof inputQuery === 'string' && !queryParts.includes(inputQuery)) {
         queryParts.push(inputQuery);
       }
     }

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -107,4 +107,20 @@ describe('EventView.getEventsAPIPayload()', function() {
       'event.type:csp TypeError'
     );
   });
+
+  it('does not duplicate conditions', function() {
+    const eventView = new EventView({
+      fields: ['id'],
+      sorts: [],
+      tags: [],
+      query: 'event.type:csp',
+    });
+
+    const location = {
+      query: {
+        query: 'event.type:csp',
+      },
+    };
+    expect(eventView.getEventsAPIPayload(location).query).toEqual('event.type:csp');
+  });
 });


### PR DESCRIPTION
Check the query state before appending values to prevent duplicates. In practice this adds one additional `includes` check on a list with only 1 item in it.

Fixes SEN-1038