### PR TITLE
feat(app-platform): prevent duplicate installs

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_installations.py
+++ b/src/sentry/api/endpoints/sentry_app_installations.py
@@ -49,11 +49,16 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
+        # check for an exiting installation and return that if it exists
+        slug = serializer.validated_data.get("slug")
+        install_list = SentryAppInstallation.objects.filter(
+            sentry_app__slug=slug, organization=organization
+        )
+        if install_list:
+            return Response(serialize(install_list[0]))
+
         install = Creator.run(
-            organization=organization,
-            slug=serializer.validated_data.get("slug"),
-            user=request.user,
-            request=request,
+            organization=organization, slug=slug, user=request.user, request=request
         )
 
         return Response(serialize(install))

--- a/src/sentry/api/endpoints/sentry_app_installations.py
+++ b/src/sentry/api/endpoints/sentry_app_installations.py
@@ -51,14 +51,13 @@ class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
 
         # check for an exiting installation and return that if it exists
         slug = serializer.validated_data.get("slug")
-        install_list = SentryAppInstallation.objects.filter(
-            sentry_app__slug=slug, organization=organization
-        )
-        if install_list:
-            return Response(serialize(install_list[0]))
-
-        install = Creator.run(
-            organization=organization, slug=slug, user=request.user, request=request
-        )
+        try:
+            install = SentryAppInstallation.objects.get(
+                sentry_app__slug=slug, organization=organization
+            )
+        except SentryAppInstallation.DoesNotExist:
+            install = Creator.run(
+                organization=organization, slug=slug, user=request.user, request=request
+            )
 
         return Response(serialize(install))

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -5,6 +5,7 @@ import six
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase
+from sentry.models import SentryAppInstallation
 
 
 class SentryAppInstallationsTest(APITestCase):
@@ -115,3 +116,11 @@ class PostSentryAppInstallationsTest(SentryAppInstallationsTest):
         app = self.create_sentry_app(name="Sample", organization=self.org, published=True)
         response = self.client.post(self.url, data={"slug": app.slug}, format="json")
         assert response.status_code == 403
+
+    def test_install_twice(self):
+        self.login_as(user=self.user)
+        app = self.create_sentry_app(name="Sample", organization=self.org)
+        self.client.post(self.url, data={"slug": app.slug}, format="json")
+        response = self.client.post(self.url, data={"slug": app.slug}, format="json")
+        assert SentryAppInstallation.objects.filter(sentry_app=app).count() == 1
+        assert response.status_code == 200


### PR DESCRIPTION
If someone tries to install a Sentry App that is already installed for that org, then just return the existing install instead of making a new one.