### PR TITLE
fix(transactions): Preserve quotes inside of request body

### DIFF
--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -73,6 +73,7 @@ function analyzeStringForRepr(value) {
 class ContextData extends React.Component {
   static propTypes = {
     data: PropTypes.any,
+    preserveQuotes: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -86,6 +87,8 @@ class ContextData extends React.Component {
         .toggleClass('val-toggle-open');
       evt.preventDefault();
     }
+
+    const {preserveQuotes} = this.props;
 
     function makeToggle(highUp, childCount, children) {
       if (childCount === 0) {
@@ -122,7 +125,7 @@ class ContextData extends React.Component {
               (valueInfo.isMultiLine ? ' val-string-multiline' : '')
             }
           >
-            "{valueInfo.repr}"
+            {preserveQuotes ? `"${valueInfo.repr}"` : valueInfo.repr}
           </span>,
         ];
 
@@ -169,7 +172,7 @@ class ContextData extends React.Component {
           children.push(
             <span className="val-dict-pair" key={key}>
               <span className="val-dict-key">
-                <span className="val-string">"{key}"</span>
+                <span className="val-string">{preserveQuotes ? `"${key}"` : key}</span>
               </span>
               <span className="val-dict-col">{': '}</span>
               <span className="val-dict-value">

--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -122,7 +122,7 @@ class ContextData extends React.Component {
               (valueInfo.isMultiLine ? ' val-string-multiline' : '')
             }
           >
-            {valueInfo.repr}
+            "{valueInfo.repr}"
           </span>,
         ];
 
@@ -169,7 +169,7 @@ class ContextData extends React.Component {
           children.push(
             <span className="val-dict-pair" key={key}>
               <span className="val-dict-key">
-                <span className="val-string">{key}</span>
+                <span className="val-string">"{key}"</span>
               </span>
               <span className="val-dict-col">{': '}</span>
               <span className="val-dict-value">

--- a/src/sentry/static/sentry/app/components/events/interfaces/richHttpContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/richHttpContent.jsx
@@ -34,7 +34,7 @@ class RichHttpContent extends React.Component {
     } else if (value) {
       switch (data.inferredContentType) {
         case 'application/json':
-          return <ContextData data={value} />;
+          return <ContextData data={value} preserveQuotes={true} />;
         case 'application/x-www-form-urlencoded':
         case 'multipart/form-data':
           return (

--- a/tests/js/spec/components/contextData.spec.jsx
+++ b/tests/js/spec/components/contextData.spec.jsx
@@ -15,7 +15,7 @@ describe('ContextData', function() {
             .find('span')
             .at(0)
             .text()
-        ).toEqual('"' + URL + '"'); // Quotes should not be stripped away to ensure valid json
+        ).toEqual(URL);
         expect(
           wrapper
             .find('a')

--- a/tests/js/spec/components/contextData.spec.jsx
+++ b/tests/js/spec/components/contextData.spec.jsx
@@ -15,7 +15,7 @@ describe('ContextData', function() {
             .find('span')
             .at(0)
             .text()
-        ).toEqual(URL);
+        ).toEqual('"' + URL + '"'); // Quotes should not be stripped away to ensure valid json
         expect(
           wrapper
             .find('a')


### PR DESCRIPTION
Inside the request tab of a detailed transaction view there is a [json body](https://www.dropbox.com/s/gvl43r97zf6mk48/Screen-Shot-2019-08-28-15-36-48.88.png?dl=0) that is shown without quotations. I added code to have an option in the ContextData component for preserving these quotes when json is being displayed. This way it can be easily copied and be valid json.

A js object like this
```JS
{
  blank_string: "", 
  test: "data", 
  testing: {
    numbers: 2, 
    should: [
      "show", 
      100, 
      "normally"
    ], 
    this: "seems to", 
    work: "correctly"
  }
}
```
will turn into

![image](https://user-images.githubusercontent.com/9372512/65081659-f4dd3d00-d958-11e9-8e51-436e3bec523c.png)

Fixes SEN-998