### PR TITLE
fix(apm): Always display the span row message when it is rendered

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/styles.tsx
@@ -41,6 +41,8 @@ export const SpanRow = styled.div<SpanRowAndDivProps>`
 `;
 
 export const SpanRowMessage = styled(SpanRow)`
+  display: block;
+
   cursor: auto;
 
   color: #4a3e56;


### PR DESCRIPTION
Span row messages weren't being displayed due to an introduction of a visibility prop on the span row component. Thus, when view a timeslice of a transaction, a user is not informed if there are any spans out of view.

This prop was introduced in https://github.com/getsentry/sentry/pull/14542

------

We always display the span row message whenever it is rendered:

![Screen Shot 2019-09-17 at 6 20 32 PM](https://user-images.githubusercontent.com/139499/65084243-acce1280-d978-11e9-9217-dca6196bbcd4.png)



