### PR TITLE
fix(ui) Skip loading discover queries when feature is off

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
@@ -45,7 +45,9 @@ class Discover2Item extends React.Component<Props, State> {
 
   componentDidMount() {
     const {api, organization} = this.props;
-    fetchSavedQueries(api, organization.slug);
+    if (organization.features.includes('discover-v2-query-builder')) {
+      fetchSavedQueries(api, organization.slug);
+    }
     this.menuId = domId('discover-menu');
   }
 


### PR DESCRIPTION
Don't load saved queries when the discover-2 feature is off.