### PR TITLE
fix(wizard): Remove private DSN from wizard overview

### DIFF
--- a/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
@@ -66,15 +66,9 @@ class ProjectInstallOverview extends AsyncComponent {
           <DsnInfo>
             <DsnContainer>
               <strong>{t('DSN')}</strong>
-              <DsnValue>{dsn.secret}</DsnValue>
-
-              <strong>{t('Public DSN')}</strong>
               <DsnValue>{dsn.public}</DsnValue>
             </DsnContainer>
 
-            <p>
-              <small>{t('The public DSN should be used with JavaScript.')}</small>
-            </p>
             <Button priority="primary" to={issueStreamLink}>
               {t('Got it! Take me to the Issue Stream.')}
             </Button>


### PR DESCRIPTION
The project wizard still shows the secret DSN in _Project Settings > Error Tracking_ after clicking on _Get your DSN_. Since this DSN is now fully deprecated, let's remove it from the UI.

Ref https://github.com/getsentry/sentry-native/issues/46#issuecomment-532548943