### PR TITLE
feat(discover2) Add save/update for discover2 queries

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/discoverSavedQueries.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/discoverSavedQueries.tsx
@@ -1,9 +1,9 @@
 import {Client} from 'app/api';
 
+import {SavedQuery, NewQuery} from 'app/stores/discoverSavedQueriesStore';
 import DiscoverSavedQueryActions from 'app/actions/discoverSavedQueryActions';
 import {t} from 'app/locale';
 import {addErrorMessage} from 'app/actionCreators/indicator';
-import {SavedQuery, Query} from 'app/views/discover/types';
 
 export function fetchSavedQueries(api: Client, orgId: string): Promise<SavedQuery[]> {
   DiscoverSavedQueryActions.startFetchSavedQueries();
@@ -25,7 +25,7 @@ export function fetchSavedQueries(api: Client, orgId: string): Promise<SavedQuer
 export function createSavedQuery(
   api: Client,
   orgId: string,
-  query: Query
+  query: NewQuery
 ): Promise<SavedQuery> {
   const promise = api.requestPromise(`/organizations/${orgId}/discover/saved/`, {
     method: 'POST',
@@ -44,7 +44,7 @@ export function createSavedQuery(
 export function updateSavedQuery(
   api: Client,
   orgId: string,
-  query: SavedQuery
+  query: NewQuery
 ): Promise<SavedQuery> {
   const promise = api.requestPromise(
     `/organizations/${orgId}/discover/saved/${query.id}/`,

--- a/src/sentry/static/sentry/app/components/dropdownButton.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownButton.jsx
@@ -8,17 +8,22 @@ import {omit} from 'lodash';
 class DropdownButton extends React.Component {
   static propTypes = {
     isOpen: PropTypes.bool,
+    showChevron: PropTypes.bool,
   };
   render() {
-    const {isOpen, children, ...otherProps} = this.props;
+    const {isOpen, showChevron, children, ...otherProps} = this.props;
     return (
       <StyledButton isOpen={isOpen} {...otherProps}>
         {children}
-        <StyledChevronDown />
+        {showChevron && <StyledChevronDown />}
       </StyledButton>
     );
   }
 }
+
+DropdownButton.defaultProps = {
+  showChevron: true,
+};
 
 const StyledChevronDown = styled(props => (
   <InlineSvg src="icon-chevron-down" {...props} />

--- a/src/sentry/static/sentry/app/icons/icon-bookmark.svg
+++ b/src/sentry/static/sentry/app/icons/icon-bookmark.svg
@@ -1,0 +1,3 @@
+<svg width="11" height="14" viewBox="0 0 11 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10.0001 12.5715L5.61111 9.43654L1.22217 12.5715V2.53963C1.22217 1.84707 1.7836 1.28564 2.47615 1.28564H8.74607C9.43863 1.28564 10.0001 1.84707 10.0001 2.53963V12.5715Z" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/sentry/static/sentry/app/stores/discoverSavedQueriesStore.tsx
+++ b/src/sentry/static/sentry/app/stores/discoverSavedQueriesStore.tsx
@@ -1,7 +1,28 @@
 import Reflux from 'reflux';
-
-import {SavedQuery} from 'app/views/discover/types';
 import DiscoverSavedQueryActions from 'app/actions/discoverSavedQueryActions';
+
+type Versions = 1 | 2;
+
+export type NewQuery = {
+  id: string | undefined;
+  version: Versions;
+  name: string;
+  projects: number[];
+  fields: string[];
+  fieldnames: string[];
+  query: string;
+  orderby?: string;
+  range?: string;
+  start?: string;
+  end?: string;
+};
+
+export type SavedQuery = NewQuery & {
+  id: string;
+  dateCreated: string;
+  dateUpdated: string;
+  createdBy?: string;
+};
 
 export type SavedQueryState = {
   savedQueries: SavedQuery[];
@@ -88,7 +109,8 @@ const DiscoverSavedQueriesStore = Reflux.createStore({
     let savedQueries;
     const index = this.state.savedQueries.findIndex(item => item.id === query.id);
     if (index > -1) {
-      savedQueries = [...this.state.savedQueries].splice(index, 1, query);
+      savedQueries = [...this.state.savedQueries];
+      savedQueries.splice(index, 1, query);
     } else {
       savedQueries = [...this.state.savedQueries, query];
     }

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -2,7 +2,8 @@ import {Location, Query} from 'history';
 import {isString, cloneDeep, pick} from 'lodash';
 
 import {EventViewv1} from 'app/types';
-import {SavedQuery} from 'app/views/discover/types';
+import {SavedQuery as LegacySavedQuery} from 'app/views/discover/types';
+import {SavedQuery, NewQuery} from 'app/stores/discoverSavedQueriesStore';
 import {DEFAULT_PER_PAGE} from 'app/constants';
 
 import {AUTOLINK_FIELDS, SPECIAL_FIELDS, FIELD_FORMATTERS} from './data';
@@ -165,11 +166,17 @@ const decodeScalar = (
   return isString(unwrapped) ? unwrapped : void 0;
 };
 
-const queryStringFromSavedQuery = (saved: SavedQuery): string => {
-  if (saved.query) {
+function isLegacySavedQuery(
+  query: LegacySavedQuery | SavedQuery
+): query is LegacySavedQuery {
+  return (query as LegacySavedQuery).conditions !== undefined;
+}
+
+const queryStringFromSavedQuery = (saved: LegacySavedQuery | SavedQuery): string => {
+  if (!isLegacySavedQuery(saved) && saved.query) {
     return saved.query;
   }
-  if (saved.conditions) {
+  if (isLegacySavedQuery(saved) && saved.conditions) {
     const conditions = saved.conditions.map(item => {
       const [field, op, value] = item;
       let operator = op;
@@ -185,6 +192,7 @@ const queryStringFromSavedQuery = (saved: SavedQuery): string => {
 };
 
 class EventView {
+  id: string | undefined;
   name: string | undefined;
   fields: Field[];
   sorts: Sort[];
@@ -196,6 +204,7 @@ class EventView {
   end: string | undefined;
 
   constructor(props: {
+    id: string | undefined;
     name: string | undefined;
     fields: Field[];
     sorts: Sort[];
@@ -206,6 +215,7 @@ class EventView {
     start: string | undefined;
     end: string | undefined;
   }) {
+    this.id = props.id;
     this.name = props.name;
     this.fields = props.fields;
     this.sorts = props.sorts;
@@ -219,6 +229,7 @@ class EventView {
 
   static fromLocation(location: Location): EventView {
     return new EventView({
+      id: decodeScalar(location.query.id),
       name: decodeScalar(location.query.name),
       fields: decodeFields(location),
       sorts: decodeSorts(location),
@@ -246,19 +257,28 @@ class EventView {
       tags: eventViewV1.tags,
       query: eventViewV1.data.query,
       project: [],
+      id: undefined,
       range: undefined,
       start: undefined,
       end: undefined,
     });
   }
 
-  static fromSavedQuery(saved: SavedQuery): EventView {
-    const fields = saved.fields.map(field => {
-      return {field, title: field};
-    });
+  static fromSavedQuery(saved: SavedQuery | LegacySavedQuery): EventView {
+    let fields;
+    if (isLegacySavedQuery(saved)) {
+      fields = saved.fields.map(field => {
+        return {field, title: field};
+      });
+    } else {
+      fields = saved.fields.map((field, i) => {
+        return {field, title: saved.fieldnames[i] || field};
+      });
+    }
 
     return new EventView({
       fields,
+      id: saved.id,
       name: saved.name,
       query: queryStringFromSavedQuery(saved),
       project: saved.projects,
@@ -270,8 +290,25 @@ class EventView {
     });
   }
 
+  toNewQuery(): NewQuery {
+    return {
+      id: this.id,
+      version: 2,
+      name: this.name || '',
+      query: this.query || '',
+      projects: this.project,
+      start: this.start,
+      end: this.end,
+      range: this.range,
+      fields: this.fields.map(item => item.field),
+      fieldnames: this.fields.map(item => item.title),
+    };
+  }
+
   generateQueryStringObject(): Query {
+    // TODO(mark) normalize naming conventions for aliases to be more consistent.
     const output = {
+      id: this.id,
       field: this.fields.map(item => item.field),
       alias: this.fields.map(item => item.title),
       sort: encodeSorts(this.sorts),

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -272,7 +272,9 @@ class EventView {
       });
     } else {
       fields = saved.fields.map((field, i) => {
-        return {field, title: saved.fieldnames[i] || field};
+        const title =
+          saved.fieldnames && saved.fieldnames[i] ? saved.fieldnames[i] : field;
+        return {field, title};
       });
     }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -21,6 +21,7 @@ import withOrganization from 'app/utils/withOrganization';
 
 import Events from './events';
 import EventDetails from './eventDetails';
+import EventsSaveQueryButton from './saveQueryButton';
 import {getFirstQueryString} from './utils';
 import {ALL_VIEWS} from './data';
 import EventView from './eventView';
@@ -87,7 +88,6 @@ class EventsV2 extends React.Component<Props> {
       .reverse()
       .join(' - ');
     const pageTitle = this.getEventViewName().join(' \u2014 ');
-
     return (
       <Feature features={['events-v2']} organization={organization} renderDisabled>
         <DocumentTitle title={`${documentTitle} - ${organization.slug} - Sentry`}>
@@ -99,6 +99,19 @@ class EventsV2 extends React.Component<Props> {
                   <PageHeading>
                     {pageTitle} <BetaTag />
                   </PageHeading>
+                  {hasQuery && (
+                    <Feature
+                      organization={organization}
+                      features={['discover-v2-query-builder']}
+                    >
+                      <EventsSaveQueryButton
+                        isEditing={!!location.query.edit}
+                        location={location}
+                        organization={organization}
+                        eventView={eventView}
+                      />
+                    </Feature>
+                  )}
                 </PageHeader>
                 {!hasQuery && this.renderQueryList()}
                 {hasQuery && (

--- a/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
@@ -132,9 +132,7 @@ const StyledInput = styled(Input)`
   margin-bottom: ${space(1)};
 `;
 
-const StyledDropdownButton = styled(
-  React.forwardRef((prop, ref) => <DropdownButton innerRef={ref} {...prop} />)
-)`
+const StyledDropdownButton = styled(DropdownButton)`
   z-index: ${p => p.theme.zIndex.dropdownAutocomplete.actor};
   white-space: nowrap;
 `;

--- a/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import styled from 'react-emotion';
+import {browserHistory} from 'react-router';
+import {Location} from 'history';
+
+import {Client} from 'app/api';
+import {Organization} from 'app/types';
+import {t} from 'app/locale';
+import {
+  createSavedQuery,
+  updateSavedQuery,
+} from 'app/actionCreators/discoverSavedQueries';
+import {addSuccessMessage} from 'app/actionCreators/indicator';
+import DropdownControl from 'app/components/dropdownControl';
+import DropdownButton from 'app/components/dropdownButton';
+import Button from 'app/components/button';
+import InlineSvg from 'app/components/inlineSvg';
+import space from 'app/styles/space';
+import withApi from 'app/utils/withApi';
+
+import EventView from './eventView';
+
+type Props = {
+  api: Client;
+  organization: Organization;
+  eventView: EventView;
+  location: Location;
+  isEditing: boolean;
+};
+
+type State = {
+  queryName: string;
+};
+
+class EventsSaveQueryButton extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      queryName: props.isEditing ? props.eventView.name : '',
+    };
+  }
+
+  swallowEvent = (event: React.MouseEvent) => {
+    // Stop propagation for the input and container so
+    // people can interact with the inputs in the dropdown.
+    const capturedElements = ['LI', 'INPUT'];
+    if (
+      event.target instanceof Element &&
+      capturedElements.includes(event.target.nodeName)
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  };
+
+  handleSave = () => {
+    const {api, eventView, organization, location, isEditing} = this.props;
+
+    const payload = eventView.toNewQuery();
+    if (this.state.queryName) {
+      payload.name = this.state.queryName;
+    }
+    let promise;
+    if (isEditing) {
+      promise = updateSavedQuery(api, organization.slug, payload);
+    } else {
+      promise = createSavedQuery(api, organization.slug, payload);
+    }
+    promise.then(saved => {
+      const view = EventView.fromSavedQuery(saved);
+      addSuccessMessage(t('Query saved'));
+
+      browserHistory.push({
+        pathname: location.pathname,
+        query: view.generateQueryStringObject(),
+      });
+    });
+  };
+
+  handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    this.setState({queryName: value});
+  };
+
+  render() {
+    const {isEditing} = this.props;
+    const buttonText = isEditing ? t('Update') : t('Save');
+
+    return (
+      <DropdownControl
+        alignRight={true}
+        menuWidth="220px"
+        button={({isOpen, getActorProps}) => (
+          <StyledDropdownButton
+            {...getActorProps({isStyled: true})}
+            isOpen={isOpen}
+            showChevron={false}
+          >
+            <StyledInlineSvg src="icon-bookmark" size="14" />
+            {t('Save Search')}
+          </StyledDropdownButton>
+        )}
+      >
+        <SaveQueryContainer onClick={this.swallowEvent}>
+          <StyledInput
+            type="text"
+            placeholder={t('display name')}
+            value={this.state.queryName}
+            onChange={this.handleInputChange}
+          />
+          <Button size="small" onClick={this.handleSave} priority="primary">
+            {buttonText}
+          </Button>
+        </SaveQueryContainer>
+      </DropdownControl>
+    );
+  }
+}
+
+const SaveQueryContainer = styled('li')`
+  padding: ${space(1)};
+`;
+
+const StyledInlineSvg = styled(InlineSvg)`
+  margin-right: 0.33em;
+`;
+
+const StyledInput = styled('input')`
+  width: 100%;
+  margin-bottom: ${space(1)};
+`;
+
+const StyledDropdownButton = styled(
+  React.forwardRef((prop, ref) => <DropdownButton innerRef={ref} {...prop} />)
+)`
+  z-index: ${p => p.theme.zIndex.dropdownAutocomplete.actor};
+  white-space: nowrap;
+`;
+
+export default withApi(EventsSaveQueryButton);

--- a/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
@@ -106,7 +106,7 @@ class EventsSaveQueryButton extends React.Component<Props, State> {
         <SaveQueryContainer onClick={this.swallowEvent}>
           <StyledInput
             type="text"
-            placeholder={t('display name')}
+            placeholder={t('Display name')}
             value={this.state.queryName}
             onChange={this.handleInputChange}
           />

--- a/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
@@ -14,6 +14,7 @@ import {addSuccessMessage} from 'app/actionCreators/indicator';
 import DropdownControl from 'app/components/dropdownControl';
 import DropdownButton from 'app/components/dropdownButton';
 import Button from 'app/components/button';
+import Input from 'app/components/forms/input';
 import InlineSvg from 'app/components/inlineSvg';
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
@@ -126,7 +127,7 @@ const StyledInlineSvg = styled(InlineSvg)`
   margin-right: 0.33em;
 `;
 
-const StyledInput = styled('input')`
+const StyledInput = styled(Input)`
   width: 100%;
   margin-bottom: ${space(1)};
 `;

--- a/tests/js/spec/stores/discoverSavedQueriesStore.spec.jsx
+++ b/tests/js/spec/stores/discoverSavedQueriesStore.spec.jsx
@@ -85,11 +85,12 @@ describe('DiscoverSavedQueriesStore', function() {
 
   it('updating a query updates the store', async function() {
     Client.addMockResponse({
-      url: '/organizations/org-1/discover/saved/1/',
+      url: '/organizations/org-1/discover/saved/2/',
       method: 'PUT',
       body: {
         id: '2',
         name: 'best query',
+        fields: ['title', 'count()'],
         dateCreated: now,
         dateUpdated: now,
         createdBy: '2',
@@ -110,7 +111,41 @@ describe('DiscoverSavedQueriesStore', function() {
     expect(state.isLoading).toEqual(false);
     expect(state.hasError).toEqual(false);
     expect(state.savedQueries).toHaveLength(2);
-    expect(state.savedQueries[0].dateCreated).toEqual(now);
+    expect(state.savedQueries[0].name).toEqual('first query');
+    expect(state.savedQueries[1].name).toEqual('best query');
+  });
+
+  it('updating a query appends the store', async function() {
+    Client.addMockResponse({
+      url: '/organizations/org-1/discover/saved/9/',
+      method: 'PUT',
+      body: {
+        id: '9',
+        name: 'best query',
+        fields: ['title', 'count()'],
+        dateCreated: now,
+        dateUpdated: now,
+        createdBy: '2',
+      },
+    });
+    fetchSavedQueries(api, 'org-1');
+    await tick();
+
+    const query = {
+      id: '9',
+      name: 'best query',
+      fields: ['title', 'count()'],
+    };
+    updateSavedQuery(api, 'org-1', query);
+    await tick();
+
+    const state = DiscoverSavedQueriesStore.get();
+    expect(state.isLoading).toEqual(false);
+    expect(state.hasError).toEqual(false);
+    expect(state.savedQueries).toHaveLength(3);
+    expect(state.savedQueries[0].name).toEqual('first query');
+    expect(state.savedQueries[1].name).toEqual('second query');
+    expect(state.savedQueries[2].name).toEqual('best query');
   });
 
   it('creating a query updates the store', async function() {

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -194,6 +194,7 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                     >
                                       <DropdownButton
                                         isOpen={false}
+                                        showChevron={true}
                                         size="xsmall"
                                       >
                                         <StyledButton

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -5,6 +5,7 @@ describe('EventView.fromSavedQuery()', function() {
     const saved = {
       name: 'best query',
       fields: ['count()', 'id'],
+      conditions: [],
       range: '14d',
       start: '',
       end: '',
@@ -27,6 +28,26 @@ describe('EventView.fromSavedQuery()', function() {
     };
     const eventView = EventView.fromSavedQuery(saved);
     expect(eventView.query).toEqual('event.type:error');
+  });
+
+  it('maps properties from v2 saved query', function() {
+    const saved = {
+      name: 'best query',
+      fields: ['count()', 'title'],
+      fieldnames: ['volume', 'caption'],
+      range: '14d',
+      start: '',
+      end: '',
+    };
+    const eventView = EventView.fromSavedQuery(saved);
+    expect(eventView.fields).toEqual([
+      {field: 'count()', title: 'volume'},
+      {field: 'title', title: 'caption'},
+    ]);
+    expect(eventView.name).toEqual(saved.name);
+    expect(eventView.range).toEqual('14d');
+    expect(eventView.start).toEqual('');
+    expect(eventView.end).toEqual('');
   });
 });
 

--- a/tests/js/spec/views/eventsV2/saveQueryButton.spec.jsx
+++ b/tests/js/spec/views/eventsV2/saveQueryButton.spec.jsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {browserHistory} from 'react-router';
+
+import EventSaveQueryButton from 'app/views/eventsV2/saveQueryButton';
+import {ALL_VIEWS} from 'app/views/eventsV2/data';
+import EventView from 'app/views/eventsV2/eventView';
+
+describe('EventsV2 > SaveQueryButton', function() {
+  const errorsView = EventView.fromEventViewv1(
+    ALL_VIEWS.find(view => view.name === 'Errors')
+  );
+  let organization, location;
+  beforeEach(function() {
+    organization = TestStubs.Organization();
+    location = {
+      pathname: '/organization/eventsv2/',
+      query: {},
+    };
+  });
+
+  it('renders a button', function() {
+    const wrapper = mount(
+      <EventSaveQueryButton
+        organization={organization}
+        location={location}
+        isEditing={false}
+        eventView={errorsView}
+      />,
+      TestStubs.routerContext()
+    );
+    const button = wrapper.find('StyledDropdownButton');
+    expect(button.text()).toEqual('Save Search');
+  });
+
+  it('renders a popover for a new query', function() {
+    const wrapper = mount(
+      <EventSaveQueryButton
+        organization={organization}
+        location={location}
+        isEditing={false}
+        eventView={errorsView}
+      />,
+      TestStubs.routerContext()
+    );
+    const button = wrapper.find('StyledDropdownButton');
+    button.simulate('click');
+
+    const input = wrapper.find('SaveQueryContainer input');
+    expect(input).toHaveLength(1);
+
+    const submit = wrapper.find('SaveQueryContainer Button');
+    expect(submit).toHaveLength(1);
+    expect(submit.text()).toEqual('Save');
+  });
+
+  it('renders a popover for an existing query', function() {
+    const wrapper = mount(
+      <EventSaveQueryButton
+        organization={organization}
+        location={location}
+        eventView={errorsView}
+        isEditing
+      />,
+      TestStubs.routerContext()
+    );
+    const button = wrapper.find('StyledDropdownButton');
+    button.simulate('click');
+
+    const submit = wrapper.find('SaveQueryContainer Button');
+    expect(submit).toHaveLength(1);
+    expect(submit.text()).toEqual('Update');
+  });
+
+  it('saves a new query', async function() {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/discover/saved/',
+      method: 'POST',
+      body: {
+        id: '2',
+        name: 'my query',
+        fields: ['title', 'count()'],
+        fieldnames: ['title', 'total'],
+      },
+    });
+    const wrapper = mount(
+      <EventSaveQueryButton
+        organization={organization}
+        location={location}
+        eventView={errorsView}
+      />,
+      TestStubs.routerContext()
+    );
+    const button = wrapper.find('StyledDropdownButton');
+    button.simulate('click');
+
+    const input = wrapper.find('SaveQueryContainer input');
+    input.simulate('change', {target: {value: 'my query'}});
+
+    const submit = wrapper.find('SaveQueryContainer Button');
+    submit.simulate('click');
+
+    // Wait for reflux
+    await tick();
+    await tick();
+
+    // should redirect to query
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: location.pathname,
+      query: {
+        field: ['title', 'count()'],
+        id: '2',
+        alias: ['title', 'total'],
+        name: 'my query',
+        query: '',
+        sort: [],
+        tag: [],
+      },
+    });
+  });
+
+  it('updates an existing query', async function() {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/discover/saved/1/',
+      method: 'PUT',
+      body: {
+        id: '1',
+        name: 'my query',
+        fields: ['title', 'count()'],
+        fieldnames: ['title', 'total'],
+      },
+    });
+    errorsView.id = 1;
+    const wrapper = mount(
+      <EventSaveQueryButton
+        organization={organization}
+        location={location}
+        eventView={errorsView}
+        isEditing
+      />,
+      TestStubs.routerContext()
+    );
+    const button = wrapper.find('StyledDropdownButton');
+    button.simulate('click');
+
+    const input = wrapper.find('SaveQueryContainer input');
+    input.simulate('change', {target: {value: 'my query'}});
+
+    const submit = wrapper.find('SaveQueryContainer Button');
+    submit.simulate('click');
+
+    // Wait for reflux
+    await tick();
+    await tick();
+
+    // should redirect to query
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: location.pathname,
+      query: {
+        field: ['title', 'count()'],
+        id: '1',
+        alias: ['title', 'total'],
+        name: 'my query',
+        query: '',
+        sort: [],
+        tag: [],
+      },
+    });
+  });
+});

--- a/tests/js/spec/views/eventsV2/saveQueryButton.spec.jsx
+++ b/tests/js/spec/views/eventsV2/saveQueryButton.spec.jsx
@@ -97,7 +97,7 @@ describe('EventsV2 > SaveQueryButton', function() {
     const input = wrapper.find('SaveQueryContainer input');
     input.simulate('change', {target: {value: 'my query'}});
 
-    const submit = wrapper.find('SaveQueryContainer Button');
+    const submit = wrapper.find('button[aria-label="Save"]');
     submit.simulate('click');
 
     // Wait for reflux
@@ -130,12 +130,15 @@ describe('EventsV2 > SaveQueryButton', function() {
         fieldnames: ['title', 'total'],
       },
     });
-    errorsView.id = 1;
+    const errors = EventView.fromEventViewv1(
+      ALL_VIEWS.find(view => view.name === 'Errors')
+    );
+    errors.id = '1';
     const wrapper = mount(
       <EventSaveQueryButton
         organization={organization}
         location={location}
-        eventView={errorsView}
+        eventView={errors}
         isEditing
       />,
       TestStubs.routerContext()
@@ -146,7 +149,7 @@ describe('EventsV2 > SaveQueryButton', function() {
     const input = wrapper.find('SaveQueryContainer input');
     input.simulate('change', {target: {value: 'my query'}});
 
-    const submit = wrapper.find('SaveQueryContainer Button');
+    const submit = wrapper.find('button[aria-label="Update"]');
     submit.simulate('click');
 
     // Wait for reflux

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -559,6 +559,7 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                               aria-label="Add Team"
                                               disabled={true}
                                               isOpen={false}
+                                              showChevron={true}
                                               size="xsmall"
                                             >
                                               <StyledButton


### PR DESCRIPTION
Add button to enable saving queries. Once a query has fields and conditions it can be saved. If the `edit` query parameter is present we will update the currently selected query instead.

This has required adding the `id` to the URL parameters so that we know which saved query is being edited. The `edit` query parameter might be removed in the future but we'll figure that out later.

![Screen Shot 2019-09-18 at 1 49 27 PM](https://user-images.githubusercontent.com/24086/65172569-33d3c700-da1b-11e9-9137-2da48e92eb13.png)


Refs SEN-948