### PR TITLE
build(babel): Add `displayName` to React components

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -31,6 +31,7 @@ module.exports = {
             additionalLibraries: [/app\/sentryTypes$/],
           },
         ],
+        ['babel-plugin-add-react-displayname'],
       ],
     },
     development: {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "algoliasearch": "^3.32.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^8.0.0",
+    "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-emotion": "9.2.11",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3126,6 +3126,11 @@ babel-loader@^8.0.0:
     mkdirp "^0.5.1"
     pify "^4.0.1"
 
+babel-plugin-add-react-displayname@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"
+  integrity sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=
+
 babel-plugin-dynamic-import-node@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.2.0.tgz#c0adfb07d95f4a4495e9aaac6ec386c4d7c2524e"


### PR DESCRIPTION
This adds a babel plugin to add `displayName` to ES6 class and functional React components. Reason being, these generally get minified away, and it makes debugging in production a bit easier. e.g. React dev tools and for React error boundaries.

Another option would be to configure `terser` to not minify class/function names.

Increases gzipd filesize of app bundle about .1% from 168647 -> 170205.