### PR TITLE
fix(discover2) Fix pagination when array fields are used

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -860,6 +860,10 @@ def get_reference_event_conditions(snuba_args, event_slug):
             value = tags.get(match.group(1), None)
         else:
             value = event_data.get(field, None)
+            # If the value is a sequence use the first element as snuba
+            # doesn't support `=` or `IN` operations on fields like exception_frames.filename
+            if isinstance(value, (list, set)) and len(value):
+                value = value.pop()
         if value:
             conditions.append([field, "=", value])
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -862,7 +862,7 @@ def get_reference_event_conditions(snuba_args, event_slug):
             value = event_data.get(field, None)
             # If the value is a sequence use the first element as snuba
             # doesn't support `=` or `IN` operations on fields like exception_frames.filename
-            if isinstance(value, (list, set)) and len(value):
+            if isinstance(value, (list, set)) and value:
                 value = value.pop()
         if value:
             conditions.append([field, "=", value])

--- a/tests/js/spec/components/sidebar/discover2Item.spec.jsx
+++ b/tests/js/spec/components/sidebar/discover2Item.spec.jsx
@@ -69,9 +69,11 @@ describe('Sidebar > Discover2Item', function() {
     const wrapper = makeWrapper({organization, client});
     // Wait for reflux
     await tick();
+    await tick();
 
     const nav = wrapper.find('nav');
     nav.simulate('mouseEnter');
+    await wrapper.update();
 
     const menu = wrapper.find('Menu');
     expect(menu).toHaveLength(1);
@@ -89,10 +91,11 @@ describe('Sidebar > Discover2Item', function() {
     const wrapper = makeWrapper({organization, client});
     // Wait for reflux
     await tick();
+    await tick();
 
     const nav = wrapper.find('nav');
     nav.simulate('mouseEnter');
-    await tick();
+    await wrapper.update();
 
     const item = wrapper.find('Menu MenuItem').first();
     item.find('MenuItemButton[icon="icon-trash"]').simulate('click');
@@ -105,10 +108,11 @@ describe('Sidebar > Discover2Item', function() {
     const wrapper = makeWrapper({organization, client});
     // Wait for reflux
     await tick();
+    await tick();
 
     const nav = wrapper.find('nav');
     nav.simulate('mouseEnter');
-    await tick();
+    await wrapper.update();
 
     const item = wrapper.find('Menu MenuItem').first();
     item.find('MenuItemButton[icon="icon-edit"]').simulate('click');

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1338,7 +1338,6 @@ class GetReferenceEventConditionsTest(SnubaTestCase, TestCase):
         assert result == [
             ["exception_stacks.value", "=", "This is a test exception sent from the Raven CLI."],
             ["exception_stacks.type", "=", "Exception"],
-            ["exception_stacks.mechanism_handled", "=", None],
         ]
 
     def test_stack_field(self):
@@ -1350,7 +1349,7 @@ class GetReferenceEventConditionsTest(SnubaTestCase, TestCase):
         result = get_reference_event_conditions(self.conditions, slug)
         assert result == [
             ["exception_frames.filename", "=", "/Users/example/Development/raven-php/bin/raven"],
-            ["exception_frames.function", "=", "null"],
+            ["exception_frames.function", "=", "raven_cli_test"],
         ]
 
     def test_tag_value(self):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1336,9 +1336,9 @@ class GetReferenceEventConditionsTest(SnubaTestCase, TestCase):
         slug = "{}:{}".format(self.project.slug, event.event_id)
         result = get_reference_event_conditions(self.conditions, slug)
         assert result == [
-            ["exception_stacks.value", "=", ["This is a test exception sent from the Raven CLI."]],
-            ["exception_stacks.type", "=", ["Exception"]],
-            ["exception_stacks.mechanism_handled", "=", [None]],
+            ["exception_stacks.value", "=", "This is a test exception sent from the Raven CLI."],
+            ["exception_stacks.type", "=", "Exception"],
+            ["exception_stacks.mechanism_handled", "=", None],
         ]
 
     def test_stack_field(self):
@@ -1349,17 +1349,8 @@ class GetReferenceEventConditionsTest(SnubaTestCase, TestCase):
         slug = "{}:{}".format(self.project.slug, event.event_id)
         result = get_reference_event_conditions(self.conditions, slug)
         assert result == [
-            [
-                "exception_frames.filename",
-                "=",
-                [
-                    "/Users/example/Development/raven-php/bin/raven",
-                    "/Users/example/Development/raven-php/bin/raven",
-                    "/Users/example/Development/raven-php/bin/raven",
-                    "/Users/example/Development/raven-php/bin/raven",
-                ],
-            ],
-            ["exception_frames.function", "=", ["null", "main", "cmd_test", "raven_cli_test"]],
+            ["exception_frames.filename", "=", "/Users/example/Development/raven-php/bin/raven"],
+            ["exception_frames.function", "=", "null"],
         ]
 
     def test_tag_value(self):


### PR DESCRIPTION
When a query contains an aggregate and an array field we should not jam the entire array value in the condition as snuba cannot generate a query for that scenario. Instead pick the last value in the list and use that. This is arbitrary but for stack frames, the 0th element generally is from the framework which isn't helpful.

Refs SEN-997