### PR TITLE
fix(discover2) Don't splat array fields into table columns

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -245,7 +245,9 @@ export const FIELD_FORMATTERS: FieldFormatters = {
           query: `${field}:${data[field]}`,
         },
       };
-      return <QueryLink to={target}>{data[field]}</QueryLink>;
+      // Some fields have long arrays in them, only show the tail of the data.
+      const value = Array.isArray(data[field]) ? data[field].slice(-1) : data[field];
+      return <QueryLink to={target}>{value}</QueryLink>;
     },
   },
 };


### PR DESCRIPTION
When an array field is selected don't mush the entire array into a cell. Instead only show the last element.

Refs SEN-997