### PR TITLE
feat(api): Add CRUD endpoints for alert rule triggers (SEN-990)

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+
+from collections import defaultdict
+
+import six
+
+from sentry.api.serializers import register, Serializer
+from sentry.incidents.models import AlertRuleTrigger, AlertRuleTriggerExclusion
+
+
+@register(AlertRuleTrigger)
+class AlertRuleTriggerSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        return {
+            "id": six.text_type(obj.id),
+            "alertRuleId": six.text_type(obj.alert_rule_id),
+            "label": obj.label,
+            "thresholdType": obj.threshold_type,
+            "alertThreshold": obj.alert_threshold,
+            "resolveThreshold": obj.resolve_threshold,
+            "dateAdded": obj.date_added,
+        }
+
+
+class DetailedAlertRuleTriggerSerializer(AlertRuleTriggerSerializer):
+    def get_attrs(self, item_list, user, **kwargs):
+        triggers = {item.id: item for item in item_list}
+        result = defaultdict(dict)
+        for trigger_id, project_slug in AlertRuleTriggerExclusion.objects.filter(
+            alert_rule_trigger__in=item_list
+        ).values_list("alert_rule_trigger_id", "query_subscription__project__slug"):
+            exclusions = result[triggers[trigger_id]].setdefault("excludedProjects", [])
+            exclusions.append(project_slug)
+        return result
+
+    def serialize(self, obj, attrs, user):
+        data = super(DetailedAlertRuleTriggerSerializer, self).serialize(obj, attrs, user)
+        data["excludedProjects"] = sorted(attrs.get("excludedProjects", []))
+        return data

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -282,6 +282,12 @@ from sentry.incidents.endpoints.organization_alert_rule_details import (
 from sentry.incidents.endpoints.organization_alert_rule_index import (
     OrganizationAlertRuleIndexEndpoint,
 )
+from sentry.incidents.endpoints.organization_alert_rule_trigger_details import (
+    OrganizationAlertRuleTriggerDetailsEndpoint,
+)
+from sentry.incidents.endpoints.organization_alert_rule_trigger_index import (
+    OrganizationAlertRuleTriggerIndexEndpoint,
+)
 from sentry.incidents.endpoints.project_alert_rule_details import ProjectAlertRuleDetailsEndpoint
 from sentry.incidents.endpoints.project_alert_rule_index import ProjectAlertRuleIndexEndpoint
 
@@ -547,6 +553,16 @@ urlpatterns = patterns(
                     r"^(?P<organization_slug>[^\/]+)/alert-rules/$",
                     OrganizationAlertRuleIndexEndpoint.as_view(),
                     name="sentry-api-0-organization-alert-rules",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/alert-rules/(?P<alert_rule_id>[^\/]+)/triggers/(?P<alert_rule_trigger_id>[^\/]+)$",
+                    OrganizationAlertRuleTriggerDetailsEndpoint.as_view(),
+                    name="sentry-api-0-organization-alert-rule-trigger-details",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/alert-rules/(?P<alert_rule_id>[^\/]+)/triggers/$",
+                    OrganizationAlertRuleTriggerIndexEndpoint.as_view(),
+                    name="sentry-api-0-organization-alert-rules-triggers",
                 ),
                 # Incidents
                 url(

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -6,7 +6,7 @@ from sentry import features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.incidents.models import AlertRule
+from sentry.incidents.models import AlertRule, AlertRuleTrigger
 
 
 class ProjectAlertRuleEndpoint(ProjectEndpoint):
@@ -45,6 +45,27 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
                 organization=organization, id=alert_rule_id
             )
         except AlertRule.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        return args, kwargs
+
+
+class OrganizationAlertRuleTriggerEndpoint(OrganizationAlertRuleEndpoint):
+    def convert_args(self, request, alert_rule_trigger_id, *args, **kwargs):
+        args, kwargs = super(OrganizationAlertRuleTriggerEndpoint, self).convert_args(
+            request, *args, **kwargs
+        )
+        organization = kwargs["organization"]
+        alert_rule = kwargs["alert_rule"]
+
+        if not features.has("organizations:incidents", organization, actor=request.user):
+            raise ResourceDoesNotExist
+
+        try:
+            kwargs["alert_rule_trigger"] = AlertRuleTrigger.objects.get(
+                alert_rule=alert_rule, id=alert_rule_trigger_id
+            )
+        except AlertRuleTrigger.DoesNotExist:
             raise ResourceDoesNotExist
 
         return args, kwargs

--- a/src/sentry/incidents/endpoints/organization_alert_rule_trigger_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_trigger_details.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.alert_rule_trigger import DetailedAlertRuleTriggerSerializer
+from sentry.incidents.endpoints.bases import OrganizationAlertRuleTriggerEndpoint
+from sentry.incidents.endpoints.serializers import AlertRuleTriggerSerializer
+from sentry.incidents.logic import AlreadyDeletedError, delete_alert_rule_trigger
+
+
+class OrganizationAlertRuleTriggerDetailsEndpoint(OrganizationAlertRuleTriggerEndpoint):
+    def get(self, request, organization, alert_rule, alert_rule_trigger):
+        """
+        Fetch an alert rule trigger.
+        ``````````````````
+        :auth: required
+        """
+        data = serialize(alert_rule_trigger, request.user, DetailedAlertRuleTriggerSerializer())
+        return Response(data)
+
+    def put(self, request, organization, alert_rule, alert_rule_trigger):
+        serializer = AlertRuleTriggerSerializer(
+            context={
+                "organization": organization,
+                "alert_rule": alert_rule,
+                "access": request.access,
+            },
+            instance=alert_rule_trigger,
+            data=request.data,
+            partial=True,
+        )
+
+        if serializer.is_valid():
+            trigger = serializer.save()
+            return Response(serialize(trigger, request.user), status=status.HTTP_200_OK)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, organization, alert_rule, alert_rule_trigger):
+        try:
+            delete_alert_rule_trigger(alert_rule_trigger)
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except AlreadyDeletedError:
+            return Response(
+                "This trigger has already been deleted", status=status.HTTP_400_BAD_REQUEST
+            )

--- a/src/sentry/incidents/endpoints/organization_alert_rule_trigger_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_trigger_index.py
@@ -1,0 +1,52 @@
+from __future__ import absolute_import
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
+from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint
+from sentry.incidents.endpoints.serializers import AlertRuleTriggerSerializer
+from sentry.incidents.logic import get_triggers_for_alert_rule
+
+
+class OrganizationAlertRuleTriggerIndexEndpoint(OrganizationAlertRuleEndpoint):
+    def get(self, request, organization, alert_rule):
+        """
+        Fetches triggers for an alert_rule
+        """
+        if not features.has("organizations:incidents", organization, actor=request.user):
+            raise ResourceDoesNotExist
+
+        return self.paginate(
+            request,
+            queryset=get_triggers_for_alert_rule(alert_rule),
+            order_by="-label",
+            paginator_cls=OffsetPaginator,
+            on_results=lambda x: serialize(x, request.user),
+            default_per_page=25,
+        )
+
+    def post(self, request, organization, alert_rule):
+        """
+        Create a trigger on an alert rule
+        """
+        if not features.has("organizations:incidents", organization, actor=request.user):
+            raise ResourceDoesNotExist
+
+        serializer = AlertRuleTriggerSerializer(
+            context={
+                "organization": organization,
+                "alert_rule": alert_rule,
+                "access": request.access,
+            },
+            data=request.data,
+        )
+
+        if serializer.is_valid():
+            trigger = serializer.save()
+            return Response(serialize(trigger, request.user), status=status.HTTP_201_CREATED)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -10,11 +10,14 @@ from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.incidents.logic import (
     AlertRuleNameAlreadyUsedError,
+    AlertRuleTriggerLabelAlreadyUsedError,
     create_alert_rule,
+    create_alert_rule_trigger,
     get_excluded_projects_for_alert_rule,
     update_alert_rule,
+    update_alert_rule_trigger,
 )
-from sentry.incidents.models import AlertRule, AlertRuleThresholdType
+from sentry.incidents.models import AlertRule, AlertRuleThresholdType, AlertRuleTrigger
 from sentry.models.project import Project
 from sentry.snuba.models import QueryAggregations
 
@@ -52,8 +55,6 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         extra_kwargs = {
             "query": {"allow_blank": True, "required": True},
             "threshold_period": {"default": 1, "min_value": 1, "max_value": 20},
-            "alert_threshold": {"required": True},
-            "resolve_threshold": {"required": True},
             "time_window": {
                 "min_value": 1,
                 "max_value": int(timedelta(days=1).total_seconds() / 60),
@@ -140,3 +141,67 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
     def update(self, instance, validated_data):
         validated_data = self._remove_unchanged_fields(instance, validated_data)
         return update_alert_rule(instance, **validated_data)
+
+
+class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
+    """
+    Serializer for creating/updating an alert rule trigger. Required context:
+     - `alert_rule`: The alert_rule related to this trigger.
+     - `organization`: The organization related to this trigger.
+     - `access`: An access object (from `request.access`)
+    """
+
+    # TODO: These might be slow for many projects, since it will query for each
+    # individually. If we find this to be a problem then we can look into batching.
+    excluded_projects = serializers.ListField(child=ProjectField(), required=False)
+
+    class Meta:
+        model = AlertRuleTrigger
+        fields = [
+            "label",
+            "threshold_type",
+            "alert_threshold",
+            "resolve_threshold",
+            "excluded_projects",
+        ]
+        extra_kwargs = {"label": {"min_length": 1, "max_length": 64}}
+
+    def validate_threshold_type(self, threshold_type):
+        try:
+            return AlertRuleThresholdType(threshold_type)
+        except ValueError:
+            raise serializers.ValidationError(
+                "Invalid threshold type, valid values are %s"
+                % [item.value for item in AlertRuleThresholdType]
+            )
+
+    def create(self, validated_data):
+        try:
+            return create_alert_rule_trigger(
+                alert_rule=self.context["alert_rule"], **validated_data
+            )
+        except AlertRuleTriggerLabelAlreadyUsedError:
+            raise serializers.ValidationError("This label is already in use for this alert rule")
+
+    def _remove_unchanged_fields(self, instance, validated_data):
+        for field_name, value in list(six.iteritems(validated_data)):
+            # Remove any fields that haven't actually changed
+            if field_name == "excluded_projects":
+                excluded_slugs = [
+                    e.query_subscription.project.slug for e in instance.exclusions.all()
+                ]
+                if set(excluded_slugs) == set(project.slug for project in value):
+                    validated_data.pop(field_name)
+                continue
+            if isinstance(value, Enum):
+                value = value.value
+            if getattr(instance, field_name) == value:
+                validated_data.pop(field_name)
+        return validated_data
+
+    def update(self, instance, validated_data):
+        validated_data = self._remove_unchanged_fields(instance, validated_data)
+        try:
+            return update_alert_rule_trigger(instance, **validated_data)
+        except AlertRuleTriggerLabelAlreadyUsedError:
+            raise serializers.ValidationError("This label is already in use for this alert rule")

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -976,6 +976,10 @@ def delete_alert_rule_trigger(trigger):
     trigger.delete()
 
 
+def get_triggers_for_alert_rule(alert_rule):
+    return AlertRuleTrigger.objects.filter(alert_rule=alert_rule)
+
+
 def get_subscriptions_from_alert_rule(alert_rule, projects):
     """
     Fetches subscriptions associated with an alert rule filtered by a list of projects.

--- a/tests/sentry/api/serializers/test_alert_rule_trigger.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import six
+
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.alert_rule_trigger import DetailedAlertRuleTriggerSerializer
+from sentry.incidents.logic import create_alert_rule_trigger
+from sentry.incidents.models import AlertRuleThresholdType
+from sentry.testutils import TestCase
+
+
+class BaseAlertRuleTriggerSerializerTest(object):
+    def assert_alert_rule_serialized(self, trigger, result):
+        assert result["id"] == six.text_type(trigger.id)
+        assert result["alertRuleId"] == six.text_type(trigger.alert_rule_id)
+        assert result["label"] == trigger.label
+        assert result["thresholdType"] == trigger.threshold_type
+        assert result["alertThreshold"] == trigger.alert_threshold
+        assert result["resolveThreshold"] == trigger.resolve_threshold
+        assert result["dateAdded"] == trigger.date_added
+
+
+class AlertRuleSerializerTest(BaseAlertRuleTriggerSerializerTest, TestCase):
+    def test_simple(self):
+        alert_rule = self.create_alert_rule()
+        trigger = create_alert_rule_trigger(
+            alert_rule, "hi", AlertRuleThresholdType.ABOVE, 1000, 200
+        )
+        result = serialize(trigger)
+        self.assert_alert_rule_serialized(trigger, result)
+
+
+class DetailedAlertRuleSerializerTest(BaseAlertRuleTriggerSerializerTest, TestCase):
+    def test_simple(self):
+        alert_rule = self.create_alert_rule()
+        trigger = create_alert_rule_trigger(
+            alert_rule, "hi", AlertRuleThresholdType.ABOVE, 1000, 200
+        )
+        result = serialize(trigger, serializer=DetailedAlertRuleTriggerSerializer())
+        self.assert_alert_rule_serialized(trigger, result)
+        assert result["excludedProjects"] == []
+
+    def test_excluded_projects(self):
+        excluded = [self.create_project()]
+        alert_rule = self.create_alert_rule(projects=excluded)
+        trigger = create_alert_rule_trigger(
+            alert_rule, "hi", AlertRuleThresholdType.ABOVE, 1000, 200, excluded_projects=excluded
+        )
+        result = serialize(trigger, serializer=DetailedAlertRuleTriggerSerializer())
+        self.assert_alert_rule_serialized(trigger, result)
+        assert result["excludedProjects"] == [p.slug for p in excluded]

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_trigger_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_trigger_details.py
@@ -1,0 +1,137 @@
+from __future__ import absolute_import
+
+from exam import fixture
+
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.alert_rule_trigger import DetailedAlertRuleTriggerSerializer
+from sentry.incidents.logic import create_alert_rule, create_alert_rule_trigger
+from sentry.incidents.models import AlertRuleThresholdType, AlertRuleTrigger
+from sentry.snuba.models import QueryAggregations
+from sentry.testutils import APITestCase
+
+
+class AlertRuleTriggerDetailsBase(object):
+    endpoint = "sentry-api-0-organization-alert-rule-trigger-details"
+
+    @fixture
+    def organization(self):
+        return self.create_organization()
+
+    @fixture
+    def project(self):
+        return self.create_project(organization=self.organization)
+
+    @fixture
+    def user(self):
+        return self.create_user()
+
+    @fixture
+    def alert_rule(self):
+        return create_alert_rule(
+            self.organization,
+            [self.project],
+            "hello",
+            AlertRuleThresholdType.ABOVE,
+            "level:error",
+            QueryAggregations.TOTAL,
+            10,
+            1000,
+            400,
+            1,
+        )
+
+    @fixture
+    def trigger(self):
+        return create_alert_rule_trigger(
+            self.alert_rule, "hello", AlertRuleThresholdType.ABOVE, 1000, 400
+        )
+
+    def test_invalid_trigger_id(self):
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+        with self.feature("organizations:incidents"):
+            resp = self.get_response(self.organization.slug, self.alert_rule.id, 1234)
+
+        assert resp.status_code == 404
+
+    def test_permissions(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        self.login_as(self.create_user())
+        with self.feature("organizations:incidents"):
+            resp = self.get_response(self.organization.slug, self.alert_rule.id, self.trigger.id)
+
+        assert resp.status_code == 403
+
+    def test_no_feature(self):
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+        resp = self.get_response(self.organization.slug, self.alert_rule.id, self.trigger.id)
+        assert resp.status_code == 404
+
+
+class AlertRuleTriggerDetailsGetEndpointTest(AlertRuleTriggerDetailsBase, APITestCase):
+    def test_simple(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        self.login_as(self.user)
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(
+                self.organization.slug, self.alert_rule.id, self.trigger.id
+            )
+
+        assert resp.data == serialize(self.trigger, serializer=DetailedAlertRuleTriggerSerializer())
+
+
+class AlertRuleTriggerDetailsPutEndpointTest(AlertRuleTriggerDetailsBase, APITestCase):
+    method = "put"
+
+    def test_simple(self):
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+
+        self.login_as(self.user)
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(
+                self.organization.slug, self.alert_rule.id, self.trigger.id, label="what"
+            )
+
+        self.trigger.label = "what"
+        assert resp.data == serialize(self.trigger)
+        assert resp.data["label"] == "what"
+
+    def test_not_updated_fields(self):
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+
+        self.login_as(self.user)
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(
+                self.organization.slug,
+                self.alert_rule.id,
+                self.trigger.id,
+                alert_threshold=self.alert_rule.alert_threshold,
+            )
+
+        # Alert rule should be exactly the same
+        assert resp.data == serialize(self.trigger)
+
+
+class AlertRuleTriggerDetailsDeleteEndpointTest(AlertRuleTriggerDetailsBase, APITestCase):
+    method = "delete"
+
+    def test_simple(self):
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+        with self.feature("organizations:incidents"):
+            self.get_valid_response(
+                self.organization.slug, self.alert_rule.id, self.trigger.id, status_code=204
+            )
+
+        assert not AlertRuleTrigger.objects.filter(id=self.trigger.id).exists()

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_trigger_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_trigger_index.py
@@ -1,0 +1,122 @@
+from __future__ import absolute_import
+
+from exam import fixture
+from freezegun import freeze_time
+
+from sentry.api.serializers import serialize
+from sentry.incidents.logic import create_alert_rule_trigger
+from sentry.incidents.models import AlertRuleThresholdType, AlertRuleTrigger
+from sentry.testutils import APITestCase
+
+
+class AlertRuleTriggerListEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-alert-rules-triggers"
+
+    @fixture
+    def organization(self):
+        return self.create_organization()
+
+    @fixture
+    def project(self):
+        return self.create_project(organization=self.organization)
+
+    @fixture
+    def user(self):
+        return self.create_user()
+
+    def test_simple(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        alert_rule = self.create_alert_rule()
+        trigger = create_alert_rule_trigger(
+            alert_rule, "test", AlertRuleThresholdType.ABOVE, 1000, 400
+        )
+
+        self.login_as(self.user)
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(self.organization.slug, alert_rule.id)
+
+        assert resp.data == serialize([trigger])
+
+    def test_no_feature(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        self.login_as(self.user)
+        resp = self.get_response(self.organization.slug, self.create_alert_rule().id)
+        assert resp.status_code == 404
+
+
+@freeze_time()
+class AlertRuleTriggerCreateEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-alert-rules-triggers"
+    method = "post"
+
+    @fixture
+    def organization(self):
+        return self.create_organization()
+
+    @fixture
+    def project(self):
+        return self.create_project(organization=self.organization)
+
+    @fixture
+    def user(self):
+        return self.create_user()
+
+    @fixture
+    def alert_rule(self):
+        return self.create_alert_rule()
+
+    def test_simple(self):
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(
+                self.organization.slug,
+                self.alert_rule.id,
+                label="an alert",
+                thresholdType=1,
+                alertThreshold=1000,
+                resolveThreshold=300,
+                status_code=201,
+            )
+        assert "id" in resp.data
+        trigger = AlertRuleTrigger.objects.get(id=resp.data["id"])
+        assert resp.data == serialize(trigger, self.user)
+
+    def test_invalid_excluded_projects(self):
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(
+                self.organization.slug,
+                self.alert_rule.id,
+                label="an alert",
+                thresholdType=1,
+                alertThreshold=1000,
+                resolveThreshold=300,
+                excludedProjects=[
+                    self.project.slug,
+                    self.create_project(organization=self.create_organization()).slug,
+                ],
+                status_code=400,
+            )
+        assert resp.data == {"excludedProjects": [u"Invalid project"]}
+
+    def test_no_feature(self):
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+        resp = self.get_response(self.organization.slug, self.alert_rule.id)
+        assert resp.status_code == 404
+
+    def test_no_perms(self):
+        self.create_member(
+            user=self.user, organization=self.organization, role="member", teams=[self.team]
+        )
+        self.login_as(self.user)
+        resp = self.get_response(self.organization.slug, self.alert_rule.id)
+        assert resp.status_code == 403

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 from exam import fixture
 
 from sentry.auth.access import from_user
-from sentry.incidents.endpoints.serializers import AlertRuleSerializer
-from sentry.incidents.logic import create_alert_rule
+from sentry.incidents.endpoints.serializers import AlertRuleSerializer, AlertRuleTriggerSerializer
+from sentry.incidents.logic import create_alert_rule, create_alert_rule_trigger
 from sentry.incidents.models import AlertRuleThresholdType
 from sentry.snuba.models import QueryAggregations
 from sentry.testutils import TestCase
@@ -48,8 +48,6 @@ class TestAlertRuleSerializer(TestCase):
             "name": field_is_required,
             "timeWindow": field_is_required,
             "query": field_is_required,
-            "resolveThreshold": field_is_required,
-            "alertThreshold": field_is_required,
         }
 
     def test_time_window(self):
@@ -188,4 +186,122 @@ class TestAlertRuleSerializer(TestCase):
         self._run_changed_fields_test(alert_rule, {"include_all_projects": True}, {})
         self._run_changed_fields_test(
             alert_rule, {"include_all_projects": False}, {"include_all_projects": False}
+        )
+
+
+class TestAlertRuleTriggerSerializer(TestCase):
+    @fixture
+    def other_project(self):
+        return self.create_project()
+
+    @fixture
+    def alert_rule(self):
+        return self.create_alert_rule(projects=[self.project, self.other_project])
+
+    @fixture
+    def valid_params(self):
+        return {
+            "label": "something",
+            "threshold_type": 0,
+            "resolve_threshold": 1,
+            "alert_threshold": 0,
+            "excluded_projects": [self.project.slug],
+        }
+
+    @fixture
+    def access(self):
+        return from_user(self.user, self.organization)
+
+    @fixture
+    def context(self):
+        return {
+            "organization": self.organization,
+            "access": self.access,
+            "alert_rule": self.alert_rule,
+        }
+
+    def run_fail_validation_test(self, params, errors):
+        base_params = self.valid_params.copy()
+        base_params.update(params)
+        serializer = AlertRuleTriggerSerializer(context=self.context, data=base_params)
+        assert not serializer.is_valid()
+        assert serializer.errors == errors
+
+    def test_validation_no_params(self):
+        serializer = AlertRuleTriggerSerializer(context=self.context, data={})
+        assert not serializer.is_valid()
+        field_is_required = ["This field is required."]
+        assert serializer.errors == {
+            "label": field_is_required,
+            "thresholdType": field_is_required,
+            "alertThreshold": field_is_required,
+        }
+
+    def test_threshold_type(self):
+        invalid_values = [
+            "Invalid threshold type, valid values are %s"
+            % [item.value for item in AlertRuleThresholdType]
+        ]
+        self.run_fail_validation_test(
+            {"thresholdType": "a"}, {"thresholdType": ["A valid integer is required."]}
+        )
+        self.run_fail_validation_test({"thresholdType": 50}, {"thresholdType": invalid_values})
+
+    def _run_changed_fields_test(self, trigger, params, expected):
+        serializer = AlertRuleTriggerSerializer(
+            context=self.context, instance=trigger, data=params, partial=True
+        )
+        assert serializer.is_valid(), serializer.errors
+        assert serializer._remove_unchanged_fields(trigger, serializer.validated_data) == expected
+
+    def test_remove_unchanged_fields(self):
+        excluded_projects = [self.project]
+        label = "hello"
+        threshold_type = AlertRuleThresholdType.ABOVE
+        alert_threshold = 1000
+        resolve_threshold = 400
+        trigger = create_alert_rule_trigger(
+            self.alert_rule,
+            label,
+            threshold_type,
+            alert_threshold,
+            resolve_threshold,
+            excluded_projects=excluded_projects,
+        )
+
+        self._run_changed_fields_test(
+            trigger,
+            {
+                "label": label,
+                "threshold_type": threshold_type.value,
+                "alert_threshold": alert_threshold,
+                "resolve_threshold": resolve_threshold,
+                "excludedProjects": [p.slug for p in excluded_projects],
+            },
+            {},
+        )
+
+        self._run_changed_fields_test(trigger, {"label": label}, {})
+        self._run_changed_fields_test(trigger, {"label": "a name"}, {"label": "a name"})
+
+        self._run_changed_fields_test(trigger, {"threshold_type": threshold_type.value}, {})
+        self._run_changed_fields_test(
+            trigger, {"threshold_type": 1}, {"threshold_type": AlertRuleThresholdType.BELOW}
+        )
+
+        self._run_changed_fields_test(trigger, {"alert_threshold": alert_threshold}, {})
+        self._run_changed_fields_test(trigger, {"alert_threshold": 2000}, {"alert_threshold": 2000})
+
+        self._run_changed_fields_test(trigger, {"resolve_threshold": resolve_threshold}, {})
+        self._run_changed_fields_test(
+            trigger, {"resolve_threshold": 200}, {"resolve_threshold": 200}
+        )
+
+        self._run_changed_fields_test(
+            trigger, {"excluded_projects": [p.slug for p in excluded_projects]}, {}
+        )
+        self._run_changed_fields_test(
+            trigger,
+            {"excluded_projects": [self.other_project.slug]},
+            {"excluded_projects": [self.other_project]},
         )

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -40,6 +40,7 @@ from sentry.incidents.logic import (
     get_incident_subscribers,
     get_incident_suspect_commits,
     get_incident_suspects,
+    get_triggers_for_alert_rule,
     INCIDENT_START_ROLLUP,
     ProjectsNotAssociatedWithAlertRuleError,
     subscribe_to_incident,
@@ -1296,3 +1297,12 @@ class DeleteAlertRuleTriggerTest(TestCase):
         assert not AlertRuleTriggerExclusion.objects.filter(
             alert_rule_trigger=trigger, query_subscription__project=self.project
         ).exists()
+
+
+class GetTriggersForAlertRuleTest(TestCase):
+    def test(self):
+        alert_rule = self.create_alert_rule()
+        trigger = create_alert_rule_trigger(
+            alert_rule, "hi", AlertRuleThresholdType.ABOVE, 1000, 400
+        )
+        assert get_triggers_for_alert_rule(alert_rule).get() == trigger


### PR DESCRIPTION
This adds CRUD endpoints for alert rule triggers. These all exist under the alert-rules url, and
mostly follow the same patterns that we have for the old thresholds that were at the alert rule
level.