### PR TITLE
feat(transactions): select transaction color based on op name

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/minimap.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/minimap.tsx
@@ -19,7 +19,7 @@ import {ParsedTraceType, TickAlignment, SpanType, SpanChildrenLookupType} from '
 import {zIndex} from './styles';
 
 export const MINIMAP_CONTAINER_HEIGHT = 106;
-export const MINIMAP_SPAN_BAR_HEIGHT = 5;
+export const MINIMAP_SPAN_BAR_HEIGHT = 2;
 const MINIMAP_HEIGHT = 75;
 export const NUM_OF_SPANS_FIT_IN_MINI_MAP = MINIMAP_HEIGHT / MINIMAP_SPAN_BAR_HEIGHT;
 const TIME_AXIS_HEIGHT = 30;
@@ -360,7 +360,7 @@ class ActualMinimap extends React.PureComponent<{trace: ParsedTraceType}> {
     spanTree: JSX.Element;
     nextSpanNumber: number;
   } => {
-    const spanBarColour: string = pickSpanBarColour(spanNumber);
+    const spanBarColour: string = pickSpanBarColour(span.op);
 
     const bounds = generateBounds({
       startTimestamp: span.start_timestamp,
@@ -616,6 +616,7 @@ const MinimapSpanBar = styled('div')`
   height: ${MINIMAP_SPAN_BAR_HEIGHT}px;
   min-height: ${MINIMAP_SPAN_BAR_HEIGHT}px;
   max-height: ${MINIMAP_SPAN_BAR_HEIGHT}px;
+  margin: 2px 0;
 
   min-width: 1px;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -53,7 +53,7 @@ class SpanTree extends React.Component<PropType> {
     childSpans: Readonly<SpanChildrenLookupType>;
     generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
   }): RenderedSpanTree => {
-    const spanBarColour: string = pickSpanBarColour(spanNumber - 1);
+    const spanBarColour: string = pickSpanBarColour(span.op);
 
     const spanChildren: Array<SpanType> = get(childSpans, span.span_id, []);
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -1,4 +1,5 @@
 import {isString} from 'lodash';
+import {divergentColorScale, spanColors} from 'app/utils/theme';
 
 type Rect = {
   // x and y are left/top coords respectively
@@ -236,29 +237,29 @@ export const getHumanDuration = (duration: number): string => {
   return `${durationMS.toFixed(2)}ms`;
 };
 
-const COLORS = [
-  '#7274AC',
-  '#9D85B8',
-  '#BF8CB6',
-  '#CF7CA0',
-  '#ED8898',
-  '#F6A189',
-  '#F8B26D',
-  '#F7D36E',
+const getLetterIndex = (letter: string): number => {
+  const index = 'abcdefghijklmnopqrstuvwxyz'.indexOf(letter) || 0;
+  return index === -1 ? 0 : index;
+};
 
-  // reverse fade
+export const pickSpanBarColour = (input: string | undefined): string => {
+  // We pick the color for span bars using the first two letters of the op name.
+  // That way colors stay consistent between transactions.
 
-  '#F8B26D',
-  '#F6A189',
-  '#ED8898',
-  '#CF7CA0',
-  '#BF8CB6',
-  '#9D85B8',
-];
-export const pickSpanBarColour = (input: number): string => {
-  const index = input % COLORS.length;
+  if (!input || input.length < 2) {
+    return divergentColorScale.blue;
+  }
+  if (spanColors[input]) {
+    return spanColors[input];
+  }
 
-  return COLORS[index];
+  const colorsAsArray = Object.keys(divergentColorScale).map(
+    key => divergentColorScale[key]
+  );
+  const letterIndex1 = getLetterIndex(input.slice(0, 1));
+  const letterIndex2 = getLetterIndex(input.slice(1, 2));
+
+  return colorsAsArray[(letterIndex1 + letterIndex2) % colorsAsArray.length];
 };
 
 export type UserSelectValues = {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -242,6 +242,10 @@ const getLetterIndex = (letter: string): number => {
   return index === -1 ? 0 : index;
 };
 
+const colorsAsArray = Object.keys(divergentColorScale).map(
+  key => divergentColorScale[key]
+);
+
 export const pickSpanBarColour = (input: string | undefined): string => {
   // We pick the color for span bars using the first two letters of the op name.
   // That way colors stay consistent between transactions.
@@ -253,9 +257,6 @@ export const pickSpanBarColour = (input: string | undefined): string => {
     return spanColors[input];
   }
 
-  const colorsAsArray = Object.keys(divergentColorScale).map(
-    key => divergentColorScale[key]
-  );
   const letterIndex1 = getLetterIndex(input.slice(0, 1));
   const letterIndex2 = getLetterIndex(input.slice(1, 2));
 

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -76,6 +76,43 @@ const colors = {
   placeholderBackground: '#f5f5f5',
 };
 
+// from the Sentry design system: most useful for showing a transition
+// from one extreme, through a neutral middle, to an opposite extreme.
+export const divergentColorScale = {
+  blue: '#444674',
+  maroon: '#955389',
+  magenta: '#C15584',
+  salmon: '#E65D73',
+  purple: '#694E86',
+  orange: '#F27A58',
+  marigold: '#F6983B',
+  yellow: '#F2B712',
+  softBlue: '#535577',
+  softMaroon: '#805567',
+  softMagenta: '#70506A',
+  softSalmon: '#96545E',
+  softPurple: '#6B597E',
+  softOrange: '#D17D65',
+  softMarigold: '#E4944E',
+  softYellow: '#EDC658',
+  darkOrange: '#98361B',
+  darkBlue: '#1E1F33',
+  darkMaroon: '#382947',
+  darkMagenta: '#522E4B',
+  darkSalmon: '#833054',
+  darkPurple: '#AF2C41',
+  darkMarigold: '#C36609',
+  darkYellow: '#E2B22E',
+};
+
+// you can link span operation types to specific colors here
+export const spanColors = {
+  default: divergentColorScale.blue,
+  transaction: divergentColorScale.softBlue,
+  db: divergentColorScale.softPurple,
+  http: divergentColorScale.marigold,
+};
+
 const warning = {
   backgroundLight: colors.yellowLightest,
   background: colors.yellowDarkest,

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -89,7 +89,7 @@ export const divergentColorScale = {
   yellow: '#F2B712',
   softBlue: '#535577',
   softMaroon: '#805567',
-  softMagenta: '#70506A',
+  softMagenta: '#99628F',
   softSalmon: '#96545E',
   softPurple: '#6B597E',
   softOrange: '#D17D65',
@@ -109,7 +109,7 @@ export const divergentColorScale = {
 export const spanColors = {
   default: divergentColorScale.blue,
   transaction: divergentColorScale.softBlue,
-  db: divergentColorScale.softPurple,
+  db: divergentColorScale.magenta,
   http: divergentColorScale.marigold,
 };
 

--- a/tests/js/spec/components/events/interfaces/spanComponents/utils.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/spanComponents/utils.spec.jsx
@@ -1,0 +1,40 @@
+import {divergentColorScale, spanColors} from 'app/utils/theme';
+import {pickSpanBarColour} from 'app/components/events/interfaces/spans/utils';
+
+describe('pickSpanBarColour()', function() {
+  it('returns blue when undefined', function() {
+    expect(pickSpanBarColour(undefined)).toEqual(spanColors.default);
+  });
+
+  it('returns blue when the string is too short', function() {
+    expect(pickSpanBarColour('')).toEqual(spanColors.default);
+    expect(pickSpanBarColour('c')).toEqual(spanColors.default);
+  });
+
+  it('returns the predefined color when available', function() {
+    expect(pickSpanBarColour('transaction')).toEqual(spanColors.transaction);
+  });
+
+  it('returns a random color when no predefined option is available', function() {
+    const colorsAsArray = Object.keys(divergentColorScale).map(
+      key => divergentColorScale[key]
+    );
+
+    let randomColor = pickSpanBarColour('a normal string');
+    expect(colorsAsArray).toContain(randomColor);
+
+    randomColor = pickSpanBarColour(
+      'this is a rather long string, it is longer than most'
+    );
+    expect(colorsAsArray).toContain(randomColor);
+
+    randomColor = pickSpanBarColour('.periods.period');
+    expect(colorsAsArray).toContain(randomColor);
+
+    randomColor = pickSpanBarColour('!!!!!!!!!!!');
+    expect(colorsAsArray).toContain(randomColor);
+
+    randomColor = pickSpanBarColour('           ');
+    expect(colorsAsArray).toContain(randomColor);
+  });
+});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/435981/65293073-bab59c00-db0e-11e9-9464-6691c2b91540.png)

Instead of randomly picking a color, or walking down a series of colors, let's pick a color for each operation, and use that across all views for consistency. 

Our color picker does three things:

1. returns a color specified in `spanColors` if a color is defined for any operation name.
2. if no color is predefined, return a color based on the operation name. We want to use the first *two* letters, since letters like "p", "d", and "a" will consume a much larger share of operation names.
3. if the operation name is undefined, empty, random characters, or less than two characters, we want to return a generic color.

