### PR TITLE
feat(app-platform): removes expensive queries related to sentry app authentication

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -18,6 +18,7 @@ from sentry.models import (
     ProjectStatus,
     SentryApp,
     UserPermission,
+    Team,
 )
 
 
@@ -310,7 +311,7 @@ def from_sentry_app(user, organization=None):
     if not sentry_app.is_installed_on(organization):
         return NoAccess()
 
-    team_list = list(sentry_app.teams.all())
+    team_list = list(Team.objects.filter(organization=organization))
     project_list = list(
         Project.objects.filter(status=ProjectStatus.VISIBLE, teams__in=team_list).distinct()
     )
@@ -318,7 +319,7 @@ def from_sentry_app(user, organization=None):
     return Access(
         scopes=sentry_app.scope_list,
         is_active=True,
-        organization_id=organization.id if organization else None,
+        organization_id=organization.id,
         teams=team_list,
         projects=project_list,
         permissions=(),

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -12,7 +12,6 @@ from django.utils import timezone
 from django.template.defaultfilters import slugify
 from hashlib import sha256
 from sentry.constants import SentryAppStatus, SENTRY_APP_SLUG_MAX_LENGTH
-from sentry.models import Organization
 from sentry.models.apiscopes import HasApiScopes
 from sentry.db.models import (
     ArrayField,
@@ -112,24 +111,6 @@ class SentryApp(ParanoidModel, HasApiScopes):
         return cls.objects.filter(status=SentryAppStatus.PUBLISHED)
 
     @property
-    def organizations(self):
-        if not self.pk:
-            return Organization.objects.none()
-
-        return Organization.objects.select_related("sentry_app_installations").filter(
-            sentry_app_installations__sentry_app_id=self.id
-        )
-
-    @property
-    def teams(self):
-        from sentry.models import Team
-
-        if not self.pk:
-            return Team.objects.none()
-
-        return Team.objects.filter(organization__in=self.organizations)
-
-    @property
     def is_published(self):
         return self.status == SentryAppStatus.PUBLISHED
 
@@ -147,7 +128,9 @@ class SentryApp(ParanoidModel, HasApiScopes):
         return super(SentryApp, self).save(*args, **kwargs)
 
     def is_installed_on(self, organization):
-        return self.organizations.filter(pk=organization.pk).exists()
+        from sentry.models import SentryAppInstallation
+
+        return SentryAppInstallation.objects.filter(organization=organization).exists()
 
     def _set_slug(self):
         """

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -20,6 +20,7 @@ from sentry.db.models import (
     FlexibleForeignKey,
     ParanoidModel,
 )
+from sentry.models.sentryappinstallation import SentryAppInstallation
 
 # When a developer selects to receive "<Resource> Webhooks" it really means
 # listening to a list of specific events. This is a mapping of what those
@@ -128,8 +129,6 @@ class SentryApp(ParanoidModel, HasApiScopes):
         return super(SentryApp, self).save(*args, **kwargs)
 
     def is_installed_on(self, organization):
-        from sentry.models import SentryAppInstallation
-
         return SentryAppInstallation.objects.filter(organization=organization).exists()
 
     def _set_slug(self):

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -201,9 +201,11 @@ class FromSentryAppTest(TestCase):
         self.user = self.create_user("integration@example.com")
 
         self.org = self.create_organization()
+        self.org2 = self.create_organization()
         self.out_of_scope_org = self.create_organization()
 
         self.team = self.create_team(organization=self.org)
+        self.team2 = self.create_team(organization=self.org2)
         self.out_of_scope_team = self.create_team(organization=self.out_of_scope_org)
 
         self.sentry_app = self.create_sentry_app(name="SlowDB", organization=self.org)
@@ -213,11 +215,15 @@ class FromSentryAppTest(TestCase):
         self.install = self.create_sentry_app_installation(
             organization=self.org, slug=self.sentry_app.slug, user=self.user
         )
+        self.install2 = self.create_sentry_app_installation(
+            organization=self.org2, slug=self.sentry_app.slug, user=self.user
+        )
 
-    def test_has_access(self):
+    def test_has_access_org(self):
         result = access.from_sentry_app(self.proxy_user, self.org)
         assert result.is_active
         assert result.has_team_access(self.team)
+        assert result.teams == [self.team]
 
     def test_no_access(self):
         result = access.from_sentry_app(self.proxy_user, self.out_of_scope_org)

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -219,7 +219,7 @@ class FromSentryAppTest(TestCase):
             organization=self.org2, slug=self.sentry_app.slug, user=self.user
         )
 
-    def test_has_access_org(self):
+    def test_has_access(self):
         result = access.from_sentry_app(self.proxy_user, self.org)
         assert result.is_active
         assert result.has_team_access(self.team)


### PR DESCRIPTION
Currently, we query all teams for all organizations a sentry app is installed on when determining permissions. This could cause huge load if an integration is installed on many orgs. We only need to query the teams for the org related to the request.