### PR TITLE
test: Refactor group_tag_export to work with Snuba tagstore backend

### DIFF
--- a/tests/sentry/web/frontend/test_group_tag_export.py
+++ b/tests/sentry/web/frontend/test_group_tag_export.py
@@ -1,34 +1,64 @@
 from __future__ import absolute_import
 
-from datetime import timedelta
-from django.utils import timezone
+from datetime import datetime, timedelta
 
-from sentry import tagstore
-from sentry.testutils import TestCase
+from django.conf import settings
+
+from sentry.testutils import SnubaTestCase, TestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
-class GroupTagExportTest(TestCase):
+class GroupTagExportTest(TestCase, SnubaTestCase):
     def test_simple(self):
         key, value = "foo", u"b\xe4r"
-
-        now = timezone.now()
-
         project = self.create_project()
-        group = self.create_group(project=project)
-        tagstore.create_tag_key(project_id=project.id, environment_id=self.environment.id, key=key)
-        tagstore.create_tag_value(
-            project_id=project.id, environment_id=self.environment.id, key=key, value=value
-        )
-        group_tag_value = tagstore.create_group_tag_value(
-            project_id=project.id,
-            group_id=group.id,
-            environment_id=self.environment.id,
-            key=key,
-            value=value,
-            times_seen=1,
-            first_seen=now - timedelta(hours=1),
-            last_seen=now,
-        )
+
+        if settings.SENTRY_TAGSTORE.startswith("sentry.tagstore.snuba"):
+            event_timestamp = iso_format(before_now(seconds=1))
+
+            event = self.store_event(
+                data={
+                    "tags": {key: value},
+                    "timestamp": event_timestamp,
+                    "environment": self.environment.name,
+                },
+                project_id=project.id,
+                assert_no_errors=False,
+            )
+
+            group = event.group
+
+            first_seen = datetime.strptime(event_timestamp, "%Y-%m-%dT%H:%M:%S").strftime(
+                "%Y-%m-%dT%H:%M:%S.%fZ"
+            )
+            last_seen = first_seen
+
+        else:
+            from django.utils import timezone
+            from sentry import tagstore
+
+            now = timezone.now()
+
+            group = self.create_group(project=project)
+            tagstore.create_tag_key(
+                project_id=project.id, environment_id=self.environment.id, key=key
+            )
+            tagstore.create_tag_value(
+                project_id=project.id, environment_id=self.environment.id, key=key, value=value
+            )
+            group_tag_value = tagstore.create_group_tag_value(
+                project_id=project.id,
+                group_id=group.id,
+                environment_id=self.environment.id,
+                key=key,
+                value=value,
+                times_seen=1,
+                first_seen=now - timedelta(hours=1),
+                last_seen=now,
+            )
+
+            first_seen = group_tag_value.first_seen.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            last_seen = group_tag_value.last_seen.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
         self.login_as(user=self.user)
 
@@ -51,5 +81,5 @@ class GroupTagExportTest(TestCase):
             else:
                 assert bits[0] == value
                 assert bits[1] == "1"
-                assert bits[2] == group_tag_value.last_seen.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-                assert bits[3] == group_tag_value.first_seen.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                assert bits[2] == last_seen
+                assert bits[3] == first_seen

--- a/tests/sentry/web/frontend/test_group_tag_export.py
+++ b/tests/sentry/web/frontend/test_group_tag_export.py
@@ -13,7 +13,10 @@ class GroupTagExportTest(TestCase, SnubaTestCase):
         key, value = "foo", u"b\xe4r"
         project = self.create_project()
 
-        if settings.SENTRY_TAGSTORE.startswith("sentry.tagstore.snuba"):
+        if settings.SENTRY_TAGSTORE in [
+            "sentry.tagstore.snuba.SnubaCompatibilityTagStorage",
+            "sentry.tagstore.snuba.SnubaTagStorage",
+        ]:
             event_timestamp = iso_format(before_now(seconds=1))
 
             event = self.store_event(


### PR DESCRIPTION
Since we be deprecating the legacy tagstore backend, we need to rewrite
this test to also pass for the Snuba backend.