### PR TITLE
fix(comments): long words break outside of container

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/item/index.jsx
+++ b/src/sentry/static/sentry/app/components/activity/item/index.jsx
@@ -137,6 +137,7 @@ const ActivityFooter = styled(HeaderAndFooter)`
 
 const ActivityBody = styled('div')`
   padding: ${space(2)} ${space(2)};
+  word-break: break-all;
 
   ${textStyles}
 `;


### PR DESCRIPTION
before:

![image](https://user-images.githubusercontent.com/435981/65354990-c0aa8c00-dba5-11e9-8372-d82316fca1ec.png)

after:

![image](https://user-images.githubusercontent.com/435981/65354903-8fca5700-dba5-11e9-9335-e6973ebb01f4.png)


resolves [ISSUE-536](https://getsentry.atlassian.net/browse/ISSUE-536)