### PR TITLE
fix(slack): Check plugin first before SentryApp

### DIFF
--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -68,8 +68,6 @@ class NotifyEventServiceAction(EventAction):
                 extra["plugin"] = service
                 self.logger.info("rules.fail.plugin_does_not_exist", extra=extra)
                 return
-            else:
-                pass
 
         if plugin:
             if not plugin.is_enabled(self.project):
@@ -83,9 +81,9 @@ class NotifyEventServiceAction(EventAction):
                 extra["group_id"] = group.id
                 self.logger.info("rule.fail.should_notify", extra=extra)
                 return
-            else:
-                metrics.incr("notifications.sent", instance=plugin.slug, skip_internal=False)
-                yield self.future(plugin.rule_notify)
+
+            metrics.incr("notifications.sent", instance=plugin.slug, skip_internal=False)
+            yield self.future(plugin.rule_notify)
 
     def get_sentry_app_services(self):
         apps = SentryApp.objects.filter(

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -25,7 +25,7 @@ from sentry.models import (
 )
 from sentry.models.sentryapp import VALID_EVENTS
 
-logger = logging.Logger("sentry.tasks.sentry_apps")
+logger = logging.getLogger("sentry.tasks.sentry_apps")
 
 TASK_OPTIONS = {
     "queue": "app_platform",

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -41,3 +41,24 @@ class NotifyEventServiceActionTest(RuleTestCase):
 
         assert len(results) is 1
         assert results[0].callback is notify_sentry_app
+
+    def test_notify_sentry_app_and_plugin_with_same_slug(self):
+        event = self.get_event()
+
+        self.create_sentry_app(organization=event.organization, name="Notify", is_alertable=True)
+
+        plugin = MagicMock()
+        plugin.is_enabled.return_value = True
+        plugin.should_notify.return_value = True
+
+        rule = self.get_rule(data={"service": "notify"})
+
+        with patch("sentry.plugins.plugins.get") as get_plugin:
+            get_plugin.return_value = plugin
+
+            results = list(rule.after(event=event, state=self.get_state()))
+
+        assert len(results) is 2
+        assert plugin.should_notify.call_count is 1
+        assert results[0].callback is notify_sentry_app
+        assert results[1].callback is plugin.rule_notify


### PR DESCRIPTION
**Problem:**
On 8-28-19, the Legacy Slack integration stopped working for some folks. This did not effect users who had `Send a notification for {all legacy integrations}` - only those with `Slack` selected. 

**Cause:**
Turns out that someone had created a Sentry App with the slug `slack` and this took priority over the plugins. This meant that the notification was attempting to be sent to this Sentry App BUT since that app is unpublished (only available for the org that it was created in) it failed. Additionally there was no helpful logging around this because the logger was not set up correctly in the sentry_apps task.

**Solution:**
* Use `logging.getLogger` not `logging.Logger`
* Don't let the SentryApp override the plugins
