### PR TITLE
ref(app-platform): Mask auth tokens and client secret when needed

### DIFF
--- a/src/sentry/api/endpoints/organization_sentry_apps.py
+++ b/src/sentry/api/endpoints/organization_sentry_apps.py
@@ -16,5 +16,5 @@ class OrganizationSentryAppsEndpoint(OrganizationEndpoint):
             queryset=queryset,
             order_by="-date_added",
             paginator_cls=OffsetPaginator,
-            on_results=lambda x: serialize(x, request.user),
+            on_results=lambda x: serialize(x, request.user, access=request.access),
         )

--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
     def get(self, request, sentry_app):
-        return Response(serialize(sentry_app, request.user))
+        return Response(serialize(sentry_app, request.user, access=request.access))
 
     @catch_raised_errors
     def put(self, request, sentry_app):
@@ -59,7 +59,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                 allowed_origins=result.get("allowedOrigins"),
             )
 
-            return Response(serialize(updated_app, request.user))
+            return Response(serialize(updated_app, request.user, access=request.access))
 
         # log any errors with schema
         if "schema" in serializer.errors:

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -45,7 +45,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             queryset=queryset,
             order_by="-date_added",
             paginator_cls=OffsetPaginator,
-            on_results=lambda x: serialize(x, request.user),
+            on_results=lambda x: serialize(x, request.user, access=request.access),
         )
 
     def post(self, request, organization):
@@ -91,7 +91,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             creator = InternalCreator if data.get("isInternal") else Creator
             sentry_app = creator.run(request=request, **data)
 
-            return Response(serialize(sentry_app), status=201)
+            return Response(serialize(sentry_app, access=request.access), status=201)
 
         # log any errors with schema
         if "schema" in serializer.errors:

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -4,11 +4,12 @@ from sentry.app import env
 from sentry.auth.superuser import is_active_superuser
 from sentry.api.serializers import Serializer, register
 from sentry.models import SentryApp
+from sentry.models.sentryapp import MASKED_VALUE
 
 
 @register(SentryApp)
 class SentryAppSerializer(Serializer):
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user, access):
         from sentry.mediators.service_hooks.creator import consolidate_events
 
         data = {
@@ -31,10 +32,13 @@ class SentryAppSerializer(Serializer):
         if is_active_superuser(env.request) or (
             hasattr(user, "get_orgs") and obj.owner in user.get_orgs()
         ):
+            client_secret = (
+                obj.application.client_secret if obj.show_auth_info(access) else MASKED_VALUE
+            )
             data.update(
                 {
                     "clientId": obj.application.client_id,
-                    "clientSecret": obj.application.client_secret,
+                    "clientSecret": client_secret,
                     "owner": {"id": obj.owner.id, "slug": obj.owner.slug},
                 }
             )

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -49,6 +49,8 @@ REQUIRED_EVENT_PERMISSIONS = {
 # events.
 VALID_EVENTS = tuple(itertools.chain(*EVENT_EXPANSION.values()))
 
+MASKED_VALUE = "*" * 64
+
 
 def default_uuid():
     return six.binary_type(uuid.uuid4())
@@ -153,3 +155,7 @@ class SentryApp(ParanoidModel, HasApiScopes):
         return hmac.new(
             key=secret.encode("utf-8"), msg=body.encode("utf-8"), digestmod=sha256
         ).hexdigest()
+
+    def show_auth_info(self, access):
+        encoded_scopes = set({u"%s" % scope for scope in list(access.scopes)})
+        return set(self.scope_list).issubset(encoded_scopes)

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -31,6 +31,7 @@ import {
   removeSentryAppToken,
 } from 'app/actionCreators/sentryAppTokens';
 import {SentryApp, InternalAppApiToken} from 'app/types';
+import Tooltip from 'app/components/tooltip';
 
 class SentryAppFormModel extends FormModel {
   /**
@@ -143,6 +144,14 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
     return this.props.route.path === 'new-internal/';
   }
 
+  get showAuthInfo() {
+    const {app} = this.state;
+    if (app && app.clientSecret && app.clientSecret[0] === '*') {
+      return false;
+    }
+    return true;
+  }
+
   onAddToken = async (evt: React.MouseEvent): Promise<void> => {
     evt.preventDefault();
     const {app, tokens} = this.state;
@@ -178,9 +187,18 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
         return (
           <StyledPanelItem key={token.token}>
             <TokenItem>
-              <TextCopyInput>
-                {getDynamicText({value: token.token, fixed: 'xxxxxx'})}
-              </TextCopyInput>
+              <Tooltip
+                disabled={this.showAuthInfo}
+                position="right"
+                containerDisplayMode="inline"
+                title={t(
+                  'You do not have access to view these credentials because the permissions for this integration exceed those of your role.'
+                )}
+              >
+                <TextCopyInput>
+                  {getDynamicText({value: token.token, fixed: 'xxxxxx'})}
+                </TextCopyInput>
+              </Tooltip>
             </TokenItem>
             <CreatedDate>
               <CreatedTitle>Created:</CreatedTitle>
@@ -311,9 +329,18 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
                 <FormField overflow name="clientSecret" label="Client Secret">
                   {({value}) => {
                     return value ? (
-                      <TextCopyInput>
-                        {getDynamicText({value, fixed: 'PERCY_CLIENT_SECRET'})}
-                      </TextCopyInput>
+                      <Tooltip
+                        disabled={this.showAuthInfo}
+                        position="right"
+                        containerDisplayMode="inline"
+                        title={t(
+                          'You do not have access to view these credentials because the permissions for this integration exceed those of your role.'
+                        )}
+                      >
+                        <TextCopyInput>
+                          {getDynamicText({value, fixed: 'PERCY_CLIENT_SECRET'})}
+                        </TextCopyInput>
+                      </Tooltip>
                     ) : (
                       <em>hidden</em>
                     );

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDetails.spec.jsx
@@ -19,6 +19,7 @@ describe('Sentry Application Details', function() {
 
   const verifyInstallToggle = 'Switch[name="verifyInstall"]';
   const redirectUrlInput = 'Input[name="redirectUrl"]';
+  const maskedValue = '*'.repeat(64);
 
   beforeEach(() => {
     Client.clearMockResponses();
@@ -204,6 +205,45 @@ describe('Sentry Application Details', function() {
     it('shows just clientSecret', function() {
       expect(wrapper.find('#clientSecret').exists()).toBe(true);
       expect(wrapper.find('#clientId').exists()).toBe(false);
+    });
+  });
+
+  describe('Renders masked values', () => {
+    beforeEach(() => {
+      sentryApp = TestStubs.SentryApp({
+        status: 'internal',
+        clientSecret: maskedValue,
+      });
+      token = TestStubs.SentryAppToken({token: maskedValue, refreshToken: maskedValue});
+      sentryApp.events = ['issue'];
+
+      Client.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/`,
+        body: sentryApp,
+      });
+
+      Client.addMockResponse({
+        url: `/sentry-apps/${sentryApp.slug}/api-tokens/`,
+        body: [token],
+      });
+
+      wrapper = mount(
+        <SentryApplicationDetails params={{appSlug: sentryApp.slug, orgId}} />,
+        TestStubs.routerContext()
+      );
+    });
+
+    it('shows masked tokens', function() {
+      expect(
+        wrapper
+          .find('TextCopyInput input')
+          .first()
+          .prop('value')
+      ).toBe(maskedValue);
+    });
+
+    it('shows masked clientSecret', function() {
+      expect(wrapper.find('#clientSecret input').prop('value')).toBe(maskedValue);
     });
   });
 


### PR DESCRIPTION
**Problem**
Currently it's possible for an integration to be created that has permissions greater than members who have access to see the tokens (or client secret) for that integration. 

**Solution**
1.) Mask the values of the tokens (or client secret for non-internal apps) if the user making the request doesn't have at least the same scopes as the integration.
2.) Prevent users from making an integration (possibly also adding a token) with permissions that exceed their own. 

![Screen Shot 2019-09-24 at 1 12 49 PM](https://user-images.githubusercontent.com/15368179/65549102-b3f1a500-ded1-11e9-8541-4b19a48abf1b.png)


This PR handles step 1. 