### PR TITLE
ref(discover2) Consolidate next/prev code and remove unused endpoints

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -108,11 +108,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         Returns the next event ID if there is a subsequent event matching the
         conditions provided. Ignores the project_id.
         """
-        conditions = copy(snuba_args["conditions"])
-        if "start" in snuba_args:
-            conditions.append(["timestamp", ">=", snuba_args["start"]])
-        if "end" in snuba_args:
-            conditions.append(["timestamp", "<=", snuba_args["end"]])
+        conditions = self._apply_start_and_end(snuba_args)
         next_event = eventstore.get_next_event_id(
             event, conditions=conditions, filter_keys=snuba_args["filter_keys"]
         )
@@ -125,18 +121,21 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         Returns the previous event ID if there is a previous event matching the
         conditions provided. Ignores the project_id.
         """
-        conditions = copy(snuba_args["conditions"])
-        if "start" in snuba_args:
-            conditions.append(["timestamp", ">=", snuba_args["start"]])
-        if "end" in snuba_args:
-            conditions.append(["timestamp", "<=", snuba_args["end"]])
-
+        conditions = self._apply_start_and_end(snuba_args)
         prev_event = eventstore.get_prev_event_id(
             event, conditions=conditions, filter_keys=snuba_args["filter_keys"]
         )
 
         if prev_event:
             return prev_event[1]
+
+    def _apply_start_and_end(self, snuba_args):
+        conditions = copy(snuba_args["conditions"])
+        if "start" in snuba_args:
+            conditions.append(["timestamp", ">=", snuba_args["start"]])
+        if "end" in snuba_args:
+            conditions.append(["timestamp", "<=", snuba_args["end"]])
+        return conditions
 
     def oldest_event_id(self, snuba_args, event):
         """

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -1,16 +1,13 @@
 from __future__ import absolute_import
 
 from rest_framework.response import Response
-import six
 from enum import Enum
 
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
 from sentry.api.event_search import get_reference_event_conditions
 from sentry import eventstore, features
-from sentry.models import SnubaEvent
 from sentry.models.project import Project
 from sentry.api.serializers import serialize
-from sentry.utils.snuba import raw_query
 
 
 class EventOrdering(Enum):
@@ -57,69 +54,3 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         data["projectSlug"] = project_slug
 
         return Response(data)
-
-
-class OrganizationEventsLatestOrOldest(OrganizationEventsEndpointBase):
-    def get(self, latest_or_oldest, request, organization):
-        if not features.has("organizations:events-v2", organization, actor=request.user):
-            return Response(status=404)
-
-        try:
-            params = self.get_filter_params(request, organization)
-            snuba_args = self.get_snuba_query_args(request, organization, params)
-        except OrganizationEventsError as exc:
-            return Response({"detail": exc.message}, status=400)
-        except NoProjects:
-            return Response(status=404)
-
-        if latest_or_oldest == EventOrdering.LATEST:
-            orderby = ["-timestamp", "-event_id"]
-        else:
-            orderby = ["timestamp", "event_id"]
-
-        result = raw_query(
-            start=snuba_args["start"],
-            end=snuba_args["end"],
-            selected_columns=SnubaEvent.selected_columns,
-            conditions=snuba_args["conditions"],
-            filter_keys=snuba_args["filter_keys"],
-            orderby=orderby,
-            limit=2,
-            referrer="api.organization-event-details-latest-or-oldest",
-        )
-
-        if "error" in result or len(result["data"]) == 0:
-            return Response({"detail": "Event not found"}, status=404)
-
-        try:
-            project_id = result["data"][0]["project_id"]
-            project_slug = Project.objects.get(organization=organization, id=project_id).slug
-        except Project.DoesNotExist:
-            project_slug = None
-
-        data = serialize(SnubaEvent(result["data"][0]))
-        data["previousEventID"] = None
-        data["nextEventID"] = None
-        data["projectSlug"] = project_slug
-
-        if latest_or_oldest == EventOrdering.LATEST and len(result["data"]) == 2:
-            data["previousEventID"] = six.text_type(result["data"][1]["event_id"])
-
-        if latest_or_oldest == EventOrdering.OLDEST and len(result["data"]) == 2:
-            data["nextEventID"] = six.text_type(result["data"][1]["event_id"])
-
-        return Response(data)
-
-
-class OrganizationEventDetailsLatestEndpoint(OrganizationEventsLatestOrOldest):
-    def get(self, request, organization):
-        return super(OrganizationEventDetailsLatestEndpoint, self).get(
-            EventOrdering.LATEST, request, organization
-        )
-
-
-class OrganizationEventDetailsOldestEndpoint(OrganizationEventsLatestOrOldest):
-    def get(self, request, organization):
-        return super(OrganizationEventDetailsOldestEndpoint, self).get(
-            EventOrdering.OLDEST, request, organization
-        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -86,11 +86,7 @@ from .endpoints.organization_dashboard_widgets import OrganizationDashboardWidge
 from .endpoints.organization_dashboards import OrganizationDashboardsEndpoint
 from .endpoints.organization_details import OrganizationDetailsEndpoint
 from .endpoints.organization_environments import OrganizationEnvironmentsEndpoint
-from .endpoints.organization_event_details import (
-    OrganizationEventDetailsEndpoint,
-    OrganizationEventDetailsLatestEndpoint,
-    OrganizationEventDetailsOldestEndpoint,
-)
+from .endpoints.organization_event_details import OrganizationEventDetailsEndpoint
 from .endpoints.organization_eventid import EventIdLookupEndpoint
 from .endpoints.organization_events import OrganizationEventsEndpoint, OrganizationEventsV2Endpoint
 from .endpoints.organization_events_distribution import OrganizationEventsDistributionEndpoint
@@ -721,16 +717,6 @@ urlpatterns = patterns(
                     r"^(?P<organization_slug>[^\/]+)/events/(?P<project_slug>[^\/]+):(?P<event_id>(?:\d+|[A-Fa-f0-9]{32}))/$",
                     OrganizationEventDetailsEndpoint.as_view(),
                     name="sentry-api-0-organization-event-details",
-                ),
-                url(
-                    r"^(?P<organization_slug>[^\/]+)/events/latest/$",
-                    OrganizationEventDetailsLatestEndpoint.as_view(),
-                    name="sentry-api-0-organization-event-details-latest",
-                ),
-                url(
-                    r"^(?P<organization_slug>[^\/]+)/events/oldest/$",
-                    OrganizationEventDetailsOldestEndpoint.as_view(),
-                    name="sentry-api-0-organization-event-details-oldest",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/events-stats/$",

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -6,9 +6,9 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.models import Group
 
 
-class OrganizationEventDetailsTestBase(APITestCase, SnubaTestCase):
+class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventDetailsTestBase, self).setUp()
+        super(OrganizationEventDetailsEndpointTest, self).setUp()
         min_ago = iso_format(before_now(minutes=1))
         two_min_ago = iso_format(before_now(minutes=2))
         three_min_ago = iso_format(before_now(minutes=3))
@@ -45,8 +45,6 @@ class OrganizationEventDetailsTestBase(APITestCase, SnubaTestCase):
         )
         self.groups = list(Group.objects.all().order_by("id"))
 
-
-class OrganizationEventDetailsEndpointTest(OrganizationEventDetailsTestBase):
     def test_simple(self):
         url = reverse(
             "sentry-api-0-organization-event-details",
@@ -219,115 +217,3 @@ class OrganizationEventDetailsEndpointTest(OrganizationEventDetailsTestBase):
         assert response.data["oldestEventID"] is None, "no older matching events"
         assert response.data["nextEventID"] == "2" * 32, "2 is older and has matching tags "
         assert response.data["latestEventID"] == "2" * 32, "2 is oldest matching message"
-
-
-class OrganizationEventDetailsLatestEndpointTest(OrganizationEventDetailsTestBase):
-    def test_simple(self):
-        url = reverse(
-            "sentry-api-0-organization-event-details-latest",
-            kwargs={"organization_slug": self.project.organization.slug},
-        )
-
-        with self.feature("organizations:events-v2"):
-            response = self.client.get(url, format="json")
-
-        assert response.status_code == 200, response.content
-        assert response.data["id"] == "c" * 32
-        assert response.data["previousEventID"] == "b" * 32
-        assert response.data["nextEventID"] is None
-        assert response.data["projectSlug"] == self.project.slug
-
-    def test_no_access(self):
-        url = reverse(
-            "sentry-api-0-organization-event-details-latest",
-            kwargs={"organization_slug": self.project.organization.slug},
-        )
-
-        response = self.client.get(url, format="json")
-
-        assert response.status_code == 404, response.content
-
-    def test_no_event(self):
-        new_org = self.create_organization(owner=self.user)
-        self.create_project(organization=new_org)
-        url = reverse(
-            "sentry-api-0-organization-event-details-latest",
-            kwargs={"organization_slug": new_org.slug},
-        )
-
-        with self.feature("organizations:events-v2"):
-            response = self.client.get(url, format="json")
-
-        assert response.status_code == 404, response.content
-
-    def test_query_with_issue_id(self):
-        url = reverse(
-            "sentry-api-0-organization-event-details-latest",
-            kwargs={"organization_slug": self.project.organization.slug},
-        )
-        query = {"query": "issue.id:{}".format(self.groups[1].id)}
-
-        with self.feature("organizations:events-v2"):
-            response = self.client.get(url, query, format="json")
-
-        assert response.status_code == 200, response.content
-        assert response.data["id"] == "c" * 32
-        assert response.data["previousEventID"] is None
-        assert response.data["nextEventID"] is None
-        assert response.data["projectSlug"] == self.project.slug
-
-
-class OrganizationEventDetailsOldestEndpointTest(OrganizationEventDetailsTestBase):
-    def test_simple(self):
-        url = reverse(
-            "sentry-api-0-organization-event-details-oldest",
-            kwargs={"organization_slug": self.project.organization.slug},
-        )
-
-        with self.feature("organizations:events-v2"):
-            response = self.client.get(url, format="json")
-
-        assert response.status_code == 200, response.content
-        assert response.data["id"] == "a" * 32
-        assert response.data["previousEventID"] is None
-        assert response.data["nextEventID"] == "b" * 32
-        assert response.data["projectSlug"] == self.project.slug
-
-    def test_no_access(self):
-        url = reverse(
-            "sentry-api-0-organization-event-details-oldest",
-            kwargs={"organization_slug": self.project.organization.slug},
-        )
-
-        response = self.client.get(url, format="json")
-
-        assert response.status_code == 404, response.content
-
-    def test_no_event(self):
-        new_org = self.create_organization(owner=self.user)
-        self.create_project(organization=new_org)
-        url = reverse(
-            "sentry-api-0-organization-event-details-oldest",
-            kwargs={"organization_slug": new_org.slug},
-        )
-
-        with self.feature("organizations:events-v2"):
-            response = self.client.get(url, format="json")
-
-        assert response.status_code == 404, response.content
-
-    def test_query_with_issue_id(self):
-        url = reverse(
-            "sentry-api-0-organization-event-details-oldest",
-            kwargs={"organization_slug": self.project.organization.slug},
-        )
-        query = {"query": "issue.id:{}".format(self.groups[1].id)}
-
-        with self.feature("organizations:events-v2"):
-            response = self.client.get(url, query, format="json")
-
-        assert response.status_code == 200, response.content
-        assert response.data["id"] == "c" * 32
-        assert response.data["previousEventID"] is None
-        assert response.data["nextEventID"] is None
-        assert response.data["projectSlug"] == self.project.slug


### PR DESCRIPTION
The latest & oldest endpoints are no longer in use now that org event details includes the oldest & newest ids in its response. I've also consolidated the code for applying date conditions to the next/prev event.