### PR TITLE
fix(event processing): Extend data scrubbing to all user attributes

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -273,6 +273,7 @@ OK_PLUGIN_SAVED = _("Configuration for the {name} integration has been saved.")
 
 WARN_SESSION_EXPIRED = "Your session has expired."  # TODO: translate this
 
+# If this value changes, also change it in src/sentry/static/sentry/app/constants/index.tsx
 FILTER_MASK = "[Filtered]"
 
 # Maximum length of a symbol

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -274,6 +274,8 @@ OK_PLUGIN_SAVED = _("Configuration for the {name} integration has been saved.")
 WARN_SESSION_EXPIRED = "Your session has expired."  # TODO: translate this
 
 # If this value changes, also change it in src/sentry/static/sentry/app/constants/index.tsx
+# TODO(kmclb): once relay is doing the filtering, this will change, at minimum to become
+# "DEFAULT_FILTER_MASK" or some such, since the mask value will be dynamic
 FILTER_MASK = "[Filtered]"
 
 # Maximum length of a symbol

--- a/src/sentry/static/sentry/app/components/events/contextSummary.jsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import Avatar from 'app/components/avatar';
 import DeviceName from 'app/components/deviceName';
+import {removeFilteredValues} from 'app/components/events/interfaces/utils';
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
 import {objectIsEmpty} from 'app/utils';
@@ -109,7 +110,7 @@ class UserSummary extends React.Component {
   };
 
   render() {
-    const user = this.props.data;
+    const user = removeFilteredValues(this.props.data);
 
     if (objectIsEmpty(user)) {
       return <NoSummary title={t('Unknown User')} />;

--- a/src/sentry/static/sentry/app/components/events/contextSummary.jsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary.jsx
@@ -26,7 +26,7 @@ class NoSummary extends React.Component {
     return (
       <div className="context-item">
         <span className="context-item-icon" />
-        <h3>{this.props.title}</h3>
+        <h3 data-test-id="no-summary-title">{this.props.title}</h3>
       </div>
     );
   }
@@ -104,7 +104,7 @@ export class OsSummary extends React.Component {
   }
 }
 
-class UserSummary extends React.Component {
+export class UserSummary extends React.Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
   };
@@ -131,7 +131,7 @@ class UserSummary extends React.Component {
         ) : (
           <span className="context-item-icon" />
         )}
-        <h3>{userTitle}</h3>
+        <h3 data-test-id="user-title">{userTitle}</h3>
         {user.id && user.id !== userTitle ? (
           <p>
             <strong>{t('ID:')}</strong> {user.id}

--- a/src/sentry/static/sentry/app/components/events/contextSummary.jsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import Avatar from 'app/components/avatar';
 import DeviceName from 'app/components/deviceName';
-import {removeFilteredValues} from 'app/components/events/interfaces/utils';
+import {removeFilterMaskedEntries} from 'app/components/events/interfaces/utils';
 import SentryTypes from 'app/sentryTypes';
 import {t} from 'app/locale';
 import {objectIsEmpty} from 'app/utils';
@@ -110,7 +110,7 @@ class UserSummary extends React.Component {
   };
 
   render() {
-    const user = removeFilteredValues(this.props.data);
+    const user = removeFilterMaskedEntries(this.props.data);
 
     if (objectIsEmpty(user)) {
       return <NoSummary title={t('Unknown User')} />;

--- a/src/sentry/static/sentry/app/components/events/contexts/user.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/user.jsx
@@ -7,6 +7,7 @@ import Avatar from 'app/components/avatar';
 import ErrorBoundary from 'app/components/errorBoundary';
 import ExternalLink from 'app/components/links/externalLink';
 import KeyValueList from 'app/components/events/interfaces/keyValueList';
+import {removeFilteredValues} from 'app/components/events/interfaces/utils';
 
 const EMAIL_REGEX = /[^@]+@[^\.]+\..+/;
 
@@ -46,7 +47,7 @@ class UserContextType extends React.Component {
     return (
       <div className="user-widget">
         <div className="pull-left">
-          <Avatar user={user} size={48} gravatar={false} />
+          <Avatar user={removeFilteredValues(user)} size={48} gravatar={false} />
         </div>
         <table className="key-value table">
           <tbody>

--- a/src/sentry/static/sentry/app/components/events/contexts/user.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/user.jsx
@@ -7,7 +7,7 @@ import Avatar from 'app/components/avatar';
 import ErrorBoundary from 'app/components/errorBoundary';
 import ExternalLink from 'app/components/links/externalLink';
 import KeyValueList from 'app/components/events/interfaces/keyValueList';
-import {removeFilteredValues} from 'app/components/events/interfaces/utils';
+import {removeFilterMaskedEntries} from 'app/components/events/interfaces/utils';
 
 const EMAIL_REGEX = /[^@]+@[^\.]+\..+/;
 
@@ -21,7 +21,7 @@ class UserContextType extends React.Component {
     const builtins = [];
     const children = [];
 
-    // Handle our native attributes special
+    // Handle our native attributes specially
     user.id && builtins.push(['ID', <pre>{user.id}</pre>]);
     user.email &&
       builtins.push([
@@ -47,7 +47,7 @@ class UserContextType extends React.Component {
     return (
       <div className="user-widget">
         <div className="pull-left">
-          <Avatar user={removeFilteredValues(user)} size={48} gravatar={false} />
+          <Avatar user={removeFilterMaskedEntries(user)} size={48} gravatar={false} />
         </div>
         <table className="key-value table">
           <tbody>

--- a/src/sentry/static/sentry/app/components/events/contexts/user.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/user.jsx
@@ -57,7 +57,11 @@ class UserContextType extends React.Component {
                   <td className="key" key="0">
                     {key}
                   </td>
-                  <td className="value" key="1">
+                  <td
+                    className="value"
+                    key="1"
+                    data-test-id={`user-context-${key.toLowerCase()}-value`}
+                  >
                     {value}
                   </td>
                 </tr>

--- a/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
@@ -126,7 +126,7 @@ export function objectToSortedTupleArray(obj) {
 }
 
 // for context summaries and avatars
-export function removeFilteredValues(rawData) {
+export function removeFilterMaskedEntries(rawData) {
   const cleanedData = {};
   for (const key of Object.getOwnPropertyNames(rawData)) {
     if (rawData[key] !== FILTER_MASK) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
@@ -2,6 +2,7 @@ import {isEmpty, isString} from 'lodash';
 import * as Sentry from '@sentry/browser';
 import queryString from 'query-string';
 
+import {FILTER_MASK} from 'app/constants';
 import {defined} from 'app/utils';
 
 export function escapeQuotes(v) {
@@ -122,4 +123,15 @@ export function objectToSortedTupleArray(obj) {
 
       return keyA < keyB ? -1 : 1;
     });
+}
+
+// for context summaries and avatars
+export function removeFilteredValues(rawData) {
+  const cleanedData = {};
+  for (const key of Object.getOwnPropertyNames(rawData)) {
+    if (rawData[key] !== FILTER_MASK) {
+      cleanedData[key] = rawData[key];
+    }
+  }
+  return cleanedData;
 }

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -175,3 +175,6 @@ export const DEPLOY_PREVIEW_CONFIG = process.env.DEPLOY_PREVIEW_CONFIG;
 // Webpack configures EXPERIMENTAL_SPA.
 // eslint-disable-next-line no-undef
 export const EXPERIMENTAL_SPA = process.env.EXPERIMENTAL_SPA;
+
+// so we don't use filtered values in certain display contexts
+export const FILTER_MASK = '[Filtered]';

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -177,4 +177,6 @@ export const DEPLOY_PREVIEW_CONFIG = process.env.DEPLOY_PREVIEW_CONFIG;
 export const EXPERIMENTAL_SPA = process.env.EXPERIMENTAL_SPA;
 
 // so we don't use filtered values in certain display contexts
+// TODO(kmclb): once relay is doing the scrubbing, the masking value will be dynamic,
+// so this will have to change
 export const FILTER_MASK = '[Filtered]';

--- a/src/sentry/utils/data_scrubber.py
+++ b/src/sentry/utils/data_scrubber.py
@@ -163,10 +163,10 @@ class SensitiveDataFilter(object):
                 # already been decoded by the request interface.
                 data[n] = varmap(self.sanitize, data[n])
 
-    def filter_user(self, data):
-        if not data.get("data"):
-            return
-        data["data"] = varmap(self.sanitize, data["data"])
+    def filter_user(self, user):
+        for key in user:
+            if user[key]:  # no need to scrub falsy values, as there's no data there
+                user[key] = varmap(self.sanitize, user[key], name=key)
 
     def filter_crumb(self, data):
         for key in "data", "message":

--- a/tests/js/spec/components/events/__snapshots__/contextSummary.spec.jsx.snap
+++ b/tests/js/spec/components/events/__snapshots__/contextSummary.spec.jsx.snap
@@ -1,5 +1,139 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ContextSummary render() renders at least three contexts 1`] = `
+<div
+  className="context-summary"
+>
+  <UserSummary
+    data={
+      Object {
+        "email": "mail@example.org",
+        "id": "1",
+      }
+    }
+    key="user"
+  />
+  <GenericSummary
+    data={Object {}}
+    key="browser"
+    unknownTitle="Unknown Browser"
+  />
+  <DeviceSummary
+    data={
+      Object {
+        "arch": "x86",
+        "family": "iOS",
+        "model": "iPhone10,5",
+        "type": "device",
+      }
+    }
+    key="device"
+  />
+</div>
+`;
+
+exports[`ContextSummary render() renders client_os too 1`] = `
+<div
+  className="context-summary"
+>
+  <UserSummary
+    data={
+      Object {
+        "email": "mail@example.org",
+        "id": "1",
+      }
+    }
+    key="user"
+  />
+  <GenericSummary
+    data={
+      Object {
+        "name": "Chrome",
+        "version": "65.0.3325",
+      }
+    }
+    key="browser"
+    unknownTitle="Unknown Browser"
+  />
+  <GenericSummary
+    data={
+      Object {
+        "name": "Electron",
+        "type": "runtime",
+        "version": "1.7.13",
+      }
+    }
+    key="runtime"
+    unknownTitle="Unknown Runtime"
+  />
+  <OsSummary
+    data={
+      Object {
+        "build": "17E199",
+        "kernel_version": "17.5.0",
+        "name": "Mac OS X",
+        "type": "os",
+        "version": "10.13.4",
+      }
+    }
+    key="client_os"
+  />
+</div>
+`;
+
+exports[`ContextSummary render() renders nothing with a single user context 1`] = `""`;
+
+exports[`ContextSummary render() renders nothing without contexts 1`] = `""`;
+
+exports[`ContextSummary render() renders up to four contexts 1`] = `
+<div
+  className="context-summary"
+>
+  <UserSummary
+    data={
+      Object {
+        "email": "mail@example.org",
+        "id": "1",
+      }
+    }
+    key="user"
+  />
+  <GenericSummary
+    data={
+      Object {
+        "name": "Chrome",
+        "version": "65.0.3325",
+      }
+    }
+    key="browser"
+    unknownTitle="Unknown Browser"
+  />
+  <GenericSummary
+    data={
+      Object {
+        "name": "Electron",
+        "type": "runtime",
+        "version": "1.7.13",
+      }
+    }
+    key="runtime"
+    unknownTitle="Unknown Runtime"
+  />
+  <OsSummary
+    data={
+      Object {
+        "build": "17E199",
+        "kernel_version": "17.5.0",
+        "name": "Mac OS X",
+        "type": "os",
+        "version": "10.13.4",
+      }
+    }
+    key="os"
+  />
+</div>
+`;
+
 exports[`ContextSummary render() should bail out with empty contexts 1`] = `""`;
 
 exports[`ContextSummary render() should prefer client_os over os 1`] = `
@@ -47,140 +181,6 @@ exports[`ContextSummary render() should prefer client_os over os 1`] = `
       }
     }
     key="client_os"
-  />
-</div>
-`;
-
-exports[`ContextSummary render() should render at least three contexts 1`] = `
-<div
-  className="context-summary"
->
-  <UserSummary
-    data={
-      Object {
-        "email": "mail@example.org",
-        "id": "1",
-      }
-    }
-    key="user"
-  />
-  <GenericSummary
-    data={Object {}}
-    key="browser"
-    unknownTitle="Unknown Browser"
-  />
-  <DeviceSummary
-    data={
-      Object {
-        "arch": "x86",
-        "family": "iOS",
-        "model": "iPhone10,5",
-        "type": "device",
-      }
-    }
-    key="device"
-  />
-</div>
-`;
-
-exports[`ContextSummary render() should render client_os too 1`] = `
-<div
-  className="context-summary"
->
-  <UserSummary
-    data={
-      Object {
-        "email": "mail@example.org",
-        "id": "1",
-      }
-    }
-    key="user"
-  />
-  <GenericSummary
-    data={
-      Object {
-        "name": "Chrome",
-        "version": "65.0.3325",
-      }
-    }
-    key="browser"
-    unknownTitle="Unknown Browser"
-  />
-  <GenericSummary
-    data={
-      Object {
-        "name": "Electron",
-        "type": "runtime",
-        "version": "1.7.13",
-      }
-    }
-    key="runtime"
-    unknownTitle="Unknown Runtime"
-  />
-  <OsSummary
-    data={
-      Object {
-        "build": "17E199",
-        "kernel_version": "17.5.0",
-        "name": "Mac OS X",
-        "type": "os",
-        "version": "10.13.4",
-      }
-    }
-    key="client_os"
-  />
-</div>
-`;
-
-exports[`ContextSummary render() should render nothing with a single user context 1`] = `""`;
-
-exports[`ContextSummary render() should render nothing without contexts 1`] = `""`;
-
-exports[`ContextSummary render() should render up to four contexts 1`] = `
-<div
-  className="context-summary"
->
-  <UserSummary
-    data={
-      Object {
-        "email": "mail@example.org",
-        "id": "1",
-      }
-    }
-    key="user"
-  />
-  <GenericSummary
-    data={
-      Object {
-        "name": "Chrome",
-        "version": "65.0.3325",
-      }
-    }
-    key="browser"
-    unknownTitle="Unknown Browser"
-  />
-  <GenericSummary
-    data={
-      Object {
-        "name": "Electron",
-        "type": "runtime",
-        "version": "1.7.13",
-      }
-    }
-    key="runtime"
-    unknownTitle="Unknown Runtime"
-  />
-  <OsSummary
-    data={
-      Object {
-        "build": "17E199",
-        "kernel_version": "17.5.0",
-        "name": "Mac OS X",
-        "type": "os",
-        "version": "10.13.4",
-      }
-    }
-    key="os"
   />
 </div>
 `;
@@ -276,7 +276,7 @@ exports[`ContextSummary render() should skip non-default named contexts 1`] = `
 </div>
 `;
 
-exports[`GpuSummary render() should render name and vendor 1`] = `
+exports[`GpuSummary render() renders name and vendor 1`] = `
 <div
   className="context-item arm"
 >
@@ -296,7 +296,7 @@ exports[`GpuSummary render() should render name and vendor 1`] = `
 </div>
 `;
 
-exports[`GpuSummary render() should render unknown when no vendor 1`] = `
+exports[`GpuSummary render() renders unknown when no vendor 1`] = `
 <div
   className="context-item apple-a"
 >
@@ -316,7 +316,7 @@ exports[`GpuSummary render() should render unknown when no vendor 1`] = `
 </div>
 `;
 
-exports[`OsSummary render() should render the kernel version when no version 1`] = `
+exports[`OsSummary render() renders the kernel version when no version 1`] = `
 <div
   className="context-item mac-os-x"
 >
@@ -336,7 +336,7 @@ exports[`OsSummary render() should render the kernel version when no version 1`]
 </div>
 `;
 
-exports[`OsSummary render() should render the version string 1`] = `
+exports[`OsSummary render() renders the version string 1`] = `
 <div
   className="context-item mac-os-x"
 >
@@ -356,7 +356,7 @@ exports[`OsSummary render() should render the version string 1`] = `
 </div>
 `;
 
-exports[`OsSummary render() should render unknown when no version 1`] = `
+exports[`OsSummary render() renders unknown when no version 1`] = `
 <div
   className="context-item mac-os-x"
 >

--- a/tests/js/spec/components/events/contextSummary.spec.jsx
+++ b/tests/js/spec/components/events/contextSummary.spec.jsx
@@ -49,7 +49,7 @@ const CONTEXT_BROWSER = {
 
 describe('ContextSummary', function() {
   describe('render()', function() {
-    it('should render nothing without contexts', () => {
+    it('renders nothing without contexts', () => {
       const event = {
         id: '',
         contexts: {},
@@ -59,7 +59,7 @@ describe('ContextSummary', function() {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render nothing with a single user context', () => {
+    it('renders nothing with a single user context', () => {
       const event = {
         id: '',
         user: CONTEXT_USER,
@@ -84,7 +84,7 @@ describe('ContextSummary', function() {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render at least three contexts', () => {
+    it('renders at least three contexts', () => {
       const event = {
         id: '',
         user: CONTEXT_USER,
@@ -97,7 +97,7 @@ describe('ContextSummary', function() {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render up to four contexts', () => {
+    it('renders up to four contexts', () => {
       const event = {
         id: '',
         user: CONTEXT_USER,
@@ -129,7 +129,7 @@ describe('ContextSummary', function() {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render client_os too', () => {
+    it('renders client_os too', () => {
       const event = {
         id: '',
         user: CONTEXT_USER,
@@ -179,7 +179,7 @@ describe('ContextSummary', function() {
 
 describe('OsSummary', function() {
   describe('render()', function() {
-    it('should render the version string', () => {
+    it('renders the version string', () => {
       const os = {
         kernel_version: '17.5.0',
         version: '10.13.4',
@@ -192,7 +192,7 @@ describe('OsSummary', function() {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render the kernel version when no version', () => {
+    it('renders the kernel version when no version', () => {
       const os = {
         kernel_version: '17.5.0',
         type: 'os',
@@ -204,7 +204,7 @@ describe('OsSummary', function() {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render unknown when no version', () => {
+    it('renders unknown when no version', () => {
       const os = {
         type: 'os',
         build: '17E199',
@@ -219,7 +219,7 @@ describe('OsSummary', function() {
 
 describe('GpuSummary', function() {
   describe('render()', function() {
-    it('should render name and vendor', () => {
+    it('renders name and vendor', () => {
       const gpu = {
         name: 'Mali-T880',
         vendor_name: 'ARM',
@@ -230,7 +230,7 @@ describe('GpuSummary', function() {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render unknown when no vendor', () => {
+    it('renders unknown when no vendor', () => {
       const gpu = {
         type: 'gpu',
         name: 'Apple A8 GPU',
@@ -244,7 +244,7 @@ describe('GpuSummary', function() {
 
 describe('UserSummary', function() {
   describe('render', function() {
-    it('should prefer email, then IP, then id, then username for title', function() {
+    it('prefers email, then IP, then id, then username for title', function() {
       const user1 = {
         email: 'maisey@dogsrule.com',
         ip_address: '12.31.20.12',
@@ -290,7 +290,7 @@ describe('UserSummary', function() {
       expect(wrapper4.find('[data-test-id="user-title"]').text()).toEqual(user4.username);
     });
 
-    it('should render NoSummary if no email, IP, id, or username', function() {
+    it('renders NoSummary if no email, IP, id, or username', function() {
       const user = {
         name: 'Maisey Dog',
         data: {siblings: ['Charlie Dog'], dreamsOf: 'squirrels'},
@@ -303,7 +303,7 @@ describe('UserSummary', function() {
       );
     });
 
-    it('should not use filtered values for title', function() {
+    it('does not use filtered values for title', function() {
       const user1 = {
         email: FILTER_MASK,
       };
@@ -340,7 +340,7 @@ describe('UserSummary', function() {
       );
     });
 
-    it('should not use filtered values for avatar', function() {
+    it('does not use filtered values for avatar', function() {
       // id is never used for avatar purposes, but is enough to keep us from
       // ending up with a NoSummary component where the UserSummary component
       // should be

--- a/tests/js/spec/components/events/interfaces/contexts.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/contexts.spec.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import {mount} from 'enzyme';
+
+import UserContextType from 'app/components/events/contexts/user';
+import {FILTER_MASK} from 'app/constants';
+
+describe('UserContextType', function() {
+  it("displays filtered values but doesn't use them for avatar", function() {
+    const user1 = {
+      id: '26',
+      name: FILTER_MASK,
+    };
+
+    const wrapper1 = mount(<UserContextType data={user1} />);
+    expect(wrapper1.find('[data-test-id="user-context-name-value"]').text()).toEqual(
+      FILTER_MASK
+    );
+    expect(wrapper1.find('LetterAvatar').text()).toEqual('?');
+
+    const user2 = {
+      id: '26',
+      email: FILTER_MASK,
+    };
+
+    const wrapper2 = mount(<UserContextType data={user2} />);
+    expect(wrapper2.find('[data-test-id="user-context-email-value"]').text()).toEqual(
+      FILTER_MASK
+    );
+    expect(wrapper2.find('LetterAvatar').text()).toEqual('?');
+
+    const user3 = {
+      id: '26',
+      username: FILTER_MASK,
+    };
+
+    const wrapper3 = mount(<UserContextType data={user3} />);
+    expect(wrapper3.find('[data-test-id="user-context-username-value"]').text()).toEqual(
+      FILTER_MASK
+    );
+    expect(wrapper3.find('LetterAvatar').text()).toEqual('?');
+  });
+});

--- a/tests/js/spec/components/events/interfaces/utils.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/utils.spec.jsx
@@ -2,7 +2,9 @@ import {MetaProxy, withMeta} from 'app/components/events/meta/metaProxy';
 import {
   getCurlCommand,
   objectToSortedTupleArray,
+  removeFilteredValues,
 } from 'app/components/events/interfaces/utils';
+import {FILTER_MASK} from 'app/constants';
 
 describe('components/interfaces/utils', function() {
   describe('getCurlCommand()', function() {
@@ -165,6 +167,27 @@ describe('components/interfaces/utils', function() {
           foo: ['bar', 'baz'],
         })
       ).toEqual([['foo', 'bar'], ['foo', 'baz']]);
+    });
+  });
+
+  describe('removeFilteredValues()', function() {
+    const rawData = {
+      id: '26',
+      name: FILTER_MASK,
+      username: 'maiseythedog',
+      email: FILTER_MASK,
+    };
+    it('should remove filtered values', function() {
+      const result = removeFilteredValues(rawData);
+      expect(result).not.toHaveProperty('name');
+      expect(result).not.toHaveProperty('email');
+    });
+    it('should preserve unfiltered values', function() {
+      const result = removeFilteredValues(rawData);
+      expect(result).toHaveProperty('id');
+      expect(result.id).toEqual('26');
+      expect(result).toHaveProperty('username');
+      expect(result.username).toEqual('maiseythedog');
     });
   });
 });

--- a/tests/js/spec/components/events/interfaces/utils.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/utils.spec.jsx
@@ -2,7 +2,7 @@ import {MetaProxy, withMeta} from 'app/components/events/meta/metaProxy';
 import {
   getCurlCommand,
   objectToSortedTupleArray,
-  removeFilteredValues,
+  removeFilterMaskedEntries,
 } from 'app/components/events/interfaces/utils';
 import {FILTER_MASK} from 'app/constants';
 
@@ -170,7 +170,7 @@ describe('components/interfaces/utils', function() {
     });
   });
 
-  describe('removeFilteredValues()', function() {
+  describe('removeFilterMaskedEntries()', function() {
     const rawData = {
       id: '26',
       name: FILTER_MASK,
@@ -178,12 +178,12 @@ describe('components/interfaces/utils', function() {
       email: FILTER_MASK,
     };
     it('should remove filtered values', function() {
-      const result = removeFilteredValues(rawData);
+      const result = removeFilterMaskedEntries(rawData);
       expect(result).not.toHaveProperty('name');
       expect(result).not.toHaveProperty('email');
     });
     it('should preserve unfiltered values', function() {
-      const result = removeFilteredValues(rawData);
+      const result = removeFilterMaskedEntries(rawData);
       expect(result).toHaveProperty('id');
       expect(result.id).toEqual('26');
       expect(result).toHaveProperty('username');


### PR DESCRIPTION
During event processing, after normalization, user data looks like this:

```python
user = {
    "id": "1226",
    "email": "hi@hello.com",
    # other standard attributes (name, username, ip_address, geo)
    "data": {
        "non-standard key 1": "stuff",
        "non-standard key 2": "things",
    },
}
```
Currently, we only run `user["data"]` through the data scrubber. This means that there's no way to scrub PII like name, email, etc.\*

This PR:
- extends the scrubbing to all user data
- removes filtered entries from the data used to display the user summary at the top of event details, so only good data comes through**
- makes sure that even if data is filtered, we don't end up with a circle with a `[` in the center as the user avatar, in either the user summary or user context section**
- tests the whole business


\* This in spite of the fact that our exemplar blacklist field is, in fact, `email`:
![image](https://user-images.githubusercontent.com/14812505/65527969-6ca2ee80-dea8-11e9-8604-cde06e12cb3c.png)

\** These two will have to be revisited once the mask value becomes dynamic.