### PR TITLE
fix(transaction): Removed preserveQuote prop before it is sent to dom element

### DIFF
--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -1,6 +1,9 @@
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
+
+import classNames from 'classnames';
+
 import _ from 'lodash';
 
 import {isUrl} from 'app/utils';
@@ -208,12 +211,13 @@ class ContextData extends React.Component {
   };
 
   render() {
-    // We do not use preserveQuotes, but require it to be removed from ...other
-    // eslint-disable-next-line no-unused-vars
-    const {data, className, preserveQuotes, ...other} = this.props;
-    other.className = 'val ' + (className || '');
+    const {data, className, preserveQuotes: _preserveQuotes, ...other} = this.props;
 
-    return <pre {...other}>{this.renderValue(data)}</pre>;
+    return (
+      <pre className={classNames('val', className || '')} {...other}>
+        {this.renderValue(data)}
+      </pre>
+    );
   }
 }
 

--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -208,16 +208,9 @@ class ContextData extends React.Component {
   };
 
   render() {
-    // XXX(dcramer): babel does not support this yet
-    // let {data, className, ...other} = this.props;
-    const data = this.props.data;
-    const className = this.props.className;
-    const other = {};
-    for (const key in this.props) {
-      if (key !== 'data' && key !== 'className') {
-        other[key] = this.props[key];
-      }
-    }
+    // We do not use preserveQuotes, but require it to be removed from ...other
+    // eslint-disable-next-line no-unused-vars
+    const {data, className, preserveQuotes, ...other} = this.props;
     other.className = 'val ' + (className || '');
 
     return <pre {...other}>{this.renderValue(data)}</pre>;


### PR DESCRIPTION
Adding the [preserveQuote prop](https://github.com/getsentry/sentry/pull/14756) to ContextData would trigger a console error stating `React does not recognize the preserveQuotes prop on a DOM element...` To fix this warning, I added it to a list of props that should not be forwarded to the DOM element. Also cleaned up the render function a bit.

![image](https://user-images.githubusercontent.com/9372512/65551471-e3ef7700-ded6-11e9-949a-69a31ebe37aa.png)
