### PR TITLE
feat(ui): Added performance marks into organizationContext

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -169,11 +169,11 @@ const OrganizationContext = createReactClass({
           () => {
             // Take a measurement for when organization details are done loading and the new state is applied
             metric.measure({
-              name: 'app.component.organization-details-fetch',
+              name: 'app.component.perf',
               start: 'organization-details-fetch-start',
               data: {
                 route: getRouteStringFromRoutes(this.props.routes),
-                organization_id: data.id,
+                organization_id: parseInt(data.id, 10),
               },
             });
           }

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -118,12 +118,12 @@ const OrganizationContext = createReactClass({
   },
 
   fetchData() {
-    metric.mark('organization-details-fetch-start');
     if (!this.getOrganizationSlug()) {
       this.setState({loading: this.props.organizationsLoading});
       return;
     }
 
+    metric.mark('organization-details-fetch-start');
     const promises = [
       this.props.api.requestPromise(this.getOrganizationDetailsEndpoint()),
       fetchOrganizationEnvironments(this.props.api, this.getOrganizationSlug()),


### PR DESCRIPTION
Added a measurement with `metric` from `app/utils/analytics`. It will record the time it takes for the `organizationDetails` endpoint to finish and refresh the state of the app. The measurement comes with additional data such as the current frontend route (url) and organization id. This should help us measure performance improvements by switching from "detailed" organizationDetails to "lightweight" organizationDetails.

Refs SEN-1058