### PR TITLE
feat(ui): Added name to previously created performance metric

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -172,6 +172,7 @@ const OrganizationContext = createReactClass({
               name: 'app.component.perf',
               start: 'organization-details-fetch-start',
               data: {
+                name: 'org-details',
                 route: getRouteStringFromRoutes(this.props.routes),
                 organization_id: parseInt(data.id, 10),
               },


### PR DESCRIPTION
Added 'org-details' as a name in the performance metric created from [here](https://github.com/getsentry/sentry/pull/14820)