### PR TITLE
fix(app-platform): Use timezone.now for token expiration

### DIFF
--- a/src/sentry/mediators/token_exchange/util.py
+++ b/src/sentry/mediators/token_exchange/util.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
-from datetime import datetime, timedelta
+from datetime import timedelta
+from django.utils import timezone
 
 
 TOKEN_LIFE_IN_HOURS = 8
@@ -15,4 +16,4 @@ class GrantTypes(object):
 
 
 def token_expiration():
-    return datetime.utcnow() + timedelta(hours=TOKEN_LIFE_IN_HOURS)
+    return timezone.now() + timedelta(hours=TOKEN_LIFE_IN_HOURS)

--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import six
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 
@@ -46,7 +46,7 @@ class TestSentryAppAuthorizations(APITestCase):
         return self.client.post(self.url, data, headers={"Content-Type": "application/json"})
 
     def test_exchanges_for_token_successfully(self):
-        expected_expires_at = (datetime.now() + timedelta(hours=8)).replace(second=0, microsecond=0)
+        expected_expires_at = (timezone.now() + timedelta(hours=8)).replace(second=0, microsecond=0)
 
         response = self._run_request()
 
@@ -119,7 +119,7 @@ class TestSentryAppAuthorizations(APITestCase):
 
         assert response.data["token"] != token
         assert response.data["refreshToken"] != refresh_token
-        assert response.data["expiresAt"] > datetime.utcnow()
+        assert response.data["expiresAt"] > timezone.now()
 
         old_token = ApiToken.objects.filter(id=token_id)
         assert not old_token.exists()


### PR DESCRIPTION
we are currently returning `expires_at` without timezone info, we should make this consistent with `date_added`