### PR TITLE
ref: Remove sampling code from eventstream

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -35,7 +35,6 @@ class EventStream(Service):
         self,
         event,
         is_new,
-        is_sample,
         is_regression,
         is_new_group_environment,
         primary_hash,
@@ -47,7 +46,6 @@ class EventStream(Service):
             post_process_group.delay(
                 event=event,
                 is_new=is_new,
-                is_sample=is_sample,
                 is_regression=is_regression,
                 is_new_group_environment=is_new_group_environment,
                 primary_hash=primary_hash,
@@ -58,20 +56,14 @@ class EventStream(Service):
         group,
         event,
         is_new,
-        is_sample,
         is_regression,
         is_new_group_environment,
         primary_hash,
         skip_consume=False,
+        is_sample=False,  # TODO: Remove once this is no longer passed
     ):
         self._dispatch_post_process_group_task(
-            event,
-            is_new,
-            is_sample,
-            is_regression,
-            is_new_group_environment,
-            primary_hash,
-            skip_consume,
+            event, is_new, is_regression, is_new_group_environment, primary_hash, skip_consume
         )
 
     def start_delete_groups(self, project_id, group_ids):

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -51,7 +51,7 @@ def basic_protocol_handler(unsupported_operations):
             "primary_hash": event_data["primary_hash"],
         }
 
-        for name in ("is_new", "is_sample", "is_regression", "is_new_group_environment"):
+        for name in ("is_new", "is_regression", "is_new_group_environment"):
             kwargs[name] = task_state[name]
 
         return kwargs

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -243,6 +243,7 @@ class SnubaEventStream(SnubaProtocolEventStream):
         is_new_group_environment,
         primary_hash,
         skip_consume=False,
+        is_sample=False,  # TODO: Remove once this is no longer passed
     ):
         super(SnubaEventStream, self).insert(
             group,

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -80,11 +80,11 @@ class SnubaProtocolEventStream(EventStream):
         group,
         event,
         is_new,
-        is_sample,
         is_regression,
         is_new_group_environment,
         primary_hash,
         skip_consume=False,
+        is_sample=False,  # TODO: Remove once this is no longer passed
     ):
         project = event.project
         retention_days = quotas.get_event_retention(organization=project.organization)
@@ -121,7 +121,6 @@ class SnubaProtocolEventStream(EventStream):
                 },
                 {
                     "is_new": is_new,
-                    "is_sample": is_sample,
                     "is_regression": is_regression,
                     "is_new_group_environment": is_new_group_environment,
                     "skip_consume": skip_consume,
@@ -240,7 +239,6 @@ class SnubaEventStream(SnubaProtocolEventStream):
         group,
         event,
         is_new,
-        is_sample,
         is_regression,
         is_new_group_environment,
         primary_hash,
@@ -250,18 +248,11 @@ class SnubaEventStream(SnubaProtocolEventStream):
             group,
             event,
             is_new,
-            is_sample,
             is_regression,
             is_new_group_environment,
             primary_hash,
             skip_consume,
         )
         self._dispatch_post_process_group_task(
-            event,
-            is_new,
-            is_sample,
-            is_regression,
-            is_new_group_environment,
-            primary_hash,
-            skip_consume,
+            event, is_new, is_regression, is_new_group_environment, primary_hash, skip_consume
         )

--- a/src/sentry/management/commands/backfill_eventstream.py
+++ b/src/sentry/management/commands/backfill_eventstream.py
@@ -91,7 +91,6 @@ class Command(BaseCommand):
                 group=event.group,
                 event=event,
                 is_new=False,
-                is_sample=False,
                 is_regression=False,
                 is_new_group_environment=False,
                 primary_hash=primary_hash,

--- a/tests/sentry/eventstream/kafka/test_protocol.py
+++ b/tests/sentry/eventstream/kafka/test_protocol.py
@@ -36,12 +36,7 @@ def test_get_task_kwargs_for_message_version_1():
         "primary_hash": "49f68a5c8493ec2c0bf489821c21fc3b",
     }
 
-    task_state = {
-        "is_new": True,
-        "is_sample": False,
-        "is_regression": False,
-        "is_new_group_environment": True,
-    }
+    task_state = {"is_new": True, "is_regression": False, "is_new_group_environment": True}
 
     kwargs = get_task_kwargs_for_message(json.dumps([1, "insert", event_data, task_state]))
     event = kwargs.pop("event")
@@ -56,7 +51,6 @@ def test_get_task_kwargs_for_message_version_1():
     assert kwargs.pop("primary_hash") == "49f68a5c8493ec2c0bf489821c21fc3b"
 
     assert kwargs.pop("is_new") is True
-    assert kwargs.pop("is_sample") is False
     assert kwargs.pop("is_regression") is False
     assert kwargs.pop("is_new_group_environment") is True
 

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -30,11 +30,7 @@ class PostProcessGroupTest(TestCase):
     ):
         event = self.create_issueless_event(project=self.project)
         post_process_group(
-            event=event,
-            is_new=True,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=True,
+            event=event, is_new=True, is_regression=False, is_new_group_environment=True
         )
 
         mock_processor.assert_not_called()  # NOQA
@@ -56,11 +52,7 @@ class PostProcessGroupTest(TestCase):
         mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
 
         post_process_group(
-            event=event,
-            is_new=True,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=True,
+            event=event, is_new=True, is_regression=False, is_new_group_environment=True
         )
 
         mock_processor.assert_called_once_with(event, True, False, True, False)
@@ -86,11 +78,7 @@ class PostProcessGroupTest(TestCase):
         mock_processor.return_value.apply.return_value = [(mock_callback, mock_futures)]
 
         post_process_group(
-            event=event,
-            is_new=True,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=True,
+            event=event, is_new=True, is_regression=False, is_new_group_environment=True
         )
 
         assert event.group == group2
@@ -103,11 +91,7 @@ class PostProcessGroupTest(TestCase):
         snooze = GroupSnooze.objects.create(group=group, until=timezone.now() - timedelta(hours=1))
 
         post_process_group(
-            event=event,
-            is_new=True,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=True,
+            event=event, is_new=True, is_regression=False, is_new_group_environment=True
         )
 
         mock_processor.assert_called_with(event, True, False, True, True)
@@ -124,11 +108,7 @@ class PostProcessGroupTest(TestCase):
         snooze = GroupSnooze.objects.create(group=group, until=timezone.now() + timedelta(hours=1))
 
         post_process_group(
-            event=event,
-            is_new=True,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=True,
+            event=event, is_new=True, is_regression=False, is_new_group_environment=True
         )
 
         mock_processor.assert_called_with(event, True, False, True, False)
@@ -158,11 +138,7 @@ class PostProcessGroupTest(TestCase):
             project_id=self.project.id,
         )
         post_process_group(
-            event=event,
-            is_new=False,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=False,
+            event=event, is_new=False, is_regression=False, is_new_group_environment=False
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user is None
@@ -179,11 +155,7 @@ class PostProcessGroupTest(TestCase):
             project_id=self.project.id,
         )
         post_process_group(
-            event=event,
-            is_new=False,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=False,
+            event=event, is_new=False, is_regression=False, is_new_group_environment=False
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user == self.user
@@ -199,11 +171,7 @@ class PostProcessGroupTest(TestCase):
             project_id=self.project.id,
         )
         post_process_group(
-            event=event,
-            is_new=False,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=False,
+            event=event, is_new=False, is_regression=False, is_new_group_environment=False
         )
         assert not event.group.assignee_set.exists()
 
@@ -219,11 +187,7 @@ class PostProcessGroupTest(TestCase):
         )
         event.group.assignee_set.create(team=self.team, project=self.project)
         post_process_group(
-            event=event,
-            is_new=False,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=False,
+            event=event, is_new=False, is_regression=False, is_new_group_environment=False
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user is None
@@ -243,11 +207,7 @@ class PostProcessGroupTest(TestCase):
             project_id=self.project.id,
         )
         post_process_group(
-            event=event,
-            is_new=False,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=False,
+            event=event, is_new=False, is_regression=False, is_new_group_environment=False
         )
         assignee = event.group.assignee_set.first()
         assert assignee is None
@@ -266,11 +226,7 @@ class PostProcessGroupTest(TestCase):
 
         with self.feature("projects:servicehooks"):
             post_process_group(
-                event=event,
-                is_new=False,
-                is_regression=False,
-                is_sample=False,
-                is_new_group_environment=False,
+                event=event, is_new=False, is_regression=False, is_new_group_environment=False
             )
 
         mock_process_service_hook.delay.assert_called_once_with(servicehook_id=hook.id, event=event)
@@ -295,11 +251,7 @@ class PostProcessGroupTest(TestCase):
 
         with self.feature("projects:servicehooks"):
             post_process_group(
-                event=event,
-                is_new=False,
-                is_regression=False,
-                is_sample=False,
-                is_new_group_environment=False,
+                event=event, is_new=False, is_regression=False, is_new_group_environment=False
             )
 
         mock_process_service_hook.delay.assert_called_once_with(servicehook_id=hook.id, event=event)
@@ -323,11 +275,7 @@ class PostProcessGroupTest(TestCase):
 
         with self.feature("projects:servicehooks"):
             post_process_group(
-                event=event,
-                is_new=False,
-                is_regression=False,
-                is_sample=False,
-                is_new_group_environment=False,
+                event=event, is_new=False, is_regression=False, is_new_group_environment=False
             )
 
         assert not mock_process_service_hook.delay.mock_calls
@@ -343,11 +291,7 @@ class PostProcessGroupTest(TestCase):
 
         with self.feature("projects:servicehooks"):
             post_process_group(
-                event=event,
-                is_new=True,
-                is_regression=False,
-                is_sample=False,
-                is_new_group_environment=False,
+                event=event, is_new=True, is_regression=False, is_new_group_environment=False
             )
 
         assert not mock_process_service_hook.delay.mock_calls
@@ -358,11 +302,7 @@ class PostProcessGroupTest(TestCase):
         event = self.create_event(group=group)
 
         post_process_group(
-            event=event,
-            is_new=True,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=False,
+            event=event, is_new=True, is_regression=False, is_new_group_environment=False
         )
 
         delay.assert_called_once_with(action="created", sender="Group", instance_id=group.id)
@@ -389,11 +329,7 @@ class PostProcessGroupTest(TestCase):
         )
 
         post_process_group(
-            event=event,
-            is_new=False,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=False,
+            event=event, is_new=False, is_regression=False, is_new_group_environment=False
         )
 
         kwargs = {"instance": event}
@@ -411,11 +347,7 @@ class PostProcessGroupTest(TestCase):
         )
 
         post_process_group(
-            event=event,
-            is_new=False,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=False,
+            event=event, is_new=False, is_regression=False, is_new_group_environment=False
         )
 
         assert not delay.called
@@ -429,11 +361,7 @@ class PostProcessGroupTest(TestCase):
         )
 
         post_process_group(
-            event=event,
-            is_new=False,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=False,
+            event=event, is_new=False, is_regression=False, is_new_group_environment=False
         )
 
         assert not delay.called
@@ -457,11 +385,7 @@ class PostProcessGroupTest(TestCase):
         )
 
         post_process_group(
-            event=event,
-            is_new=False,
-            is_regression=False,
-            is_sample=False,
-            is_new_group_environment=False,
+            event=event, is_new=False, is_regression=False, is_new_group_environment=False
         )
 
         assert not delay.called

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -162,11 +162,7 @@ class TestProcessResourceChange(TestCase):
 
         with self.tasks():
             post_process_group(
-                event=event,
-                is_new=True,
-                is_regression=False,
-                is_sample=False,
-                is_new_group_environment=False,
+                event=event, is_new=True, is_regression=False, is_new_group_environment=False
             )
 
         data = json.loads(faux(safe_urlopen).kwargs["data"])
@@ -227,11 +223,7 @@ class TestProcessResourceChange(TestCase):
 
         with self.tasks():
             post_process_group(
-                event=event,
-                is_new=False,
-                is_regression=False,
-                is_sample=False,
-                is_new_group_environment=False,
+                event=event, is_new=False, is_regression=False, is_new_group_environment=False
             )
 
         data = json.loads(faux(safe_urlopen).kwargs["data"])


### PR DESCRIPTION
Since we no longer sample events, we can remove sampling related code
from the eventstream.