### PR TITLE
feat(ui): Implement CRUD actions for Incident Rule Triggers

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
@@ -1,5 +1,5 @@
 import {Client} from 'app/api';
-import {IncidentRule} from './types';
+import {IncidentRule, Trigger} from './types';
 
 export function deleteRule(
   api: Client,
@@ -9,4 +9,17 @@ export function deleteRule(
   return api.requestPromise(`/organizations/${orgId}/alert-rules/${rule.id}/`, {
     method: 'DELETE',
   });
+}
+
+export function deleteTrigger(
+  api: Client,
+  orgId: string,
+  trigger: Trigger
+): Promise<void> {
+  return api.requestPromise(
+    `/organizations/${orgId}/alert-rules/${trigger.alertRuleId}/triggers/${trigger.id}`,
+    {
+      method: 'DELETE',
+    }
+  );
 }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/details.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/details.tsx
@@ -1,11 +1,14 @@
 import {RouteComponentProps} from 'react-router/lib/Router';
+import {findIndex} from 'lodash';
 import React from 'react';
 import styled, {css} from 'react-emotion';
 
-import {IncidentRule} from 'app/views/settings/incidentRules/types';
+import {IncidentRule, Trigger} from 'app/views/settings/incidentRules/types';
 import {Organization, Project} from 'app/types';
+import {addErrorMessage} from 'app/actionCreators/indicator';
+import {deleteTrigger} from 'app/views/settings/incidentRules/actions';
 import {openModal} from 'app/actionCreators/modal';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import RuleForm from 'app/views/settings/incidentRules/ruleForm';
@@ -49,23 +52,98 @@ class IncidentRulesDetails extends AsyncView<
     ];
   }
 
-  handleNewTrigger = () => {
+  openTriggersModal = (trigger?: Trigger) => {
     const {organization, projects} = this.props;
 
     openModal(
-      () => (
+      ({closeModal}) => (
         <TriggersModal
           organization={organization}
           projects={projects || []}
           rule={this.state.rule}
+          trigger={trigger}
+          closeModal={closeModal}
+          onSubmitSuccess={trigger ? this.handleEditedTrigger : this.handleAddedTrigger}
         />
       ),
       {dialogClassName: widthCss}
     );
   };
 
+  handleAddedTrigger = (trigger: Trigger) => {
+    this.setState(({rule}) => ({
+      rule: {
+        ...rule,
+        triggers: [...rule.triggers, trigger],
+      },
+    }));
+  };
+
+  handleEditedTrigger = (trigger: Trigger) => {
+    this.setState(({rule}) => {
+      const triggerIndex = findIndex(rule.triggers, ({id}) => id === trigger.id);
+      const triggers = [...rule.triggers];
+      triggers.splice(triggerIndex, 1, trigger);
+
+      return {
+        rule: {
+          ...rule,
+          triggers,
+        },
+      };
+    });
+  };
+
+  handleNewTrigger = () => {
+    this.openTriggersModal();
+  };
+
+  handleEditTrigger = (trigger: Trigger) => {
+    this.openTriggersModal(trigger);
+  };
+
+  handleDeleteTrigger = async (trigger: Trigger) => {
+    const {organization} = this.props;
+
+    // Optimistically update
+    const triggerIndex = findIndex(this.state.rule.triggers, ({id}) => id === trigger.id);
+    const triggersAfterDelete = [...this.state.rule.triggers];
+    triggersAfterDelete.splice(triggerIndex, 1);
+
+    this.setState(({rule}) => {
+      return {
+        rule: {
+          ...rule,
+          triggers: triggersAfterDelete,
+        },
+      };
+    });
+
+    try {
+      await deleteTrigger(this.api, organization.slug, trigger);
+    } catch (err) {
+      addErrorMessage(
+        tct('There was a problem deleting trigger: [label]', {label: trigger.label})
+      );
+
+      // Add trigger back to list
+      this.setState(({rule}) => {
+        const triggers = [...rule.triggers];
+        triggers.splice(triggerIndex, 0, trigger);
+
+        return {
+          rule: {
+            ...rule,
+            triggers,
+          },
+        };
+      });
+    }
+  };
+
   renderBody() {
     const {orgId, incidentRuleId} = this.props.params;
+    const {rule} = this.state;
 
     return (
       <div>
@@ -75,7 +153,7 @@ class IncidentRulesDetails extends AsyncView<
           saveOnBlur={true}
           orgId={orgId}
           incidentRuleId={incidentRuleId}
-          initialData={this.state.rule}
+          initialData={rule}
         />
 
         <TriggersHeader
@@ -85,7 +163,7 @@ class IncidentRulesDetails extends AsyncView<
               size="small"
               priority="primary"
               icon="icon-circle-add"
-              disabled={!this.state.rule}
+              disabled={!rule}
               onClick={this.handleNewTrigger}
             >
               {t('New Trigger')}
@@ -93,7 +171,11 @@ class IncidentRulesDetails extends AsyncView<
           }
         />
 
-        <TriggersList />
+        <TriggersList
+          triggers={rule.triggers}
+          onDelete={this.handleDeleteTrigger}
+          onEdit={this.handleEditTrigger}
+        />
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/modal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/modal.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import styled from 'react-emotion';
 
-import {IncidentRule} from 'app/views/settings/incidentRules/types';
+import {IncidentRule, Trigger} from 'app/views/settings/incidentRules/types';
 import {Organization, Project} from 'app/types';
-import {addSuccessMessage} from 'app/actionCreators/indicator';
-import {t} from 'app/locale';
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import {t, tct} from 'app/locale';
 import TriggerForm from 'app/views/settings/incidentRules/triggers/form';
 import space from 'app/styles/space';
 
@@ -12,15 +12,34 @@ type Props = {
   organization: Organization;
   projects: Project[];
   rule: IncidentRule;
+  closeModal: Function;
+  trigger?: Trigger;
+  onSubmitSuccess: Function;
 };
 
 class TriggersModal extends React.Component<Props> {
-  handleSubmitSuccess = () => {
-    addSuccessMessage(t('Successfully saved Incident Rule'));
+  handleSubmitSuccess = (newTrigger: Trigger) => {
+    const {onSubmitSuccess, closeModal, trigger} = this.props;
+
+    if (trigger) {
+      addSuccessMessage(
+        tct('Successfully updated trigger: [label]', {label: newTrigger.label})
+      );
+    } else {
+      addSuccessMessage(
+        tct('Successfully saved trigger: [label]', {label: newTrigger.label})
+      );
+    }
+    onSubmitSuccess(newTrigger);
+    closeModal();
+  };
+
+  handleSubmitError = () => {
+    addErrorMessage(t('There was a problem saving trigger'));
   };
 
   render() {
-    const {organization, projects, rule} = this.props;
+    const {organization, projects, rule, trigger} = this.props;
     return (
       <div>
         <TinyHeader>{t('Trigger for')}</TinyHeader>
@@ -31,6 +50,7 @@ class TriggersModal extends React.Component<Props> {
           orgId={organization.slug}
           onSubmitSuccess={this.handleSubmitSuccess}
           rule={rule}
+          trigger={trigger}
         />
       </div>
     );

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -13,6 +13,22 @@ export enum AlertRuleAggregations {
   UNIQUE_USERS,
 }
 
+export type UnsavedTrigger = {
+  alertRuleId: string;
+  label: string;
+  thresholdType: AlertRuleThresholdType;
+  alertThreshold: number;
+  resolveThreshold: number;
+  timeWindow: number;
+};
+
+export type SavedTrigger = UnsavedTrigger & {
+  id: string;
+  dateAdded: string;
+};
+
+export type Trigger = Partial<SavedTrigger> & UnsavedTrigger;
+
 export type IncidentRule = {
   aggregations: number[];
   aggregation?: number;
@@ -30,6 +46,7 @@ export type IncidentRule = {
   thresholdPeriod: number;
   thresholdType: number;
   timeWindow: number;
+  triggers: Trigger[];
 };
 
 export enum TimeWindow {

--- a/tests/js/fixtures/incidentRule.js
+++ b/tests/js/fixtures/incidentRule.js
@@ -1,3 +1,5 @@
+import {IncidentTrigger} from './incidentTrigger';
+
 export function IncidentRule(params) {
   return {
     status: 0,
@@ -15,6 +17,7 @@ export function IncidentRule(params) {
     projectId: '1',
     resolution: 1,
     dateModified: '2019-07-31T23:02:02.731Z',
+    triggers: [IncidentTrigger()],
     ...params,
   };
 }

--- a/tests/js/fixtures/incidentTrigger.js
+++ b/tests/js/fixtures/incidentTrigger.js
@@ -1,0 +1,12 @@
+export function IncidentTrigger(params) {
+  return {
+    alertRuleId: '4',
+    alertThreshold: 70,
+    dateAdded: '2019-09-24T18:07:47.714Z',
+    id: '1',
+    label: 'Trigger',
+    resolveThreshold: 36,
+    thresholdType: 0,
+    ...params,
+  };
+}

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -1,28 +1,199 @@
-import {mount} from 'enzyme';
 import React from 'react';
+import {mount} from 'enzyme';
 
 import {initializeOrg} from 'app-test/helpers/initializeOrg';
 import IncidentRulesDetails from 'app/views/settings/incidentRules/details';
+import GlobalModal from 'app/components/globalModal';
 
 describe('Incident Rules Details', function() {
-  it('renders', function() {
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/tags/',
+    body: [],
+  });
+
+  it('renders and adds and edits trigger', async function() {
     const {organization, routerContext} = initializeOrg();
     const rule = TestStubs.IncidentRule();
     const req = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/alert-rules/${rule.id}/`,
       body: rule,
     });
-    mount(
-      <IncidentRulesDetails
-        params={{
-          orgId: organization.slug,
-          incidentRuleId: rule.id,
-        }}
-        organization={organization}
-      />,
+    const createTrigger = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/alert-rules/${rule.id}/triggers`,
+      method: 'POST',
+      body: (_, options) =>
+        TestStubs.IncidentTrigger({
+          ...options.data,
+          id: '123',
+        }),
+    });
+    const updateTrigger = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/alert-rules/${rule.id}/triggers/123`,
+      method: 'PUT',
+      body: (_, options) =>
+        TestStubs.IncidentTrigger({
+          ...options.data,
+        }),
+    });
+
+    const wrapper = mount(
+      <React.Fragment>
+        <GlobalModal />
+        <IncidentRulesDetails
+          params={{
+            orgId: organization.slug,
+            incidentRuleId: rule.id,
+          }}
+          organization={organization}
+        />
+      </React.Fragment>,
       routerContext
     );
+    wrapper.update();
 
     expect(req).toHaveBeenCalled();
+    expect(wrapper.find('TriggersList Label').text()).toBe('Trigger');
+
+    // Create a new Trigger
+    wrapper.find('button[aria-label="New Trigger"]').simulate('click');
+    await tick(); // tick opening a modal
+    wrapper.update();
+
+    wrapper
+      .find('TriggersModal input[name="label"]')
+      .simulate('change', {target: {value: 'New Trigger'}});
+    wrapper
+      .find('TriggersModal input[name="alertThreshold"]')
+      .simulate('input', {target: {value: 13}});
+    wrapper
+      .find('TriggersModal input[name="resolveThreshold"]')
+      .simulate('input', {target: {value: 12}});
+
+    // Save Trigger
+    wrapper.find('TriggersModal button[aria-label="Create Trigger"]').simulate('submit');
+    expect(createTrigger).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {
+          label: 'New Trigger',
+          alertThreshold: 13,
+          resolveThreshold: 12,
+          thresholdType: 0,
+        },
+      })
+    );
+
+    // New Trigger should be in list
+    await tick();
+    wrapper.update();
+    expect(
+      wrapper
+        .find('TriggersList Label')
+        .last()
+        .text()
+    ).toBe('New Trigger');
+    expect(wrapper.find('TriggersModal')).toHaveLength(1);
+
+    // Edit new trigger
+    wrapper
+      .find('button[aria-label="Edit"]')
+      .last()
+      .simulate('click');
+    await tick(); // tick opening a modal
+    wrapper.update();
+
+    // Has correct values
+
+    expect(wrapper.find('TriggersModal input[name="label"]').prop('value')).toBe(
+      'New Trigger'
+    );
+    expect(wrapper.find('TriggersModal input[name="alertThreshold"]').prop('value')).toBe(
+      13
+    );
+    expect(
+      wrapper.find('TriggersModal input[name="resolveThreshold"]').prop('value')
+    ).toBe(12);
+
+    wrapper
+      .find('TriggersModal input[name="label"]')
+      .simulate('change', {target: {value: 'New Trigger!!'}});
+
+    // Save Trigger
+    wrapper.find('TriggersModal button[aria-label="Update Trigger"]').simulate('submit');
+    expect(updateTrigger).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          alertRuleId: '4',
+          alertThreshold: 13,
+          id: '123',
+          label: 'New Trigger!!',
+          resolveThreshold: 12,
+          thresholdType: 0,
+        }),
+      })
+    );
+    // New Trigger should be in list
+    await tick();
+    wrapper.update();
+
+    expect(
+      wrapper
+        .find('TriggersList Label')
+        .last()
+        .text()
+    ).toBe('New Trigger!!');
+    expect(wrapper.find('TriggersModal')).toHaveLength(1);
+
+    // Attempt and fail to delete trigger
+    let deleteTrigger = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/alert-rules/${rule.id}/triggers/123`,
+      method: 'DELETE',
+      statusCode: 400,
+    });
+
+    wrapper
+      .find('TriggersList button[aria-label="Delete Trigger"]')
+      .last()
+      .simulate('click');
+
+    wrapper.find('Confirm button[aria-label="Confirm"]').simulate('click');
+
+    await tick();
+    wrapper.update();
+
+    expect(deleteTrigger).toHaveBeenCalled();
+
+    expect(
+      wrapper
+        .find('TriggersList Label')
+        .last()
+        .text()
+    ).toBe('New Trigger!!');
+
+    // Actually delete trigger
+    deleteTrigger = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/alert-rules/${rule.id}/triggers/123`,
+      method: 'DELETE',
+    });
+
+    wrapper
+      .find('TriggersList button[aria-label="Delete Trigger"]')
+      .last()
+      .simulate('click');
+
+    wrapper.find('Confirm button[aria-label="Confirm"]').simulate('click');
+
+    await tick();
+    wrapper.update();
+
+    expect(deleteTrigger).toHaveBeenCalled();
+
+    expect(
+      wrapper
+        .find('TriggersList Label')
+        .last()
+        .text()
+    ).toBe('Trigger');
   });
 });

--- a/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
@@ -18,15 +18,17 @@ describe('Incident Rules Form', function() {
       routerContext
     );
 
+  beforeEach(function() {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      body: [],
+    });
+  });
+
   describe('Creating a new rule', function() {
     let createRule;
     beforeEach(function() {
-      MockApiClient.clearMockResponses();
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/tags/',
-        body: [],
-      });
-
       createRule = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/alert-rules/',
         method: 'POST',
@@ -97,7 +99,6 @@ describe('Incident Rules Form', function() {
     const rule = TestStubs.IncidentRule();
 
     beforeEach(function() {
-      MockApiClient.clearMockResponses();
       editRule = MockApiClient.addMockResponse({
         url: `/organizations/org-slug/alert-rules/${rule.id}/`,
         method: 'PUT',

--- a/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
@@ -18,15 +18,15 @@ describe('Incident Rules Form', function() {
       routerContext
     );
 
-  MockApiClient.addMockResponse({
-    url: '/organizations/org-slug/tags/',
-    body: [],
-  });
-
   describe('Creating a new rule', function() {
     let createRule;
     beforeEach(function() {
       MockApiClient.clearMockResponses();
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/tags/',
+        body: [],
+      });
+
       createRule = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/alert-rules/',
         method: 'POST',

--- a/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
@@ -17,6 +17,12 @@ describe('Incident Rules Form', function() {
       />,
       routerContext
     );
+
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/tags/',
+    body: [],
+  });
+
   describe('Creating a new rule', function() {
     let createRule;
     beforeEach(function() {


### PR DESCRIPTION
This removes the Trigger row placeholder and renders Triggers based on API
response of an Incident Rule. Implements creating, updating, and deleting
triggers as well.

Closes SEN-994
Closes SEN-1052