### PR TITLE
fix(grouping): Trim traits from generic rust functions

### DIFF
--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -10,6 +10,7 @@ from sentry.utils.safe import setdefault_path
 _windecl_hash = re.compile(r"^@?(.*?)@[0-9]+$")
 _rust_hash = re.compile(r"::h[a-z0-9]{16}$")
 _cpp_trailer_re = re.compile(r"(\bconst\b|&)$")
+_rust_blanket_re = re.compile(r"^([A-Z] as )")
 _lambda_re = re.compile(
     r"""(?x)
     # gcc
@@ -159,14 +160,28 @@ def trim_function_name(function, platform, normalize_lambdas=True):
     # Resolve generic types, but special case rust which uses things like
     # <Foo as Bar>::baz to denote traits.
     def process_generics(value, start):
-        # Rust special case
-        if start == 0:
-            return "<%s>" % replace_enclosed_string(value, "<", ">", process_generics)
-        return "<T>"
+        # Special case for lambdas
+        if value == "lambda" or _lambda_re.match(value):
+            return "<%s>" % value
+
+        if start > 0:
+            return "<T>"
+
+        # Rust special cases
+        value = _rust_blanket_re.sub("", value)  # prefer trait for blanket impls
+        value = replace_enclosed_string(value, "<", ">", process_generics)
+        return value.split(" as ", 1)[0]
 
     function = replace_enclosed_string(function, "<", ">", process_generics)
 
     tokens = split_func_tokens(function)
+
+    # MSVC demangles generic operator functions with a space between the
+    # function name and the generics. Ensure that those two components both end
+    # up in the function name.
+    if len(tokens) > 1 and tokens[-1] == "<T>":
+        tokens.pop()
+        tokens[-1] += " <T>"
 
     # find the token which is the function name.  Since we chopped of C++
     # trailers there are only two cases we care about: the token left to

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/actix.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2019-09-17T14:11:44.692676Z'
+created: '2019-09-26T13:46:35.595143Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: '3abe7858e37e8eb76c484efa7c7ba121'
+  hash: '703d3dd9cb763e3f5037f659d27da947'
   component:
     app*
       exception*
@@ -20,11 +20,11 @@ app:
               u'thread.rs'
             function*
               u'std::sys::unix::thread::Thread::new::thread_start'
-          frame*
+          frame (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'boxed.rs'
             function* (isolated function)
-              u'<F as alloc::boxed::FnBox<T>>::call_box'
+              u'alloc::boxed::FnBox<T>::call_box'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
@@ -50,11 +50,11 @@ app:
               u'panicking.rs'
             function*
               u'std::panicking::try::do_call'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panic.rs'
             function* (isolated function)
-              u'<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once'
+              u'std::panic::AssertUnwindSafe<T>::call_once'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
@@ -85,16 +85,16 @@ app:
               u'lib.rs'
             function*
               u'tokio_reactor::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
@@ -110,16 +110,16 @@ app:
               u'clock.rs'
             function*
               u'tokio_timer::clock::clock::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'clock.rs'
@@ -135,16 +135,16 @@ app:
               u'handle.rs'
             function*
               u'tokio_timer::timer::handle::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'handle.rs'
@@ -160,16 +160,16 @@ app:
               u'global.rs'
             function*
               u'tokio_executor::global::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'global.rs'
@@ -189,37 +189,37 @@ app:
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Entered<T>>::block_on'
+              u'tokio_current_thread::Entered<T>::block_on'
           frame*
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Entered<T>>::tick'
+              u'tokio_current_thread::Entered<T>::tick'
           frame*
             filename*
               u'scheduler.rs'
             function* (isolated function)
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick'
           frame*
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Borrow<T>>::enter'
-          frame (non app frame)
+              u'tokio_current_thread::Borrow<T>::enter'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}'
           frame*
             filename*
               u'lib.rs'
@@ -229,32 +229,32 @@ app:
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function* (isolated function)
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick::{{closure}}'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function* (isolated function)
-              u'<tokio_current_thread::scheduler::Scheduled<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduled<T>::tick'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::poll_future_notify'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::poll_fn_notify'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::poll_fn_notify'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::enter'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::enter'
           frame*
             filename*
               u'mod.rs'
@@ -263,93 +263,93 @@ app:
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::enter::{{closure}}'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::enter::{{closure}}'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify::{{closure}}'
-          frame (non app frame)
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}'
+          frame (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'mod.rs'
             function* (isolated function)
-              u'<alloc::boxed::Box<T> as futures::future::Future>::poll'
+              u'alloc::boxed::Box<T>::poll'
           frame*
             filename*
               u'then.rs'
             function* (isolated function)
-              u'<futures::future::then::Then<T> as futures::future::Future>::poll'
+              u'futures::future::then::Then<T>::poll'
           frame*
             filename*
               u'chain.rs'
             function* (isolated function)
-              u'<futures::future::chain::Chain<T>>::poll'
+              u'futures::future::chain::Chain<T>::poll'
           frame*
             filename*
               u'either.rs'
             function* (isolated function)
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame (ignored due to recursion)
             filename*
               u'either.rs'
             function* (isolated function)
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame*
             filename*
               u'acceptor.rs'
-            function*
-              u'<actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T> as futures::future::Future>::poll'
+            function* (isolated function)
+              u'actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll'
           frame*
             filename*
               u'and_then.rs'
             function* (isolated function)
-              u'<actix_net::service::and_then::AndThenFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::and_then::AndThenFuture<T>::poll'
           frame*
             filename*
               u'map_err.rs'
             function* (isolated function)
-              u'<actix_net::service::map_err::MapErrFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::map_err::MapErrFuture<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function* (isolated function)
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function* (isolated function)
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_handler'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_handler'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_io'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_io'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::parse'
+              u'actix_web::server::h1::Http1Dispatcher<T>::parse'
           frame*
             filename*
               u'pipeline.rs'
             function* (isolated function)
-              u'<actix_web::pipeline::Pipeline<T> as actix_web::server::handler::HttpHandlerTask>::poll_io'
+              u'actix_web::pipeline::Pipeline<T>::poll_io'
           frame*
             filename*
               u'<::log::macros::log macros>'
             function* (isolated function)
-              u'<actix_web::pipeline::ProcessResponse<T>>::poll_io'
+              u'actix_web::pipeline::ProcessResponse<T>::poll_io'
           frame*
             filename*
               u'lib.rs'
@@ -358,8 +358,8 @@ app:
           frame (non app frame)
             filename*
               u'log.rs'
-            function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+            function* (isolated function)
+              u'sentry::integrations::log::Logger::log'
           frame (non app frame)
             filename*
               u'hub.rs'
@@ -370,16 +370,16 @@ app:
               u'hub.rs'
             function*
               u'sentry::hub::Hub::with'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame (non app frame)
             filename*
               u'hub.rs'
@@ -394,7 +394,7 @@ app:
           u'actix_web::pipeline'
 --------------------------------------------------------------------------
 system:
-  hash: '7f12fecf89ac9e64cdfa36b08e634681'
+  hash: '1df163ce3be65319df4fcc9cb34b60c1'
   component:
     system*
       exception*
@@ -410,11 +410,11 @@ system:
               u'thread.rs'
             function*
               u'std::sys::unix::thread::Thread::new::thread_start'
-          frame*
+          frame* (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'boxed.rs'
             function* (isolated function)
-              u'<F as alloc::boxed::FnBox<T>>::call_box'
+              u'alloc::boxed::FnBox<T>::call_box'
           frame*
             filename*
               u'mod.rs'
@@ -444,7 +444,7 @@ system:
             filename*
               u'panic.rs'
             function* (isolated function)
-              u'<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once'
+              u'std::panic::AssertUnwindSafe<T>::call_once'
           frame*
             filename*
               u'mod.rs'
@@ -478,13 +478,13 @@ system:
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
@@ -503,13 +503,13 @@ system:
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'clock.rs'
@@ -528,13 +528,13 @@ system:
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'handle.rs'
@@ -553,13 +553,13 @@ system:
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'global.rs'
@@ -579,37 +579,37 @@ system:
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Entered<T>>::block_on'
+              u'tokio_current_thread::Entered<T>::block_on'
           frame*
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Entered<T>>::tick'
+              u'tokio_current_thread::Entered<T>::tick'
           frame*
             filename*
               u'scheduler.rs'
             function* (isolated function)
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick'
           frame*
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Borrow<T>>::enter'
+              u'tokio_current_thread::Borrow<T>::enter'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}'
           frame*
             filename*
               u'lib.rs'
@@ -619,32 +619,32 @@ system:
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function* (isolated function)
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick::{{closure}}'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function* (isolated function)
-              u'<tokio_current_thread::scheduler::Scheduled<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduled<T>::tick'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::poll_future_notify'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::poll_fn_notify'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::poll_fn_notify'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::enter'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::enter'
           frame*
             filename*
               u'mod.rs'
@@ -653,93 +653,93 @@ system:
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::enter::{{closure}}'
-          frame*
-            filename*
-              u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify::{{closure}}'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::enter::{{closure}}'
           frame*
             filename*
               u'mod.rs'
             function* (isolated function)
-              u'<alloc::boxed::Box<T> as futures::future::Future>::poll'
+              u'futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}'
+          frame*
+            filename*
+              u'mod.rs'
+            function* (isolated function)
+              u'alloc::boxed::Box<T>::poll'
           frame*
             filename*
               u'then.rs'
             function* (isolated function)
-              u'<futures::future::then::Then<T> as futures::future::Future>::poll'
+              u'futures::future::then::Then<T>::poll'
           frame*
             filename*
               u'chain.rs'
             function* (isolated function)
-              u'<futures::future::chain::Chain<T>>::poll'
+              u'futures::future::chain::Chain<T>::poll'
           frame*
             filename*
               u'either.rs'
             function* (isolated function)
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame (ignored due to recursion)
             filename*
               u'either.rs'
             function* (isolated function)
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame*
             filename*
               u'acceptor.rs'
-            function*
-              u'<actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T> as futures::future::Future>::poll'
+            function* (isolated function)
+              u'actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll'
           frame*
             filename*
               u'and_then.rs'
             function* (isolated function)
-              u'<actix_net::service::and_then::AndThenFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::and_then::AndThenFuture<T>::poll'
           frame*
             filename*
               u'map_err.rs'
             function* (isolated function)
-              u'<actix_net::service::map_err::MapErrFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::map_err::MapErrFuture<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function* (isolated function)
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function* (isolated function)
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_handler'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_handler'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_io'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_io'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::parse'
+              u'actix_web::server::h1::Http1Dispatcher<T>::parse'
           frame*
             filename*
               u'pipeline.rs'
             function* (isolated function)
-              u'<actix_web::pipeline::Pipeline<T> as actix_web::server::handler::HttpHandlerTask>::poll_io'
+              u'actix_web::pipeline::Pipeline<T>::poll_io'
           frame*
             filename*
               u'<::log::macros::log macros>'
             function* (isolated function)
-              u'<actix_web::pipeline::ProcessResponse<T>>::poll_io'
+              u'actix_web::pipeline::ProcessResponse<T>::poll_io'
           frame*
             filename*
               u'lib.rs'
@@ -748,8 +748,8 @@ system:
           frame*
             filename*
               u'log.rs'
-            function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+            function* (isolated function)
+              u'sentry::integrations::log::Logger::log'
           frame*
             filename*
               u'hub.rs'
@@ -763,13 +763,13 @@ system:
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'hub.rs'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-11T09:56:03.074860Z'
+created: '2019-09-26T13:52:57.538117Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-06-05T11:45:12.934622Z'
+created: '2019-09-26T13:52:57.552389Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-09-17T14:11:48.273375Z'
+created: '2019-09-26T13:26:22.800091Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -34,8 +34,8 @@ app:
             function*
               u'log::__private_api_log'
           frame (non app frame)
-            function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+            function* (isolated function)
+              u'sentry::integrations::log::Logger::log'
           frame (non app frame)
             function*
               u'sentry::hub::Hub::with_active'
@@ -55,7 +55,7 @@ app:
           u'log_demo'
 --------------------------------------------------------------------------
 system:
-  hash: '06f8f02638bc75df5a5c88712055ee5f'
+  hash: '00719910980352c06ba93641057012e0'
   component:
     system*
       exception*
@@ -85,8 +85,8 @@ system:
             function*
               u'log::__private_api_log'
           frame*
-            function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+            function* (isolated function)
+              u'sentry::integrations::log::Logger::log'
           frame*
             function*
               u'sentry::hub::Hub::with_active'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-16T18:21:46.150575Z'
+created: '2019-09-26T13:52:57.633610Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/actix.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2019-09-17T14:11:51.796827Z'
+created: '2019-09-26T13:46:37.308539Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: 'c9dc61e20bb252c9ec1e28a75f015132'
+  hash: '0b1576b98e87afe7e4de476f6f290c65'
   component:
     app*
       exception*
@@ -22,7 +22,7 @@ app:
               u'std::sys::unix::thread::Thread::new::thread_start'
             lineno (function takes precedence)
               24
-          frame*
+          frame (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'boxed.rs'
             function*
@@ -64,7 +64,7 @@ app:
               u'std::panicking::try::do_call'
             lineno (function takes precedence)
               310
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panic.rs'
             function*
@@ -113,14 +113,14 @@ app:
               u'tokio_reactor::with_default'
             lineno (function takes precedence)
               212
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
               u'<std::thread::local::LocalKey<T>>::with'
             lineno (function takes precedence)
               255
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
@@ -148,14 +148,14 @@ app:
               u'tokio_timer::clock::clock::with_default'
             lineno (function takes precedence)
               124
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
               u'<std::thread::local::LocalKey<T>>::with'
             lineno (function takes precedence)
               255
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
@@ -183,14 +183,14 @@ app:
               u'tokio_timer::timer::handle::with_default'
             lineno (function takes precedence)
               81
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
               u'<std::thread::local::LocalKey<T>>::with'
             lineno (function takes precedence)
               255
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
@@ -218,14 +218,14 @@ app:
               u'tokio_executor::global::with_default'
             lineno (function takes precedence)
               162
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
               u'<std::thread::local::LocalKey<T>>::with'
             lineno (function takes precedence)
               255
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
@@ -281,14 +281,14 @@ app:
               u"<tokio_current_thread::Borrow<'a, U>>::enter"
             lineno (function takes precedence)
               776
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
               u'<std::thread::local::LocalKey<T>>::with'
             lineno (function takes precedence)
               255
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
@@ -372,7 +372,7 @@ app:
               u'<futures::task_impl::Spawn<T>>::poll_future_notify::{{closure}}'
             lineno (function takes precedence)
               326
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'mod.rs'
             function*
@@ -512,14 +512,14 @@ app:
               u'sentry::hub::Hub::with'
             lineno (function takes precedence)
               190
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
               u'<std::thread::local::LocalKey<T>>::with'
             lineno (function takes precedence)
               255
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
@@ -564,7 +564,7 @@ system:
               u'std::sys::unix::thread::Thread::new::thread_start'
             lineno (function takes precedence)
               24
-          frame*
+          frame* (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'boxed.rs'
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/actix.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2019-09-17T14:11:59.100387Z'
+created: '2019-09-26T13:46:38.943177Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: '3abe7858e37e8eb76c484efa7c7ba121'
+  hash: '703d3dd9cb763e3f5037f659d27da947'
   component:
     app*
       exception*
@@ -20,11 +20,11 @@ app:
               u'thread.rs'
             function*
               u'std::sys::unix::thread::Thread::new::thread_start'
-          frame*
+          frame (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'boxed.rs'
             function* (isolated function)
-              u'<F as alloc::boxed::FnBox<T>>::call_box'
+              u'alloc::boxed::FnBox<T>::call_box'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
@@ -50,11 +50,11 @@ app:
               u'panicking.rs'
             function*
               u'std::panicking::try::do_call'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panic.rs'
             function* (isolated function)
-              u'<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once'
+              u'std::panic::AssertUnwindSafe<T>::call_once'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
@@ -85,16 +85,16 @@ app:
               u'lib.rs'
             function*
               u'tokio_reactor::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
@@ -110,16 +110,16 @@ app:
               u'clock.rs'
             function*
               u'tokio_timer::clock::clock::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'clock.rs'
@@ -135,16 +135,16 @@ app:
               u'handle.rs'
             function*
               u'tokio_timer::timer::handle::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'handle.rs'
@@ -160,16 +160,16 @@ app:
               u'global.rs'
             function*
               u'tokio_executor::global::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'global.rs'
@@ -189,37 +189,37 @@ app:
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Entered<T>>::block_on'
+              u'tokio_current_thread::Entered<T>::block_on'
           frame*
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Entered<T>>::tick'
+              u'tokio_current_thread::Entered<T>::tick'
           frame*
             filename*
               u'scheduler.rs'
             function* (isolated function)
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick'
           frame*
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Borrow<T>>::enter'
-          frame (non app frame)
+              u'tokio_current_thread::Borrow<T>::enter'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}'
           frame*
             filename*
               u'lib.rs'
@@ -229,32 +229,32 @@ app:
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function* (isolated function)
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick::{{closure}}'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function* (isolated function)
-              u'<tokio_current_thread::scheduler::Scheduled<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduled<T>::tick'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::poll_future_notify'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::poll_fn_notify'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::poll_fn_notify'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::enter'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::enter'
           frame*
             filename*
               u'mod.rs'
@@ -263,93 +263,93 @@ app:
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::enter::{{closure}}'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::enter::{{closure}}'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify::{{closure}}'
-          frame (non app frame)
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}'
+          frame (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'mod.rs'
             function* (isolated function)
-              u'<alloc::boxed::Box<T> as futures::future::Future>::poll'
+              u'alloc::boxed::Box<T>::poll'
           frame*
             filename*
               u'then.rs'
             function* (isolated function)
-              u'<futures::future::then::Then<T> as futures::future::Future>::poll'
+              u'futures::future::then::Then<T>::poll'
           frame*
             filename*
               u'chain.rs'
             function* (isolated function)
-              u'<futures::future::chain::Chain<T>>::poll'
+              u'futures::future::chain::Chain<T>::poll'
           frame*
             filename*
               u'either.rs'
             function* (isolated function)
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame (ignored due to recursion)
             filename*
               u'either.rs'
             function* (isolated function)
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame*
             filename*
               u'acceptor.rs'
-            function*
-              u'<actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T> as futures::future::Future>::poll'
+            function* (isolated function)
+              u'actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll'
           frame*
             filename*
               u'and_then.rs'
             function* (isolated function)
-              u'<actix_net::service::and_then::AndThenFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::and_then::AndThenFuture<T>::poll'
           frame*
             filename*
               u'map_err.rs'
             function* (isolated function)
-              u'<actix_net::service::map_err::MapErrFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::map_err::MapErrFuture<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function* (isolated function)
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function* (isolated function)
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_handler'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_handler'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_io'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_io'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::parse'
+              u'actix_web::server::h1::Http1Dispatcher<T>::parse'
           frame*
             filename*
               u'pipeline.rs'
             function* (isolated function)
-              u'<actix_web::pipeline::Pipeline<T> as actix_web::server::handler::HttpHandlerTask>::poll_io'
+              u'actix_web::pipeline::Pipeline<T>::poll_io'
           frame*
             filename*
               u'<::log::macros::log macros>'
             function* (isolated function)
-              u'<actix_web::pipeline::ProcessResponse<T>>::poll_io'
+              u'actix_web::pipeline::ProcessResponse<T>::poll_io'
           frame*
             filename*
               u'lib.rs'
@@ -358,8 +358,8 @@ app:
           frame (non app frame)
             filename*
               u'log.rs'
-            function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+            function* (isolated function)
+              u'sentry::integrations::log::Logger::log'
           frame (non app frame)
             filename*
               u'hub.rs'
@@ -370,16 +370,16 @@ app:
               u'hub.rs'
             function*
               u'sentry::hub::Hub::with'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame (non app frame)
             filename*
               u'hub.rs'
@@ -394,7 +394,7 @@ app:
           u'actix_web::pipeline'
 --------------------------------------------------------------------------
 system:
-  hash: '7f12fecf89ac9e64cdfa36b08e634681'
+  hash: '1df163ce3be65319df4fcc9cb34b60c1'
   component:
     system*
       exception*
@@ -410,11 +410,11 @@ system:
               u'thread.rs'
             function*
               u'std::sys::unix::thread::Thread::new::thread_start'
-          frame*
+          frame* (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'boxed.rs'
             function* (isolated function)
-              u'<F as alloc::boxed::FnBox<T>>::call_box'
+              u'alloc::boxed::FnBox<T>::call_box'
           frame*
             filename*
               u'mod.rs'
@@ -444,7 +444,7 @@ system:
             filename*
               u'panic.rs'
             function* (isolated function)
-              u'<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once'
+              u'std::panic::AssertUnwindSafe<T>::call_once'
           frame*
             filename*
               u'mod.rs'
@@ -478,13 +478,13 @@ system:
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
@@ -503,13 +503,13 @@ system:
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'clock.rs'
@@ -528,13 +528,13 @@ system:
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'handle.rs'
@@ -553,13 +553,13 @@ system:
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'global.rs'
@@ -579,37 +579,37 @@ system:
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Entered<T>>::block_on'
+              u'tokio_current_thread::Entered<T>::block_on'
           frame*
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Entered<T>>::tick'
+              u'tokio_current_thread::Entered<T>::tick'
           frame*
             filename*
               u'scheduler.rs'
             function* (isolated function)
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick'
           frame*
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Borrow<T>>::enter'
+              u'tokio_current_thread::Borrow<T>::enter'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}'
           frame*
             filename*
               u'lib.rs'
@@ -619,32 +619,32 @@ system:
             filename*
               u'lib.rs'
             function* (isolated function)
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function* (isolated function)
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick::{{closure}}'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function* (isolated function)
-              u'<tokio_current_thread::scheduler::Scheduled<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduled<T>::tick'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::poll_future_notify'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::poll_fn_notify'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::poll_fn_notify'
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::enter'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::enter'
           frame*
             filename*
               u'mod.rs'
@@ -653,93 +653,93 @@ system:
           frame*
             filename*
               u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::enter::{{closure}}'
-          frame*
-            filename*
-              u'mod.rs'
-            function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify::{{closure}}'
+            function* (isolated function)
+              u'futures::task_impl::Spawn<T>::enter::{{closure}}'
           frame*
             filename*
               u'mod.rs'
             function* (isolated function)
-              u'<alloc::boxed::Box<T> as futures::future::Future>::poll'
+              u'futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}'
+          frame*
+            filename*
+              u'mod.rs'
+            function* (isolated function)
+              u'alloc::boxed::Box<T>::poll'
           frame*
             filename*
               u'then.rs'
             function* (isolated function)
-              u'<futures::future::then::Then<T> as futures::future::Future>::poll'
+              u'futures::future::then::Then<T>::poll'
           frame*
             filename*
               u'chain.rs'
             function* (isolated function)
-              u'<futures::future::chain::Chain<T>>::poll'
+              u'futures::future::chain::Chain<T>::poll'
           frame*
             filename*
               u'either.rs'
             function* (isolated function)
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame (ignored due to recursion)
             filename*
               u'either.rs'
             function* (isolated function)
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame*
             filename*
               u'acceptor.rs'
-            function*
-              u'<actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T> as futures::future::Future>::poll'
+            function* (isolated function)
+              u'actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll'
           frame*
             filename*
               u'and_then.rs'
             function* (isolated function)
-              u'<actix_net::service::and_then::AndThenFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::and_then::AndThenFuture<T>::poll'
           frame*
             filename*
               u'map_err.rs'
             function* (isolated function)
-              u'<actix_net::service::map_err::MapErrFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::map_err::MapErrFuture<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function* (isolated function)
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function* (isolated function)
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_handler'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_handler'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_io'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_io'
           frame*
             filename*
               u'h1.rs'
             function* (isolated function)
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::parse'
+              u'actix_web::server::h1::Http1Dispatcher<T>::parse'
           frame*
             filename*
               u'pipeline.rs'
             function* (isolated function)
-              u'<actix_web::pipeline::Pipeline<T> as actix_web::server::handler::HttpHandlerTask>::poll_io'
+              u'actix_web::pipeline::Pipeline<T>::poll_io'
           frame*
             filename*
               u'<::log::macros::log macros>'
             function* (isolated function)
-              u'<actix_web::pipeline::ProcessResponse<T>>::poll_io'
+              u'actix_web::pipeline::ProcessResponse<T>::poll_io'
           frame*
             filename*
               u'lib.rs'
@@ -748,8 +748,8 @@ system:
           frame*
             filename*
               u'log.rs'
-            function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+            function* (isolated function)
+              u'sentry::integrations::log::Logger::log'
           frame*
             filename*
               u'hub.rs'
@@ -763,13 +763,13 @@ system:
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
-            function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+            function* (isolated function)
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'hub.rs'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-11T09:56:05.696521Z'
+created: '2019-09-26T13:53:00.592370Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-06-05T11:45:15.715625Z'
+created: '2019-09-26T13:53:00.606697Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-09-17T14:12:02.733078Z'
+created: '2019-09-26T13:26:25.915829Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -34,8 +34,8 @@ app:
             function*
               u'log::__private_api_log'
           frame (non app frame)
-            function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+            function* (isolated function)
+              u'sentry::integrations::log::Logger::log'
           frame (non app frame)
             function*
               u'sentry::hub::Hub::with_active'
@@ -55,7 +55,7 @@ app:
           u'log_demo'
 --------------------------------------------------------------------------
 system:
-  hash: '06f8f02638bc75df5a5c88712055ee5f'
+  hash: '00719910980352c06ba93641057012e0'
   component:
     system*
       exception*
@@ -85,8 +85,8 @@ system:
             function*
               u'log::__private_api_log'
           frame*
-            function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+            function* (isolated function)
+              u'sentry::integrations::log::Logger::log'
           frame*
             function*
               u'sentry::hub::Hub::with_active'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-16T18:21:47.953057Z'
+created: '2019-09-26T13:53:00.686525Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/actix.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2019-09-17T14:12:05.781800Z'
+created: '2019-09-26T13:46:40.468198Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: '3abe7858e37e8eb76c484efa7c7ba121'
+  hash: '703d3dd9cb763e3f5037f659d27da947'
   component:
     app*
       exception*
@@ -20,11 +20,11 @@ app:
               u'thread.rs'
             function*
               u'std::sys::unix::thread::Thread::new::thread_start'
-          frame*
+          frame (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'boxed.rs'
             function*
-              u'<F as alloc::boxed::FnBox<T>>::call_box'
+              u'alloc::boxed::FnBox<T>::call_box'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
@@ -50,11 +50,11 @@ app:
               u'panicking.rs'
             function*
               u'std::panicking::try::do_call'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panic.rs'
             function*
-              u'<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once'
+              u'std::panic::AssertUnwindSafe<T>::call_once'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
@@ -85,16 +85,16 @@ app:
               u'lib.rs'
             function*
               u'tokio_reactor::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
@@ -110,16 +110,16 @@ app:
               u'clock.rs'
             function*
               u'tokio_timer::clock::clock::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'clock.rs'
@@ -135,16 +135,16 @@ app:
               u'handle.rs'
             function*
               u'tokio_timer::timer::handle::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'handle.rs'
@@ -160,16 +160,16 @@ app:
               u'global.rs'
             function*
               u'tokio_executor::global::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'global.rs'
@@ -189,37 +189,37 @@ app:
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Entered<T>>::block_on'
+              u'tokio_current_thread::Entered<T>::block_on'
           frame*
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Entered<T>>::tick'
+              u'tokio_current_thread::Entered<T>::tick'
           frame*
             filename*
               u'scheduler.rs'
             function*
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick'
           frame*
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Borrow<T>>::enter'
-          frame (non app frame)
+              u'tokio_current_thread::Borrow<T>::enter'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}'
           frame*
             filename*
               u'lib.rs'
@@ -229,32 +229,32 @@ app:
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function*
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick::{{closure}}'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function*
-              u'<tokio_current_thread::scheduler::Scheduled<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduled<T>::tick'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify'
+              u'futures::task_impl::Spawn<T>::poll_future_notify'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::poll_fn_notify'
+              u'futures::task_impl::Spawn<T>::poll_fn_notify'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::enter'
+              u'futures::task_impl::Spawn<T>::enter'
           frame*
             filename*
               u'mod.rs'
@@ -264,92 +264,92 @@ app:
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::enter::{{closure}}'
+              u'futures::task_impl::Spawn<T>::enter::{{closure}}'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify::{{closure}}'
-          frame (non app frame)
+              u'futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}'
+          frame (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'mod.rs'
             function*
-              u'<alloc::boxed::Box<T> as futures::future::Future>::poll'
+              u'alloc::boxed::Box<T>::poll'
           frame*
             filename*
               u'then.rs'
             function*
-              u'<futures::future::then::Then<T> as futures::future::Future>::poll'
+              u'futures::future::then::Then<T>::poll'
           frame*
             filename*
               u'chain.rs'
             function*
-              u'<futures::future::chain::Chain<T>>::poll'
+              u'futures::future::chain::Chain<T>::poll'
           frame*
             filename*
               u'either.rs'
             function*
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame (ignored due to recursion)
             filename*
               u'either.rs'
             function*
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame*
             filename*
               u'acceptor.rs'
             function*
-              u'<actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T> as futures::future::Future>::poll'
+              u'actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll'
           frame*
             filename*
               u'and_then.rs'
             function*
-              u'<actix_net::service::and_then::AndThenFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::and_then::AndThenFuture<T>::poll'
           frame*
             filename*
               u'map_err.rs'
             function*
-              u'<actix_net::service::map_err::MapErrFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::map_err::MapErrFuture<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function*
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function*
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_handler'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_handler'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_io'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_io'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::parse'
+              u'actix_web::server::h1::Http1Dispatcher<T>::parse'
           frame*
             filename*
               u'pipeline.rs'
             function*
-              u'<actix_web::pipeline::Pipeline<T> as actix_web::server::handler::HttpHandlerTask>::poll_io'
+              u'actix_web::pipeline::Pipeline<T>::poll_io'
           frame*
             filename*
               u'<::log::macros::log macros>'
             function*
-              u'<actix_web::pipeline::ProcessResponse<T>>::poll_io'
+              u'actix_web::pipeline::ProcessResponse<T>::poll_io'
           frame*
             filename*
               u'lib.rs'
@@ -359,7 +359,7 @@ app:
             filename*
               u'log.rs'
             function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+              u'sentry::integrations::log::Logger::log'
           frame (non app frame)
             filename*
               u'hub.rs'
@@ -370,16 +370,16 @@ app:
               u'hub.rs'
             function*
               u'sentry::hub::Hub::with'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame (non app frame)
             filename*
               u'hub.rs'
@@ -396,7 +396,7 @@ app:
           u'Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here'
 --------------------------------------------------------------------------
 system:
-  hash: '7f12fecf89ac9e64cdfa36b08e634681'
+  hash: '1df163ce3be65319df4fcc9cb34b60c1'
   component:
     system*
       exception*
@@ -412,11 +412,11 @@ system:
               u'thread.rs'
             function*
               u'std::sys::unix::thread::Thread::new::thread_start'
-          frame*
+          frame* (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'boxed.rs'
             function*
-              u'<F as alloc::boxed::FnBox<T>>::call_box'
+              u'alloc::boxed::FnBox<T>::call_box'
           frame*
             filename*
               u'mod.rs'
@@ -446,7 +446,7 @@ system:
             filename*
               u'panic.rs'
             function*
-              u'<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once'
+              u'std::panic::AssertUnwindSafe<T>::call_once'
           frame*
             filename*
               u'mod.rs'
@@ -481,12 +481,12 @@ system:
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
@@ -506,12 +506,12 @@ system:
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'clock.rs'
@@ -531,12 +531,12 @@ system:
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'handle.rs'
@@ -556,12 +556,12 @@ system:
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'global.rs'
@@ -581,37 +581,37 @@ system:
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Entered<T>>::block_on'
+              u'tokio_current_thread::Entered<T>::block_on'
           frame*
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Entered<T>>::tick'
+              u'tokio_current_thread::Entered<T>::tick'
           frame*
             filename*
               u'scheduler.rs'
             function*
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick'
           frame*
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Borrow<T>>::enter'
+              u'tokio_current_thread::Borrow<T>::enter'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}'
           frame*
             filename*
               u'lib.rs'
@@ -621,32 +621,32 @@ system:
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function*
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick::{{closure}}'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function*
-              u'<tokio_current_thread::scheduler::Scheduled<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduled<T>::tick'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify'
+              u'futures::task_impl::Spawn<T>::poll_future_notify'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::poll_fn_notify'
+              u'futures::task_impl::Spawn<T>::poll_fn_notify'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::enter'
+              u'futures::task_impl::Spawn<T>::enter'
           frame*
             filename*
               u'mod.rs'
@@ -656,92 +656,92 @@ system:
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::enter::{{closure}}'
+              u'futures::task_impl::Spawn<T>::enter::{{closure}}'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify::{{closure}}'
+              u'futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<alloc::boxed::Box<T> as futures::future::Future>::poll'
+              u'alloc::boxed::Box<T>::poll'
           frame*
             filename*
               u'then.rs'
             function*
-              u'<futures::future::then::Then<T> as futures::future::Future>::poll'
+              u'futures::future::then::Then<T>::poll'
           frame*
             filename*
               u'chain.rs'
             function*
-              u'<futures::future::chain::Chain<T>>::poll'
+              u'futures::future::chain::Chain<T>::poll'
           frame*
             filename*
               u'either.rs'
             function*
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame (ignored due to recursion)
             filename*
               u'either.rs'
             function*
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame*
             filename*
               u'acceptor.rs'
             function*
-              u'<actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T> as futures::future::Future>::poll'
+              u'actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll'
           frame*
             filename*
               u'and_then.rs'
             function*
-              u'<actix_net::service::and_then::AndThenFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::and_then::AndThenFuture<T>::poll'
           frame*
             filename*
               u'map_err.rs'
             function*
-              u'<actix_net::service::map_err::MapErrFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::map_err::MapErrFuture<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function*
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function*
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_handler'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_handler'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_io'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_io'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::parse'
+              u'actix_web::server::h1::Http1Dispatcher<T>::parse'
           frame*
             filename*
               u'pipeline.rs'
             function*
-              u'<actix_web::pipeline::Pipeline<T> as actix_web::server::handler::HttpHandlerTask>::poll_io'
+              u'actix_web::pipeline::Pipeline<T>::poll_io'
           frame*
             filename*
               u'<::log::macros::log macros>'
             function*
-              u'<actix_web::pipeline::ProcessResponse<T>>::poll_io'
+              u'actix_web::pipeline::ProcessResponse<T>::poll_io'
           frame*
             filename*
               u'lib.rs'
@@ -751,7 +751,7 @@ system:
             filename*
               u'log.rs'
             function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+              u'sentry::integrations::log::Logger::log'
           frame*
             filename*
               u'hub.rs'
@@ -766,12 +766,12 @@ system:
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'hub.rs'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-09-17T14:12:08.728073Z'
+created: '2019-09-26T13:26:27.401817Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -35,7 +35,7 @@ app:
               u'log::__private_api_log'
           frame (non app frame)
             function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+              u'sentry::integrations::log::Logger::log'
           frame (non app frame)
             function*
               u'sentry::hub::Hub::with_active'
@@ -57,7 +57,7 @@ app:
           u'Holy shit everything is on fire!'
 --------------------------------------------------------------------------
 system:
-  hash: '06f8f02638bc75df5a5c88712055ee5f'
+  hash: '00719910980352c06ba93641057012e0'
   component:
     system*
       exception*
@@ -88,7 +88,7 @@ system:
               u'log::__private_api_log'
           frame*
             function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+              u'sentry::integrations::log::Logger::log'
           frame*
             function*
               u'sentry::hub::Hub::with_active'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/actix.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2019-09-17T14:12:11.861540Z'
+created: '2019-09-26T13:46:41.968243Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: '3abe7858e37e8eb76c484efa7c7ba121'
+  hash: '703d3dd9cb763e3f5037f659d27da947'
   component:
     app*
       exception*
@@ -20,11 +20,11 @@ app:
               u'thread.rs'
             function*
               u'std::sys::unix::thread::Thread::new::thread_start'
-          frame*
+          frame (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'boxed.rs'
             function*
-              u'<F as alloc::boxed::FnBox<T>>::call_box'
+              u'alloc::boxed::FnBox<T>::call_box'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
@@ -50,11 +50,11 @@ app:
               u'panicking.rs'
             function*
               u'std::panicking::try::do_call'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'panic.rs'
             function*
-              u'<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once'
+              u'std::panic::AssertUnwindSafe<T>::call_once'
           frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'mod.rs'
@@ -85,16 +85,16 @@ app:
               u'lib.rs'
             function*
               u'tokio_reactor::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
@@ -110,16 +110,16 @@ app:
               u'clock.rs'
             function*
               u'tokio_timer::clock::clock::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'clock.rs'
@@ -135,16 +135,16 @@ app:
               u'handle.rs'
             function*
               u'tokio_timer::timer::handle::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'handle.rs'
@@ -160,16 +160,16 @@ app:
               u'global.rs'
             function*
               u'tokio_executor::global::with_default'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'global.rs'
@@ -189,37 +189,37 @@ app:
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Entered<T>>::block_on'
+              u'tokio_current_thread::Entered<T>::block_on'
           frame*
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Entered<T>>::tick'
+              u'tokio_current_thread::Entered<T>::tick'
           frame*
             filename*
               u'scheduler.rs'
             function*
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick'
           frame*
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Borrow<T>>::enter'
-          frame (non app frame)
+              u'tokio_current_thread::Borrow<T>::enter'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}'
           frame*
             filename*
               u'lib.rs'
@@ -229,32 +229,32 @@ app:
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function*
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick::{{closure}}'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function*
-              u'<tokio_current_thread::scheduler::Scheduled<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduled<T>::tick'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify'
+              u'futures::task_impl::Spawn<T>::poll_future_notify'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::poll_fn_notify'
+              u'futures::task_impl::Spawn<T>::poll_fn_notify'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::enter'
+              u'futures::task_impl::Spawn<T>::enter'
           frame*
             filename*
               u'mod.rs'
@@ -264,92 +264,92 @@ app:
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::enter::{{closure}}'
+              u'futures::task_impl::Spawn<T>::enter::{{closure}}'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify::{{closure}}'
-          frame (non app frame)
+              u'futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}'
+          frame (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'mod.rs'
             function*
-              u'<alloc::boxed::Box<T> as futures::future::Future>::poll'
+              u'alloc::boxed::Box<T>::poll'
           frame*
             filename*
               u'then.rs'
             function*
-              u'<futures::future::then::Then<T> as futures::future::Future>::poll'
+              u'futures::future::then::Then<T>::poll'
           frame*
             filename*
               u'chain.rs'
             function*
-              u'<futures::future::chain::Chain<T>>::poll'
+              u'futures::future::chain::Chain<T>::poll'
           frame*
             filename*
               u'either.rs'
             function*
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame (ignored due to recursion)
             filename*
               u'either.rs'
             function*
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame*
             filename*
               u'acceptor.rs'
             function*
-              u'<actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T> as futures::future::Future>::poll'
+              u'actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll'
           frame*
             filename*
               u'and_then.rs'
             function*
-              u'<actix_net::service::and_then::AndThenFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::and_then::AndThenFuture<T>::poll'
           frame*
             filename*
               u'map_err.rs'
             function*
-              u'<actix_net::service::map_err::MapErrFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::map_err::MapErrFuture<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function*
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function*
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_handler'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_handler'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_io'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_io'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::parse'
+              u'actix_web::server::h1::Http1Dispatcher<T>::parse'
           frame*
             filename*
               u'pipeline.rs'
             function*
-              u'<actix_web::pipeline::Pipeline<T> as actix_web::server::handler::HttpHandlerTask>::poll_io'
+              u'actix_web::pipeline::Pipeline<T>::poll_io'
           frame*
             filename*
               u'<::log::macros::log macros>'
             function*
-              u'<actix_web::pipeline::ProcessResponse<T>>::poll_io'
+              u'actix_web::pipeline::ProcessResponse<T>::poll_io'
           frame*
             filename*
               u'lib.rs'
@@ -359,7 +359,7 @@ app:
             filename*
               u'log.rs'
             function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+              u'sentry::integrations::log::Logger::log'
           frame (non app frame)
             filename*
               u'hub.rs'
@@ -370,16 +370,16 @@ app:
               u'hub.rs'
             function*
               u'sentry::hub::Hub::with'
-          frame (non app frame)
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
-          frame (non app frame)
+              u'std::thread::local::LocalKey<T>::with'
+          frame (marked out of app by grouping enhancement rule (family:native function:std::* -app))
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame (non app frame)
             filename*
               u'hub.rs'
@@ -396,7 +396,7 @@ app:
           u'Error occurred during request handling, status: <int> Internal Server Error Something went really wrong here'
 --------------------------------------------------------------------------
 system:
-  hash: '7f12fecf89ac9e64cdfa36b08e634681'
+  hash: '1df163ce3be65319df4fcc9cb34b60c1'
   component:
     system*
       exception*
@@ -412,11 +412,11 @@ system:
               u'thread.rs'
             function*
               u'std::sys::unix::thread::Thread::new::thread_start'
-          frame*
+          frame* (marked out of app by grouping enhancement rule (family:native function:alloc::* -app))
             filename*
               u'boxed.rs'
             function*
-              u'<F as alloc::boxed::FnBox<T>>::call_box'
+              u'alloc::boxed::FnBox<T>::call_box'
           frame*
             filename*
               u'mod.rs'
@@ -446,7 +446,7 @@ system:
             filename*
               u'panic.rs'
             function*
-              u'<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once'
+              u'std::panic::AssertUnwindSafe<T>::call_once'
           frame*
             filename*
               u'mod.rs'
@@ -481,12 +481,12 @@ system:
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
@@ -506,12 +506,12 @@ system:
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'clock.rs'
@@ -531,12 +531,12 @@ system:
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'handle.rs'
@@ -556,12 +556,12 @@ system:
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'global.rs'
@@ -581,37 +581,37 @@ system:
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Entered<T>>::block_on'
+              u'tokio_current_thread::Entered<T>::block_on'
           frame*
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Entered<T>>::tick'
+              u'tokio_current_thread::Entered<T>::tick'
           frame*
             filename*
               u'scheduler.rs'
             function*
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick'
           frame*
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Borrow<T>>::enter'
+              u'tokio_current_thread::Borrow<T>::enter'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}'
           frame*
             filename*
               u'lib.rs'
@@ -621,32 +621,32 @@ system:
             filename*
               u'lib.rs'
             function*
-              u'<tokio_current_thread::Borrow<T>>::enter::{{closure}}::{{closure}}'
+              u'tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function*
-              u'<tokio_current_thread::scheduler::Scheduler<T>>::tick::{{closure}}'
+              u'tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}}'
           frame*
             filename*
               u'scheduler.rs'
             function*
-              u'<tokio_current_thread::scheduler::Scheduled<T>>::tick'
+              u'tokio_current_thread::scheduler::Scheduled<T>::tick'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify'
+              u'futures::task_impl::Spawn<T>::poll_future_notify'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::poll_fn_notify'
+              u'futures::task_impl::Spawn<T>::poll_fn_notify'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::enter'
+              u'futures::task_impl::Spawn<T>::enter'
           frame*
             filename*
               u'mod.rs'
@@ -656,92 +656,92 @@ system:
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::enter::{{closure}}'
+              u'futures::task_impl::Spawn<T>::enter::{{closure}}'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<futures::task_impl::Spawn<T>>::poll_future_notify::{{closure}}'
+              u'futures::task_impl::Spawn<T>::poll_future_notify::{{closure}}'
           frame*
             filename*
               u'mod.rs'
             function*
-              u'<alloc::boxed::Box<T> as futures::future::Future>::poll'
+              u'alloc::boxed::Box<T>::poll'
           frame*
             filename*
               u'then.rs'
             function*
-              u'<futures::future::then::Then<T> as futures::future::Future>::poll'
+              u'futures::future::then::Then<T>::poll'
           frame*
             filename*
               u'chain.rs'
             function*
-              u'<futures::future::chain::Chain<T>>::poll'
+              u'futures::future::chain::Chain<T>::poll'
           frame*
             filename*
               u'either.rs'
             function*
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame (ignored due to recursion)
             filename*
               u'either.rs'
             function*
-              u'<futures::future::either::Either<T> as futures::future::Future>::poll'
+              u'futures::future::either::Either<T>::poll'
           frame*
             filename*
               u'acceptor.rs'
             function*
-              u'<actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T> as futures::future::Future>::poll'
+              u'actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll'
           frame*
             filename*
               u'and_then.rs'
             function*
-              u'<actix_net::service::and_then::AndThenFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::and_then::AndThenFuture<T>::poll'
           frame*
             filename*
               u'map_err.rs'
             function*
-              u'<actix_net::service::map_err::MapErrFuture<T> as futures::future::Future>::poll'
+              u'actix_net::service::map_err::MapErrFuture<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function*
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'channel.rs'
             function*
-              u'<actix_web::server::channel::HttpChannel<T> as futures::future::Future>::poll'
+              u'actix_web::server::channel::HttpChannel<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_handler'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_handler'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::poll_io'
+              u'actix_web::server::h1::Http1Dispatcher<T>::poll_io'
           frame*
             filename*
               u'h1.rs'
             function*
-              u'<actix_web::server::h1::Http1Dispatcher<T>>::parse'
+              u'actix_web::server::h1::Http1Dispatcher<T>::parse'
           frame*
             filename*
               u'pipeline.rs'
             function*
-              u'<actix_web::pipeline::Pipeline<T> as actix_web::server::handler::HttpHandlerTask>::poll_io'
+              u'actix_web::pipeline::Pipeline<T>::poll_io'
           frame*
             filename*
               u'<::log::macros::log macros>'
             function*
-              u'<actix_web::pipeline::ProcessResponse<T>>::poll_io'
+              u'actix_web::pipeline::ProcessResponse<T>::poll_io'
           frame*
             filename*
               u'lib.rs'
@@ -751,7 +751,7 @@ system:
             filename*
               u'log.rs'
             function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+              u'sentry::integrations::log::Logger::log'
           frame*
             filename*
               u'hub.rs'
@@ -766,12 +766,12 @@ system:
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::with'
+              u'std::thread::local::LocalKey<T>::with'
           frame*
             filename*
               u'local.rs'
             function*
-              u'<std::thread::local::LocalKey<T>>::try_with'
+              u'std::thread::local::LocalKey<T>::try_with'
           frame*
             filename*
               u'hub.rs'

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-09-17T14:12:15.305004Z'
+created: '2019-09-26T13:26:28.893497Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -35,7 +35,7 @@ app:
               u'log::__private_api_log'
           frame (non app frame)
             function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+              u'sentry::integrations::log::Logger::log'
           frame (non app frame)
             function*
               u'sentry::hub::Hub::with_active'
@@ -57,7 +57,7 @@ app:
           u'Holy shit everything is on fire!'
 --------------------------------------------------------------------------
 system:
-  hash: '06f8f02638bc75df5a5c88712055ee5f'
+  hash: '00719910980352c06ba93641057012e0'
   component:
     system*
       exception*
@@ -88,7 +88,7 @@ system:
               u'log::__private_api_log'
           frame*
             function*
-              u'<sentry::integrations::log::Logger as log::Log>::log'
+              u'sentry::integrations::log::Logger::log'
           frame*
             function*
               u'sentry::hub::Hub::with_active'

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -26,13 +26,13 @@ from sentry.stacktraces.functions import (
         ],
         [
             "<actix_web::pipeline::Pipeline<S, H> as actix_web::server::handler::HttpHandlerTask>::poll_io",
-            "<actix_web::pipeline::Pipeline<T> as actix_web::server::handler::HttpHandlerTask>::poll_io",
+            "actix_web::pipeline::Pipeline<T>::poll_io",
         ],
         ["+[FLFoo barBaz]", "+[FLFoo barBaz]"],
         ["-[FLFoo barBaz]", "-[FLFoo barBaz]"],
         [
             "<tokio_current_thread::scheduler::Scheduled<'a, U>>::tick",
-            "<tokio_current_thread::scheduler::Scheduled<T>>::tick",
+            "tokio_current_thread::scheduler::Scheduled<T>::tick",
         ],
         [
             "tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}}::{{closure}}",
@@ -40,7 +40,7 @@ from sentry.stacktraces.functions import (
         ],
         [
             "<std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once",
-            "<std::panic::AssertUnwindSafe<T> as core::ops::function::FnOnce<T>>::call_once",
+            "std::panic::AssertUnwindSafe<T>::call_once",
         ],
         [
             "struct style::gecko_bindings::sugar::ownership::Strong<style::gecko_bindings::structs::root::RawServoStyleSheetContents> geckoservo::glue::Servo_StyleSheet_Empty(style::gecko_bindings::structs::root::mozilla::css::SheetParsingMode) const",
@@ -68,9 +68,14 @@ from sentry.stacktraces.functions import (
             "mynamespace::MyClass::operator()",
         ],
         [
-            "<actix::contextimpl::ContextFut<A, C> as futures::future::Future>::poll::h9de5fbebc1652d47",
-            "<actix::contextimpl::ContextFut<T> as futures::future::Future>::poll",
+            "std::basic_ostream<char, std::char_traits<char> >& std::operator<< <std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char)",
+            "std::operator<< <T>",
         ],
+        [
+            "<actix::contextimpl::ContextFut<A, C> as futures::future::Future>::poll::h9de5fbebc1652d47",
+            "actix::contextimpl::ContextFut<T>::poll",
+        ],
+        ["<T as core::convert::Into<U>>::into", "core::convert::Into<T>::into"],
         ["ThreadStartWhatever@16", "ThreadStartWhatever"],
         ["@ThreadStartWhatever@16", "ThreadStartWhatever"],
         ["@objc ViewController.causeCrash(Any) -> ()", "ViewController.causeCrash"],
@@ -85,6 +90,7 @@ from sentry.stacktraces.functions import (
         ["main::{lambda(int)#1}", "main::lambda"],
         ["main::{lambda()#42}", "main::lambda"],
         ["lambda_7156c3ceaa11256748687ab67e3ef4cd", "lambda"],
+        ["<lambda_7156c3ceaa11256748687ab67e3ef4cd>::operator()", "<lambda>::operator()"],
     ],
 )
 def test_trim_function_name(input, output):


### PR DESCRIPTION
This PR changes trimming of Rust generic, hopefully improving readability. Also, this makes it easier to write grouping enhancements. There are two cases that are normalized differently:

- **Default**: `<Foo as Bar>::baz` -> `Foo::baz`
- **Blanket impl**: `<T as Bar>::baz` -> `Bar::baz` (since the trait name here is more useful

This will break grouping for all Rust projects that have opted into newstyle grouping.
I have not looked how many that are, but I don't expect that this is a significant amount.

---

This also fixes a bug when serializing MSVC generic operators: `std::basic_ostream<char, std::char_traits<char> >& std::operator<< <std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char)`
- Old trimming: `<T>`
- New trimming: `operator<< <T>`.