### PR TITLE
feat(discover2) Insert into transactions store in tests

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -222,12 +222,20 @@ class SnubaEventStream(SnubaProtocolEventStream):
     def _send(self, project_id, _type, extra_data=(), asynchronous=True):
         data = (self.EVENT_PROTOCOL_VERSION, _type) + extra_data
 
+        # TODO remove this once the unified dataset is available.
+        # Inserting into both events and transactions datasets lets us
+        # simulate what is currently happening via kafka when both the events
+        # and transactions consumers are running.
+        datasets = ["events"]
+        if get_path(extra_data, 0, "data", "type") == "transaction":
+            datasets.append("transactions")
         try:
-            resp = snuba._snuba_pool.urlopen(
-                "POST", "/tests/events/eventstream", body=json.dumps(data)
-            )
-            if resp.status != 200:
-                raise snuba.SnubaError("HTTP %s response from Snuba!" % resp.status)
+            for dataset in datasets:
+                resp = snuba._snuba_pool.urlopen(
+                    "POST", "/tests/{}/eventstream".format(dataset), body=json.dumps(data)
+                )
+                if resp.status != 200:
+                    raise snuba.SnubaError("HTTP %s response from Snuba!" % resp.status)
             return resp
         except urllib3.exceptions.HTTPError as err:
             raise snuba.SnubaError(err)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -768,6 +768,7 @@ class SnubaTestCase(BaseTestCase):
         self.snuba_eventstream = SnubaEventStream()
         self.snuba_tagstore = SnubaCompatibilityTagStorage()
         assert requests.post(settings.SENTRY_SNUBA + "/tests/events/drop").status_code == 200
+        assert requests.post(settings.SENTRY_SNUBA + "/tests/transactions/drop").status_code == 200
 
     def store_event(self, *args, **kwargs):
         with contextlib.nested(

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
-from sentry.testutils import TestCase
+from sentry.testutils import TestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry import options
 
 
-class ProjectEventTest(TestCase):
+class ProjectEventTest(SnubaTestCase, TestCase):
     def setUp(self):
         super(ProjectEventTest, self).setUp()
         self.user = self.create_user()
@@ -48,9 +48,11 @@ class ProjectEventTest(TestCase):
         event = self.store_event(
             data={
                 "type": "transaction",
+                "transaction": "api.test",
                 "timestamp": min_ago,
                 "start_timestamp": min_ago,
                 "spans": [],
+                "contexts": {"trace": {"trace_id": "a" * 32, "span_id": "b" * 16}},
             },
             project_id=self.project.id,
         )


### PR DESCRIPTION
When saving transaction events we should insert the event into both the event dataset *and* the transactions dataset. Doing both lets us simulate production state in our test suite which is something I need to write integration tests.

Refs SEN-1043