### PR TITLE
perf(ui): Decompose organization details for projects page

### DIFF
--- a/src/sentry/static/sentry/app/components/noProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/noProjectMessage.tsx
@@ -3,7 +3,7 @@ import styled from 'react-emotion';
 import PropTypes from 'prop-types';
 
 import {t} from 'app/locale';
-import {Organization} from 'app/types';
+import {Organization, Project} from 'app/types';
 import Button from 'app/components/button';
 import PageHeading from 'app/components/pageHeading';
 import Tooltip from 'app/components/tooltip';
@@ -15,6 +15,7 @@ import img from '../../images/dashboard/hair-on-fire.svg';
 
 type Props = {
   organization: Organization;
+  projects?: Project[];
 };
 
 export default class NoProjectMessage extends React.Component<Props> {
@@ -23,19 +24,25 @@ export default class NoProjectMessage extends React.Component<Props> {
     children are included. Otherwise we show the message */
     children: PropTypes.node,
     organization: SentryTypes.Organization,
+    projects: PropTypes.arrayOf(SentryTypes.Project),
   };
 
   render() {
-    const {children, organization} = this.props;
+    const {children, organization, projects} = this.props;
     const orgId = organization.slug;
     const canCreateProject = organization.access.includes('project:write');
     const canJoinTeam = organization.access.includes('team:read');
 
-    const {isSuperuser} = ConfigStore.get('user');
+    let hasProjects;
+    if (projects) {
+      hasProjects = projects.length > 0;
+    } else {
+      const {isSuperuser} = ConfigStore.get('user');
 
-    const hasProjects = isSuperuser
-      ? organization.projects.some(p => p.hasAccess)
-      : organization.projects.some(p => p.isMember && p.hasAccess);
+      hasProjects = isSuperuser
+        ? organization.projects.some(p => p.hasAccess)
+        : organization.projects.some(p => p.isMember && p.hasAccess);
+    }
 
     return hasProjects ? (
       children

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -10,7 +10,9 @@ import IssueListContainer from 'app/views/issueList/container';
 import IssueListOverview from 'app/views/issueList/overview';
 import LazyLoad from 'app/components/lazyLoad';
 import OrganizationContext from 'app/views/organizationContext';
-import OrganizationDetails from 'app/views/organizationDetails';
+import OrganizationDetails, {
+  LightWeightOrganizationDetails,
+} from 'app/views/organizationDetails';
 import OrganizationRoot from 'app/views/organizationRoot';
 import ProjectEventRedirect from 'app/views/projectEventRedirect';
 import RouteNotFound from 'app/views/routeNotFound';
@@ -953,22 +955,25 @@ function routes() {
           </Route>
         </Route>
       </Route>
+      {/* A route tree for lightweight organizational detail views */}
+      <Route path="/:orgId/" component={errorHandler(LightWeightOrganizationDetails)}>
+        <IndexRoute
+          componentPromise={() =>
+            import(/* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard')
+          }
+          component={errorHandler(LazyLoad)}
+        />
+        <Route
+          path="/organizations/:orgId/projects/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard')
+          }
+          component={errorHandler(LazyLoad)}
+        />
+      </Route>
       <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
         <Route component={errorHandler(OrganizationRoot)}>
-          <IndexRoute
-            componentPromise={() =>
-              import(/* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard')
-            }
-            component={errorHandler(LazyLoad)}
-          />
           {hook('routes:organization-root')}
-          <Route
-            path="/organizations/:orgId/projects/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard')
-            }
-            component={errorHandler(LazyLoad)}
-          />
           />
           <Route
             path="/organizations/:orgId/stats/"

--- a/src/sentry/static/sentry/app/utils/withTeamsForUser.tsx
+++ b/src/sentry/static/sentry/app/utils/withTeamsForUser.tsx
@@ -6,7 +6,6 @@ import {Organization, Project, Team, TeamWithProjects} from 'app/types';
 import getDisplayName from 'app/utils/getDisplayName';
 import getProjectsByTeams from 'app/utils/getProjectsByTeams';
 import ConfigStore from 'app/stores/configStore';
-import TeamActions from 'app/actions/teamActions';
 import {metric} from './analytics';
 
 // We require these props when using this HOC
@@ -74,10 +73,6 @@ const withTeamsForUser = <P extends InjectedTeamsProps>(
             });
           }
         );
-
-        // also fill up TeamStore so org context does not have to refetch org
-        // details due to lack of teams/projects
-        TeamActions.loadTeams(teamsWithProjects);
       } catch (error) {
         this.setState({
           error,
@@ -104,7 +99,9 @@ const withTeamsForUser = <P extends InjectedTeamsProps>(
     }
 
     render() {
-      return <WrappedComponent {...this.props as (P & DependentProps)} {...this.state} />;
+      return (
+        <WrappedComponent {...(this.props as (P & DependentProps))} {...this.state} />
+      );
     }
   };
 

--- a/src/sentry/static/sentry/app/utils/withTeamsForUser.tsx
+++ b/src/sentry/static/sentry/app/utils/withTeamsForUser.tsx
@@ -99,9 +99,7 @@ const withTeamsForUser = <P extends InjectedTeamsProps>(
     }
 
     render() {
-      return (
-        <WrappedComponent {...(this.props as (P & DependentProps))} {...this.state} />
-      );
+      return <WrappedComponent {...this.props as (P & DependentProps)} {...this.state} />;
     }
   };
 

--- a/src/sentry/static/sentry/app/views/organizationDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDetails/index.jsx
@@ -130,12 +130,12 @@ class OrganizationDetailsBody extends Component {
     detailed: PropTypes.bool,
   };
 
-  static defaultProps = {
-    detailed: true,
-  };
-
   static contextTypes = {
     organization: SentryTypes.Organization,
+  };
+
+  static defaultProps = {
+    detailed: true,
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/organizationDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDetails/index.jsx
@@ -1,4 +1,5 @@
 import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 import {Client} from 'app/api';
 import {switchOrganization} from 'app/actionCreators/organizations';
@@ -12,6 +13,7 @@ import OrganizationContext from 'app/views/organizationContext';
 import SentryTypes from 'app/sentryTypes';
 
 import InstallPromptBanner from './installPromptBanner';
+import LightWeightInstallPromptBanner from './lightWeightInstallPromptBanner';
 
 class DeletionInProgress extends Component {
   static propTypes = {
@@ -124,6 +126,14 @@ class DeletionPending extends Component {
 }
 
 class OrganizationDetailsBody extends Component {
+  static propTypes = {
+    detailed: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    detailed: true,
+  };
+
   static contextTypes = {
     organization: SentryTypes.Organization,
   };
@@ -140,7 +150,12 @@ class OrganizationDetailsBody extends Component {
     }
     return (
       <React.Fragment>
-        {organization && <InstallPromptBanner organization={organization} />}
+        {organization &&
+          (this.props.detailed ? (
+            <InstallPromptBanner organization={organization} />
+          ) : (
+            <LightWeightInstallPromptBanner organization={organization} />
+          ))}
         <ErrorBoundary>{this.props.children}</ErrorBoundary>
         <Footer />
       </React.Fragment>
@@ -161,8 +176,14 @@ export default class OrganizationDetails extends Component {
   render() {
     return (
       <OrganizationContext includeSidebar useLastOrganization {...this.props}>
-        <OrganizationDetailsBody>{this.props.children}</OrganizationDetailsBody>
+        <OrganizationDetailsBody {...this.props}>
+          {this.props.children}
+        </OrganizationDetailsBody>
       </OrganizationContext>
     );
   }
+}
+
+export function LightWeightOrganizationDetails(props) {
+  return <OrganizationDetails detailed={false} {...props} />;
 }

--- a/src/sentry/static/sentry/app/views/organizationDetails/installPromptBanner.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDetails/installPromptBanner.jsx
@@ -13,6 +13,7 @@ class InstallPromptBanner extends React.Component {
   static propTypes = {
     organization: PropTypes.object,
     config: SentryTypes.Config,
+    projects: PropTypes.arrayOf(SentryTypes.Project),
   };
 
   componentDidMount() {
@@ -25,10 +26,9 @@ class InstallPromptBanner extends React.Component {
   }
 
   sentFirstEvent() {
-    const {
-      organization: {projects},
-      config,
-    } = this.props;
+    const {config} = this.props;
+    // if projects were provided use them, otherwise assume they are in the detailed organization
+    const projects = this.props.projects || this.props.organization.projects;
     return !!projects.find(p => p.firstEvent) || !!config.sentFirstEvent;
   }
 
@@ -36,7 +36,7 @@ class InstallPromptBanner extends React.Component {
     const {organization} = this.props;
 
     // if project with a valid platform then go straight to instructions
-    const projects = organization.projects;
+    const projects = this.props.projects || organization.projects;
     const projectCount = projects.length;
     if (projectCount > 0 && getPlatformName(projects[projectCount - 1].platform)) {
       return `/onboarding/${organization.slug}/get-started/`;

--- a/src/sentry/static/sentry/app/views/organizationDetails/lightWeightInstallPromptBanner.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDetails/lightWeightInstallPromptBanner.jsx
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import InstallPromptBanner from 'app/views/organizationDetails/installPromptBanner';
+
+import SentryTypes from 'app/sentryTypes';
+import Projects from 'app/utils/projects';
+
+class LightWeightInstallPromptBanner extends React.Component {
+  static propTypes = {
+    organization: SentryTypes.Organization,
+    teams: PropTypes.arrayOf(SentryTypes.Team),
+    loadingTeams: PropTypes.bool,
+    error: PropTypes.instanceOf(Error),
+  };
+
+  renderChildren = ({projects, fetching}) => {
+    if (fetching) {
+      return null;
+    }
+    return <InstallPromptBanner {...this.props} projects={projects} />;
+  };
+
+  render() {
+    return (
+      <Projects orgId={this.props.organization.slug} allProjects>
+        {this.renderChildren}
+      </Projects>
+    );
+  }
+}
+
+export default LightWeightInstallPromptBanner;

--- a/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
@@ -3,11 +3,12 @@ import LazyLoad from 'react-lazyload';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
+import _ from 'lodash';
 
 import {sortProjects} from 'app/utils';
 import {t} from 'app/locale';
+import LoadingError from 'app/components/loadingError';
 import Button from 'app/components/button';
-import ConfigStore from 'app/stores/configStore';
 import IdBadge from 'app/components/idBadge';
 import NoProjectMessage from 'app/components/noProjectMessage';
 import PageHeading from 'app/components/pageHeading';
@@ -18,9 +19,10 @@ import getProjectsByTeams from 'app/utils/getProjectsByTeams';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 import profiler from 'app/utils/profiler';
 import space from 'app/styles/space';
+import LoadingIndicator from 'app/components/loadingIndicator';
+import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
-import withProjects from 'app/utils/withProjects';
-import withTeams from 'app/utils/withTeams';
+import withTeamsForUser from 'app/utils/withTeamsForUser';
 
 import Resources from './resources';
 import TeamSection from './teamSection';
@@ -29,9 +31,10 @@ class Dashboard extends React.Component {
   static propTypes = {
     routes: PropTypes.array,
     teams: PropTypes.array,
-    projects: PropTypes.array,
     organization: SentryTypes.Organization,
     finishProfile: PropTypes.func,
+    loadingTeams: PropTypes.bool,
+    error: PropTypes.instanceOf(Error),
   };
 
   componentDidMount() {
@@ -52,24 +55,35 @@ class Dashboard extends React.Component {
   }
 
   render() {
-    const {teams, projects, params, organization} = this.props;
-    const sortedProjects = sortProjects(projects);
+    const {teams, params, organization, loadingTeams, error} = this.props;
 
-    const {isSuperuser} = ConfigStore.get('user');
-    const {projectsByTeam} = getProjectsByTeams(teams, sortedProjects, isSuperuser);
-    const teamSlugs = Object.keys(projectsByTeam).sort();
+    if (loadingTeams) {
+      return <LoadingIndicator />;
+    }
+
+    if (error) {
+      return <LoadingError message="An error occurred while fetching your projects" />;
+    }
+
+    const filteredTeams = teams.filter(team => team.projects.length);
+    filteredTeams.sort((team1, team2) => team1.slug.localeCompare(team2.slug));
+
+    const projects = _.uniq(_.flatten(teams.map(teamObj => teamObj.projects)), 'id');
     const favorites = projects.filter(project => project.isBookmarked);
 
     const access = new Set(organization.access);
     const canCreateProjects = access.has('project:admin');
-    const teamsMap = new Map(teams.map(teamObj => [teamObj.slug, teamObj]));
     const hasTeamAdminAccess = access.has('team:admin');
 
-    const showEmptyMessage = teamSlugs.length === 0 && favorites.length === 0;
+    const showEmptyMessage = projects.length === 0 && favorites.length === 0;
     const showResources = projects.length === 1 && !projects[0].firstEvent;
 
     if (showEmptyMessage) {
-      return <NoProjectMessage organization={organization}>{null}</NoProjectMessage>;
+      return (
+        <NoProjectMessage organization={organization} projects={projects}>
+          {null}
+        </NoProjectMessage>
+      );
     }
     return (
       <React.Fragment>
@@ -97,11 +111,10 @@ class Dashboard extends React.Component {
           </ProjectsHeader>
         )}
 
-        {teamSlugs.map((slug, index) => {
-          const showBorder = index !== teamSlugs.length - 1;
-          const team = teamsMap.get(slug);
+        {filteredTeams.map((team, index) => {
+          const showBorder = index !== teams.length - 1;
           return (
-            <LazyLoad key={slug} once debounce={50} height={300} offset={300}>
+            <LazyLoad key={team.slug} once debounce={50} height={300} offset={300}>
               <TeamSection
                 orgId={params.orgId}
                 team={team}
@@ -115,7 +128,7 @@ class Dashboard extends React.Component {
                     <IdBadge team={team} avatarSize={22} />
                   )
                 }
-                projects={projectsByTeam[slug]}
+                projects={sortProjects(team.projects)}
                 access={access}
               />
             </LazyLoad>
@@ -155,6 +168,6 @@ const OrganizationDashboardWrapper = styled('div')`
 `;
 
 export {Dashboard};
-export default withTeams(
-  withProjects(withOrganization(profiler()(OrganizationDashboard)))
+export default withApi(
+  withOrganization(withTeamsForUser(profiler()(OrganizationDashboard)))
 );

--- a/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
@@ -15,7 +15,6 @@ import PageHeading from 'app/components/pageHeading';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import ProjectsStatsStore from 'app/stores/projectsStatsStore';
 import SentryTypes from 'app/sentryTypes';
-import getProjectsByTeams from 'app/utils/getProjectsByTeams';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 import profiler from 'app/utils/profiler';
 import space from 'app/styles/space';

--- a/tests/js/spec/utils/withTeamsForUser.spec.jsx
+++ b/tests/js/spec/utils/withTeamsForUser.spec.jsx
@@ -63,8 +63,6 @@ describe('withUserTeams HoC', function() {
         .find('MyComponent')
         .prop('teams')
     ).toEqual(mockTeams);
-
-    expect(TeamActions.loadTeams).toHaveBeenCalledWith(mockTeams);
   });
 
   it('does not fetch teams if information is in organization', async function() {

--- a/tests/js/spec/views/organizationDetails/installPromptBanner.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/installPromptBanner.spec.jsx
@@ -25,4 +25,19 @@ describe('InstallPromptBanner', function() {
     );
     expect(wrapper.find('StyledAlert').exists()).toBe(false);
   });
+
+  it('renders using projects props', function() {
+    const project1 = TestStubs.Project();
+    const project2 = TestStubs.Project({firstEvent: '2018-03-18'});
+    const organization = TestStubs.Organization();
+    const wrapper = shallow(
+      <InstallPromptBanner
+        config={{}}
+        organization={organization}
+        projects={[project1, project2]}
+      />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.find('StyledAlert').exists()).toBe(false);
+  });
 });

--- a/tests/js/spec/views/organizationDetails/lightWeightInstallPromptBanner.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/lightWeightInstallPromptBanner.spec.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {mountWithTheme} from 'sentry-test/enzyme';
+import LightWeightInstallPromptBanner from 'app/views/organizationDetails/lightWeightInstallPromptBanner';
+
+describe('LightWeightInstallPromptBanner', function() {
+  it('renders', async function() {
+    const project1 = TestStubs.Project();
+    const project2 = TestStubs.Project({firstEvent: null});
+    const organization = TestStubs.Organization({projects: [project1, project2]});
+    const getProjectsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project1, project2],
+    });
+    const wrapper = mountWithTheme(
+      <LightWeightInstallPromptBanner organization={organization} />,
+      TestStubs.routerContext()
+    );
+    await tick();
+    wrapper.update();
+    expect(getProjectsMock).toHaveBeenCalled();
+    expect(wrapper.find('StyledAlert').exists()).toBe(true);
+    expect(wrapper.find('a').text()).toContain('Start capturing errors');
+  });
+});

--- a/tests/js/spec/views/organizationDetails/lightWeightInstallPromptBanner.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/lightWeightInstallPromptBanner.spec.jsx
@@ -6,7 +6,7 @@ describe('LightWeightInstallPromptBanner', function() {
   it('renders', async function() {
     const project1 = TestStubs.Project();
     const project2 = TestStubs.Project({firstEvent: null});
-    const organization = TestStubs.Organization({projects: [project1, project2]});
+    const organization = TestStubs.Organization({slug: 'org-slug'});
     const getProjectsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
       body: [project1, project2],

--- a/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
@@ -1,21 +1,31 @@
 import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
 
-import OrganizationDetails from 'app/views/organizationDetails';
+import OrganizationDetails, {
+  LightWeightOrganizationDetails,
+} from 'app/views/organizationDetails';
 import OrganizationStore from 'app/stores/organizationStore';
 
+let tree;
+
 describe('OrganizationDetails', function() {
-  beforeEach(function() {
+  beforeEach(async function() {
     OrganizationStore.reset();
+    await tick();
+
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: '/broadcasts/',
+      url: '/organizations/org-slug/broadcasts/',
       body: [],
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/environments/',
       body: [],
     });
+  });
+
+  afterEach(function() {
+    tree.unmount();
   });
 
   describe('render()', function() {
@@ -31,7 +41,7 @@ describe('OrganizationDetails', function() {
             },
           }),
         });
-        const tree = mountWithTheme(
+        tree = mountWithTheme(
           <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />,
           TestStubs.routerContext()
         );
@@ -56,7 +66,7 @@ describe('OrganizationDetails', function() {
             },
           }),
         });
-        const tree = mountWithTheme(
+        tree = mountWithTheme(
           <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />,
           TestStubs.routerContext()
         );
@@ -88,7 +98,7 @@ describe('OrganizationDetails', function() {
       });
 
       it('should render a deletion in progress prompt', async function() {
-        const tree = mountWithTheme(
+        tree = mountWithTheme(
           <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />,
           TestStubs.routerContext()
         );
@@ -101,5 +111,39 @@ describe('OrganizationDetails', function() {
         expect(tree.find('button[aria-label="Restore Organization"]')).toHaveLength(0);
       });
     });
+  });
+  it('can render a lightweight version of itself and fetches teams', async function() {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/',
+      body: TestStubs.Organization({
+        slug: 'org-slug',
+      }),
+    });
+    const getTeamsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/teams/',
+      body: [TestStubs.Team()],
+    });
+    const getProjectsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [TestStubs.Project()],
+    });
+    tree = mountWithTheme(
+      <LightWeightOrganizationDetails
+        params={{orgId: 'org-slug'}}
+        location={{}}
+        routes={[]}
+        includeSidebar={false}
+      >
+        {null}
+      </LightWeightOrganizationDetails>,
+      TestStubs.routerContext()
+    );
+    await tick();
+    await tick();
+    await tick();
+    tree.update();
+    expect(getTeamsMock).toHaveBeenCalled();
+    expect(getProjectsMock).toHaveBeenCalled();
+    expect(tree.find('LightWeightInstallPromptBanner')).toHaveLength(1);
   });
 });

--- a/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
@@ -11,6 +11,7 @@ let tree;
 describe('OrganizationDetails', function() {
   beforeEach(async function() {
     OrganizationStore.reset();
+    // wait for store reset changes to propagate
     await tick();
 
     MockApiClient.clearMockResponses();
@@ -25,6 +26,7 @@ describe('OrganizationDetails', function() {
   });
 
   afterEach(function() {
+    // necessary to unsubscribe successfully from org store
     tree.unmount();
   });
 

--- a/tests/js/spec/views/projectsDashboard/index.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/index.spec.jsx
@@ -48,10 +48,11 @@ describe('ProjectsDashboard', function() {
 
   describe('empty state', function() {
     it('renders with no projects', function() {
+      const noProjectTeams = [TestStubs.Team({projects: []})];
+
       const wrapper = mountWithTheme(
         <Dashboard
-          teams={teams}
-          projects={[]}
+          teams={noProjectTeams}
           organization={org}
           params={{orgId: org.slug}}
         />,
@@ -65,10 +66,11 @@ describe('ProjectsDashboard', function() {
     it('renders with 1 project, with no first event', function() {
       const projects = [TestStubs.Project({teams})];
 
+      const teamsWithOneProject = [TestStubs.Team({projects})];
+
       const wrapper = mountWithTheme(
         <Dashboard
-          teams={teams}
-          projects={projects}
+          teams={teamsWithOneProject}
           organization={org}
           params={{orgId: org.slug}}
         />,
@@ -96,10 +98,11 @@ describe('ProjectsDashboard', function() {
         }),
       ];
 
+      const teamsWithTwoProjects = [TestStubs.Team({projects})];
+
       const wrapper = shallow(
         <Dashboard
-          teams={teams}
-          projects={projects}
+          teams={teamsWithTwoProjects}
           organization={org}
           params={{orgId: org.slug}}
         />,
@@ -157,6 +160,9 @@ describe('ProjectsDashboard', function() {
           stats: [],
         }),
       ];
+
+      const teamsWithFavProjects = [TestStubs.Team({projects})];
+
       MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/projects/`,
         body: [
@@ -170,8 +176,7 @@ describe('ProjectsDashboard', function() {
       jest.useFakeTimers();
       const wrapper = mountWithTheme(
         <Dashboard
-          teams={teams}
-          projects={projects}
+          teams={teamsWithFavProjects}
           organization={org}
           params={{orgId: org.slug}}
         />,
@@ -231,6 +236,8 @@ describe('ProjectsDashboard', function() {
       }),
     ];
 
+    const teamsWithStatTestProjects = [TestStubs.Team({projects})];
+
     it('uses ProjectsStatsStore to load stats', async function() {
       jest.useFakeTimers();
       ProjectsStatsStore.onStatsLoadSuccess([{...projects[0], stats: [[1517281200, 2]]}]);
@@ -245,8 +252,7 @@ describe('ProjectsDashboard', function() {
 
       const wrapper = mountWithTheme(
         <Dashboard
-          teams={teams}
-          projects={projects}
+          teams={teamsWithStatTestProjects}
           organization={org}
           params={{orgId: org.slug}}
         />,
@@ -282,6 +288,15 @@ describe('ProjectsDashboard', function() {
       // Resets store when it unmounts
       wrapper.unmount();
       expect(ProjectsStatsStore.getAll()).toEqual({});
+    });
+
+    it('renders an error from withTeamsForUser', function() {
+      const wrapper = mountWithTheme(
+        <Dashboard error={Error('uhoh')} organization={org} params={{orgId: org.slug}} />,
+        routerContext
+      );
+
+      expect(wrapper.find('LoadingError').exists()).toBe(true);
     });
   });
 });

--- a/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
@@ -42,4 +42,17 @@ describe('NoProjectMessage', function() {
       true
     );
   });
+
+  it('handles projects from props', function() {
+    const lightWeightOrg = TestStubs.Organization();
+    delete lightWeightOrg.projects;
+
+    const wrapper = shallow(
+      <NoProjectMessage projects={[]} organization={lightWeightOrg} />,
+      TestStubs.routerContext()
+    );
+    expect(
+      wrapper.find('Button[to="/organizations/org-slug/projects/new/"]')
+    ).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
Currently, the projects page relies on OrganizationDetails which fetches the org details, all projects, and all teams which blocks page load for a few seconds with larger customers. The projects page only requires the teams and projects which the user belongs to. A new "lite" version of OrganizationDetails is now being used. To fill in the missing info (user teams and projects) I made use of a new HOC which fetches a user's teams with the projects of that team. This information is forwarded to the projectsDashboard which now exists in a different route tree which uses the "lite" OrganizationDetails. These "lite" versions all have a detailed prop which governs whether they are using the detailed version of organization or not.

Error screen looks like this
![image](https://user-images.githubusercontent.com/9372512/65996991-5d461700-e44d-11e9-81b5-38c3f263cc82.png)


Refs: SEN-1057