### PR TITLE
fix(ui): Fix `<OrganizationBadge>` errors for superusers

### DIFF
--- a/src/sentry/static/sentry/app/components/idBadge/organizationBadge.jsx
+++ b/src/sentry/static/sentry/app/components/idBadge/organizationBadge.jsx
@@ -70,13 +70,13 @@ const OrganizationBadgeContainer = createReactClass({
   },
 
   onOrganizationStoreUpdate() {
-    const org = OrganizationStore.get(this.state.organization.slug);
-    if (isEqual(org.avatar, this.state.organization.avatar)) {
+    const organization = OrganizationStore.get(this.state.organization.slug);
+    if (organization && isEqual(organization.avatar, this.state.organization.avatar)) {
       return;
     }
 
     this.setState({
-      organization: OrganizationStore.get(this.state.organization.slug),
+      organization,
     });
   },
 


### PR DESCRIPTION
There seems to be a potential race condition here where organization is undefined when store updates.

Seems to only affect superusers.

Fixes JAVASCRIPT-1FS7