### PR TITLE
tests(js): Suppress `console.error` in `<OrganizationContext>` tests

### DIFF
--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -121,12 +121,14 @@ describe('OrganizationContext', function() {
       url: '/organizations/org-slug/',
       statusCode: 403,
     });
+    console.error = jest.fn(); // eslint-disable-line no-console
     wrapper = createWrapper();
 
     await tick();
     wrapper.update();
 
     expect(wrapper.find('LoadingError')).toHaveLength(1);
+    console.error.mockRestore(); // eslint-disable-line no-console
   });
 
   it('opens sudo modal for superusers on 403s', async function() {


### PR DESCRIPTION
Suppress `console.error` messages in a test that is intended to test error state.

We intentionally call `console.error` in `<OrganizationContext>` because it can be hard to debug, so just make sure we mock it in the test that goes through this error condition.