### PR TITLE
feat(api): Make message queries use Snuba instead of Postgres

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -16,7 +16,6 @@ from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.models import Group, Release, GroupEnvironment
 from sentry.search.base import SearchBackend
 from sentry.utils import snuba, metrics
-from sentry.utils.db import is_postgres
 
 logger = logging.getLogger("sentry.search.snuba")
 datetime_format = "%Y-%m-%dT%H:%M:%S+00:00"
@@ -247,19 +246,19 @@ class SnubaSearchBackend(SearchBackend):
             "active_at": ScalarCondition("active_at"),
         }
 
-        message = [
-            search_filter for search_filter in search_filters if search_filter.key.name == "message"
-        ]
-        if message and message[0].value.raw_value:
-            message = message[0]
-            # We only support full wildcard matching in postgres
-            if is_postgres() and message.value.is_wildcard():
-                group_queryset = message_regex_filter(group_queryset, message)
-            else:
-                # Otherwise, use the standard LIKE query
-                qs_builder_conditions["message"] = QCallbackCondition(
-                    lambda message: Q(Q(message__icontains=message) | Q(culprit__icontains=message))
-                )
+        # message = [
+        #     search_filter for search_filter in search_filters if search_filter.key.name == "message"
+        # ]
+        # if message and message[0].value.raw_value:
+        #     message = message[0]
+        #     # We only support full wildcard matching in postgres
+        #     if is_postgres() and message.value.is_wildcard():
+        #         group_queryset = message_regex_filter(group_queryset, message)
+        #     else:
+        #         # Otherwise, use the standard LIKE query
+        #         qs_builder_conditions["message"] = QCallbackCondition(
+        #             lambda message: Q(Q(message__icontains=message) | Q(culprit__icontains=message))
+        #         )
 
         group_queryset = QuerySetBuilder(qs_builder_conditions).build(
             group_queryset, search_filters

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -158,19 +158,6 @@ def unassigned_filter(unassigned, projects):
     return query
 
 
-def message_regex_filter(queryset, message):
-    operator = ("!" if message.operator == "!=" else "") + "~*"
-
-    # XXX: We translate these to a regex like '^<pattern>$'. Since we want to
-    # search anywhere in the string, drop those characters.
-    message_value = message.value.value[1:-1]
-
-    return queryset.extra(
-        where=["message {0} %s OR view {0} %s".format(operator)],
-        params=[message_value, message_value],
-    )
-
-
 def get_search_filter(search_filters, name, operator):
     """
     Finds the value of a search filter with the passed name and operator. If
@@ -245,20 +232,6 @@ class SnubaSearchBackend(SearchBackend):
             ),
             "active_at": ScalarCondition("active_at"),
         }
-
-        # message = [
-        #     search_filter for search_filter in search_filters if search_filter.key.name == "message"
-        # ]
-        # if message and message[0].value.raw_value:
-        #     message = message[0]
-        #     # We only support full wildcard matching in postgres
-        #     if is_postgres() and message.value.is_wildcard():
-        #         group_queryset = message_regex_filter(group_queryset, message)
-        #     else:
-        #         # Otherwise, use the standard LIKE query
-        #         qs_builder_conditions["message"] = QCallbackCondition(
-        #             lambda message: Q(Q(message__icontains=message) | Q(culprit__icontains=message))
-        #         )
 
         group_queryset = QuerySetBuilder(qs_builder_conditions).build(
             group_queryset, search_filters
@@ -388,7 +361,7 @@ class SnubaSearchBackend(SearchBackend):
                 not [
                     sf
                     for sf in search_filters
-                    if sf.key.name not in issue_only_fields.union(["date", "message"])
+                    if sf.key.name not in issue_only_fields.union(["date"])
                 ]
             ):
                 group_queryset = group_queryset.order_by("-last_seen")

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -40,7 +40,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             data={
                 "fingerprint": ["put-me-in-group1"],
                 "event_id": "a" * 32,
-                "message": "foo",
+                "message": "foo - but not just any foo. Oh, no no no. meow. This foo is intended to be a better and bigger foo than all the rest. This foo is intended to be over 98 characters or something, so that it gets truncated (???) and I can probably test that we're using snuba for themessage search. And Nalatika is a special word at the end to search for.",
                 "environment": "production",
                 "tags": {"server": "example.com"},
                 "timestamp": event1_timestamp,
@@ -128,7 +128,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
                 "event_id": "a" * 32,
                 "fingerprint": ["put-me-in-groupP2"],
                 "timestamp": iso_format(self.base_datetime - timedelta(days=21)),
-                "message": "foo",
+                "message": "foo - Nalatika",
                 "stacktrace": {"frames": [{"module": "group_p2"}]},
                 "tags": {"server": "example.com"},
                 "environment": "production",
@@ -163,6 +163,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             search_filters = self.build_search_filter(
                 search_filter_query, projects, environments=environments
             )
+
         kwargs = {}
         if limit is not None:
             kwargs["limit"] = limit
@@ -216,11 +217,13 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
 
     def test_query_with_environment_multi_project(self):
         self.set_up_multi_project()
+
         results = self.make_query(
             [self.project, self.project2],
             environments=[self.environments["production"]],
-            search_filter_query="foo",
+            search_filter_query="Nalatika",
         )
+
         assert set(results) == set([self.group1, self.group_p2])
 
         results = self.make_query(

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -40,7 +40,7 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             data={
                 "fingerprint": ["put-me-in-group1"],
                 "event_id": "a" * 32,
-                "message": "This is a really long test message. You can ignore it and skip right to the end, where you will find the only relevant piece of this message. It is a 3 letter piece and it begins with an f. This is a really long test message. You can ignore it and skip right to the end, where you will find the only relevant piece of this message. It is a 3 letter piece and it begins with an f. This is a really long test message. You can ignore it and skip right to the end, where you will find the only relevant piece of this message. It is a 3 letter piece and it begins with an f. And your special word is: foo.",
+                "message": "foo. Also,this message is intended to be greater than 256 characters so that we can put some unique string identifier after that point in the string. The purpose of this is in order to verify we are using snuba to search messsages instead of Postgres (postgres truncates at 256 characters and clickhouse does not). santryrox.",
                 "environment": "production",
                 "tags": {"server": "example.com"},
                 "timestamp": event1_timestamp,
@@ -206,6 +206,15 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
             environments=[self.environments["staging"]], search_filter_query="bar"
         )
         assert set(results) == set([self.group2])
+
+    def test_query_for_text_in_long_message(self):
+        results = self.make_query(
+            [self.project],
+            environments=[self.environments["production"]],
+            search_filter_query="santryrox",
+        )
+
+        assert set(results) == set([self.group1])
 
     def test_multi_environments(self):
         self.set_up_multi_project()

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -226,13 +226,11 @@ class SnubaSearchTest(TestCase, SnubaTestCase):
 
     def test_query_with_environment_multi_project(self):
         self.set_up_multi_project()
-
         results = self.make_query(
             [self.project, self.project2],
             environments=[self.environments["production"]],
             search_filter_query="foo",
         )
-
         assert set(results) == set([self.group1, self.group_p2])
 
         results = self.make_query(


### PR DESCRIPTION
When searching issues, the snuba backend will use postgres results to filter on `message`.

This PR removes this functionality, and we now use Snuba for filtering on messages.