### PR TITLE
feat(discover2) Add a function to detect datasets

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -346,6 +346,9 @@ def detect_dataset(query_args):
     """
     Determine the dataset to use based on the conditions, selected_columns,
     groupby clauses.
+
+    This function operates on the end user field aliases and not the internal column
+    names that have been converted using the field mappings.
     """
     if query_args.get("dataset", None):
         return query_args["dataset"]


### PR DESCRIPTION
As part of the new discover implementation we need to transparently select either the events or transactions dataset based on the query the user provides us. This change also adds the field mappings for the transactions dataset and adds another map that will allow other utility functions to resolve column aliases based on the selected dataset.

Refs SEN-1043