### PR TITLE
ref(discover2) Update aggregations to use list form

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -652,13 +652,7 @@ def get_snuba_query_args(query=None, params=None):
 
 FIELD_ALIASES = {
     "last_seen": {"aggregations": [["max", "timestamp", "last_seen"]]},
-    "latest_event": {
-        "aggregations": [
-            # TODO(mark) This is a hack to work around jsonschema limitations
-            # in snuba.
-            ["argMax(event_id, timestamp)", "", "latest_event"]
-        ]
-    },
+    "latest_event": {"aggregations": [["argMax", ["id", "timestamp"], "latest_event"]]},
     "project": {"fields": ["project.id"]},
     "user": {"fields": ["user.id", "user.name", "user.username", "user.email", "user.ip"]}
     # TODO(mark) Add rpm alias.
@@ -781,7 +775,7 @@ def resolve_field_list(fields, snuba_args):
         if aggregations and "latest_event" not in fields:
             aggregations.extend(deepcopy(FIELD_ALIASES["latest_event"]["aggregations"]))
         if aggregations and "project.id" not in columns:
-            aggregations.append(["argMax(project_id, timestamp)", "", "projectid"])
+            aggregations.append(["argMax", ["project_id", "timestamp"], "projectid"])
 
     if rollup and columns and not aggregations:
         raise InvalidSearchQuery("You cannot use rollup without an aggregate field.")

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -451,7 +451,10 @@ def transform_aliases_and_query(skip_conditions=False, **kwargs):
 
     for aggregation in aggregations or []:
         derived_columns.add(aggregation[2])
-        aggregation[1] = get_snuba_column_name(aggregation[1])
+        if isinstance(aggregation[1], six.string_types):
+            aggregation[1] = get_snuba_column_name(aggregation[1])
+        elif isinstance(aggregation[1], (set, tuple, list)):
+            aggregation[1] = [get_snuba_column_name(col) for col in aggregation[1]]
 
     if not skip_conditions:
         for (col, _value) in six.iteritems(filter_keys):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1097,8 +1097,8 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["selected_columns"] == ["title"]
         assert result["aggregations"] == [
             ["max", "timestamp", "last_seen"],
-            ["argMax(event_id, timestamp)", "", "latest_event"],
-            ["argMax(project_id, timestamp)", "", "projectid"],
+            ["argMax", ["id", "timestamp"], "latest_event"],
+            ["argMax", ["project_id", "timestamp"], "projectid"],
         ]
         assert result["groupby"] == ["title"]
 
@@ -1117,7 +1117,7 @@ class ResolveFieldListTest(unittest.TestCase):
         ]
         assert result["aggregations"] == [
             ["max", "timestamp", "last_seen"],
-            ["argMax(event_id, timestamp)", "", "latest_event"],
+            ["argMax", ["id", "timestamp"], "latest_event"],
         ]
         assert result["groupby"] == [
             "title",
@@ -1139,8 +1139,8 @@ class ResolveFieldListTest(unittest.TestCase):
             ["uniq", "user", "count_unique_user"],
             ["count", "id", "count_id"],
             ["min", "timestamp", "min_timestamp"],
-            ["argMax(event_id, timestamp)", "", "latest_event"],
-            ["argMax(project_id, timestamp)", "", "projectid"],
+            ["argMax", ["id", "timestamp"], "latest_event"],
+            ["argMax", ["project_id", "timestamp"], "projectid"],
         ]
         assert result["groupby"] == []
 
@@ -1149,8 +1149,8 @@ class ResolveFieldListTest(unittest.TestCase):
         result = resolve_field_list(fields, {})
         assert result["aggregations"] == [
             ["uniq", "user.id", "count_unique_user_id"],
-            ["argMax(event_id, timestamp)", "", "latest_event"],
-            ["argMax(project_id, timestamp)", "", "projectid"],
+            ["argMax", ["id", "timestamp"], "latest_event"],
+            ["argMax", ["project_id", "timestamp"], "projectid"],
         ]
 
     def test_aggregate_function_invalid_name(self):
@@ -1217,8 +1217,8 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["selected_columns"] == []
         assert result["aggregations"] == [
             ["max", "timestamp", "last_seen"],
-            ["argMax(event_id, timestamp)", "", "latest_event"],
-            ["argMax(project_id, timestamp)", "", "projectid"],
+            ["argMax", ["id", "timestamp"], "latest_event"],
+            ["argMax", ["project_id", "timestamp"], "projectid"],
         ]
         assert result["groupby"] == []
 
@@ -1230,8 +1230,8 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["aggregations"] == [
             ["count", "id", "count_id"],
             ["uniq", "user", "count_unique_user"],
-            ["argMax(event_id, timestamp)", "", "latest_event"],
-            ["argMax(project_id, timestamp)", "", "projectid"],
+            ["argMax", ["id", "timestamp"], "latest_event"],
+            ["argMax", ["project_id", "timestamp"], "projectid"],
         ]
         assert result["groupby"] == []
 


### PR DESCRIPTION
Snuba now supports list style aggregations that need multiple parameters. Having separate fields is a pre-requisite for multi-dataset queries as we need to re-alias `timestamp` depending on which dataset is being used.

Refs SEN-1043