### PR TITLE
perf(reports): Prepare reports 3h earlier to avoid conflict with Monday morning traffic increase.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -683,7 +683,7 @@ CELERYBEAT_SCHEDULE = {
     "schedule-weekly-organization-reports": {
         "task": "sentry.tasks.reports.prepare_reports",
         "schedule": crontab(
-            minute=0, hour=12, day_of_week="monday"  # 05:00 PDT, 09:00 EDT, 12:00 UTC
+            minute=0, hour=9, day_of_week="monday"  # 02:00 PDT, 06:00 EDT, 9:00 UTC
         ),
         "options": {"expires": 60 * 60 * 3},
     },


### PR DESCRIPTION
Starting at 5am runs into the tail end of 7-8am traffic increase and puts an unnecessary amount of load on things.

Goal of starting this earlier was for folks to read the email Monday as they go into work. We can probably start this earlier now that it takes much longer to finish.