### PR TITLE
feat(discover2) Remove the discover query builder flag

### DIFF
--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -21,6 +21,7 @@ class DiscoverSavedQuerySerializer(Serializer):
             "end",
             "orderby",
             "limit",
+            "version",
         ]
 
         data = {

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -816,8 +816,6 @@ SENTRY_FEATURES = {
     "organizations:create": True,
     # Enable the 'discover' interface.
     "organizations:discover": False,
-    # Enable the Discover v2 query builder
-    "organizations:discover-v2-query-builder": False,
     # Enable attaching arbitrary files to events.
     "organizations:event-attachments": False,
     # Allow organizations to configure built-in symbol sources.

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -97,7 +97,6 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
             )
 
     def post(self, request, organization):
-
         if not features.has("organizations:discover", organization, actor=request.user):
             return Response(status=404)
 

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -16,9 +16,7 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
     def has_feature(self, organization, request):
         return features.has(
             "organizations:discover", organization, actor=request.user
-        ) or features.has(
-            "organizations:discover-v2-query-builder", organization, actor=request.user
-        )
+        ) or features.has("organizations:events-v2", organization, actor=request.user)
 
     def get(self, request, organization):
         """

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -16,9 +16,7 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
     def has_feature(self, organization, request):
         return features.has(
             "organizations:discover", organization, actor=request.user
-        ) or features.has(
-            "organizations:discover-v2-query-builder", organization, actor=request.user
-        )
+        ) or features.has("organizations:events-v2", organization, actor=request.user)
 
     def get(self, request, organization, query_id):
         """

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -57,7 +57,6 @@ default_manager.add("organizations:advanced-search", OrganizationFeature)  # NOQ
 default_manager.add("organizations:boolean-search", OrganizationFeature)  # NOQA
 default_manager.add("organizations:api-keys", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover", OrganizationFeature)  # NOQA
-default_manager.add("organizations:discover-v2-query-builder", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:event-attachments", OrganizationFeature)  # NOQA

--- a/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
@@ -6,7 +6,6 @@ import {Client} from 'app/api';
 import AutoComplete from 'app/components/autoComplete';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
-import Feature from 'app/components/acl/feature';
 import {
   fetchSavedQueries,
   deleteSavedQuery,
@@ -15,7 +14,7 @@ import Highlight from 'app/components/highlight';
 import InlineSvg from 'app/components/inlineSvg';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
-import {SavedQuery} from 'app/views/discover/types';
+import {SavedQuery} from 'app/stores/discoverSavedQueriesStore';
 import EventView from 'app/views/eventsV2/eventView';
 
 import {domId} from 'app/utils/domId';
@@ -45,9 +44,7 @@ class Discover2Item extends React.Component<Props, State> {
 
   componentDidMount() {
     const {api, organization} = this.props;
-    if (organization.features.includes('discover-v2-query-builder')) {
-      fetchSavedQueries(api, organization.slug);
-    }
+    fetchSavedQueries(api, organization.slug);
     this.menuId = domId('discover-menu');
   }
 
@@ -61,7 +58,7 @@ class Discover2Item extends React.Component<Props, State> {
     this.setState({isOpen: false});
   };
 
-  handleSelect = item => {
+  handleSelect = (item: SavedQuery) => {
     const {organization} = this.props;
     const target = {
       pathname: `/organizations/${organization.slug}/eventsv2/`,
@@ -70,7 +67,7 @@ class Discover2Item extends React.Component<Props, State> {
     browserHistory.push(target);
   };
 
-  handleEdit = (event, item) => {
+  handleEdit = (event: React.MouseEvent<Element>, item: SavedQuery) => {
     event.preventDefault();
     event.stopPropagation();
     const {organization} = this.props;
@@ -153,47 +150,41 @@ class Discover2Item extends React.Component<Props, State> {
     const inputId = `${this.menuId}-input`;
 
     return (
-      <Feature
-        features={['discover-v2-query-builder']}
-        organization={organization}
-        renderDisabled={() => sidebarItem}
-      >
-        <nav {...navProps}>
-          {sidebarItem}
-          <AutoComplete
-            inputIsActor={false}
-            itemToString={item => item.name}
-            isOpen={isOpen}
-            onSelect={this.handleSelect}
-            resetInputOnClose
-          >
-            {({getInputProps, getItemProps, inputValue, highlightedIndex}) => {
-              return (
-                <Hitbox role="menu" id={this.menuId} isOpen={isOpen}>
-                  <InputContainer>
-                    <StyledLabel htmlFor={inputId}>
-                      <InlineSvg src="icon-search" size="16" />
-                    </StyledLabel>
-                    <StyledInput
-                      type="text"
-                      id={inputId}
-                      placeholder={t('Filter searches')}
-                      {...getInputProps({})}
-                    />
-                  </InputContainer>
-                  <Menu>
-                    {this.renderSavedQueries({
-                      getItemProps,
-                      inputValue,
-                      highlightedIndex,
-                    })}
-                  </Menu>
-                </Hitbox>
-              );
-            }}
-          </AutoComplete>
-        </nav>
-      </Feature>
+      <nav {...navProps}>
+        {sidebarItem}
+        <AutoComplete
+          inputIsActor={false}
+          itemToString={item => item.name}
+          isOpen={isOpen}
+          onSelect={this.handleSelect}
+          resetInputOnClose
+        >
+          {({getInputProps, getItemProps, inputValue, highlightedIndex}) => {
+            return (
+              <Hitbox role="menu" id={this.menuId} isOpen={isOpen}>
+                <InputContainer>
+                  <StyledLabel htmlFor={inputId}>
+                    <InlineSvg src="icon-search" size="16" />
+                  </StyledLabel>
+                  <StyledInput
+                    type="text"
+                    id={inputId}
+                    placeholder={t('Filter searches')}
+                    {...getInputProps({})}
+                  />
+                </InputContainer>
+                <Menu>
+                  {this.renderSavedQueries({
+                    getItemProps,
+                    inputValue,
+                    highlightedIndex,
+                  })}
+                </Menu>
+              </Hitbox>
+            );
+          }}
+        </AutoComplete>
+      </nav>
     );
   }
 }

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -343,7 +343,7 @@ export type EventViewv1 = {
   name: string;
   data: {
     fields: string[];
-    columnNames: string[];
+    fieldnames: string[];
     sort: string[];
     query?: string;
   };

--- a/src/sentry/static/sentry/app/utils/withDiscoverSavedQueries.tsx
+++ b/src/sentry/static/sentry/app/utils/withDiscoverSavedQueries.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 
-import DiscoverSavedQueriesStore from 'app/stores/discoverSavedQueriesStore';
+import DiscoverSavedQueriesStore, {
+  SavedQuery,
+} from 'app/stores/discoverSavedQueriesStore';
 import getDisplayName from 'app/utils/getDisplayName';
-import {SavedQuery} from 'app/views/discover/types';
 
 type InjectedDiscoverSavedQueriesProps = {
   savedQueries: SavedQuery[];
@@ -44,11 +45,10 @@ const withDiscoverSavedQueries = <P extends InjectedDiscoverSavedQueriesProps>(
     },
 
     updateQueries() {
-      const state = DiscoverSavedQueriesStore.get();
-
-      if (this.state.savedQueries !== state.savedQueries) {
-        this.setState({savedQueries: state.savedQueries});
-      }
+      const queries = DiscoverSavedQueriesStore.get().savedQueries.filter(
+        (item: SavedQuery) => item.version === 2
+      );
+      this.setState({savedQueries: queries});
     },
 
     render() {

--- a/src/sentry/static/sentry/app/views/discover/types.tsx
+++ b/src/sentry/static/sentry/app/views/discover/types.tsx
@@ -7,6 +7,7 @@ export type Query = {
   fields: string[];
   aggregations: Aggregation[];
   conditions?: Condition[];
+  version?: number;
   query?: string;
   orderby?: string;
   limit?: number;

--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -24,7 +24,7 @@ export const DEFAULT_EVENT_VIEW_V1: Readonly<EventViewv1> = {
   name: t('All Events'),
   data: {
     fields: ['title', 'event.type', 'project', 'user', 'timestamp'],
-    columnNames: ['title', 'type', 'project', 'user', 'time'],
+    fieldnames: ['title', 'type', 'project', 'user', 'time'],
     sort: ['-timestamp'],
   },
   tags: ['event.type', 'release', 'project.name', 'user.email', 'user.ip', 'environment'],
@@ -36,7 +36,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     name: t('Project Summary'),
     data: {
       fields: ['project', 'count()', 'count_unique(issue.id)'],
-      columnNames: ['project', 'events', 'unique errors'],
+      fieldnames: ['project', 'events', 'unique errors'],
       sort: ['-count'],
       query: 'event.type:error',
     },
@@ -46,7 +46,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     name: t('Errors'),
     data: {
       fields: ['title', 'count()', 'count_unique(user)', 'project', 'last_seen'],
-      columnNames: ['error', 'events', 'users', 'project', 'last seen'],
+      fieldnames: ['error', 'events', 'users', 'project', 'last seen'],
       sort: ['-count', '-title'],
       query: 'event.type:error',
     },
@@ -56,7 +56,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     name: t('Errors by URL'),
     data: {
       fields: ['url', 'count()', 'count_unique(issue.id)'],
-      columnNames: ['URL', 'events', 'unique errors'],
+      fieldnames: ['URL', 'events', 'unique errors'],
       sort: ['-count'],
       query: 'event.type:error',
     },
@@ -66,7 +66,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     name: t('Errors by User'),
     data: {
       fields: ['user', 'count()', 'count_unique(issue.id)'],
-      columnNames: ['User', 'events', 'unique errors'],
+      fieldnames: ['User', 'events', 'unique errors'],
       sort: ['-count'],
       query: 'event.type:error',
     },
@@ -76,7 +76,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     name: t('CSP'),
     data: {
       fields: ['title', 'count()', 'count_unique(user)', 'project', 'last_seen'],
-      columnNames: ['csp', 'events', 'users', 'project', 'last seen'],
+      fieldnames: ['csp', 'events', 'users', 'project', 'last seen'],
       sort: ['-count', '-title'],
       query: 'event.type:csp',
     },
@@ -92,7 +92,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     name: t('CSP Report by Directive'),
     data: {
       fields: ['effective-directive', 'count()', 'count_unique(title)'],
-      columnNames: ['directive', 'events', 'reports'],
+      fieldnames: ['directive', 'events', 'reports'],
       sort: ['-count'],
       query: 'event.type:csp',
     },
@@ -102,7 +102,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     name: t('CSP Report by Blocked URI'),
     data: {
       fields: ['blocked-uri', 'count()'],
-      columnNames: ['URI', 'events'],
+      fieldnames: ['URI', 'events'],
       sort: ['-count'],
       query: 'event.type:csp',
     },
@@ -112,7 +112,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     name: t('CSP Report by User'),
     data: {
       fields: ['user', 'count()', 'count_unique(title)'],
-      columnNames: ['User', 'events', 'reports'],
+      fieldnames: ['User', 'events', 'reports'],
       sort: ['-count'],
       query: 'event.type:csp',
     },
@@ -122,7 +122,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     name: t('Transactions'),
     data: {
       fields: ['transaction', 'project', 'count()'],
-      columnNames: ['transaction', 'project', 'volume'],
+      fieldnames: ['transaction', 'project', 'volume'],
       sort: ['-count'],
       query: 'event.type:transaction',
     },
@@ -132,7 +132,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     name: t('Transactions by User'),
     data: {
       fields: ['user', 'count()', 'count_unique(transaction)'],
-      columnNames: ['user', 'events', 'unique transactions'],
+      fieldnames: ['user', 'events', 'unique transactions'],
       sort: ['-count'],
       query: 'event.type:transaction',
     },
@@ -142,7 +142,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     name: t('Transactions by Region'),
     data: {
       fields: ['geo.region', 'count()'],
-      columnNames: ['Region', 'events'],
+      fieldnames: ['Region', 'events'],
       sort: ['-count'],
       query: 'event.type:transaction',
     },

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -29,17 +29,17 @@ const decodeFields = (location: Location): Array<Field> => {
   }
 
   const fields: string[] = isString(query.field) ? [query.field] : query.field;
-  const aliases: string[] = Array.isArray(query.alias)
-    ? query.alias
-    : isString(query.alias)
-    ? [query.alias]
+  const fieldnames: string[] = Array.isArray(query.fieldnames)
+    ? query.fieldnames
+    : isString(query.fieldnames)
+    ? [query.fieldnames]
     : [];
 
   const parsed: Field[] = [];
   fields.forEach((field, i) => {
     let title = field;
-    if (aliases[i]) {
-      title = aliases[i];
+    if (fieldnames[i]) {
+      title = fieldnames[i];
     }
     parsed.push({field, title});
   });
@@ -239,7 +239,7 @@ class EventView {
     const fields = eventViewV1.data.fields.map((fieldName: string, index: number) => {
       return {
         field: fieldName,
-        title: eventViewV1.data.columnNames[index],
+        title: eventViewV1.data.fieldnames[index],
       };
     });
 
@@ -301,11 +301,10 @@ class EventView {
   }
 
   generateQueryStringObject(): Query {
-    // TODO(mark) normalize naming conventions for aliases to be more consistent.
     const output = {
       id: this.id,
       field: this.fields.map(item => item.field),
-      alias: this.fields.map(item => item.title),
+      fieldnames: this.fields.map(item => item.title),
       sort: encodeSorts(this.sorts),
       tag: this.tags,
       query: this.query,

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -100,17 +100,12 @@ class EventsV2 extends React.Component<Props> {
                     {pageTitle} <BetaTag />
                   </PageHeading>
                   {hasQuery && (
-                    <Feature
+                    <EventsSaveQueryButton
+                      isEditing={!!location.query.edit}
+                      location={location}
                       organization={organization}
-                      features={['discover-v2-query-builder']}
-                    >
-                      <EventsSaveQueryButton
-                        isEditing={!!location.query.edit}
-                        location={location}
-                        organization={organization}
-                        eventView={eventView}
-                      />
-                    </Feature>
+                      eventView={eventView}
+                    />
                   )}
                 </PageHeader>
                 {!hasQuery && this.renderQueryList()}

--- a/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
@@ -34,12 +34,26 @@ type State = {
 };
 
 class EventsSaveQueryButton extends React.Component<Props, State> {
-  constructor(props) {
-    super(props);
+  state = {
+    queryName: '',
+  };
 
-    this.state = {
-      queryName: props.isEditing ? props.eventView.name : '',
-    };
+  componentDidUpdate(prevProps: Props) {
+    // Going from one query to another whilst not leaving edit mode
+    if (
+      this.props.isEditing === true &&
+      this.props.eventView.id !== prevProps.eventView.id
+    ) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({queryName: this.props.eventView.name || ''});
+    }
+    // entering or leaving edit mode
+    if (this.props.isEditing !== prevProps.isEditing) {
+      const queryName =
+        this.props.isEditing === true ? this.props.eventView.name || '' : '';
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({queryName});
+    }
   }
 
   swallowEvent = (event: React.MouseEvent) => {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -78,7 +78,7 @@ class Table extends React.PureComponent<TableProps, TableState> {
     if (
       this.props.location !== prevProps.location ||
       this.props.location.query !== prevProps.location.query ||
-      this.props.location.query.alias !== prevProps.location.query.alias ||
+      this.props.location.query.fieldnames !== prevProps.location.query.fieldnames ||
       this.props.location.query.field !== prevProps.location.query.field ||
       this.props.location.query.sort !== prevProps.location.query.sort
     ) {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -62,7 +62,7 @@ class TableView extends React.Component<TableViewProps, TableState> {
     return {
       columnOrder: decodeColumnOrder({
         field: eventView.getFieldNames(),
-        alias: eventView.getFieldTitles(),
+        fieldnames: eventView.getFieldTitles(),
       }),
       columnSortBy: decodeColumnSortBy({
         sort: eventView.getDefaultSort(),

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -1,18 +1,9 @@
 import React from 'react';
 import {Location} from 'history';
-import {omit} from 'lodash';
-import styled from 'react-emotion';
 
-import {t} from 'app/locale';
 import {Organization} from 'app/types';
-import space from 'app/styles/space';
 
-import Alert from 'app/components/alert';
-import EmptyStateWarning from 'app/components/emptyStateWarning';
 import GridEditable from 'app/components/gridEditable';
-import LoadingContainer from 'app/components/loading/loadingContainer';
-import Panel from 'app/components/panels/panel';
-import Placeholder from 'app/components/placeholder';
 
 import {
   decodeColumnOrder,
@@ -35,9 +26,6 @@ export type TableViewProps = {
   eventView: EventView;
   tableData: TableData | null | undefined;
 };
-export type TableViewState = TableState & {
-  hasFlagQueryBuilder: boolean;
-};
 
 /**
  * `TableView` is currently in turmoil as it is containing 2 implementations
@@ -51,7 +39,7 @@ export type TableViewState = TableState & {
  * is coupled to the `Location` object and derives its state entirely from it.
  * It implements methods to mutate the column state in `Location.query`.
  */
-class TableView extends React.Component<TableViewProps, TableViewState> {
+class TableView extends React.Component<TableViewProps, TableState> {
   constructor(props) {
     super(props);
 
@@ -65,19 +53,13 @@ class TableView extends React.Component<TableViewProps, TableViewState> {
   state = {
     columnOrder: [],
     columnSortBy: [],
-    hasFlagQueryBuilder: false,
-  } as TableViewState;
+  } as TableState;
 
-  static getDerivedStateFromProps(props: TableViewProps): TableViewState {
-    const hasFlagQueryBuilder = props.organization.features.includes(
-      'discover-v2-query-builder'
-    );
-
+  static getDerivedStateFromProps(props: TableViewProps): TableState {
     // Avoid using props.location to get derived state.
     const {eventView} = props;
 
     return {
-      hasFlagQueryBuilder,
       columnOrder: decodeColumnOrder({
         field: eventView.getFieldNames(),
         alias: eventView.getFieldTitles(),
@@ -191,141 +173,21 @@ class TableView extends React.Component<TableViewProps, TableViewState> {
     column: TableColumn<keyof TableDataRow>,
     dataRow: TableDataRow
   ): React.ReactNode => {
-    const {location, organization, tableData} = this.props;
-
+    const {location, organization, tableData, eventView} = this.props;
     if (!tableData) {
       return dataRow[column.key];
     }
+    const hasLinkField = eventView.hasAutolinkField();
+    const forceLink =
+      !hasLinkField && eventView.getFieldNames().indexOf(column.field) === 0;
 
-    const fieldRenderer = getFieldRenderer(String(column.key), tableData.meta, true);
+    const fieldRenderer = getFieldRenderer(String(column.key), tableData.meta, forceLink);
     return fieldRenderer(dataRow, {organization, location});
   };
 
-  renderHeader = () => {
-    const {eventView, location, tableData} = this.props;
-
-    if (eventView.fields.length <= 0) {
-      return null;
-    }
-
-    const defaultSort = eventView.getDefaultSort() || eventView.fields[0].field;
-
-    return eventView.fields.map((field, index) => {
-      if (!tableData) {
-        return <PanelHeaderCell key={index}>{field.title}</PanelHeaderCell>;
-      }
-
-      const {meta} = tableData;
-      const sortKey = eventView.getSortKey(field.field, meta);
-
-      if (sortKey === null) {
-        return <PanelHeaderCell key={index}>{field.title}</PanelHeaderCell>;
-      }
-
-      return (
-        <PanelHeaderCell key={index}>
-          <SortLink
-            defaultSort={defaultSort}
-            sortKey={sortKey}
-            title={field.title}
-            location={location}
-          />
-        </PanelHeaderCell>
-      );
-    });
-  };
-
-  renderContent = (): React.ReactNode => {
-    const {
-      isLoading,
-      tableData: dataPayload,
-      eventView,
-      organization,
-      location,
-    } = this.props;
-
-    if (isLoading && !dataPayload) {
-      return (
-        <PanelGridInfo numOfCols={eventView.numOfColumns()}>
-          <Placeholder height="240px" width="100%" />
-        </PanelGridInfo>
-      );
-    }
-    if (!(dataPayload && dataPayload.data && dataPayload.data.length > 0)) {
-      return (
-        <PanelGridInfo numOfCols={eventView.numOfColumns()}>
-          <EmptyStateWarning>
-            <p>{t('No results found')}</p>
-          </EmptyStateWarning>
-        </PanelGridInfo>
-      );
-    }
-
-    const {meta} = dataPayload;
-    const fields = eventView.getFieldNames();
-    const lastRowIndex = dataPayload.data.length - 1;
-    const hasLinkField = eventView.hasAutolinkField();
-    const firstCellIndex = 0;
-    const lastCellIndex = fields.length - 1;
-
-    return dataPayload.data.map((row, rowIndex) => {
-      return (
-        <React.Fragment key={rowIndex}>
-          {fields.map((field, columnIndex) => {
-            const key = `${columnIndex}.${field}`;
-            const forceLinkField = !hasLinkField && columnIndex === 0;
-
-            const fieldRenderer = getFieldRenderer(field, meta, forceLinkField);
-            return (
-              <PanelItemCell
-                hideBottomBorder={rowIndex === lastRowIndex}
-                style={{
-                  paddingLeft: columnIndex === firstCellIndex ? space(1) : void 0,
-                  paddingRight: columnIndex === lastCellIndex ? space(1) : void 0,
-                }}
-                key={key}
-              >
-                {fieldRenderer(row, {organization, location})}
-              </PanelItemCell>
-            );
-          })}
-        </React.Fragment>
-      );
-    });
-  };
-
-  renderTable() {
-    const {isLoading, tableData: dataPayload} = this.props;
-    return (
-      <React.Fragment>
-        {this.renderHeader()}
-        {isLoading && (
-          <FloatingLoadingContainer
-            isLoading={true}
-            isReloading={isLoading && !!dataPayload}
-          />
-        )}
-        {this.renderContent()}
-      </React.Fragment>
-    );
-  }
-
-  renderError() {
-    const {error, eventView} = this.props;
-    return (
-      <React.Fragment>
-        <Alert type="error" icon="icon-circle-exclamation">
-          {error}
-        </Alert>
-        {this.renderHeader()}
-        <PanelGrid numOfCols={eventView.numOfColumns()}>{this.renderHeader()}</PanelGrid>
-      </React.Fragment>
-    );
-  }
-
   render() {
-    const {eventView, isLoading, error, tableData} = this.props;
-    const {hasFlagQueryBuilder, columnOrder, columnSortBy} = this.state;
+    const {isLoading, error, tableData} = this.props;
+    const {columnOrder, columnSortBy} = this.state;
     const {
       renderModalBodyWithForm,
       renderModalFooter,
@@ -334,124 +196,29 @@ class TableView extends React.Component<TableViewProps, TableViewState> {
       updateColumn: this._updateColumn,
     });
 
-    if (hasFlagQueryBuilder) {
-      return (
-        <GridEditable
-          isEditable={hasFlagQueryBuilder}
-          isLoading={isLoading}
-          error={error}
-          data={tableData ? tableData.data : []}
-          columnOrder={columnOrder}
-          columnSortBy={columnSortBy}
-          grid={{
-            renderHeaderCell: this._renderGridHeaderCell as any,
-            renderBodyCell: this._renderGridBodyCell as any,
-          }}
-          modalEditColumn={{
-            renderBodyWithForm: renderModalBodyWithForm as any,
-            renderFooter: renderModalFooter,
-          }}
-          actions={{
-            deleteColumn: this._deleteColumn,
-            moveColumn: this._moveColumn,
-          }}
-        />
-      );
-    }
-
-    // GridResizable has its own error-handling, but PanelGrid does not.
-    if (error) {
-      return this.renderError();
-    }
-
     return (
-      <PanelGrid numOfCols={eventView.numOfColumns()}>{this.renderTable()}</PanelGrid>
+      <GridEditable
+        isEditable={true}
+        isLoading={isLoading}
+        error={error}
+        data={tableData ? tableData.data : []}
+        columnOrder={columnOrder}
+        columnSortBy={columnSortBy}
+        grid={{
+          renderHeaderCell: this._renderGridHeaderCell as any,
+          renderBodyCell: this._renderGridBodyCell as any,
+        }}
+        modalEditColumn={{
+          renderBodyWithForm: renderModalBodyWithForm as any,
+          renderFooter: renderModalFooter,
+        }}
+        actions={{
+          deleteColumn: this._deleteColumn,
+          moveColumn: this._moveColumn,
+        }}
+      />
     );
   }
 }
 
 export default TableView;
-
-type PanelGridProps = {
-  numOfCols: number;
-};
-const PanelGrid = styled((props: PanelGridProps) => {
-  const otherProps = omit(props, 'numOfCols');
-  return <Panel {...otherProps} />;
-})<PanelGridProps>`
-  display: grid;
-
-  overflow-x: auto;
-
-  ${(props: PanelGridProps) => {
-    const firstColumn = '3fr';
-
-    function generateRestColumns(): string {
-      if (props.numOfCols <= 1) {
-        return '';
-      }
-
-      return `repeat(${props.numOfCols - 1}, auto)`;
-    }
-
-    return `
-      grid-template-columns:  ${firstColumn} ${generateRestColumns()};
-    `;
-  }};
-`;
-
-const PanelHeaderCell = styled('div')`
-  color: ${p => p.theme.gray3};
-  font-size: 13px;
-  font-weight: 600;
-  text-transform: uppercase;
-  border-bottom: 1px solid ${p => p.theme.borderDark};
-  background: ${p => p.theme.offWhite};
-  line-height: 1;
-
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-
-  padding: ${space(2)};
-
-  /**
-   * By default, a grid item cannot be smaller than the size of its content.
-   * We override this by setting it to be 0.
-   */
-  min-width: 0;
-`;
-
-type PanelGridInfoProps = {
-  numOfCols: number;
-};
-
-const PanelGridInfo = styled('div')<PanelGridInfoProps>`
-  ${(props: PanelGridInfoProps) => {
-    return `grid-column: 1 / span ${props.numOfCols};`;
-  }};
-`;
-
-const PanelItemCell = styled('div')<{hideBottomBorder: boolean}>`
-  border-bottom: ${p =>
-    p.hideBottomBorder ? 'none' : `1px solid ${p.theme.borderLight}`};
-
-  font-size: ${p => p.theme.fontSizeMedium};
-
-  padding-top: ${space(1)};
-  padding-bottom: ${space(1)};
-
-  /**
-   * By default, a grid item cannot be smaller than the size of its content.
-   * We override this by setting it to be 0.
-   */
-  min-width: 0;
-`;
-
-const FloatingLoadingContainer = styled(LoadingContainer)<LoadingContainer['props']>`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-`;

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -219,7 +219,7 @@ export function getFirstQueryString(
 export type QueryWithColumnState =
   | Query
   | {
-      alias: string | string[] | null | undefined;
+      fieldnames: string | string[] | null | undefined;
       field: string | string[] | null | undefined;
       sort: string | string[] | null | undefined;
     };
@@ -246,21 +246,21 @@ export function decodeColumnOrderAndColumnSortBy(location: Location): TableState
 export function decodeColumnOrder(
   query: QueryWithColumnState
 ): TableColumn<React.ReactText>[] {
-  const {alias, field} = query;
+  const {fieldnames, field} = query;
   const columnsRaw: {
     aggregationField: string;
     name: string;
   }[] = [];
 
-  if (typeof alias === 'string' && typeof field === 'string') {
-    columnsRaw.push({aggregationField: field, name: alias});
+  if (typeof fieldnames === 'string' && typeof field === 'string') {
+    columnsRaw.push({aggregationField: field, name: fieldnames});
   } else if (
-    Array.isArray(alias) &&
+    Array.isArray(fieldnames) &&
     Array.isArray(field) &&
-    alias.length === field.length
+    fieldnames.length === field.length
   ) {
     field.forEach((f, i) => {
-      columnsRaw.push({aggregationField: f, name: alias[i]});
+      columnsRaw.push({aggregationField: f, name: fieldnames[i]});
     });
   }
 
@@ -312,13 +312,13 @@ export function encodeColumnOrderAndColumnSortBy(
   tableState: TableState
 ): QueryWithColumnState {
   return {
-    alias: encodeColumnAlias(tableState),
+    fieldnames: encodeColumnFieldName(tableState),
     field: encodeColumnField(tableState),
     sort: encodeColumnSort(tableState),
   };
 }
 
-function encodeColumnAlias(tableState: TableState): string[] {
+function encodeColumnFieldName(tableState: TableState): string[] {
   return tableState.columnOrder.map(col => col.name);
 }
 

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -8,7 +8,7 @@ from sentry.utils.samples import load_data
 from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
-FEATURE_NAMES = ("organizations:events-v2", "organizations:discover-v2-query-builder")
+FEATURE_NAMES = "organizations:events-v2"
 
 all_view = "field=title&field=event.type&field=project&field=user&field=timestamp&alias=title&alias=type&alias=project&alias=user&alias=time&name=All+Events&sort=-timestamp&tag=event.type&tag=release&tag=project.name&tag=user.email&tag=user.ip&tag=environment"
 error_view = "field=title&alias=error&field=count%28id%29&alias=events&field=count_unique%28user%29&alias=users&field=project&alias=project&field=last_seen&alias=last+seen&name=Errors&query=event.type%3Aerror&sort=-last_seen&sort=-title&tag=error.type&tag=project.name"

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -10,8 +10,8 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 FEATURE_NAMES = "organizations:events-v2"
 
-all_view = "field=title&field=event.type&field=project&field=user&field=timestamp&alias=title&alias=type&alias=project&alias=user&alias=time&name=All+Events&sort=-timestamp&tag=event.type&tag=release&tag=project.name&tag=user.email&tag=user.ip&tag=environment"
-error_view = "field=title&alias=error&field=count%28id%29&alias=events&field=count_unique%28user%29&alias=users&field=project&alias=project&field=last_seen&alias=last+seen&name=Errors&query=event.type%3Aerror&sort=-last_seen&sort=-title&tag=error.type&tag=project.name"
+all_view = "field=title&field=event.type&field=project&field=user&field=timestamp&fieldnames=title&fieldnames=type&fieldnames=project&fieldnames=user&fieldnames=time&name=All+Events&sort=-timestamp&tag=event.type&tag=release&tag=project.name&tag=user.email&tag=user.ip&tag=environment"
+error_view = "field=title&fieldnames=error&field=count%28id%29&fieldnames=events&field=count_unique%28user%29&fieldnames=users&field=project&fieldnames=project&field=last_seen&fieldnames=last+seen&name=Errors&query=event.type%3Aerror&sort=-last_seen&sort=-title&tag=error.type&tag=project.name"
 
 
 class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):

--- a/tests/js/spec/components/sidebar/discover2Item.spec.jsx
+++ b/tests/js/spec/components/sidebar/discover2Item.spec.jsx
@@ -21,6 +21,7 @@ describe('Sidebar > Discover2Item', function() {
       body: [
         {
           id: '1',
+          version: 2,
           name: 'first query',
           fields: ['title', 'count()'],
           dateCreated: now,
@@ -30,6 +31,15 @@ describe('Sidebar > Discover2Item', function() {
         {
           id: '2',
           name: 'second query',
+          version: 2,
+          fields: ['transaction', 'count()'],
+          dateCreated: now,
+          dateUpdated: now,
+          createdBy: '1',
+        },
+        {
+          id: '2',
+          name: 'old query',
           fields: ['transaction', 'count()'],
           dateCreated: now,
           dateUpdated: now,
@@ -45,17 +55,7 @@ describe('Sidebar > Discover2Item', function() {
     DiscoverSavedQueriesStore.reset();
   });
 
-  it('renders no menu when feature is off', async function() {
-    const wrapper = makeWrapper({organization, client});
-    // Wait for reflux
-    await tick();
-
-    const menu = wrapper.find('AutoComplete');
-    expect(menu).toHaveLength(0);
-  });
-
-  it('renders a menu when feature is on', async function() {
-    organization.features.push('discover-v2-query-builder');
+  it('renders a menu', async function() {
     const wrapper = makeWrapper({organization, client});
     // Wait for reflux
     await tick();
@@ -65,7 +65,6 @@ describe('Sidebar > Discover2Item', function() {
   });
 
   it('opens the menu', async function() {
-    organization.features.push('discover-v2-query-builder');
     const wrapper = makeWrapper({organization, client});
     // Wait for reflux
     await tick();
@@ -78,6 +77,7 @@ describe('Sidebar > Discover2Item', function() {
     const menu = wrapper.find('Menu');
     expect(menu).toHaveLength(1);
 
+    // Old versionless items should be excluded
     const menuItems = menu.find('MenuItem');
     expect(menuItems).toHaveLength(2);
   });
@@ -87,7 +87,6 @@ describe('Sidebar > Discover2Item', function() {
       url: '/organizations/org-slug/discover/saved/1/',
       method: 'DELETE',
     });
-    organization.features.push('discover-v2-query-builder');
     const wrapper = makeWrapper({organization, client});
     // Wait for reflux
     await tick();
@@ -104,7 +103,6 @@ describe('Sidebar > Discover2Item', function() {
   });
 
   it('handles edit buttons', async function() {
-    organization.features.push('discover-v2-query-builder');
     const wrapper = makeWrapper({organization, client});
     // Wait for reflux
     await tick();

--- a/tests/js/spec/utils/withDiscoverSavedQueries.spec.jsx
+++ b/tests/js/spec/utils/withDiscoverSavedQueries.spec.jsx
@@ -19,6 +19,7 @@ describe('withDiscoverSavedQueries HoC', function() {
     // Insert into the store
     const query = {
       id: '1',
+      version: 2,
       fields: ['title', 'count()'],
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -30,5 +31,27 @@ describe('withDiscoverSavedQueries HoC', function() {
     const props = wrapper.find('MyComponent').prop('savedQueries');
     expect(props).toHaveLength(1);
     expect(props[0].id).toBe(query.id);
+  });
+
+  it('filters out versionless queries', function() {
+    const MyComponent = () => null;
+    const Container = withDiscoverSavedQueries(MyComponent);
+    const wrapper = mount(<Container />);
+
+    expect(wrapper.find('MyComponent').prop('savedQueries')).toEqual([]);
+
+    // Insert into the store
+    const query = {
+      id: '1',
+      fields: ['title', 'count()'],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      createdBy: '1',
+    };
+    DiscoverSavedQueriesStore.fetchSavedQueriesSuccess([query]);
+
+    wrapper.update();
+    const props = wrapper.find('MyComponent').prop('savedQueries');
+    expect(props).toHaveLength(0);
   });
 });

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -69,7 +69,7 @@ describe('EventView.generateQueryStringObject()', function() {
     expect(query.project).toBeUndefined();
   });
 
-  it('encodes fields and alias', function() {
+  it('encodes fields and fieldnames', function() {
     const eventView = new EventView({
       fields: [{field: 'id', title: 'ID'}, {field: 'title', title: 'Event'}],
       tags: [],
@@ -77,7 +77,7 @@ describe('EventView.generateQueryStringObject()', function() {
     });
     const query = eventView.generateQueryStringObject();
     expect(query.field).toEqual(['id', 'title']);
-    expect(query.alias).toEqual(['ID', 'Event']);
+    expect(query.fieldnames).toEqual(['ID', 'Event']);
   });
 
   it('returns a copy of data preventing mutation', function() {
@@ -88,12 +88,12 @@ describe('EventView.generateQueryStringObject()', function() {
     });
     const query = eventView.generateQueryStringObject();
     query.field.push('newthing');
-    query.alias.push('new thing');
+    query.fieldnames.push('new thing');
 
     // Getting the query again should return the original values.
     const secondQuery = eventView.generateQueryStringObject();
     expect(secondQuery.field).toEqual(['id', 'title']);
-    expect(secondQuery.alias).toEqual(['ID', 'Event']);
+    expect(secondQuery.fieldnames).toEqual(['ID', 'Event']);
   });
 });
 

--- a/tests/js/spec/views/eventsV2/saveQueryButton.spec.jsx
+++ b/tests/js/spec/views/eventsV2/saveQueryButton.spec.jsx
@@ -72,6 +72,38 @@ describe('EventsV2 > SaveQueryButton', function() {
     expect(submit.text()).toEqual('Update');
   });
 
+  it('sets input value based on props', function() {
+    const wrapper = mount(
+      <EventSaveQueryButton
+        organization={organization}
+        location={location}
+        eventView={errorsView}
+      />,
+      TestStubs.routerContext()
+    );
+    const button = wrapper.find('StyledDropdownButton');
+    button.simulate('click');
+
+    // Creating a new query
+    expect(wrapper.find('StyledInput').props().value).toEqual('');
+
+    // Enter edit mode
+    wrapper.setProps({isEditing: true});
+    wrapper.update();
+    expect(wrapper.find('StyledInput').props().value).toEqual(errorsView.name);
+
+    // Edit a different view
+    const otherView = {...errorsView, name: 'other view', id: 99};
+    wrapper.setProps({isEditing: true, eventView: otherView});
+    wrapper.update();
+    expect(wrapper.find('StyledInput').props().value).toEqual(otherView.name);
+
+    // Leave edit mode
+    wrapper.setProps({isEditing: false});
+    wrapper.update();
+    expect(wrapper.find('StyledInput').props().value).toEqual('');
+  });
+
   it('saves a new query', async function() {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/discover/saved/',
@@ -110,7 +142,7 @@ describe('EventsV2 > SaveQueryButton', function() {
       query: {
         field: ['title', 'count()'],
         id: '2',
-        alias: ['title', 'total'],
+        fieldnames: ['title', 'total'],
         name: 'my query',
         query: '',
         sort: [],
@@ -162,7 +194,7 @@ describe('EventsV2 > SaveQueryButton', function() {
       query: {
         field: ['title', 'count()'],
         id: '1',
-        alias: ['title', 'total'],
+        fieldnames: ['title', 'total'],
         name: 'my query',
         query: '',
         sort: [],

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -104,7 +104,7 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
 
 
 class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
-    feature_name = "organizations:discover-v2-query-builder"
+    feature_name = "organizations:events-v2"
 
     def test_post_invalid_conditions(self):
         with self.feature(self.feature_name):


### PR DESCRIPTION
Remove the discover2 query builder flag and only show version=2 queries in the sidebar. I've not yet ironed out all the compatibility between old and new discover queries. Until that is fixed we'll hide old discover queries.

This will need to wait until the other query builder pull requests are merged.

Refs SEN-1060