### PR TITLE
feat(teams): Modified user teams endpoint to include projects

### DIFF
--- a/src/sentry/api/endpoints/organization_user_teams.py
+++ b/src/sentry/api/endpoints/organization_user_teams.py
@@ -7,6 +7,7 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.base import DocSection
 from sentry.api.serializers import serialize
 from sentry.auth.superuser import is_active_superuser
+from sentry.api.serializers.models.team import TeamWithProjectsSerializer
 
 
 class OrganizationUserTeamsEndpoint(OrganizationEndpoint):
@@ -26,6 +27,8 @@ class OrganizationUserTeamsEndpoint(OrganizationEndpoint):
             queryset = Team.objects.filter(
                 organization=organization, status=TeamStatus.VISIBLE
             ).order_by("slug")
-            return Response(serialize(list(queryset), request.user))
+            return Response(serialize(list(queryset), request.user, TeamWithProjectsSerializer()))
         else:
-            return Response(serialize(list(request.access.teams), request.user))
+            return Response(
+                serialize(list(request.access.teams), request.user, TeamWithProjectsSerializer())
+            )

--- a/tests/sentry/api/endpoints/test_organization_user_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_user_teams.py
@@ -15,6 +15,8 @@ class OrganizationUserTeamsTest(APITestCase):
         self.team1 = self.create_team(organization=self.org)
         self.team2 = self.create_team(organization=self.org)
         self.team3 = self.create_team(organization=self.org)
+        self.project1 = self.create_project(teams=[self.team1])
+        self.project2 = self.create_project(teams=[self.team2])
         self.create_member(organization=self.org, user=self.foo, teams=[self.team1, self.team2])
         self.create_member(organization=self.org, user=self.bar, teams=[self.team2])
 
@@ -35,8 +37,11 @@ class OrganizationUserTeamsTest(APITestCase):
         response.data.sort(key=lambda x: x["id"])
         assert response.data[0]["id"] == six.text_type(self.team1.id)
         assert response.data[0]["isMember"]
+        assert response.data[0]["projects"][0]["id"] == six.text_type(self.project1.id)
+
         assert response.data[1]["id"] == six.text_type(self.team2.id)
         assert response.data[1]["isMember"]
+        assert response.data[1]["projects"][0]["id"] == six.text_type(self.project2.id)
 
     def test_super_user(self):
         self.login_as(user=self.bar, superuser=True)
@@ -51,7 +56,11 @@ class OrganizationUserTeamsTest(APITestCase):
         response.data.sort(key=lambda x: x["id"])
         assert response.data[0]["id"] == six.text_type(self.team1.id)
         assert not response.data[0]["isMember"]
+        assert response.data[0]["projects"][0]["id"] == six.text_type(self.project1.id)
+
         assert response.data[1]["id"] == six.text_type(self.team2.id)
         assert response.data[1]["isMember"]
+        assert response.data[1]["projects"][0]["id"] == six.text_type(self.project2.id)
+
         assert response.data[2]["id"] == six.text_type(self.team3.id)
         assert not response.data[2]["isMember"]


### PR DESCRIPTION
Modified the endpoint added from https://github.com/getsentry/sentry/pull/14801 to also return the projects with each team so that the projects page can be rendered without having to fire 2 requests one after the other (one for teams, one for projects)

Refs: SEN-1057