### PR TITLE
ref: Remove references to multi sampling tagstore setting

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -110,9 +110,6 @@ register("analytics.options", default={}, flags=FLAG_NOSTORE)
 
 register("cloudflare.secret-key", default="")
 
-# Tagstore
-register("tagstore.multi-sampling", default=0.0)
-
 # Slack Integration
 register("slack.client-id", flags=FLAG_PRIORITIZE_DISK)
 register("slack.client-secret", flags=FLAG_PRIORITIZE_DISK)

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import mock
 
-from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from sentry import tagstore
@@ -59,13 +58,9 @@ class ProjectTagKeyDeleteTest(APITestCase):
 
         assert response.status_code == 204
 
-        if settings.SENTRY_TAGSTORE.startswith("sentry.tagstore.multi"):
-            backend_count = len(settings.SENTRY_TAGSTORE_OPTIONS.get("backends", []))
-            assert mock_delete_tag_key.delay.call_count == backend_count
-        else:
-            from sentry.tagstore.models import TagKey
+        from sentry.tagstore.models import TagKey
 
-            mock_delete_tag_key.delay.assert_called_once_with(object_id=tagkey.id, model=TagKey)
+        mock_delete_tag_key.delay.assert_called_once_with(object_id=tagkey.id, model=TagKey)
 
         assert (
             tagstore.get_tag_key(


### PR DESCRIPTION
This appears to be a legacy tagstore setting that is not used anywhere
in the codebase anymore.