### PR TITLE
ref(ui): Move and rename `getConditionString` for Incident Trigger

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/list.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/list.tsx
@@ -8,7 +8,8 @@ import Confirm from 'app/components/confirm';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import space from 'app/styles/space';
 
-import {Trigger, AlertRuleThresholdType} from '../types';
+import {Trigger} from '../types';
+import getTriggerConditionDisplayName from '../utils/getTriggerConditionDisplayName';
 
 type Props = {
   triggers: Trigger[];
@@ -16,23 +17,6 @@ type Props = {
   onEdit: (trigger: Trigger) => void;
 };
 
-function getConditionStrings(trigger: Trigger): [string, string | null] {
-  if (trigger.thresholdType === AlertRuleThresholdType.ABOVE) {
-    return [
-      `> ${trigger.alertThreshold}`,
-      typeof trigger.resolveThreshold !== 'undefined' && trigger.resolveThreshold !== null
-        ? `Auto-resolves when metric falls below ${trigger.resolveThreshold}`
-        : null,
-    ];
-  } else {
-    return [
-      `< ${trigger.alertThreshold}`,
-      typeof trigger.resolveThreshold !== 'undefined' && trigger.resolveThreshold !== null
-        ? `Auto-resolves when metric is above ${trigger.resolveThreshold}`
-        : null,
-    ];
-  }
-}
 export default class TriggersList extends React.Component<Props> {
   handleEdit = (trigger: Trigger) => {
     this.props.onEdit(trigger);
@@ -57,7 +41,9 @@ export default class TriggersList extends React.Component<Props> {
         <PanelBody>
           {isEmpty && <EmptyMessage>{t('No triggers added')}</EmptyMessage>}
           {triggers.map(trigger => {
-            const [mainCondition, secondaryCondition] = getConditionStrings(trigger);
+            const [mainCondition, secondaryCondition] = getTriggerConditionDisplayName(
+              trigger
+            );
 
             return (
               <Grid key={trigger.id}>

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/utils/getTriggerConditionDisplayName.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/utils/getTriggerConditionDisplayName.tsx
@@ -1,3 +1,5 @@
+import {t} from 'app/locale';
+
 import {Trigger, AlertRuleThresholdType} from '../types';
 
 export default function getTriggerConditionDisplayName(
@@ -7,14 +9,14 @@ export default function getTriggerConditionDisplayName(
     return [
       `> ${trigger.alertThreshold}`,
       typeof trigger.resolveThreshold !== 'undefined' && trigger.resolveThreshold !== null
-        ? `Auto-resolves when metric falls below ${trigger.resolveThreshold}`
+        ? t('Auto-resolves when metric falls below %s', trigger.resolveThreshold)
         : null,
     ];
   } else {
     return [
       `< ${trigger.alertThreshold}`,
       typeof trigger.resolveThreshold !== 'undefined' && trigger.resolveThreshold !== null
-        ? `Auto-resolves when metric is above ${trigger.resolveThreshold}`
+        ? t('Auto-resolves when metric is above %s', trigger.resolveThreshold)
         : null,
     ];
   }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/utils/getTriggerConditionDisplayName.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/utils/getTriggerConditionDisplayName.tsx
@@ -1,0 +1,21 @@
+import {Trigger, AlertRuleThresholdType} from '../types';
+
+export default function getTriggerConditionDisplayName(
+  trigger: Trigger
+): [string, string | null] {
+  if (trigger.thresholdType === AlertRuleThresholdType.ABOVE) {
+    return [
+      `> ${trigger.alertThreshold}`,
+      typeof trigger.resolveThreshold !== 'undefined' && trigger.resolveThreshold !== null
+        ? `Auto-resolves when metric falls below ${trigger.resolveThreshold}`
+        : null,
+    ];
+  } else {
+    return [
+      `< ${trigger.alertThreshold}`,
+      typeof trigger.resolveThreshold !== 'undefined' && trigger.resolveThreshold !== null
+        ? `Auto-resolves when metric is above ${trigger.resolveThreshold}`
+        : null,
+    ];
+  }
+}


### PR DESCRIPTION
This renames `getConditionString()` to `getTriggerConditionDisplayName()` and moves it into a module so that it can be re-used in the Incident Rules List.