### PR TITLE
feat(api): Change Alert Rules serializer to include Triggers

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -49,11 +49,11 @@ class AlertRuleSerializer(Serializer):
 
 class DetailedAlertRuleSerializer(AlertRuleSerializer):
     def get_attrs(self, item_list, user, **kwargs):
+        result = super(DetailedAlertRuleSerializer, self).get_attrs(item_list, user, **kwargs)
         alert_rule_projects = AlertRule.objects.filter(
             id__in=[item.id for item in item_list]
         ).values_list("id", "query_subscriptions__project__slug")
         alert_rules = {item.id: item for item in item_list}
-        result = defaultdict(dict)
         for alert_rule_id, project_slug in alert_rule_projects:
             rule_result = result[alert_rules[alert_rule_id]].setdefault("projects", [])
             rule_result.append(project_slug)

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -48,6 +48,14 @@ class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
         result = serialize(alert_rule)
         self.assert_alert_rule_serialized(alert_rule, result)
 
+    def test_triggers(self):
+        alert_rule = self.create_alert_rule()
+        other_alert_rule = self.create_alert_rule()
+        trigger = create_alert_rule_trigger(alert_rule, "test", AlertRuleThresholdType.ABOVE, 1000)
+        result = serialize([alert_rule, other_alert_rule])
+        assert result[0]["triggers"] == [serialize(trigger)]
+        assert result[1]["triggers"] == []
+
 
 class DetailedAlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
     def test_simple(self):


### PR DESCRIPTION
This changes the Alert Rule serializer to include triggers and also include projects/excludedProjects in the "detailed" serializer.
This is so we can show thresholds in our UI when viewing all Incident Rules.