### PR TITLE
ref(modals): Rename RenderProps type to ModalProps

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/modal.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/modal.tsx
@@ -5,7 +5,7 @@ import {ModalHeader, ModalBody, ModalFooter} from 'react-bootstrap';
 import ModalActions from 'app/actions/modalActions';
 import {Integration, IntegrationProvider, Organization, SentryApp} from 'app/types';
 
-export type RenderProps = {
+export type ModalRenderProps = {
   closeModal: () => void;
   Header: typeof ModalHeader;
   Body: typeof ModalBody;
@@ -36,7 +36,7 @@ export type SentryAppDetailsModalOptions = {
  * Show a modal
  */
 export function openModal(
-  renderer: (renderProps: RenderProps) => React.ReactNode,
+  renderer: (renderProps: ModalRenderProps) => React.ReactNode,
   options?: ModalOptions
 ) {
   ModalActions.openModal(renderer, options);

--- a/src/sentry/static/sentry/app/components/globalModal.tsx
+++ b/src/sentry/static/sentry/app/components/globalModal.tsx
@@ -5,12 +5,12 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 
-import {closeModal, RenderProps, ModalOptions} from 'app/actionCreators/modal';
+import {closeModal, ModalRenderProps, ModalOptions} from 'app/actionCreators/modal';
 import Confirm from 'app/components/confirm';
 import ModalStore from 'app/stores/modalStore';
 
 type Props = {
-  children?: (renderProps: RenderProps) => React.ReactNode;
+  children?: (renderProps: ModalRenderProps) => React.ReactNode;
   options: ModalOptions;
   visible: boolean;
   onClose?: () => void;

--- a/src/sentry/static/sentry/app/stores/modalStore.tsx
+++ b/src/sentry/static/sentry/app/stores/modalStore.tsx
@@ -1,9 +1,9 @@
 import Reflux from 'reflux';
 
 import ModalActions from 'app/actions/modalActions';
-import {RenderProps, ModalOptions} from 'app/actionCreators/modal';
+import {ModalRenderProps, ModalOptions} from 'app/actionCreators/modal';
 
-type Renderer = (renderProps: RenderProps) => React.ReactNode;
+type Renderer = (renderProps: ModalRenderProps) => React.ReactNode;
 
 type ModalStoreState = {
   renderer: Renderer | null;


### PR DESCRIPTION
This makes it more obvious what it is when used in typed modals, since the props will include these prop types.