### PR TITLE
fix: drop and create db in the sentry_postgres container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,13 @@ build: locale
 
 drop-db:
 	@echo "--> Dropping existing 'sentry' database"
-	dropdb -h 127.0.0.1 -U postgres sentry || true
+	docker exec $$(docker ps --filter 'name=sentry_postgres' --format '{{.ID}}') \
+		dropdb -U postgres sentry || true
 
 create-db:
 	@echo "--> Creating 'sentry' database"
-	createdb -h 127.0.0.1 -U postgres -E utf-8 sentry || true
+	docker exec $$(docker ps --filter 'name=sentry_postgres' --format '{{.ID}}') \
+		createdb -U postgres -E utf-8 sentry || true
 
 apply-migrations:
 	@echo "--> Applying migrations"


### PR DESCRIPTION
We don't use local postgres anymore and I needed to use at least `reset-db` to reset state while testing some stuff.