### PR TITLE
feat(ui): Add more columns to Incident Rules list [SEN-1053]

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/list.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/list.tsx
@@ -1,7 +1,7 @@
-import {RouteComponentProps} from 'react-router/lib/Router';
 import {Link} from 'react-router';
+import {RouteComponentProps} from 'react-router/lib/Router';
 import React from 'react';
-import styled from 'react-emotion';
+import styled, {css} from 'react-emotion';
 
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import {t} from 'app/locale';
@@ -15,6 +15,7 @@ import space from 'app/styles/space';
 
 import {IncidentRule} from './types';
 import {deleteRule} from './actions';
+import getMetricDisplayName from './utils/getMetricDisplayName';
 
 type State = {
   rules: IncidentRule[];
@@ -79,7 +80,14 @@ class IncidentRulesList extends AsyncView<Props, State> {
       <div>
         <SettingsPageHeader title={t('Incident Rules')} action={action} />
         <Panel>
-          <PanelHeader>{t('Rules')}</PanelHeader>
+          <GridPanelHeader>
+            <NameColumn>{t('Name')}</NameColumn>
+
+            <span>{t('Metric')}</span>
+
+            <span>{t('Threshold')}</span>
+          </GridPanelHeader>
+
           <PanelBody>
             {isLoading && <LoadingIndicator />}
 
@@ -90,17 +98,26 @@ class IncidentRulesList extends AsyncView<Props, State> {
                   <RuleLink to={`/settings/${orgId}/incident-rules/${rule.id}/`}>
                     {rule.name}
                   </RuleLink>
-                  <Confirm
-                    priority="danger"
-                    onConfirm={() => this.handleRemoveRule(rule)}
-                    message={t('Are you sure you want to remove this rule?')}
-                  >
-                    <RemoveButton
-                      size="small"
-                      icon="icon-trash"
-                      label={t('Remove Rule')}
-                    />
-                  </Confirm>
+                  <span>{getMetricDisplayName(rule.thresholdType)}</span>
+
+                  <ThresholdColumn>
+                    <div>
+                      {rule.triggers.map(trigger => trigger.alertThreshold).join(', ')}
+                    </div>
+
+                    <Confirm
+                      priority="danger"
+                      onConfirm={() => this.handleRemoveRule(rule)}
+                      message={t('Are you sure you want to remove this rule?')}
+                    >
+                      <RemoveButton
+                        type="button"
+                        size="small"
+                        icon="icon-trash"
+                        label={t('Remove Rule')}
+                      />
+                    </Confirm>
+                  </ThresholdColumn>
                 </RuleRow>
               ))}
 
@@ -116,15 +133,39 @@ class IncidentRulesList extends AsyncView<Props, State> {
 
 export default IncidentRulesList;
 
+const gridCss = css`
+  display: grid;
+  grid-template-columns: 2fr 1fr 3fr;
+  align-items: center;
+`;
+
+const nameColumnCss = css`
+  padding: ${space(2)};
+`;
+
+const GridPanelHeader = styled(PanelHeader)`
+  padding: 0;
+  ${gridCss};
+`;
+
 const RuleRow = styled(PanelItem)`
   padding: 0;
   align-items: center;
-  justify-content: space-between;
+  ${gridCss};
+`;
+
+const NameColumn = styled('span')`
+  ${nameColumnCss};
 `;
 
 const RuleLink = styled(Link)`
-  flex: 1;
-  padding: ${space(2)};
+  ${nameColumnCss}
+`;
+
+const ThresholdColumn = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 `;
 
 const RemoveButton = styled(Button)`

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/list.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/list.tsx
@@ -83,9 +83,9 @@ class IncidentRulesList extends AsyncView<Props, State> {
           <GridPanelHeader>
             <NameColumn>{t('Name')}</NameColumn>
 
-            <span>{t('Metric')}</span>
+            <div>{t('Metric')}</div>
 
-            <span>{t('Threshold')}</span>
+            <div>{t('Threshold')}</div>
           </GridPanelHeader>
 
           <PanelBody>
@@ -98,25 +98,37 @@ class IncidentRulesList extends AsyncView<Props, State> {
                   <RuleLink to={`/settings/${orgId}/incident-rules/${rule.id}/`}>
                     {rule.name}
                   </RuleLink>
-                  <span>{getMetricDisplayName(rule.thresholdType)}</span>
+
+                  <MetricName>{getMetricDisplayName(rule.thresholdType)}</MetricName>
 
                   <ThresholdColumn>
-                    <div>
+                    <Thresholds>
                       {rule.triggers.map(trigger => trigger.alertThreshold).join(', ')}
-                    </div>
+                    </Thresholds>
 
-                    <Confirm
-                      priority="danger"
-                      onConfirm={() => this.handleRemoveRule(rule)}
-                      message={t('Are you sure you want to remove this rule?')}
-                    >
-                      <RemoveButton
-                        type="button"
+                    <Actions>
+                      <Button
+                        to={`/settings/${orgId}/incident-rules/${rule.id}/`}
                         size="small"
-                        icon="icon-trash"
-                        label={t('Remove Rule')}
-                      />
-                    </Confirm>
+                        icon="icon-edit"
+                        aria-label={t('Edit Rule')}
+                      >
+                        {t('Edit')}
+                      </Button>
+
+                      <Confirm
+                        priority="danger"
+                        onConfirm={() => this.handleRemoveRule(rule)}
+                        message={t('Are you sure you want to remove this rule?')}
+                      >
+                        <Button
+                          type="button"
+                          size="small"
+                          icon="icon-trash"
+                          label={t('Remove Rule')}
+                        />
+                      </Confirm>
+                    </Actions>
                   </ThresholdColumn>
                 </RuleRow>
               ))}
@@ -135,7 +147,7 @@ export default IncidentRulesList;
 
 const gridCss = css`
   display: grid;
-  grid-template-columns: 2fr 1fr 3fr;
+  grid-template-columns: 3fr 1fr 2fr;
   align-items: center;
 `;
 
@@ -154,7 +166,7 @@ const RuleRow = styled(PanelItem)`
   ${gridCss};
 `;
 
-const NameColumn = styled('span')`
+const NameColumn = styled('div')`
   ${nameColumnCss};
 `;
 
@@ -162,12 +174,21 @@ const RuleLink = styled(Link)`
   ${nameColumnCss}
 `;
 
+// For tests
+const MetricName = styled('div')``;
+
 const ThresholdColumn = styled('div')`
   display: flex;
   align-items: center;
   justify-content: space-between;
 `;
 
-const RemoveButton = styled(Button)`
+// For tests
+const Thresholds = styled('div')``;
+
+const Actions = styled('div')`
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: ${space(1)};
   margin: ${space(2)};
 `;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm.tsx
@@ -12,6 +12,7 @@ import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
 
 import {AlertRuleAggregations, IncidentRule, TimeWindow} from './types';
+import getMetricDisplayName from './utils/getMetricDisplayName';
 
 const DEFAULT_METRIC = [AlertRuleAggregations.TOTAL];
 
@@ -89,8 +90,14 @@ class RuleForm extends React.Component<Props> {
                 label: t('Metric'),
                 help: t('Choose which metric to trigger on'),
                 choices: [
-                  [AlertRuleAggregations.UNIQUE_USERS, 'Users Affected'],
-                  [AlertRuleAggregations.TOTAL, 'Events'],
+                  [
+                    AlertRuleAggregations.UNIQUE_USERS,
+                    getMetricDisplayName(AlertRuleAggregations.UNIQUE_USERS),
+                  ],
+                  [
+                    AlertRuleAggregations.TOTAL,
+                    getMetricDisplayName(AlertRuleAggregations.TOTAL),
+                  ],
                 ],
                 required: true,
                 setValue: value => (value && value.length ? value[0] : value),

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/list.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/list.tsx
@@ -86,7 +86,7 @@ export default class TriggersList extends React.Component<Props> {
                       priority="danger"
                     >
                       <Button
-                        priority="danger"
+                        priority="default"
                         size="small"
                         aria-label={t('Delete Trigger')}
                         icon="icon-trash"

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/utils/getMetricDisplayName.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/utils/getMetricDisplayName.tsx
@@ -1,0 +1,15 @@
+import {t} from 'app/locale';
+
+import {AlertRuleAggregations} from '../types';
+
+export default function getMetricDisplayName(metric: AlertRuleAggregations): string {
+  switch (metric) {
+    case AlertRuleAggregations.UNIQUE_USERS:
+      return t('Users Affected');
+    case AlertRuleAggregations.TOTAL:
+      return t('Events');
+
+    default:
+      return '';
+  }
+}

--- a/tests/js/spec/views/settings/incidentRules/list.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/list.spec.jsx
@@ -22,5 +22,12 @@ describe('Incident Rules List', function() {
 
     expect(req).toHaveBeenCalled();
     expect(wrapper.find('RuleLink').text()).toEqual('My Incident Rule');
+    expect(
+      wrapper
+        .find('RuleRow span')
+        .at(0)
+        .text()
+    ).toEqual('Events');
+    expect(wrapper.find('RuleRow ThresholdColumn').text()).toEqual('70');
   });
 });

--- a/tests/js/spec/views/settings/incidentRules/list.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/list.spec.jsx
@@ -22,12 +22,8 @@ describe('Incident Rules List', function() {
 
     expect(req).toHaveBeenCalled();
     expect(wrapper.find('RuleLink').text()).toEqual('My Incident Rule');
-    expect(
-      wrapper
-        .find('RuleRow span')
-        .at(0)
-        .text()
-    ).toEqual('Events');
-    expect(wrapper.find('RuleRow ThresholdColumn').text()).toEqual('70');
+    expect(wrapper.find('MetricName').text()).toEqual('Events');
+
+    expect(wrapper.find('Thresholds').text()).toEqual('70');
   });
 });


### PR DESCRIPTION
This adds the "Metric" and "Thresholds" columns to Incident Rules list.

![image](https://user-images.githubusercontent.com/79684/65921829-3b3e8d00-e398-11e9-8a3f-3886610fdb11.png)

Depends on https://github.com/getsentry/sentry/pull/14874
Closes SEN-1053