### PR TITLE
fix(percy): Wait for EventCauseEmpty to load

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
@@ -119,7 +119,7 @@ class EventCauseEmpty extends React.Component {
     }
 
     return (
-      <div className="box">
+      <div className="box" data-test-id="loaded-event-cause-empty">
         <StyledPanel dashedBorder>
           <BoxHeader>
             <Description>

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -148,6 +148,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         self.browser.wait_until(".entries")
         self.browser.wait_until_test_id("linked-issues")
         self.browser.wait_until_test_id("loaded-device-name")
+        self.browser.wait_until_test_id("loaded-event-cause-empty")
 
     def dismiss_assistant(self):
         # Forward session cookie to django client.


### PR DESCRIPTION
Fixes the flakey `issue details python formdata` snapshot by waiting for the event cause empty state to load.