### PR TITLE
fix(discover2): Project and environment tags does not get reflected in the global selection header

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventTags.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.tsx
@@ -8,13 +8,12 @@ import {Event, EventTag, Group} from 'app/types';
 
 import EventDataSection from 'app/components/events/eventDataSection';
 import DeviceName from 'app/components/deviceName';
-import {isUrl} from 'app/utils';
+import {isUrl, generateQueryWithTag} from 'app/utils';
 import {t} from 'app/locale';
 import Pills from 'app/components/pills';
 import Pill from 'app/components/pill';
 import VersionHoverCard from 'app/components/versionHoverCard';
 import InlineSvg from 'app/components/inlineSvg';
-import {generateQueryWithTag} from 'app/utils';
 
 type EventTagsProps = {
   group: Group;

--- a/src/sentry/static/sentry/app/components/events/eventTags.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.tsx
@@ -33,7 +33,7 @@ class EventTags extends React.Component<EventTagsProps> {
 
   renderPill(tag: EventTag, streamPath: string, releasesPath: string) {
     const {orgId, projectId, location} = this.props;
-    const query = {...location.query, ...generateQueryWithTag(tag)};
+    const query = generateQueryWithTag(location.query, tag);
 
     const locationSearch = `?${queryString.stringify(query)}`;
 

--- a/src/sentry/static/sentry/app/components/events/eventTags.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.tsx
@@ -14,7 +14,7 @@ import Pills from 'app/components/pills';
 import Pill from 'app/components/pill';
 import VersionHoverCard from 'app/components/versionHoverCard';
 import InlineSvg from 'app/components/inlineSvg';
-import {appendTagCondition} from 'app/utils/queryString';
+import {generateQueryWithTag} from 'app/utils';
 
 type EventTagsProps = {
   group: Group;
@@ -33,18 +33,7 @@ class EventTags extends React.Component<EventTagsProps> {
 
   renderPill(tag: EventTag, streamPath: string, releasesPath: string) {
     const {orgId, projectId, location} = this.props;
-    const query = {...location.query};
-
-    switch (tag.key) {
-      case 'environment':
-        query.environment = tag.value;
-        break;
-      case 'project':
-        query.project = tag.value;
-        break;
-      default:
-        query.query = appendTagCondition(query.query, tag.key, tag.value);
-    }
+    const query = {...location.query, ...generateQueryWithTag(tag)};
 
     const locationSearch = `?${queryString.stringify(query)}`;
 

--- a/src/sentry/static/sentry/app/utils.tsx
+++ b/src/sentry/static/sentry/app/utils.tsx
@@ -1,5 +1,8 @@
 import _ from 'lodash';
+import {Query} from 'history';
+
 import {Project} from 'app/types/index';
+import {appendTagCondition} from 'app/utils/queryString';
 
 function arrayIsEqual(arr?: any[], other?: any[], deep?: boolean): boolean {
   // if the other array is a falsy value, return
@@ -246,3 +249,22 @@ export type OmitHtmlDivProps<P extends object> = Omit<
   keyof P
 > &
   P;
+
+export function generateQueryWithTag(tag: {key: string; value: string}): Query {
+  const query: Query = {};
+
+  // some tags are dedicated query strings since other parts of the app consumes this,
+  // for example, the global selection header.
+  switch (tag.key) {
+    case 'environment':
+      query.environment = tag.value;
+      break;
+    case 'project':
+      query.project = tag.value;
+      break;
+    default:
+      query.query = appendTagCondition(query.query, tag.key, tag.value);
+  }
+
+  return query;
+}

--- a/src/sentry/static/sentry/app/utils.tsx
+++ b/src/sentry/static/sentry/app/utils.tsx
@@ -250,8 +250,11 @@ export type OmitHtmlDivProps<P extends object> = Omit<
 > &
   P;
 
-export function generateQueryWithTag(tag: {key: string; value: string}): Query {
-  const query: Query = {};
+export function generateQueryWithTag(
+  prevQuery: Query,
+  tag: {key: string; value: string}
+): Query {
+  const query = {...prevQuery};
 
   // some tags are dedicated query strings since other parts of the app consumes this,
   // for example, the global selection header.

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -64,10 +64,7 @@ export function getEventTagSearchUrl(
   tagValue: string,
   location: Location
 ) {
-  const query = {
-    ...location.query,
-    ...generateQueryWithTag({key: tagKey, value: tagValue}),
-  };
+  const query = generateQueryWithTag(location.query, {key: tagKey, value: tagValue});
 
   // Remove the event slug so the user sees new search results.
   delete query.eventSlug;

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -68,7 +68,7 @@ export function getEventTagSearchUrl(
 
   // some tags are dedicated query strings since other parts of the app consumes this,
   // for example, the global selection header.
-  switch (tagKey.toLowerCase()) {
+  switch (tagKey) {
     case 'environment':
       query.environment = tagValue;
       break;

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -4,7 +4,7 @@ import {browserHistory} from 'react-router';
 
 import {Client} from 'app/api';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
-import {appendTagCondition} from 'app/utils/queryString';
+import {generateQueryWithTag} from 'app/utils';
 
 import {
   AGGREGATE_ALIASES,
@@ -64,20 +64,10 @@ export function getEventTagSearchUrl(
   tagValue: string,
   location: Location
 ) {
-  const query = {...location.query};
-
-  // some tags are dedicated query strings since other parts of the app consumes this,
-  // for example, the global selection header.
-  switch (tagKey) {
-    case 'environment':
-      query.environment = tagValue;
-      break;
-    case 'project':
-      query.project = tagValue;
-      break;
-    default:
-      query.query = appendTagCondition(query.query, tagKey, tagValue);
-  }
+  const query = {
+    ...location.query,
+    ...generateQueryWithTag({key: tagKey, value: tagValue}),
+  };
 
   // Remove the event slug so the user sees new search results.
   delete query.eventSlug;

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -65,7 +65,19 @@ export function getEventTagSearchUrl(
   location: Location
 ) {
   const query = {...location.query};
-  query.query = appendTagCondition(query.query, tagKey, tagValue);
+
+  // some tags are dedicated query strings since other parts of the app consumes this,
+  // for example, the global selection header.
+  switch (tagKey.toLowerCase()) {
+    case 'environment':
+      query.environment = tagValue;
+      break;
+    case 'project':
+      query.project = tagValue;
+      break;
+    default:
+      query.query = appendTagCondition(query.query, tagKey, tagValue);
+  }
 
   // Remove the event slug so the user sees new search results.
   delete query.eventSlug;

--- a/tests/js/spec/views/eventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/eventsV2/tags.spec.jsx
@@ -71,7 +71,7 @@ describe('Tags', function() {
     const initialData = initializeOrg({
       organization: org,
       router: {
-        location: {query: {lol: 42}},
+        location: {query: {}},
       },
     });
 
@@ -95,8 +95,6 @@ describe('Tags', function() {
     // component has loaded
     expect(wrapper.find('StyledPlaceholder')).toHaveLength(0);
 
-    // console.log(wrapper.debug());
-
     const environmentFacetMap = wrapper
       .find('TagDistributionMeter')
       .filterWhere(component => {
@@ -106,17 +104,14 @@ describe('Tags', function() {
 
     const clickable = environmentFacetMap.find('Segment').first();
 
-    console.log('dumbbutton', clickable.debug());
-
-    clickable.simulate('click');
+    clickable.simulate('click', {button: 0});
 
     await tick();
     wrapper.update();
 
-    console.log('router', initialData.router);
-
-    expect(initialData.router.push).toHaveBeenCalled();
-
-    expect(false).toBe(true);
+    expect(initialData.router.push).toHaveBeenCalledWith({
+      pathname: undefined,
+      query: {environment: 'abcd123'},
+    });
   });
 });

--- a/tests/js/spec/views/eventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/eventsV2/tags.spec.jsx
@@ -4,6 +4,7 @@ import {mount} from 'enzyme';
 import {Client} from 'app/api';
 import {Tags} from 'app/views/eventsV2/tags';
 import EventView from 'app/views/eventsV2/eventView';
+import {initializeOrg} from 'app-test/helpers/initializeOrg';
 
 describe('Tags', function() {
   const org = TestStubs.Organization();
@@ -57,7 +58,7 @@ describe('Tags', function() {
     Client.clearMockResponses();
   });
 
-  it('renders', async function() {
+  it.only('renders', async function() {
     const api = new Client();
 
     const view = new EventView({
@@ -67,14 +68,22 @@ describe('Tags', function() {
       query: 'event.type:csp',
     });
 
+    const initialData = initializeOrg({
+      organization: org,
+      router: {
+        location: {query: {lol: 42}},
+      },
+    });
+
     const wrapper = mount(
       <Tags
         eventView={view}
         api={api}
         organization={org}
         selection={{projects: [], environments: [], datetime: {}}}
-        location={{query: {}}}
-      />
+        location={initialData.router.location}
+      />,
+      initialData.routerContext
     );
 
     // component is in loading state
@@ -85,5 +94,29 @@ describe('Tags', function() {
 
     // component has loaded
     expect(wrapper.find('StyledPlaceholder')).toHaveLength(0);
+
+    // console.log(wrapper.debug());
+
+    const environmentFacetMap = wrapper
+      .find('TagDistributionMeter')
+      .filterWhere(component => {
+        return component.props().title === 'environment';
+      })
+      .first();
+
+    const clickable = environmentFacetMap.find('Segment').first();
+
+    console.log('dumbbutton', clickable.debug());
+
+    clickable.simulate('click');
+
+    await tick();
+    wrapper.update();
+
+    console.log('router', initialData.router);
+
+    expect(initialData.router.push).toHaveBeenCalled();
+
+    expect(false).toBe(true);
   });
 });

--- a/tests/js/spec/views/eventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/eventsV2/tags.spec.jsx
@@ -58,7 +58,37 @@ describe('Tags', function() {
     Client.clearMockResponses();
   });
 
-  it.only('renders', async function() {
+  it('renders', async function() {
+    const api = new Client();
+
+    const view = new EventView({
+      fields: [],
+      sorts: [],
+      tags: ['release', 'environment'],
+      query: 'event.type:csp',
+    });
+
+    const wrapper = mount(
+      <Tags
+        eventView={view}
+        api={api}
+        organization={org}
+        selection={{projects: [], environments: [], datetime: {}}}
+        location={{query: {}}}
+      />
+    );
+
+    // component is in loading state
+    expect(wrapper.find('StyledPlaceholder')).toHaveLength(2);
+
+    await tick();
+    wrapper.update();
+
+    // component has loaded
+    expect(wrapper.find('StyledPlaceholder')).toHaveLength(0);
+  });
+
+  it('environment tag is a dedicated query string', async function() {
     const api = new Client();
 
     const view = new EventView({


### PR DESCRIPTION
Clicking on the `environment` tag on the facet maps for discover2 does not get reflected on the global selection header.

Neither does the `project` facet map.

This pull-request addresses this by adding project and environment to be dedicated query string keys rather than tags.

## TODO

- [x] add jest test
- [x] centralize code