### PR TITLE
fix(unmerge): Fix message field in group unmerge

### DIFF
--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -549,6 +549,9 @@ def unmerge(
 
     events = eventstore.get_events(
         filter_keys={"project_id": [project_id], "issue": [source.id]},
+        # We need the text-only "search message" from Snuba, not the raw message
+        # dict field from nodestore.
+        additional_columns=[eventstore.Columns.MESSAGE],
         conditions=conditions,
         limit=batch_size,
         referrer="unmerge",


### PR DESCRIPTION
Fetch the message field from Snuba to make sure we have have a correctly
formatted message to update the group with. The message in node data might
not be present or incorrectly formatted (it's a dict and not text).

Fixes https://sentry.io/share/issue/7404184e542548f986589ec32e0b937d/