### PR TITLE
ref(deletions): Nodestore deletions no longer depend on event.data.id

### DIFF
--- a/src/sentry/deletions/defaults/event.py
+++ b/src/sentry/deletions/defaults/event.py
@@ -27,9 +27,12 @@ class EventDeletionTask(ModelDeletionTask):
         return relations
 
     def get_child_relations_bulk(self, instance_list):
+        from sentry.models import Event
+
         node_ids = []
         for i in instance_list:
-            node_ids.append(i.data.id)
+            node_id = Event.generate_node_id(i.project_id, i.event_id)
+            node_ids.append(node_id)
             # Unbind the NodeField so it doesn't attempt to get
             # get deleted a second time after NodeDeletionTask
             # runs, when the Event itself is deleted.


### PR DESCRIPTION
Update nodestore deletions code to not depend on the node_id stored in the
sentry_message database table. Since the node ID is now always a hash
of the project ID and event UUID we can generate it rather than relying
on this field being populated in the database. This will allow us to
stop writing to this field in https://github.com/getsentry/sentry/pull/14725.