### PR TITLE
xrange() was removed in Python 3 in favor of range()

### DIFF
--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1084,11 +1084,11 @@ class CalculateIncidentStartTest(TestCase, BaseIncidentsTest):
     def test_single_spike(self):
         fingerprint = "hello"
         start = self.now - (INCIDENT_START_ROLLUP * 2)
-        for _ in xrange(3):
+        for _ in range(3):
             event = self.create_event(start, fingerprint=fingerprint)
 
         end = self.now - INCIDENT_START_ROLLUP
-        for _ in xrange(4):
+        for _ in range(4):
             event = self.create_event(end, fingerprint=fingerprint)
         assert start + ((end - start) / 3) == calculate_incident_start(
             "", [self.project], [event.group]
@@ -1098,11 +1098,11 @@ class CalculateIncidentStartTest(TestCase, BaseIncidentsTest):
         # The most recent spike should take precedence
         fingerprint = "hello"
         older_spike = self.now - (INCIDENT_START_ROLLUP * 3)
-        for _ in xrange(3):
+        for _ in range(3):
             event = self.create_event(older_spike, fingerprint=fingerprint)
 
         newer_spike = self.now - INCIDENT_START_ROLLUP
-        for _ in xrange(3):
+        for _ in range(3):
             event = self.create_event(newer_spike, fingerprint=fingerprint)
         assert newer_spike == calculate_incident_start("", [self.project], [event.group])
 
@@ -1110,11 +1110,11 @@ class CalculateIncidentStartTest(TestCase, BaseIncidentsTest):
         # The older spike should take precedence because it's much larger
         fingerprint = "hello"
         older_spike = self.now - (INCIDENT_START_ROLLUP * 2)
-        for _ in xrange(4):
+        for _ in range(4):
             event = self.create_event(older_spike, fingerprint=fingerprint)
 
         newer_spike = self.now - INCIDENT_START_ROLLUP
-        for _ in xrange(2):
+        for _ in range(2):
             event = self.create_event(newer_spike, fingerprint=fingerprint)
         assert older_spike == calculate_incident_start("", [self.project], [event.group])
 
@@ -1123,11 +1123,11 @@ class CalculateIncidentStartTest(TestCase, BaseIncidentsTest):
         # older spike is larger, it's much older.
         fingerprint = "hello"
         older_spike = self.now - (INCIDENT_START_ROLLUP * 1000)
-        for _ in xrange(3):
+        for _ in range(3):
             event = self.create_event(older_spike, fingerprint=fingerprint)
 
         newer_spike = self.now - INCIDENT_START_ROLLUP
-        for _ in xrange(2):
+        for _ in range(2):
             event = self.create_event(newer_spike, fingerprint=fingerprint)
         assert newer_spike == calculate_incident_start("", [self.project], [event.group])
 


### PR DESCRIPTION
For such small values of n, there is no difference between __range(n)__ and __xrange(n)__ for these uses.

91 days until Python 2 end of life. https://www.python.org/doc/sunset-python-2

[flake8](http://flake8.pycqa.org) testing of https://github.com/getsentry/sentry on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./tests/sentry/incidents/test_logic.py:1087:18: F821 undefined name 'xrange'
        for _ in xrange(3):
                 ^
./tests/sentry/incidents/test_logic.py:1091:18: F821 undefined name 'xrange'
        for _ in xrange(4):
                 ^
./tests/sentry/incidents/test_logic.py:1101:18: F821 undefined name 'xrange'
        for _ in xrange(3):
                 ^
./tests/sentry/incidents/test_logic.py:1105:18: F821 undefined name 'xrange'
        for _ in xrange(3):
                 ^
./tests/sentry/incidents/test_logic.py:1113:18: F821 undefined name 'xrange'
        for _ in xrange(4):
                 ^
./tests/sentry/incidents/test_logic.py:1117:18: F821 undefined name 'xrange'
        for _ in xrange(2):
                 ^
./tests/sentry/incidents/test_logic.py:1126:18: F821 undefined name 'xrange'
        for _ in xrange(3):
                 ^
./tests/sentry/incidents/test_logic.py:1130:18: F821 undefined name 'xrange'
        for _ in xrange(2):
                 ^
./tests/sentry/integrations/github_enterprise/testutils.py:213:0: E999 SyntaxError: bytes can only contain ASCII literal characters.
}"""
^
./tests/sentry/integrations/github/testutils.py:224:0: E999 SyntaxError: bytes can only contain ASCII literal characters.
}"""
^
./src/sentry/utils/snuba.py:445:22: F821 undefined name 'xrange'
            for i in xrange(0, function_name_index):
                     ^
./src/sentry/utils/types.py:167:5: F821 undefined name 'long'
    long: Int,  # noqa: B311
    ^
2     E999 SyntaxError: bytes can only contain ASCII literal characters.
10    F821 undefined name 'xrange'
12
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree