### PR TITLE
build(ci): Add basic linting on Travis for Python 3 syntax errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,10 +130,11 @@ matrix:
         - nvm install
         - ./bin/yarn install --pure-lockfile
 
+    # Proactive linting on 3.7 during the porting process
     - python: 3.7
-      name: 'Linter for Python 3'
-      install: pip install flake8
-      script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      name: 'Linter (Python 3.7)'
+      install: pip install 'sentry-flake8>=0.2.0,<0.3.0'
+      script: flake8
 
     - <<: *postgres_default
       name: 'Backend [Postgres] (1/2)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,11 @@ matrix:
         - nvm install
         - ./bin/yarn install --pure-lockfile
 
+    - python: 3.7
+      name: 'Linter for Python 3'
+      install: pip install flake8
+      script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+
     - <<: *postgres_default
       name: 'Backend [Postgres] (1/2)'
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,6 +134,7 @@ matrix:
     - python: 3.7
       name: 'Linter (Python 3.7)'
       install: pip install 'sentry-flake8>=0.2.0,<0.3.0'
+      # configuration for flake8 can be found in setup.cfg
       script: flake8
 
     - <<: *postgres_default

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ endif
 
 lint: lint-python lint-js
 
+# configuration for flake8 can be found in setup.cfg
 lint-python:
 	@echo "--> Linting python"
 	bash -eo pipefail -c "flake8 | tee .artifacts/flake8.pycodestyle.log"

--- a/src/sentry/__init__.py
+++ b/src/sentry/__init__.py
@@ -7,7 +7,7 @@ from subprocess import check_output
 
 try:
     VERSION = __import__("pkg_resources").get_distribution("sentry").version
-except Exception as e:
+except Exception:
     VERSION = "unknown"
 
 

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -87,7 +87,7 @@ class Endpoint(APIView):
     def handle_exception(self, request, exc):
         try:
             response = super(Endpoint, self).handle_exception(exc)
-        except Exception as exc:
+        except Exception:
             import sys
             import traceback
 

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -266,7 +266,7 @@ class DifAssembleEndpoint(ProjectEndpoint):
             jsonschema.validate(files, schema)
         except jsonschema.ValidationError as e:
             return Response({"error": str(e).splitlines()[0]}, status=400)
-        except BaseException as e:
+        except BaseException:
             return Response({"error": "Invalid json body"}, status=400)
 
         file_response = {}

--- a/src/sentry/api/endpoints/organization_release_assemble.py
+++ b/src/sentry/api/endpoints/organization_release_assemble.py
@@ -50,7 +50,7 @@ class OrganizationReleaseAssembleEndpoint(OrganizationReleasesBaseEndpoint):
             jsonschema.validate(data, schema)
         except jsonschema.ValidationError as e:
             return Response({"error": str(e).splitlines()[0]}, status=400)
-        except BaseException as e:
+        except BaseException:
             return Response({"error": "Invalid json body"}, status=400)
 
         checksum = data.get("checksum", None)

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -27,7 +27,7 @@ class GitHubRepositoryProvider(providers.IntegrationRepositoryProvider):
             # when installing the app (commits can be accessed for public repos)
             # https://developer.github.com/v3/repos/hooks/#list-hooks
             client.repo_hooks(repo)
-        except ApiError as e:
+        except ApiError:
             raise IntegrationError(u"You must grant Sentry access to {}".format(repo))
 
         return repo_data

--- a/src/sentry/integrations/github_enterprise/repository.py
+++ b/src/sentry/integrations/github_enterprise/repository.py
@@ -24,7 +24,7 @@ class GitHubEnterpriseRepositoryProvider(GitHubRepositoryProvider):
         try:
             # make sure installation has access to this specific repo
             client.get_commits(repo)
-        except ApiError as e:
+        except ApiError:
             raise IntegrationError(u"You must grant Sentry access to {}".format(repo))
 
         return repo_data

--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -70,7 +70,7 @@ class SafeConnectionMixin(object):
             # to establish our own connection.
             conn = safe_create_connection((self._dns_host, self.port), self.timeout, **extra_kw)
 
-        except SocketTimeout as e:
+        except SocketTimeout:
             raise ConnectTimeoutError(
                 self, "Connection to %s timed out. (connect timeout=%s)" % (self.host, self.timeout)
             )

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -29,7 +29,7 @@ def pytest_configure(config):
 
             if last_built <= 3600:
                 print(  # noqa: B314
-                    """
+                    u"""
 ###################
 #
 # Frontend assets last built {} seconds ago, skipping rebuilds for another {} seconds.

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import os
 import json
@@ -28,7 +28,7 @@ def pytest_configure(config):
             last_built = int(time.time()) - data["built"]
 
             if last_built <= 3600:
-                print (
+                print(
                     """
 ###################
 #
@@ -46,7 +46,7 @@ def pytest_configure(config):
     except Exception:
         pass
 
-    print (
+    print(
         """
 ###################
 #

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -28,7 +28,7 @@ def pytest_configure(config):
             last_built = int(time.time()) - data["built"]
 
             if last_built <= 3600:
-                print(
+                print(  # noqa: B314
                     """
 ###################
 #
@@ -46,7 +46,7 @@ def pytest_configure(config):
     except Exception:
         pass
 
-    print(
+    print(  # noqa: B314
         """
 ###################
 #

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -28,16 +28,17 @@ def pytest_configure(config):
             last_built = int(time.time()) - data["built"]
 
             if last_built <= 3600:
-                print (  # noqa: B314
+                print (
                     """
 ###################
 #
-# Frontend assets last built %d seconds ago, skipping rebuilds for another %d seconds.
+# Frontend assets last built {} seconds ago, skipping rebuilds for another {} seconds.
 # Delete the file: `.webpack.meta` to rebuild.
 #
 ###################
-                """
-                    % (last_built, 3600 - last_built)
+                """.format(
+                        last_built, 3600 - last_built
+                    )
                 )
                 return
     except IOError:
@@ -45,7 +46,7 @@ def pytest_configure(config):
     except Exception:
         pass
 
-    print (  # noqa: B314
+    print (
         """
 ###################
 #

--- a/tests/sentry/api/endpoints/test_group_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_group_tagkey_details.py
@@ -9,7 +9,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 class GroupTagDetailsTest(APITestCase, SnubaTestCase):
     def test_simple(self):
-        for i in xrange(3):
+        for i in range(3):
             self.store_event(
                 data={
                     "tags": {"foo": "bar"},

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -23,7 +23,7 @@ class ProjectTagKeyDetailsTest(APITestCase, SnubaTestCase):
                 project_id=project.id,
             )
 
-        for i in xrange(0, 16):
+        for i in range(0, 16):
             make_event(i)
 
         self.login_as(user=self.user)

--- a/tests/sentry/integrations/github_enterprise/testutils.py
+++ b/tests/sentry/integrations/github_enterprise/testutils.py
@@ -212,7 +212,7 @@ PUSH_EVENT_EXAMPLE = r"""{
   }
 }"""
 
-PUSH_EVENT_EXAMPLE_INSTALLATION = b"""{
+PUSH_EVENT_EXAMPLE_INSTALLATION = r"""{
   "ref": "refs/heads/changes",
   "installation" : {
     "id": 12345


### PR DESCRIPTION
Also finds undefined names, etc.  @untitaker To help in the Python 3 porting efforts.

These tests are run in __allow_failures__ mode for now.