### PR TITLE
feat(growth): Added endpoint to return if any of an organization's projects have received an event

### DIFF
--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.models import Project
+from sentry.api.base import DocSection
+from sentry.api.serializers import serialize
+from sentry.api.bases.organization import OrganizationEndpoint
+
+
+class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
+    doc_section = DocSection.ORGANIZATIONS
+
+    def get(self, request, organization):
+        """
+        Verify If Any Project Within An Organization Has Received a First Event
+        ```````````````````````````````````````````````````````````````````````
+
+        Returns true if any projects within the organization have received
+        a first event, false otherwise.
+
+        :pparam string organization_slug: the slug of the organization
+                                          containing the projects to check
+                                          for a first event from.
+        :auth: required
+        """
+        queryset = Project.objects.filter(organization=organization, first_event__isnull=False)
+        has_sent_event = len(list(queryset)) > 0
+        return Response(serialize({"sentFirstEvent": has_sent_event}, request.user))

--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -25,5 +25,4 @@ class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
         :auth: required
         """
         queryset = Project.objects.filter(organization=organization, first_event__isnull=False)
-        has_sent_event = len(list(queryset)) > 0
-        return Response(serialize({"sentFirstEvent": has_sent_event}, request.user))
+        return Response(serialize({"sentFirstEvent": queryset.count() > 0}, request.user))

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -862,6 +862,11 @@ urlpatterns = patterns(
                     name="sentry-api-0-organization-projects",
                 ),
                 url(
+                    r"^(?P<organization_slug>[^\/]+)/sent-first-event/$",
+                    OrganizationProjectsSentFirstEventEndpoint.as_view(),
+                    name="sentry-api-0-organization-sent-first-event",
+                ),
+                url(
                     r"^(?P<organization_slug>[^\/]+)/repos/$",
                     OrganizationRepositoriesEndpoint.as_view(),
                     name="sentry-api-0-organization-repositories",
@@ -960,11 +965,6 @@ urlpatterns = patterns(
                     r"^(?P<organization_slug>[^\/]+)/user-teams/$",
                     OrganizationUserTeamsEndpoint.as_view(),
                     name="sentry-api-0-organization-user-teams",
-                ),
-                url(
-                    r"^(?P<organization_slug>[^\/]+)/sent-first-event/$",
-                    OrganizationProjectsSentFirstEventEndpoint.as_view(),
-                    name="sentry-api-0-organization-sent-first-event",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/tags/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -156,6 +156,9 @@ from .endpoints.organization_tags import OrganizationTagsEndpoint
 from .endpoints.organization_teams import OrganizationTeamsEndpoint
 from .endpoints.organization_user_teams import OrganizationUserTeamsEndpoint
 from .endpoints.organization_user_details import OrganizationUserDetailsEndpoint
+from .endpoints.organization_projects_sent_first_event import (
+    OrganizationProjectsSentFirstEventEndpoint,
+)
 from .endpoints.organization_user_issues import OrganizationUserIssuesEndpoint
 from .endpoints.organization_user_issues_search import OrganizationUserIssuesSearchEndpoint
 from .endpoints.organization_user_reports import OrganizationUserReportsEndpoint
@@ -957,6 +960,11 @@ urlpatterns = patterns(
                     r"^(?P<organization_slug>[^\/]+)/user-teams/$",
                     OrganizationUserTeamsEndpoint.as_view(),
                     name="sentry-api-0-organization-user-teams",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/sent-first-event/$",
+                    OrganizationProjectsSentFirstEventEndpoint.as_view(),
+                    name="sentry-api-0-organization-sent-first-event",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/tags/$",

--- a/tests/sentry/api/endpoints/test_organization_projects_sent_first_event.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_sent_first_event.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+
+from datetime import datetime
+
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase
+
+
+class OrganizationProjectsSentFirstEventEndpointTest(APITestCase):
+    def setUp(self):
+        self.foo = self.create_user("foo@example.com")
+        self.org = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.org)
+        self.url = reverse(
+            "sentry-api-0-organization-sent-first-event",
+            kwargs={"organization_slug": self.org.slug},
+        )
+
+    def test_simple_sent_first_event(self):
+        self.create_project(teams=[self.team], first_event=datetime.now())
+        self.create_member(organization=self.org, user=self.foo, teams=[self.team])
+
+        self.login_as(user=self.foo)
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+        assert response.data["sentFirstEvent"]
+
+    def test_simple_no_first_event(self):
+        self.create_project(teams=[self.team])
+        self.create_member(organization=self.org, user=self.foo, teams=[self.team])
+
+        self.login_as(user=self.foo)
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+        assert not response.data["sentFirstEvent"]
+
+    def test_first_event_in_org(self):
+        self.create_project(teams=[self.team], first_event=datetime.now())
+        self.create_member(organization=self.org, user=self.foo)
+
+        self.login_as(user=self.foo)
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+        assert response.data["sentFirstEvent"]


### PR DESCRIPTION
Added an endpoint which requires an organization and returns
```
{
    "sentFirstEvent": true/false
}
```
depending on whether the organization contains a project which has a received an event. This endpoint will be called by atleast the lightweight version of the `installPromptBanner.jsx` and `trialBanner.jsx` components in order to decouple them from organization details and facilitate decomposition of these organization details.

Refs: SEN-1057