### PR TITLE
fix(unmerge): Fix unmerge task serialization error

### DIFF
--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -542,8 +542,11 @@ def unmerge(
     if last_event is not None:
         conditions.extend(
             [
-                ["timestamp", "<=", last_event.timestamp],
-                [["timestamp", "<", last_event.timestamp], ["event_id", "<", last_event.event_id]],
+                ["timestamp", "<=", last_event["timestamp"]],
+                [
+                    ["timestamp", "<", last_event["timestamp"]],
+                    ["event_id", "<", last_event["event_id"]],
+                ],
             ]
         )
 
@@ -604,7 +607,7 @@ def unmerge(
         destination_id,
         fingerprints,
         actor_id,
-        last_event=events[-1],
+        last_event={"timestamp": events[-1].timestamp, "event_id": events[-1].event_id},
         batch_size=batch_size,
         source_fields_reset=source_fields_reset,
         eventstream_state=eventstream_state,


### PR DESCRIPTION
We can't put the entire SnubaEvent into the unmerge queue as it causes a
recursion error when it gets serialized. Instead just pass the event_id
and timestamp which are the only properties we need to calculate the
previous event position.

Fixes SENTRY-CYQ