### PR TITLE
ref(endpoints): Reposition /organizations/{slug}/user-teams/ endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -924,6 +924,11 @@ urlpatterns = patterns(
                     name="sentry-api-0-organization-user-feedback",
                 ),
                 url(
+                    r"^(?P<organization_slug>[^\/]+)/user-teams/$",
+                    OrganizationUserTeamsEndpoint.as_view(),
+                    name="sentry-api-0-organization-user-teams",
+                ),
+                url(
                     r"^(?P<organization_slug>[^\/]+)/users/$",
                     OrganizationUsersEndpoint.as_view(),
                     name="sentry-api-0-organization-users",
@@ -932,11 +937,6 @@ urlpatterns = patterns(
                     r"^(?P<organization_slug>[^\/]+)/users/(?P<user_id>[^\/]+)/$",
                     OrganizationUserDetailsEndpoint.as_view(),
                     name="sentry-api-0-organization-user-details",
-                ),
-                url(
-                    r"^(?P<organization_slug>[^\/]+)/user-teams/$",
-                    OrganizationUserTeamsEndpoint.as_view(),
-                    name="sentry-api-0-organization-user-teams",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/sentry-app-installations/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -934,6 +934,11 @@ urlpatterns = patterns(
                     name="sentry-api-0-organization-user-details",
                 ),
                 url(
+                    r"^(?P<organization_slug>[^\/]+)/user-teams/$",
+                    OrganizationUserTeamsEndpoint.as_view(),
+                    name="sentry-api-0-organization-user-teams",
+                ),
+                url(
                     r"^(?P<organization_slug>[^\/]+)/sentry-app-installations/$",
                     SentryAppInstallationsEndpoint.as_view(),
                     name="sentry-api-0-sentry-app-installations",
@@ -952,11 +957,6 @@ urlpatterns = patterns(
                     r"^(?P<organization_slug>[^\/]+)/teams/$",
                     OrganizationTeamsEndpoint.as_view(),
                     name="sentry-api-0-organization-teams",
-                ),
-                url(
-                    r"^(?P<organization_slug>[^\/]+)/user-teams/$",
-                    OrganizationUserTeamsEndpoint.as_view(),
-                    name="sentry-api-0-organization-user-teams",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/tags/$",


### PR DESCRIPTION
Place the url declaration for `/organizations/{slug}/user-teams/` next to the rest of organization user endpoints in a semi-alphabetic order?