### PR TITLE
Python 3: bytes can only contain ASCII literal chars

### DIFF
--- a/tests/sentry/integrations/github/testutils.py
+++ b/tests/sentry/integrations/github/testutils.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 # we keep this as a raw string as order matters for hmac signing
-PUSH_EVENT_EXAMPLE_INSTALLATION = b"""{
+PUSH_EVENT_EXAMPLE_INSTALLATION = r"""{
   "ref": "refs/heads/changes",
   "installation" : {
     "id": 12345

--- a/tests/sentry/integrations/github_enterprise/testutils.py
+++ b/tests/sentry/integrations/github_enterprise/testutils.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 # we keep this as a raw string as order matters for hmac signing
-PUSH_EVENT_EXAMPLE = b"""{
+PUSH_EVENT_EXAMPLE = r"""{
   "ref": "refs/heads/changes",
   "before": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
   "after": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",


### PR DESCRIPTION
__SyntaxError: bytes can only contain ASCII literal characters__ in Python 3 as detected via #14906

The comment says we will use a raw string but the code uses a bytes string.  This PR proposes using an r"string" instead of a b"string".