### PR TITLE
ref(symbols): Search Microsoft Symbol Server for all symbols

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1525,7 +1525,7 @@ SENTRY_BUILTIN_SOURCES = {
         "id": "sentry:microsoft",
         "name": "Microsoft",
         "layout": {"type": "symstore"},
-        "filters": {"filetypes": ["pdb", "pe"], "path_patterns": ["?:/windows/**"]},
+        "filters": {"filetypes": ["pdb", "pe"]},
         "url": "https://msdl.microsoft.com/download/symbols/",
         "is_public": True,
     },


### PR DESCRIPTION
Removes the path filter from the Microsoft Symbol Server.

Certain Microsoft symbols, such as DirectX or Visual C++ libraries, are usually not located in the Windows folder. At the moment, we're not able to resolve them, since we don't query the Microsoft symbol server for those locations.

This change will slightly increase the number of requests to the Microsoft symbol server.