### PR TITLE
fix(app-platform): Honor per_page in stats api

### DIFF
--- a/src/sentry/api/endpoints/sentry_apps_stats.py
+++ b/src/sentry/api/endpoints/sentry_apps_stats.py
@@ -12,18 +12,19 @@ class SentryAppsStatsEndpoint(SentryAppsBaseEndpoint):
     permission_classes = (SuperuserPermission,)
 
     def get(self, request):
-        sentry_apps = SentryApp.objects.filter(installations__date_deleted=None).annotate(
-            Count("installations")
-        )
-        results = []
-        for app in sentry_apps:
-            results.append(
-                {
-                    "id": app.id,
-                    "slug": app.slug,
-                    "name": app.name,
-                    "installs": app.installations__count,
-                }
-            )
+        sentry_apps = SentryApp.objects \
+            .filter(installations__date_deleted=None) \
+            .annotate(Count("installations")) \
+            .order_by()
 
-        return Response(results)
+        if 'per_page' in request.query_params:
+            sentry_apps = sentry_apps[:int(request.query_params['per_page'])]
+
+        apps = [{
+            "id": app.id,
+            "slug": app.slug,
+            "name": app.name,
+            "installs": app.installations__count,
+        } for app in sentry_apps]
+
+        return Response(apps)

--- a/tests/sentry/api/endpoints/test_sentry_apps_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps_stats.py
@@ -50,3 +50,29 @@ class SentryAppsStatsTest(APITestCase):
         response = self.client.get(self.url, format="json")
 
         assert response.status_code == 403
+
+    def test_per_page(self):
+        self.login_as(user=self.superuser, superuser=True)
+
+        self.create_sentry_app_installation(
+            slug=self.app_1.slug,
+            organization=self.create_organization(),
+        )
+
+        for i in range(15):
+            app = self.create_sentry_app(
+                name="Test {}".format(i),
+                organization=self.super_org,
+                published=True,
+            )
+
+            self.create_sentry_app_installation(
+                slug=app.slug,
+                organization=self.org,
+            )
+
+        response = self.client.get(self.url + '?per_page=10', format="json")
+        integrations = json.loads(response.content)
+
+        assert len(integrations) == 10  # honors per_page
+        assert integrations[0]['installs'] == 2  # sorted by installs


### PR DESCRIPTION
This endpoint returns a list of all platform integrations. Previously it wasn't honoring the `per_page` query param and so _admin is showing wayyyyy too many rows.

This change honors `per_page`.