### PR TITLE
feat(request-join): Add organization setting

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -136,6 +136,7 @@ class OrganizationSerializer(serializers.Serializer):
     isEarlyAdopter = serializers.BooleanField(required=False)
     require2FA = serializers.BooleanField(required=False)
     trustedRelays = ListField(child=serializers.CharField(), required=False)
+    allowJoinRequests = serializers.BooleanField(required=False)
 
     @memoize
     def _has_legacy_rate_limits(self):
@@ -265,6 +266,8 @@ class OrganizationSerializer(serializers.Serializer):
             org.flags.early_adopter = self.initial_data["isEarlyAdopter"]
         if "require2FA" in self.initial_data:
             org.flags.require_2fa = self.initial_data["require2FA"]
+        if "allowJoinRequests" in self.initial_data:
+            org.flags.disable_join_requests = not self.initial_data["allowJoinRequests"]
         if "name" in self.initial_data:
             org.name = self.initial_data["name"]
         if "slug" in self.initial_data:
@@ -280,6 +283,7 @@ class OrganizationSerializer(serializers.Serializer):
                 "disable_shared_issues": org.flags.disable_shared_issues.is_set,
                 "early_adopter": org.flags.early_adopter.is_set,
                 "require_2fa": org.flags.require_2fa.is_set,
+                "disable_join_requests": org.flags.disable_join_requests.is_set,
             },
         }
 

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -82,6 +82,7 @@ ORG_OPTIONS = (
         org_serializers.REQUIRE_SCRUB_IP_ADDRESS_DEFAULT,
     ),
     ("trustedRelays", "sentry:trusted-relays", list, org_serializers.TRUSTED_RELAYS_DEFAULT),
+    ("allowJoinRequests", "sentry:join_requests", bool, org_serializers.JOIN_REQUESTS_DEFAULT),
 )
 
 delete_logger = logging.getLogger("sentry.deletions.api")
@@ -266,8 +267,6 @@ class OrganizationSerializer(serializers.Serializer):
             org.flags.early_adopter = self.initial_data["isEarlyAdopter"]
         if "require2FA" in self.initial_data:
             org.flags.require_2fa = self.initial_data["require2FA"]
-        if "allowJoinRequests" in self.initial_data:
-            org.flags.disable_join_requests = not self.initial_data["allowJoinRequests"]
         if "name" in self.initial_data:
             org.name = self.initial_data["name"]
         if "slug" in self.initial_data:
@@ -283,7 +282,6 @@ class OrganizationSerializer(serializers.Serializer):
                 "disable_shared_issues": org.flags.disable_shared_issues.is_set,
                 "early_adopter": org.flags.early_adopter.is_set,
                 "require_2fa": org.flags.require_2fa.is_set,
-                "disable_join_requests": org.flags.disable_join_requests.is_set,
             },
         }
 

--- a/src/sentry/api/endpoints/organization_join_request.py
+++ b/src/sentry/api/endpoints/organization_join_request.py
@@ -58,7 +58,7 @@ class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
         if assignment != 1:
             return Response(status=403)
 
-        if bool(organization.flags.disable_join_requests):
+        if organization.get_option("sentry:join_requests") is False:
             return Response(
                 {"detail": "Your organization does not allow access requests."}, status=403
             )

--- a/src/sentry/api/endpoints/organization_join_request.py
+++ b/src/sentry/api/endpoints/organization_join_request.py
@@ -60,7 +60,7 @@ class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
 
         if organization.get_option("sentry:join_requests") is False:
             return Response(
-                {"detail": "Your organization does not allow access requests."}, status=403
+                {"detail": "Your organization does not allow join requests."}, status=403
             )
 
         # users can already join organizations with SSO enabled without an invite

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -162,6 +162,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 "require2FA": bool(obj.flags.require_2fa),
                 "allowSharedIssues": not obj.flags.disable_shared_issues,
                 "enhancedPrivacy": bool(obj.flags.enhanced_privacy),
+                "allowJoinRequests": not bool(obj.flags.disable_join_requests),
                 "dataScrubber": bool(
                     obj.get_option("sentry:require_scrub_data", REQUIRE_SCRUB_DATA_DEFAULT)
                 ),

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -34,6 +34,7 @@ ATTACHMENTS_ROLE_DEFAULT = settings.SENTRY_DEFAULT_ROLE
 REQUIRE_SCRUB_IP_ADDRESS_DEFAULT = False
 SCRAPE_JAVASCRIPT_DEFAULT = True
 TRUSTED_RELAYS_DEFAULT = None
+JOIN_REQUESTS_DEFAULT = True
 
 
 @register(Organization)
@@ -162,7 +163,6 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 "require2FA": bool(obj.flags.require_2fa),
                 "allowSharedIssues": not obj.flags.disable_shared_issues,
                 "enhancedPrivacy": bool(obj.flags.enhanced_privacy),
-                "allowJoinRequests": not bool(obj.flags.disable_join_requests),
                 "dataScrubber": bool(
                     obj.get_option("sentry:require_scrub_data", REQUIRE_SCRUB_DATA_DEFAULT)
                 ),
@@ -190,6 +190,9 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 ),
                 "trustedRelays": obj.get_option("sentry:trusted-relays", TRUSTED_RELAYS_DEFAULT)
                 or [],
+                "allowJoinRequests": bool(
+                    obj.get_option("sentry:join_requests", JOIN_REQUESTS_DEFAULT)
+                ),
             }
         )
         context["access"] = access.scopes

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -137,6 +137,7 @@ class Organization(Model):
                 "disable_new_visibility_features",
                 "Temporarily opt out of new visibility features and ui",
             ),
+            ("disable_join_requests", "Do not allow users to request to join the organization."),
         ),
         default=1,
     )

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -137,7 +137,6 @@ class Organization(Model):
                 "disable_new_visibility_features",
                 "Temporarily opt out of new visibility features and ui",
             ),
-            ("disable_join_requests", "Do not allow users to request to join the organization."),
         ),
         default=1,
     )

--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
@@ -74,7 +74,7 @@ const formGroups = [
         name: 'require2FA',
         type: 'boolean',
         label: t('Require Two-Factor Authentication'),
-        help: t('Require two-factor authentication for all members'),
+        help: t('Require and enforce two-factor authentication for all members'),
         confirm: {
           true: t(
             'This will remove all members without two-factor authentication' +
@@ -228,6 +228,20 @@ const formGroups = [
         getValue: val => extractMultilineFields(val),
         setValue: val => (val && typeof val.join === 'function' && val.join('\n')) || '',
         visible: ({features}) => features.has('relay'),
+      },
+      {
+        name: 'allowJoinRequests',
+        type: 'boolean',
+
+        label: t('Allow Access Requests'),
+        help: t('Allow users to request access to your organization'),
+        confirm: {
+          true: t(
+            'Are you sure you want to allow users to request access to your organization?'
+          ),
+        },
+        visible: ({experiments}) =>
+          !!experiments && experiments.JoinRequestExperiment === 1,
       },
     ],
   },

--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
@@ -141,7 +141,7 @@ const formGroups = [
         autosize: true,
         maxRows: 10,
         placeholder: 'e.g. email',
-        label: t('Global sensitive fields'),
+        label: t('Global Sensitive Fields'),
         help: t(
           'Additional field names to match against when scrubbing data for all projects. Separate multiple entries with a newline.'
         ),
@@ -158,7 +158,7 @@ const formGroups = [
         autosize: true,
         maxRows: 10,
         placeholder: t('e.g. business-email'),
-        label: t('Global safe fields'),
+        label: t('Global Safe Fields'),
         help: t(
           'Field names which data scrubbers should ignore. Separate multiple entries with a newline.'
         ),
@@ -189,7 +189,7 @@ const formGroups = [
             "Are you sure you want to disable sourcecode fetching for JavaScript events? This will affect Sentry's ability to aggregate issues if you're not already uploading sourcemaps as artifacts."
           ),
         },
-        label: t('Allow JavaScript source fetching'),
+        label: t('Allow JavaScript Source Fetching'),
         help: t('Allow Sentry to scrape missing JavaScript source context when possible'),
       },
       {
@@ -233,11 +233,11 @@ const formGroups = [
         name: 'allowJoinRequests',
         type: 'boolean',
 
-        label: t('Allow Access Requests'),
-        help: t('Allow users to request access to your organization'),
+        label: t('Allow Join Requests'),
+        help: t('Allow users to request to join your organization'),
         confirm: {
           true: t(
-            'Are you sure you want to allow users to request access to your organization?'
+            'Are you sure you want to allow users to request to join your organization?'
           ),
         },
         visible: ({experiments}) =>

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formPanel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formPanel.tsx
@@ -20,6 +20,7 @@ type Props = {
   // TODO(ts): See if this is still in use
   access: any;
   features: any;
+  experiments: any;
 
   additionalFieldProps: {[key: string]: any};
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.tsx
@@ -62,6 +62,7 @@ class JsonForm extends React.Component<Props, State> {
 
     access: PropTypes.object,
     features: PropTypes.object,
+    experiments: PropTypes.object,
     renderFooter: PropTypes.func,
     /**
      * Renders inside of PanelBody
@@ -129,6 +130,7 @@ class JsonForm extends React.Component<Props, State> {
       access,
       disabled,
       features,
+      experiments,
       additionalFieldProps,
       renderFooter,
       renderHeader,
@@ -140,6 +142,7 @@ class JsonForm extends React.Component<Props, State> {
       access,
       disabled,
       features,
+      experiments,
       additionalFieldProps,
       renderFooter,
       renderHeader,

--- a/src/sentry/static/sentry/app/views/settings/organizationGeneralSettings/organizationSettingsForm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationGeneralSettings/organizationSettingsForm.jsx
@@ -42,6 +42,7 @@ class OrganizationSettingsForm extends React.Component {
       >
         <PermissionAlert />
         <JsonForm
+          experiments={organization.experiments}
           features={new Set(organization.features)}
           access={access}
           location={this.props.location}

--- a/tests/js/spec/views/settings/organizationGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/settings/organizationGeneralSettings.spec.jsx
@@ -185,7 +185,7 @@ describe('OrganizationGeneralSettings', function() {
     );
   });
 
-  it('shows require2fa switch w/ feature flag', async function() {
+  it('shows require2fa switch', async function() {
     const wrapper = mount(
       <OrganizationGeneralSettings params={{orgId: org.slug}} />,
       TestStubs.routerContext()
@@ -292,5 +292,62 @@ describe('OrganizationGeneralSettings', function() {
     expect(wrapper.find('Switch[name="require2FA"]').prop('isActive')).toBe(false);
     // eslint-disable-next-line no-console
     console.error.mockRestore();
+  });
+
+  it('renders access request switch with experiment', async function() {
+    const organization = TestStubs.Organization({
+      experiments: {JoinRequestExperiment: 1},
+    });
+    const wrapper = mount(
+      <OrganizationGeneralSettings params={{orgId: organization.slug}} />,
+      TestStubs.routerContext([{organization}])
+    );
+
+    wrapper.setState({loading: false});
+    await tick();
+    wrapper.update();
+    expect(wrapper.find('Switch[name="allowJoinRequests"]').exists()).toBe(true);
+  });
+
+  it('does not render access request switch not in experiment', async function() {
+    const organization = TestStubs.Organization({
+      experiments: {JoinRequestExperiment: -1},
+    });
+    const wrapper = mount(
+      <OrganizationGeneralSettings params={{orgId: organization.slug}} />,
+      TestStubs.routerContext([{organization}])
+    );
+
+    wrapper.setState({loading: false});
+    await tick();
+    wrapper.update();
+    expect(wrapper.find('Switch[name="allowJoinRequests"]').exists()).toBe(false);
+  });
+
+  it('does not render access request switch in experiment control', async function() {
+    const organization = TestStubs.Organization({
+      experiments: {JoinRequestExperiment: 0},
+    });
+    const wrapper = mount(
+      <OrganizationGeneralSettings params={{orgId: organization.slug}} />,
+      TestStubs.routerContext([{organization}])
+    );
+
+    wrapper.setState({loading: false});
+    await tick();
+    wrapper.update();
+    expect(wrapper.find('Switch[name="allowJoinRequests"]').exists()).toBe(false);
+  });
+
+  it('does not render access request switch without experiments', async function() {
+    const wrapper = mount(
+      <OrganizationGeneralSettings params={{orgId: org.slug}} />,
+      TestStubs.routerContext()
+    );
+
+    wrapper.setState({loading: false});
+    await tick();
+    wrapper.update();
+    expect(wrapper.find('Switch[name="allowJoinRequests"]').exists()).toBe(false);
   });
 });

--- a/tests/js/spec/views/settings/organizationGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/settings/organizationGeneralSettings.spec.jsx
@@ -294,7 +294,7 @@ describe('OrganizationGeneralSettings', function() {
     console.error.mockRestore();
   });
 
-  it('renders access request switch with experiment', async function() {
+  it('renders join request switch with experiment', async function() {
     const organization = TestStubs.Organization({
       experiments: {JoinRequestExperiment: 1},
     });
@@ -309,7 +309,7 @@ describe('OrganizationGeneralSettings', function() {
     expect(wrapper.find('Switch[name="allowJoinRequests"]').exists()).toBe(true);
   });
 
-  it('does not render access request switch not in experiment', async function() {
+  it('does not render join request switch not in experiment', async function() {
     const organization = TestStubs.Organization({
       experiments: {JoinRequestExperiment: -1},
     });
@@ -324,7 +324,7 @@ describe('OrganizationGeneralSettings', function() {
     expect(wrapper.find('Switch[name="allowJoinRequests"]').exists()).toBe(false);
   });
 
-  it('does not render access request switch in experiment control', async function() {
+  it('does not render join request switch in experiment control', async function() {
     const organization = TestStubs.Organization({
       experiments: {JoinRequestExperiment: 0},
     });
@@ -339,7 +339,7 @@ describe('OrganizationGeneralSettings', function() {
     expect(wrapper.find('Switch[name="allowJoinRequests"]').exists()).toBe(false);
   });
 
-  it('does not render access request switch without experiments', async function() {
+  it('does not render join request switch without experiments', async function() {
     const wrapper = mount(
       <OrganizationGeneralSettings params={{orgId: org.slug}} />,
       TestStubs.routerContext()

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -203,6 +203,7 @@ class OrganizationUpdateTest(APITestCase):
             "scrapeJavaScript": False,
             "defaultRole": "owner",
             "require2FA": True,
+            "allowJoinRequests": False,
         }
 
         # needed to set require2FA
@@ -220,6 +221,7 @@ class OrganizationUpdateTest(APITestCase):
         assert org.flags.disable_shared_issues
         assert org.flags.enhanced_privacy
         assert org.flags.require_2fa
+        assert org.flags.disable_join_requests
         assert org.default_role == "owner"
 
         options = {o.key: o.value for o in OrganizationOption.objects.filter(organization=org)}
@@ -249,6 +251,7 @@ class OrganizationUpdateTest(APITestCase):
         assert u"to {}".format(data["safeFields"]) in log.data["safeFields"]
         assert u"to {}".format(data["scrubIPAddresses"]) in log.data["scrubIPAddresses"]
         assert u"to {}".format(data["scrapeJavaScript"]) in log.data["scrapeJavaScript"]
+        assert u"to {}".format(not data["allowJoinRequests"]) in log.data["disable_join_requests"]
 
     def test_setting_trusted_relays_forbidden(self):
         org = self.create_organization(owner=self.user)

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -221,7 +221,6 @@ class OrganizationUpdateTest(APITestCase):
         assert org.flags.disable_shared_issues
         assert org.flags.enhanced_privacy
         assert org.flags.require_2fa
-        assert org.flags.disable_join_requests
         assert org.default_role == "owner"
 
         options = {o.key: o.value for o in OrganizationOption.objects.filter(organization=org)}
@@ -233,6 +232,7 @@ class OrganizationUpdateTest(APITestCase):
         assert options.get("sentry:safe_fields") == ["email"]
         assert options.get("sentry:store_crash_reports") is True
         assert options.get("sentry:scrape_javascript") is False
+        assert options.get("sentry:join_requests") is False
 
         # log created
         log = AuditLogEntry.objects.get(organization=org)
@@ -251,7 +251,7 @@ class OrganizationUpdateTest(APITestCase):
         assert u"to {}".format(data["safeFields"]) in log.data["safeFields"]
         assert u"to {}".format(data["scrubIPAddresses"]) in log.data["scrubIPAddresses"]
         assert u"to {}".format(data["scrapeJavaScript"]) in log.data["scrapeJavaScript"]
-        assert u"to {}".format(not data["allowJoinRequests"]) in log.data["disable_join_requests"]
+        assert u"to {}".format(data["allowJoinRequests"]) in log.data["allowJoinRequests"]
 
     def test_setting_trusted_relays_forbidden(self):
         org = self.create_organization(owner=self.user)

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -2,9 +2,8 @@ from __future__ import absolute_import
 
 from exam import fixture
 from mock import patch
-from django.db.models import F
 
-from sentry.models import AuthProvider, InviteStatus, Organization, OrganizationMember
+from sentry.models import AuthProvider, InviteStatus, OrganizationOption, OrganizationMember
 from sentry.testutils import APITestCase
 from sentry.api.endpoints.organization_join_request import JOIN_REQUEST_EXPERIMENT
 
@@ -53,7 +52,9 @@ class OrganizationJoinRequestTest(APITestCase):
 
     @patch("sentry.experiments.get", return_value=1)
     def test_organization_setting_disabled(self, mock_experiment):
-        self.org.update(flags=F("flags").bitor(Organization.flags.disable_join_requests))
+        OrganizationOption.objects.create(
+            organization_id=self.org.id, key="sentry:join_requests", value=False
+        )
 
         resp = self.get_response(self.org.slug)
         assert resp.status_code == 403


### PR DESCRIPTION
This adds a toggle in organization settings for `Allow Access Requests`. This setting defaults to `True` and can be disabled if organizations don't want to allow outside access requests. 