### PR TITLE
fix(discover) Fix error clearing condition

### DIFF
--- a/src/sentry/static/sentry/app/views/discover/aggregations/aggregation.tsx
+++ b/src/sentry/static/sentry/app/views/discover/aggregations/aggregation.tsx
@@ -28,10 +28,10 @@ export default class AggregationRow extends React.Component<
   AggregationProps,
   AggregationState
 > {
+  state = initalState;
+
   // This is the ref of the inner react-select component
   private select: any;
-
-  state = initalState;
 
   getOptions() {
     const currentValue = getInternal(this.props.value);

--- a/src/sentry/static/sentry/app/views/discover/conditions/condition.tsx
+++ b/src/sentry/static/sentry/app/views/discover/conditions/condition.tsx
@@ -142,7 +142,8 @@ export default class ConditionRow extends React.Component<
 
   inputRenderer = (props: ConditionProps) => {
     const onChange = (evt: any) => {
-      if (evt.target.value === '') {
+      if (evt.target && evt.target.value === '') {
+        evt.persist();
         // React select won't trigger an onChange event when a value is completely
         // cleared, so we'll force this before calling onChange
         this.setState({inputValue: evt.target.value}, () => {


### PR DESCRIPTION
When clearing the condition field the event needs to be persisted in order for ~Select2~ react-select to have access to the target later on.

Fixes #14597