### PR TITLE
fix(alerts): Rules that check if tags is (not) set do not require value

### DIFF
--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -35,7 +35,16 @@ MATCH_CHOICES = OrderedDict(
 class TaggedEventForm(forms.Form):
     key = forms.CharField(widget=forms.TextInput())
     match = forms.ChoiceField(MATCH_CHOICES.items(), widget=forms.Select())
-    value = forms.CharField(widget=forms.TextInput())
+    value = forms.CharField(widget=forms.TextInput(), required=False)
+
+    def clean(self):
+        super(TaggedEventForm, self).clean()
+
+        match = self.cleaned_data.get("match")
+        value = self.cleaned_data.get("value")
+
+        if match != MatchType.IS_SET and match != MatchType.NOT_SET and not value:
+            raise forms.ValidationError("This field is required.")
 
 
 class TaggedEventCondition(EventCondition):

--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -43,7 +43,7 @@ class TaggedEventForm(forms.Form):
         match = self.cleaned_data.get("match")
         value = self.cleaned_data.get("value")
 
-        if match != MatchType.IS_SET and match != MatchType.NOT_SET and not value:
+        if match not in (MatchType.IS_SET, MatchType.NOT_SET) and not value:
             raise forms.ValidationError("This field is required.")
 
 

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleEditor/ruleNode.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleEditor/ruleNode.jsx
@@ -88,6 +88,16 @@ class RuleNode extends React.Component {
       }
 
       const key = part.slice(1, -1);
+
+      // If matcher is "is set" or "is not set", then we do not want to show the value input
+      // because it is not required
+      if (
+        key === 'value' &&
+        (this.props.data.match === 'is' || this.props.data.match === 'ns')
+      ) {
+        return null;
+      }
+
       return formFields[key] ? this.getField(key, formFields[key]) : part;
     });
   }


### PR DESCRIPTION
This fixes a bug introduced with #14544 where making a rule with "is set" or "is not set" requires a value (even though logically it does not need one). The UI now hides the field, and the API no longer requires it in these cases.

Closes SEN-1055