### PR TITLE
fix(ui): replaced width percent with flex-basis in stackframe

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1042,10 +1042,10 @@ div.traceback > ul {
       padding-left: 15px;
 
       .package {
-        width: 15%;
         font-size: 13px;
         font-weight: bold;
         .truncate;
+        flex-basis: 120px;
         flex-grow: 0;
         flex-shrink: 0;
       }


### PR DESCRIPTION
Note to self: The btn-toggle has a set width while the rest of the content has flex-grow: 1. This means the content grows if the stacktrace is not expandable. With this conditional, children widths shouldn't be percentage based since it's based on the parent. Applying flex-basis is a quick fix. 