### PR TITLE
fix(api): Return users regardless of project association

### DIFF
--- a/src/sentry/api/endpoints/organization_users.py
+++ b/src/sentry/api/endpoints/organization_users.py
@@ -12,7 +12,11 @@ class OrganizationUsersEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
         projects = self.get_projects(request, organization)
         qs = (
-            OrganizationMember.objects.filter(user__is_active=True, organization=organization)
+            OrganizationMember.objects.filter(
+                user__is_active=True,
+                organization=organization,
+                teams__projectteam__project__in=projects,
+            )
             .select_related("user")
             .prefetch_related("teams", "teams__projectteam_set", "teams__projectteam_set__project")
             .order_by("user__email")

--- a/src/sentry/api/endpoints/organization_users.py
+++ b/src/sentry/api/endpoints/organization_users.py
@@ -12,11 +12,7 @@ class OrganizationUsersEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
         projects = self.get_projects(request, organization)
         qs = (
-            OrganizationMember.objects.filter(
-                user__is_active=True,
-                organization=organization,
-                teams__projectteam__project__in=projects,
-            )
+            OrganizationMember.objects.filter(user__is_active=True, organization=organization)
             .select_related("user")
             .prefetch_related("teams", "teams__projectteam_set", "teams__projectteam_set__project")
             .order_by("user__email")

--- a/src/sentry/static/sentry/app/utils/attachmentUrl.tsx
+++ b/src/sentry/static/sentry/app/utils/attachmentUrl.tsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {OrganizationDetailed, Event, EventAttachment} from 'app/types';
-import ConfigStore from 'app/stores/configStore';
 import MemberListStore from 'app/stores/memberListStore';
 import withOrganization from 'app/utils/withOrganization';
 import SentryTypes from 'app/sentryTypes';
@@ -25,7 +24,8 @@ class AttachmentUrl extends React.PureComponent<Props> {
   };
 
   hasAttachmentsRole() {
-    const user = ConfigStore.get('user');
+    const member = MemberListStore.getMe();
+    const user = member && member.user;
     if (!user) {
       return false;
     }
@@ -39,12 +39,9 @@ class AttachmentUrl extends React.PureComponent<Props> {
       return false;
     }
 
-    const member = MemberListStore.getById(user.id);
-    const currentRole = member && member.role;
-
     const roleIds = availableRoles.map(role => role.id);
     const requiredIndex = roleIds.indexOf(attachmentsRole);
-    const currentIndex = roleIds.indexOf(currentRole);
+    const currentIndex = roleIds.indexOf(member.role);
     return currentIndex >= requiredIndex;
   }
 


### PR DESCRIPTION
Our organization users endpoint only returned users that were members of at least one team with at least one project associated. The response is used to fill the `MemberListStore`, which is used to perform permission checks in the UI.

As it turns out, Manager and Owner users do not need to be part of any team to have access to an organization's entities, but the UI did not grant it in some cases. One example was the attachment download:

![image](https://user-images.githubusercontent.com/1433023/66207365-e14d0880-e6b2-11e9-95a9-aa6b4e92f57d.png)

Fixes ISSUE-504