### PR TITLE
ref(ui): Add page titles to organization projects and settings

### DIFF
--- a/src/sentry/static/sentry/app/components/sentryDocumentTitle.tsx
+++ b/src/sentry/static/sentry/app/components/sentryDocumentTitle.tsx
@@ -1,0 +1,19 @@
+import React, {FunctionComponent, ReactChildren} from 'react';
+import DocumentTitle from 'react-document-title';
+
+type DocumentTitleProps = {
+  // Main page title
+  title: string;
+  // Organization or project slug to give title some context
+  objSlug: string;
+  children?: ReactChildren;
+};
+
+const SentryDocumentTitle: FunctionComponent<DocumentTitleProps> = (
+  props: DocumentTitleProps
+) => {
+  const _title = `${props.title} - ${props.objSlug} - Sentry`;
+  return <DocumentTitle title={_title}>{props.children}</DocumentTitle>;
+};
+
+export default SentryDocumentTitle;

--- a/src/sentry/static/sentry/app/utils/routeTitle.tsx
+++ b/src/sentry/static/sentry/app/utils/routeTitle.tsx
@@ -1,0 +1,10 @@
+function routeTitleGen(
+  routeName: string,
+  orgSlug: string,
+  withSentry: boolean = true
+): string {
+  const tmpl = `${routeName} - ${orgSlug}`;
+  return withSentry ? `${tmpl} - Sentry` : tmpl;
+}
+
+export default routeTitleGen;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.tsx
@@ -10,6 +10,7 @@ import {sortArray} from 'app/utils';
 import {t} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
 import LoadingIndicator from 'app/components/loadingIndicator';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import MigrationWarnings from 'app/views/organizationIntegrations/migrationWarnings';
 import PermissionAlert from 'app/views/settings/organization/permissionAlert';
 import ProviderRow from 'app/views/organizationIntegrations/providerRow';
@@ -255,6 +256,7 @@ class OrganizationIntegrations extends AsyncComponent<
   };
 
   renderBody() {
+    const {orgId} = this.props.params;
     const {reloading, orgOwnedApps, publishedApps} = this.state;
     const published = publishedApps || [];
     // we dont want the app to render twice if its the org that created
@@ -283,9 +285,12 @@ class OrganizationIntegrations extends AsyncComponent<
       orgOwned.filter(a => a.status === 'internal')
     );
 
+    const title = t('Integrations');
+
     return (
       <React.Fragment>
-        {!this.props.hideHeader && <SettingsPageHeader title={t('Integrations')} />}
+        <SentryDocumentTitle title={title} objSlug={orgId} />
+        {!this.props.hideHeader && <SettingsPageHeader title={title} />}
         <PermissionAlert access={['org:integrations']} />
 
         <MigrationWarnings

--- a/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
@@ -12,6 +12,7 @@ import ConfigStore from 'app/stores/configStore';
 import IdBadge from 'app/components/idBadge';
 import NoProjectMessage from 'app/components/noProjectMessage';
 import PageHeading from 'app/components/pageHeading';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import ProjectsStatsStore from 'app/stores/projectsStatsStore';
 import SentryTypes from 'app/sentryTypes';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
@@ -64,9 +65,12 @@ class Dashboard extends React.Component {
     if (showEmptyMessage) {
       return <NoProjectMessage organization={organization}>{null}</NoProjectMessage>;
     }
-
     return (
       <React.Fragment>
+        <SentryDocumentTitle
+          title={t('Projects Dashboard')}
+          objSlug={organization.slug}
+        />
         {projects.length > 0 && (
           <ProjectsHeader>
             <PageHeading>Projects</PageHeading>

--- a/src/sentry/static/sentry/app/views/settings/organizationAuditLog/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuditLog/index.jsx
@@ -4,6 +4,8 @@ import React from 'react';
 
 import AsyncView from 'app/views/asyncView';
 import SentryTypes from 'app/sentryTypes';
+import {t} from 'app/locale';
+import routeTitleGen from 'app/utils/routeTitle';
 
 import AuditLogList from './auditLogList';
 
@@ -82,8 +84,7 @@ class OrganizationAuditLog extends AsyncView {
   }
 
   getTitle() {
-    const org = this.context.organization;
-    return `${org.name} Audit Log`;
+    return routeTitleGen(t('Audit Log'), this.context.organization.slug, false);
   }
 
   handleEventSelect = value => {

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/index.jsx
@@ -4,6 +4,7 @@ import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import IndicatorStore from 'app/stores/indicatorStore';
 import SentryTypes from 'app/sentryTypes';
+import routeTitleGen from 'app/utils/routeTitle';
 
 import OrganizationAuthList from './organizationAuthList';
 
@@ -30,8 +31,7 @@ class OrganizationAuth extends AsyncView {
   }
 
   getTitle() {
-    const org = this.context.organization;
-    return `${org.name} - Auth Settings`;
+    return routeTitleGen(t('Auth Settings'), this.context.organization.slug, false);
   }
 
   handleSendReminders = provider => {

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.jsx
@@ -11,11 +11,17 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import SentryApplicationRow from 'app/views/settings/organizationDeveloperSettings/sentryApplicationRow';
 import withOrganization from 'app/utils/withOrganization';
 import {t} from 'app/locale';
+import routeTitleGen from 'app/utils/routeTitle';
 
 class OrganizationDeveloperSettings extends AsyncView {
   static propTypes = {
     organization: SentryTypes.Organization.isRequired,
   };
+
+  getTitle() {
+    const {orgId} = this.props.params;
+    return routeTitleGen(t('Developer Settings'), orgId, false);
+  }
 
   getEndpoints() {
     const {orgId} = this.props.params;

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -20,6 +20,7 @@ import {
   internalIntegrationForms,
 } from 'app/data/forms/sentryApplication';
 import getDynamicText from 'app/utils/getDynamicText';
+import routeTitleGen from 'app/utils/routeTitle';
 
 import DateTime from 'app/components/dateTime';
 import Button from 'app/components/button';
@@ -92,7 +93,8 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
   }
 
   getTitle() {
-    return t('Sentry Integration Details');
+    const {orgId} = this.props.params;
+    return routeTitleGen(t('Sentry Integration Details'), orgId, false);
   }
 
   // Events may come from the API as "issue.created" when we just want "issue" here.

--- a/src/sentry/static/sentry/app/views/settings/organizationGeneralSettings/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationGeneralSettings/index.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 
 import {Panel, PanelHeader} from 'app/components/panels';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {addLoadingMessage} from 'app/actionCreators/indicator';
 import {
   changeOrganizationSlug,
@@ -97,6 +98,7 @@ const OrganizationGeneralSettings = createReactClass({
 
     return (
       <div>
+        <SentryDocumentTitle title={t('General Settings')} objSlug={orgId} />
         {error && <LoadingError />}
         {loading && !error && <LoadingIndicator />}
 

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/index.jsx
@@ -12,6 +12,7 @@ import ConfigStore from 'app/stores/configStore';
 import Pagination from 'app/components/pagination';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
+import routeTitleGen from 'app/utils/routeTitle';
 import {redirectToRemainingOrganization} from 'app/actionCreators/organizations';
 import {openInviteMembersModal} from 'app/actionCreators/modal';
 
@@ -77,8 +78,8 @@ class OrganizationMembersView extends AsyncView {
   }
 
   getTitle() {
-    const org = this.context.organization;
-    return `${org.name} Members`;
+    const orgId = this.context.organization.slug;
+    return routeTitleGen(t('Members'), orgId, false);
   }
 
   removeMember = id => {

--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
@@ -13,6 +13,7 @@ import ProjectListItem from 'app/views/settings/components/settingsProjectItem';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import withOrganization from 'app/utils/withOrganization';
+import routeTitleGen from 'app/utils/routeTitle';
 
 import ProjectStatsGraph from './projectStatsGraph';
 
@@ -67,8 +68,8 @@ class OrganizationProjects extends AsyncView {
   }
 
   getTitle() {
-    const org = this.props.organization;
-    return `${org.name} Projects`;
+    const {organization} = this.props;
+    return routeTitleGen(t('Projects'), organization.slug, false);
   }
 
   renderBody() {

--- a/src/sentry/static/sentry/app/views/settings/organizationRepositories/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRepositories/index.jsx
@@ -3,6 +3,9 @@ import React from 'react';
 import {sortArray} from 'app/utils';
 import AsyncView from 'app/views/asyncView';
 import Pagination from 'app/components/pagination';
+import {t} from 'app/locale';
+import routeTitleGen from 'app/utils/routeTitle';
+
 import OrganizationRepositories from './organizationRepositories';
 
 export default class OrganizationRepositoriesContainer extends AsyncView {
@@ -34,7 +37,8 @@ export default class OrganizationRepositoriesContainer extends AsyncView {
   };
 
   getTitle() {
-    return 'Repositories';
+    const {orgId} = this.props.params;
+    return routeTitleGen(t('Repositories'), orgId, false);
   }
 
   renderBody() {

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/organizationTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/organizationTeams.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {openCreateTeamModal} from 'app/actionCreators/modal';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
@@ -64,10 +65,12 @@ class OrganizationTeams extends React.Component {
 
     const activeTeamIds = new Set(activeTeams.map(team => team.id));
     const otherTeams = allTeams.filter(team => !activeTeamIds.has(team.id));
+    const title = t('Teams');
 
     return (
       <div data-test-id="team-list">
-        <SettingsPageHeader title={t('Teams')} action={action} />
+        <SentryDocumentTitle title={title} objSlug={organization.slug} />
+        <SettingsPageHeader title={title} action={action} />
         <Panel>
           <PanelHeader>{t('Your Teams')}</PanelHeader>
           <PanelBody>

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamDetails.jsx
@@ -10,6 +10,7 @@ import {fetchTeamDetails, joinTeam} from 'app/actionCreators/teams';
 import {t, tct} from 'app/locale';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import IdBadge from 'app/components/idBadge';
 import ListLink from 'app/components/links/listLink';
 import LoadingError from 'app/components/loadingError';
@@ -157,9 +158,9 @@ const TeamDetails = createReactClass({
     }
 
     const routePrefix = recreateRoute('', {routes, params, stepBack: -1}); //`/organizations/${orgId}/teams/${teamId}`;
-
     return (
       <div>
+        <SentryDocumentTitle title={t('Team Details')} objSlug={params.orgId} />
         <h3>
           <IdBadge hideAvatar team={team} avatarSize={36} />
         </h3>

--- a/tests/js/spec/views/settings/__snapshots__/auditLogView.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/auditLogView.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OrganizationAuditLog renders 1`] = `
 <SideEffect(DocumentTitle)
-  title="Organization Name Audit Log - Sentry"
+  title="Audit Log - org-slug - Sentry"
 >
   <AuditLogList
     entries={

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -54,10 +54,10 @@ exports[`OrganizationProjects Should render the projects in the store 1`] = `
     }
   >
     <SideEffect(DocumentTitle)
-      title="Organization Name Projects - Sentry"
+      title="Projects - org-slug - Sentry"
     >
       <DocumentTitle
-        title="Organization Name Projects - Sentry"
+        title="Projects - org-slug - Sentry"
       >
         <div>
           <StyledSettingsPageHeading

--- a/tests/js/spec/views/settings/__snapshots__/organizationRepositoriesContainer.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationRepositoriesContainer.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`OrganizationRepositoriesContainer render() without any providers is loading when initially rendering 1`] = `
 <SideEffect(DocumentTitle)
-  title="Repositories - Sentry"
+  title="Repositories - org-slug - Sentry"
 >
   <OrganizationRepositories
     api={

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -72,10 +72,10 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
     }
   >
     <SideEffect(DocumentTitle)
-      title="Sentry"
+      title="Developer Settings - org-slug - Sentry"
     >
       <DocumentTitle
-        title="Sentry"
+        title="Developer Settings - org-slug - Sentry"
       >
         <div>
           <StyledSettingsPageHeading


### PR DESCRIPTION
Add descriptive page titles for:

* Organization projects dashboard
* Organization settings:
	* General Settings
	* Projects
	* Teams
		 * Team Details
	* Members
	* Auth
	* Audit Log
	* Repositories
	* Integrations
	* Developer Settings

Used format `<title> - <orgSlug> - Sentry`

Partially fixes GH-10007