### PR TITLE
perf(db): Don't join on organization if we're looking for a single Project.

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -12,7 +12,6 @@ from sentry.incidents.models import IncidentStatus
 from sentry.utils import json
 from sentry.utils.assets import get_asset_url
 from sentry.utils.dates import to_timestamp
-from sentry.utils.hashlib import hash_values
 from sentry.utils.http import absolute_uri
 from sentry.models import (
     GroupStatus,
@@ -22,7 +21,7 @@ from sentry.models import (
     User,
     Identity,
     Team,
-    Release,
+    ReleaseProject,
 )
 
 logger = logging.getLogger("sentry.integrations.slack")
@@ -177,12 +176,10 @@ def build_group_attachment(group, event=None, tags=None, identity=None, actions=
 
     project = Project.objects.get_from_cache(id=group.project_id)
 
-    cache_key = "has_releases:1:%s" % hash_values([project.id, project.organization_id])
+    cache_key = "has_releases:2:%s" % (project.id)
     has_releases = cache.get(cache_key)
     if has_releases is None:
-        has_releases = Release.objects.filter(
-            projects=project, organization_id=project.organization_id
-        ).exists()
+        has_releases = ReleaseProject.objects.filter(project_id=project.id).exists()
         if has_releases:
             cache.set(cache_key, True, 3600)
         else:


### PR DESCRIPTION
On the quest of removing this normalized query. Think it could be this change, think it could be something else.

```sql
SELECT (1) AS "a" FROM "sentry_release" INNER JOIN "sentry_release_project" ON ("sentry_release"."id" = "sentry_release_project"."release_id") WHERE ("sentry_release"."organization_id" = **** AND "sentry_release_project"."project_id" = *****) LIMIT 1;
```