### PR TITLE
perf(db): cache release setup completion tasks

### DIFF
--- a/src/sentry/api/endpoints/project_release_setup.py
+++ b/src/sentry/api/endpoints/project_release_setup.py
@@ -21,27 +21,29 @@ class ProjectReleaseSetupCompletionEndpoint(ProjectEndpoint):
         """
 
         tag_key = "onboard_tag:1:%s" % (project.id)
-        tag = cache.get(tag_key)
+        repo_key = "onboard_repo:1:%s" % (project.organization_id)
+        commit_key = "onboard_commit:1:%s" % hash_values([project.organization_id, project.id])
+        deploy_key = "onboard_deploy:1:%s" % hash_values([project.organization_id, project.id])
+        onboard_cache = cache.get_many([tag_key, repo_key, commit_key, deploy_key])
+
+        tag = onboard_cache.get("tag_key")
         if tag is None:
             tag = Group.objects.filter(project=project.id, first_release__isnull=False).exists()
             cache.set(tag_key, tag, 3600 if tag else 60)
 
-        repo_key = "onboard_repo:1:%s" % (project.organization_id)
-        repo = cache.get(repo_key)
+        repo = onboard_cache.get("repo_key")
         if repo is None:
             repo = Repository.objects.filter(organization_id=project.organization_id).exists()
             cache.set(repo_key, repo, 3600 if repo else 60)
 
-        commit_key = "onboard_commit:1:%s" % hash_values([project.organization_id, project.id])
-        commit = cache.get(commit_key)
+        commit = onboard_cache.get("commit_key")
         if commit is None:
             commit = ReleaseCommit.objects.filter(
                 organization_id=project.organization_id, release__projects=project.id
             ).exists()
             cache.set(commit_key, commit, 3600 if commit else 60)
 
-        deploy_key = "onboard_deploy:1:%s" % hash_values([project.organization_id, project.id])
-        deploy = cache.get(deploy_key)
+        deploy = onboard_cache.get("deploy_key")
         if deploy is None:
             deploy = Deploy.objects.filter(
                 organization_id=project.organization_id, release__projects=project.id

--- a/src/sentry/api/endpoints/project_release_setup.py
+++ b/src/sentry/api/endpoints/project_release_setup.py
@@ -26,24 +26,24 @@ class ProjectReleaseSetupCompletionEndpoint(ProjectEndpoint):
         deploy_key = "onboard_deploy:1:%s" % hash_values([project.organization_id, project.id])
         onboard_cache = cache.get_many([tag_key, repo_key, commit_key, deploy_key])
 
-        tag = onboard_cache.get("tag_key")
+        tag = onboard_cache.get(tag_key)
         if tag is None:
             tag = Group.objects.filter(project=project.id, first_release__isnull=False).exists()
             cache.set(tag_key, tag, 3600 if tag else 60)
 
-        repo = onboard_cache.get("repo_key")
+        repo = onboard_cache.get(repo_key)
         if repo is None:
             repo = Repository.objects.filter(organization_id=project.organization_id).exists()
             cache.set(repo_key, repo, 3600 if repo else 60)
 
-        commit = onboard_cache.get("commit_key")
+        commit = onboard_cache.get(commit_key)
         if commit is None:
             commit = ReleaseCommit.objects.filter(
                 organization_id=project.organization_id, release__projects=project.id
             ).exists()
             cache.set(commit_key, commit, 3600 if commit else 60)
 
-        deploy = onboard_cache.get("deploy_key")
+        deploy = onboard_cache.get(deploy_key)
         if deploy is None:
             deploy = Deploy.objects.filter(
                 organization_id=project.organization_id, release__projects=project.id


### PR DESCRIPTION
```sql
SELECT
    uniq(request_uri),
    count(),
    any(request_uri)
FROM clicktail.access_log
WHERE hasToken(request_uri, 'completion') AND (statsd_path = 'api.other') AND (_date = yesterday())
ORDER BY count() ASC

┌─uniq(request_uri)─┬─count()─┬─any(request_uri)───────────────────────────────────────────┐
│             16689 │  105183 │ /api/0/projects/***/***/releases/completion/ │
└───────────────────┴─────────┴────────────────────────────────────────────────────────────┘
```

16k unique orgs/projects
105k hits in 24h
lets cache it ✨ 