### PR TITLE
feat(sdk): Upgrade to `@sentry/browser@5.7.0-beta.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
     "@babel/runtime": "~7.4.4",
-    "@sentry/browser": "5.6.0-beta.4",
+    "@sentry/browser": "5.7.0-beta.1",
     "@sentry/integrations": "5.6.0-beta.4",
     "@types/classnames": "^2.2.0",
     "@types/clipboard": "^2.0.1",

--- a/src/sentry/static/sentry/app/api.tsx
+++ b/src/sentry/static/sentry/app/api.tsx
@@ -265,13 +265,14 @@ export class Client {
       }
     }
 
+    // TODO(kamil): We forgot to add this to Spans interface
     const requestSpan = Sentry.startSpan({
       data: {
         request_data: data,
       },
       op: 'http',
       description: `${method} ${fullUrl}`,
-    });
+    }) as Sentry.Span;
 
     const errorObject = new Error();
 
@@ -340,8 +341,7 @@ export class Client {
           );
         },
         complete: (jqXHR: JQueryXHR, textStatus: string) => {
-          // TODO(kamil): We forgot to add this to Spans interface
-          (requestSpan as any).finish();
+          requestSpan.finish();
 
           return this.wrapCallback<[JQueryXHR, string]>(id, options.complete, true)(
             jqXHR,

--- a/src/sentry/static/sentry/app/api.tsx
+++ b/src/sentry/static/sentry/app/api.tsx
@@ -340,7 +340,9 @@ export class Client {
           );
         },
         complete: (jqXHR: JQueryXHR, textStatus: string) => {
-          Sentry.finishSpan(requestSpan);
+          // TODO(kamil): We forgot to add this to Spans interface
+          (requestSpan as any).finish();
+
           return this.wrapCallback<[JQueryXHR, string]>(id, options.complete, true)(
             jqXHR,
             textStatus

--- a/src/sentry/static/sentry/app/bootstrap.jsx
+++ b/src/sentry/static/sentry/app/bootstrap.jsx
@@ -27,6 +27,8 @@ import {startApm} from 'app/utils/apm';
 // SDK INIT  --------------------------------------------------------
 Sentry.init({
   ...window.__SENTRY__OPTIONS,
+  // TODO: Default `*` in ALLOWED_HOSTS doesn't work as we don't use globs in the SDK
+  whitelistUrls: 'http',
   integrations: [
     new ExtraErrorData({
       // 6 is arbitrary, seems like a nice number

--- a/src/sentry/static/sentry/app/bootstrap.jsx
+++ b/src/sentry/static/sentry/app/bootstrap.jsx
@@ -27,8 +27,6 @@ import {startApm} from 'app/utils/apm';
 // SDK INIT  --------------------------------------------------------
 Sentry.init({
   ...window.__SENTRY__OPTIONS,
-  // TODO: Default `*` in ALLOWED_HOSTS doesn't work as we don't use globs in the SDK
-  whitelistUrls: 'http',
   integrations: [
     new ExtraErrorData({
       // 6 is arbitrary, seems like a nice number

--- a/src/sentry/static/sentry/app/utils/apm.jsx
+++ b/src/sentry/static/sentry/app/utils/apm.jsx
@@ -7,22 +7,20 @@ function startTransaction() {
   // We do set the transaction name in the router but we want to start it here
   // since in the App component where we set the transaction name, it's called multiple
   // times. This would result in losing the start of the transaction.
-  const hub = Sentry.getCurrentHub();
-  hub.configureScope(scope => {
+  Sentry.configureScope(scope => {
     if (firstPageLoad) {
       firstPageLoad = false;
     } else {
       const prevTransactionSpan = scope.getSpan();
       // If there is a transaction we set the name to the route
       if (prevTransactionSpan && prevTransactionSpan.timestamp === undefined) {
-        hub.finishSpan(prevTransactionSpan);
+        prevTransactionSpan.finish();
       }
-      Sentry.startSpan(
-        {
+      scope.setSpan(
+        Sentry.startSpan({
           op: 'navigation',
           sampled: true,
-        },
-        true
+        })
       );
     }
   });
@@ -35,17 +33,25 @@ function finishTransaction(delay) {
   if (flushTransactionTimeout) {
     clearTimeout(flushTransactionTimeout);
   }
-  flushTransactionTimeout = setTimeout(() => Sentry.finishSpan(), delay || 5000);
+  flushTransactionTimeout = setTimeout(() => {
+    Sentry.configureScope(scope => {
+      const span = scope.getSpan();
+      if (span) {
+        span.finish();
+      }
+    });
+  }, delay || 5000);
 }
 
 export function startApm() {
-  Sentry.startSpan(
-    {
-      op: 'pageload',
-      sampled: true,
-    },
-    true
-  );
+  Sentry.configureScope(scope => {
+    scope.setSpan(
+      Sentry.startSpan({
+        op: 'pageload',
+        sampled: true,
+      })
+    );
+  });
   startTransaction();
   Router.browserHistory.listen(() => startTransaction());
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,34 +1545,34 @@
     hey-listen "^1.0.8"
     style-value-types "^3.1.4"
 
-"@sentry/browser@5.6.0-beta.4":
-  version "5.6.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.6.0-beta.4.tgz#1f1f12a63c30dbecb63cda6c84dffb0e2684c778"
-  integrity sha512-7u06iH5gKpK2duloRVY+yId0xL+++dnM1Su65uvM3V0ubmv3+HyCqe2wXuSCi6M2NGt9GTWB7yRUw3OCooGlRw==
+"@sentry/browser@5.7.0-beta.1":
+  version "5.7.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.7.0-beta.1.tgz#937ff3d35d1b0d66e52382b4349947fa5b9fedff"
+  integrity sha512-OsuqdkiwcbGtKIo8/Z75N+jQell3YWbt+BwePm2HDgojOsoZiSORytVM5yyCuQGNOF/n7/YkQMICoMPvHyh1qA==
   dependencies:
-    "@sentry/core" "5.6.0-beta.4"
-    "@sentry/types" "5.6.0-beta.4"
-    "@sentry/utils" "5.6.0-beta.4"
+    "@sentry/core" "5.7.0-beta.1"
+    "@sentry/types" "5.7.0-beta.1"
+    "@sentry/utils" "5.7.0-beta.1"
     tslib "^1.9.3"
 
-"@sentry/core@5.6.0-beta.4":
-  version "5.6.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.6.0-beta.4.tgz#a75271896cc6973c61ccc8bc138c59301e69bf72"
-  integrity sha512-Xq09gz+/G26xOEKOmXPp+s0VIj6IR2DQ7lXxxqfUGjAtdFzkHMk3RrukznFvc8Sdp2ZgD3z1zrSwx+2poKYbqw==
+"@sentry/core@5.7.0-beta.1":
+  version "5.7.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.7.0-beta.1.tgz#fa6e206574e72f4cb2520ea7881b5dbc7f947fd9"
+  integrity sha512-pbiO2MsV7VikKuERvYJwaQspt6egvTkoYyExdYXXb2Ja8uXD+bm94wdIvZbTpQuSrhqDWbxyaIsGWNJyzQgadQ==
   dependencies:
-    "@sentry/hub" "5.6.0-beta.4"
-    "@sentry/minimal" "5.6.0-beta.4"
-    "@sentry/types" "5.6.0-beta.4"
-    "@sentry/utils" "5.6.0-beta.4"
+    "@sentry/hub" "5.7.0-beta.1"
+    "@sentry/minimal" "5.7.0-beta.1"
+    "@sentry/types" "5.7.0-beta.1"
+    "@sentry/utils" "5.7.0-beta.1"
     tslib "^1.9.3"
 
-"@sentry/hub@5.6.0-beta.4":
-  version "5.6.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.6.0-beta.4.tgz#69db4c5753f49e002fb9d3d068ef2b67a6f947cb"
-  integrity sha512-ShtUkmLVf5vSTTgvAZ5MCQdDBe+Y3H0rxqndF2PNwZwK1ozpgpHAbzn8CKbLq65oYYMk6W30PCrhOtHHvFtA2A==
+"@sentry/hub@5.7.0-beta.1":
+  version "5.7.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.7.0-beta.1.tgz#a07813b28a7c7ad04097da9af65d95f5e81a0265"
+  integrity sha512-SAx8+arIfP59c4L7EIXtxJ1G0HbdRObUGoxNaNOCOnIEfTLBDYcrEU1RqKUcdpDjYc+hclBB5KsbdhDEEXvj0g==
   dependencies:
-    "@sentry/types" "5.6.0-beta.4"
-    "@sentry/utils" "5.6.0-beta.4"
+    "@sentry/types" "5.7.0-beta.1"
+    "@sentry/utils" "5.7.0-beta.1"
     tslib "^1.9.3"
 
 "@sentry/integrations@5.6.0-beta.4":
@@ -1584,13 +1584,13 @@
     "@sentry/utils" "5.6.0-beta.4"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.6.0-beta.4":
-  version "5.6.0-beta.4"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.6.0-beta.4.tgz#1066556b0768fc65f3e8345b0174e4443e94540b"
-  integrity sha512-Iju4VhRIhaiFgXYI8/ZyS4YcUB/7w3gjgqSYVqVP0ARR8GlG7ZJNzYFz7IIstimVleZDylXKMlwvtqiiJFvLjg==
+"@sentry/minimal@5.7.0-beta.1":
+  version "5.7.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.7.0-beta.1.tgz#886e9b7498613186c74d7dadcf137126de49a127"
+  integrity sha512-WiMmy6u6uuzpulynJRAlSKz07dAMSC5LeD+n2ZF17f8FHUSsgvcPnizxSjtKzxycf43xD3B26wrZQyFaSHfXoQ==
   dependencies:
-    "@sentry/hub" "5.6.0-beta.4"
-    "@sentry/types" "5.6.0-beta.4"
+    "@sentry/hub" "5.7.0-beta.1"
+    "@sentry/types" "5.7.0-beta.1"
     tslib "^1.9.3"
 
 "@sentry/types@5.6.0-beta.4":
@@ -1598,12 +1598,25 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.6.0-beta.4.tgz#7ad453fd6969cc38c97c85c4d7e5e1f7588276b2"
   integrity sha512-YVloNOyyek0Qackamn1kDyFpVTRysj8CBUJwZx774VMtYHMy48Lre2rxz3s1j/XztsaZEqn0nO86aP8DzlNNzg==
 
+"@sentry/types@5.7.0-beta.1":
+  version "5.7.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.7.0-beta.1.tgz#91e79fb3862a285275b094330c2d44d93c2af927"
+  integrity sha512-0qbS4TzD1/JJy7YEHONA5ItXiTdDPOk9svjj1/+VuBv95yjmlRJ8fIrpv4woN9Lijas+uUB1tDxOpPCpq8InwQ==
+
 "@sentry/utils@5.6.0-beta.4":
   version "5.6.0-beta.4"
   resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.6.0-beta.4.tgz#d3e2ffc7487590af7555da836d17f3a19ff07a8d"
   integrity sha512-ysrXMsbdiB3rogh4sridexazJKZRIJdSYarj8fGMKryPsF7FwvVu8i3VGCz4nmGqxtFhyDDUu0udhxgx9wQhZA==
   dependencies:
     "@sentry/types" "5.6.0-beta.4"
+    tslib "^1.9.3"
+
+"@sentry/utils@5.7.0-beta.1":
+  version "5.7.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.7.0-beta.1.tgz#fd7a0235617f177a5e36028c19a0a15a4ff9d51f"
+  integrity sha512-Mf4Hm+dykF817ybspVuevsEfFAWgogtnwOUDkue1iUFZBJiYUJoJS76Auaw8VA/Us2tj1bIcZkCEQsG/93EqvA==
+  dependencies:
+    "@sentry/types" "5.7.0-beta.1"
     tslib "^1.9.3"
 
 "@storybook/addon-a11y@^4.1.3":


### PR DESCRIPTION
This upgrades our Sentry SDK to the latest w/ APM (beta). Tracing API has changed a bit where we call `finish()` on the span instance.