### PR TITLE
feat(ui): Add organization store

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/organizations.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organizations.jsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 import {resetGlobalSelection} from 'app/actionCreators/globalSelection';
 import {Client} from 'app/api';
 import IndicatorStore from 'app/stores/indicatorStore';
+import OrganizationActions from 'app/actions/organizationActions';
 import OrganizationsActions from 'app/actions/organizationsActions';
 import OrganizationsStore from 'app/stores/organizationsStore';
 import ProjectsStore from 'app/stores/projectsStore';
@@ -68,6 +69,7 @@ export function changeOrganizationSlug(prev, next) {
 
 export function updateOrganization(org) {
   OrganizationsActions.update(org);
+  OrganizationActions.update(org);
 }
 
 export async function fetchOrganizationByMember(memberId, {addOrg, fetchOrgDetails}) {

--- a/src/sentry/static/sentry/app/actions/organizationActions.jsx
+++ b/src/sentry/static/sentry/app/actions/organizationActions.jsx
@@ -1,0 +1,3 @@
+import Reflux from 'reflux';
+
+export default Reflux.createActions(['update']);

--- a/src/sentry/static/sentry/app/stores/organizationStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationStore.jsx
@@ -1,14 +1,11 @@
 import Reflux from 'reflux';
 
 import OrganizationActions from 'app/actions/organizationActions';
-import OrganizationsActions from 'app/actions/organizationsActions';
 
 const OrganizationStore = Reflux.createStore({
   init() {
     this.reset();
     this.listenTo(OrganizationActions.update, this.onUpdate);
-    // also listen to updates from OrganizationsActions triggered from settings
-    this.listenTo(OrganizationsActions.update, this.onUpdate);
   },
 
   reset() {

--- a/src/sentry/static/sentry/app/stores/organizationStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationStore.jsx
@@ -1,0 +1,30 @@
+import Reflux from 'reflux';
+
+import OrganizationActions from 'app/actions/organizationActions';
+import OrganizationsActions from 'app/actions/organizationsActions';
+
+const OrganizationStore = Reflux.createStore({
+  listenables: OrganizationActions,
+
+  init() {
+    this.reset();
+
+    // also listen to updates from OrganizationsActions triggered from settings
+    this.listenTo(OrganizationsActions.update, this.onUpdate);
+  },
+
+  reset() {
+    this.org = {};
+  },
+
+  onUpdate(updatedOrg) {
+    this.org = {...this.org, ...updatedOrg};
+    this.trigger(this.org);
+  },
+
+  getOrganization() {
+    return this.org;
+  },
+});
+
+export default OrganizationStore;

--- a/src/sentry/static/sentry/app/stores/organizationStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationStore.jsx
@@ -12,7 +12,7 @@ const OrganizationStore = Reflux.createStore({
   },
 
   reset() {
-    this.org = {};
+    this.org = null;
   },
 
   onUpdate(updatedOrg) {

--- a/src/sentry/static/sentry/app/stores/organizationStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationStore.jsx
@@ -4,11 +4,9 @@ import OrganizationActions from 'app/actions/organizationActions';
 import OrganizationsActions from 'app/actions/organizationsActions';
 
 const OrganizationStore = Reflux.createStore({
-  listenables: OrganizationActions,
-
   init() {
     this.reset();
-
+    this.listenTo(OrganizationActions.update, this.onUpdate);
     // also listen to updates from OrganizationsActions triggered from settings
     this.listenTo(OrganizationsActions.update, this.onUpdate);
   },

--- a/tests/js/spec/stores/organizationStore.spec.jsx
+++ b/tests/js/spec/stores/organizationStore.spec.jsx
@@ -1,0 +1,27 @@
+import OrganizationStore from 'app/stores/organizationStore';
+import OrganizationActions from 'app/actions/organizationActions';
+import OrganizationsActions from 'app/actions/organizationsActions';
+
+describe('OrganizationStore', function() {
+  beforeEach(function() {
+    OrganizationStore.reset();
+  });
+
+  it('updates correctly', async function() {
+    const org = TestStubs.Organization();
+    OrganizationActions.update(org);
+    await tick();
+    expect(OrganizationStore.getOrganization()).toMatchObject(org);
+    org.slug = 'newslug';
+    OrganizationActions.update(org);
+    await tick();
+    expect(OrganizationStore.getOrganization()).toMatchObject(org);
+  });
+
+  it('updates correctly from setting changes', async function() {
+    const org = TestStubs.Organization();
+    OrganizationsActions.update(org);
+    await tick();
+    expect(OrganizationStore.getOrganization()).toMatchObject(org);
+  });
+});

--- a/tests/js/spec/stores/organizationStore.spec.jsx
+++ b/tests/js/spec/stores/organizationStore.spec.jsx
@@ -1,6 +1,6 @@
 import OrganizationStore from 'app/stores/organizationStore';
 import OrganizationActions from 'app/actions/organizationActions';
-import OrganizationsActions from 'app/actions/organizationsActions';
+import {updateOrganization} from 'app/actionCreators/organizations';
 
 describe('OrganizationStore', function() {
   beforeEach(function() {
@@ -16,7 +16,7 @@ describe('OrganizationStore', function() {
 
   it('updates correctly from setting changes', async function() {
     const org = TestStubs.Organization();
-    OrganizationsActions.update(org);
+    updateOrganization(org);
     await tick();
     expect(OrganizationStore.getOrganization()).toMatchObject(org);
   });

--- a/tests/js/spec/stores/organizationStore.spec.jsx
+++ b/tests/js/spec/stores/organizationStore.spec.jsx
@@ -12,10 +12,6 @@ describe('OrganizationStore', function() {
     OrganizationActions.update(org);
     await tick();
     expect(OrganizationStore.getOrganization()).toMatchObject(org);
-    org.slug = 'newslug';
-    OrganizationActions.update(org);
-    await tick();
-    expect(OrganizationStore.getOrganization()).toMatchObject(org);
   });
 
   it('updates correctly from setting changes', async function() {


### PR DESCRIPTION
Add a store to hold the current organization to be used to aid in navigation between a lightweight organization details route tree and a heavyweight organization details route tree. In both route trees OrganizationContext will first read from store to see if fetching the organization is necessary. In the lightweight route tree, some pages will eventually attempt to populate the lightweight organization details with additional information (projects, teams) to mimic the heavyweight org details.

Refs: SEN-1143