### PR TITLE
feat: Disabled raw event handling in some situations

### DIFF
--- a/src/sentry/reprocessing.py
+++ b/src/sentry/reprocessing.py
@@ -3,9 +3,6 @@ from __future__ import absolute_import
 import uuid
 import logging
 
-from sentry.stacktraces.processing import find_stacktraces_in_data
-from sentry.stacktraces.platform import NATIVE_PLATFORMS, JAVASCRIPT_PLATFORMS
-
 
 REPROCESSING_OPTION = "sentry:processing-rev"
 
@@ -15,6 +12,8 @@ logger = logging.getLogger("sentry.events")
 
 def event_supports_reprocessing(data):
     """Only events of a certain format support reprocessing."""
+    from sentry.stacktraces.processing import find_stacktraces_in_data
+    from sentry.stacktraces.platform import NATIVE_PLATFORMS, JAVASCRIPT_PLATFORMS
     platform = data.get("platform")
     if platform in NATIVE_PLATFORMS:
         return True

--- a/src/sentry/reprocessing.py
+++ b/src/sentry/reprocessing.py
@@ -1,9 +1,31 @@
 from __future__ import absolute_import
 
 import uuid
+import logging
+
+from sentry.stacktraces.processing import find_stacktraces_in_data
+from sentry.stacktraces.platform import NATIVE_PLATFORMS, JAVASCRIPT_PLATFORMS
 
 
 REPROCESSING_OPTION = "sentry:processing-rev"
+
+
+logger = logging.getLogger("sentry.events")
+
+
+def event_supports_reprocessing(data):
+    """Only events of a certain format support reprocessing."""
+    platform = data.get("platform")
+    if platform in NATIVE_PLATFORMS:
+        return True
+    elif platform == "java" and data.get("debug_meta"):
+        return True
+    elif platform not in JAVASCRIPT_PLATFORMS:
+        return False
+    for stacktrace_info in find_stacktraces_in_data(data):
+        if not stacktrace_info.platforms.isdisjoint(NATIVE_PLATFORMS):
+            return True
+    return False
 
 
 def get_reprocessing_revision(project, cached=True):
@@ -40,6 +62,12 @@ def report_processing_issue(event_data, scope, object=None, type=None, data=None
         from sentry.models import EventError
 
         type = EventError.INVALID_DATA
+
+    # This really should not happen.
+    if not event_supports_reprocessing(event_data):
+        logger.error("processing_issue.bad_report", extra={"platform": event_data.get("platform")})
+        return
+
     uid = "%s:%s" % (scope, object)
     event_data.setdefault("processing_issues", {})[uid] = {
         "scope": scope,

--- a/src/sentry/stacktraces/platform.py
+++ b/src/sentry/stacktraces/platform.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import
 
 
+NATIVE_PLATFORMS = frozenset(("objc", "cocoa", "swift", "native", "c"))
+JAVASCRIPT_PLATFORMS = frozenset(("javascript", "node"))
+
+
 def get_behavior_family_for_platform(platform):
-    if platform in ("objc", "cocoa", "swift", "native", "c"):
+    if platform in NATIVE_PLATFORMS:
         return "native"
-    if platform in ("javascript", "node"):
+    if platform in JAVASCRIPT_PLATFORMS:
         return "javascript"
     return "other"

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -247,6 +247,7 @@ def _do_process_event(cache_key, start_time, event_id, process_task, data=None):
         try:
             if issues and create_failed_event(
                 cache_key,
+                data,
                 project_id,
                 list(issues.values()),
                 event_id=event_id,
@@ -320,11 +321,16 @@ def delete_raw_event(project_id, event_id, allow_hint_clear=False):
 
 
 def create_failed_event(
-    cache_key, project_id, issues, event_id, start_time=None, reprocessing_rev=None
+    cache_key, data, project_id, issues, event_id, start_time=None, reprocessing_rev=None
 ):
     """If processing failed we put the original data from the cache into a
     raw event.  Returns `True` if a failed event was inserted
     """
+    # We can only create failed events for events that can potentially
+    # create failed events.
+    if not reprocessing.event_supports_reprocessing(data):
+        return False
+
     reprocessing_active = ProjectOption.objects.get_value(
         project_id, "sentry:reprocessing_active", REPROCESSING_DEFAULT
     )
@@ -451,7 +457,10 @@ def _do_save_event(
         key_id = int(key_id)
     timestamp = to_datetime(start_time) if start_time is not None else None
 
-    delete_raw_event(project_id, event_id, allow_hint_clear=True)
+    # We only need to delete raw events for events that support
+    # reprocessing
+    if reprocessing.event_supports_reprocessing(data):
+        delete_raw_event(project_id, event_id, allow_hint_clear=True)
 
     # This covers two cases: where data is None because we did not manage
     # to fetch it from the default cache or the empty dictionary was


### PR DESCRIPTION
This should optimize some cases where raw event / processing issue handling can be skipped.

#sync-getsentry