### PR TITLE
ref(ui): Add page titles to organization projects settings

### DIFF
--- a/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/overview.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {t, tct} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
 import AutoSelectText from 'app/components/autoSelectText';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
 import PlatformPicker from 'app/components/platformPicker';
@@ -46,7 +47,7 @@ class ProjectInstallOverview extends AsyncComponent {
   };
 
   render() {
-    const {orgId} = this.props.params;
+    const {orgId, projectId} = this.props.params;
     const {keyList} = this.state;
 
     const issueStreamLink = `/organizations/${orgId}/issues/#welcome`;
@@ -55,6 +56,7 @@ class ProjectInstallOverview extends AsyncComponent {
 
     return (
       <div>
+        <SentryDocumentTitle title={t('Error Tracking')} objSlug={projectId} />
         <SettingsPageHeader title={t('Configure your application')} />
         <TextBlock>
           {t(

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.jsx
@@ -11,6 +11,7 @@ import Button from 'app/components/button';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import NotFound from 'app/components/errors/notFound';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import SentryTypes from 'app/sentryTypes';
 import platforms from 'app/data/platforms';
 import withApi from 'app/utils/withApi';
@@ -122,7 +123,13 @@ class ProjectInstallPlatform extends React.Component {
           ) : this.state.error ? (
             <LoadingError onRetry={this.fetchData} />
           ) : (
-            <DocumentationWrapper dangerouslySetInnerHTML={{__html: this.state.html}} />
+            <React.Fragment>
+              <SentryDocumentTitle
+                title={`${t('Configure')} ${platform.name}`}
+                objSlug={projectId}
+              />
+              <DocumentationWrapper dangerouslySetInnerHTML={{__html: this.state.html}} />
+            </React.Fragment>
           )}
 
           {this.isGettingStarted && (

--- a/src/sentry/static/sentry/app/views/settings/project/projectEnvironments.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectEnvironments.jsx
@@ -8,6 +8,7 @@ import {Panel, PanelHeader, PanelBody, PanelItem} from 'app/components/panels';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {t, tct} from 'app/locale';
 import Access from 'app/components/acl/access';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import withApi from 'app/utils/withApi';
 import Button from 'app/components/button';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
@@ -184,6 +185,7 @@ class ProjectEnvironments extends React.Component {
     const baseUrl = recreateRoute('', {routes, params, stepBack: -1});
     return (
       <div>
+        <SentryDocumentTitle title={t('Environments')} objSlug={params.projectId} />
         <SettingsPageHeader
           title={t('Manage Environments')}
           tabs={

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/index.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {t} from 'app/locale';
 import GroupTombstones from 'app/views/settings/project/projectFilters/groupTombstones';
 import NavTabs from 'app/components/navTabs';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import PermissionAlert from 'app/views/settings/project/permissionAlert';
 import ProjectFiltersChart from 'app/views/settings/project/projectFilters/projectFiltersChart';
 import ProjectFiltersSettings from 'app/views/settings/project/projectFilters/projectFiltersSettings';
@@ -28,6 +29,7 @@ class ProjectFilters extends React.Component {
 
     return (
       <div>
+        <SentryDocumentTitle title={t('Inbound Filters')} objSlug={projectId} />
         <SettingsPageHeader title={t('Inbound Data Filters')} />
         <PermissionAlert />
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/index.jsx
@@ -1,6 +1,5 @@
 import {Box, Flex} from 'grid-emotion';
 import {Link} from 'react-router';
-import DocumentTitle from 'react-document-title';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
@@ -25,6 +24,7 @@ import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import recreateRoute from 'app/utils/recreateRoute';
+import routeTitleGen from 'app/utils/routeTitle';
 
 class KeyRow extends React.Component {
   static propTypes = {
@@ -180,7 +180,8 @@ export default class ProjectKeys extends AsyncView {
   };
 
   getTitle() {
-    return t('Client Keys');
+    const {projectId} = this.props.params;
+    return routeTitleGen(t('Client Keys'), projectId, false);
   }
 
   getEndpoints() {
@@ -274,39 +275,37 @@ export default class ProjectKeys extends AsyncView {
     const isEmpty = !this.state.keyList.length;
 
     return (
-      <DocumentTitle title={t('Client Keys')}>
-        <div className="ref-keys">
-          <SettingsPageHeader
-            title={t('Client Keys')}
-            action={
-              access.has('project:write') ? (
-                <Button
-                  onClick={this.handleCreateKey}
-                  size="small"
-                  priority="primary"
-                  icon="icon-circle-add"
-                >
-                  {t('Generate New Key')}
-                </Button>
-              ) : null
+      <div className="ref-keys">
+        <SettingsPageHeader
+          title={t('Client Keys')}
+          action={
+            access.has('project:write') ? (
+              <Button
+                onClick={this.handleCreateKey}
+                size="small"
+                priority="primary"
+                icon="icon-circle-add"
+              >
+                {t('Generate New Key')}
+              </Button>
+            ) : null
+          }
+        />
+        <TextBlock>
+          {tct(
+            `To send data to Sentry you will need to configure an SDK with a client key
+          (usually referred to as the [code:SENTRY_DSN] value). For more
+          information on integrating Sentry with your application take a look at our
+          [link:documentation].`,
+            {
+              link: <ExternalLink href="https://docs.sentry.io/" />,
+              code: <code />,
             }
-          />
-          <TextBlock>
-            {tct(
-              `To send data to Sentry you will need to configure an SDK with a client key
-            (usually referred to as the [code:SENTRY_DSN] value). For more
-            information on integrating Sentry with your application take a look at our
-            [link:documentation].`,
-              {
-                link: <ExternalLink href="https://docs.sentry.io/" />,
-                code: <code />,
-              }
-            )}
-          </TextBlock>
+          )}
+        </TextBlock>
 
-          {isEmpty ? this.renderEmpty() : this.renderResults()}
-        </div>
-      </DocumentTitle>
+        {isEmpty ? this.renderEmpty() : this.renderResults()}
+      </div>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.jsx
@@ -3,6 +3,7 @@ import styled from 'react-emotion';
 
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t, tct} from 'app/locale';
+import routeTitleGen from 'app/utils/routeTitle';
 import AsyncView from 'app/views/asyncView';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
@@ -24,7 +25,8 @@ class ProjectOwnership extends AsyncView {
   };
 
   getTitle() {
-    return t('Ownership');
+    const {project} = this.props;
+    return routeTitleGen(t('Issue Owners'), project.slug, false);
   }
 
   getEndpoints() {

--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
@@ -5,6 +5,7 @@ import {Panel, PanelAlert} from 'app/components/panels';
 import {addLoadingMessage, removeIndicator} from 'app/actionCreators/indicator';
 import {t, tn} from 'app/locale';
 import Access from 'app/components/acl/access';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import AutoSelectText from 'app/components/autoSelectText';
 import Button from 'app/components/button';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
@@ -435,9 +436,12 @@ class ProjectProcessingIssues extends React.Component {
   };
 
   render() {
+    const {projectId} = this.props.params;
+    const title = t('Processing Issues');
     return (
       <div>
-        <SettingsPageHeader title={t('Processing Issues')} />
+        <SentryDocumentTitle title={title} objSlug={projectId} />
+        <SettingsPageHeader title={title} />
         <TextBlock>
           {t(
             `

--- a/src/sentry/static/sentry/app/views/settings/project/projectReleaseTracking.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectReleaseTracking.jsx
@@ -17,6 +17,7 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
 import getDynamicText from 'app/utils/getDynamicText';
 import withPlugins from 'app/utils/withPlugins';
+import routeTitleGen from 'app/utils/routeTitle';
 
 const TOKEN_PLACEHOLDER = 'YOUR_TOKEN';
 const WEBHOOK_PLACEHOLDER = 'YOUR_WEBHOOK_URL';
@@ -29,7 +30,8 @@ class ProjectReleaseTracking extends AsyncView {
   };
 
   getTitle() {
-    return 'Release Tracking';
+    const {projectId} = this.props.params;
+    return routeTitleGen(t('Releases'), projectId, false);
   }
 
   getEndpoints() {

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.jsx
@@ -11,11 +11,17 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import TeamSelect from 'app/views/settings/components/teamSelect';
 import Tooltip from 'app/components/tooltip';
 import space from 'app/styles/space';
+import routeTitleGen from 'app/utils/routeTitle';
 
 class ProjectTeams extends AsyncView {
   getEndpoints() {
     const {orgId, projectId} = this.props.params;
     return [['projectTeams', `/projects/${orgId}/${projectId}/teams/`]];
+  }
+
+  getTitle() {
+    const {projectId} = this.props.params;
+    return routeTitleGen(t('Project Teams'), projectId, false);
   }
 
   canCreateTeam = () => {

--- a/src/sentry/static/sentry/app/views/settings/project/projectUserFeedback.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectUserFeedback.tsx
@@ -14,6 +14,7 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import space from 'app/styles/space';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import formGroups from 'app/data/forms/userFeedback';
+import routeTitleGen from 'app/utils/routeTitle';
 
 type RouteParams = {
   orgId: string;
@@ -57,6 +58,11 @@ class ProjectUserFeedbackSettings extends AsyncView<Props> {
       ['keyList', `/projects/${orgId}/${projectId}/keys/`],
       ['project', `/projects/${orgId}/${projectId}/`],
     ];
+  }
+
+  getTitle(): string {
+    const {projectId} = this.props.params;
+    return routeTitleGen(t('User Feedback'), projectId, false);
   }
 
   handleClick = () => {

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertRules.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertRules.jsx
@@ -20,6 +20,7 @@ import EmptyStateWarning from 'app/components/emptyStateWarning';
 import PermissionAlert from 'app/views/settings/project/permissionAlert';
 import SentryTypes from 'app/sentryTypes';
 import Tooltip from 'app/components/tooltip';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import recreateRoute from 'app/utils/recreateRoute';
 import withApi from 'app/utils/withApi';
 import {getDisplayName} from 'app/utils/environment';
@@ -248,6 +249,7 @@ class ProjectAlertRules extends AsyncView {
 
     return (
       <React.Fragment>
+        <SentryDocumentTitle title={t('Alerts Rules')} objSlug={projectId} />
         <ProjectAlertHeader projectId={projectId} />
         <PermissionAlert />
         {!!ruleList.length && this.renderResults()}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertSettings.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {PanelAlert} from 'app/components/panels';
 import {fields} from 'app/data/forms/projectAlerts';
 import {t} from 'app/locale';
+import routeTitleGen from 'app/utils/routeTitle';
 import Access from 'app/components/acl/access';
 import AlertLink from 'app/components/alertLink';
 import AsyncView from 'app/views/asyncView';
@@ -62,7 +63,8 @@ export default class ProjectAlertSettings extends AsyncView {
   };
 
   getTitle() {
-    return 'Project Alert Settings';
+    const {projectId} = this.props.params;
+    return routeTitleGen(t('Alerts Settings'), projectId, false);
   }
 
   renderBody() {

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleEditor/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleEditor/index.jsx
@@ -17,6 +17,7 @@ import {t} from 'app/locale';
 import withApi from 'app/utils/withApi';
 import Button from 'app/components/button';
 import LoadingIndicator from 'app/components/loadingIndicator';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import RuleNodeList from 'app/views/settings/projectAlerts/ruleEditor/ruleNodeList';
 import recreateRoute from 'app/utils/recreateRoute';
 import space from 'app/styles/space';
@@ -197,6 +198,7 @@ const RuleEditor = createReactClass({
   },
 
   render() {
+    const {projectId} = this.props.params;
     const {environments} = this.state;
     const environmentChoices = [
       [ALL_ENVIRONMENTS_KEY, t('All Environments')],
@@ -213,10 +215,13 @@ const RuleEditor = createReactClass({
     const environment =
       rule.environment === null ? ALL_ENVIRONMENTS_KEY : rule.environment;
 
+    const title = rule.id ? t('Edit Alert Rule') : t('New Alert Rule');
+
     return (
       <form onSubmit={this.handleSubmit} ref={node => (this.formNode = node)}>
+        <SentryDocumentTitle title={title} objSlug={projectId} />
         <Panel className="rule-detail">
-          <PanelHeader>{rule.id ? 'Edit Alert Rule' : 'New Alert Rule'}</PanelHeader>
+          <PanelHeader>{title}</PanelHeader>
           <PanelBody disablePadding={false}>
             {error && (
               <div className="alert alert-block alert-error">

--- a/src/sentry/static/sentry/app/views/settings/projectDataForwarding.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataForwarding.jsx
@@ -15,6 +15,7 @@ import StackedBarChart from 'app/components/stackedBarChart';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 
 class DataForwardingStats extends AsyncComponent {
   getEndpoints() {
@@ -35,10 +36,12 @@ class DataForwardingStats extends AsyncComponent {
   }
 
   renderBody() {
+    const {projectId} = this.props.params;
     const stats = this.state.stats.map(p => ({x: p[0], y: [p[1]]}));
 
     return (
       <Panel>
+        <SentryDocumentTitle title={t('Data Forwarding')} objSlug={projectId} />
         <PanelHeader>{t('Forwarded events in the last 30 days (by day)')}</PanelHeader>
         <PanelBody>
           {stats.length > 0 && stats[0][0] ? (

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles.jsx
@@ -8,6 +8,7 @@ import {fields} from 'app/data/forms/projectDebugFiles';
 import {t} from 'app/locale';
 import Access from 'app/components/acl/access';
 import AsyncComponent from 'app/components/asyncComponent';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import Form from 'app/views/settings/components/forms/form';
@@ -226,6 +227,8 @@ class ProjectDebugSymbols extends AsyncComponent {
 
     return (
       <React.Fragment>
+        <SentryDocumentTitle objSlug={projectId} title={t('Debug Files')} />
+
         <SettingsPageHeader title={t('Debug Information Files')} />
 
         <TextBlock>

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -30,6 +30,7 @@ import TextField from 'app/views/settings/components/forms/textField';
 import BetaTag from 'app/components/betaTag';
 import handleXhrErrorResponse from 'app/utils/handleXhrErrorResponse';
 import recreateRoute from 'app/utils/recreateRoute';
+import routeTitleGen from 'app/utils/routeTitle';
 
 class ProjectGeneralSettings extends AsyncView {
   static propTypes = {
@@ -47,7 +48,7 @@ class ProjectGeneralSettings extends AsyncView {
 
   getTitle() {
     const {projectId} = this.props.params;
-    return t('%s Settings', projectId);
+    return routeTitleGen(t('Project Settings'), projectId, false);
   }
 
   getEndpoints() {

--- a/src/sentry/static/sentry/app/views/settings/projectPlugins/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectPlugins/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {fetchPlugins, enablePlugin, disablePlugin} from 'app/actionCreators/plugins';
 import {t} from 'app/locale';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import PermissionAlert from 'app/views/settings/project/permissionAlert';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
@@ -30,10 +31,14 @@ class ProjectPluginsContainer extends React.Component {
 
   render() {
     const {loading, error, plugins} = this.props.plugins || {};
+    const {orgId} = this.props.params;
+
+    const title = t('Legacy Integrations');
 
     return (
       <React.Fragment>
-        <SettingsPageHeader title={t('Legacy Integrations')} />
+        <SentryDocumentTitle title={title} objSlug={orgId} />
+        <SettingsPageHeader title={title} />
         <PermissionAlert />
 
         <ProjectPlugins

--- a/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/csp.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/csp.jsx
@@ -14,6 +14,7 @@ import ReportUri, {
 } from 'app/views/settings/projectSecurityHeaders/reportUri';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import formGroups from 'app/data/forms/cspReports';
+import routeTitleGen from 'app/utils/routeTitle';
 
 export default class ProjectCspReports extends AsyncView {
   static propTypes = {
@@ -31,6 +32,11 @@ export default class ProjectCspReports extends AsyncView {
       ['keyList', `/projects/${orgId}/${projectId}/keys/`],
       ['project', `/projects/${orgId}/${projectId}/`],
     ];
+  }
+
+  getTitle() {
+    const {projectId} = this.props.params;
+    return routeTitleGen(t('Content Security Policy (CSP)'), projectId, false);
   }
 
   getInstructions() {

--- a/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/expectCt.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/expectCt.jsx
@@ -10,6 +10,7 @@ import ReportUri, {
   getSecurityDsn,
 } from 'app/views/settings/projectSecurityHeaders/reportUri';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
+import routeTitleGen from 'app/utils/routeTitle';
 
 export default class ProjectExpectCtReports extends AsyncView {
   static propTypes = {
@@ -24,6 +25,11 @@ export default class ProjectExpectCtReports extends AsyncView {
   getEndpoints() {
     const {orgId, projectId} = this.props.params;
     return [['keyList', `/projects/${orgId}/${projectId}/keys/`]];
+  }
+
+  getTitle() {
+    const {projectId} = this.props.params;
+    return routeTitleGen(t('Certificate Transparency (Expect-CT)'), projectId, false);
   }
 
   getInstructions() {

--- a/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/hpkp.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/hpkp.jsx
@@ -10,6 +10,7 @@ import ReportUri, {
 } from 'app/views/settings/projectSecurityHeaders/reportUri';
 import PreviewFeature from 'app/components/previewFeature';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
+import routeTitleGen from 'app/utils/routeTitle';
 
 export default class ProjectHpkpReports extends AsyncView {
   static propTypes = {
@@ -27,6 +28,11 @@ export default class ProjectHpkpReports extends AsyncView {
       ['keyList', `/projects/${orgId}/${projectId}/keys/`],
       ['project', `/projects/${orgId}/${projectId}/`],
     ];
+  }
+
+  getTitle() {
+    const {projectId} = this.props.params;
+    return routeTitleGen(t('HTTP Public Key Pinning (HPKP)'), projectId, false);
   }
 
   getInstructions() {

--- a/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSecurityHeaders/index.jsx
@@ -8,6 +8,7 @@ import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import recreateRoute from 'app/utils/recreateRoute';
+import routeTitleGen from 'app/utils/routeTitle';
 import ReportUri from 'app/views/settings/projectSecurityHeaders/reportUri';
 import PreviewFeature from 'app/components/previewFeature';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
@@ -30,6 +31,11 @@ export default class ProjectSecurityHeaders extends AsyncView {
   getEndpoints() {
     const {orgId, projectId} = this.props.params;
     return [['keyList', `/projects/${orgId}/${projectId}/keys/`]];
+  }
+
+  getTitle() {
+    const {projectId} = this.props.params;
+    return routeTitleGen(t('Security Headers'), projectId, false);
   }
 
   getReports() {

--- a/src/sentry/static/sentry/app/views/settings/projectTags.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectTags.jsx
@@ -13,11 +13,17 @@ import PermissionAlert from 'app/views/settings/project/permissionAlert';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import Tooltip from 'app/components/tooltip';
+import routeTitleGen from 'app/utils/routeTitle';
 
 export default class ProjectTags extends AsyncView {
   getEndpoints() {
     const {projectId, orgId} = this.props.params;
     return [['tags', `/projects/${orgId}/${projectId}/tags/`]];
+  }
+
+  getTitle() {
+    const {projectId} = this.props.params;
+    return routeTitleGen(t('Tags'), projectId, false);
   }
 
   onDelete(key, idx) {

--- a/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectAlertSettings.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProjectAlertSettings render() renders 1`] = `
 <SideEffect(DocumentTitle)
-  title="Project Alert Settings - Sentry"
+  title="Alerts Settings - project-slug - Sentry"
 >
   <withConfig(AccessContainer)
     access={

--- a/tests/js/spec/views/__snapshots__/projectDebugFiles.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectDebugFiles.spec.jsx.snap
@@ -14,6 +14,18 @@ exports[`ProjectDebugFiles renders 1`] = `
     }
   }
 >
+  <SentryDocumentTitle
+    objSlug="project"
+    title="Debug Files"
+  >
+    <SideEffect(DocumentTitle)
+      title="Debug Files - project - Sentry"
+    >
+      <DocumentTitle
+        title="Debug Files - project - Sentry"
+      />
+    </SideEffect(DocumentTitle)>
+  </SentryDocumentTitle>
   <StyledSettingsPageHeading
     noTitleStyles={false}
     title="Debug Information Files"
@@ -296,6 +308,10 @@ exports[`ProjectDebugFiles renders 1`] = `
 
 exports[`ProjectDebugFiles renders empty 1`] = `
 <Fragment>
+  <SentryDocumentTitle
+    objSlug="project"
+    title="Debug Files"
+  />
   <StyledSettingsPageHeading
     noTitleStyles={false}
     title="Debug Information Files"

--- a/tests/js/spec/views/__snapshots__/projectOwnership.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectOwnership.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProjectTeamsSettings render() renders 1`] = `
 <SideEffect(DocumentTitle)
-  title="Ownership - Sentry"
+  title="Issue Owners - project-slug - Sentry"
 >
   <div>
     <StyledSettingsPageHeading

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -10,10 +10,10 @@ exports[`ProjectTags renders 1`] = `
   }
 >
   <SideEffect(DocumentTitle)
-    title="Sentry"
+    title="Tags - project-slug - Sentry"
   >
     <DocumentTitle
-      title="Sentry"
+      title="Tags - project-slug - Sentry"
     >
       <StyledSettingsPageHeading
         noTitleStyles={false}

--- a/tests/js/spec/views/__snapshots__/projectTeams.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTeams.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProjectTeams renders 1`] = `
 <SideEffect(DocumentTitle)
-  title="Sentry"
+  title="Project Teams - project-slug - Sentry"
 >
   <div>
     <StyledSettingsPageHeading

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectCspReports.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectCspReports.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProjectCspReports renders 1`] = `
 <SideEffect(DocumentTitle)
-  title="Sentry"
+  title="Content Security Policy (CSP) - project-slug - Sentry"
 >
   <div>
     <StyledSettingsPageHeading

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectExpectCtReports.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectExpectCtReports.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProjectExpectCtReports renders 1`] = `
 <SideEffect(DocumentTitle)
-  title="Sentry"
+  title="Certificate Transparency (Expect-CT) - project-slug - Sentry"
 >
   <div>
     <StyledSettingsPageHeading

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectHpkpReports.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectHpkpReports.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProjectHpkpReports renders 1`] = `
 <SideEffect(DocumentTitle)
-  title="Sentry"
+  title="HTTP Public Key Pinning (HPKP) - project-slug - Sentry"
 >
   <div>
     <StyledSettingsPageHeading

--- a/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectSecurityHeaders.spec.jsx.snap
+++ b/tests/js/spec/views/projectSecurityHeaders/__snapshots__/projectSecurityHeaders.spec.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProjectSecurityHeaders renders 1`] = `
 <SideEffect(DocumentTitle)
-  title="Sentry"
+  title="Security Headers - project-slug - Sentry"
 >
   <div>
     <StyledSettingsPageHeading

--- a/tests/js/spec/views/settings/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -25,6 +25,18 @@ exports[`ProjectEnvironments render active renders empty message 1`] = `
   routes={Array []}
 >
   <div>
+    <SentryDocumentTitle
+      objSlug="project-slug"
+      title="Environments"
+    >
+      <SideEffect(DocumentTitle)
+        title="Environments - project-slug - Sentry"
+      >
+        <DocumentTitle
+          title="Environments - project-slug - Sentry"
+        />
+      </SideEffect(DocumentTitle)>
+    </SentryDocumentTitle>
     <StyledSettingsPageHeading
       noTitleStyles={false}
       tabs={
@@ -396,6 +408,18 @@ exports[`ProjectEnvironments render hidden renders empty message 1`] = `
   routes={Array []}
 >
   <div>
+    <SentryDocumentTitle
+      objSlug="project-slug"
+      title="Environments"
+    >
+      <SideEffect(DocumentTitle)
+        title="Environments - project-slug - Sentry"
+      >
+        <DocumentTitle
+          title="Environments - project-slug - Sentry"
+        />
+      </SideEffect(DocumentTitle)>
+    </SentryDocumentTitle>
     <StyledSettingsPageHeading
       noTitleStyles={false}
       tabs={
@@ -767,6 +791,18 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
   routes={Array []}
 >
   <div>
+    <SentryDocumentTitle
+      objSlug="project-slug"
+      title="Environments"
+    >
+      <SideEffect(DocumentTitle)
+        title="Environments - project-slug - Sentry"
+      >
+        <DocumentTitle
+          title="Environments - project-slug - Sentry"
+        />
+      </SideEffect(DocumentTitle)>
+    </SentryDocumentTitle>
     <StyledSettingsPageHeading
       noTitleStyles={false}
       tabs={


### PR DESCRIPTION
Add descriptive page titles for:

* Project
	* Project Settings
	* Project Teams
	* Alerts
		 * Rules
		 * Settings
		 * New/Edit alert rule
	* Tags
	* Environments
	* Issue Owners
	* Date Forwarding
	* Debug Files
	* Processing Issues

* Project SDK Setup
  * Error Tracking
     * Error Tracking nested routes
  * Client Keys
  * Releases
  * Security Headers
     * Inner routes
  * User Feedback

* Legacy integrations

Used format `<PageTitle> - <projectSlug> - Sentry`

fixes GH-10007