### PR TITLE
feat(ui): Connect organization context to organization store

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/organization.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organization.jsx
@@ -1,0 +1,34 @@
+import {setActiveOrganization} from 'app/actionCreators/organizations';
+
+import OrganizationActions from 'app/actions/organizationActions';
+import TeamStore from 'app/stores/teamStore';
+import ProjectsStore from 'app/stores/projectsStore';
+
+/**
+ * Fetches an organization's details with an option for the detailed representation
+ * with teams and projects
+ *
+ * @param {Object} api A reference to the api client
+ * @param {String} slug The organization slug
+ * @param {boolean} detailed whether or not the detailed org details should be retrieved
+ */
+export async function fetchOrganizationDetails(api, slug, detailed) {
+  OrganizationActions.fetchOrg();
+  try {
+    const org = await api.requestPromise(`/organizations/${slug}/`, {
+      query: {detailed: detailed ? 1 : 0},
+    });
+    if (!org) {
+      OrganizationActions.fetchOrgError(new Error('retrieved organization is falsey'));
+      return;
+    }
+    OrganizationActions.fetchOrgSuccess(org);
+    setActiveOrganization(org);
+    if (detailed) {
+      TeamStore.loadInitialData(org.teams);
+      ProjectsStore.loadInitialData(org.projects);
+    }
+  } catch (err) {
+    OrganizationActions.fetchOrgError(err);
+  }
+}

--- a/src/sentry/static/sentry/app/actionCreators/organization.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organization.jsx
@@ -22,7 +22,7 @@ export async function fetchOrganizationDetails(api, slug, detailed) {
       OrganizationActions.fetchOrgError(new Error('retrieved organization is falsey'));
       return;
     }
-    OrganizationActions.fetchOrgSuccess(org);
+    OrganizationActions.update(org);
     setActiveOrganization(org);
     if (detailed) {
       TeamStore.loadInitialData(org.teams);

--- a/src/sentry/static/sentry/app/actions/organizationActions.jsx
+++ b/src/sentry/static/sentry/app/actions/organizationActions.jsx
@@ -1,3 +1,8 @@
 import Reflux from 'reflux';
 
-export default Reflux.createActions(['update']);
+export default Reflux.createActions([
+  'fetchOrg',
+  'fetchOrgSuccess',
+  'fetchOrgError',
+  'update',
+]);

--- a/src/sentry/static/sentry/app/actions/organizationActions.jsx
+++ b/src/sentry/static/sentry/app/actions/organizationActions.jsx
@@ -1,8 +1,3 @@
 import Reflux from 'reflux';
 
-export default Reflux.createActions([
-  'fetchOrg',
-  'fetchOrgSuccess',
-  'fetchOrgError',
-  'update',
-]);
+export default Reflux.createActions(['fetchOrg', 'fetchOrgError', 'update']);

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -210,3 +210,8 @@ export const EXPERIMENTAL_SPA = process.env.EXPERIMENTAL_SPA;
 // TODO(kmclb): once relay is doing the scrubbing, the masking value will be dynamic,
 // so this will have to change
 export const FILTER_MASK = '[Filtered]';
+
+// Errors that may occur during the fetching of organization details
+export const ORGANIZATION_FETCH_ERROR_TYPES = {
+  ORG_NOT_FOUND: 'ORG_NOT_FOUND',
+};

--- a/src/sentry/static/sentry/app/stores/organizationStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationStore.jsx
@@ -2,24 +2,63 @@ import Reflux from 'reflux';
 
 import OrganizationActions from 'app/actions/organizationActions';
 
+const ERROR_TYPES = {
+  ORG_NOT_FOUND: 'ORG_NOT_FOUND',
+};
+
 const OrganizationStore = Reflux.createStore({
   init() {
     this.reset();
     this.listenTo(OrganizationActions.update, this.onUpdate);
+    this.listenTo(OrganizationActions.fetchOrg, this.onFetchOrg);
+    this.listenTo(OrganizationActions.fetchOrgSuccess, this.onUpdate);
+    this.listenTo(OrganizationActions.fetchOrgError, this.onFetchOrgError);
   },
 
   reset() {
-    this.org = null;
+    this.loading = true;
+    this.error = null;
+    this.errorType = null;
+    this.organization = null;
   },
 
   onUpdate(updatedOrg) {
-    this.org = {...this.org, ...updatedOrg};
-    this.trigger(this.org);
+    this.loading = false;
+    this.error = null;
+    this.errorType = null;
+    this.organization = {...this.organization, ...updatedOrg};
+    this.trigger(this.get());
   },
 
-  getOrganization() {
-    return this.org;
+  onFetchOrg() {
+    this.reset();
+  },
+
+  onFetchOrgError(err) {
+    this.organization = null;
+    this.errorType = null;
+
+    switch (err.statusText) {
+      case 'NOT FOUND':
+        this.errorType = ERROR_TYPES.ORG_NOT_FOUND;
+        break;
+      default:
+    }
+    this.loading = false;
+    this.error = err;
+    this.trigger(this.get());
+  },
+
+  get() {
+    return {
+      organization: this.organization,
+      error: this.error,
+      loading: this.loading,
+      errorType: this.errorType,
+    };
   },
 });
+
+export {ERROR_TYPES};
 
 export default OrganizationStore;

--- a/src/sentry/static/sentry/app/stores/organizationStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationStore.jsx
@@ -1,10 +1,7 @@
 import Reflux from 'reflux';
 
 import OrganizationActions from 'app/actions/organizationActions';
-
-const ERROR_TYPES = {
-  ORG_NOT_FOUND: 'ORG_NOT_FOUND',
-};
+import {ORGANIZATION_FETCH_ERROR_TYPES} from 'app/constants';
 
 const OrganizationStore = Reflux.createStore({
   init() {
@@ -35,7 +32,7 @@ const OrganizationStore = Reflux.createStore({
 
     switch (err.statusText) {
       case 'NOT FOUND':
-        this.errorType = ERROR_TYPES.ORG_NOT_FOUND;
+        this.errorType = ORGANIZATION_FETCH_ERROR_TYPES.ORG_NOT_FOUND;
         break;
       default:
     }
@@ -53,7 +50,5 @@ const OrganizationStore = Reflux.createStore({
     };
   },
 });
-
-export {ERROR_TYPES};
 
 export default OrganizationStore;

--- a/src/sentry/static/sentry/app/stores/organizationStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationStore.jsx
@@ -10,7 +10,7 @@ const OrganizationStore = Reflux.createStore({
   init() {
     this.reset();
     this.listenTo(OrganizationActions.update, this.onUpdate);
-    this.listenTo(OrganizationActions.fetchOrg, this.onFetchOrg);
+    this.listenTo(OrganizationActions.fetchOrg, this.reset);
     this.listenTo(OrganizationActions.fetchOrgSuccess, this.onUpdate);
     this.listenTo(OrganizationActions.fetchOrgError, this.onFetchOrgError);
   },
@@ -28,10 +28,6 @@ const OrganizationStore = Reflux.createStore({
     this.errorType = null;
     this.organization = {...this.organization, ...updatedOrg};
     this.trigger(this.get());
-  },
-
-  onFetchOrg() {
-    this.reset();
   },
 
   onFetchOrgError(err) {

--- a/src/sentry/static/sentry/app/stores/organizationStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationStore.jsx
@@ -15,13 +15,11 @@ const OrganizationStore = Reflux.createStore({
     // mark the store as dirty if projects or teams change
     this.listenTo(ProjectActions.createSuccess, this.onProjectOrTeamChange);
     this.listenTo(ProjectActions.updateSuccess, this.onProjectOrTeamChange);
-    this.listenTo(ProjectActions.loadStatsSuccess, this.onProjectOrTeamChange);
     this.listenTo(ProjectActions.changeSlug, this.onProjectOrTeamChange);
     this.listenTo(ProjectActions.addTeamSuccess, this.onProjectOrTeamChange);
     this.listenTo(ProjectActions.removeTeamSuccess, this.onProjectOrTeamChange);
 
     this.listenTo(TeamActions.updateSuccess, this.onProjectOrTeamChange);
-    this.listenTo(TeamActions.fetchDetailsSuccess, this.onProjectOrTeamChange);
     this.listenTo(TeamActions.removeTeamSuccess, this.onProjectOrTeamChange);
     this.listenTo(TeamActions.createTeamSuccess, this.onProjectOrTeamChange);
   },

--- a/src/sentry/static/sentry/app/stores/organizationStore.jsx
+++ b/src/sentry/static/sentry/app/stores/organizationStore.jsx
@@ -11,7 +11,6 @@ const OrganizationStore = Reflux.createStore({
     this.reset();
     this.listenTo(OrganizationActions.update, this.onUpdate);
     this.listenTo(OrganizationActions.fetchOrg, this.reset);
-    this.listenTo(OrganizationActions.fetchOrgSuccess, this.onUpdate);
     this.listenTo(OrganizationActions.fetchOrgError, this.onFetchOrgError);
   },
 

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -94,6 +94,9 @@ const OrganizationContext = createReactClass({
   },
 
   onProjectCreation() {
+    // If a new project was created, we need to re-fetch the
+    // org details endpoint, which will propagate re-rendering
+    // for the entire component tree
     fetchOrganizationDetails(this.props.api, this.getOrganizationSlug(), true);
   },
 
@@ -113,7 +116,7 @@ const OrganizationContext = createReactClass({
       this.setState({loading: this.props.organizationsLoading});
       return;
     }
-    // fetch from the store, if need be then fetch from the API
+    // fetch from the store, then fetch from the API if necessary
     const {organization} = OrganizationStore.get();
 
     if (

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -118,9 +118,9 @@ const OrganizationContext = createReactClass({
       return;
     }
     // fetch from the store, then fetch from the API if necessary
-    const {organization} = OrganizationStore.get();
-
+    const {organization, dirty} = OrganizationStore.get();
     if (
+      !dirty &&
       organization &&
       organization.slug === this.getOrganizationSlug() &&
       organization.projects &&

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -26,10 +26,6 @@ import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 import withOrganizations from 'app/utils/withOrganizations';
 
-const ERROR_TYPES = {
-  ORG_NOT_FOUND: 'ORG_NOT_FOUND',
-};
-
 const OrganizationContext = createReactClass({
   displayName: 'OrganizationContext',
 

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/browser';
 import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
+import {ORGANIZATION_FETCH_ERROR_TYPES} from 'app/constants';
 import {fetchOrganizationDetails} from 'app/actionCreators/organization';
 import {metric} from 'app/utils/analytics';
 import {openSudo} from 'app/actionCreators/modal';
@@ -16,7 +17,7 @@ import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import HookStore from 'app/stores/hookStore';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import OrganizationStore, {ERROR_TYPES} from 'app/stores/organizationStore';
+import OrganizationStore from 'app/stores/organizationStore';
 import ProjectActions from 'app/actions/projectActions';
 import SentryTypes from 'app/sentryTypes';
 import Sidebar from 'app/components/sidebar';
@@ -206,7 +207,7 @@ const OrganizationContext = createReactClass({
     let errorComponent;
 
     switch (this.state.errorType) {
-      case ERROR_TYPES.ORG_NOT_FOUND:
+      case ORGANIZATION_FETCH_ERROR_TYPES.ORG_NOT_FOUND:
         errorComponent = (
           <Alert type="error">
             {t('The organization you were looking for was not found.')}

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -6,9 +6,9 @@ import * as Sentry from '@sentry/browser';
 import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
+import {fetchOrganizationDetails} from 'app/actionCreators/organization';
 import {metric} from 'app/utils/analytics';
 import {openSudo} from 'app/actionCreators/modal';
-import {setActiveOrganization} from 'app/actionCreators/organizations';
 import {t} from 'app/locale';
 import Alert from 'app/components/alert';
 import ConfigStore from 'app/stores/configStore';
@@ -16,11 +16,10 @@ import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import HookStore from 'app/stores/hookStore';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
+import OrganizationStore, {ERROR_TYPES} from 'app/stores/organizationStore';
 import ProjectActions from 'app/actions/projectActions';
-import ProjectsStore from 'app/stores/projectsStore';
 import SentryTypes from 'app/sentryTypes';
 import Sidebar from 'app/components/sidebar';
-import TeamStore from 'app/stores/teamStore';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 import profiler from 'app/utils/profiler';
 import space from 'app/styles/space';
@@ -48,15 +47,14 @@ const OrganizationContext = createReactClass({
     organization: SentryTypes.Organization,
   },
 
-  mixins: [Reflux.listenTo(ProjectActions.createSuccess, 'onProjectCreation')],
+  mixins: [
+    Reflux.listenTo(ProjectActions.createSuccess, 'onProjectCreation'),
+    Reflux.listenTo(OrganizationStore, 'loadOrganization'),
+  ],
 
   getInitialState() {
-    return {
-      loading: true,
-      error: false,
-      errorType: null,
-      organization: null,
-    };
+    // retrieve initial state from store
+    return OrganizationStore.get();
   },
 
   getChildContext() {
@@ -95,19 +93,12 @@ const OrganizationContext = createReactClass({
     }
   },
 
-  componentWillUnmount() {
-    TeamStore.reset();
-  },
-
   remountComponent() {
     this.setState(this.getInitialState(), this.fetchData);
   },
 
   onProjectCreation() {
-    // If a new project was created, we need to re-fetch the
-    // org details endpoint, which will propagate re-rendering
-    // for the entire component tree
-    this.fetchData();
+    fetchOrganizationDetails(this.props.api, this.getOrganizationSlug(), true);
   },
 
   getOrganizationSlug() {
@@ -126,88 +117,71 @@ const OrganizationContext = createReactClass({
       this.setState({loading: this.props.organizationsLoading});
       return;
     }
+    // fetch from the store, if need be then fetch from the API
+    const {organization} = OrganizationStore.get();
 
+    if (
+      organization &&
+      organization.slug === this.getOrganizationSlug() &&
+      organization.projects &&
+      organization.teams
+    ) {
+      return;
+    }
     metric.mark('organization-details-fetch-start');
+    fetchOrganizationDetails(this.props.api, this.getOrganizationSlug(), true);
+  },
 
-    this.props.api
-      .requestPromise(this.getOrganizationDetailsEndpoint())
-      .then(data => {
-        // Allow injection via getsentry et all
-        const hooks = [];
-        HookStore.get('organization:header').forEach(cb => {
-          hooks.push(cb(data));
-        });
+  loadOrganization(orgData) {
+    const {organization, error} = orgData;
+    if (organization && !error) {
+      const hooks = [];
+      HookStore.get('organization:header').forEach(cb => {
+        hooks.push(cb(organization));
+      });
 
-        setActiveOrganization(data);
-
-        // Configure scope to have organization tag
-        Sentry.configureScope(scope => {
-          scope.setTag('organization', data.id);
-        });
-
-        TeamStore.loadInitialData(data.teams);
-        ProjectsStore.loadInitialData(data.projects);
-
-        // Make an exception for issue details in the case where it is accessed directly (e.g. from email)
-        // We do not want to load the user's last used env/project in this case, otherwise will
-        // lead to very confusing behavior.
-        if (
-          !this.props.routes.find(
-            ({path}) => path && path.includes('/organizations/:orgId/issues/:groupId/')
-          )
-        ) {
-          GlobalSelectionStore.loadInitialData(data, this.props.location.query);
-        }
-        this.setState(
-          {
-            organization: data,
-            loading: false,
-            error: false,
-            errorType: null,
-            hooks,
-          },
-          () => {
-            // Take a measurement for when organization details are done loading and the new state is applied
-            metric.measure({
-              name: 'app.component.perf',
-              start: 'organization-details-fetch-start',
-              data: {
-                name: 'org-details',
-                route: getRouteStringFromRoutes(this.props.routes),
-                organization_id: parseInt(data.id, 10),
-              },
-            });
-          }
-        );
-      })
-      .catch(err => {
-        let errorType = null;
-
-        switch (err.statusText) {
-          case 'NOT FOUND':
-            errorType = ERROR_TYPES.ORG_NOT_FOUND;
-            break;
-          default:
-        }
-        this.setState({
-          loading: false,
-          error: true,
-          errorType,
-        });
-
-        // If user is superuser, open sudo window
-        const user = ConfigStore.get('user');
-        if (!user || !user.isSuperuser || err.status !== 403) {
-          // This `catch` can swallow up errors in development (and tests)
-          // So let's log them. This may create some noise, especially the test case where
-          // we specifically test this branch
-          console.error(err); // eslint-disable-line no-console
-          return;
-        }
+      // Configure scope to have organization tag
+      Sentry.configureScope(scope => {
+        scope.setTag('organization', organization.id);
+      });
+      // Make an exception for issue details in the case where it is accessed directly (e.g. from email)
+      // We do not want to load the user's last used env/project in this case, otherwise will
+      // lead to very confusing behavior.
+      if (
+        !this.props.routes.find(
+          ({path}) => path && path.includes('/organizations/:orgId/issues/:groupId/')
+        )
+      ) {
+        GlobalSelectionStore.loadInitialData(organization, this.props.location.query);
+      }
+    } else if (error) {
+      // If user is superuser, open sudo window
+      const user = ConfigStore.get('user');
+      if (!user || !user.isSuperuser || error.status !== 403) {
+        // This `catch` can swallow up errors in development (and tests)
+        // So let's log them. This may create some noise, especially the test case where
+        // we specifically test this branch
+        console.error(error); // eslint-disable-line no-console
+      } else {
         openSudo({
           retryRequest: () => Promise.resolve(this.fetchData()),
         });
-      });
+      }
+    }
+    this.setState(orgData, () => {
+      // Take a measurement for when organization details are done loading and the new state is applied
+      if (organization) {
+        metric.measure({
+          name: 'app.component.perf',
+          start: 'organization-details-fetch-start',
+          data: {
+            name: 'org-details',
+            route: getRouteStringFromRoutes(this.props.routes),
+            organization_id: parseInt(organization.id, 10),
+          },
+        });
+      }
+    });
   },
 
   getOrganizationDetailsEndpoint() {

--- a/tests/js/spec/actionCreators/organization.spec.jsx
+++ b/tests/js/spec/actionCreators/organization.spec.jsx
@@ -1,0 +1,94 @@
+import * as OrganizationsActionCreator from 'app/actionCreators/organizations';
+import {fetchOrganizationDetails} from 'app/actionCreators/organization';
+import TeamStore from 'app/stores/teamStore';
+import ProjectsStore from 'app/stores/projectsStore';
+import OrganizationActions from 'app/actions/organizationActions';
+
+describe('OrganizationActionCreator', function() {
+  const detailedOrg = TestStubs.Organization({
+    teams: [TestStubs.Team()],
+    projects: [TestStubs.Project()],
+  });
+
+  const lightOrg = TestStubs.Organization();
+  delete lightOrg.teams;
+  delete lightOrg.projects;
+
+  const api = new MockApiClient();
+
+  beforeEach(function() {
+    MockApiClient.clearMockResponses();
+    // getOrgMock = MockApiClient.addMockResponse({
+    //   url: '/organizations/org-slug',
+    // });
+    jest.spyOn(TeamStore, 'loadInitialData');
+    jest.spyOn(ProjectsStore, 'loadInitialData');
+    jest.spyOn(OrganizationActions, 'fetchOrg');
+    jest.spyOn(OrganizationActions, 'fetchOrgSuccess');
+    jest.spyOn(OrganizationActions, 'fetchOrgError');
+    jest.spyOn(OrganizationsActionCreator, 'setActiveOrganization');
+  });
+
+  afterEach(function() {
+    jest.restoreAllMocks();
+    MockApiClient.clearMockResponses();
+  });
+
+  it('fetches heavyweight organization details', async function() {
+    const getOrgMock = MockApiClient.addMockResponse({
+      url: `/organizations/${detailedOrg.slug}/`,
+      body: detailedOrg,
+    });
+
+    fetchOrganizationDetails(api, detailedOrg.slug, true);
+    await tick();
+    expect(OrganizationActions.fetchOrg).toHaveBeenCalled();
+
+    expect(getOrgMock).toHaveBeenCalledWith(
+      `/organizations/${detailedOrg.slug}/`,
+      expect.anything()
+    );
+    expect(OrganizationActions.fetchOrgSuccess).toHaveBeenCalledWith(detailedOrg);
+    expect(OrganizationsActionCreator.setActiveOrganization).toHaveBeenCalled();
+
+    expect(TeamStore.loadInitialData).toHaveBeenCalledWith(detailedOrg.teams);
+    expect(ProjectsStore.loadInitialData).toHaveBeenCalledWith(detailedOrg.projects);
+  });
+
+  it('fetches lightweight organization details', async function() {
+    const getOrgMock = MockApiClient.addMockResponse({
+      url: `/organizations/${lightOrg.slug}/`,
+      body: lightOrg,
+    });
+
+    fetchOrganizationDetails(api, lightOrg.slug, false);
+    await tick();
+    expect(OrganizationActions.fetchOrg).toHaveBeenCalled();
+
+    expect(getOrgMock).toHaveBeenCalledWith(
+      `/organizations/${lightOrg.slug}/`,
+      expect.anything()
+    );
+    expect(OrganizationActions.fetchOrgSuccess).toHaveBeenCalledWith(lightOrg);
+    expect(OrganizationsActionCreator.setActiveOrganization).toHaveBeenCalled();
+
+    expect(TeamStore.loadInitialData).not.toHaveBeenCalled();
+    expect(ProjectsStore.loadInitialData).not.toHaveBeenCalled();
+  });
+
+  it('errors out correctly', async function() {
+    const getOrgMock = MockApiClient.addMockResponse({
+      url: `/organizations/${detailedOrg.slug}/`,
+      statusCode: 400,
+    });
+
+    fetchOrganizationDetails(api, detailedOrg.slug, true);
+    await tick();
+    expect(OrganizationActions.fetchOrg).toHaveBeenCalled();
+    expect(getOrgMock).toHaveBeenCalledWith(
+      `/organizations/${detailedOrg.slug}/`,
+      expect.anything()
+    );
+    expect(OrganizationActions.fetchOrgError).toHaveBeenCalled();
+  });
+});

--- a/tests/js/spec/actionCreators/organization.spec.jsx
+++ b/tests/js/spec/actionCreators/organization.spec.jsx
@@ -18,13 +18,10 @@ describe('OrganizationActionCreator', function() {
 
   beforeEach(function() {
     MockApiClient.clearMockResponses();
-    // getOrgMock = MockApiClient.addMockResponse({
-    //   url: '/organizations/org-slug',
-    // });
     jest.spyOn(TeamStore, 'loadInitialData');
     jest.spyOn(ProjectsStore, 'loadInitialData');
     jest.spyOn(OrganizationActions, 'fetchOrg');
-    jest.spyOn(OrganizationActions, 'fetchOrgSuccess');
+    jest.spyOn(OrganizationActions, 'update');
     jest.spyOn(OrganizationActions, 'fetchOrgError');
     jest.spyOn(OrganizationsActionCreator, 'setActiveOrganization');
   });
@@ -48,7 +45,7 @@ describe('OrganizationActionCreator', function() {
       `/organizations/${detailedOrg.slug}/`,
       expect.anything()
     );
-    expect(OrganizationActions.fetchOrgSuccess).toHaveBeenCalledWith(detailedOrg);
+    expect(OrganizationActions.update).toHaveBeenCalledWith(detailedOrg);
     expect(OrganizationsActionCreator.setActiveOrganization).toHaveBeenCalled();
 
     expect(TeamStore.loadInitialData).toHaveBeenCalledWith(detailedOrg.teams);
@@ -69,7 +66,7 @@ describe('OrganizationActionCreator', function() {
       `/organizations/${lightOrg.slug}/`,
       expect.anything()
     );
-    expect(OrganizationActions.fetchOrgSuccess).toHaveBeenCalledWith(lightOrg);
+    expect(OrganizationActions.update).toHaveBeenCalledWith(lightOrg);
     expect(OrganizationsActionCreator.setActiveOrganization).toHaveBeenCalled();
 
     expect(TeamStore.loadInitialData).not.toHaveBeenCalled();

--- a/tests/js/spec/stores/organizationStore.spec.jsx
+++ b/tests/js/spec/stores/organizationStore.spec.jsx
@@ -18,7 +18,7 @@ describe('OrganizationStore', function() {
 
   it('updates correctly', async function() {
     const organization = TestStubs.Organization();
-    OrganizationActions.fetchOrgSuccess(organization);
+    OrganizationActions.update(organization);
     await tick();
     expect(OrganizationStore.get()).toMatchObject({
       loading: false,
@@ -29,7 +29,7 @@ describe('OrganizationStore', function() {
 
     // updates
     organization.slug = 'a new slug';
-    OrganizationActions.fetchOrgSuccess(organization);
+    OrganizationActions.update(organization);
     await tick();
     expect(OrganizationStore.get()).toMatchObject({
       loading: false,

--- a/tests/js/spec/stores/organizationStore.spec.jsx
+++ b/tests/js/spec/stores/organizationStore.spec.jsx
@@ -13,6 +13,7 @@ describe('OrganizationStore', function() {
       error: null,
       errorType: null,
       organization: null,
+      dirty: false,
     });
   });
 
@@ -25,6 +26,7 @@ describe('OrganizationStore', function() {
       error: null,
       errorType: null,
       organization,
+      dirty: false,
     });
 
     // updates
@@ -36,6 +38,7 @@ describe('OrganizationStore', function() {
       error: null,
       errorType: null,
       organization,
+      dirty: false,
     });
   });
 
@@ -48,6 +51,7 @@ describe('OrganizationStore', function() {
       error: null,
       errorType: null,
       organization,
+      dirty: false,
     });
   });
 
@@ -61,6 +65,7 @@ describe('OrganizationStore', function() {
       error,
       errorType: 'ORG_NOT_FOUND',
       organization: null,
+      dirty: false,
     });
   });
 });

--- a/tests/js/spec/stores/organizationStore.spec.jsx
+++ b/tests/js/spec/stores/organizationStore.spec.jsx
@@ -7,17 +7,60 @@ describe('OrganizationStore', function() {
     OrganizationStore.reset();
   });
 
+  it('starts with loading state', function() {
+    expect(OrganizationStore.get()).toMatchObject({
+      loading: true,
+      error: null,
+      errorType: null,
+      organization: null,
+    });
+  });
+
   it('updates correctly', async function() {
-    const org = TestStubs.Organization();
-    OrganizationActions.update(org);
+    const organization = TestStubs.Organization();
+    OrganizationActions.fetchOrgSuccess(organization);
     await tick();
-    expect(OrganizationStore.getOrganization()).toMatchObject(org);
+    expect(OrganizationStore.get()).toMatchObject({
+      loading: false,
+      error: null,
+      errorType: null,
+      organization,
+    });
+
+    // updates
+    organization.slug = 'a new slug';
+    OrganizationActions.fetchOrgSuccess(organization);
+    await tick();
+    expect(OrganizationStore.get()).toMatchObject({
+      loading: false,
+      error: null,
+      errorType: null,
+      organization,
+    });
   });
 
   it('updates correctly from setting changes', async function() {
-    const org = TestStubs.Organization();
-    updateOrganization(org);
+    const organization = TestStubs.Organization();
+    updateOrganization(organization);
     await tick();
-    expect(OrganizationStore.getOrganization()).toMatchObject(org);
+    expect(OrganizationStore.get()).toMatchObject({
+      loading: false,
+      error: null,
+      errorType: null,
+      organization,
+    });
+  });
+
+  it('errors correctly', async function() {
+    const error = new Error('uh-oh');
+    error.statusText = 'NOT FOUND';
+    OrganizationActions.fetchOrgError(error);
+    await tick();
+    expect(OrganizationStore.get()).toMatchObject({
+      loading: false,
+      error,
+      errorType: 'ORG_NOT_FOUND',
+      organization: null,
+    });
   });
 });

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -54,13 +54,16 @@ describe('OrganizationContext', function() {
   });
 
   afterEach(async function() {
+    wrapper.unmount();
     OrganizationStore.reset();
+    // await for store change to finish propagating
+    await tick();
+
     TeamStore.loadInitialData.mockRestore();
     ProjectsStore.loadInitialData.mockRestore();
     ConfigStore.get.mockRestore();
     GlobalSelectionStore.loadInitialData.mockRestore();
     OrganizationActionCreator.fetchOrganizationDetails.mockRestore();
-    wrapper.unmount();
   });
 
   it('renders and fetches org', async function() {

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -94,6 +94,7 @@ describe('OrganizationContext', function() {
   it('fetches new org when router params change', async function() {
     wrapper = createWrapper();
     await tick();
+    await tick();
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/new-slug/',
       body: org,

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -78,6 +78,8 @@ describe('OrganizationContext', function() {
     expect(wrapper.state('error')).toBe(null);
     expect(wrapper.state('organization')).toEqual(org);
 
+    expect(TeamStore.loadInitialData).toHaveBeenCalledWith(org.teams);
+    expect(ProjectsStore.loadInitialData).toHaveBeenCalledWith(org.projects);
     expect(OrganizationActionCreator.fetchOrganizationDetails).toHaveBeenCalledWith(
       api,
       'org-slug',

--- a/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
 
 import OrganizationDetails from 'app/views/organizationDetails';
+import OrganizationStore from 'app/stores/organizationStore';
 
 describe('OrganizationDetails', function() {
   beforeEach(function() {
+    OrganizationStore.reset();
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/broadcasts/',
@@ -42,7 +44,6 @@ describe('OrganizationDetails', function() {
         );
         expect(tree.find('button[aria-label="Restore Organization"]')).toHaveLength(1);
       });
-
       it('should render a restoration prompt without action for members', async function() {
         MockApiClient.addMockResponse({
           url: '/organizations/org-slug/',


### PR DESCRIPTION
Integrate organization context with organization store. Now before fetching for the organization, org context checks to see if there is an organization in the store which is fully populated with teams and projects and matches the current slug. If there is a heavyweight matching organization then no data will be fetched, otherwise the organization will be fetched and the store will be set accordingly.

Refs: SEN-1145