### PR TITLE
ref(ui): Remove borders on disabled link buttons

### DIFF
--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -300,7 +300,7 @@ const StyledButton = styled(
     outline: none;
   }
 
-  ${p => p.borderless && 'border-color: transparent'};
+  ${p => (p.borderless || p.priority === 'link') && 'border-color: transparent'};
 `;
 
 /**

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1672,7 +1672,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             <ForwardRef
                                               aria-disabled={false}
                                               aria-label="Go to Support"
-                                              className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                              className="css-budrs3-StyledButton-getColors edwq9my0"
                                               disabled={false}
                                               onClick={[Function]}
                                               priority="link"
@@ -1682,7 +1682,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                               <Link
                                                 aria-disabled={false}
                                                 aria-label="Go to Support"
-                                                className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                                className="css-budrs3-StyledButton-getColors edwq9my0"
                                                 onClick={[Function]}
                                                 onlyActiveOnIndex={false}
                                                 role="button"
@@ -1692,7 +1692,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                 <a
                                                   aria-disabled={false}
                                                   aria-label="Go to Support"
-                                                  className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                                  className="css-budrs3-StyledButton-getColors edwq9my0"
                                                   onClick={[Function]}
                                                   role="button"
                                                   style={Object {}}
@@ -1987,7 +1987,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             <ForwardRef
                                               aria-disabled={false}
                                               aria-label="Go to Support"
-                                              className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                              className="css-budrs3-StyledButton-getColors edwq9my0"
                                               disabled={false}
                                               onClick={[Function]}
                                               priority="link"
@@ -1997,7 +1997,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                               <Link
                                                 aria-disabled={false}
                                                 aria-label="Go to Support"
-                                                className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                                className="css-budrs3-StyledButton-getColors edwq9my0"
                                                 onClick={[Function]}
                                                 onlyActiveOnIndex={false}
                                                 role="button"
@@ -2007,7 +2007,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                 <a
                                                   aria-disabled={false}
                                                   aria-label="Go to Support"
-                                                  className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                                  className="css-budrs3-StyledButton-getColors edwq9my0"
                                                   onClick={[Function]}
                                                   role="button"
                                                   style={Object {}}
@@ -2300,7 +2300,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             <ForwardRef
                                               aria-disabled={false}
                                               aria-label="Go to Support"
-                                              className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                              className="css-budrs3-StyledButton-getColors edwq9my0"
                                               disabled={false}
                                               onClick={[Function]}
                                               priority="link"
@@ -2310,7 +2310,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                               <Link
                                                 aria-disabled={false}
                                                 aria-label="Go to Support"
-                                                className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                                className="css-budrs3-StyledButton-getColors edwq9my0"
                                                 onClick={[Function]}
                                                 onlyActiveOnIndex={false}
                                                 role="button"
@@ -2320,7 +2320,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                 <a
                                                   aria-disabled={false}
                                                   aria-label="Go to Support"
-                                                  className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                                  className="css-budrs3-StyledButton-getColors edwq9my0"
                                                   onClick={[Function]}
                                                   role="button"
                                                   style={Object {}}
@@ -2617,7 +2617,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             <ForwardRef
                                               aria-disabled={false}
                                               aria-label="Go to Support"
-                                              className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                              className="css-budrs3-StyledButton-getColors edwq9my0"
                                               disabled={false}
                                               onClick={[Function]}
                                               priority="link"
@@ -2627,7 +2627,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                               <Link
                                                 aria-disabled={false}
                                                 aria-label="Go to Support"
-                                                className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                                className="css-budrs3-StyledButton-getColors edwq9my0"
                                                 onClick={[Function]}
                                                 onlyActiveOnIndex={false}
                                                 role="button"
@@ -2637,7 +2637,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                 <a
                                                   aria-disabled={false}
                                                   aria-label="Go to Support"
-                                                  className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                                  className="css-budrs3-StyledButton-getColors edwq9my0"
                                                   onClick={[Function]}
                                                   role="button"
                                                   style={Object {}}
@@ -2936,7 +2936,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             <ForwardRef
                                               aria-disabled={false}
                                               aria-label="Go to Support"
-                                              className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                              className="css-budrs3-StyledButton-getColors edwq9my0"
                                               disabled={false}
                                               onClick={[Function]}
                                               priority="link"
@@ -2946,7 +2946,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                               <Link
                                                 aria-disabled={false}
                                                 aria-label="Go to Support"
-                                                className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                                className="css-budrs3-StyledButton-getColors edwq9my0"
                                                 onClick={[Function]}
                                                 onlyActiveOnIndex={false}
                                                 role="button"
@@ -2956,7 +2956,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                 <a
                                                   aria-disabled={false}
                                                   aria-label="Go to Support"
-                                                  className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                                  className="css-budrs3-StyledButton-getColors edwq9my0"
                                                   onClick={[Function]}
                                                   role="button"
                                                   style={Object {}}
@@ -3255,7 +3255,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             <ForwardRef
                                               aria-disabled={false}
                                               aria-label="Go to Support"
-                                              className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                              className="css-budrs3-StyledButton-getColors edwq9my0"
                                               disabled={false}
                                               onClick={[Function]}
                                               priority="link"
@@ -3265,7 +3265,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                               <Link
                                                 aria-disabled={false}
                                                 aria-label="Go to Support"
-                                                className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                                className="css-budrs3-StyledButton-getColors edwq9my0"
                                                 onClick={[Function]}
                                                 onlyActiveOnIndex={false}
                                                 role="button"
@@ -3275,7 +3275,7 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                                 <a
                                                   aria-disabled={false}
                                                   aria-label="Go to Support"
-                                                  className="css-6x2oxd-StyledButton-getColors edwq9my0"
+                                                  className="css-budrs3-StyledButton-getColors edwq9my0"
                                                   onClick={[Function]}
                                                   role="button"
                                                   style={Object {}}


### PR DESCRIPTION
The border was set when a `priority="link"` button is disabled