### PR TITLE
fix: Request to join wording

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationJoinRequest.tsx
+++ b/src/sentry/static/sentry/app/views/organizationJoinRequest.tsx
@@ -28,7 +28,7 @@ class OrganizationJoinRequest extends React.Component<Props, State> {
   };
 
   handleSubmitError() {
-    addErrorMessage(t('Access request failed'));
+    addErrorMessage(t('Request to join failed'));
   }
 
   handleCancel = e => {
@@ -48,7 +48,7 @@ class OrganizationJoinRequest extends React.Component<Props, State> {
           <SuccessModal>
             <MegaphoneIcon src="icon-megaphone" size="5em" />
             <StyledHeader>{t('Request Sent')}</StyledHeader>
-            <StyledText>{t('Your access request has been sent.')}</StyledText>
+            <StyledText>{t('Your request to join has been sent.')}</StyledText>
             <ReceiveEmailMessage>
               {tct('You will receive an email when your request is approved.', {orgId})}
             </ReceiveEmailMessage>
@@ -60,7 +60,7 @@ class OrganizationJoinRequest extends React.Component<Props, State> {
     return (
       <NarrowLayout maxWidth="650px">
         <MegaphoneIcon src="icon-megaphone" size="5em" />
-        <StyledHeader>{t('Request Access')}</StyledHeader>
+        <StyledHeader>{t('Request to Join')}</StyledHeader>
         <StyledText>
           {tct('Ask the admins if you can join the [orgId] organization.', {
             orgId,
@@ -70,7 +70,7 @@ class OrganizationJoinRequest extends React.Component<Props, State> {
           requireChanges
           apiEndpoint={`/organizations/${orgId}/join-request/`}
           apiMethod="POST"
-          submitLabel={t('Request Access')}
+          submitLabel={t('Request to Join')}
           onSubmitSuccess={this.handleSubmitSuccess}
           onSubmitError={this.handleSubmitError}
           onCancel={this.handleCancel}

--- a/tests/js/spec/views/organizationJoinRequest.spec.jsx
+++ b/tests/js/spec/views/organizationJoinRequest.spec.jsx
@@ -20,9 +20,9 @@ describe('OrganizationJoinRequest', function() {
       TestStubs.routerContext()
     );
 
-    expect(wrapper.find('h3').text()).toBe('Request Access');
+    expect(wrapper.find('h3').text()).toBe('Request to Join');
     expect(wrapper.find('EmailField').exists()).toBe(true);
-    expect(wrapper.find('button[aria-label="Request Access"]').exists()).toBe(true);
+    expect(wrapper.find('button[aria-label="Request to Join"]').exists()).toBe(true);
   });
 
   it('submits', async function() {
@@ -48,7 +48,7 @@ describe('OrganizationJoinRequest', function() {
 
     expect(wrapper.find('h3').text()).toBe('Request Sent');
     expect(wrapper.find('EmailField').exists()).toBe(false);
-    expect(wrapper.find('button[aria-label="Request Access"]').exists()).toBe(false);
+    expect(wrapper.find('button[aria-label="Request to Join"]').exists()).toBe(false);
   });
 
   it('errors', async function() {
@@ -74,9 +74,9 @@ describe('OrganizationJoinRequest', function() {
     wrapper.update();
 
     expect(addErrorMessage).toHaveBeenCalled();
-    expect(wrapper.find('h3').text()).toBe('Request Access');
+    expect(wrapper.find('h3').text()).toBe('Request to Join');
     expect(wrapper.find('EmailField').exists()).toBe(true);
-    expect(wrapper.find('button[aria-label="Request Access"]').exists()).toBe(true);
+    expect(wrapper.find('button[aria-label="Request to Join"]').exists()).toBe(true);
   });
 
   it('cancels', function() {


### PR DESCRIPTION
There's been some back and forth around what to call this, but we've landed on `Request to Join` since organization access requests already refer to team requests, and we want to keep the wording pretty consistent 
cc @adhiraj 