### PR TITLE
fix(tests) Fix flaky test

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -309,7 +309,6 @@ class SnubaSearchBackend(SearchBackend):
                 }
             ).build(group_queryset, search_filters)
         else:
-
             group_queryset = QuerySetBuilder(
                 {
                     "first_release": QCallbackCondition(
@@ -625,7 +624,7 @@ def snuba_search(
         filters["environment"] = environment_ids
 
     if candidate_ids:
-        filters["issue"] = candidate_ids
+        filters["issue"] = sorted(candidate_ids)
 
     conditions = []
     having = []


### PR DESCRIPTION
The groupids could come out of postgres in a non-deterministic order causing test failures. This fixates the order of parameters in snuba queries which allows mocks to more reliably match query parameters.