### PR TITLE
feat(discover2): Add draggable columns on discover2 table

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/flags.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/flags.tsx
@@ -7,4 +7,4 @@
  * 3. Allow drag-to-rearrage columns
  */
 export const FLAG_GRID_RESIZABLE = false;
-export const FLAG_GRID_DRAGGABLE = false;
+export const FLAG_GRID_DRAGGABLE = true;

--- a/src/sentry/static/sentry/app/components/gridEditable/flags.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/flags.tsx
@@ -7,4 +7,3 @@
  * 3. Allow drag-to-rearrage columns
  */
 export const FLAG_GRID_RESIZABLE = false;
-export const FLAG_GRID_DRAGGABLE = true;

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -87,7 +87,7 @@ class GridHeadCell<Column> extends React.Component<
             />
           }
 
-          <GridHeadCellButtonHoverButtonGroup isFlagged={FLAG_GRID_DRAGGABLE}>
+          <GridHeadCellButtonHoverButtonGroup>
             <GridHeadCellButtonHoverButton onClick={this.toggleModal}>
               <InlineSvg src="icon-edit-pencil" />
             </GridHeadCellButtonHoverButton>

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -74,7 +74,17 @@ class GridHeadCell<Column> extends React.Component<
 
         <GridHeadCellButtonHover>
           {FLAG_GRID_DRAGGABLE && (
-            <GridHeadCellButtonHoverDraggable src="icon-grabbable" />
+            <GridHeadCellButtonHoverDraggable
+              src="icon-grabbable"
+              onClick={() => {
+                const fromColumn = this.props.indexColumnOrder;
+                const destinationColumn = this.props.indexColumnOrder - 1;
+
+                if (destinationColumn >= 0) {
+                  this.props.actions.moveColumn(fromColumn, destinationColumn);
+                }
+              }}
+            />
           )}
 
           <GridHeadCellButtonHoverButtonGroup isFlagged={FLAG_GRID_DRAGGABLE}>
@@ -87,7 +97,17 @@ class GridHeadCell<Column> extends React.Component<
           </GridHeadCellButtonHoverButtonGroup>
 
           {FLAG_GRID_DRAGGABLE && (
-            <GridHeadCellButtonHoverDraggable src="icon-grabbable" />
+            <GridHeadCellButtonHoverDraggable
+              src="icon-grabbable"
+              onClick={() => {
+                const fromColumn = this.props.indexColumnOrder;
+                const destinationColumn = this.props.indexColumnOrder + 1;
+
+                if (destinationColumn >= 0) {
+                  this.props.actions.moveColumn(fromColumn, destinationColumn);
+                }
+              }}
+            />
           )}
         </GridHeadCellButtonHover>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -13,9 +13,11 @@ import {
   GridHeadCellButtonHoverDraggable,
   GridHeadCellResizer,
 } from './styles';
+import {GridColumnHeader} from './types';
 
 export type GridHeadCellProps<Column> = {
   isColumnDragging: boolean;
+
   isEditing: boolean;
   isPrimary: boolean;
 
@@ -42,7 +44,7 @@ export type GridHeadCellState = {
  * states that are only specific to the header. This component aims to abstract
  * the complexity of GridHeadCell away.
  */
-class GridHeadCell<Column> extends React.Component<
+class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
   GridHeadCellProps<Column>,
   GridHeadCellState
 > {
@@ -119,7 +121,7 @@ class GridHeadCell<Column> extends React.Component<
   }
 
   render() {
-    const {isEditing, children} = this.props;
+    const {isEditing, children, column} = this.props;
 
     return (
       <GridHeadCellWrapper
@@ -127,7 +129,11 @@ class GridHeadCell<Column> extends React.Component<
         onMouseMove={() => this.setHovering(true)}
         onMouseLeave={() => this.setHovering(false)}
       >
-        <GridHeadCellButton className="grid-head-cell-button" isEditing={isEditing}>
+        <GridHeadCellButton
+          isDragging={column.isDragging}
+          className="grid-head-cell-button"
+          isEditing={isEditing}
+        >
           {children}
           {this.renderButtonHoverDraggable(children)}
         </GridHeadCellButton>

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -71,6 +71,11 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
     actions.toggleModalEditColumn(indexColumnOrder, column);
   };
 
+  onDragStart = (event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+    const fromColumn = this.props.indexColumnOrder;
+    this.props.actions.onDragStart(event, fromColumn);
+  };
+
   renderButtonHoverDraggable(children: React.ReactNode) {
     const {isHovering} = this.state;
     const {isEditing, isColumnDragging} = this.props;
@@ -89,10 +94,7 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
         <GridHeadCellButtonHover>
           <GridHeadCellButtonHoverDraggable
             src="icon-grabbable"
-            onMouseDown={(event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
-              const fromColumn = this.props.indexColumnOrder;
-              this.props.actions.onDragStart(event, fromColumn);
-            }}
+            onMouseDown={this.onDragStart}
           />
 
           <div>
@@ -106,10 +108,7 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
 
           <GridHeadCellButtonHoverDraggable
             src="icon-grabbable"
-            onMouseDown={(event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
-              const fromColumn = this.props.indexColumnOrder;
-              this.props.actions.onDragStart(event, fromColumn);
-            }}
+            onMouseDown={this.onDragStart}
           />
         </GridHeadCellButtonHover>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -23,7 +23,8 @@ export type GridHeadCellProps<Column> = {
   children: React.ReactNode | React.ReactChild;
 
   actions: {
-    moveColumn: (indexFrom: number, indexTo: number) => void;
+    moveColumnCommit: (indexFrom: number, indexTo: number) => void;
+    moveColumnStage: (indexFrom: number, indexTo: number) => void;
     deleteColumn: (index: number) => void;
     toggleModalEditColumn: (index?: number, column?: Column) => void;
   };
@@ -81,7 +82,7 @@ class GridHeadCell<Column> extends React.Component<
                 const destinationColumn = this.props.indexColumnOrder - 1;
 
                 if (destinationColumn >= 0) {
-                  this.props.actions.moveColumn(fromColumn, destinationColumn);
+                  this.props.actions.moveColumnStage(fromColumn, destinationColumn);
                 }
               }}
             />
@@ -104,7 +105,7 @@ class GridHeadCell<Column> extends React.Component<
                 const destinationColumn = this.props.indexColumnOrder + 1;
 
                 if (destinationColumn >= 0) {
-                  this.props.actions.moveColumn(fromColumn, destinationColumn);
+                  this.props.actions.moveColumnStage(fromColumn, destinationColumn);
                 }
               }}
             />

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -88,15 +88,13 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
         <GridHeadCellButtonHoverBackground>{children}</GridHeadCellButtonHoverBackground>
 
         <GridHeadCellButtonHover>
-          {
-            <GridHeadCellButtonHoverDraggable
-              src="icon-grabbable"
-              onMouseDown={(event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
-                const fromColumn = this.props.indexColumnOrder;
-                this.props.actions.onDragStart(event, fromColumn);
-              }}
-            />
-          }
+          <GridHeadCellButtonHoverDraggable
+            src="icon-grabbable"
+            onMouseDown={(event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+              const fromColumn = this.props.indexColumnOrder;
+              this.props.actions.onDragStart(event, fromColumn);
+            }}
+          />
 
           <GridHeadCellButtonHoverButtonGroup>
             <GridHeadCellButtonHoverButton onClick={this.toggleModal}>
@@ -107,15 +105,13 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
             </GridHeadCellButtonHoverButton>
           </GridHeadCellButtonHoverButtonGroup>
 
-          {
-            <GridHeadCellButtonHoverDraggable
-              src="icon-grabbable"
-              onMouseDown={(event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
-                const fromColumn = this.props.indexColumnOrder;
-                this.props.actions.onDragStart(event, fromColumn);
-              }}
-            />
-          }
+          <GridHeadCellButtonHoverDraggable
+            src="icon-grabbable"
+            onMouseDown={(event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+              const fromColumn = this.props.indexColumnOrder;
+              this.props.actions.onDragStart(event, fromColumn);
+            }}
+          />
         </GridHeadCellButtonHover>
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -24,7 +24,7 @@ export type GridHeadCellProps<Column> = {
 
   actions: {
     moveColumnCommit: (indexFrom: number, indexTo: number) => void;
-    moveColumnStage: (indexFrom: number, indexTo: number) => void;
+    onDragStart: (indexFrom: number) => void;
     deleteColumn: (index: number) => void;
     toggleModalEditColumn: (index?: number, column?: Column) => void;
   };
@@ -79,11 +79,7 @@ class GridHeadCell<Column> extends React.Component<
               src="icon-grabbable"
               onClick={() => {
                 const fromColumn = this.props.indexColumnOrder;
-                const destinationColumn = this.props.indexColumnOrder - 1;
-
-                if (destinationColumn >= 0) {
-                  this.props.actions.moveColumnStage(fromColumn, destinationColumn);
-                }
+                this.props.actions.onDragStart(fromColumn);
               }}
             />
           )}
@@ -102,11 +98,7 @@ class GridHeadCell<Column> extends React.Component<
               src="icon-grabbable"
               onClick={() => {
                 const fromColumn = this.props.indexColumnOrder;
-                const destinationColumn = this.props.indexColumnOrder + 1;
-
-                if (destinationColumn >= 0) {
-                  this.props.actions.moveColumnStage(fromColumn, destinationColumn);
-                }
+                this.props.actions.onDragStart(fromColumn);
               }}
             />
           )}

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -117,6 +117,7 @@ class GridHeadCell<Column> extends React.Component<
     return (
       <GridHeadCellWrapper
         onMouseEnter={() => this.setHovering(true)}
+        onMouseMove={() => this.setHovering(true)}
         onMouseLeave={() => this.setHovering(false)}
       >
         <GridHeadCellButton className="grid-head-cell-button" isEditing={isEditing}>

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -15,6 +15,7 @@ import {
 } from './styles';
 
 export type GridHeadCellProps<Column> = {
+  isColumnDragging: boolean;
   isEditing: boolean;
   isPrimary: boolean;
 
@@ -69,6 +70,13 @@ class GridHeadCell<Column> extends React.Component<
   };
 
   renderButtonHoverDraggable(children: React.ReactNode) {
+    const {isHovering} = this.state;
+    const {isEditing, isColumnDragging} = this.props;
+
+    if (!isEditing || !isHovering || isColumnDragging) {
+      return null;
+    }
+
     return (
       <React.Fragment>
         {/* Ensure that background is always at the top. The background must be
@@ -112,7 +120,6 @@ class GridHeadCell<Column> extends React.Component<
 
   render() {
     const {isEditing, children} = this.props;
-    const {isHovering} = this.state;
 
     return (
       <GridHeadCellWrapper
@@ -122,7 +129,7 @@ class GridHeadCell<Column> extends React.Component<
       >
         <GridHeadCellButton className="grid-head-cell-button" isEditing={isEditing}>
           {children}
-          {isEditing && isHovering && this.renderButtonHoverDraggable(children)}
+          {this.renderButtonHoverDraggable(children)}
         </GridHeadCellButton>
 
         {/* Keep the Resizer at the bottom to ensure that it is will always

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import InlineSvg from 'app/components/inlineSvg';
 
-import {FLAG_GRID_RESIZABLE, FLAG_GRID_DRAGGABLE} from './flags';
+import {FLAG_GRID_RESIZABLE} from './flags';
 import {
   GridHeadCell as GridHeadCellWrapper,
   GridHeadCellButton,
@@ -77,7 +77,7 @@ class GridHeadCell<Column> extends React.Component<
         <GridHeadCellButtonHoverBackground>{children}</GridHeadCellButtonHoverBackground>
 
         <GridHeadCellButtonHover>
-          {FLAG_GRID_DRAGGABLE && (
+          {
             <GridHeadCellButtonHoverDraggable
               src="icon-grabbable"
               onMouseDown={(event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
@@ -85,7 +85,7 @@ class GridHeadCell<Column> extends React.Component<
                 this.props.actions.onDragStart(event, fromColumn);
               }}
             />
-          )}
+          }
 
           <GridHeadCellButtonHoverButtonGroup isFlagged={FLAG_GRID_DRAGGABLE}>
             <GridHeadCellButtonHoverButton onClick={this.toggleModal}>
@@ -96,7 +96,7 @@ class GridHeadCell<Column> extends React.Component<
             </GridHeadCellButtonHoverButton>
           </GridHeadCellButtonHoverButtonGroup>
 
-          {FLAG_GRID_DRAGGABLE && (
+          {
             <GridHeadCellButtonHoverDraggable
               src="icon-grabbable"
               onMouseDown={(event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
@@ -104,7 +104,7 @@ class GridHeadCell<Column> extends React.Component<
                 this.props.actions.onDragStart(event, fromColumn);
               }}
             />
-          )}
+          }
         </GridHeadCellButtonHover>
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -72,6 +72,9 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
   };
 
   onDragStart = (event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+    // hide hovers when dragging
+    this.setHovering(false);
+
     const fromColumn = this.props.indexColumnOrder;
     this.props.actions.onDragStart(event, fromColumn);
   };

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -119,7 +119,7 @@ class GridHeadCell<Column> extends React.Component<
         onMouseEnter={() => this.setHovering(true)}
         onMouseLeave={() => this.setHovering(false)}
       >
-        <GridHeadCellButton isEditing={isEditing}>
+        <GridHeadCellButton className="grid-head-cell-button" isEditing={isEditing}>
           {children}
           {isEditing && isHovering && this.renderButtonHoverDraggable(children)}
         </GridHeadCellButton>

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -24,7 +24,10 @@ export type GridHeadCellProps<Column> = {
 
   actions: {
     moveColumnCommit: (indexFrom: number, indexTo: number) => void;
-    onDragStart: (indexFrom: number) => void;
+    onDragStart: (
+      event: React.MouseEvent<SVGSVGElement, MouseEvent>,
+      indexFrom: number
+    ) => void;
     deleteColumn: (index: number) => void;
     toggleModalEditColumn: (index?: number, column?: Column) => void;
   };
@@ -77,9 +80,9 @@ class GridHeadCell<Column> extends React.Component<
           {FLAG_GRID_DRAGGABLE && (
             <GridHeadCellButtonHoverDraggable
               src="icon-grabbable"
-              onClick={() => {
+              onMouseDown={(event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
                 const fromColumn = this.props.indexColumnOrder;
-                this.props.actions.onDragStart(fromColumn);
+                this.props.actions.onDragStart(event, fromColumn);
               }}
             />
           )}
@@ -96,9 +99,9 @@ class GridHeadCell<Column> extends React.Component<
           {FLAG_GRID_DRAGGABLE && (
             <GridHeadCellButtonHoverDraggable
               src="icon-grabbable"
-              onClick={() => {
+              onMouseDown={(event: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
                 const fromColumn = this.props.indexColumnOrder;
-                this.props.actions.onDragStart(fromColumn);
+                this.props.actions.onDragStart(event, fromColumn);
               }}
             />
           )}

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -8,7 +8,6 @@ import {
   GridHeadCellButton,
   GridHeadCellButtonHover,
   GridHeadCellButtonHoverBackground,
-  GridHeadCellButtonHoverButtonGroup,
   GridHeadCellButtonHoverButton,
   GridHeadCellButtonHoverDraggable,
   GridHeadCellResizer,
@@ -96,14 +95,14 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
             }}
           />
 
-          <GridHeadCellButtonHoverButtonGroup>
+          <div>
             <GridHeadCellButtonHoverButton onClick={this.toggleModal}>
               <InlineSvg src="icon-edit-pencil" />
             </GridHeadCellButtonHoverButton>
             <GridHeadCellButtonHoverButton onClick={this.deleteColumn}>
               <InlineSvg src="icon-trash" />
             </GridHeadCellButtonHoverButton>
-          </GridHeadCellButtonHoverButtonGroup>
+          </div>
 
           <GridHeadCellButtonHoverDraggable
             src="icon-grabbable"

--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -17,6 +17,7 @@ import {GridColumnHeader} from './types';
 
 export type GridHeadCellProps<Column> = {
   isColumnDragging: boolean;
+  gridHeadCellButtonProps: {[prop: string]: any};
 
   isEditing: boolean;
   isPrimary: boolean;
@@ -121,7 +122,7 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
   }
 
   render() {
-    const {isEditing, children, column} = this.props;
+    const {isEditing, children, column, gridHeadCellButtonProps} = this.props;
 
     return (
       <GridHeadCellWrapper
@@ -131,8 +132,8 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
       >
         <GridHeadCellButton
           isDragging={column.isDragging}
-          className="grid-head-cell-button"
           isEditing={isEditing}
+          {...gridHeadCellButtonProps}
         >
           {children}
           {this.renderButtonHoverDraggable(children)}

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -29,6 +29,7 @@ import {
 type GridEditableProps<DataRow, ColumnKey extends keyof DataRow> = {
   isEditable?: boolean;
   isLoading?: boolean;
+  isColumnDragging: boolean;
   error?: React.ReactNode | null;
 
   /**
@@ -228,6 +229,7 @@ class GridEditable<
           {columnOrder.map((column, columnIndex) => (
             <GridHeadCell
               key={`${columnIndex}.${column.key}`}
+              isColumnDragging={this.props.isColumnDragging}
               isPrimary={column.isPrimary}
               isEditing={enableEdit}
               indexColumnOrder={columnIndex}

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -9,7 +9,13 @@ import InlineSvg from 'app/components/inlineSvg';
 import LoadingContainer from 'app/components/loading/loadingContainer';
 import ToolTip from 'app/components/tooltip';
 
-import {GridColumn, GridColumnHeader, GridColumnOrder, GridColumnSortBy} from './types';
+import {
+  GridColumn,
+  GridColumnHeader,
+  GridColumnOrder,
+  GridColumnSortBy,
+  ObjectKey,
+} from './types';
 import GridHeadCell from './gridHeadCell';
 import GridModalEditColumn from './gridModalEditColumn';
 import {
@@ -26,7 +32,7 @@ import {
   GridEditGroupButton,
 } from './styles';
 
-type GridEditableProps<DataRow, ColumnKey extends keyof DataRow> = {
+type GridEditableProps<DataRow, ColumnKey> = {
   isEditable?: boolean;
   isLoading?: boolean;
   isColumnDragging: boolean;
@@ -96,8 +102,8 @@ type GridEditableState = {
 };
 
 class GridEditable<
-  DataRow extends Object,
-  ColumnKey extends keyof DataRow
+  DataRow extends {[key: string]: any},
+  ColumnKey extends ObjectKey
 > extends React.Component<GridEditableProps<DataRow, ColumnKey>, GridEditableState> {
   static defaultProps = {
     isEditable: false,

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -81,7 +81,7 @@ type GridEditableProps<DataRow, ColumnKey extends keyof DataRow> = {
    */
   actions: {
     moveColumnCommit: (indexFrom: number, indexTo: number) => void;
-    moveColumnStage: (indexFrom: number, indexTo: number) => void;
+    onDragStart: (indexFrom: number) => void;
     deleteColumn: (index: number) => void;
   };
 };
@@ -231,7 +231,7 @@ class GridEditable<
               column={column}
               actions={{
                 moveColumnCommit: actions.moveColumnCommit,
-                moveColumnStage: actions.moveColumnStage,
+                onDragStart: actions.onDragStart,
                 deleteColumn: actions.deleteColumn,
                 toggleModalEditColumn: this.toggleModalEditColumn,
               }}

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -80,7 +80,8 @@ type GridEditableProps<DataRow, ColumnKey extends keyof DataRow> = {
    * have to provide functions to move/delete the columns
    */
   actions: {
-    moveColumn: (indexFrom: number, indexTo: number) => void;
+    moveColumnCommit: (indexFrom: number, indexTo: number) => void;
+    moveColumnStage: (indexFrom: number, indexTo: number) => void;
     deleteColumn: (index: number) => void;
   };
 };
@@ -229,7 +230,8 @@ class GridEditable<
               indexColumnOrder={columnIndex}
               column={column}
               actions={{
-                moveColumn: actions.moveColumn,
+                moveColumnCommit: actions.moveColumnCommit,
+                moveColumnStage: actions.moveColumnStage,
                 deleteColumn: actions.deleteColumn,
                 toggleModalEditColumn: this.toggleModalEditColumn,
               }}

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -33,6 +33,8 @@ import {
 } from './styles';
 
 type GridEditableProps<DataRow, ColumnKey> = {
+  gridHeadCellButtonProps?: {[prop: string]: any};
+
   isEditable?: boolean;
   isLoading?: boolean;
   isColumnDragging: boolean;
@@ -240,6 +242,7 @@ class GridEditable<
               isEditing={enableEdit}
               indexColumnOrder={columnIndex}
               column={column}
+              gridHeadCellButtonProps={this.props.gridHeadCellButtonProps || {}}
               actions={{
                 moveColumnCommit: actions.moveColumnCommit,
                 onDragStart: actions.onDragStart,

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -81,7 +81,10 @@ type GridEditableProps<DataRow, ColumnKey extends keyof DataRow> = {
    */
   actions: {
     moveColumnCommit: (indexFrom: number, indexTo: number) => void;
-    onDragStart: (indexFrom: number) => void;
+    onDragStart: (
+      event: React.MouseEvent<SVGSVGElement, MouseEvent>,
+      indexFrom: number
+    ) => void;
     deleteColumn: (index: number) => void;
   };
 };

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -99,8 +99,6 @@ export const GridHeadCell = styled('th')`
   background: ${p => p.theme.offWhite};
 `;
 export const GridHeadCellButton = styled('div')<GridEditableProps>`
-  outline: 1px solid blue;
-
   position: relative;
   min-width: 24px; /* Ensure that edit/remove buttons are never hidden */
   display: block;
@@ -226,8 +224,6 @@ export const GridHeadCellButtonHoverButton = styled('div')`
 export const GridHeadCellButtonHoverDraggable = styled(InlineSvg)`
   cursor: grab;
   user-select: none;
-
-  outline: 1px solid red;
 `;
 
 /**

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -21,7 +21,6 @@ type GridEditableProps = {
   isEditable?: boolean;
   isEditing?: boolean;
   isPrimary?: boolean;
-  isFlagged?: boolean;
   isDragging?: boolean;
 };
 

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -160,6 +160,8 @@ export const GridHeadCellResizer = styled('span')<GridEditableProps>`
  *
  */
 export const GridHeadCellButtonHover = styled('div')<GridEditableProps>`
+  outline: 1px solid blue;
+
   position: absolute;
   top: 0;
   left: 0;
@@ -224,6 +226,8 @@ export const GridHeadCellButtonHoverButton = styled('div')`
 export const GridHeadCellButtonHoverDraggable = styled(InlineSvg)`
   cursor: grab;
   user-select: none;
+
+  outline: 1px solid red;
 `;
 
 /**

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -108,7 +108,13 @@ export const GridHeadCellButton = styled('div')<GridEditableProps>`
   padding: ${space(1)} ${space(1.5)};
   border-radius: ${p => p.theme.borderRadius};
 
-  color: ${p => p.theme.gray2};
+  color: ${p => {
+    if (p.isDragging) {
+      return p.theme.offWhite2;
+    }
+
+    return p.theme.gray2;
+  }};
   font-size: 13px;
   font-weight: 600;
   line-height: 1;
@@ -119,7 +125,7 @@ export const GridHeadCellButton = styled('div')<GridEditableProps>`
 
   background: ${p => {
     if (p.isDragging) {
-      return '#CEC2D8';
+      return p.theme.gray2;
     }
 
     if (p.isEditing) {
@@ -130,16 +136,37 @@ export const GridHeadCellButton = styled('div')<GridEditableProps>`
   }};
 
   a {
-    color: ${p => p.theme.gray2};
+    color: ${p => {
+      if (p.isDragging) {
+        return p.theme.offWhite2;
+      }
+
+      return p.theme.gray2;
+    }};
   }
 
   &:hover,
   &:active {
-    color: ${p => p.theme.gray3};
+    color: ${p => {
+      if (p.isDragging) {
+        return p.theme.offWhite2;
+      }
+
+      return p.theme.gray2;
+    }};
+
     a {
-      color: ${p => p.theme.gray3};
+      color: ${p => {
+        if (p.isDragging) {
+          return p.theme.offWhite2;
+        }
+
+        return p.theme.gray2;
+      }};
     }
   }
+
+  user-select: none;
 `;
 export const GridHeadCellResizer = styled('span')<GridEditableProps>`
   position: absolute;

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -99,6 +99,8 @@ export const GridHeadCell = styled('th')`
   background: ${p => p.theme.offWhite};
 `;
 export const GridHeadCellButton = styled('div')<GridEditableProps>`
+  outline: 1px solid blue;
+
   position: relative;
   min-width: 24px; /* Ensure that edit/remove buttons are never hidden */
   display: block;
@@ -160,8 +162,6 @@ export const GridHeadCellResizer = styled('span')<GridEditableProps>`
  *
  */
 export const GridHeadCellButtonHover = styled('div')<GridEditableProps>`
-  outline: 1px solid blue;
-
   position: absolute;
   top: 0;
   left: 0;

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -22,6 +22,7 @@ type GridEditableProps = {
   isEditing?: boolean;
   isPrimary?: boolean;
   isFlagged?: boolean;
+  isDragging?: boolean;
 };
 
 export const GridPanel = styled(Panel)`
@@ -116,7 +117,17 @@ export const GridHeadCellButton = styled('div')<GridEditableProps>`
   text-overflow: ellipsis;
   overflow: hidden;
 
-  background: ${p => (p.isEditing ? p.theme.offWhite2 : 'none')};
+  background: ${p => {
+    if (p.isDragging) {
+      return '#CEC2D8';
+    }
+
+    if (p.isEditing) {
+      return p.theme.offWhite2;
+    }
+
+    return 'none';
+  }};
 
   a {
     color: ${p => p.theme.gray2};

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -195,9 +195,9 @@ export const GridHeadCellButtonHoverBackground = styled(GridHeadCellButton)`
     color: ${p => p.theme.gray1} !important;
   }
 `;
-export const GridHeadCellButtonHoverButtonGroup = styled('div')<GridEditableProps>`
-  ${p => !p.isFlagged && 'margin: 0 auto;'}
-`;
+
+export const GridHeadCellButtonHoverButtonGroup = styled('div')<GridEditableProps>``;
+
 export const GridHeadCellButtonHoverButton = styled('div')`
   display: inline-flex;
   justify-content: center;

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -233,8 +233,6 @@ export const GridHeadCellButtonHoverBackground = styled(GridHeadCellButton)`
   }
 `;
 
-export const GridHeadCellButtonHoverButtonGroup = styled('div')<GridEditableProps>``;
-
 export const GridHeadCellButtonHoverButton = styled('div')`
   display: inline-flex;
   justify-content: center;

--- a/src/sentry/static/sentry/app/components/gridEditable/types.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/types.tsx
@@ -5,7 +5,7 @@
  *   - columnKey should have the same set of values as K
  */
 
-type ObjectKey = React.ReactText;
+export type ObjectKey = React.ReactText;
 
 export type GridColumn<K = ObjectKey> = {
   key: K;
@@ -13,6 +13,7 @@ export type GridColumn<K = ObjectKey> = {
 
 export type GridColumnHeader<K = ObjectKey> = GridColumn<K> & {
   name: string;
+  isDragging: boolean;
   isPrimary?: boolean;
 };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -760,6 +760,10 @@ class EventView {
       delete payload.cursor;
     }
 
+    if (!payload.query) {
+      delete payload.query;
+    }
+
     return payload;
   }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -496,6 +496,7 @@ class EventView {
     return decodeColumnOrder({
       field: this.getFields(),
       fieldnames: this.getFieldNames(),
+      fields: this.fields,
     });
   }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -760,10 +760,6 @@ class EventView {
       delete payload.cursor;
     }
 
-    if (!payload.query) {
-      delete payload.query;
-    }
-
     return payload;
   }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -13,6 +13,8 @@ export type DraggableColumnsChildrenProps = {
     event: React.MouseEvent<SVGSVGElement, MouseEvent>,
     initialColumnIndex: number
   ) => void;
+  draggingColumnIndex: undefined | number;
+  destinationColumnIndex: undefined | number;
 };
 
 type Props = {
@@ -22,19 +24,23 @@ type Props = {
 
 type State = {
   isDragging: boolean;
-  draggingColumnIndex: undefined | number;
   left: undefined | number;
   top: undefined | number;
+
+  draggingColumnIndex: undefined | number;
+  destinationColumnIndex: undefined | number;
 };
 
 class DraggableColumns extends React.Component<Props, State> {
   state: State = {
     isDragging: false,
-    draggingColumnIndex: void 0,
 
     // initial coordinates for when the drag began
     left: void 0,
     top: void 0,
+
+    draggingColumnIndex: void 0,
+    destinationColumnIndex: void 0,
   };
 
   previousUserSelect: UserSelectValues | null = null;
@@ -91,14 +97,14 @@ class DraggableColumns extends React.Component<Props, State> {
 
       const reference = document.createElement('div');
       reference.style.height = '10px';
-      reference.style.width = `${rects.width}px`;
+      reference.style.width = `${rects.width * 0.8}px`;
       reference.style.position = 'absolute';
       reference.style.top = `${rects.top}px`;
-      reference.style.left = `${rects.left}px`;
+      reference.style.left = `${rects.left + rects.width * 0.1}px`;
       reference.style.zIndex = '9999';
       reference.style.backgroundColor = 'yellow';
 
-      document.body.appendChild(reference);
+      //   document.body.appendChild(reference);
     });
   };
 
@@ -117,21 +123,27 @@ class DraggableColumns extends React.Component<Props, State> {
 
     const gridHeadCellButtons = document.querySelectorAll('.grid-head-cell-button');
 
-    const destinationIndex = Array.from(gridHeadCellButtons).findIndex(headerElement => {
-      const rects = headerElement.getBoundingClientRect();
+    const destinationColumnIndex = Array.from(gridHeadCellButtons).findIndex(
+      headerElement => {
+        const rects = headerElement.getBoundingClientRect();
 
-      const left = event.pageX;
+        const left = event.pageX;
 
-      const thresholdStart = rects.left + rects.width * 0.25;
-      const thresholdEnd = rects.left + rects.width * 0.75;
+        const thresholdStart = rects.left;
+        const thresholdEnd = rects.left + rects.width;
 
-      return left >= thresholdStart && left <= thresholdEnd;
-    });
+        return left >= thresholdStart && left <= thresholdEnd;
+      }
+    );
 
-    if (destinationIndex >= 0) {
-      const destinationColumn = this.props.columnOrder[destinationIndex];
+    if (destinationColumnIndex >= 0) {
+      const destinationColumn = this.props.columnOrder[destinationColumnIndex];
 
       console.log('move to', destinationColumn.name);
+
+      this.setState({
+        destinationColumnIndex,
+      });
     }
   };
 
@@ -155,9 +167,10 @@ class DraggableColumns extends React.Component<Props, State> {
 
     this.setState({
       isDragging: false,
-      draggingColumnIndex: void 0,
       left: void 0,
       top: void 0,
+      draggingColumnIndex: void 0,
+      destinationColumnIndex: void 0,
     });
 
     console.log('ended');
@@ -195,6 +208,8 @@ class DraggableColumns extends React.Component<Props, State> {
   renderChildren = () => {
     const childrenProps = {
       startColumnDrag: this.startColumnDrag,
+      draggingColumnIndex: this.state.draggingColumnIndex,
+      destinationColumnIndex: this.state.destinationColumnIndex,
     };
 
     return this.props.children(childrenProps);

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'react-emotion';
 
+import space from 'app/styles/space';
 import {
   UserSelectValues,
   setBodyUserSelect,
-} from 'app/components/events/interfaces/spans/utils.tsx';
+} from 'app/components/events/interfaces/spans/utils';
+
 import {TableColumn} from './types';
 
 export type DraggableColumnsChildrenProps = {
@@ -137,13 +139,15 @@ class DraggableColumns extends React.Component<Props, State> {
     );
 
     if (destinationColumnIndex >= 0) {
-      const destinationColumn = this.props.columnOrder[destinationColumnIndex];
+      //   const destinationColumn = this.props.columnOrder[destinationColumnIndex];
 
-      console.log('move to', destinationColumn.name);
+      //   console.log('move to', destinationColumn.name);
 
-      this.setState({
-        destinationColumnIndex,
-      });
+      if (this.state.destinationColumnIndex !== destinationColumnIndex) {
+        this.setState({
+          destinationColumnIndex,
+        });
+      }
     }
   };
 
@@ -265,7 +269,19 @@ const GhostPlacement = styled('div')`
 const GhostContentBox = styled('div')`
   background-color: white;
 
-  outline: 1px solid red;
+  padding: ${space(1)} ${space(1.5)};
+  border-radius: ${p => p.theme.borderRadius};
+
+  color: ${p => p.theme.gray2};
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  text-transform: uppercase;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+
+  background: ${p => p.theme.offWhite2};
 `;
 
 // const MouseGuide = styled('div')`

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -199,7 +199,7 @@ class DraggableColumns extends React.Component<Props, State> {
     return this.props.children(childrenProps);
   };
 
-  renderThing = () => {
+  activeDragPlaceholder = () => {
     if (
       this.portal &&
       this.state.isDragging &&
@@ -230,7 +230,7 @@ class DraggableColumns extends React.Component<Props, State> {
   render() {
     return (
       <React.Fragment>
-        {this.renderThing()}
+        {this.activeDragPlaceholder()}
         {this.renderChildren()}
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -125,7 +125,7 @@ class DraggableColumns extends React.Component<Props, State> {
     this.setState({
       destinationColumnIndex,
     });
-  }, 25);
+  }, 100);
 
   onDragEnd = (event: MouseEvent) => {
     if (!this.state.isDragging || event.type !== 'mouseup') {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -11,6 +11,8 @@ import {
 
 import {TableColumn} from './types';
 
+export const DRAGGABLE_COLUMN_CLASSNAME_IDENTIFIER = 'grid-head-cell-button';
+
 export type DraggableColumnsChildrenProps = {
   isColumnDragging: boolean;
   startColumnDrag: (
@@ -99,7 +101,9 @@ class DraggableColumns extends React.Component<Props, State> {
       ghostDOM.style.top = `${event.pageY}px`;
     }
 
-    const gridHeadCellButtons = document.querySelectorAll('.grid-head-cell-button');
+    const gridHeadCellButtons = document.querySelectorAll(
+      `.${DRAGGABLE_COLUMN_CLASSNAME_IDENTIFIER}`
+    );
 
     const destinationColumnIndex = Array.from(gridHeadCellButtons).findIndex(
       headerElement => {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -68,7 +68,6 @@ class DraggableColumns extends React.Component<Props, State> {
     }
 
     // prevent the user from selecting things when dragging a column.
-
     this.previousUserSelect = setBodyUserSelect({
       userSelect: 'none',
       MozUserSelect: 'none',
@@ -76,7 +75,6 @@ class DraggableColumns extends React.Component<Props, State> {
     });
 
     // attach event listeners so that the mouse cursor can drag anywhere
-
     window.addEventListener('mousemove', this.onDragMove);
     window.addEventListener('mouseup', this.onDragEnd);
 
@@ -95,7 +93,6 @@ class DraggableColumns extends React.Component<Props, State> {
 
     if (this.dragGhostRef.current) {
       // move the ghosted column title
-
       const ghostDOM = this.dragGhostRef.current;
       ghostDOM.style.left = `${event.pageX}px`;
       ghostDOM.style.top = `${event.pageY}px`;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -79,6 +79,7 @@ class DraggableColumns extends React.Component<Props, State> {
     if (this.dragGhostRef.current) {
       const ghostDOM = this.dragGhostRef.current;
       ghostDOM.style.left = `${event.pageX}px`;
+      ghostDOM.style.top = `${event.pageY}px`;
     }
   };
 
@@ -147,11 +148,22 @@ class DraggableColumns extends React.Component<Props, State> {
   };
 
   renderThing = () => {
-    if (this.portal && this.state.isDragging) {
-      return ReactDOM.createPortal(
-        <MouseGuide innerRef={this.dragGhostRef} />,
-        this.portal
+    if (
+      this.portal &&
+      this.state.isDragging &&
+      typeof this.state.draggingColumnIndex === 'number'
+    ) {
+      const columnBeingDragged = this.props.columnOrder[this.state.draggingColumnIndex];
+
+      const ghost = (
+        <React.Fragment>
+          <DebugSquare innerRef={this.dragGhostRef}>
+            <GhostContentBox>{columnBeingDragged.name}</GhostContentBox>
+          </DebugSquare>
+        </React.Fragment>
       );
+
+      return ReactDOM.createPortal(ghost, this.portal);
     }
 
     return null;
@@ -167,14 +179,26 @@ class DraggableColumns extends React.Component<Props, State> {
   }
 }
 
-const MouseGuide = styled('div')`
+const DebugSquare = styled('div')`
   position: absolute;
   top: 0;
   bottom: 0;
-
-  width: 1px;
-  height: 100vh;
-  background-color: red;
 `;
+
+const GhostContentBox = styled('div')`
+  background-color: white;
+
+  outline: 1px solid red;
+`;
+
+// const MouseGuide = styled('div')`
+//   position: absolute;
+//   top: 0;
+//   bottom: 0;
+
+//   width: 1px;
+//   height: 100vh;
+//   background-color: red;
+// `;
 
 export default DraggableColumns;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -22,6 +22,10 @@ export type DraggableColumnsChildrenProps = {
 type Props = {
   children: (props: DraggableColumnsChildrenProps) => JSX.Element;
   columnOrder: TableColumn<React.ReactText>[];
+  onDragDone: (props: {
+    draggingColumnIndex: undefined | number;
+    destinationColumnIndex: undefined | number;
+  }) => void;
 };
 
 type State = {
@@ -169,6 +173,9 @@ class DraggableColumns extends React.Component<Props, State> {
 
     // indicate drag has ended
 
+    const destinationColumnIndex = this.state.destinationColumnIndex;
+    const draggingColumnIndex = this.state.draggingColumnIndex;
+
     this.setState({
       isDragging: false,
       left: void 0,
@@ -177,7 +184,7 @@ class DraggableColumns extends React.Component<Props, State> {
       destinationColumnIndex: void 0,
     });
 
-    console.log('ended');
+    this.props.onDragDone({draggingColumnIndex, destinationColumnIndex});
   };
 
   cleanUpListeners = () => {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -152,10 +152,10 @@ class DraggableColumns extends React.Component<Props, State> {
 
     this.setState({
       isDragging: false,
-      left: void 0,
-      top: void 0,
-      draggingColumnIndex: void 0,
-      destinationColumnIndex: void 0,
+      left: undefined,
+      top: undefined,
+      draggingColumnIndex: undefined,
+      destinationColumnIndex: undefined,
     });
 
     this.props.onDragDone({draggingColumnIndex, destinationColumnIndex});

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -11,6 +11,7 @@ import {
 import {TableColumn} from './types';
 
 export type DraggableColumnsChildrenProps = {
+  isColumnDragging: boolean;
   startColumnDrag: (
     event: React.MouseEvent<SVGSVGElement, MouseEvent>,
     initialColumnIndex: number
@@ -215,6 +216,7 @@ class DraggableColumns extends React.Component<Props, State> {
 
   renderChildren = () => {
     const childrenProps = {
+      isColumnDragging: this.state.isDragging,
       startColumnDrag: this.startColumnDrag,
       draggingColumnIndex: this.state.draggingColumnIndex,
       destinationColumnIndex: this.state.destinationColumnIndex,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'react-emotion';
+import {debounce} from 'lodash';
 
 import space from 'app/styles/space';
 import {
@@ -115,12 +116,16 @@ class DraggableColumns extends React.Component<Props, State> {
 
     if (destinationColumnIndex >= 0) {
       if (this.state.destinationColumnIndex !== destinationColumnIndex) {
-        this.setState({
-          destinationColumnIndex,
-        });
+        this.setDestinationColumnIndex(destinationColumnIndex);
       }
     }
   };
+
+  setDestinationColumnIndex = debounce((destinationColumnIndex: number) => {
+    this.setState({
+      destinationColumnIndex,
+    });
+  }, 25);
 
   onDragEnd = (event: MouseEvent) => {
     if (!this.state.isDragging || event.type !== 'mouseup') {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -67,6 +67,14 @@ class DraggableColumns extends React.Component<Props, State> {
     });
 
     console.log('dragging column', initialColumnIndex, columnBeingDragged);
+
+    const foo = document.querySelectorAll('.grid-head-cell-button');
+    const moo = Array.from(foo).map(column => {
+      return column.getBoundingClientRect();
+    });
+
+    console.log('foo', foo);
+    console.log('moo', moo);
   };
 
   onDragMove = (event: MouseEvent) => {
@@ -156,7 +164,7 @@ class DraggableColumns extends React.Component<Props, State> {
 
       const ghost = (
         <React.Fragment>
-          <GhostPlacement innerRef={this.dragGhostRef}>
+          <GhostPlacement innerRef={this.dragGhostRef} style={{display: 'block'}}>
             <GhostContentBox>{columnBeingDragged.name}</GhostContentBox>
           </GhostPlacement>
         </React.Fragment>
@@ -182,6 +190,7 @@ const GhostPlacement = styled('div')`
   position: absolute;
   top: 0;
   bottom: 0;
+  display: none;
 
   user-select: none;
 `;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+export type DraggableColumnsChildrenProps = {
+  startColumnDrag: (
+    event: React.MouseEvent<SVGSVGElement, MouseEvent>,
+    initialColumnIndex: number
+  ) => void;
+};
+
+type Props = {
+  children: (props: DraggableColumnsChildrenProps) => JSX.Element;
+};
+
+type State = {
+  isDragging: boolean;
+};
+
+class DraggableColumns extends React.Component<Props, State> {
+  state: State = {
+    isDragging: false,
+  };
+
+  startColumnDrag = (
+    event: React.MouseEvent<SVGSVGElement, MouseEvent>,
+    initialColumnIndex: number
+  ) => {
+    const isDragging = this.state.isDragging;
+
+    if (isDragging || event.type !== 'mousedown') {
+      return;
+    }
+
+    window.addEventListener('mousemove', this.onDragMove);
+    window.addEventListener('mouseup', this.onDragEnd);
+
+    this.setState({
+      isDragging: true,
+    });
+
+    console.log('dragging column', initialColumnIndex);
+  };
+
+  onDragMove = (event: MouseEvent) => {
+    if (!this.state.isDragging || event.type !== 'mousemove') {
+      return;
+    }
+  };
+
+  onDragEnd = (event: MouseEvent) => {
+    if (!this.state.isDragging || event.type !== 'mouseup') {
+      return;
+    }
+
+    // remove listeners that were attached in startColumnDrag
+
+    this.cleanUpListeners();
+
+    this.setState({
+      isDragging: false,
+    });
+  };
+
+  cleanUpListeners = () => {
+    if (this.state.isDragging) {
+      window.removeEventListener('mousemove', this.onDragMove);
+      window.removeEventListener('mouseup', this.onDragEnd);
+    }
+  };
+
+  componentWillUnmount() {
+    this.cleanUpListeners();
+  }
+
+  render() {
+    const childrenProps = {
+      startColumnDrag: this.startColumnDrag,
+    };
+
+    return this.props.children(childrenProps);
+  }
+}
+
+export default DraggableColumns;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -81,6 +81,7 @@ class DraggableColumns extends React.Component<Props, State> {
     this.setState({
       isDragging: true,
       draggingColumnIndex: initialColumnIndex,
+      destinationColumnIndex: initialColumnIndex,
       left: event.pageX,
       top: event.pageY,
     });

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -6,6 +6,7 @@ import {
   UserSelectValues,
   setBodyUserSelect,
 } from 'app/components/events/interfaces/spans/utils.tsx';
+import {TableColumn} from './types';
 
 export type DraggableColumnsChildrenProps = {
   startColumnDrag: (
@@ -16,15 +17,18 @@ export type DraggableColumnsChildrenProps = {
 
 type Props = {
   children: (props: DraggableColumnsChildrenProps) => JSX.Element;
+  columnOrder: TableColumn<React.ReactText>[];
 };
 
 type State = {
   isDragging: boolean;
+  draggingColumnIndex: undefined | number;
 };
 
 class DraggableColumns extends React.Component<Props, State> {
   state: State = {
     isDragging: false,
+    draggingColumnIndex: void 0,
   };
 
   previousUserSelect: UserSelectValues | null = null;
@@ -55,11 +59,14 @@ class DraggableColumns extends React.Component<Props, State> {
     window.addEventListener('mousemove', this.onDragMove);
     window.addEventListener('mouseup', this.onDragEnd);
 
+    const columnBeingDragged = this.props.columnOrder[initialColumnIndex];
+
     this.setState({
       isDragging: true,
+      draggingColumnIndex: initialColumnIndex,
     });
 
-    console.log('dragging column', initialColumnIndex);
+    console.log('dragging column', initialColumnIndex, columnBeingDragged);
   };
 
   onDragMove = (event: MouseEvent) => {
@@ -67,7 +74,7 @@ class DraggableColumns extends React.Component<Props, State> {
       return;
     }
 
-    console.log('event.pageX', event.pageX);
+    // console.log('event.pageX', event.pageX);
 
     if (this.dragGhostRef.current) {
       const ghostDOM = this.dragGhostRef.current;
@@ -95,6 +102,7 @@ class DraggableColumns extends React.Component<Props, State> {
 
     this.setState({
       isDragging: false,
+      draggingColumnIndex: void 0,
     });
 
     console.log('ended');

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 
+import {
+  UserSelectValues,
+  setBodyUserSelect,
+} from 'app/components/events/interfaces/spans/utils.tsx';
+
 export type DraggableColumnsChildrenProps = {
   startColumnDrag: (
     event: React.MouseEvent<SVGSVGElement, MouseEvent>,
@@ -20,6 +25,8 @@ class DraggableColumns extends React.Component<Props, State> {
     isDragging: false,
   };
 
+  previousUserSelect: UserSelectValues | null = null;
+
   startColumnDrag = (
     event: React.MouseEvent<SVGSVGElement, MouseEvent>,
     initialColumnIndex: number
@@ -29,6 +36,17 @@ class DraggableColumns extends React.Component<Props, State> {
     if (isDragging || event.type !== 'mousedown') {
       return;
     }
+
+    // prevent the user from selecting things outside the minimap when dragging
+    // the mouse cursor outside the minimap
+
+    this.previousUserSelect = setBodyUserSelect({
+      userSelect: 'none',
+      MozUserSelect: 'none',
+      msUserSelect: 'none',
+    });
+
+    // attach event listeners so that the mouse cursor can drag anywhere
 
     window.addEventListener('mousemove', this.onDragMove);
     window.addEventListener('mouseup', this.onDragEnd);
@@ -54,6 +72,15 @@ class DraggableColumns extends React.Component<Props, State> {
     // remove listeners that were attached in startColumnDrag
 
     this.cleanUpListeners();
+
+    // restore body styles
+
+    if (this.previousUserSelect) {
+      setBodyUserSelect(this.previousUserSelect);
+      this.previousUserSelect = null;
+    }
+
+    // indicate drag has ended
 
     this.setState({
       isDragging: false,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -156,9 +156,9 @@ class DraggableColumns extends React.Component<Props, State> {
 
       const ghost = (
         <React.Fragment>
-          <DebugSquare innerRef={this.dragGhostRef}>
+          <GhostPlacement innerRef={this.dragGhostRef}>
             <GhostContentBox>{columnBeingDragged.name}</GhostContentBox>
-          </DebugSquare>
+          </GhostPlacement>
         </React.Fragment>
       );
 
@@ -178,10 +178,12 @@ class DraggableColumns extends React.Component<Props, State> {
   }
 }
 
-const DebugSquare = styled('div')`
+const GhostPlacement = styled('div')`
   position: absolute;
   top: 0;
   bottom: 0;
+
+  user-select: none;
 `;
 
 const GhostContentBox = styled('div')`

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -63,8 +63,7 @@ class DraggableColumns extends React.Component<Props, State> {
       return;
     }
 
-    // prevent the user from selecting things outside the minimap when dragging
-    // the mouse cursor outside the minimap
+    // prevent the user from selecting things when dragging a column.
 
     this.previousUserSelect = setBodyUserSelect({
       userSelect: 'none',

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -119,7 +119,6 @@ class DraggableColumns extends React.Component<Props, State> {
   componentDidMount() {
     if (!this.portal) {
       const portal = document.createElement('div');
-      portal.setAttribute('id', 'draggable-columns-portal');
 
       portal.style.position = 'absolute';
       portal.style.top = '0';

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -76,6 +76,8 @@ class DraggableColumns extends React.Component<Props, State> {
 
     console.log('dragging column', initialColumnIndex, columnBeingDragged);
 
+    // TODO: experiment, clean this up
+
     const foo = document.querySelectorAll('.grid-head-cell-button');
     const moo = Array.from(foo).map(column => {
       return column.getBoundingClientRect();
@@ -83,6 +85,21 @@ class DraggableColumns extends React.Component<Props, State> {
 
     console.log('foo', foo);
     console.log('moo', moo);
+
+    foo.forEach(element => {
+      const rects = element.getBoundingClientRect();
+
+      const reference = document.createElement('div');
+      reference.style.height = '10px';
+      reference.style.width = `${rects.width}px`;
+      reference.style.position = 'absolute';
+      reference.style.top = `${rects.top}px`;
+      reference.style.left = `${rects.left}px`;
+      reference.style.zIndex = '9999';
+      reference.style.backgroundColor = 'yellow';
+
+      document.body.appendChild(reference);
+    });
   };
 
   onDragMove = (event: MouseEvent) => {
@@ -90,12 +107,31 @@ class DraggableColumns extends React.Component<Props, State> {
       return;
     }
 
-    // console.log('event.pageX', event.pageX);
-
     if (this.dragGhostRef.current) {
+      // move the ghosted column title
+
       const ghostDOM = this.dragGhostRef.current;
       ghostDOM.style.left = `${event.pageX}px`;
       ghostDOM.style.top = `${event.pageY}px`;
+    }
+
+    const gridHeadCellButtons = document.querySelectorAll('.grid-head-cell-button');
+
+    const destinationIndex = Array.from(gridHeadCellButtons).findIndex(headerElement => {
+      const rects = headerElement.getBoundingClientRect();
+
+      const left = event.pageX;
+
+      const thresholdStart = rects.left + rects.width * 0.25;
+      const thresholdEnd = rects.left + rects.width * 0.75;
+
+      return left >= thresholdStart && left <= thresholdEnd;
+    });
+
+    if (destinationIndex >= 0) {
+      const destinationColumn = this.props.columnOrder[destinationIndex];
+
+      console.log('move to', destinationColumn.name);
     }
   };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -245,8 +245,6 @@ const GhostPlacement = styled('div')`
 `;
 
 const GhostContentBox = styled('div')`
-  background-color: white;
-
   padding: ${space(1)} ${space(1.5)};
   border-radius: ${p => p.theme.borderRadius};
 
@@ -261,15 +259,5 @@ const GhostContentBox = styled('div')`
 
   background: ${p => p.theme.offWhite2};
 `;
-
-// const MouseGuide = styled('div')`
-//   position: absolute;
-//   top: 0;
-//   bottom: 0;
-
-//   width: 1px;
-//   height: 100vh;
-//   background-color: red;
-// `;
 
 export default DraggableColumns;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -211,14 +211,12 @@ class DraggableColumns extends React.Component<Props, State> {
       const left = `${this.state.left}px`;
 
       const ghost = (
-        <React.Fragment>
-          <GhostPlacement
-            innerRef={this.dragGhostRef}
-            style={{display: 'block', top, left}}
-          >
-            <GhostContentBox>{columnBeingDragged.name}</GhostContentBox>
-          </GhostPlacement>
-        </React.Fragment>
+        <GhostPlacement
+          innerRef={this.dragGhostRef}
+          style={{display: 'block', top, left}}
+        >
+          <GhostContentBox>{columnBeingDragged.name}</GhostContentBox>
+        </GhostPlacement>
       );
 
       return ReactDOM.createPortal(ghost, this.portal);

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -95,6 +95,8 @@ class DraggableColumns extends React.Component<Props, State> {
       return column.getBoundingClientRect();
     });
 
+    // TODO: remvoe this
+
     console.log('foo', foo);
     console.log('moo', moo);
 
@@ -143,10 +145,6 @@ class DraggableColumns extends React.Component<Props, State> {
     );
 
     if (destinationColumnIndex >= 0) {
-      //   const destinationColumn = this.props.columnOrder[destinationColumnIndex];
-
-      //   console.log('move to', destinationColumn.name);
-
       if (this.state.destinationColumnIndex !== destinationColumnIndex) {
         this.setState({
           destinationColumnIndex,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -77,42 +77,11 @@ class DraggableColumns extends React.Component<Props, State> {
     window.addEventListener('mousemove', this.onDragMove);
     window.addEventListener('mouseup', this.onDragEnd);
 
-    const columnBeingDragged = this.props.columnOrder[initialColumnIndex];
-
     this.setState({
       isDragging: true,
       draggingColumnIndex: initialColumnIndex,
       left: event.pageX,
       top: event.pageY,
-    });
-
-    console.log('dragging column', initialColumnIndex, columnBeingDragged);
-
-    // TODO: experiment, clean this up
-
-    const foo = document.querySelectorAll('.grid-head-cell-button');
-    const moo = Array.from(foo).map(column => {
-      return column.getBoundingClientRect();
-    });
-
-    // TODO: remvoe this
-
-    console.log('foo', foo);
-    console.log('moo', moo);
-
-    foo.forEach(element => {
-      const rects = element.getBoundingClientRect();
-
-      const reference = document.createElement('div');
-      reference.style.height = '10px';
-      reference.style.width = `${rects.width * 0.8}px`;
-      reference.style.position = 'absolute';
-      reference.style.top = `${rects.top}px`;
-      reference.style.left = `${rects.left + rects.width * 0.1}px`;
-      reference.style.zIndex = '9999';
-      reference.style.backgroundColor = 'yellow';
-
-      //   document.body.appendChild(reference);
     });
   };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/draggableColumns.tsx
@@ -23,12 +23,18 @@ type Props = {
 type State = {
   isDragging: boolean;
   draggingColumnIndex: undefined | number;
+  left: undefined | number;
+  top: undefined | number;
 };
 
 class DraggableColumns extends React.Component<Props, State> {
   state: State = {
     isDragging: false,
     draggingColumnIndex: void 0,
+
+    // initial coordinates for when the drag began
+    left: void 0,
+    top: void 0,
   };
 
   previousUserSelect: UserSelectValues | null = null;
@@ -64,6 +70,8 @@ class DraggableColumns extends React.Component<Props, State> {
     this.setState({
       isDragging: true,
       draggingColumnIndex: initialColumnIndex,
+      left: event.pageX,
+      top: event.pageY,
     });
 
     console.log('dragging column', initialColumnIndex, columnBeingDragged);
@@ -112,6 +120,8 @@ class DraggableColumns extends React.Component<Props, State> {
     this.setState({
       isDragging: false,
       draggingColumnIndex: void 0,
+      left: void 0,
+      top: void 0,
     });
 
     console.log('ended');
@@ -162,9 +172,15 @@ class DraggableColumns extends React.Component<Props, State> {
     ) {
       const columnBeingDragged = this.props.columnOrder[this.state.draggingColumnIndex];
 
+      const top = `${this.state.top}px`;
+      const left = `${this.state.left}px`;
+
       const ghost = (
         <React.Fragment>
-          <GhostPlacement innerRef={this.dragGhostRef} style={{display: 'block'}}>
+          <GhostPlacement
+            innerRef={this.dragGhostRef}
+            style={{display: 'block', top, left}}
+          >
             <GhostContentBox>{columnBeingDragged.name}</GhostContentBox>
           </GhostPlacement>
         </React.Fragment>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -103,13 +103,16 @@ class TableView extends React.Component<TableViewProps> {
     });
   };
 
-  _moveColumnStage = (fromIndex: number, toIndex: number) => {
-    this.setState({
-      moveColumnStage: {
-        fromIndex,
-        toIndex,
-      },
+  _onDragStart = (fromIndex: number) => {
+    console.log({
+      fromIndex,
     });
+    // this.setState({
+    //   moveColumnStage: {
+    //     fromIndex,
+    //     toIndex,
+    //   },
+    // });
   };
 
   /**
@@ -177,6 +180,21 @@ class TableView extends React.Component<TableViewProps> {
     return fieldRenderer(dataRow, {organization, location});
   };
 
+  generateColumnOrder = (): TableState['columnOrder'] => {
+    const {columnOrder} = this.state;
+
+    if (this.state.moveColumnStage) {
+      const {fromIndex, toIndex} = this.state.moveColumnStage;
+
+      const nextColumnOrder = [...columnOrder];
+      nextColumnOrder.splice(toIndex, 0, nextColumnOrder.splice(fromIndex, 1)[0]);
+
+      return nextColumnOrder;
+    }
+
+    return columnOrder;
+  };
+
   render() {
     const {organization, isLoading, error, tableData, eventView} = this.props;
 
@@ -197,7 +215,7 @@ class TableView extends React.Component<TableViewProps> {
         isLoading={isLoading}
         error={error}
         data={tableData ? tableData.data : []}
-        columnOrder={columnOrder}
+        columnOrder={this.generateColumnOrder()}
         columnSortBy={columnSortBy}
         grid={{
           renderHeaderCell: this._renderGridHeaderCell as any,
@@ -210,7 +228,7 @@ class TableView extends React.Component<TableViewProps> {
         actions={{
           deleteColumn: this._deleteColumn,
           moveColumnCommit: this._moveColumnCommit,
-          moveColumnStage: this._moveColumnStage,
+          onDragStart: this._onDragStart,
         }}
       />
     );

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -176,18 +176,21 @@ class TableView extends React.Component<TableViewProps> {
     initialColumnIndex: undefined | number;
     destinationColumnIndex: undefined | number;
   }) => {
+    const {eventView} = this.props;
+    const columnOrder = eventView.getColumns();
+
     if (
       typeof destinationColumnIndex !== 'number' ||
       typeof initialColumnIndex !== 'number'
     ) {
-      return this.state.columnOrder;
+      return columnOrder;
     }
 
     if (destinationColumnIndex === initialColumnIndex) {
-      return this.state.columnOrder;
+      return columnOrder;
     }
 
-    const nextColumnOrder = [...this.state.columnOrder];
+    const nextColumnOrder = [...columnOrder];
 
     nextColumnOrder.splice(
       destinationColumnIndex!,
@@ -214,7 +217,7 @@ class TableView extends React.Component<TableViewProps> {
 
     return (
       <DraggableColumns
-        columnOrder={this.state.columnOrder}
+        columnOrder={columnOrder}
         onDragDone={({draggingColumnIndex, destinationColumnIndex}) => {
           if (
             typeof draggingColumnIndex === 'number' &&

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -184,7 +184,7 @@ class TableView extends React.Component<TableViewProps> {
     });
 
     return (
-      <DraggableColumns>
+      <DraggableColumns columnOrder={this.state.columnOrder}>
         {({startColumnDrag}) => {
           return (
             <GridEditable

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -11,7 +11,9 @@ import SortLink from '../sortLink';
 import renderTableModalEditColumnFactory from './tableModalEditColumn';
 import {TableColumn, TableData, TableDataRow} from './types';
 import {ColumnValueType} from '../eventQueryParams';
-import DraggableColumns from './draggableColumns';
+import DraggableColumns, {
+  DRAGGABLE_COLUMN_CLASSNAME_IDENTIFIER,
+} from './draggableColumns';
 
 export type TableViewProps = {
   location: Location;
@@ -252,6 +254,7 @@ class TableView extends React.Component<TableViewProps> {
             <GridEditable
               isEditable
               isColumnDragging={isColumnDragging}
+              gridHeadCellButtonProps={{className: DRAGGABLE_COLUMN_CLASSNAME_IDENTIFIER}}
               isLoading={isLoading}
               error={error}
               data={tableData ? tableData.data : []}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -104,6 +104,10 @@ class TableView extends React.Component<TableViewProps> {
     });
   };
 
+  _moveColumnStage = (fromIndex: number, toIndex: number) => {
+    // TODO:
+  };
+
   /**
    * Please read the comment on `_createColumn`
    */

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -183,12 +183,16 @@ class TableView extends React.Component<TableViewProps> {
       return this.state.columnOrder;
     }
 
+    if (destinationColumnIndex === initialColumnIndex) {
+      return this.state.columnOrder;
+    }
+
     const nextColumnOrder = [...this.state.columnOrder];
 
     nextColumnOrder.splice(
-      destinationColumnIndex,
+      destinationColumnIndex!,
       0,
-      nextColumnOrder.splice(initialColumnIndex, 1)[0]
+      nextColumnOrder.splice(initialColumnIndex!, 1)[0]
     );
 
     return nextColumnOrder;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -131,13 +131,11 @@ class TableView extends React.Component<TableViewProps> {
     const field = column.eventViewField;
 
     // establish alignment based on the type
-
     const alignedTypes: ColumnValueType[] = ['number', 'duration'];
     let align: 'right' | 'left' = alignedTypes.includes(column.type) ? 'right' : 'left';
 
     if (column.type === 'never' || column.type === '*') {
       // fallback to align the column based on the table metadata
-
       const maybeType = tableData.meta[getAggregateAlias(field.field)];
 
       if (maybeType === 'integer' || maybeType === 'number') {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -218,7 +218,8 @@ class TableView extends React.Component<TableViewProps> {
         onDragDone={({draggingColumnIndex, destinationColumnIndex}) => {
           if (
             typeof draggingColumnIndex === 'number' &&
-            typeof destinationColumnIndex === 'number'
+            typeof destinationColumnIndex === 'number' &&
+            draggingColumnIndex !== destinationColumnIndex
           ) {
             this._moveColumnCommit(draggingColumnIndex, destinationColumnIndex);
           }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -31,7 +31,6 @@ export type TableViewProps = {
  * and re-ordering columns.
  */
 class TableView extends React.Component<TableViewProps> {
-  // TODO: update this docs
   /**
    * The entire state of the table view (or event view) is co-located within
    * the EventView object. This object is fed from the props.
@@ -105,13 +104,18 @@ class TableView extends React.Component<TableViewProps> {
   };
 
   _moveColumnStage = (fromIndex: number, toIndex: number) => {
-    // TODO:
+    this.setState({
+      moveColumnStage: {
+        fromIndex,
+        toIndex,
+      },
+    });
   };
 
   /**
    * Please read the comment on `_createColumn`
    */
-  _moveColumn = (fromIndex: number, toIndex: number) => {
+  _moveColumnCommit = (fromIndex: number, toIndex: number) => {
     const {location, eventView} = this.props;
 
     const nextEventView = eventView.withMovedColumn({fromIndex, toIndex});
@@ -205,7 +209,8 @@ class TableView extends React.Component<TableViewProps> {
         }}
         actions={{
           deleteColumn: this._deleteColumn,
-          moveColumn: this._moveColumn,
+          moveColumnCommit: this._moveColumnCommit,
+          moveColumnStage: this._moveColumnStage,
         }}
       />
     );

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -225,10 +225,16 @@ class TableView extends React.Component<TableViewProps> {
           }
         }}
       >
-        {({startColumnDrag, draggingColumnIndex, destinationColumnIndex}) => {
+        {({
+          isColumnDragging,
+          startColumnDrag,
+          draggingColumnIndex,
+          destinationColumnIndex,
+        }) => {
           return (
             <GridEditable
               isEditable
+              isColumnDragging={isColumnDragging}
               isLoading={isLoading}
               error={error}
               data={tableData ? tableData.data : []}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -169,6 +169,31 @@ class TableView extends React.Component<TableViewProps> {
     return fieldRenderer(dataRow, {organization, location});
   };
 
+  generateColumnOrder = ({
+    initialColumnIndex,
+    destinationColumnIndex,
+  }: {
+    initialColumnIndex: undefined | number;
+    destinationColumnIndex: undefined | number;
+  }) => {
+    if (
+      typeof destinationColumnIndex !== 'number' ||
+      typeof initialColumnIndex !== 'number'
+    ) {
+      return this.state.columnOrder;
+    }
+
+    const nextColumnOrder = [...this.state.columnOrder];
+
+    nextColumnOrder.splice(
+      destinationColumnIndex,
+      0,
+      nextColumnOrder.splice(initialColumnIndex, 1)[0]
+    );
+
+    return nextColumnOrder;
+  };
+
   render() {
     const {organization, isLoading, error, tableData, eventView} = this.props;
 
@@ -185,14 +210,17 @@ class TableView extends React.Component<TableViewProps> {
 
     return (
       <DraggableColumns columnOrder={this.state.columnOrder}>
-        {({startColumnDrag}) => {
+        {({startColumnDrag, draggingColumnIndex, destinationColumnIndex}) => {
           return (
             <GridEditable
               isEditable
               isLoading={isLoading}
               error={error}
               data={tableData ? tableData.data : []}
-              columnOrder={this.state.columnOrder}
+              columnOrder={this.generateColumnOrder({
+                initialColumnIndex: draggingColumnIndex,
+                destinationColumnIndex,
+              })}
               columnSortBy={columnSortBy}
               grid={{
                 renderHeaderCell: this._renderGridHeaderCell as any,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -169,21 +169,6 @@ class TableView extends React.Component<TableViewProps> {
     return fieldRenderer(dataRow, {organization, location});
   };
 
-  generateColumnOrder = (): TableState['columnOrder'] => {
-    const {columnOrder} = this.state;
-
-    if (this.state.moveColumnStage) {
-      const {fromIndex, toIndex} = this.state.moveColumnStage;
-
-      const nextColumnOrder = [...columnOrder];
-      nextColumnOrder.splice(toIndex, 0, nextColumnOrder.splice(fromIndex, 1)[0]);
-
-      return nextColumnOrder;
-    }
-
-    return columnOrder;
-  };
-
   render() {
     const {organization, isLoading, error, tableData, eventView} = this.props;
 
@@ -207,7 +192,7 @@ class TableView extends React.Component<TableViewProps> {
               isLoading={isLoading}
               error={error}
               data={tableData ? tableData.data : []}
-              columnOrder={this.generateColumnOrder()}
+              columnOrder={this.state.columnOrder}
               columnSortBy={columnSortBy}
               grid={{
                 renderHeaderCell: this._renderGridHeaderCell as any,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -11,6 +11,7 @@ import SortLink from '../sortLink';
 import renderTableModalEditColumnFactory from './tableModalEditColumn';
 import {TableColumn, TableData, TableDataRow} from './types';
 import {ColumnValueType} from '../eventQueryParams';
+import DraggableColumns from './draggableColumns';
 
 export type TableViewProps = {
   location: Location;
@@ -101,18 +102,6 @@ class TableView extends React.Component<TableViewProps> {
       nextEventView,
       extraQuery: pickRelevantLocationQueryStrings(location),
     });
-  };
-
-  _onDragStart = (fromIndex: number) => {
-    console.log({
-      fromIndex,
-    });
-    // this.setState({
-    //   moveColumnStage: {
-    //     fromIndex,
-    //     toIndex,
-    //   },
-    // });
   };
 
   /**
@@ -210,27 +199,33 @@ class TableView extends React.Component<TableViewProps> {
     });
 
     return (
-      <GridEditable
-        isEditable
-        isLoading={isLoading}
-        error={error}
-        data={tableData ? tableData.data : []}
-        columnOrder={this.generateColumnOrder()}
-        columnSortBy={columnSortBy}
-        grid={{
-          renderHeaderCell: this._renderGridHeaderCell as any,
-          renderBodyCell: this._renderGridBodyCell as any,
+      <DraggableColumns>
+        {({startColumnDrag}) => {
+          return (
+            <GridEditable
+              isEditable
+              isLoading={isLoading}
+              error={error}
+              data={tableData ? tableData.data : []}
+              columnOrder={this.generateColumnOrder()}
+              columnSortBy={columnSortBy}
+              grid={{
+                renderHeaderCell: this._renderGridHeaderCell as any,
+                renderBodyCell: this._renderGridBodyCell as any,
+              }}
+              modalEditColumn={{
+                renderBodyWithForm: renderModalBodyWithForm as any,
+                renderFooter: renderModalFooter,
+              }}
+              actions={{
+                deleteColumn: this._deleteColumn,
+                moveColumnCommit: this._moveColumnCommit,
+                onDragStart: startColumnDrag,
+              }}
+            />
+          );
         }}
-        modalEditColumn={{
-          renderBodyWithForm: renderModalBodyWithForm as any,
-          renderFooter: renderModalFooter,
-        }}
-        actions={{
-          deleteColumn: this._deleteColumn,
-          moveColumnCommit: this._moveColumnCommit,
-          onDragStart: this._onDragStart,
-        }}
-      />
+      </DraggableColumns>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -188,6 +188,13 @@ class TableView extends React.Component<TableViewProps> {
     }
 
     if (destinationColumnIndex === initialColumnIndex) {
+      const currentDraggingColumn: TableColumn<keyof TableDataRow> = {
+        ...columnOrder[destinationColumnIndex],
+        isDragging: true,
+      };
+
+      columnOrder[destinationColumnIndex] = currentDraggingColumn;
+
       return columnOrder;
     }
 
@@ -198,6 +205,12 @@ class TableView extends React.Component<TableViewProps> {
       0,
       nextColumnOrder.splice(initialColumnIndex, 1)[0]
     );
+
+    const currentDraggingColumn: TableColumn<keyof TableDataRow> = {
+      ...nextColumnOrder[destinationColumnIndex],
+      isDragging: true,
+    };
+    nextColumnOrder[destinationColumnIndex] = currentDraggingColumn;
 
     return nextColumnOrder;
   };

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -119,22 +119,23 @@ class TableView extends React.Component<TableViewProps> {
     });
   };
 
-  _renderGridHeaderCell = (
-    column: TableColumn<keyof TableDataRow>,
-    columnIndex: number
-  ): React.ReactNode => {
+  _renderGridHeaderCell = (column: TableColumn<keyof TableDataRow>): React.ReactNode => {
     const {eventView, location, tableData} = this.props;
+
     if (!tableData) {
       return column.name;
     }
 
-    const field = eventView.fields[columnIndex];
+    const field = column.eventViewField;
+
+    // establish alignment based on the type
 
     const alignedTypes: ColumnValueType[] = ['number', 'duration'];
     let align: 'right' | 'left' = alignedTypes.includes(column.type) ? 'right' : 'left';
 
-    // TODO(alberto): clean this
     if (column.type === 'never' || column.type === '*') {
+      // fallback to align the column based on the table metadata
+
       const maybeType = tableData.meta[getAggregateAlias(field.field)];
 
       if (maybeType === 'integer' || maybeType === 'number') {
@@ -193,9 +194,9 @@ class TableView extends React.Component<TableViewProps> {
     const nextColumnOrder = [...columnOrder];
 
     nextColumnOrder.splice(
-      destinationColumnIndex!,
+      destinationColumnIndex,
       0,
-      nextColumnOrder.splice(initialColumnIndex!, 1)[0]
+      nextColumnOrder.splice(initialColumnIndex, 1)[0]
     );
 
     return nextColumnOrder;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -209,7 +209,17 @@ class TableView extends React.Component<TableViewProps> {
     });
 
     return (
-      <DraggableColumns columnOrder={this.state.columnOrder}>
+      <DraggableColumns
+        columnOrder={this.state.columnOrder}
+        onDragDone={({draggingColumnIndex, destinationColumnIndex}) => {
+          if (
+            typeof draggingColumnIndex === 'number' &&
+            typeof destinationColumnIndex === 'number'
+          ) {
+            this._moveColumnCommit(draggingColumnIndex, destinationColumnIndex);
+          }
+        }}
+      >
         {({startColumnDrag, draggingColumnIndex, destinationColumnIndex}) => {
           return (
             <GridEditable

--- a/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
@@ -1,6 +1,7 @@
 import {GridColumnOrder, GridColumnSortBy} from 'app/components/gridEditable';
 
 import {ColumnValueType, Aggregation, Field} from '../eventQueryParams';
+import {Field as FieldType} from '../eventView';
 import {MetaType} from '../utils';
 
 /**
@@ -11,6 +12,7 @@ export type TableColumn<K> = GridColumnOrder<K> & {
   // name: string               From GridColumnHeader
   aggregation: Aggregation;
   field: Field;
+  eventViewField: FieldType;
 
   type: ColumnValueType;
   isSortable: boolean;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
@@ -22,6 +22,10 @@ export type TableColumnSort<K> = GridColumnSortBy<K>;
 export type TableState = {
   columnOrder: TableColumn<keyof TableDataRow>[];
   columnSortBy: TableColumnSort<keyof TableDataRow>[];
+  moveColumnStage?: {
+    fromIndex: number;
+    toIndex: number;
+  };
 };
 
 export type TableDataRow = {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
@@ -12,7 +12,7 @@ export type TableColumn<K> = GridColumnOrder<K> & {
   // name: string               From GridColumnHeader
   aggregation: Aggregation;
   field: Field;
-  eventViewField: FieldType;
+  eventViewField: Readonly<FieldType>;
 
   type: ColumnValueType;
   isSortable: boolean;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
@@ -22,10 +22,6 @@ export type TableColumnSort<K> = GridColumnSortBy<K>;
 export type TableState = {
   columnOrder: TableColumn<keyof TableDataRow>[];
   columnSortBy: TableColumnSort<keyof TableDataRow>[];
-  moveColumnStage?: {
-    fromIndex: number;
-    toIndex: number;
-  };
 };
 
 export type TableDataRow = {

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -230,7 +230,7 @@ const TEMPLATE_TABLE_COLUMN: TableColumn<React.ReactText> = {
   name: '',
   aggregation: '',
   field: '',
-  eventViewField: {field: '', title: ''},
+  eventViewField: Object.freeze({field: '', title: ''}),
   isDragging: false,
 
   type: 'never',

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -102,11 +102,9 @@ export function fetchTagDistribution(
   key: string,
   query: EventQuery
 ): Promise<Tag> {
-  // const urlParams = pick(query, Object.values(URL_PARAM));
+  const urlParams = pick(query, Object.values(URL_PARAM));
 
-  const queryOption = {...query, key};
-
-  console.log(key, queryOption);
+  const queryOption = {...urlParams, key, query: query.query};
 
   return api.requestPromise(`/organizations/${orgSlug}/events-distribution/`, {
     query: queryOption,

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -102,9 +102,11 @@ export function fetchTagDistribution(
   key: string,
   query: EventQuery
 ): Promise<Tag> {
-  const urlParams = pick(query, Object.values(URL_PARAM));
+  // const urlParams = pick(query, Object.values(URL_PARAM));
 
-  const queryOption = {...urlParams, key, query: query.query};
+  const queryOption = {...query, key};
+
+  console.log(key, queryOption);
 
   return api.requestPromise(`/organizations/${orgSlug}/events-distribution/`, {
     query: queryOption,

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -229,6 +229,7 @@ const TEMPLATE_TABLE_COLUMN: TableColumn<React.ReactText> = {
   aggregation: '',
   field: '',
   eventViewField: {field: '', title: ''},
+  isDragging: false,
 
   type: 'never',
   isSortable: false,

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -5,7 +5,6 @@ import {browserHistory} from 'react-router';
 import {Client} from 'app/api';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {generateQueryWithTag} from 'app/utils';
-import {Field as FieldType} from './eventView';
 
 import {
   AGGREGATE_ALIASES,
@@ -15,7 +14,7 @@ import {
   FieldTypes,
   FieldFormatterRenderFunctionPartial,
 } from './data';
-import EventView from './eventView';
+import EventView, {Field as FieldType} from './eventView';
 import {
   Aggregation,
   Field,

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -5,6 +5,7 @@ import {browserHistory} from 'react-router';
 import {Client} from 'app/api';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {generateQueryWithTag} from 'app/utils';
+import {Field as FieldType} from './eventView';
 
 import {
   AGGREGATE_ALIASES,
@@ -228,6 +229,7 @@ const TEMPLATE_TABLE_COLUMN: TableColumn<React.ReactText> = {
   name: '',
   aggregation: '',
   field: '',
+  eventViewField: {field: '', title: ''},
 
   type: 'never',
   isSortable: false,
@@ -237,8 +239,9 @@ const TEMPLATE_TABLE_COLUMN: TableColumn<React.ReactText> = {
 export function decodeColumnOrder(props: {
   fieldnames: string[];
   field: string[];
+  fields: Readonly<FieldType[]>;
 }): TableColumn<React.ReactText>[] {
-  const {fieldnames, field} = props;
+  const {fieldnames, field, fields} = props;
 
   return field.map((f: string, index: number) => {
     const col = {aggregationField: f, name: fieldnames[index]};
@@ -266,6 +269,8 @@ export function decodeColumnOrder(props: {
       ? AGGREGATIONS[column.aggregation].isSortable
       : false;
     column.isPrimary = column.field === 'title';
+
+    column.eventViewField = fields[index];
 
     return column;
   });

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -272,7 +272,10 @@ export function decodeColumnOrder(props: {
       : false;
     column.isPrimary = column.field === 'title';
 
-    column.eventViewField = fields[index];
+    column.eventViewField = {
+      title: fields[index].title,
+      field: fields[index].field,
+    };
 
     return column;
   });

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -260,15 +260,21 @@ describe('decodeColumnOrder', function() {
     const results = decodeColumnOrder({
       field: ['title'],
       fieldnames: ['Event title'],
+      fields: [{field: 'title', title: 'Event title'}],
     });
 
     expect(Array.isArray(results)).toBeTruthy();
 
-    expect(results[0]).toMatchObject({
+    expect(results[0]).toEqual({
       key: 'title',
       name: 'Event title',
       aggregation: '',
       field: 'title',
+      eventViewField: {field: 'title', title: 'Event title'},
+      isDragging: false,
+      isPrimary: true,
+      isSortable: false,
+      type: 'string',
     });
   });
 
@@ -276,15 +282,21 @@ describe('decodeColumnOrder', function() {
     const results = decodeColumnOrder({
       field: ['count()'],
       fieldnames: ['projects'],
+      fields: [{field: 'count()', title: 'projects'}],
     });
 
     expect(Array.isArray(results)).toBeTruthy();
 
-    expect(results[0]).toMatchObject({
+    expect(results[0]).toEqual({
       key: 'count()',
       name: 'projects',
       aggregation: 'count',
       field: '',
+      eventViewField: {field: 'count()', title: 'projects'},
+      isDragging: false,
+      isPrimary: false,
+      isSortable: true,
+      type: 'never',
     });
   });
 
@@ -292,15 +304,21 @@ describe('decodeColumnOrder', function() {
     const results = decodeColumnOrder({
       field: ['avg(transaction.duration)'],
       fieldnames: ['average'],
+      fields: [{field: 'avg(transaction.duration)', title: 'average'}],
     });
 
     expect(Array.isArray(results)).toBeTruthy();
 
-    expect(results[0]).toMatchObject({
+    expect(results[0]).toEqual({
       key: 'avg(transaction.duration)',
       name: 'average',
       aggregation: 'avg',
       field: 'transaction.duration',
+      eventViewField: {field: 'avg(transaction.duration)', title: 'average'},
+      isDragging: false,
+      isPrimary: false,
+      isSortable: true,
+      type: 'duration',
     });
   });
 });


### PR DESCRIPTION

## TODO

- [x] defer to Danny regarding referencing `.grid-head-cell-button`; or at least the right approach. EDIT: see: https://github.com/getsentry/sentry/pull/14980/commits/4bda109de193db22c4087df699404af47877e59a
- [x] clean up things
- [x] more emphasis on the column being dragged
- [x] do not reload the table.

------


Closes SEN-1126