### PR TITLE
feat(discover2) Add basic duration aggregates

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -667,19 +667,19 @@ FIELD_ALIASES = {
     "last_seen": {"aggregations": [["max", "timestamp", "last_seen"]]},
     "latest_event": {"aggregations": [["argMax", ["id", "timestamp"], "latest_event"]]},
     "project": {"fields": ["project.id"]},
-    "user": {"fields": ["user.id", "user.name", "user.username", "user.email", "user.ip"]}
-    # TODO(mark) Add rpm alias.
+    "user": {"fields": ["user.id", "user.name", "user.username", "user.email", "user.ip"]},
+    # Long term these will become more complex functions but these are
+    # field aliases.
+    "p75": {"aggregations": [["quantileTiming(0.75)(duration)", "", "p75"]]},
+    "p95": {"aggregations": [["quantileTiming(0.95)(duration)", "", "p95"]]},
 }
 
 VALID_AGGREGATES = {
     "count_unique": {"snuba_name": "uniq", "fields": "*"},
     "count": {"snuba_name": "count", "fields": "*"},
-    "min": {"snuba_name": "min", "fields": ["timestamp", "duration"]},
-    "max": {"snuba_name": "max", "fields": ["timestamp", "duration"]},
-    "sum": {"snuba_name": "sum", "fields": ["duration"]},
-    # These don't entirely work yet but are intended to be illustrative
-    "avg": {"snuba_name": "avg", "fields": ["duration"]},
-    "p75": {"snuba_name": "quantileTiming(0.75)", "fields": ["duration"]},
+    "min": {"snuba_name": "min", "fields": ["timestamp", "transaction.duration"]},
+    "max": {"snuba_name": "max", "fields": ["timestamp", "transaction.duration"]},
+    "avg": {"snuba_name": "avg", "fields": ["transaction.duration"]},
 }
 
 AGGREGATE_PATTERN = re.compile(r"^(?P<function>[^\(]+)\((?P<column>[a-z\._]*)\)$")

--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -121,8 +121,15 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
   {
     name: t('Transactions'),
     data: {
-      fields: ['transaction', 'project', 'count()'],
-      fieldnames: ['transaction', 'project', 'volume'],
+      fields: [
+        'transaction',
+        'project',
+        'count()',
+        'avg(transaction.duration)',
+        'p75',
+        'p95',
+      ],
+      fieldnames: ['transaction', 'project', 'volume', 'avg', '75th', '95th'],
       sort: ['-count'],
       query: 'event.type:transaction',
     },
@@ -131,8 +138,15 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
   {
     name: t('Transactions by User'),
     data: {
-      fields: ['user', 'count()', 'count_unique(transaction)'],
-      fieldnames: ['user', 'events', 'unique transactions'],
+      fields: [
+        'user',
+        'count()',
+        'count_unique(transaction)',
+        'avg(transaction.duration)',
+        'p75',
+        'p95',
+      ],
+      fieldnames: ['user', 'events', 'unique transactions', 'avg', '75th', '95th'],
       sort: ['-count'],
       query: 'event.type:transaction',
     },
@@ -141,8 +155,8 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
   {
     name: t('Transactions by Region'),
     data: {
-      fields: ['geo.region', 'count()'],
-      fieldnames: ['Region', 'events'],
+      fields: ['geo.region', 'count()', 'avg(transaction.duration)', 'p75', 'p95'],
+      fieldnames: ['Region', 'events', 'avg', '75th', '95th'],
       sort: ['-count'],
       query: 'event.type:transaction',
     },

--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -34,15 +34,15 @@ export const AGGREGATIONS = {
     type: ['timestamp', 'duration'],
     isSortable: true,
   },
-  /*
   sum: {
-    type: 'duration',
+    type: ['transaction.duration'],
     isSortable: true,
   },
   avg: {
-    type: 'duration',
+    type: ['duration'],
     isSortable: true,
   },
+  /*
   cidr: {
     type: 'string',
     isSortable: true,
@@ -126,5 +126,11 @@ export const FIELDS = {
   contexts: 'string',
   'contexts.key': 'string',
   'contexts.value': 'string',
+
+  'transaction.duration': 'duration',
+  'transaction.op': 'string',
+  // duration aliases
+  p75: 'number',
+  p95: 'number',
 };
 export type Field = keyof typeof FIELDS | '';

--- a/src/sentry/static/sentry/app/views/eventsV2/sortLink.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/sortLink.tsx
@@ -2,19 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 import {Location} from 'history';
+import {omit} from 'lodash';
 
 import InlineSvg from 'app/components/inlineSvg';
 import Link from 'app/components/links/link';
+
+type Alignments = 'left' | 'right' | undefined;
 
 type Props = {
   title: string;
   sortKey: string;
   defaultSort: string;
   location: Location;
+  align: Alignments;
 };
 
 class SortLink extends React.Component<Props> {
   static propTypes = {
+    align: PropTypes.string,
     title: PropTypes.string.isRequired,
     sortKey: PropTypes.string.isRequired,
     defaultSort: PropTypes.string.isRequired,
@@ -62,17 +67,24 @@ class SortLink extends React.Component<Props> {
   }
 
   render() {
-    const {title} = this.props;
+    const {align, title} = this.props;
     return (
-      <StyledLink to={this.getTarget()}>
+      <StyledLink align={align} to={this.getTarget()}>
         {title} {this.renderChevron()}
       </StyledLink>
     );
   }
 }
 
-const StyledLink = styled(Link)`
+type StyledLinkProps = Link['props'] & {align: Alignments};
+
+const StyledLink = styled((props: StyledLinkProps) => {
+  const forwardProps = omit(props, ['align']);
+  return <Link {...forwardProps} />;
+})`
+  display: block;
   white-space: nowrap;
+  ${(p: StyledLinkProps) => (p.align ? `text-align: ${p.align};` : '')}
 `;
 
 export default SortLink;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -158,9 +158,13 @@ class TableView extends React.Component<TableViewProps, TableState> {
 
     // TODO(leedongwei): Deprecate eventView and use state.columnSortBy
     const defaultSort = eventView.getDefaultSort() || eventView.fields[0].field;
+    const align = ['integer', 'number', 'duration'].includes(column.type)
+      ? 'right'
+      : 'left';
 
     return (
       <SortLink
+        align={align}
         defaultSort={defaultSort}
         sortKey={`${column.key}`}
         title={column.name}

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1102,6 +1102,17 @@ class ResolveFieldListTest(unittest.TestCase):
         ]
         assert result["groupby"] == ["title"]
 
+    def test_field_alias_duration_expansion(self):
+        fields = ["avg(duration)", "p95", "p75"]
+        result = resolve_field_list(fields, {})
+        assert result["selected_columns"] == ["project_id"]
+        assert result["aggregations"] == [
+            ["avg", "duration", "avg_duration"],
+            ["quantileTiming(0.75)(duration)", "", "p75"],
+            ["quantileTiming(0.95)(duration)", "", "p95"],
+        ]
+        assert result["groupby"] == ["project.id"]
+
     def test_field_alias_expansion(self):
         fields = ["title", "last_seen", "latest_event", "project", "user", "message"]
         result = resolve_field_list(fields, {})
@@ -1167,7 +1178,7 @@ class ResolveFieldListTest(unittest.TestCase):
 
     def test_aggregate_function_invalid_column(self):
         with pytest.raises(InvalidSearchQuery) as err:
-            fields = ["p75(message)"]
+            fields = ["min(message)"]
             resolve_field_list(fields, {})
         assert "Invalid column" in six.text_type(err)
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1105,13 +1105,15 @@ class ResolveFieldListTest(unittest.TestCase):
     def test_field_alias_duration_expansion(self):
         fields = ["avg(transaction.duration)", "p95", "p75"]
         result = resolve_field_list(fields, {})
-        assert result["selected_columns"] == ["project_id"]
+        assert result["selected_columns"] == []
         assert result["aggregations"] == [
-            ["avg", "duration", "avg_duration"],
-            ["quantileTiming(0.75)(duration)", "", "p75"],
+            ["avg", "transaction.duration", "avg_transaction_duration"],
             ["quantileTiming(0.95)(duration)", "", "p95"],
+            ["quantileTiming(0.75)(duration)", "", "p75"],
+            ["argMax", ["id", "timestamp"], "latest_event"],
+            ["argMax", ["project_id", "timestamp"], "projectid"],
         ]
-        assert result["groupby"] == ["project.id"]
+        assert result["groupby"] == []
 
     def test_field_alias_expansion(self):
         fields = ["title", "last_seen", "latest_event", "project", "user", "message"]

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1103,7 +1103,7 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["groupby"] == ["title"]
 
     def test_field_alias_duration_expansion(self):
-        fields = ["avg(duration)", "p95", "p75"]
+        fields = ["avg(transaction.duration)", "p95", "p75"]
         result = resolve_field_list(fields, {})
         assert result["selected_columns"] == ["project_id"]
         assert result["aggregations"] == [


### PR DESCRIPTION
Add basic duration aggregates as special field aliases. Longer term we want to have more flexible `pxx(rate, field)` functions but that requires additional UI and API work. This lets us surface important APM data more easily to help validate its usefulness.

Refs SEN-862