### PR TITLE
chore(tagstore): Remove LegacyTagStorage as a tagstore option

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1052,18 +1052,10 @@ SENTRY_NODESTORE = "sentry.nodestore.django.DjangoNodeStorage"
 SENTRY_NODESTORE_OPTIONS = {}
 
 # Tag storage backend
-_SENTRY_TAGSTORE_DEFAULT_MULTI_OPTIONS = {
-    "backends": [("sentry.tagstore.legacy.LegacyTagStorage", {})],
-    "runner": "ImmediateRunner",
-}
 SENTRY_TAGSTORE = os.environ.get(
     "SENTRY_TAGSTORE", "sentry.tagstore.snuba.SnubaCompatibilityTagStorage"
 )
-SENTRY_TAGSTORE_OPTIONS = (
-    _SENTRY_TAGSTORE_DEFAULT_MULTI_OPTIONS
-    if "SENTRY_TAGSTORE_DEFAULT_MULTI_OPTIONS" in os.environ
-    else {}
-)
+SENTRY_TAGSTORE_OPTIONS = {}
 
 # Search backend
 SENTRY_SEARCH = os.environ.get("SENTRY_SEARCH", "sentry.search.snuba.SnubaSearchBackend")


### PR DESCRIPTION
This tagstore is deprecated, do not allow this to be used anymore.