### PR TITLE
ref(tagstore): Fix tagstore imports

### DIFF
--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -6,7 +6,7 @@ from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsE
 from sentry.api.paginator import SequencePaginator
 from sentry.api.serializers import serialize
 from sentry.tagstore.base import TAG_KEY_RE
-from sentry.tagstore.snuba.backend import SnubaTagStorage
+from sentry import tagstore
 
 
 class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
@@ -21,9 +21,6 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
         except NoProjects:
             paginator = SequencePaginator([])
         else:
-            # TODO(jess): update this when snuba tagstore is the primary backend for us
-            tagstore = SnubaTagStorage()
-
             paginator = tagstore.get_tag_value_paginator_for_projects(
                 filter_params["project_id"],
                 filter_params.get("environment"),

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
+from sentry import tagstore
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
 from sentry.api.serializers import serialize
-from sentry.tagstore.snuba.backend import SnubaTagStorage
 
 
 class OrganizationTagsEndpoint(OrganizationEventsEndpointBase):
@@ -15,9 +15,6 @@ class OrganizationTagsEndpoint(OrganizationEventsEndpointBase):
             return Response({"detail": exc.message}, status=400)
         except NoProjects:
             return Response([])
-
-        # TODO(jess): update this when snuba tagstore is the primary backend for us
-        tagstore = SnubaTagStorage()
 
         results = tagstore.get_tag_keys_for_projects(
             filter_params["project_id"],

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -37,7 +37,6 @@ from sentry.models import (
     UserOption,
     UserOptionValue,
 )
-from sentry.tagstore.snuba.backend import SnubaTagStorage
 from sentry.tsdb.snuba import SnubaTSDB
 from sentry.utils.db import attach_foreignkey
 from sentry.utils.safe import safe_execute
@@ -559,7 +558,6 @@ class GroupSerializerSnuba(GroupSerializerBase):
         self.end = end
 
     def _get_seen_stats(self, item_list, user):
-        tagstore = SnubaTagStorage()
         project_ids = list(set([item.project_id for item in item_list]))
         group_ids = [item.id for item in item_list]
         user_counts = tagstore.get_groups_user_counts(

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -58,6 +58,7 @@ class TagStorage(Service):
             "get_tag_value_paginator_for_projects",
             "get_group_tag_value_iter",
             "get_group_tag_value_qs",
+            "get_group_seen_values_for_environments",
         ]
     )
 
@@ -439,5 +440,10 @@ class TagStorage(Service):
 
     def delay_index_event_tags(
         self, organization_id, project_id, group_id, environment_id, event_id, tags, date_added
+    ):
+        raise NotImplementedError
+
+    def get_group_seen_values_for_environments(
+        self, project_ids, group_id_list, environment_ids, start=None, end=None
     ):
         raise NotImplementedError


### PR DESCRIPTION
Since SnubaTagStorage is the default tagstore now, we can import it the
regular way from sentry.tagstore.