### PR TITLE
fix(member-invite): Provide roles for admins using the invite modal

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled, {css} from 'react-emotion';
 
 import {t, tn, tct} from 'app/locale';
+import {MEMBER_ROLES} from 'app/constants';
 import {ModalRenderProps} from 'app/actionCreators/modal';
 import InlineSvg from 'app/components/inlineSvg';
 import Button from 'app/components/button';
@@ -242,7 +243,7 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
             emails={[...emails]}
             role={role}
             teams={[...teams]}
-            roleOptions={member && member.roles}
+            roleOptions={member ? member.roles : MEMBER_ROLES}
             teamOptions={organization.teams}
             inviteStatus={inviteStatus}
             onRemove={() => this.removeInviteRow(i)}

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -32,6 +32,36 @@ export const DEFAULT_API_SCOPES = [
   'member:read',
 ];
 
+// These should only be used in the case where we cannot obtain roles through
+// the members endpoint (primarily in cases where a user is admining a
+// different organization they are not a OrganizationMember of ).
+export const MEMBER_ROLES = [
+  {
+    id: 'member',
+    name: 'Member',
+    desc:
+      'Members can view and act on events, as well as view most other data within the organization.',
+  },
+  {
+    id: 'admin',
+    name: 'Admin',
+    desc:
+      "Admin privileges on any teams of which they're a member. They can create new teams and projects, as well as remove teams and projects which they already hold membership on (or all teams, if open membership is on).",
+  },
+  {
+    id: 'manager',
+    name: 'Manager',
+    desc:
+      'Gains admin access on all teams as well as the ability to add and remove members.',
+  },
+  {
+    id: 'owner',
+    name: 'Organization Owner',
+    desc:
+      'Unrestricted access to the organization, its data, and its settings. Can add, modify, and delete projects and members, as well as make billing and plan changes.',
+  },
+];
+
 // We expose permissions for Sentry Apps in a more resource-centric way.
 // All of the API_SCOPES from above should be represented in a more
 // User-friendly way here.

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/index.jsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import * as Sentry from '@sentry/browser';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import {MEMBER_ROLES} from 'app/constants';
 import {t, tct} from 'app/locale';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
@@ -19,34 +20,6 @@ import TeamSelect from 'app/views/settings/components/teamSelect';
 import replaceRouterParams from 'app/utils/replaceRouterParams';
 
 import RoleSelect from './roleSelect';
-
-// These don't have allowed and are only used for superusers. superceded by server result of allowed roles
-const STATIC_ROLE_LIST = [
-  {
-    id: 'member',
-    name: 'Member',
-    desc:
-      'Members can view and act on events, as well as view most other data within the organization.',
-  },
-  {
-    id: 'admin',
-    name: 'Admin',
-    desc:
-      "Admin privileges on any teams of which they're a member. They can create new teams and projects, as well as remove teams and projects which they already hold membership on (or all teams, if open membership is on).",
-  },
-  {
-    id: 'manager',
-    name: 'Manager',
-    desc:
-      'Gains admin access on all teams as well as the ability to add and remove members.',
-  },
-  {
-    id: 'owner',
-    name: 'Organization Owner',
-    desc:
-      'Unrestricted access to the organization, its data, and its settings. Can add, modify, and delete projects and members, as well as make billing and plan changes.',
-  },
-];
 
 class InviteMember extends React.Component {
   static propTypes = {
@@ -106,7 +79,7 @@ class InviteMember extends React.Component {
       error: error => {
         if (error.status === 404 && isSuperuser) {
           // use the static list
-          this.setState({roleList: STATIC_ROLE_LIST, loading: false});
+          this.setState({roleList: MEMBER_ROLES, loading: false});
         } else if (error.status !== 0) {
           Sentry.withScope(scope => {
             scope.setExtra('error', error);


### PR DESCRIPTION
When a super user admining an organization loads the invite modal for that organization, they will be unable to load the roles list as the `/me` endpoint will 404.