### PR TITLE
feat(dev): add post-merge hook to suggest virtualenv refresh

### DIFF
--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | \
+    grep --quiet requirements && \
+    cat <<EOF
+WARNING!
+It looks like python requirements were updated upstream.
+You'll want to run "make install-sentry-dev" to refresh your virtual environment.
+EOF

--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | \
-    grep --quiet requirements && \
+    egrep --quiet 'requirements.*\.txt' && \
     cat <<EOF
 WARNING!
 It looks like python requirements were updated upstream.

--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -1,9 +1,12 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+
+red="$(tput setaf 1)"
+bold="$(tput bold)"
+reset="$(tput sgr0)"
 
 git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD | \
     egrep --quiet 'requirements.*\.txt' && \
     cat <<EOF
-WARNING!
-It looks like python requirements were updated upstream.
+${red}${bold}WARNING! It looks like python requirements were updated upstream.${reset}
 You'll want to run "make install-sentry-dev" to refresh your virtual environment.
 EOF


### PR DESCRIPTION
Python 3 is coming soon, and that includes a lot of dependency bumps. When people pull upstream master, sometimes they'll forget to reinstall/update the virtualenv, leading to confusing errors.

This adds a post-merge hook to suggest (not do) a virtualenv refresh, if any requirements files are changed.

Note that people have to rerun `make setup-git` (or `make develop`) for this hook to get installed.
