### PR TITLE
Revert "Cache has_release_permissions for a minute."

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 from rest_framework.exceptions import PermissionDenied, ParseError
 
-from django.core.cache import cache
-
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
@@ -19,7 +17,6 @@ from sentry.models import (
     ReleaseProject,
 )
 from sentry.utils import auth
-from sentry.utils.hashlib import hash_values
 from sentry.utils.sdk import configure_scope
 
 
@@ -297,19 +294,6 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
         Does the given request have permission to access this release, based
         on the projects to which the release is attached?
         """
-        actor_id = None
-        if getattr(request, "user", None) and request.user.id:
-            actor_id = "user:%s" % request.user.id
-        if getattr(request, "auth", None) and request.auth.id:
-            actor_id = "apikey:%s" % request.auth.id
-        if actor_id is None:
-            return False
-        key = "release_perms:1:%s" % hash_values([actor_id, organization.id, release.id])
-        has_perms = cache.get(key)
-        if has_perms is None:
-            has_perms = ReleaseProject.objects.filter(
-                release=release, project__in=self.get_projects(request, organization)
-            ).exists()
-            cache.set(key, has_perms, 60)
-
-        return has_perms
+        return ReleaseProject.objects.filter(
+            release=release, project__in=self.get_projects(request, organization)
+        ).exists()


### PR DESCRIPTION
Reverts getsentry/sentry#14955

Fails to properly cache Heroku Release setup because we fake ApiKey objects.