### PR TITLE
fix(dashboards) Fix release events when there are no releases

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboards/discoverQuery.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/discoverQuery.jsx
@@ -130,7 +130,7 @@ class DiscoverQuery extends React.Component {
     queries.forEach(({constraints, ...query}) => {
       if (constraints && constraints.includes('recentReleases')) {
         // Can't create query yet because no releases
-        if (!this.props.releases) {
+        if (!(this.props.releases && this.props.releases.length)) {
           return;
         }
         const newQuery = {
@@ -138,6 +138,7 @@ class DiscoverQuery extends React.Component {
           fields: [],
           conditionFields:
             this.props.releases &&
+            this.props.releases.length > 0 &&
             createReleaseFieldCondition(this.props.releases.map(({version}) => version)),
         };
         this.queryBuilders.push(


### PR DESCRIPTION
Fix 500 from discover1 when getting events by release. This popped up after a deploy I did as the stacktrace had a new hash.

Fixes SEN-1146
Fixes SENTRY-CZE