### PR TITLE
py3(pytest): bump pytest and friends to last 2.7 supported versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ install-yarn-pkgs:
 
 install-sentry-dev:
 	@echo "--> Installing Sentry (for development)"
-	$(PIP) install -e ".[dev,tests,optional]" $(PIP_OPTS)
+	$(PIP) install -e ".[dev,optional]" $(PIP_OPTS)
 
 build-js-po: node-version-check
 	mkdir -p build

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,10 +5,10 @@ exam>=0.5.1
 freezegun==0.3.11
 honcho>=1.0.0,<1.1.0
 isort>=4.3.4,<4.4.0
-pytest>=3.5.0,<3.6.0
-pytest-cov>=2.5.1,<2.6.0
-pytest-django>=2.9.1,<2.10.0
-pytest-html>=1.9.0,<1.10.0
+pytest==4.6.5
+pytest-cov==2.5.1
+pytest-django==3.5.1
+pytest-html==1.22.0
 responses>=0.8.1,<0.9.0
 sentry-flake8==0.1.1
 werkzeug==0.15.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,14 @@
 Babel
+datadog
 docker>=3.7.0,<3.8.0
 exam>=0.5.1
+freezegun==0.3.11
 honcho>=1.0.0,<1.1.0
 isort>=4.3.4,<4.4.0
 pytest>=3.5.0,<3.6.0
+pytest-cov>=2.5.1,<2.6.0
 pytest-django>=2.9.1,<2.10.0
 pytest-html>=1.9.0,<1.10.0
+responses>=0.8.1,<0.9.0
 sentry-flake8==0.1.1
+werkzeug==0.15.5

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,0 @@
-datadog
-freezegun==0.3.11
-pytest-cov>=2.5.1,<2.6.0
-responses>=0.8.1,<0.9.0
-werkzeug==0.15.5

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ def get_requirements(env):
 
 install_requires = get_requirements("base")
 dev_requires = get_requirements("dev")
-tests_require = get_requirements("test")
 optional_requires = get_requirements("optional")
 
 # override django version in requirements file if DJANGO_VERSION is set
@@ -139,7 +138,6 @@ setup(
     extras_require={
         "dev": dev_requires,
         "postgres": [],
-        "tests": tests_require,
         "optional": optional_requires,
     },
     cmdclass=cmdclass,

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -370,7 +370,7 @@ def browser(request, percy, live_server):
 def _environment(request):
     config = request.config
     # add environment details to the pytest-html plugin
-    config._environment.append(("Driver", config.option.selenium_driver))
+    config._metadata.update({"Driver": config.option.selenium_driver})
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)

--- a/tests/sentry/event_manager/interfaces/snapshots/test_stacktrace/test_get_stacktrace_with_only_filename.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_stacktrace/test_get_stacktrace_with_only_filename.pysnap
@@ -1,0 +1,15 @@
+---
+created: '2019-10-09T18:09:55.047738Z'
+creator: sentry
+source: tests/sentry/event_manager/interfaces/test_stacktrace.py
+---
+errors: null
+get_stacktrace: "Stacktrace (most recent call last):\n\n  File \"foo\"\n  File \"\
+  bar\""
+to_json:
+  frames:
+  - abs_path: foo
+    filename: foo
+  - abs_path: bar
+    filename: bar
+to_string: "Stacktrace (most recent call last):\n\n  File \"foo\"\n  File \"bar\""

--- a/tests/sentry/event_manager/interfaces/test_stacktrace.py
+++ b/tests/sentry/event_manager/interfaces/test_stacktrace.py
@@ -117,7 +117,7 @@ def test_to_string_returns_stacktrace(make_stacktrace_snapshot):
 
 
 @mock.patch("sentry.interfaces.stacktrace.is_newest_frame_first", mock.Mock(return_value=False))
-def test_get_stacktrace_with_only_filename():
+def test_get_stacktrace_with_only_filename(make_stacktrace_snapshot):
     make_stacktrace_snapshot(dict(frames=[{"filename": "foo"}, {"filename": "bar"}]))
 
 

--- a/tests/sentry/event_manager/interfaces/test_stacktrace.py
+++ b/tests/sentry/event_manager/interfaces/test_stacktrace.py
@@ -28,7 +28,6 @@ def test_works_with_empty_filename():
     assert result == [(0, "hello world")]
 
 
-@pytest.fixture
 def make_stacktrace_snapshot(insta_snapshot):
     def inner(data):
         mgr = EventManager(data={"stacktrace": data})
@@ -49,7 +48,7 @@ def make_stacktrace_snapshot(insta_snapshot):
     return inner
 
 
-def test_basic(make_stacktrace_snapshot):
+def test_basic():
     make_stacktrace_snapshot(
         dict(
             frames=[
@@ -61,41 +60,41 @@ def test_basic(make_stacktrace_snapshot):
 
 
 @pytest.mark.parametrize("input", [{"frames": [{}]}, {"frames": [{"abs_path": None}]}])
-def test_null_values_in_frames(make_stacktrace_snapshot, input):
+def test_null_values_in_frames(input):
     make_stacktrace_snapshot(input)
 
 
-def test_filename(make_stacktrace_snapshot):
+def test_filename():
     make_stacktrace_snapshot(dict(frames=[{"filename": "foo.py"}]))
 
 
-def test_filename2(make_stacktrace_snapshot):
+def test_filename2():
     make_stacktrace_snapshot(dict(frames=[{"lineno": 1, "filename": "foo.py"}]))
 
 
-def test_allows_abs_path_without_filename(make_stacktrace_snapshot):
+def test_allows_abs_path_without_filename():
     make_stacktrace_snapshot(dict(frames=[{"lineno": 1, "abs_path": "foo/bar/baz.py"}]))
 
 
-def test_coerces_url_filenames(make_stacktrace_snapshot):
+def test_coerces_url_filenames():
     make_stacktrace_snapshot(dict(frames=[{"lineno": 1, "filename": "http://foo.com/foo.js"}]))
 
 
-def test_does_not_overwrite_filename(make_stacktrace_snapshot):
+def test_does_not_overwrite_filename():
     make_stacktrace_snapshot(
         dict(frames=[{"lineno": 1, "filename": "foo.js", "abs_path": "http://foo.com/foo.js"}])
     )
 
 
-def test_ignores_results_with_empty_path(make_stacktrace_snapshot):
+def test_ignores_results_with_empty_path():
     make_stacktrace_snapshot(dict(frames=[{"lineno": 1, "filename": "http://foo.com"}]))
 
 
-def test_serialize_returns_frames(make_stacktrace_snapshot):
+def test_serialize_returns_frames():
     make_stacktrace_snapshot(dict(frames=[{"lineno": 1, "filename": "foo.py"}]))
 
 
-def test_frame_hard_limit(make_stacktrace_snapshot):
+def test_frame_hard_limit():
     hard_limit = settings.SENTRY_STACKTRACE_FRAMES_HARD_LIMIT
     make_stacktrace_snapshot(
         {
@@ -112,7 +111,7 @@ def test_frame_hard_limit(make_stacktrace_snapshot):
 
 
 @mock.patch("sentry.interfaces.stacktrace.Stacktrace.get_stacktrace", mock.Mock(return_value="foo"))
-def test_to_string_returns_stacktrace(make_stacktrace_snapshot):
+def test_to_string_returns_stacktrace():
     make_stacktrace_snapshot(dict(frames=[]))
 
 
@@ -122,12 +121,12 @@ def test_get_stacktrace_with_only_filename():
 
 
 @mock.patch("sentry.interfaces.stacktrace.is_newest_frame_first", mock.Mock(return_value=False))
-def test_get_stacktrace_with_module(make_stacktrace_snapshot):
+def test_get_stacktrace_with_module():
     make_stacktrace_snapshot(dict(frames=[{"module": "foo"}, {"module": "bar"}]))
 
 
 @mock.patch("sentry.interfaces.stacktrace.is_newest_frame_first", mock.Mock(return_value=False))
-def test_get_stacktrace_with_filename_and_function(make_stacktrace_snapshot):
+def test_get_stacktrace_with_filename_and_function():
     make_stacktrace_snapshot(
         dict(
             frames=[{"filename": "foo", "function": "biz"}, {"filename": "bar", "function": "baz"}]
@@ -136,7 +135,7 @@ def test_get_stacktrace_with_filename_and_function(make_stacktrace_snapshot):
 
 
 @mock.patch("sentry.interfaces.stacktrace.is_newest_frame_first", mock.Mock(return_value=False))
-def test_get_stacktrace_with_filename_function_lineno_and_context(make_stacktrace_snapshot):
+def test_get_stacktrace_with_filename_function_lineno_and_context():
     make_stacktrace_snapshot(
         dict(
             frames=[

--- a/tests/sentry/event_manager/interfaces/test_stacktrace.py
+++ b/tests/sentry/event_manager/interfaces/test_stacktrace.py
@@ -28,6 +28,7 @@ def test_works_with_empty_filename():
     assert result == [(0, "hello world")]
 
 
+@pytest.fixture
 def make_stacktrace_snapshot(insta_snapshot):
     def inner(data):
         mgr = EventManager(data={"stacktrace": data})
@@ -48,7 +49,7 @@ def make_stacktrace_snapshot(insta_snapshot):
     return inner
 
 
-def test_basic():
+def test_basic(make_stacktrace_snapshot):
     make_stacktrace_snapshot(
         dict(
             frames=[
@@ -60,41 +61,41 @@ def test_basic():
 
 
 @pytest.mark.parametrize("input", [{"frames": [{}]}, {"frames": [{"abs_path": None}]}])
-def test_null_values_in_frames(input):
+def test_null_values_in_frames(make_stacktrace_snapshot, input):
     make_stacktrace_snapshot(input)
 
 
-def test_filename():
+def test_filename(make_stacktrace_snapshot):
     make_stacktrace_snapshot(dict(frames=[{"filename": "foo.py"}]))
 
 
-def test_filename2():
+def test_filename2(make_stacktrace_snapshot):
     make_stacktrace_snapshot(dict(frames=[{"lineno": 1, "filename": "foo.py"}]))
 
 
-def test_allows_abs_path_without_filename():
+def test_allows_abs_path_without_filename(make_stacktrace_snapshot):
     make_stacktrace_snapshot(dict(frames=[{"lineno": 1, "abs_path": "foo/bar/baz.py"}]))
 
 
-def test_coerces_url_filenames():
+def test_coerces_url_filenames(make_stacktrace_snapshot):
     make_stacktrace_snapshot(dict(frames=[{"lineno": 1, "filename": "http://foo.com/foo.js"}]))
 
 
-def test_does_not_overwrite_filename():
+def test_does_not_overwrite_filename(make_stacktrace_snapshot):
     make_stacktrace_snapshot(
         dict(frames=[{"lineno": 1, "filename": "foo.js", "abs_path": "http://foo.com/foo.js"}])
     )
 
 
-def test_ignores_results_with_empty_path():
+def test_ignores_results_with_empty_path(make_stacktrace_snapshot):
     make_stacktrace_snapshot(dict(frames=[{"lineno": 1, "filename": "http://foo.com"}]))
 
 
-def test_serialize_returns_frames():
+def test_serialize_returns_frames(make_stacktrace_snapshot):
     make_stacktrace_snapshot(dict(frames=[{"lineno": 1, "filename": "foo.py"}]))
 
 
-def test_frame_hard_limit():
+def test_frame_hard_limit(make_stacktrace_snapshot):
     hard_limit = settings.SENTRY_STACKTRACE_FRAMES_HARD_LIMIT
     make_stacktrace_snapshot(
         {
@@ -111,7 +112,7 @@ def test_frame_hard_limit():
 
 
 @mock.patch("sentry.interfaces.stacktrace.Stacktrace.get_stacktrace", mock.Mock(return_value="foo"))
-def test_to_string_returns_stacktrace():
+def test_to_string_returns_stacktrace(make_stacktrace_snapshot):
     make_stacktrace_snapshot(dict(frames=[]))
 
 
@@ -121,12 +122,12 @@ def test_get_stacktrace_with_only_filename():
 
 
 @mock.patch("sentry.interfaces.stacktrace.is_newest_frame_first", mock.Mock(return_value=False))
-def test_get_stacktrace_with_module():
+def test_get_stacktrace_with_module(make_stacktrace_snapshot):
     make_stacktrace_snapshot(dict(frames=[{"module": "foo"}, {"module": "bar"}]))
 
 
 @mock.patch("sentry.interfaces.stacktrace.is_newest_frame_first", mock.Mock(return_value=False))
-def test_get_stacktrace_with_filename_and_function():
+def test_get_stacktrace_with_filename_and_function(make_stacktrace_snapshot):
     make_stacktrace_snapshot(
         dict(
             frames=[{"filename": "foo", "function": "biz"}, {"filename": "bar", "function": "baz"}]
@@ -135,7 +136,7 @@ def test_get_stacktrace_with_filename_and_function():
 
 
 @mock.patch("sentry.interfaces.stacktrace.is_newest_frame_first", mock.Mock(return_value=False))
-def test_get_stacktrace_with_filename_function_lineno_and_context():
+def test_get_stacktrace_with_filename_function_lineno_and_context(make_stacktrace_snapshot):
     make_stacktrace_snapshot(
         dict(
             frames=[


### PR DESCRIPTION
This bumps the following in preparation for python3:

- pytest to 4.6.5 (2.7 LTS and last compatible version)
- pytest-html to 1.22.0 (last 2.7 compatible version)
- pytest-django to 3.5.1 (latest version, still compat with pytest 4.x)

I also moved "tests requirements" to dev, since they're pretty much redundant.