### PR TITLE
fix(ui): Fix `cursorPoller` when no data

### DIFF
--- a/src/sentry/static/sentry/app/utils/cursorPoller.jsx
+++ b/src/sentry/static/sentry/app/utils/cursorPoller.jsx
@@ -50,7 +50,7 @@ class CursorPoller {
         }
 
         // if theres no data, nothing changes
-        if (!data.length) {
+        if (!data || !data.length) {
           this._reqsWithoutData += 1;
           return;
         }


### PR DESCRIPTION
We check `data.length` when `data` can sometimes be undefined.

Fixes JAVASCRIPT-1JXS