### PR TITLE
fix(ui): Fix `GuideStore` handling empty responses [SEN-1159]

### DIFF
--- a/src/sentry/static/sentry/app/stores/guideStore.jsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.jsx
@@ -57,12 +57,18 @@ const GuideStore = Reflux.createStore({
     this.updateCurrentGuide();
   },
 
-  onChangeOrgSlug(prev, next) {
+  onChangeOrgSlug(_prev, next) {
     this.state.org = next;
     this.updateCurrentGuide();
   },
 
   onFetchSucceeded(data) {
+    // It's possible we can get empty responses (seems to be Firefox specific)
+    // Do nothing if `data` is empty
+    if (!data) {
+      return;
+    }
+
     this.state.guides = data;
     this.updateCurrentGuide();
   },


### PR DESCRIPTION
This fixes `GuideStore` handling empty/invalid responses. We should do
nothing if we do not have any data.

Fixes JAVASCRIPT-1AKA
Fixes SEN-1159