### PR TITLE
fix(ui): Fix `<EventsTable>` for events without a user [SEN-1160]

### DIFF
--- a/src/sentry/static/sentry/app/views/events/events.jsx
+++ b/src/sentry/static/sentry/app/views/events/events.jsx
@@ -125,6 +125,11 @@ class Events extends AsyncView {
   onRequestSuccess({data, jqXHR}) {
     const {organization} = this.props;
 
+    // TODO: This is actually not optimal because `AsyncComponent.handleRequestSuccess`
+    // still gets called and updates state when the response may not be what the component
+    // expects.
+    //
+    // Ideally when a direct hit is found, we should not update state in `handleRequestSuccess`
     if (jqXHR.getResponseHeader('X-Sentry-Direct-Hit') === '1') {
       const event = data[0];
       const project = organization.projects.find(p => p.id === event.projectID);

--- a/src/sentry/static/sentry/app/views/events/eventsTable.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsTable.jsx
@@ -51,7 +51,9 @@ class EventsTableBody extends React.PureComponent {
           </TableData>
 
           <TableData>
-            <IdBadge user={event.user} hideEmail avatarSize={16} />
+            {event && event.user && (
+              <IdBadge user={event.user} hideEmail avatarSize={16} />
+            )}
           </TableData>
 
           <TableData>


### PR DESCRIPTION
Fixes the case where you search for an event id in "Events" and you get a direct hit for an issue whose event has no user.

Ideally we do not update Events list when we get a direct hit, but because of `AsyncComponent` and class properties, we cannot easily do this.

Fixes SEN-1160
Fixes JAVASCRIPT-1GZ5