### PR TITLE
feat(api): Monkeypatch Django Migrations to have various safety features

### DIFF
--- a/src/sentry/new_migrations/django_19_executor/__init__.py
+++ b/src/sentry/new_migrations/django_19_executor/__init__.py
@@ -1,17 +1,1 @@
 from __future__ import absolute_import
-
-from django import VERSION
-from django.db.migrations import executor, migration
-
-from sentry.new_migrations.django_19_executor.django import Django19MigrationExecutor
-
-# XXX: We're calling this `new_migrations` for the moment. Calling it `migrations`
-# causes Django migrations to attempt to load the new style migrations. Once we've got
-# everything in place and are ready to switch we'll rename this module.
-
-
-# Monkeypatch Django 1.8 migration executor to use the much faster version
-# from Django 1.9.1.
-if VERSION[:2] < (1, 9):
-    executor.MigrationExecutor = Django19MigrationExecutor
-    migration.Migration.initial = None

--- a/src/sentry/new_migrations/monkey/__init__.py
+++ b/src/sentry/new_migrations/monkey/__init__.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+
+from django import VERSION
+
+from sentry.new_migrations.monkey.executor import SentryMigrationExecutor
+from sentry.new_migrations.monkey.writer import SENTRY_MIGRATION_TEMPLATE
+
+from django.db.migrations import migration, executor, writer
+
+LAST_VERIFIED_DJANGO_VERSION = (1, 8)
+CHECK_MESSAGE = """Looks like you're trying to upgrade Django! Since we monkeypatch
+the Django migration library in several places, please verify that we have the latest
+code, and that the monkeypatching still works as expected. Currently the main things
+to check are:
+ - `django.db.migrations.executor.MigrationExecutor`. The `is_dangerous` flag should
+   continue to work here when we set `MIGRATION_SKIP_DANGEROUS=1` as an environment
+   variable. Confirm that the structure of the class hasn't drastically changed.
+- `django.db.migrations.writer.MIGRATION_TEMPLATE`. Verify that the template hasn't
+  significantly changed. Details on what we've changed are in a comment on
+  `sentry.migrations.monkey.writer.SENTRY_MIGRATION_TEMPLATE`
+
+When you're happy that these changes are good to go, update
+`LAST_VERIFIED_DJANGO_VERSION` to the version of Django you're upgrading to. If the
+changes are backwards incompatible, change the monkeying to handle both versions.
+"""
+
+if VERSION[:2] > LAST_VERIFIED_DJANGO_VERSION:
+    raise Exception(CHECK_MESSAGE)
+
+# Monkeypatch Django 1.8 migration executor to use the much faster version
+# from Django 1.9.1. We'll continue to monkeypatch once we're on 1.9.1, just a smaller
+# set of functionality
+executor.MigrationExecutor = SentryMigrationExecutor
+migration.Migration.initial = None
+writer.MIGRATION_TEMPLATE = SENTRY_MIGRATION_TEMPLATE

--- a/src/sentry/new_migrations/monkey/executor.py
+++ b/src/sentry/new_migrations/monkey/executor.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+
+import logging
+import os
+
+from sentry.new_migrations.django_19_executor.django import Django19MigrationExecutor
+
+logger = logging.getLogger(__name__)
+
+
+class SentryMigrationExecutor(Django19MigrationExecutor):
+    # TODO: Once we're on Django 1.9, just inherit from
+    # `django.db.migrations.executor.MigrationExecutor`
+
+    def _check_fake(self, migration, fake):
+        if (
+            os.environ.get("MIGRATION_SKIP_DANGEROUS", "0") == "1"
+            or os.environ.get("SOUTH_SKIP_DANGEROUS", "0") == "1"
+        ) and getattr(migration, "is_dangerous", False):
+            # If we plan to skip migrations we just set `fake` to True here. This causes
+            # Django to skip running the migration, but records the row as expected.
+            fake = True
+            logger.warning("(too dangerous)")
+        return fake
+
+    def apply_migration(self, state, migration, fake=False, fake_initial=False):
+        fake = self._check_fake(migration, fake)
+        return super(SentryMigrationExecutor, self).apply_migration(
+            state, migration, fake=fake, fake_initial=fake_initial
+        )
+
+    def unapply_migration(self, state, migration, fake=False):
+        fake = self._check_fake(migration, fake)
+        return super(SentryMigrationExecutor, self).unapply_migration(state, migration, fake=fake)

--- a/src/sentry/new_migrations/monkey/writer.py
+++ b/src/sentry/new_migrations/monkey/writer.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+
+# This should be exactly the same as `django.db.migrations.writer.py.MIGRATION_TEMPLATE`,
+# except that we add
+# - `atomic = False`
+# - `is_dangerous = False`
+# to the class definition. Compare this template after each Django version bump to make
+# sure we're not missing any important changes.
+SENTRY_MIGRATION_TEMPLATE = """\
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+%(imports)s
+
+class Migration(migrations.Migration):
+    # This flag is used to mark that a migration shouldn't be automatically run in
+    # production. We set this to True for operations that we think are risky and want
+    # someone from ops to run manually and monitor.
+    # General advice is that if in doubt, mark your migration as `is_dangerous`.
+    # Some things you should always mark as dangerous:
+    # - Adding indexes to large tables. These indexes should be created concurrently,
+    #   unfortunately we can't run migrations outside of a transaction until Django
+    #   1.10. So until then these should be run manually.
+    # - Large data migrations. Typically we want these to be run manually by ops so that
+    #   they can be monitored. Since data migrations will now hold a transaction open
+    #   this is even more important.
+    # - Adding columns to highly active tables, even ones that are NULL.
+    is_dangerous = False
+
+%(replaces_str)s
+    dependencies = [
+%(dependencies)s\
+    ]
+
+    operations = [
+%(operations)s\
+    ]
+"""

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -406,7 +406,7 @@ def fix_south(settings):
 def monkeypatch_django_migrations():
     # This monkey patches the django 1.8 migration executor with a backported 1.9
     # executor. This improves the speed that Django builds the migration state.
-    import sentry.new_migrations.django_19_executor  # NOQA
+    import sentry.new_migrations.monkey  # NOQA
 
 
 def bind_cache_to_option_store():


### PR DESCRIPTION
This monkeypatches change migrations as follows:
 - Support `is_dangerous` in the same way we do in south. This skips migrations that have
   `is_dangerous` set to True when the `MIGRATION_SKIP_DANGEROUS` or `SOUTH_SKIP_DANGEROUS` env
   variables are set

Also causes an exception with a helpful error message to be raised if someone tries to run this code in a 
newer version of django. This is to help remind people to check the monkeypatches don't get broken 
between versions.