### PR TITLE
fix(ui): Fix `<PasswordField>` calling `setState()` in constructor

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/passwordField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/passwordField.tsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import InputField from 'app/components/forms/inputField';
 import FormState from 'app/components/forms/state';
+import {Context} from 'app/components/forms/form';
 
 type Props = InputField['props'] & {
   hasSavedValue?: boolean;
@@ -28,11 +29,11 @@ export default class PasswordField extends InputField<Props, State> {
     prefix: '',
   };
 
-  state = {
-    editing: false,
-    value: this.props.value || '',
-    error: null,
-  };
+  constructor(props: Props, context: Context) {
+    super(props, context);
+
+    this.state = {...this.state, editing: false};
+  }
 
   componentWillReceiveProps(nextProps: Props) {
     // close edit mode after successful save

--- a/src/sentry/static/sentry/app/components/forms/passwordField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/passwordField.tsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import InputField from 'app/components/forms/inputField';
 import FormState from 'app/components/forms/state';
-import {Context} from 'app/components/forms/form';
 
 type Props = InputField['props'] & {
   hasSavedValue?: boolean;
@@ -29,11 +28,11 @@ export default class PasswordField extends InputField<Props, State> {
     prefix: '',
   };
 
-  constructor(props: Props, context: Context) {
-    super(props, context);
-
-    this.setState({editing: false});
-  }
+  state = {
+    editing: false,
+    value: '',
+    error: null,
+  };
 
   componentWillReceiveProps(nextProps: Props) {
     // close edit mode after successful save

--- a/src/sentry/static/sentry/app/components/forms/passwordField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/passwordField.tsx
@@ -30,7 +30,7 @@ export default class PasswordField extends InputField<Props, State> {
 
   state = {
     editing: false,
-    value: '',
+    value: this.props.value || '',
     error: null,
   };
 


### PR DESCRIPTION
This is throwing React warnings in our tests due to using `setState` in the
constructor. We should add an eslint rule for this.