### PR TITLE
fix(ui): Add role to organization for attachment check

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -192,6 +192,8 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
             }
         )
         context["access"] = access.scopes
+        if access.role is not None:
+            context["role"] = access.role
         context["pendingAccessRequests"] = OrganizationAccessRequest.objects.filter(
             team__organization=obj
         ).count()

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -182,6 +182,7 @@ class Access(BaseAccess):
         sso_is_valid,
         requires_sso,
         permissions=None,
+        role=None,
     ):
         self.organization_id = organization_id
         self.teams = teams
@@ -190,6 +191,8 @@ class Access(BaseAccess):
         self.scopes = scopes
         if permissions is not None:
             self.permissions = permissions
+        if role is not None:
+            self.role = role
 
         self.is_active = is_active
         self.sso_is_valid = sso_is_valid
@@ -272,6 +275,7 @@ def from_request(request, organization=None, scopes=None):
         return from_sentry_app(request.user, organization=organization)
 
     if is_active_superuser(request):
+        role = None
         # we special case superuser so that if they're a member of the org
         # they must still follow SSO checks, but they gain global access
         try:
@@ -280,6 +284,7 @@ def from_request(request, organization=None, scopes=None):
             requires_sso, sso_is_valid = False, True
         else:
             requires_sso, sso_is_valid = _sso_params(member)
+            role = member.role
 
         team_list = ()
 
@@ -294,6 +299,7 @@ def from_request(request, organization=None, scopes=None):
             requires_sso=requires_sso,
             has_global_access=True,
             permissions=UserPermission.for_user(request.user.id),
+            role=role,
         )
 
     if hasattr(request, "auth") and not request.user.is_authenticated():
@@ -373,6 +379,7 @@ def from_member(member, scopes=None):
         has_global_access=bool(member.organization.flags.allow_joinleave)
         or roles.get(member.role).is_global,
         permissions=UserPermission.for_user(member.user_id),
+        role=member.role,
     )
 
 

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -80,6 +80,7 @@ class BaseAccess(object):
     has_global_access = False
     scopes = frozenset()
     permissions = frozenset()
+    role = None
 
     def has_permission(self, permission):
         """

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -34,6 +34,7 @@ export type OrganizationDetailed = Organization & {
   scrubIPAddresses: boolean;
   scrapeJavaScript: boolean;
   trustedRelays: string[];
+  role?: string;
 };
 
 export type Project = {

--- a/src/sentry/static/sentry/app/utils/attachmentUrl.tsx
+++ b/src/sentry/static/sentry/app/utils/attachmentUrl.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import {OrganizationDetailed, Event, EventAttachment} from 'app/types';
 import ConfigStore from 'app/stores/configStore';
-import MemberListStore from 'app/stores/memberListStore';
 import withOrganization from 'app/utils/withOrganization';
 import SentryTypes from 'app/sentryTypes';
 
@@ -34,17 +33,14 @@ class AttachmentUrl extends React.PureComponent<Props> {
       return true;
     }
 
-    const {availableRoles, attachmentsRole} = this.props.organization;
+    const {availableRoles, attachmentsRole, role} = this.props.organization;
     if (!Array.isArray(availableRoles)) {
       return false;
     }
 
-    const member = MemberListStore.getById(user.id);
-    const currentRole = member && member.role;
-
-    const roleIds = availableRoles.map(role => role.id);
+    const roleIds = availableRoles.map(r => r.id);
     const requiredIndex = roleIds.indexOf(attachmentsRole);
-    const currentIndex = roleIds.indexOf(currentRole);
+    const currentIndex = roleIds.indexOf(role || '');
     return currentIndex >= requiredIndex;
   }
 

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -38,6 +38,7 @@ class OrganizationDetailsTest(APITestCase):
         assert response.data["onboardingTasks"] == []
         assert response.status_code == 200, response.content
         assert response.data["id"] == six.text_type(org.id)
+        assert response.data["role"] == "owner"
         assert len(response.data["teams"]) == 0
         assert len(response.data["projects"]) == 0
 


### PR DESCRIPTION
This is a revisit of #14951. Manager and Owner users do not need to be part of any team to have access to an organization's entities, but the UI did not grant it in some cases. One example was the attachment download:

![image](https://user-images.githubusercontent.com/1433023/66207365-e14d0880-e6b2-11e9-95a9-aa6b4e92f57d.png)

We now serialize the user's role in the `Organization` details endpoint (next to `access` scopes), so that UI components have access to it.

Fixes ISSUE-504