### PR TITLE
fix(discover2) Clear sidebar menu on selection

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
@@ -152,38 +152,41 @@ class Discover2Item extends React.Component<Props, State> {
     return (
       <nav {...navProps}>
         {sidebarItem}
-        <AutoComplete
-          inputIsActor={false}
-          itemToString={item => item.name}
-          isOpen={isOpen}
-          onSelect={this.handleSelect}
-          resetInputOnClose
-        >
-          {({getInputProps, getItemProps, inputValue, highlightedIndex}) => {
-            return (
-              <Hitbox role="menu" id={this.menuId} isOpen={isOpen}>
-                <InputContainer>
-                  <StyledLabel htmlFor={inputId}>
-                    <InlineSvg src="icon-search" size="16" />
-                  </StyledLabel>
-                  <StyledInput
-                    type="text"
-                    id={inputId}
-                    placeholder={t('Filter searches')}
-                    {...getInputProps({})}
-                  />
-                </InputContainer>
-                <Menu>
-                  {this.renderSavedQueries({
-                    getItemProps,
-                    inputValue,
-                    highlightedIndex,
-                  })}
-                </Menu>
-              </Hitbox>
-            );
-          }}
-        </AutoComplete>
+        {isOpen && (
+          <AutoComplete
+            inputIsActor={false}
+            itemToString={(item: SavedQuery) => item.name}
+            onSelect={this.handleSelect}
+            isOpen
+            closeOnSelect
+            resetInputOnClose
+          >
+            {({getInputProps, getItemProps, inputValue, highlightedIndex}) => {
+              return (
+                <Hitbox role="menu" id={this.menuId} isOpen={isOpen}>
+                  <InputContainer>
+                    <StyledLabel htmlFor={inputId}>
+                      <InlineSvg src="icon-search" size="16" />
+                    </StyledLabel>
+                    <StyledInput
+                      type="text"
+                      id={inputId}
+                      placeholder={t('Filter searches')}
+                      {...getInputProps({})}
+                    />
+                  </InputContainer>
+                  <Menu>
+                    {this.renderSavedQueries({
+                      getItemProps,
+                      inputValue,
+                      highlightedIndex,
+                    })}
+                  </Menu>
+                </Hitbox>
+              );
+            }}
+          </AutoComplete>
+        )}
       </nav>
     );
   }

--- a/tests/js/spec/components/sidebar/discover2Item.spec.jsx
+++ b/tests/js/spec/components/sidebar/discover2Item.spec.jsx
@@ -55,16 +55,16 @@ describe('Sidebar > Discover2Item', function() {
     DiscoverSavedQueriesStore.reset();
   });
 
-  it('renders a menu', async function() {
+  it('renders no menu when closed', async function() {
     const wrapper = makeWrapper({organization, client});
     // Wait for reflux
     await tick();
 
     const menu = wrapper.find('AutoComplete');
-    expect(menu).toHaveLength(1);
+    expect(menu).toHaveLength(0);
   });
 
-  it('opens the menu', async function() {
+  it('opens the menu on mouseEnter', async function() {
     const wrapper = makeWrapper({organization, client});
     // Wait for reflux
     await tick();


### PR DESCRIPTION
The sidebar autocomplete should reset its state after navigation, or on hide. Because of how AutoComplete works in a 'controlled' mode this is most simply achieved by removing it from the render tree.

Fixes SEN-1142