### PR TITLE
fix(discover2) Remove padding in discover results

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -11,7 +11,6 @@ import UserBadge from 'app/components/idBadge/userBadge';
 import getDynamicText from 'app/utils/getDynamicText';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import pinIcon from 'app/../images/location-pin.png';
-import space from 'app/styles/space';
 import {EventViewv1, Organization} from 'app/types';
 
 import {QueryLink} from './styles';
@@ -459,12 +458,10 @@ export const SPECIAL_FIELDS: SpecialFields = {
 export const AUTOLINK_FIELDS: string[] = ['transaction', 'title'];
 
 const Container = styled('div')`
-  padding: ${space(1)};
   ${overflowEllipsis};
 `;
 
 const NumberContainer = styled('div')`
-  padding: ${space(1)};
   text-align: right;
   ${overflowEllipsis};
 `;


### PR DESCRIPTION
Reduce the padding on the table to get higher information density on smaller displays.

## Before
![Screen Shot 2019-10-03 at 4 51 25 PM](https://user-images.githubusercontent.com/24086/66520398-17c1c380-eab7-11e9-96e2-76a7a36c62b4.png)

## Now
![Screen Shot 2019-10-09 at 4 56 40 PM](https://user-images.githubusercontent.com/24086/66520424-21e3c200-eab7-11e9-98c6-641895a9d94f.png)

