### PR TITLE
feat(outcomes): TSDB queries snuba for outcomes

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -852,6 +852,36 @@ class SnubaTestCase(BaseTestCase):
         )
 
 
+@pytest.mark.snuba
+@requires_snuba
+class OutcomesSnubaTest(TestCase):
+    def setUp(self):
+        super(OutcomesSnubaTest, self).setUp()
+        assert requests.post(settings.SENTRY_SNUBA + "/tests/outcomes/drop").status_code == 200
+
+    def __format(self, org_id, project_id, outcome, timestamp):
+        return {
+            "project_id": project_id,
+            "timestamp": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "org_id": org_id,
+            "reason": None,
+            "key_id": 1,
+            "outcome": outcome,
+        }
+
+    def store_outcomes(self, org_id, project_id, outcome, timestamp, num_times):
+        outcomes = []
+        for _ in range(num_times):
+            outcomes.append(self.__format(org_id, project_id, outcome, timestamp))
+
+        assert (
+            requests.post(
+                settings.SENTRY_SNUBA + "/tests/outcomes/insert", data=json.dumps(outcomes)
+            ).status_code
+            == 200
+        )
+
+
 class IntegrationRepositoryTestCase(APITestCase):
     def setUp(self):
         super(IntegrationRepositoryTestCase, self).setUp()

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -10,7 +10,7 @@ from sentry.utils.dates import to_datetime
 
 
 SnubaModelSettings = collections.namedtuple(
-    "SnubaModelSettings", ["group", "aggregate", "dataset", "aggregate_function", "conditions"]
+    "SnubaModelSettings", ["groupby", "aggregate", "dataset", "aggregate_function", "conditions"]
 )
 
 
@@ -127,7 +127,7 @@ class SnubaTSDB(BaseTSDB):
         if model_columns is None:
             raise Exception(u"Unsupported TSDBModel: {}".format(model.name))
 
-        model_group = model_columns.group
+        model_group = model_columns.groupby
         model_aggregate = model_columns.aggregate
 
         groupby = []

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -182,8 +182,7 @@ class SnubaError(Exception):
 
 class UnqualifiedQueryError(SnubaError):
     """
-    Exception raised when no project_id qualifications were provided in the
-    query or could be derived from other filter criteria.
+    Exception raised when a required qualification was not satisfied in the query.
     """
 
 
@@ -644,70 +643,7 @@ def transform_aliases_and_query(skip_conditions=False, **kwargs):
     return result
 
 
-def _prepare_query_params_outcomes(query_params):
-    # convert to naive UTC datetimes, as Snuba only deals in UTC
-    # and this avoids offset-naive and offset-aware issues
-    start = naiveify_datetime(query_params.start)
-    end = naiveify_datetime(query_params.end)
-
-    with timer("get_snuba_map"):
-        forward, reverse = get_snuba_translators(
-            query_params.filter_keys, is_grouprelease=query_params.is_grouprelease
-        )
-
-    if "project_id" in query_params.filter_keys:
-        project_ids = list(set(query_params.filter_keys["project_id"]))
-        project = Project.objects.get(pk=project_ids[0])
-        organization_id = project.organization_id
-    elif "org_id" in query_params.filter_keys:
-        organization_id = list(set(query_params.filter_keys["org_id"]))[0]
-    else:
-        raise UnqualifiedQueryError("No project_id, nor org_id found.")
-
-    for col, keys in six.iteritems(forward(deepcopy(query_params.filter_keys))):
-        if keys:
-            if len(keys) == 1 and None in keys:
-                query_params.conditions.append((col, "IS NULL", None))
-            else:
-                query_params.conditions.append((col, "IN", keys))
-
-    retention = quotas.get_event_retention(organization=Organization(organization_id))
-    if retention:
-        start = max(start, datetime.utcnow() - timedelta(days=retention))
-        if start > end:
-            raise QueryOutsideRetentionError
-
-    if start > end:
-        raise QueryOutsideGroupActivityError
-
-    query_params.kwargs.update(
-        {
-            "dataset": query_params.dataset.value,
-            "from_date": start.isoformat(),
-            "to_date": end.isoformat(),
-            "groupby": query_params.groupby,
-            "conditions": query_params.conditions,
-            "aggregations": query_params.aggregations,
-            "granularity": query_params.rollup,  # TODO name these things the same
-        }
-    )
-    kwargs = {k: v for k, v in six.iteritems(query_params.kwargs) if v is not None}
-
-    kwargs.update(OVERRIDE_OPTIONS)
-    return kwargs, forward, reverse
-
-
-def _prepare_query_params_with_project(query_params):
-    # convert to naive UTC datetimes, as Snuba only deals in UTC
-    # and this avoids offset-naive and offset-aware issues
-    start = naiveify_datetime(query_params.start)
-    end = naiveify_datetime(query_params.end)
-
-    with timer("get_snuba_map"):
-        forward, reverse = get_snuba_translators(
-            query_params.filter_keys, is_grouprelease=query_params.is_grouprelease
-        )
-
+def get_query_params_to_update_for_projects(query_params):
     if "project_id" in query_params.filter_keys:
         # If we are given a set of project ids, use those directly.
         project_ids = list(set(query_params.filter_keys["project_id"]))
@@ -722,6 +658,59 @@ def _prepare_query_params_with_project(query_params):
     else:
         project_ids = []
 
+    if not project_ids:
+        raise UnqualifiedQueryError(
+            "No project_id filter, or none could be inferred from other filters."
+        )
+
+    organization_id = Project.objects.get(pk=project_ids[0]).organization_id
+
+    return organization_id, {"project": project_ids}
+
+
+def get_query_params_to_update_for_organizations(query_params):
+    if "org_id" in query_params.filter_keys:
+        organization_ids = list(set(query_params.filter_keys["org_id"]))
+        if len(organization_ids) != 1:
+            raise UnqualifiedQueryError("Multiple organization_ids found. Only one allowed.")
+        organization_id = organization_ids[0]
+    elif "project_id" in query_params.filter_keys:
+        project_ids = list(set(query_params.filter_keys["project_id"]))
+        project = Project.objects.get(pk=project_ids[0])
+        organization_id = project.organization_id
+    else:
+        organization_id = None
+
+    if not organization_id:
+        raise UnqualifiedQueryError(
+            "No organization_id filter, or none could be inferred from other filters."
+        )
+
+    return organization_id, {"organization": organization_id}
+
+
+def _prepare_query_params(query_params):
+    # convert to naive UTC datetimes, as Snuba only deals in UTC
+    # and this avoids offset-naive and offset-aware issues
+    start = naiveify_datetime(query_params.start)
+    end = naiveify_datetime(query_params.end)
+
+    with timer("get_snuba_map"):
+        forward, reverse = get_snuba_translators(
+            query_params.filter_keys, is_grouprelease=query_params.is_grouprelease
+        )
+
+    if query_params.dataset in [Dataset.Events, Dataset.Transactions]:
+        (organization_id, params_to_update) = get_query_params_to_update_for_projects(query_params)
+        query_params.kwargs.update(params_to_update)
+    elif query_params.dataset == Dataset.Outcomes:
+        (organization_id, params_to_update) = get_query_params_to_update_for_organizations(
+            query_params
+        )
+        query_params.kwargs.update(params_to_update)
+    else:
+        raise UnqualifiedQueryError("No organization found for querying")
+
     for col, keys in six.iteritems(forward(deepcopy(query_params.filter_keys))):
         if keys:
             if len(keys) == 1 and None in keys:
@@ -729,14 +718,8 @@ def _prepare_query_params_with_project(query_params):
             else:
                 query_params.conditions.append((col, "IN", keys))
 
-    if not project_ids:
-        raise UnqualifiedQueryError(
-            "No project_id filter, or none could be inferred from other filters."
-        )
-
     # any project will do, as they should all be from the same organization
-    project = Project.objects.get(pk=project_ids[0])
-    retention = quotas.get_event_retention(organization=Organization(project.organization_id))
+    retention = quotas.get_event_retention(organization=Organization(organization_id))
     if retention:
         start = max(start, datetime.utcnow() - timedelta(days=retention))
         if start > end:
@@ -766,7 +749,6 @@ def _prepare_query_params_with_project(query_params):
             "groupby": query_params.groupby,
             "conditions": query_params.conditions,
             "aggregations": query_params.aggregations,
-            "project": project_ids,
             "granularity": query_params.rollup,  # TODO name these things the same
         }
     )
@@ -774,18 +756,6 @@ def _prepare_query_params_with_project(query_params):
 
     kwargs.update(OVERRIDE_OPTIONS)
     return kwargs, forward, reverse
-
-
-DATASET_PREPARE_QUERY_MAPPING = {
-    Dataset.Events: _prepare_query_params_with_project,
-    Dataset.Transactions: _prepare_query_params_with_project,
-    Dataset.Outcomes: _prepare_query_params_outcomes,
-}
-
-
-def _prepare_query_params(query_params):
-    func = DATASET_PREPARE_QUERY_MAPPING.get(query_params.dataset)
-    return func(query_params)
 
 
 class SnubaQueryParams(object):

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -644,6 +644,10 @@ def transform_aliases_and_query(skip_conditions=False, **kwargs):
 
 
 def get_query_params_to_update_for_projects(query_params):
+    """
+    Get the project ID and query params that need to be updated for project
+    based datasets, before we send the query to Snuba.
+    """
     if "project_id" in query_params.filter_keys:
         # If we are given a set of project ids, use those directly.
         project_ids = list(set(query_params.filter_keys["project_id"]))
@@ -669,6 +673,10 @@ def get_query_params_to_update_for_projects(query_params):
 
 
 def get_query_params_to_update_for_organizations(query_params):
+    """
+    Get the organization ID and query params that need to be updated for organization
+    based datasets, before we send the query to Snuba.
+    """
     if "org_id" in query_params.filter_keys:
         organization_ids = list(set(query_params.filter_keys["org_id"]))
         if len(organization_ids) != 1:

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -684,9 +684,7 @@ def get_query_params_to_update_for_organizations(query_params):
             raise UnqualifiedQueryError("Multiple organization_ids found. Only one allowed.")
         organization_id = organization_ids[0]
     elif "project_id" in query_params.filter_keys:
-        project_ids = list(set(query_params.filter_keys["project_id"]))
-        project = Project.objects.get(pk=project_ids[0])
-        organization_id = project.organization_id
+        organization_id, _ = get_query_params_to_update_for_projects(query_params)
     else:
         organization_id = None
 

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -55,12 +55,10 @@ class SnubaTSDBTest(OutcomesSnubaTest):
                     assert count == 0
 
     def test_project_outcomes(self):
-        from time import sleep
-
         for tsdb_model, outcome in [
-            (TSDBModel.organization_total_received, Outcome.ACCEPTED),
-            (TSDBModel.organization_total_rejected, Outcome.RATE_LIMITED),
-            (TSDBModel.organization_total_blacklisted, Outcome.FILTERED),
+            (TSDBModel.project_total_received, Outcome.ACCEPTED),
+            (TSDBModel.project_total_rejected, Outcome.RATE_LIMITED),
+            (TSDBModel.project_total_blacklisted, Outcome.FILTERED),
         ]:
             self.store_outcomes(
                 self.organization.id, self.project.id, outcome.value, self.start_time, 3
@@ -68,8 +66,6 @@ class SnubaTSDBTest(OutcomesSnubaTest):
             self.store_outcomes(
                 self.organization.id, self.project.id, outcome.value, self.one_day_later, 4
             )
-
-            sleep(2)
 
             response = self.db.get_range(
                 tsdb_model, [self.project.id], self.start_time, self.now, 3600, None

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -40,10 +40,12 @@ class SnubaTSDBTest(OutcomesSnubaTest):
                 self.organization.id, self.project.id, outcome.value, self.one_day_later, 4
             )
 
+            # Query SnubaTSDB
             response = self.db.get_range(
                 tsdb_model, [self.organization.id], self.start_time, self.now, 3600, None
             )
 
+            # Assert that the response has values set for the times we expect, and nothing more
             assert self.organization.id in response.keys()
             response_dict = {k: v for (k, v) in response[self.organization.id]}
 
@@ -60,6 +62,7 @@ class SnubaTSDBTest(OutcomesSnubaTest):
             (TSDBModel.project_total_rejected, Outcome.RATE_LIMITED),
             (TSDBModel.project_total_blacklisted, Outcome.FILTERED),
         ]:
+            # Create all the outcomes we will be querying
             self.store_outcomes(
                 self.organization.id, self.project.id, outcome.value, self.start_time, 3
             )
@@ -67,10 +70,12 @@ class SnubaTSDBTest(OutcomesSnubaTest):
                 self.organization.id, self.project.id, outcome.value, self.one_day_later, 4
             )
 
+            # Query SnubaTSDB
             response = self.db.get_range(
                 tsdb_model, [self.project.id], self.start_time, self.now, 3600, None
             )
 
+            # Assert that the response has values set for the times we expect, and nothing more
             assert self.project.id in response.keys()
             response_dict = {k: v for (k, v) in response[self.project.id]}
 

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -1,0 +1,82 @@
+from __future__ import absolute_import
+
+import pytz
+from datetime import datetime, timedelta
+
+from sentry.testutils.cases import OutcomesSnubaTest
+from sentry.tsdb.base import TSDBModel
+from sentry.tsdb.snuba import SnubaTSDB
+from sentry.utils.outcomes import Outcome
+
+
+def to_epoch_time(value):
+    value = value.replace(minute=0, second=0, microsecond=0)
+    return int((value - datetime(1970, 1, 1, tzinfo=pytz.utc)).total_seconds())
+
+
+class SnubaTSDBTest(OutcomesSnubaTest):
+    def setUp(self):
+        super(SnubaTSDBTest, self).setUp()
+        self.db = SnubaTSDB()
+
+        # Set up the times
+        self.now = datetime.now(pytz.utc)
+        self.skew_days = 7
+        self.skew = timedelta(days=self.skew_days)
+        self.start_time = self.now - self.skew
+        self.one_day_later = self.start_time + timedelta(days=1)
+
+    def test_organization_outcomes(self):
+        for tsdb_model, outcome in [
+            (TSDBModel.organization_total_received, Outcome.ACCEPTED),
+            (TSDBModel.organization_total_rejected, Outcome.RATE_LIMITED),
+            (TSDBModel.organization_total_blacklisted, Outcome.FILTERED),
+        ]:
+            # Create all the outcomes we will be querying
+            self.store_outcomes(
+                self.organization.id, self.project.id, outcome.value, self.start_time, 3
+            )
+            self.store_outcomes(
+                self.organization.id, self.project.id, outcome.value, self.one_day_later, 4
+            )
+
+            response = self.db.get_range(
+                tsdb_model, [self.organization.id], self.start_time, self.now, 3600, None
+            )
+
+            assert self.organization.id in response.keys()
+            response_dict = {k: v for (k, v) in response[self.organization.id]}
+
+            assert response_dict[to_epoch_time(self.start_time)] == 3
+            assert response_dict[to_epoch_time(self.one_day_later)] == 4
+
+            for time, count in response[self.organization.id]:
+                if time not in [to_epoch_time(self.start_time), to_epoch_time(self.one_day_later)]:
+                    assert count == 0
+
+    def test_project_outcomes(self):
+        for tsdb_model, outcome in [
+            (TSDBModel.organization_total_received, Outcome.ACCEPTED),
+            (TSDBModel.organization_total_rejected, Outcome.RATE_LIMITED),
+            (TSDBModel.organization_total_blacklisted, Outcome.FILTERED),
+        ]:
+            self.store_outcomes(
+                self.organization.id, self.project.id, outcome.value, self.start_time, 3
+            )
+            self.store_outcomes(
+                self.organization.id, self.project.id, outcome.value, self.one_day_later, 4
+            )
+
+            response = self.db.get_range(
+                tsdb_model, [self.project.id], self.start_time, self.now, 3600, None
+            )
+
+            assert self.project.id in response.keys()
+            response_dict = {k: v for (k, v) in response[self.project.id]}
+
+            assert response_dict[to_epoch_time(self.start_time)] == 3
+            assert response_dict[to_epoch_time(self.one_day_later)] == 4
+
+            for time, count in response[self.project.id]:
+                if time not in [to_epoch_time(self.start_time), to_epoch_time(self.one_day_later)]:
+                    assert count == 0

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -55,6 +55,8 @@ class SnubaTSDBTest(OutcomesSnubaTest):
                     assert count == 0
 
     def test_project_outcomes(self):
+        from time import sleep
+
         for tsdb_model, outcome in [
             (TSDBModel.organization_total_received, Outcome.ACCEPTED),
             (TSDBModel.organization_total_rejected, Outcome.RATE_LIMITED),
@@ -66,6 +68,8 @@ class SnubaTSDBTest(OutcomesSnubaTest):
             self.store_outcomes(
                 self.organization.id, self.project.id, outcome.value, self.one_day_later, 4
             )
+
+            sleep(2)
 
             response = self.db.get_range(
                 tsdb_model, [self.project.id], self.start_time, self.now, 3600, None

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -620,7 +620,6 @@ class PrepareQueryParamsTest(TestCase):
         )
 
         kwargs, _, _ = _prepare_query_params(query_params)
-        assert "project" in kwargs
         assert kwargs["project"] == [self.project.id]
 
     def test_transactions_dataset_with_project_id(self):
@@ -629,7 +628,6 @@ class PrepareQueryParamsTest(TestCase):
         )
 
         kwargs, _, _ = _prepare_query_params(query_params)
-        assert "project" in kwargs
         assert kwargs["project"] == [self.project.id]
 
     def test_outcomes_dataset_with_org_id(self):
@@ -638,7 +636,6 @@ class PrepareQueryParamsTest(TestCase):
         )
 
         kwargs, _, _ = _prepare_query_params(query_params)
-        assert "organization" in kwargs
         assert kwargs["organization"] == self.organization.id
 
     def test_outcomes_dataset_with_no_org_id_given(self):


### PR DESCRIPTION
Outcomes are now being stored in Redis and Snuba. We want to move away from storing them in Redis and only store them in Snuba.

This PR allows Sentry to query Snuba for outcome related data. However, it does not get the final answer from Snuba because of the ServiceDelegator. It will still get the final answer from Redis. That's cause we want to run Redis and Snuba in parallel and check for differences.

https://github.com/getsentry/getsentry/pull/3237 will allow us to run a difference checker, which will check the results from both sources in a background thread. This PR is a dependency for the PR in getsentry.

## Test plan
* Unit tests
* By loading http://localhost:8000/organizations/sentry/stats/ locally