### PR TITLE
fix(make): ensure latest pip before pip installing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
   global:
     - NODE_ENV=development
     # PIP_VERSION causes issues because: https://github.com/pypa/pip/issues/4528
-    - PYTHON_PIP_VERSION=19.1.1
+    - PYTHON_PIP_VERSION=19.2.3
     - PIP_USE_PEP517=off
     - PIP_DISABLE_PIP_VERSION_CHECK=on
     - PIP_QUIET=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
   global:
     - NODE_ENV=development
     # PIP_VERSION causes issues because: https://github.com/pypa/pip/issues/4528
+    # Note: this has to be synced with the pip version in the Makefile.
     - PYTHON_PIP_VERSION=19.2.3
     - PIP_USE_PEP517=off
     - PIP_DISABLE_PIP_VERSION_CHECK=on

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ ifneq "$(wildcard /usr/local/opt/openssl/lib)" ""
 endif
 
 PIP := LDFLAGS="$(LDFLAGS)" python -m pip
+# Note: this has to be synced with the pip version in .travis.yml.
 PIP_VERSION := 19.2.3
 PIP_OPTS := --no-use-pep517 --disable-pip-version-check
 WEBPACK := NODE_ENV=production ./bin/yarn webpack

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,11 @@ ifneq "$(wildcard /usr/local/opt/openssl/lib)" ""
 	LDFLAGS += -L/usr/local/opt/openssl/lib
 endif
 
-PIP = LDFLAGS="$(LDFLAGS)" pip
-PIP_OPTS = --no-use-pep517 --disable-pip-version-check
-WEBPACK = NODE_ENV=production ./bin/yarn webpack
-YARN = ./bin/yarn
+PIP := LDFLAGS="$(LDFLAGS)" python -m pip
+PIP_VERSION := 19.2.3
+PIP_OPTS := --no-use-pep517 --disable-pip-version-check
+WEBPACK := NODE_ENV=production ./bin/yarn webpack
+YARN := ./bin/yarn
 
 bootstrap: install-system-pkgs develop init-config run-dependent-services create-db apply-migrations
 
@@ -59,7 +60,7 @@ ensure-venv:
 	@./scripts/ensure-venv.sh
 
 ensure-latest-pip:
-	python -m pip install -U pip
+	$(PIP) install "pip==$(PIP_VERSION)"
 
 setup-git: ensure-latest-pip
 	@echo "--> Installing git hooks"

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ YARN = ./bin/yarn
 
 bootstrap: install-system-pkgs develop init-config run-dependent-services create-db apply-migrations
 
-develop: setup-git ensure-venv ensure-latest-pip develop-only
+develop: ensure-venv setup-git develop-only
 
-develop-only: update-submodules install-yarn-pkgs install-sentry-dev
+develop-only: ensure-venv update-submodules install-yarn-pkgs install-sentry-dev
 
 init-config:
 	sentry init --dev
@@ -25,12 +25,6 @@ run-dependent-services:
 	sentry devservices up
 
 test: develop lint test-js test-python test-cli
-
-ensure-venv:
-	@./scripts/ensure-venv.sh
-
-ensure-latest-pip:
-	python -m pip install -U pip
 
 build: locale
 
@@ -61,7 +55,13 @@ clean:
 	rm -rf build/ dist/ src/sentry/assets.json
 	@echo ""
 
-setup-git:
+ensure-venv:
+	@./scripts/ensure-venv.sh
+
+ensure-latest-pip:
+	python -m pip install -U pip
+
+setup-git: ensure-latest-pip
 	@echo "--> Installing git hooks"
 	git config branch.autosetuprebase always
 	git config core.ignorecase false


### PR DESCRIPTION
Ensure latest pip before pip install because really old pips will not have the pep517 disable flag.