### PR TITLE
fix(ui): removing wordbreak all

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/item/index.jsx
+++ b/src/sentry/static/sentry/app/components/activity/item/index.jsx
@@ -137,8 +137,6 @@ const ActivityFooter = styled(HeaderAndFooter)`
 
 const ActivityBody = styled('div')`
   padding: ${space(2)} ${space(2)};
-  word-break: break-all;
-
   ${textStyles}
 `;
 


### PR DESCRIPTION
Removed the break-all. Default is break-word and should be the case everywhere. Otherwise, it would look su

per weird. 