### PR TITLE
py3(django): fix a few Django 1.9 deprecation warnings

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -8,7 +8,7 @@ confluent-kafka==0.11.5
 # 'cryptography>=1.3,<1.4
 croniter>=0.3.26,<0.4.0
 cssutils==1.0.2
-django-crispy-forms>=1.4.0,<1.5.0
+django-crispy-forms==1.6.1
 django-jsonfield>=0.9.13,<0.9.14
 django-picklefield>=0.3.0,<1.1.0
 django-sudo>=2.1.0,<3.0.0

--- a/src/sentry/admin.py
+++ b/src/sentry/admin.py
@@ -290,7 +290,7 @@ class UserAdmin(admin.ModelAdmin):
             "adminForm": adminForm,
             "form_url": form_url,
             "form": form,
-            "is_popup": "_popup" in request.REQUEST,
+            "is_popup": "_popup" in request.GET,
             "add": True,
             "change": False,
             "has_delete_permission": False,

--- a/src/sentry/api/endpoints/team_groups_new.py
+++ b/src/sentry/api/endpoints/team_groups_new.py
@@ -19,8 +19,8 @@ class TeamGroupsNewEndpoint(TeamEndpoint, EnvironmentMixin):
         cutoff date, and then sort those by score, returning the highest scoring
         groups first.
         """
-        minutes = int(request.REQUEST.get("minutes", 15))
-        limit = min(100, int(request.REQUEST.get("limit", 10)))
+        minutes = int(request.GET.get("minutes", 15))
+        limit = min(100, int(request.GET.get("limit", 10)))
 
         project_list = Project.objects.get_for_user(user=request.user, team=team)
 

--- a/src/sentry/api/endpoints/team_groups_trending.py
+++ b/src/sentry/api/endpoints/team_groups_trending.py
@@ -19,8 +19,8 @@ class TeamGroupsTrendingEndpoint(TeamEndpoint, EnvironmentMixin):
         cutoff date, and then sort those by score, returning the highest scoring
         groups first.
         """
-        minutes = int(request.REQUEST.get("minutes", 15))
-        limit = min(100, int(request.REQUEST.get("limit", 10)))
+        minutes = int(request.GET.get("minutes", 15))
+        limit = min(100, int(request.GET.get("limit", 10)))
 
         project_list = Project.objects.get_for_user(user=request.user, team=team)
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -151,7 +151,8 @@ class BaseTestCase(Fixtures, Exam):
         request.META["REMOTE_ADDR"] = "127.0.0.1"
         request.META["SERVER_NAME"] = "testserver"
         request.META["SERVER_PORT"] = 80
-        request.REQUEST = {}
+        request.GET = {}
+        request.POST = {}
 
         # order matters here, session -> user -> other things
         request.session = self.session

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -324,9 +324,9 @@ def browser(request, percy, live_server):
             options.binary_location = chrome_path
         chromedriver_path = request.config.getoption("chromedriver_path")
         if chromedriver_path:
-            driver = webdriver.Chrome(executable_path=chromedriver_path, chrome_options=options)
+            driver = webdriver.Chrome(executable_path=chromedriver_path, options=options)
         else:
-            driver = webdriver.Chrome(chrome_options=options)
+            driver = webdriver.Chrome(options=options)
     elif driver_type == "firefox":
         driver = webdriver.Firefox()
     elif driver_type == "phantomjs":

--- a/src/sentry/web/forms/fields.py
+++ b/src/sentry/web/forms/fields.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 from django.forms.widgets import RadioFieldRenderer, TextInput, Widget
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django.forms import Field, CharField, EmailField, TypedChoiceField, ValidationError
 from django.utils.encoding import force_text
 from django.utils.html import format_html

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -247,9 +247,7 @@ class BaseAuth(object):
 
     def __init__(self, request, redirect):
         self.request = request
-        # Use request because some auth providers use POST urls with needed
-        # GET parameters on it
-        self.data = request.REQUEST
+        self.data = request.GET.update(request.POST)
         self.redirect = redirect
 
     def auth_url(self):

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -247,7 +247,10 @@ class BaseAuth(object):
 
     def __init__(self, request, redirect):
         self.request = request
-        self.data = request.GET.update(request.POST)
+        # TODO(python3): use {**x, **y} syntax once 2.7 support is dropped
+        data = request.GET.copy()
+        data.update(request.POST)
+        self.data = data
         self.redirect = redirect
 
     def auth_url(self):

--- a/src/social_auth/context_processors.py
+++ b/src/social_auth/context_processors.py
@@ -88,7 +88,7 @@ def backends_data(user):
 
 def social_auth_login_redirect(request):
     """Load current redirect to context."""
-    redirect_value = request.REQUEST.get(REDIRECT_FIELD_NAME)
+    redirect_value = request.GET.get(REDIRECT_FIELD_NAME)
     if redirect_value:
         redirect_querystring = REDIRECT_FIELD_NAME + "=" + redirect_value
     else:


### PR DESCRIPTION
Note that these changes include all the Django 1.9 deprecation fixes except occurences like:

```
  /Users/joshua.li/dev/sentry/sentry/src/sentry/web/urls.py:58: RemovedInDjango19Warning: django.db.models.get_apps is deprecated.
    for app in get_apps():

  /Users/joshua.li/dev/sentry/sentry/src/sentry/web/urls.py:60: RemovedInDjango19Warning: django.db.models.get_models is deprecated.
    get_models(app)
```

These are in https://github.com/getsentry/sentry/pull/13796.