### PR TITLE
test(acceptance): Generate UI assets before running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ coverage.xml
 junit.xml
 *.codestyle.xml
 package-lock.json
+.webpack.meta

--- a/build-utils/last-built-plugin.js
+++ b/build-utils/last-built-plugin.js
@@ -13,7 +13,8 @@ class LastBuiltPlugin {
       fs.writeFile(
         path.join(this.basePath, '.webpack.meta'),
         JSON.stringify({
-          built: new Date(new Date().toUTCString()).getTime(),
+          // in seconds
+          built: Math.floor(new Date(new Date().toUTCString()).getTime() / 1000),
         }),
         callback
       );

--- a/build-utils/last-built-plugin.js
+++ b/build-utils/last-built-plugin.js
@@ -1,0 +1,23 @@
+/*eslint-env node*/
+/*eslint import/no-nodejs-modules:0 */
+const path = require('path');
+const fs = require('fs');
+
+class LastBuiltPlugin {
+  constructor({basePath}) {
+    this.basePath = basePath;
+  }
+
+  apply(compiler) {
+    compiler.hooks.done.tapAsync('LastBuiltPlugin', (_compilation, callback) => {
+      fs.writeFile(
+        path.join(this.basePath, '.webpack.meta'),
+        JSON.stringify({
+          built: new Date(new Date().toUTCString()).getTime(),
+        }),
+        callback
+      );
+    });
+  }
+}
+module.exports = LastBuiltPlugin;

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import os
 import sys
-import subprocess
 from hashlib import md5
 
 import pytest
@@ -27,27 +26,3 @@ def pytest_collection_modifyitems(items):
         total_groups = int(os.environ.get("TOTAL_TEST_GROUPS", 1))
         group_num = int(md5(item.location[0]).hexdigest(), 16) % total_groups
         item.add_marker(getattr(pytest.mark, "group_%s" % group_num))
-
-
-@pytest.fixture(scope="session", autouse=True)
-def callattr_ahead_of_alltests(request):
-    """
-    Generate frontend assets before running any acceptance tests
-    """
-
-    # Do not build in CI because tests are run w/ `make test-acceptance` which builds assets
-    if os.environ["CI"]:
-        return
-
-    session = request.node
-    has_acceptance = False
-    for item in session.items:
-        if item.location[0].startswith("tests/acceptance/"):
-            has_acceptance = True
-            break
-
-    # Only run for acceptance tests
-    if not has_acceptance:
-        return
-
-    subprocess.call("NODE_ENV=development yarn webpack", shell=True)

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import os
 import sys
+import subprocess
 from hashlib import md5
 
 import pytest
@@ -26,3 +27,27 @@ def pytest_collection_modifyitems(items):
         total_groups = int(os.environ.get("TOTAL_TEST_GROUPS", 1))
         group_num = int(md5(item.location[0]).hexdigest(), 16) % total_groups
         item.add_marker(getattr(pytest.mark, "group_%s" % group_num))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def callattr_ahead_of_alltests(request):
+    """
+    Generate frontend assets before running any acceptance tests
+    """
+
+    # Do not build in CI because tests are run w/ `make test-acceptance` which builds assets
+    if os.environ["CI"]:
+        return
+
+    session = request.node
+    has_acceptance = False
+    for item in session.items:
+        if item.location[0].startswith("tests/acceptance/"):
+            has_acceptance = True
+            break
+
+    # Only run for acceptance tests
+    if not has_acceptance:
+        return
+
+    subprocess.call("NODE_ENV=development yarn webpack", shell=True)

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "lint:css": "yarn stylelint --syntax css-in-js 'src/sentry/static/sentry/app/**/*.jsx'",
     "dev": "(yarn check --verify-tree || yarn install --check-files) && sentry devserver",
     "dev-server": "webpack-dev-server",
+    "dev-acceptance": "NO_DEV_SERVER=1 NODE_ENV=development yarn webpack --watch",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "storybook-build": "build-storybook -c .storybook -o .storybook-out && sed -i -e 's/\\/sb_dll/sb_dll/g' .storybook-out/index.html",
     "snapshot": "build-storybook && PERCY_TOKEN=$STORYBOOK_PERCY_TOKEN PERCY_PROJECT=$STORYBOOK_PERCY_PROJECT percy-storybook --widths=1280",

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -25,7 +25,7 @@ def pytest_configure(config):
             data = json.load(f)
 
             # If built within last hour, do not build again
-            last_built = int(time.time()) - data["built"] / 1000
+            last_built = int(time.time()) - data["built"]
 
             if last_built <= 3600:
                 print (  # noqa: B314

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -15,6 +15,8 @@ def pytest_configure(config):
     """
 
     # Do not build in CI because tests are run w/ `make test-acceptance` which builds assets
+    # Can also skip with the env var `SKIP_ACCEPTANCE_UI_BUILD`
+    # `CI` is a default env var on Travis CI (see: https://docs.travis-ci.com/user/environment-variables/#default-environment-variables)
     if os.environ.get("CI") or os.environ.get("SKIP_ACCEPTANCE_UI_BUILD"):
         return
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -15,7 +15,7 @@ def pytest_configure(config):
     """
 
     # Do not build in CI because tests are run w/ `make test-acceptance` which builds assets
-    if os.environ.get("CI") or os.environ.get("SKIP_UI_BUILD"):
+    if os.environ.get("CI") or os.environ.get("SKIP_ACCEPTANCE_UI_BUILD"):
         return
 
     try:

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,0 +1,58 @@
+from __future__ import absolute_import
+
+import os
+import json
+import subprocess
+import time
+
+
+def pytest_configure(config):
+    """
+    Generate frontend assets before running any acceptance tests
+
+    TODO: There is a bug if you run `py.test` with `-f` -- the built
+    assets will trigger another `py.test` run.
+    """
+
+    # Do not build in CI because tests are run w/ `make test-acceptance` which builds assets
+    if os.environ.get("CI") or os.environ.get("SKIP_UI_BUILD"):
+        return
+
+    try:
+        with open("./.webpack.meta") as f:
+            data = json.load(f)
+
+            # If built within last hour, do not build again
+            last_built = int(time.time()) - data["built"] / 1000
+
+            if last_built <= 3600:
+                print (
+                    """
+###################
+#
+# Frontend assets last built %d seconds ago, skipping rebuilds for another %d seconds.
+# Delete the file: `.webpack.meta` to rebuild.
+#
+###################
+                """
+                    % (last_built, 3600 - last_built)
+                )
+                return
+    except IOError:
+        pass
+    except Exception:
+        pass
+
+    print (
+        """
+###################
+#
+# Running webpack to compile frontend assets - this will take awhile
+#
+###################
+    """
+    )
+
+    subprocess.call(
+        ["yarn", "webpack"], env={"NODE_ENV": "development", "PATH": os.environ["PATH"]}
+    )

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -26,7 +26,7 @@ def pytest_configure(config):
             last_built = int(time.time()) - data["built"] / 1000
 
             if last_built <= 3600:
-                print (
+                print (  # noqa: B314
                     """
 ###################
 #
@@ -43,7 +43,7 @@ def pytest_configure(config):
     except Exception:
         pass
 
-    print (
+    print (  # noqa: B314
         """
 ###################
 #

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ const SENTRY_BACKEND_PORT = env.SENTRY_BACKEND_PORT;
 const SENTRY_WEBPACK_PROXY_PORT = env.SENTRY_WEBPACK_PROXY_PORT;
 const USE_HOT_MODULE_RELOAD =
   !IS_PRODUCTION && SENTRY_BACKEND_PORT && SENTRY_WEBPACK_PROXY_PORT;
+const NO_DEV_SERVER = env.NO_DEV_SERVER;
 
 // Deploy previews are built using netlify. We can check if we're in netlifys
 // build process by checking the existance of the PULL_REQUEST env var.
@@ -374,7 +375,7 @@ if (IS_TEST || IS_STORYBOOK) {
 }
 
 // Dev only! Hot module reloading
-if (USE_HOT_MODULE_RELOAD) {
+if (USE_HOT_MODULE_RELOAD && !NO_DEV_SERVER) {
   const backendAddress = `http://localhost:${SENTRY_BACKEND_PORT}/`;
 
   appConfig.plugins.push(new webpack.HotModuleReplacementPlugin());

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 
 const {CleanWebpackPlugin} = require('clean-webpack-plugin'); // installed via npm
 const webpack = require('webpack');
+const LastBuiltPlugin = require('./build-utils/last-built-plugin');
 const OptionalLocaleChunkPlugin = require('./build-utils/optional-locale-chunk-plugin');
 const IntegrationDocsFetchPlugin = require('./build-utils/integration-docs-fetch-plugin');
 const ExtractTextPlugin = require('mini-css-extract-plugin');
@@ -372,6 +373,10 @@ if (IS_TEST || IS_STORYBOOK) {
   const plugin = new IntegrationDocsFetchPlugin({basePath: __dirname});
   appConfig.plugins.push(plugin);
   appConfig.resolve.alias['integration-docs-platforms'] = plugin.modulePath;
+}
+
+if (!IS_PRODUCTION) {
+  appConfig.plugins.push(new LastBuiltPlugin({basePath: __dirname}));
 }
 
 // Dev only! Hot module reloading


### PR DESCRIPTION
Currently when you run acceptance tests, it will probably fail because frontend assets have not been built yet. This is because webpack makes sure your `dist` directory is clean between builds (which is where the acceptance tests loads our frontend bundles from).

This uses a session fixture to look at all collected tests to determine if
any acceptance tests will be run. If so, generate frontend assets using
webpack. This *will* run everytime a file changes when `py.test` is run
with `-f`. This sucks in the case where you are only editing the test cases
and not the frontend.