### PR TITLE
ref: Add option for always emitting signals from consumer

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -172,3 +172,4 @@ register("post-process.error-hook-sample-rate", default=0.0)  # unused
 # Transaction events
 # True => kill switch to disable ingestion of transaction events for internal project.
 register("transaction-events.force-disable-internal-project", default=False)
+register("outcomes.signals-in-consumer-sample-rate", default=0.0)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -173,3 +173,4 @@ register("post-process.error-hook-sample-rate", default=0.0)  # unused
 # True => kill switch to disable ingestion of transaction events for internal project.
 register("transaction-events.force-disable-internal-project", default=False)
 register("outcomes.signals-in-consumer-sample-rate", default=0.0)
+register("outcomes.tsdb-in-consumer-sample-rate", default=0.0)


### PR DESCRIPTION
Deploy this option before we start to use it.

Note that we cannot turn on this option until we have done some performance improvements on outcomes consumer.