### PR TITLE
fix(discover2) Fix issue column not working in reference event

### DIFF
--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -10,6 +10,7 @@ class Columns(Enum):
     # TODO add all the other columns.
     EVENT_ID = "event_id"
     GROUP_ID = "group_id"
+    ISSUE = "issue"
     PROJECT_ID = "project_id"
     TIMESTAMP = "timestamp"
     CULPRIT = "culprit"

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -130,16 +130,12 @@ TRANSACTIONS_SENTRY_SNUBA_MAP = {
     "title": "transaction_name",
     "message": "transaction_name",
     "transaction": "transaction_name",
-    "transaction.name": "transaction_name",
     "transaction.op": "transaction_op",
-    "transaction_op": "transaction_op",
     "platform.name": "platform",
     "environment": "environment",
     "release": "release",
     # Time related properties
     "transaction.duration": "duration",
-    "transaction.start_time": "start_ts",
-    "transaction.end_time": "finish_ts",
     # User
     "user": "user",
     "user.id": "user_id",

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -570,9 +570,6 @@ class DetectDatasetTest(TestCase):
         query = {"conditions": [["transaction", "=", "api.do_thing"]]}
         assert detect_dataset(query) == Dataset.Events
 
-        query = {"conditions": [["transaction.name", "=", "api.do_thing"]]}
-        assert detect_dataset(query) == Dataset.Transactions
-
         query = {"conditions": [["transaction.duration", ">", "3"]]}
         assert detect_dataset(query) == Dataset.Transactions
 
@@ -605,5 +602,5 @@ class DetectDatasetTest(TestCase):
         query = {"aggregations": [["quantileTiming(0.95)", "transaction.duration", "p95_duration"]]}
         assert detect_dataset(query) == Dataset.Transactions
 
-        query = {"aggregations": [["uniq", "transaction.name", "uniq_transaction"]]}
+        query = {"aggregations": [["uniq", "trace_id", "uniq_trace_id"]]}
         assert detect_dataset(query) == Dataset.Transactions


### PR DESCRIPTION
The issue column needs to be in the eventstore list in order to be used in a reference event. I've added a failing test for transaction properties that could end up in user queries. These don't work yet as eventstore.get_event_by_id() is not dataset aware yet.

I've removed a few transaction field aliases as they are redundant and we don't yet have a use case for them being exposed to users. If scenarios come up in the future we can expose them again.

Fixes SENTRY-CZD
Fixes SEN-1147