### PR TITLE
feat(discover2) Add a feature flag for tranaction views

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -856,8 +856,6 @@ SENTRY_FEATURES = {
     # Enable the relay functionality, for use with sentry semaphore. See
     # https://github.com/getsentry/semaphore.
     "organizations:relay": False,
-    # Sentry 10 - multi project interfaces.
-    "organizations:sentry10": True,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -59,6 +59,7 @@ default_manager.add("organizations:api-keys", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events-v2", OrganizationFeature)  # NOQA
+default_manager.add("organizations:transaction-events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:event-attachments", OrganizationFeature)  # NOQA
 default_manager.add("organizations:symbol-sources", OrganizationFeature)  # NOQA
 default_manager.add("organizations:custom-symbol-sources", OrganizationFeature)  # NOQA
@@ -75,7 +76,6 @@ default_manager.add("organizations:monitors", OrganizationFeature)  # NOQA
 default_manager.add("organizations:onboarding", OrganizationFeature)  # NOQA
 default_manager.add("organizations:org-saved-searches", OrganizationFeature)  # NOQA
 default_manager.add("organizations:relay", OrganizationFeature)  # NOQA
-default_manager.add("organizations:sentry10", OrganizationFeature)  # NOQA
 default_manager.add("organizations:sso-basic", OrganizationFeature)  # NOQA
 default_manager.add("organizations:sso-rippling", OrganizationFeature)  # NOQA
 default_manager.add("organizations:sso-saml2", OrganizationFeature)  # NOQA
@@ -104,9 +104,9 @@ requires_snuba = (
     "organizations:discover",
     "organizations:events",
     "organizations:events-v2",
+    "organizations:transction-events",
     "organizations:global-views",
     "organizations:incidents",
-    "organizations:sentry10",
 )
 
 # NOTE: Don't add features down here! Add them to their specific group and sort

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -29,7 +29,6 @@ class OrganizationSerializerTest(TestCase):
                 "invite-members",
                 "sso-saml2",
                 "sso-basic",
-                "sentry10",
                 "symbol-sources",
                 "custom-symbol-sources",
                 "tweak-grouping-config",


### PR DESCRIPTION
This feature flag will be used to hide APM views from a set of customers that we want to give discover2 to, but not expose transaction views to.

The current alpha users will also be given this feature so they continue to get what they have now. I've also remove the sentry10 feature flag as it wasn't being used.

Refs SEN-1153