### PR TITLE
fix(discover2): Prefer long-form name of CSP for pre-canned CSP queries.

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -72,7 +72,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     tags: ['user.id', 'project.name', 'url'],
   },
   {
-    name: t('CSP'),
+    name: t('Content Security Policy (CSP)'),
     data: {
       fields: ['title', 'count()', 'count_unique(user)', 'project', 'last_seen'],
       fieldnames: ['csp', 'events', 'users', 'project', 'last seen'],
@@ -88,7 +88,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     ],
   },
   {
-    name: t('CSP Report by Directive'),
+    name: t('Content Security Policy (CSP) Report by Directive'),
     data: {
       fields: ['effective-directive', 'count()', 'count_unique(title)'],
       fieldnames: ['directive', 'events', 'reports'],
@@ -98,7 +98,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     tags: ['project.name', 'blocked-uri', 'browser.name', 'os.name'],
   },
   {
-    name: t('CSP Report by Blocked URI'),
+    name: t('Content Security Policy (CSP) Report by Blocked URI'),
     data: {
       fields: ['blocked-uri', 'count()'],
       fieldnames: ['URI', 'events'],
@@ -108,7 +108,7 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
     tags: ['project.name', 'blocked-uri', 'browser.name', 'os.name'],
   },
   {
-    name: t('CSP Report by User'),
+    name: t('Content Security Policy (CSP) Report by User'),
     data: {
       fields: ['user', 'count()', 'count_unique(title)'],
       fieldnames: ['User', 'events', 'reports'],


### PR DESCRIPTION
Use `Content Security Policy (CSP)` instead of just `CSP`.