### PR TITLE
ref(ui): Allow audit log filters to be cleared

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationAuditLog/auditLogList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuditLog/auditLogList.jsx
@@ -69,7 +69,7 @@ class AuditLogList extends React.Component {
           value={eventType}
           style={{width: 250}}
           options={options}
-          clearable={false}
+          clearable
         />
       </form>
     );


### PR DESCRIPTION
You couldn't unselect a filter before