### PR TITLE
feat(invites): Make invite modal permission aware

### DIFF
--- a/src/sentry/api/endpoints/organization_invite_request_details.py
+++ b/src/sentry/api/endpoints/organization_invite_request_details.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+
+from sentry.api.bases.organization import OrganizationEndpoint
+
+
+class OrganizationInviteRequestDetailsEndpoint(OrganizationEndpoint):
+    def get(self, request, organization):
+        # TODO(epurkhiser): Add listing of invite requests
+        pass
+
+    def put(self, request, organization):
+        # TODO(epurkhiser): Handle accepting invite
+        pass

--- a/src/sentry/api/endpoints/organization_invite_request_index.py
+++ b/src/sentry/api/endpoints/organization_invite_request_index.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import
+
+from django.db import transaction
+from rest_framework.response import Response
+
+from sentry.app import locks
+from sentry import roles, features
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.serializers import serialize
+from sentry.models import AuditLogEntryEvent, OrganizationMember, InviteStatus
+from sentry.utils.retries import TimedRetryPolicy
+
+from .organization_member_index import OrganizationMemberSerializer, save_team_assignments
+
+
+class InviteRequestPermissions(OrganizationPermission):
+    scope_map = {
+        "GET": ["member:read", "member:write", "member:admin"],
+        "POST": ["member:read", "member:write", "member:admin"],
+    }
+
+
+class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
+    permission_classes = (InviteRequestPermissions,)
+
+    def get(self, request, organization):
+        # TODO(epurkhiser): Add listing of invite requests
+        pass
+
+    def post(self, request, organization):
+        """
+        Add a invite request to Organization
+        ````````````````````````````````````
+
+        Creates an invite request given an email and sugested role / teams.
+
+        :pparam string organization_slug: the slug of the organization the member will belong to
+        :param string email: the email address to invite
+        :param string role: the suggested role of the new member
+        :param array teams: the suggested slugs of the teams the member should belong to.
+
+        :auth: required
+        """
+        if not features.has("organizations:invite-members", organization, actor=request.user):
+            return Response(
+                {"organization": "Your organization is not allowed to invite members"}, status=403
+            )
+
+        serializer = OrganizationMemberSerializer(
+            data=request.data,
+            context={"organization": organization, "allowed_roles": roles.get_all()},
+        )
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        result = serializer.validated_data
+
+        with transaction.atomic():
+            om = OrganizationMember.objects.create(
+                organization=organization,
+                email=result["email"],
+                role=result["role"],
+                inviter=request.user,
+                invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
+            )
+
+            if result["teams"]:
+                lock = locks.get(u"org:member:{}".format(om.id), duration=5)
+                with TimedRetryPolicy(10)(lock.acquire):
+                    save_team_assignments(om, result["teams"])
+
+            self.create_audit_entry(
+                request=request,
+                organization_id=organization.id,
+                target_object=om.id,
+                data=om.get_audit_log_data(),
+                event=AuditLogEntryEvent.INVITE_REQUEST_ADD,
+            )
+
+        return Response(serialize(om), status=201)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -117,8 +117,8 @@ from .endpoints.organization_issues_new import OrganizationIssuesNewEndpoint
 from .endpoints.organization_issues_resolved_in_release import (
     OrganizationIssuesResolvedInReleaseEndpoint,
 )
-from .endpoints.organization_member_details import OrganizationMemberDetailsEndpoint
 from .endpoints.organization_member_index import OrganizationMemberIndexEndpoint
+from .endpoints.organization_member_details import OrganizationMemberDetailsEndpoint
 from .endpoints.organization_member_issues_assigned import OrganizationMemberIssuesAssignedEndpoint
 from .endpoints.organization_member_issues_bookmarked import (
     OrganizationMemberIssuesBookmarkedEndpoint,
@@ -128,6 +128,8 @@ from .endpoints.organization_member_team_details import OrganizationMemberTeamDe
 from .endpoints.organization_member_unreleased_commits import (
     OrganizationMemberUnreleasedCommitsEndpoint,
 )
+from .endpoints.organization_invite_request_index import OrganizationInviteRequestIndexEndpoint
+from .endpoints.organization_invite_request_details import OrganizationInviteRequestDetailsEndpoint
 from .endpoints.organization_monitors import OrganizationMonitorsEndpoint
 from .endpoints.organization_onboarding_tasks import OrganizationOnboardingTaskEndpoint
 from .endpoints.organization_pinned_searches import OrganizationPinnedSearchEndpoint
@@ -783,6 +785,16 @@ urlpatterns = patterns(
                     r"^(?P<organization_slug>[^\/]+)/members/$",
                     OrganizationMemberIndexEndpoint.as_view(),
                     name="sentry-api-0-organization-member-index",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/invite-requests/$",
+                    OrganizationInviteRequestIndexEndpoint.as_view(),
+                    name="sentry-api-0-organization-invite-request-index",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/invite-requests/(?P<member_id>[^\/]+)/$",
+                    OrganizationInviteRequestDetailsEndpoint.as_view(),
+                    name="sentry-api-0-organization-invite-request-detail",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/monitors/$",

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -94,6 +94,8 @@ class AuditLogEntryEvent(object):
     INTERNAL_INTEGRATION_ADD_TOKEN = 135
     INTERNAL_INTEGRATION_REMOVE_TOKEN = 136
 
+    INVITE_REQUEST_ADD = 140
+
 
 class AuditLogEntry(Model):
     __core__ = False
@@ -174,6 +176,7 @@ class AuditLogEntry(Model):
             (AuditLogEntryEvent.TRIAL_STARTED, "trial.started"),
             (AuditLogEntryEvent.PLAN_CHANGED, "plan.changed"),
             (AuditLogEntryEvent.PLAN_CANCELLED, "plan.cancelled"),
+            (AuditLogEntryEvent.INVITE_REQUEST_ADD, "invite-request.create"),
         )
     )
     ip_address = models.GenericIPAddressField(null=True, unpack_ipv4=True)
@@ -372,5 +375,7 @@ class AuditLogEntry(Model):
             return "created a token for internal integration %s" % (self.data["sentry_app"])
         elif self.event == AuditLogEntryEvent.INTERNAL_INTEGRATION_REMOVE_TOKEN:
             return "revoked a token for internal integration %s" % (self.data["sentry_app"])
+        elif self.event == AuditLogEntryEvent.INVITE_REQUEST_ADD:
+            return "request added to invite %s" % (self.data["email"],)
 
         return ""

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -37,6 +37,13 @@ class InviteStatus(Enum):
     REQUESTED_TO_JOIN = 2
 
 
+invite_status_names = {
+    InviteStatus.APPROVED.value: "approved",
+    InviteStatus.REQUESTED_TO_BE_INVITED.value: "requested_to_be_invited",
+    InviteStatus.REQUESTED_TO_JOIN.value: "requested_to_join",
+}
+
+
 class OrganizationMemberTeam(BaseModel):
     """
     Identifies relationships between organization members and the teams they are on.
@@ -314,6 +321,7 @@ class OrganizationMember(Model):
             "teams_slugs": [t["slug"] for t in teams],
             "has_global_access": self.has_global_access,
             "role": self.role,
+            "invite_status": invite_status_names[self.invite_status],
         }
 
     def get_teams(self):

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -17,6 +17,7 @@ type Props = {
   role: string;
   teams: string[];
   roleOptions: MemberRole[];
+  roleDisabledUnallowed: boolean;
   teamOptions: Team[];
   inviteStatus: InviteStatus;
   onRemove: () => void;
@@ -34,6 +35,7 @@ const InviteRowControl = ({
   role,
   teams,
   roleOptions,
+  roleDisabledUnallowed,
   teamOptions,
   inviteStatus,
   onRemove,
@@ -65,6 +67,7 @@ const InviteRowControl = ({
         disabled={disabled}
         value={role}
         roles={roleOptions}
+        disableUnallowed={roleDisabledUnallowed}
         onChange={onChangeRole}
       />
     </div>

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/roleSelectControl.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/roleSelectControl.tsx
@@ -7,12 +7,18 @@ import {MemberRole} from 'app/types';
 
 type Props = SelectControl['props'] & {
   roles: MemberRole[];
+  disableUnallowed: boolean;
 };
 
-const RoleSelector = ({roles, ...props}: Props) => (
+const RoleSelector = ({roles, disableUnallowed, ...props}: Props) => (
   <RoleSelectControl
     options={
-      roles && roles.map(r => ({value: r.id, label: r.name, disabled: !r.allowed}))
+      roles &&
+      roles.map(r => ({
+        value: r.id,
+        label: r.name,
+        disabled: disableUnallowed && !r.allowed,
+      }))
     }
     optionRenderer={option => {
       const {name, desc} = roles.find(r => r.id === option.value)!;

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase
+from sentry.models import OrganizationMember, OrganizationMemberTeam, InviteStatus
+
+
+class OrganizationInviteRequestCreateTest(APITestCase):
+    def setUp(self):
+        self.user = self.create_user("foo@localhost")
+
+        self.org = self.create_organization()
+        self.team = self.create_team(organization=self.org)
+        self.member = self.create_member(user=self.user, organization=self.org, role="member")
+
+        self.login_as(user=self.user)
+
+        self.url = reverse(
+            "sentry-api-0-organization-invite-request-index",
+            kwargs={"organization_slug": self.org.slug},
+        )
+
+    def test_simple(self):
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self.url, {"email": "eric@localhost", "role": "member", "teams": [self.team.slug]}
+        )
+
+        assert response.status_code == 201
+        assert response.data["email"] == "eric@localhost"
+
+        member = OrganizationMember.objects.get(organization=self.org, email=response.data["email"])
+        assert member.user is None
+        assert member.role == "member"
+        assert member.inviter == self.user
+        assert member.invite_status == InviteStatus.REQUESTED_TO_BE_INVITED.value
+
+        teams = OrganizationMemberTeam.objects.filter(organizationmember=member)
+
+        assert len(teams) == 1
+        assert teams[0].team_id == self.team.id
+
+    def test_higher_role(self):
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self.url, {"email": "eric@localhost", "role": "owner", "teams": [self.team.slug]}
+        )
+
+        assert response.status_code == 201
+        assert response.data["email"] == "eric@localhost"
+
+        member = OrganizationMember.objects.get(organization=self.org, email=response.data["email"])
+        assert member.role == "owner"
+
+    def test_existing_member(self):
+        self.login_as(user=self.user)
+
+        user2 = self.create_user("foobar@example.com")
+        self.create_member(user=user2, organization=self.org)
+
+        resp = self.client.post(
+            self.url, {"email": user2.email, "role": "member", "teams": [self.team.slug]}
+        )
+
+        assert resp.status_code == 400


### PR DESCRIPTION
The member invite modal has learned to create invite requests. Members may now use this modal to suggest that a user be invited.

Refs: GROW-469

![image](https://user-images.githubusercontent.com/1421724/66610831-a1ce6280-eb71-11e9-9f2c-728ed61413b5.png)
