### PR TITLE
feat: Only bind node data if event timestamp matches day

### DIFF
--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -144,8 +144,8 @@ class NodeData(collections.MutableMapping):
         if (
             event_datetime is not None
             and timestamp_from_nodestore is not None
-            and datetime.fromtimestamp(timestamp_from_nodestore).replace(tzinfo=utc)
-            != event_datetime
+            and event_datetime.date()
+            != datetime.fromtimestamp(timestamp_from_nodestore).replace(tzinfo=utc).date()
         ):
             logger.error("Timestamp mismatch", extra=data)
             data = {}

--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -303,7 +303,6 @@ class BaseManager(Manager):
 
 
 class EventManager(BaseManager):
-    # TODO: Remove method in favour of eventstore.bind_nodes
     def bind_nodes(self, object_list, *node_names):
         """
         For a list of Event objects, and a property name where we might find an
@@ -325,4 +324,5 @@ class EventManager(BaseManager):
 
         for item, node in object_node_list:
             data = node_results.get(node.id) or {}
-            node.bind_data(data, ref=node.get_ref(item))
+
+            node.bind_data(data, ref=node.get_ref(item), event_datetime=item.datetime)

--- a/tests/sentry/models/tests.py
+++ b/tests/sentry/models/tests.py
@@ -201,6 +201,21 @@ class EventNodeStoreTest(TestCase):
 
         assert event.get_tag("foo") == "bar"
 
+        # Binds an event from the same day with different timestamp
+        event = SnubaEvent(
+            {
+                "event_id": "a" * 32,
+                "group_id": processed_event.group_id,
+                "project_id": project.id,
+                "timestamp": (processed_event.datetime - timedelta(seconds=2)).isoformat(),
+            }
+        )
+
+        Event.objects.bind_nodes([event], "data")
+        assert event.datetime != processed_event.datetime
+        assert event.get_tag("foo") == "bar"
+
+        # Do not bind event from a different day
         event = SnubaEvent(
             {
                 "event_id": "a" * 32,
@@ -211,6 +226,5 @@ class EventNodeStoreTest(TestCase):
         )
 
         Event.objects.bind_nodes([event], "data")
-        # Did not bind data since timestamp doesn't match
         assert event.data == {}
         assert not event.get_tag("foo")


### PR DESCRIPTION
Pretty soon we won't have a guarantee of unique event IDs in Snuba,
since event ids are not deduplicated over different days. Whilst
duplicate event IDs should be an edge case, we want to make sure that
bind_nodes never attaches incorrect data to an event object. bind_nodes
now checks that the timestamp of the bound event matches the day of
the data from nodestore. If they are different, we do not actually bind
the fetched data.