### PR TITLE
feat(apm): Change/fix transaction name to account for page load

### DIFF
--- a/src/sentry/static/sentry/app/api.tsx
+++ b/src/sentry/static/sentry/app/api.tsx
@@ -253,9 +253,6 @@ export class Client {
     const id: string = uniqueId();
     metric.mark(`api-request-start-${id}`);
 
-    // notify apm utils that a request has started
-    startRequest(id);
-
     let fullUrl: string;
     if (path.indexOf(this.baseUrl) === -1) {
       fullUrl = this.baseUrl + path;
@@ -278,6 +275,9 @@ export class Client {
       op: 'http',
       description: `${method} ${fullUrl}`,
     }) as Sentry.Span;
+
+    // notify apm utils that a request has started
+    startRequest(id);
 
     const errorObject = new Error();
 

--- a/src/sentry/static/sentry/app/utils/apm.jsx
+++ b/src/sentry/static/sentry/app/utils/apm.jsx
@@ -36,6 +36,7 @@ function startTransaction() {
         sampled: true,
       })
     );
+    scope.setTag('ui.nav', 'navigation');
   });
 
   // Timeout a transaction if no other spans get started
@@ -125,6 +126,7 @@ export function setTransactionName(name) {
     }
 
     span.transaction = firstPageLoad ? `PageLoad: ${name}` : name;
+    scope.setTag('ui.route', name);
   });
 }
 
@@ -140,6 +142,7 @@ export function startApm() {
         sampled: true,
       })
     );
+    scope.setTag('ui.nav', 'pageload');
   });
   startTransaction();
   Router.browserHistory.listen(() => startTransaction());

--- a/src/sentry/static/sentry/app/views/app.jsx
+++ b/src/sentry/static/sentry/app/views/app.jsx
@@ -2,7 +2,6 @@ import $ from 'jquery';
 import {ThemeProvider} from 'emotion-theming';
 import {browserHistory} from 'react-router';
 import {get, isEqual} from 'lodash';
-import {getCurrentHub} from '@sentry/browser';
 import {injectGlobal} from 'emotion';
 import Cookies from 'js-cookie';
 import PropTypes from 'prop-types';
@@ -13,6 +12,7 @@ import {DEPLOY_PREVIEW_CONFIG, EXPERIMENTAL_SPA} from 'app/constants';
 import {displayDeployPreviewAlert} from 'app/actionCreators/deployPreview';
 import {fetchGuides} from 'app/actionCreators/guides';
 import {openCommandPalette} from 'app/actionCreators/modal';
+import {setTransactionName} from 'app/utils/apm';
 import {t} from 'app/locale';
 import AlertActions from 'app/actions/alertActions';
 import Alerts from 'app/components/alerts';
@@ -179,14 +179,7 @@ class App extends React.Component {
 
   updateTracing() {
     const route = getRouteStringFromRoutes(this.props.routes);
-    const scope = getCurrentHub().getScope();
-    if (scope) {
-      const transactionSpan = scope.getSpan();
-      // If there is a transaction we set the name to the route
-      if (transactionSpan) {
-        transactionSpan.transaction = route;
-      }
-    }
+    setTransactionName(route);
   }
 
   handleConfigStoreChange(config) {


### PR DESCRIPTION
This changes the transaction name to have "PageLoad" when it is a fresh page load. The reason for this is because the set of API requests can be different vs in app navigation. This can give us poor results since page loads will always take longer.