### PR TITLE
perf(db): Get GroupSnooze from cache for notifications hot path.

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -371,7 +371,7 @@ class Group(Model):
 
         if status == GroupStatus.IGNORED:
             try:
-                snooze = GroupSnooze.objects.get(group=self)
+                snooze = GroupSnooze.objects.get_from_cache(group=self)
             except GroupSnooze.DoesNotExist:
                 pass
             else:


### PR DESCRIPTION
Only other lookup during EPP is here: https://github.com/getsentry/sentry/blob/a66bc1b6befc950d3ff146923e2a281df71cf66d/src/sentry/tasks/post_process.py#L220

`Group.get_status()` is used in both digests and slack notifications.