### PR TITLE
perf(db): Cache negative hits on GroupSnooze.

### DIFF
--- a/src/sentry/models/groupsnooze.py
+++ b/src/sentry/models/groupsnooze.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from datetime import timedelta
 
 from django.db import models
+from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
 from sentry.db.models import (
@@ -13,6 +14,7 @@ from sentry.db.models import (
     Model,
     sane_repr,
 )
+from sentry.utils.cache import cache
 
 
 class GroupSnooze(Model):
@@ -48,6 +50,10 @@ class GroupSnooze(Model):
         app_label = "sentry"
 
     __repr__ = sane_repr("group_id")
+
+    @classmethod
+    def get_cache_key(cls, group_id):
+        return "groupsnooze_group_id:1:%s" % (group_id)
 
     def is_valid(self, group=None, test_rates=False):
         if group is None:
@@ -103,3 +109,17 @@ class GroupSnooze(Model):
             return False
 
         return True
+
+
+post_save.connect(
+    lambda instance, **kwargs: cache.set(
+        GroupSnooze.get_cache_key(instance.group_id), instance, 3600
+    ),
+    sender=GroupSnooze,
+    weak=False,
+)
+post_delete.connect(
+    lambda instance, **kwargs: cache.set(GroupSnooze.get_cache_key(instance.group_id), False, 3600),
+    sender=GroupSnooze,
+    weak=False,
+)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -161,7 +161,9 @@ def post_process_group(event, is_new, is_regression, is_new_group_environment, *
 
         if event.group_id:
             # we process snoozes before rules as it might create a regression
-            has_reappeared = process_snoozes(event.group)
+            # but not if it's new because you can't immediately snooze a new group
+            if not is_new:
+                has_reappeared = process_snoozes(event.group)
 
             handle_owner_assignment(event.project, event.group, event)
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -162,8 +162,7 @@ def post_process_group(event, is_new, is_regression, is_new_group_environment, *
         if event.group_id:
             # we process snoozes before rules as it might create a regression
             # but not if it's new because you can't immediately snooze a new group
-            if not is_new:
-                has_reappeared = process_snoozes(event.group)
+            has_reappeared = False if is_new else process_snoozes(event.group)
 
             handle_owner_assignment(event.project, event.group, event)
 

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -91,11 +91,19 @@ class PostProcessGroupTest(TestCase):
         event = self.create_event(group=group)
         snooze = GroupSnooze.objects.create(group=group, until=timezone.now() - timedelta(hours=1))
 
+        # Check for has_reappeared=False if is_new=True
         post_process_group(
             event=event, is_new=True, is_regression=False, is_new_group_environment=True
         )
 
-        mock_processor.assert_called_with(event, True, False, True, True)
+        mock_processor.assert_called_with(event, True, False, True, False)
+
+        # Check for has_reappeared=True if is_new=False
+        post_process_group(
+            event=event, is_new=False, is_regression=False, is_new_group_environment=True
+        )
+
+        mock_processor.assert_called_with(event, False, False, True, True)
 
         assert not GroupSnooze.objects.filter(id=snooze.id).exists()
 


### PR DESCRIPTION
Since GroupSnoozes aren't all that common, we are still hitting Postgres for a majority of GroupSnooze lookups.