### PR TITLE
test(js): Fix console.errors from `<NarrowLayout>`

### DIFF
--- a/src/sentry/static/sentry/app/components/narrowLayout.tsx
+++ b/src/sentry/static/sentry/app/components/narrowLayout.tsx
@@ -29,7 +29,7 @@ class NarrowLayout extends React.Component<Props> {
   private api = new Client();
 
   handleLogout = () => {
-    logout(this.api).then(() => (window.location.pathname = '/auth/login'));
+    logout(this.api).then(() => window.location.assign('/auth/login'));
   };
 
   render() {

--- a/tests/js/spec/components/narrowLayout.spec.jsx
+++ b/tests/js/spec/components/narrowLayout.spec.jsx
@@ -4,14 +4,23 @@ import {mount} from 'enzyme';
 import NarrowLayout from 'app/components/narrowLayout';
 
 describe('NarrowLayout', function() {
+  beforeAll(function() {
+    jest.spyOn(window.location, 'assign').mockImplementation(() => {});
+  });
+  afterAll(function() {
+    window.location.assign.mockRestore();
+  });
+
   it('renders without logout', function() {
     const wrapper = mount(<NarrowLayout />);
     expect(wrapper.find('a.logout')).toHaveLength(0);
   });
+
   it('renders with logout', function() {
     const wrapper = mount(<NarrowLayout showLogout />);
     expect(wrapper.find('a.logout')).toHaveLength(1);
   });
+
   it('can logout', function() {
     const mock = MockApiClient.addMockResponse({
       url: '/auth/',


### PR DESCRIPTION
jsdom does not like tests trying to redirect. Change to use `window.location.assign` so we can mock them in tests

![image](https://user-images.githubusercontent.com/79684/66674000-b1ec4d80-ec16-11e9-854b-66345a1ecf06.png)
