### PR TITLE
test(js): `console.warn` for unmocked API endpoints

### DIFF
--- a/src/sentry/static/sentry/app/__mocks__/api.tsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.tsx
@@ -118,9 +118,16 @@ class Client {
 
     if (!response || !mock) {
       // Endpoints need to be mocked
-      throw new Error(
+      const err = new Error(
         `No mocked response found for request:\n\t${options.method || 'GET'} ${url}`
       );
+
+      // Throwing an error here does not do what we want it to do....
+      // Because we are mocking an API client, we generally catch errors to show
+      // user-friendly error messages, this means in tests this error gets gobbled
+      // up and developer frustration ensues.
+      console.warn(err); // eslint-disable-line no-console
+      throw err;
     } else {
       // has mocked response
 


### PR DESCRIPTION
Previously we threw an error when we find an unmocked API endpoint in tests.
However, this error generally gets caught in our app code since we generally handle API errors and thus we do not realize when we have incorrectly mocked an endpoint in our tests.

This also means we will now have a lot of warnings in our test logs with unmocked endpoints that may not be relevant, but I think this is a fine tradeoff since this will save developer frustrations.