### PR TITLE
fix(cache): Supply GroupManager with a cache property.

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -280,7 +280,7 @@ class Group(Model):
     data = GzippedDictField(blank=True, null=True)
     short_id = BoundedBigIntegerField(null=True)
 
-    objects = GroupManager()
+    objects = GroupManager(cache_fields=("id",))
 
     class Meta:
         app_label = "sentry"


### PR DESCRIPTION
We use `Group.objects.get_from_cache` in two places:
https://github.com/getsentry/sentry/blob/054b3dea84080d4cd5fae0b5bd97649c0d646971/src/sentry/models/group.py#L74
and
https://github.com/getsentry/sentry/blob/054b3dea84080d4cd5fae0b5bd97649c0d646971/src/sentry/web/frontend/unsubscribe_issue_notifications.py#L14

These lookups will always hit Postgres unless we have a cached property.