### PR TITLE
feat(store): Add sampled call to Rust data scrubber

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -168,6 +168,10 @@ register("symbolicator.minidump-refactor-random-sampling", default=0.0)  # unuse
 register("store.normalize-after-processing", default=0.0)  # unused
 register("store.disable-trim-in-renormalization", default=0.0)  # unused
 
+# Data scrubbing in Rust
+register("store.sample-rust-data-scrubber", default=0.0)  # unused
+register("store.use-rust-data-scrubber", default=False)  # unused
+
 # Post Process Error Hook Sampling
 register("post-process.use-error-hook-sampling", default=False)  # unused
 # From 0.0 to 1.0: Randomly enqueue process_resource_change task

--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -27,6 +27,7 @@ from django.views.generic.base import View as BaseView
 from functools import wraps
 from querystring_parser import parser
 from symbolic import ProcessMinidumpError, Unreal4Crash, Unreal4Error
+import semaphore
 
 from sentry import features, options, quotas
 from sentry.attachments import CachedAttachment
@@ -285,21 +286,32 @@ def process_event(event_manager, project, key, remote_addr, helper, attachments,
 
     scrub_data = datascrubbing_settings.get("scrubData")
 
-    if scrub_data:
-        # We filter data immediately before it ever gets into the queue
-        sensitive_fields = datascrubbing_settings.get("sensitiveFields")
+    if random.random() < options.get("store.sample-rust-data-scrubber", 0.0):
+        rust_scrubbed_data = safe_execute(
+            semaphore.scrub_event, datascrubbing_settings, data, _with_transaction=False
+        )
+    else:
+        rust_scrubbed_data = None
 
-        exclude_fields = datascrubbing_settings.get("excludeFields")
+    if rust_scrubbed_data and options.get("store.use-rust-data-scrubber", False):
+        data = rust_scrubbed_data
+        data["_rust_data_scrubbed"] = True  # TODO: Remove after sampling
+    else:
+        if scrub_data:
+            # We filter data immediately before it ever gets into the queue
+            sensitive_fields = datascrubbing_settings.get("sensitiveFields")
+            exclude_fields = datascrubbing_settings.get("excludeFields")
+            scrub_defaults = datascrubbing_settings.get("scrubDefaults")
 
-        scrub_defaults = datascrubbing_settings.get("scrubDefaults")
+            SensitiveDataFilter(
+                fields=sensitive_fields,
+                include_defaults=scrub_defaults,
+                exclude_fields=exclude_fields,
+            ).apply(data)
 
-        SensitiveDataFilter(
-            fields=sensitive_fields, include_defaults=scrub_defaults, exclude_fields=exclude_fields
-        ).apply(data)
-
-    if scrub_ip_address:
-        # We filter data immediately before it ever gets into the queue
-        helper.ensure_does_not_have_ip(data)
+        if scrub_ip_address:
+            # We filter data immediately before it ever gets into the queue
+            helper.ensure_does_not_have_ip(data)
 
     # mutates data (strips a lot of context if not queued)
     helper.insert_data_to_database(data, start_time=start_time, attachments=attachments)


### PR DESCRIPTION
This adds a sampled call to the Rust data scrubber, where the result can optionally be used in place of the Python implementation.

Initially, primary focus is to sample calls to the Rust implementation to check for failures and performance. Then, we can opt into using these values. 

Requires https://github.com/getsentry/semaphore/pull/263
Requires #15083