### PR TITLE
perf: Cache ProjectOwnership reads for five minutes

### DIFF
--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -5,18 +5,20 @@ import operator
 
 from django.db import models
 from django.db.models import Q
+from django.db.models.signals import post_delete, post_save
 from django.utils import timezone
 
-from sentry.db.models import BaseManager, Model, sane_repr
+from sentry.db.models import Model, sane_repr
 from sentry.db.models.fields import FlexibleForeignKey, JSONField
 from sentry.ownership.grammar import load_schema
+from sentry.utils.cache import cache
 from functools import reduce
+
+READ_CACHE_DURATION = 3600
 
 
 class ProjectOwnership(Model):
     __core__ = True
-
-    objects = BaseManager(cache_fields=["project_id", "pk"])
 
     project = FlexibleForeignKey("sentry.Project", unique=True)
     raw = models.TextField(null=True)
@@ -37,6 +39,34 @@ class ProjectOwnership(Model):
     __repr__ = sane_repr("project_id", "is_active")
 
     @classmethod
+    def get_cache_key(self, project_id):
+        return u"projectownership_project_id:1:{}".format(project_id)
+
+    @classmethod
+    def get_ownership_cached(cls, project_id):
+        """
+        Cached read access to projectownership.
+
+        This method implements a negative cache which saves us
+        a pile of read queries in post_processing as most projects
+        don't have ownership rules.
+
+        See the post_save and post_delete signals below for additional
+        cache updates.
+        """
+        cache_key = cls.get_cache_key(project_id)
+        ownership = cache.get(cache_key)
+        if ownership:
+            return ownership
+        if ownership is None:
+            try:
+                ownership = cls.objects.get(project_id=project_id)
+            except cls.DoesNotExist:
+                ownership = False
+            cache.set(cache_key, ownership, READ_CACHE_DURATION)
+        return ownership or None
+
+    @classmethod
     def get_owners(cls, project_id, data):
         """
         For a given project_id, and event data blob.
@@ -47,9 +77,8 @@ class ProjectOwnership(Model):
         If an empty list is returned, this means there are explicitly
         no owners.
         """
-        try:
-            ownership = cls.objects.get_from_cache(project_id=project_id)
-        except cls.DoesNotExist:
+        ownership = cls.get_ownership_cached(project_id)
+        if not ownership:
             ownership = cls(project_id=project_id)
 
         rules = cls._matching_ownership_rules(ownership, project_id, data)
@@ -66,11 +95,8 @@ class ProjectOwnership(Model):
 
         Will return None if there are no owners, or a list of owners.
         """
-        try:
-            ownership = cls.objects.get_from_cache(project_id=project_id)
-        except cls.DoesNotExist:
-            return None
-        if not ownership.auto_assignment:
+        ownership = cls.get_ownership_cached(project_id)
+        if not ownership or not ownership.auto_assignment:
             return None
 
         rules = cls._matching_ownership_rules(ownership, project_id, data)
@@ -156,3 +182,20 @@ def resolve_actors(owners, project_id):
         )
 
     return {o: actors.get((o.type, o.identifier.lower())) for o in owners}
+
+
+# Signals update the cached reads used in post_processing
+post_save.connect(
+    lambda instance, **kwargs: cache.set(
+        ProjectOwnership.get_cache_key(instance.project_id), instance, READ_CACHE_DURATION
+    ),
+    sender=ProjectOwnership,
+    weak=False,
+)
+post_delete.connect(
+    lambda instance, **kwargs: cache.set(
+        ProjectOwnership.get_cache_key(instance.project_id), False, READ_CACHE_DURATION
+    ),
+    sender=ProjectOwnership,
+    weak=False,
+)

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -56,8 +56,6 @@ class ProjectOwnership(Model):
         """
         cache_key = cls.get_cache_key(project_id)
         ownership = cache.get(cache_key)
-        if ownership:
-            return ownership
         if ownership is None:
             try:
                 ownership = cls.objects.get(project_id=project_id)

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -16,7 +16,6 @@ class ProjectOwnershipTestCase(TestCase):
 
     def test_get_owners_basic(self):
         rule_a = Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)])
-
         rule_b = Rule(Matcher("path", "src/*"), [Owner("user", self.user.email)])
 
         ProjectOwnership.objects.create(
@@ -55,7 +54,9 @@ class ProjectOwnershipTestCase(TestCase):
         ) == (ProjectOwnership.Everyone, None)
 
         # When fallthrough = False, we don't implicitly assign to Everyone
-        ProjectOwnership.objects.filter(project_id=self.project.id).update(fallthrough=False)
+        owner = ProjectOwnership.objects.get(project_id=self.project.id)
+        owner.fallthrough = False
+        owner.save()
 
         assert ProjectOwnership.get_owners(
             self.project.id, {"stacktrace": {"frames": [{"filename": "xxxx"}]}}

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -5,13 +5,23 @@ from sentry.api.fields.actor import Actor
 from sentry.models import ProjectOwnership, User, Team
 from sentry.models.projectownership import resolve_actors
 from sentry.ownership.grammar import Rule, Owner, Matcher, dump_schema
+from sentry.utils.cache import cache
 
 
 class ProjectOwnershipTestCase(TestCase):
+    def tearDown(self):
+        cache.delete(ProjectOwnership.get_cache_key(self.project.id))
+
+        super(ProjectOwnershipTestCase, self).tearDown()
+
     def assert_ownership_equals(self, o1, o2):
         assert sorted(o1[0]) == sorted(o2[0]) and sorted(o1[1]) == sorted(o2[1])
 
     def test_get_owners_default(self):
+        assert ProjectOwnership.get_owners(self.project.id, {}) == (ProjectOwnership.Everyone, None)
+
+    def test_get_owners_no_record(self):
+        assert ProjectOwnership.get_owners(self.project.id, {}) == (ProjectOwnership.Everyone, None)
         assert ProjectOwnership.get_owners(self.project.id, {}) == (ProjectOwnership.Everyone, None)
 
     def test_get_owners_basic(self):


### PR DESCRIPTION
Apply our default record cache to project ownership read queries. This should remove more load from postgres. This shouldn't introduce any delays in project ownership rules taking effect as updates will also update the cache data.

cc @JTCunning 