### PR TITLE
fix(discover2) Fix a typo

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -104,7 +104,7 @@ requires_snuba = (
     "organizations:discover",
     "organizations:events",
     "organizations:events-v2",
-    "organizations:transction-events",
+    "organizations:transaction-events",
     "organizations:global-views",
     "organizations:incidents",
 )


### PR DESCRIPTION
I made a typo in a feature name when updating the requires_snuba list.