### PR TITLE
fix(apm): Close correct transaction span

### DIFF
--- a/src/sentry/static/sentry/app/utils/apm.jsx
+++ b/src/sentry/static/sentry/app/utils/apm.jsx
@@ -61,13 +61,11 @@ export function finishTransaction(delay = TRANSACTION_TIMEOUT) {
   }
 
   flushTransactionTimeout = setTimeout(() => {
-    Sentry.configureScope(scope => {
-      const span = scope.getSpan();
-      if (span) {
-        span.finish();
-        firstPageLoad = false;
-      }
-    });
+    if (currentTransactionSpan) {
+      currentTransactionSpan.finish();
+      currentTransactionSpan = null;
+      firstPageLoad = false;
+    }
   }, delay);
 }
 


### PR DESCRIPTION
Previously, it was possible to have `startTransaction` start a span due to in app navigation, but instead of closing the previous transaction span that was created this way, it was finishing a different span (whatever was called immediately before navigation)

See this as an example of what was happening:

![image](https://user-images.githubusercontent.com/79684/66868400-19c1d180-ef52-11e9-8c55-df231a936b83.png)


* `startTransaction()` was called, span created
* user navigated somewhere where another span was created, but not finished
* `startTransaction()` called again, but it attempts to close the above span instead of the first span from `startTransaction()`