### PR TITLE
feat(discover2) Move transaction views to the new feature switch

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -29,6 +29,53 @@ export const DEFAULT_EVENT_VIEW_V1: Readonly<EventViewv1> = {
   tags: ['event.type', 'release', 'project.name', 'user.email', 'user.ip', 'environment'],
 };
 
+export const TRANSACTION_VIEWS: Readonly<Array<EventViewv1>> = [
+  {
+    name: t('Transactions'),
+    data: {
+      fields: [
+        'transaction',
+        'project',
+        'count()',
+        'avg(transaction.duration)',
+        'p75',
+        'p95',
+      ],
+      fieldnames: ['transaction', 'project', 'volume', 'avg', '75th', '95th'],
+      sort: ['-count'],
+      query: 'event.type:transaction',
+    },
+    tags: ['release', 'project.name', 'user.email', 'user.ip', 'environment'],
+  },
+  {
+    name: t('Transactions by User'),
+    data: {
+      fields: [
+        'user',
+        'count()',
+        'count_unique(transaction)',
+        'avg(transaction.duration)',
+        'p75',
+        'p95',
+      ],
+      fieldnames: ['user', 'events', 'unique transactions', 'avg', '75th', '95th'],
+      sort: ['-count'],
+      query: 'event.type:transaction',
+    },
+    tags: ['release', 'project.name', 'user.email', 'user.ip', 'environment'],
+  },
+  {
+    name: t('Transactions by Region'),
+    data: {
+      fields: ['geo.region', 'count()', 'avg(transaction.duration)', 'p75', 'p95'],
+      fieldnames: ['Region', 'events', 'avg', '75th', '95th'],
+      sort: ['-count'],
+      query: 'event.type:transaction',
+    },
+    tags: ['release', 'project.name', 'user.email', 'user.ip'],
+  },
+];
+
 export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
   DEFAULT_EVENT_VIEW_V1,
   {
@@ -116,50 +163,6 @@ export const ALL_VIEWS: Readonly<Array<EventViewv1>> = [
       query: 'event.type:csp',
     },
     tags: ['project.name', 'blocked-uri', 'browser.name', 'os.name'],
-  },
-  {
-    name: t('Transactions'),
-    data: {
-      fields: [
-        'transaction',
-        'project',
-        'count()',
-        'avg(transaction.duration)',
-        'p75',
-        'p95',
-      ],
-      fieldnames: ['transaction', 'project', 'volume', 'avg', '75th', '95th'],
-      sort: ['-count'],
-      query: 'event.type:transaction',
-    },
-    tags: ['release', 'project.name', 'user.email', 'user.ip', 'environment'],
-  },
-  {
-    name: t('Transactions by User'),
-    data: {
-      fields: [
-        'user',
-        'count()',
-        'count_unique(transaction)',
-        'avg(transaction.duration)',
-        'p75',
-        'p95',
-      ],
-      fieldnames: ['user', 'events', 'unique transactions', 'avg', '75th', '95th'],
-      sort: ['-count'],
-      query: 'event.type:transaction',
-    },
-    tags: ['release', 'project.name', 'user.email', 'user.ip', 'environment'],
-  },
-  {
-    name: t('Transactions by Region'),
-    data: {
-      fields: ['geo.region', 'count()', 'avg(transaction.duration)', 'p75', 'p95'],
-      fieldnames: ['Region', 'events', 'avg', '75th', '95th'],
-      sort: ['-count'],
-      query: 'event.type:transaction',
-    },
-    tags: ['release', 'project.name', 'user.email', 'user.ip'],
   },
 ];
 

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -23,7 +23,7 @@ import Events from './events';
 import EventDetails from './eventDetails';
 import EventsSaveQueryButton from './saveQueryButton';
 import {getFirstQueryString} from './utils';
-import {ALL_VIEWS} from './data';
+import {ALL_VIEWS, TRANSACTION_VIEWS} from './data';
 import EventView from './eventView';
 
 type Props = {
@@ -41,9 +41,13 @@ class EventsV2 extends React.Component<Props> {
   };
 
   renderQueryList() {
-    const {location} = this.props;
+    const {location, organization} = this.props;
+    let views = ALL_VIEWS;
+    if (organization.features.includes('transaction-events')) {
+      views = [...ALL_VIEWS, ...TRANSACTION_VIEWS];
+    }
 
-    const list = ALL_VIEWS.map((eventViewv1, index) => {
+    const list = views.map((eventViewv1, index) => {
       const eventView = EventView.fromEventViewv1(eventViewv1);
       const to = {
         pathname: location.pathname,


### PR DESCRIPTION
This will allow us to hide transaction related views from enterprise alpha customers. I've not updated the SmartSearchBar as it doesn't currently offer any autocompletion on non-tag properties, so there is nothing to hide.

Refs SEN-1156