### PR TITLE
ref(eventstore): Move get latest/earliest event to eventstore

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from rest_framework.exceptions import PermissionDenied
 
-from sentry import eventstore
 from sentry.api.bases import OrganizationEndpoint, OrganizationEventsError
 from sentry.api.event_search import (
     get_filter,
@@ -108,52 +107,3 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
             )
 
         return snuba_args
-
-    def next_event_id(self, snuba_args, event):
-        """
-        Returns the next event ID if there is a subsequent event matching the
-        conditions provided. Ignores the project_id.
-        """
-        next_event = eventstore.get_next_event_id(event, filter=self._get_filter(snuba_args))
-
-        if next_event:
-            return next_event[1]
-
-    def prev_event_id(self, snuba_args, event):
-        """
-        Returns the previous event ID if there is a previous event matching the
-        conditions provided. Ignores the project_id.
-        """
-        prev_event = eventstore.get_prev_event_id(event, filter=self._get_filter(snuba_args))
-
-        if prev_event:
-            return prev_event[1]
-
-    def _get_filter(self, snuba_args):
-        return eventstore.Filter(
-            conditions=snuba_args["conditions"],
-            start=snuba_args.get("start", None),
-            end=snuba_args.get("end", None),
-            project_ids=snuba_args["filter_keys"].get("project_id", None),
-            group_ids=snuba_args["filter_keys"].get("issue", None),
-        )
-
-    def oldest_event_id(self, snuba_args, event):
-        """
-        Returns the oldest event ID if there is a subsequent event matching the
-        conditions provided
-        """
-        oldest_event = eventstore.get_oldest_event_id(event, filter=self._get_filter(snuba_args))
-
-        if oldest_event:
-            return oldest_event[1]
-
-    def latest_event_id(self, snuba_args, event):
-        """
-        Returns the latest event ID if there is a newer event matching the
-        conditions provided
-        """
-        latest_event = eventstore.get_latest_event_id(event, filter=self._get_filter(snuba_args))
-
-        if latest_event:
-            return latest_event[1]

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -13,11 +13,6 @@ from sentry.models.project import Project
 from sentry.utils import snuba
 
 
-class Direction(object):
-    NEXT = 0
-    PREV = 1
-
-
 class OrganizationEventsEndpointBase(OrganizationEndpoint):
     def get_snuba_query_args(self, request, organization, params):
         query = request.GET.get("query")

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -54,3 +54,52 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         data["projectSlug"] = project_slug
 
         return Response(data)
+
+    def next_event_id(self, snuba_args, event):
+        """
+        Returns the next event ID if there is a subsequent event matching the
+        conditions provided. Ignores the project_id.
+        """
+        next_event = eventstore.get_next_event_id(event, filter=self._get_filter(snuba_args))
+
+        if next_event:
+            return next_event[1]
+
+    def prev_event_id(self, snuba_args, event):
+        """
+        Returns the previous event ID if there is a previous event matching the
+        conditions provided. Ignores the project_id.
+        """
+        prev_event = eventstore.get_prev_event_id(event, filter=self._get_filter(snuba_args))
+
+        if prev_event:
+            return prev_event[1]
+
+    def oldest_event_id(self, snuba_args, event):
+        """
+        Returns the oldest event ID if there is a subsequent event matching the
+        conditions provided
+        """
+        oldest_event = eventstore.get_oldest_event_id(event, filter=self._get_filter(snuba_args))
+
+        if oldest_event:
+            return oldest_event[1]
+
+    def latest_event_id(self, snuba_args, event):
+        """
+        Returns the latest event ID if there is a newer event matching the
+        conditions provided
+        """
+        latest_event = eventstore.get_latest_event_id(event, filter=self._get_filter(snuba_args))
+
+        if latest_event:
+            return latest_event[1]
+
+    def _get_filter(self, snuba_args):
+        return eventstore.Filter(
+            conditions=snuba_args["conditions"],
+            start=snuba_args.get("start", None),
+            end=snuba_args.get("end", None),
+            project_ids=snuba_args["filter_keys"].get("project_id", None),
+            group_ids=snuba_args["filter_keys"].get("issue", None),
+        )

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -1,18 +1,12 @@
 from __future__ import absolute_import
 
 from rest_framework.response import Response
-from enum import Enum
 
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
 from sentry.api.event_search import get_reference_event_conditions
 from sentry import eventstore, features
 from sentry.models.project import Project
 from sentry.api.serializers import serialize
-
-
-class EventOrdering(Enum):
-    LATEST = 0
-    OLDEST = 1
 
 
 class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -84,7 +84,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         Returns the oldest event ID if there is a subsequent event matching the
         conditions provided
         """
-        oldest_event = eventstore.get_oldest_event_id(event, filter=self._get_filter(snuba_args))
+        oldest_event = eventstore.get_earliest_event_id(event, filter=self._get_filter(snuba_args))
 
         if oldest_event:
             return oldest_event[1]

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -75,16 +75,6 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         if prev_event:
             return prev_event[1]
 
-    def oldest_event_id(self, snuba_args, event):
-        """
-        Returns the oldest event ID if there is a subsequent event matching the
-        conditions provided
-        """
-        oldest_event = eventstore.get_oldest_event_id(event, filter=self._get_filter(snuba_args))
-
-        if oldest_event:
-            return oldest_event[1]
-
     def latest_event_id(self, snuba_args, event):
         """
         Returns the latest event ID if there is a newer event matching the
@@ -94,6 +84,16 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
 
         if latest_event:
             return latest_event[1]
+
+    def oldest_event_id(self, snuba_args, event):
+        """
+        Returns the oldest event ID if there is a subsequent event matching the
+        conditions provided
+        """
+        oldest_event = eventstore.get_oldest_event_id(event, filter=self._get_filter(snuba_args))
+
+        if oldest_event:
+            return oldest_event[1]
 
     def _get_filter(self, snuba_args):
         return eventstore.Filter(

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -226,7 +226,7 @@ class EventStorage(Service):
         """
         For a list of Event objects, and a property name where we might find an
         (unfetched) NodeData on those objects, fetch all the data blobs for
-        those NodeDatas with a single multi - get command to nodestore, and bind
+        those NodeDatas with a single multi-get command to nodestore, and bind
         the returned blobs to the NodeDatas
         """
         object_node_list = [

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -123,6 +123,7 @@ class EventStorage(Service):
         "get_events",
         "get_prev_event_id",
         "get_next_event_id",
+        "get_oldest_event_id",
         "bind_nodes",
     )
 
@@ -198,11 +199,33 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
+    def get_oldest_event_id(self, event, filter):
+        """
+        Gets the earliest event given a current event and some conditions/filters.
+        Returns a tuple of (project_id, event_id)
+
+        Arguments:
+        event (Event): Event object
+        filter (Filter): Filter
+        """
+        raise NotImplementedError
+
+    def get_latest_event_id(self, event, filter):
+        """
+        Gets the latest event given a current event and some conditions/filters.
+        Returns a tuple of (project_id, event_id)
+
+        Arguments:
+        event (Event): Event object
+        filter (Filter): Filter
+        """
+        raise NotImplementedError
+
     def bind_nodes(self, object_list, node_name="data"):
         """
         For a list of Event objects, and a property name where we might find an
         (unfetched) NodeData on those objects, fetch all the data blobs for
-        those NodeDatas with a single multi-get command to nodestore, and bind
+        those NodeDatas with a single multi - get command to nodestore, and bind
         the returned blobs to the NodeDatas
         """
         object_node_list = [

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -124,6 +124,7 @@ class EventStorage(Service):
         "get_prev_event_id",
         "get_next_event_id",
         "get_oldest_event_id",
+        "get_latest_event_id",
         "bind_nodes",
     )
 

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -123,7 +123,7 @@ class EventStorage(Service):
         "get_events",
         "get_prev_event_id",
         "get_next_event_id",
-        "get_oldest_event_id",
+        "get_earliest_event_id",
         "get_latest_event_id",
         "bind_nodes",
     )
@@ -200,7 +200,7 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
-    def get_oldest_event_id(self, event, filter):
+    def get_earliest_event_id(self, event, filter):
         """
         Gets the earliest event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -74,7 +74,7 @@ class SnubaEventStorage(EventStorage):
             return SnubaEvent(result["data"][0])
         return None
 
-    def get_oldest_event_id(self, event, filter):
+    def get_earliest_event_id(self, event, filter):
         time_condition = [["timestamp", "<", event.timestamp]]
         orderby = ["timestamp", "event_id"]
 

--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -127,6 +127,23 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
         assert self.eventstore.get_prev_event_id(None, filter=filter) is None
         assert self.eventstore.get_next_event_id(None, filter=filter) is None
 
+    def test_get_latest_or_oldest_event_id(self):
+        # Returns a latest/oldest event
+        event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
+        filter = Filter(project_ids=[self.project1.id, self.project2.id])
+        oldest_event = self.eventstore.get_oldest_event_id(event, filter=filter)
+        latest_event = self.eventstore.get_latest_event_id(event, filter=filter)
+        assert oldest_event == (six.text_type(self.project1.id), "a" * 32)
+        assert latest_event == (six.text_type(self.project2.id), "e" * 32)
+
+        # Returns none when no latest/oldest event that meets conditions
+        event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
+        filter = Filter(project_ids=[self.project1.id], group_ids=[self.event2.group_id])
+        oldest_event = self.eventstore.get_oldest_event_id(event, filter=filter)
+        latest_event = self.eventstore.get_latest_event_id(event, filter=filter)
+        assert oldest_event is None
+        assert latest_event is None
+
     def test_transaction_get_event_by_id(self):
         event = self.eventstore.get_event_by_id(self.project2.id, self.transaction_event.event_id)
 

--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -131,7 +131,7 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
         # Returns a latest/oldest event
         event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
         filter = Filter(project_ids=[self.project1.id, self.project2.id])
-        oldest_event = self.eventstore.get_oldest_event_id(event, filter=filter)
+        oldest_event = self.eventstore.get_earliest_event_id(event, filter=filter)
         latest_event = self.eventstore.get_latest_event_id(event, filter=filter)
         assert oldest_event == (six.text_type(self.project1.id), "a" * 32)
         assert latest_event == (six.text_type(self.project2.id), "e" * 32)
@@ -139,7 +139,7 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
         # Returns none when no latest/oldest event that meets conditions
         event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
         filter = Filter(project_ids=[self.project1.id], group_ids=[self.event2.group_id])
-        oldest_event = self.eventstore.get_oldest_event_id(event, filter=filter)
+        oldest_event = self.eventstore.get_earliest_event_id(event, filter=filter)
         latest_event = self.eventstore.get_latest_event_id(event, filter=filter)
         assert oldest_event is None
         assert latest_event is None


### PR DESCRIPTION
Since this is pretty similar to getting a next/previous event, let's move this responsibility into the Eventstore.