### PR TITLE
fix: Never fork

### DIFF
--- a/src/sentry/ingest/outcomes_consumer.py
+++ b/src/sentry/ingest/outcomes_consumer.py
@@ -105,12 +105,8 @@ def _process_message_with_timer(message):
 
 
 class OutcomesConsumerWorker(AbstractBatchWorker):
-    def __init__(self, multiprocessing, concurrency):
-        if multiprocessing:
-            self.pool = _multiprocessing.Pool(concurrency)
-        else:
-            self.pool = _multiprocessing.dummy.Pool(concurrency)
-
+    def __init__(self, concurrency):
+        self.pool = _multiprocessing.dummy.Pool(concurrency)
         atexit.register(self.pool.close)
 
     def process_message(self, message):
@@ -124,13 +120,13 @@ class OutcomesConsumerWorker(AbstractBatchWorker):
         pass
 
 
-def get_outcomes_consumer(multiprocessing=False, concurrency=None, **options):
+def get_outcomes_consumer(concurrency=None, **options):
     """
     Handles outcome requests coming via a kafka queue from Relay.
     """
 
     return create_batching_kafka_consumer(
         topic_name=settings.KAFKA_OUTCOMES,
-        worker=OutcomesConsumerWorker(multiprocessing=multiprocessing, concurrency=concurrency),
+        worker=OutcomesConsumerWorker(concurrency=concurrency),
         **options
     )

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -435,15 +435,10 @@ def ingest_consumer(consumer_type, **options):
 @log_options()
 @batching_kafka_options("outcomes-consumer")
 @click.option(
-    "--multiprocessing/--multithreading",
-    default=False,
-    help="Use threads vs processes for concurrency. Per default it's threads.",
-)
-@click.option(
     "--concurrency",
     type=int,
-    default=None,
-    help="Spawn this many threads/processes to process outcomes. Defaults to number of CPUs.",
+    default=1,
+    help="Spawn this many threads to process outcomes. Defaults to 1.",
 )
 @configuration
 def outcome_consumer(**options):


### PR DESCRIPTION
Sentry's codebase is not forksafe. Particularly not memcached and redis connections. We learned that the hard way.

Just run more consumers I guess.