### PR TITLE
feat(discover2) Hide tracing related functions and fields in query builder

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -17,7 +17,7 @@ import {QueryLink} from './styles';
 
 export const MODAL_QUERY_KEYS = ['eventSlug'] as const;
 export const PIN_ICON = `image://${pinIcon}`;
-export const AGGREGATE_ALIASES = ['last_seen', 'latest_event'] as const;
+export const AGGREGATE_ALIASES = ['p95', 'p75', 'last_seen', 'latest_event'] as const;
 
 export const DEFAULT_EVENT_VIEW_V1: Readonly<EventViewv1> = {
   name: t('All Events'),

--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -137,3 +137,13 @@ export const FIELDS = {
   p95: 'number',
 };
 export type Field = keyof typeof FIELDS | '';
+
+// This list should be removed with the tranaction-events feature flag.
+export const TRACING_FIELDS = [
+  'avg',
+  'sum',
+  'transaction.duration',
+  'transaction.op',
+  'p95',
+  'p75',
+];

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -190,12 +190,12 @@ class TableView extends React.Component<TableViewProps, TableState> {
   };
 
   render() {
-    const {isLoading, error, tableData} = this.props;
+    const {organization, isLoading, error, tableData} = this.props;
     const {columnOrder, columnSortBy} = this.state;
     const {
       renderModalBodyWithForm,
       renderModalFooter,
-    } = renderTableModalEditColumnFactory({
+    } = renderTableModalEditColumnFactory(organization, {
       createColumn: this._createColumn,
       updateColumn: this._updateColumn,
     });


### PR DESCRIPTION
Hide the transaction related fields and aggregate functions for customers not in the tracing alpha.

Refs SEN-1156