### PR TITLE
ref(eventstore): Allow passing a dataset to Eventstore functions

### DIFF
--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -41,70 +41,65 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         event_slug = u"{}:{}".format(project.slug, event_id)
         snuba_args["conditions"].extend(get_reference_event_conditions(snuba_args, event_slug))
 
-        dataset = snuba.detect_dataset(snuba_args, aliased_conditions=True)
+        filter = self._get_filter(snuba_args)
 
         data = serialize(event)
-        data["nextEventID"] = self.next_event_id(snuba_args, event, dataset=dataset)
-        data["previousEventID"] = self.prev_event_id(snuba_args, event, dataset=dataset)
-        data["oldestEventID"] = self.oldest_event_id(snuba_args, event, dataset=dataset)
-        data["latestEventID"] = self.latest_event_id(snuba_args, event, dataset=dataset)
+        data["nextEventID"] = self.next_event_id(event, filter=filter)
+        data["previousEventID"] = self.prev_event_id(event, filter=filter)
+        data["oldestEventID"] = self.oldest_event_id(event, filter=filter)
+        data["latestEventID"] = self.latest_event_id(event, filter=filter)
         data["projectSlug"] = project_slug
 
         return Response(data)
 
-    def next_event_id(self, snuba_args, event, dataset):
+    def next_event_id(self, event, filter):
         """
         Returns the next event ID if there is a subsequent event matching the
         conditions provided. Ignores the project_id.
         """
-        next_event = eventstore.get_next_event_id(
-            event, filter=self._get_filter(snuba_args), dataset=dataset
-        )
+        next_event = eventstore.get_next_event_id(event, filter=filter)
 
         if next_event:
             return next_event[1]
 
-    def prev_event_id(self, snuba_args, event, dataset):
+    def prev_event_id(self, event, filter):
         """
         Returns the previous event ID if there is a previous event matching the
         conditions provided. Ignores the project_id.
         """
-        prev_event = eventstore.get_prev_event_id(
-            event, filter=self._get_filter(snuba_args), dataset=dataset
-        )
+        prev_event = eventstore.get_prev_event_id(event, filter=filter)
 
         if prev_event:
             return prev_event[1]
 
-    def latest_event_id(self, snuba_args, event, dataset):
+    def latest_event_id(self, event, filter):
         """
         Returns the latest event ID if there is a newer event matching the
         conditions provided
         """
-        latest_event = eventstore.get_latest_event_id(
-            event, filter=self._get_filter(snuba_args), dataset=dataset
-        )
+        latest_event = eventstore.get_latest_event_id(event, filter=filter)
 
         if latest_event:
             return latest_event[1]
 
-    def oldest_event_id(self, snuba_args, event, dataset):
+    def oldest_event_id(self, event, filter):
         """
         Returns the oldest event ID if there is a subsequent event matching the
         conditions provided
         """
-        oldest_event = eventstore.get_earliest_event_id(
-            event, filter=self._get_filter(snuba_args), dataset=dataset
-        )
+        oldest_event = eventstore.get_earliest_event_id(event, filter=filter)
 
         if oldest_event:
             return oldest_event[1]
 
     def _get_filter(self, snuba_args):
+        dataset = snuba.detect_dataset(snuba_args, aliased_conditions=True)
+
         return eventstore.Filter(
             conditions=snuba_args["conditions"],
             start=snuba_args.get("start", None),
             end=snuba_args.get("end", None),
             project_ids=snuba_args["filter_keys"].get("project_id", None),
             group_ids=snuba_args["filter_keys"].get("issue", None),
+            dataset=dataset,
         )

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from rest_framework.response import Response
 
 from sentry import eventstore
+from sentry.utils import snuba
 from sentry.api.base import DocSection
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import DetailedEventSerializer, serialize
@@ -64,9 +65,13 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
                 conditions=conditions, project_ids=[event.project_id], group_ids=[event.group_id]
             )
 
-            next_event = eventstore.get_next_event_id(event, filter=filter)
+            next_event = eventstore.get_next_event_id(
+                event, filter=filter, dataset=snuba.Dataset.Events
+            )
 
-            prev_event = eventstore.get_prev_event_id(event, filter=filter)
+            prev_event = eventstore.get_prev_event_id(
+                event, filter=filter, dataset=snuba.Dataset.Events
+            )
 
             next_event_id = next_event[1] if next_event else None
             prev_event_id = prev_event[1] if prev_event else None

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from rest_framework.response import Response
 
 from sentry import eventstore
-from sentry.utils import snuba
 from sentry.api.base import DocSection
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import DetailedEventSerializer, serialize
@@ -65,13 +64,9 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
                 conditions=conditions, project_ids=[event.project_id], group_ids=[event.group_id]
             )
 
-            next_event = eventstore.get_next_event_id(
-                event, filter=filter, dataset=snuba.Dataset.Events
-            )
+            next_event = eventstore.get_next_event_id(event, filter=filter)
 
-            prev_event = eventstore.get_prev_event_id(
-                event, filter=filter, dataset=snuba.Dataset.Events
-            )
+            prev_event = eventstore.get_prev_event_id(event, filter=filter)
 
             next_event_id = next_event[1] if next_event else None
             prev_event_id = prev_event[1] if prev_event else None

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -78,6 +78,8 @@ class Filter(object):
     project_ids (Sequence[int]): List of project IDs to fetch - default None
     group_ids (Sequence[int]): List of group IDs to fetch - defualt None
     event_ids (Sequence[int]): List of event IDs to fetch - default None
+    dataset (Dataset): Dataset - default Events
+
     """
 
     def __init__(
@@ -157,7 +159,7 @@ class EventStorage(Service):
         Columns.USERNAME,
     ]
 
-    def get_events(self, filter, additional_columns, orderby, limit, offset, dataset, referrer):
+    def get_events(self, filter, additional_columns, orderby, limit, offset, referrer):
         """
         Fetches a list of events given a set of criteria.
 
@@ -167,7 +169,6 @@ class EventStorage(Service):
         orderby (Sequence[str]): List of fields to order by - default ['-time', '-event_id']
         limit (int): Query limit - default 100
         offset (int): Query offset - default 0
-        dataset (Dataset): Dataset - default None
         referrer (string): Referrer - default "eventstore.get_events"
         """
         raise NotImplementedError
@@ -180,11 +181,11 @@ class EventStorage(Service):
         project_id (int): Project ID
         event_id (str): Event ID
         additional_columns: (Sequence[Column]) - List of addition columns to fetch - default None
-        dataset (Dataset): Dataset - default None
+        dataset (Dataset): Dataset - default Events
         """
         raise NotImplementedError
 
-    def get_next_event_id(self, event, filter, dataset):
+    def get_next_event_id(self, event, filter):
         """
         Gets the next event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)
@@ -192,11 +193,10 @@ class EventStorage(Service):
         Arguments:
         event (Event): Event object
         filter (Filter): Filter
-        dataset (Dataset): Dataset - default None
         """
         raise NotImplementedError
 
-    def get_prev_event_id(self, event, filter, dataset):
+    def get_prev_event_id(self, event, filter):
         """
         Gets the previous event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)
@@ -204,11 +204,10 @@ class EventStorage(Service):
         Arguments:
         event (Event): Event object
         filter (Filter): Filter
-        dataset (Dataset): Dataset - default None
         """
         raise NotImplementedError
 
-    def get_earliest_event_id(self, event, filter, dataset):
+    def get_earliest_event_id(self, event, filter):
         """
         Gets the earliest event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)
@@ -216,11 +215,10 @@ class EventStorage(Service):
         Arguments:
         event (Event): Event object
         filter (Filter): Filter
-        dataset (Dataset): Dataset - default None
         """
         raise NotImplementedError
 
-    def get_latest_event_id(self, event, filter, dataset):
+    def get_latest_event_id(self, event, filter):
         """
         Gets the latest event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)
@@ -228,7 +226,6 @@ class EventStorage(Service):
         Arguments:
         event (Event): Event object
         filter (Filter): Filter
-        dataset (Dataset): Dataset - default None
         """
         raise NotImplementedError
 

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -88,13 +88,17 @@ class Filter(object):
         project_ids=None,
         group_ids=None,
         event_ids=None,
+        dataset=None,
     ):
+        from sentry.utils.snuba import Dataset
+
         self.start = start
         self.end = end
         self.conditions = conditions
         self.project_ids = project_ids
         self.group_ids = group_ids
         self.event_ids = event_ids
+        self.dataset = dataset or Dataset.Events
 
     @property
     def filter_keys(self):

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -153,7 +153,7 @@ class EventStorage(Service):
         Columns.USERNAME,
     ]
 
-    def get_events(self, filter, additional_columns, orderby, limit, offset, referrer):
+    def get_events(self, filter, additional_columns, orderby, limit, offset, dataset, referrer):
         """
         Fetches a list of events given a set of criteria.
 
@@ -163,11 +163,12 @@ class EventStorage(Service):
         orderby (Sequence[str]): List of fields to order by - default ['-time', '-event_id']
         limit (int): Query limit - default 100
         offset (int): Query offset - default 0
+        dataset (Dataset): Dataset - default None
         referrer (string): Referrer - default "eventstore.get_events"
         """
         raise NotImplementedError
 
-    def get_event_by_id(self, project_id, event_id, additional_columns):
+    def get_event_by_id(self, project_id, event_id, additional_columns, dataset):
         """
         Gets a single event given a project_id and event_id.
 
@@ -175,10 +176,11 @@ class EventStorage(Service):
         project_id (int): Project ID
         event_id (str): Event ID
         additional_columns: (Sequence[Column]) - List of addition columns to fetch - default None
+        dataset (Dataset): Dataset - default None
         """
         raise NotImplementedError
 
-    def get_next_event_id(self, event, filter):
+    def get_next_event_id(self, event, filter, dataset):
         """
         Gets the next event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)
@@ -186,10 +188,11 @@ class EventStorage(Service):
         Arguments:
         event (Event): Event object
         filter (Filter): Filter
+        dataset (Dataset): Dataset - default None
         """
         raise NotImplementedError
 
-    def get_prev_event_id(self, event, filter):
+    def get_prev_event_id(self, event, filter, dataset):
         """
         Gets the previous event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)
@@ -197,10 +200,11 @@ class EventStorage(Service):
         Arguments:
         event (Event): Event object
         filter (Filter): Filter
+        dataset (Dataset): Dataset - default None
         """
         raise NotImplementedError
 
-    def get_earliest_event_id(self, event, filter):
+    def get_earliest_event_id(self, event, filter, dataset):
         """
         Gets the earliest event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)
@@ -208,10 +212,11 @@ class EventStorage(Service):
         Arguments:
         event (Event): Event object
         filter (Filter): Filter
+        dataset (Dataset): Dataset - default None
         """
         raise NotImplementedError
 
-    def get_latest_event_id(self, event, filter):
+    def get_latest_event_id(self, event, filter, dataset):
         """
         Gets the latest event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)
@@ -219,6 +224,7 @@ class EventStorage(Service):
         Arguments:
         event (Event): Event object
         filter (Filter): Filter
+        dataset (Dataset): Dataset - default None
         """
         raise NotImplementedError
 

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -26,8 +26,6 @@ class SnubaEventStorage(EventStorage):
         orderby=DEFAULT_ORDERBY,
         limit=DEFAULT_LIMIT,
         offset=DEFAULT_OFFSET,
-        # TODO: Switch default to none when transactions are supported
-        dataset=snuba.Dataset.Events,
         referrer="eventstore.get_events",
     ):
         """
@@ -47,7 +45,7 @@ class SnubaEventStorage(EventStorage):
             orderby=orderby,
             limit=limit,
             offset=offset,
-            dataset=dataset,
+            dataset=filter.dataset,
             referrer=referrer,
         )
 

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -55,12 +55,7 @@ class SnubaEventStorage(EventStorage):
         return []
 
     def get_event_by_id(
-        self,
-        project_id,
-        event_id,
-        additional_columns=None,
-        # TODO: Switch default to none when transactions are supported
-        dataset=snuba.Dataset.Events,
+        self, project_id, event_id, additional_columns=None, dataset=snuba.Dataset.Events
     ):
         """
         Get an event given a project ID and event ID


### PR DESCRIPTION
Adds a `dataset` parameter to all eventstore functions (via Filter), that supports
passing a dataset to be searched.

In many cases we already know which dataset we want to search (apart
from Discover v2 this is always Events). This avoids unnecessarily
running the detect_dataset function and possibly making an incorrect
decision in these scenarios.