### PR TITLE
fix(discover2) Add eventsv2 to the global header list

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -163,6 +163,7 @@ class Sidebar extends React.Component {
       'events',
       'releases',
       'user-feedback',
+      'eventsv2',
     ].map(route => `/organizations/${this.props.organization.slug}/${route}/`);
 
     // Only keep the querystring if the current route matches one of the above


### PR DESCRIPTION
EventsV2 was not in the global header safe list and thus had project selections dropped when navigated to from another global selection route.

Fixes SEN-1165