### PR TITLE
replace Asana id with new gid

### DIFF
--- a/src/social_auth/backends/asana.py
+++ b/src/social_auth/backends/asana.py
@@ -22,7 +22,7 @@ class AsanaBackend(OAuthBackend):
     EXTRA_DATA = [
         ("email", "email"),
         ("name", "full_name"),
-        ("id", "id"),
+        ("gid", "id"),
         ("refresh_token", "refresh_token"),
     ]
 
@@ -31,7 +31,7 @@ class AsanaBackend(OAuthBackend):
 
         return {
             "email": response.get("email"),
-            "id": response.get("id"),
+            "id": response.get("gid"),
             "full_name": response.get("name"),
         }
 


### PR DESCRIPTION
Asana is in the process of deprecating the numerical field `id` and replacing it with a string field `gid`. This has broken our Asana integration because the `id` field is now gone. More details here: https://asana.com/developers/news/string-ids