### PR TITLE
ref(grid-emotion): Refactor `<Tag>`

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/account/accountEmails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountEmails.jsx
@@ -1,7 +1,9 @@
 import {Flex, Box} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 
+import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
 import AlertLink from 'app/components/alertLink';
@@ -9,10 +11,10 @@ import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
-import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import Tag from 'app/views/settings/components/tag';
 import accountEmailsFields from 'app/data/forms/accountEmails';
+import space from 'app/styles/space';
 
 const ENDPOINT = '/users/me/emails/';
 
@@ -49,15 +51,9 @@ class EmailRow extends React.Component {
         <Flex align="center">
           {email}
           {!isVerified && (
-            <Tag ml={1} priority="warning">
-              {t('Unverified')}
-            </Tag>
+            <TagWithSpace priority="warning">{t('Unverified')}</TagWithSpace>
           )}
-          {isPrimary && (
-            <Tag ml={1} priority="success">
-              {t('Primary')}
-            </Tag>
-          )}
+          {isPrimary && <TagWithSpace priority="success">{t('Primary')}</TagWithSpace>}
         </Flex>
         <Flex>
           {!isPrimary && isVerified && (
@@ -96,7 +92,7 @@ class AccountEmails extends AsyncView {
     return 'Emails';
   }
 
-  handleSubmitSuccess = (change, model, id) => {
+  handleSubmitSuccess = (_change, model, id) => {
     model.setValue(id, '');
     this.remountComponent();
   };
@@ -199,3 +195,7 @@ class AccountEmails extends AsyncView {
 }
 
 export default AccountEmails;
+
+const TagWithSpace = styled(Tag)`
+  margin-left: ${space(1)};
+`;

--- a/src/sentry/static/sentry/app/views/settings/components/tag.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/tag.jsx
@@ -18,33 +18,14 @@ const getBorder = p =>
       };`
     : '';
 
-const Tag = ({
-  children,
-  icon,
-  priority: _priority,
-  size: _size,
-  border: _border,
-  ...props
-}) => (
-  <div {...props}>
-    {icon && <StyledInlineSvg src={icon} size="12px" />}
-    {children}
-  </div>
-);
-
-Tag.propTypes = {
-  priority: PropTypes.string,
-  size: PropTypes.string,
-  border: PropTypes.bool,
-  icon: PropTypes.string,
-  inline: PropTypes.bool,
-};
-
-const StyledInlineSvg = styled(InlineSvg)`
-  margin-right: 4px;
-`;
-
-const StyledTag = styled(Tag)`
+const Tag = styled(
+  ({children, icon, priority: _priority, size: _size, border: _border, ...props}) => (
+    <div {...props}>
+      {icon && <StyledInlineSvg src={icon} size="12px" />}
+      {children}
+    </div>
+  )
+)`
   display: inline-flex;
   box-sizing: border-box;
   padding: ${p => (p.size === 'small' ? '0.1em 0.4em 0.2em' : '0.35em 0.8em 0.4em')};
@@ -63,4 +44,16 @@ const StyledTag = styled(Tag)`
   ${p => getMarginLeft(p)};
 `;
 
-export default StyledTag;
+Tag.propTypes = {
+  priority: PropTypes.string,
+  size: PropTypes.string,
+  border: PropTypes.bool,
+  icon: PropTypes.string,
+  inline: PropTypes.bool,
+};
+
+const StyledInlineSvg = styled(InlineSvg)`
+  margin-right: 4px;
+`;
+
+export default Tag;

--- a/src/sentry/static/sentry/app/views/settings/components/tag.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/tag.jsx
@@ -1,4 +1,3 @@
-import {Box} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
@@ -19,10 +18,35 @@ const getBorder = p =>
       };`
     : '';
 
-const TagTextStyled = styled(({priority, size, border, inline, ...props}) => (
-  <Box {...props} />
-))`
+const Tag = ({
+  children,
+  icon,
+  priority: _priority,
+  size: _size,
+  border: _border,
+  ...props
+}) => (
+  <div {...props}>
+    {icon && <StyledInlineSvg src={icon} size="12px" />}
+    {children}
+  </div>
+);
+
+Tag.propTypes = {
+  priority: PropTypes.string,
+  size: PropTypes.string,
+  border: PropTypes.bool,
+  icon: PropTypes.string,
+  inline: PropTypes.bool,
+};
+
+const StyledInlineSvg = styled(InlineSvg)`
+  margin-right: 4px;
+`;
+
+const StyledTag = styled(Tag)`
   display: inline-flex;
+  box-sizing: border-box;
   padding: ${p => (p.size === 'small' ? '0.1em 0.4em 0.2em' : '0.35em 0.8em 0.4em')};
   font-size: 75%;
   line-height: 1;
@@ -39,23 +63,4 @@ const TagTextStyled = styled(({priority, size, border, inline, ...props}) => (
   ${p => getMarginLeft(p)};
 `;
 
-const Tag = ({children, icon, priority, size, border, ...props}) => (
-  <TagTextStyled priority={priority} size={size} border={border} {...props}>
-    {icon && <StyledInlineSvg src={icon} size="12px" />}
-    {children}
-  </TagTextStyled>
-);
-
-Tag.propTypes = {
-  priority: PropTypes.string,
-  size: PropTypes.string,
-  border: PropTypes.bool,
-  icon: PropTypes.string,
-  inline: PropTypes.bool,
-};
-
-const StyledInlineSvg = styled(InlineSvg)`
-  margin-right: 4px;
-`;
-
-export default Tag;
+export default StyledTag;

--- a/tests/js/spec/components/__snapshots__/tag.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/tag.spec.jsx.snap
@@ -1,11 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tag renders 1`] = `
-<TagTextStyled
+<Tag
   border={true}
   priority="info"
   size="small"
 >
-  Text to Copy
-</TagTextStyled>
+  <Component
+    border={true}
+    className="css-1kkbi00-Tag e6q9yfr0"
+    priority="info"
+    size="small"
+  >
+    <div
+      className="css-1kkbi00-Tag e6q9yfr0"
+    >
+      Text to Copy
+    </div>
+  </Component>
+</Tag>
 `;

--- a/tests/js/spec/components/tag.spec.jsx
+++ b/tests/js/spec/components/tag.spec.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import {shallow} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import Tag from 'app/views/settings/components/tag';
 
 describe('Tag', function() {
   it('renders', function() {
-    const wrapper = shallow(
+    const wrapper = mountWithTheme(
       <Tag priority="info" border size="small">
         Text to Copy
       </Tag>


### PR DESCRIPTION
Only `<AccountEmails>` was passing grid-emotion props to `<Tags>`.

### settings/components/tag
Before:
![image](https://user-images.githubusercontent.com/79684/66967509-025c1480-f036-11e9-951b-c866bd60c70e.png)

After:
![image](https://user-images.githubusercontent.com/79684/66967726-c6757f00-f036-11e9-8fd7-49d1c518e497.png)
