### PR TITLE
ref(grid-emotion): Refactor `<Events>`

### DIFF
--- a/src/sentry/static/sentry/app/views/events/events.jsx
+++ b/src/sentry/static/sentry/app/views/events/events.jsx
@@ -1,4 +1,3 @@
-import {Flex} from 'grid-emotion';
 import {browserHistory} from 'react-router';
 import {isEqual} from 'lodash';
 import PropTypes from 'prop-types';
@@ -205,7 +204,7 @@ class Events extends AsyncView {
         />
 
         {!loading && !reloading && !error && (
-          <Flex align="center" justify="space-between">
+          <PaginationWrapper>
             <RowDisplay>
               {events.length ? t(`Results ${this.renderRowCounts()}`) : t('No Results')}
               {!!events.length && eventsPageLinks && (
@@ -222,12 +221,18 @@ class Events extends AsyncView {
               )}
             </RowDisplay>
             <Pagination pageLinks={eventsPageLinks} className="" />
-          </Flex>
+          </PaginationWrapper>
         )}
       </React.Fragment>
     );
   }
 }
+
+const PaginationWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
 
 const RowDisplay = styled('div')`
   color: ${p => p.theme.gray6};


### PR DESCRIPTION
Remove `grid-emotion` usage

### views/events/events
![image](https://user-images.githubusercontent.com/79684/66961655-01ba8280-f024-11e9-840b-28f200025872.png)


