### PR TITLE
fix(ui): Fix "API dashboard" link causing full reload

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/account/accountAuthorizations.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountAuthorizations.jsx
@@ -1,3 +1,4 @@
+import {Link} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
@@ -86,7 +87,7 @@ class AccountAuthorizations extends AsyncView {
         <SettingsPageHeader title="Authorized Applications" />
         <Description>
           {tct('You can manage your own applications via the [link:API dashboard].', {
-            link: <a href="/settings/account/api/" />,
+            link: <Link to="/settings/account/api/" />,
           })}
         </Description>
 

--- a/tests/js/spec/views/__snapshots__/accountAuthorization.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/accountAuthorization.spec.jsx.snap
@@ -18,16 +18,18 @@ exports[`AccountAuthorizations renders empty 1`] = `
         >
           You can manage your own applications via the 
         </span>
-        <a
-          href="/settings/account/api/"
+        <Link
           key="2"
+          onlyActiveOnIndex={false}
+          style={Object {}}
+          to="/settings/account/api/"
         >
           <span
             key="1"
           >
             API dashboard
           </span>
-        </a>
+        </Link>
         <span
           key="3"
         >


### PR DESCRIPTION
This should be a `react-router` `<Link>`