### PR TITLE
fix(discover2) Fix issue.id formatting and missing graph data.

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -348,6 +348,7 @@ type SpecialFields = {
   project: SpecialField;
   user: SpecialField;
   last_seen: SpecialField;
+  'issue.id': SpecialField;
 };
 
 /**
@@ -356,6 +357,19 @@ type SpecialFields = {
  * displays with a custom render function.
  */
 export const SPECIAL_FIELDS: SpecialFields = {
+  'issue.id': {
+    sortField: 'issue.id',
+    renderFunc: (data, {organization}) => {
+      const target = `/organizations/${organization.slug}/issues/${data['issue.id']}/`;
+      return (
+        <Container>
+          <OverflowLink to={target} aria-label={data['issue.id']}>
+            {data['issue.id']}
+          </OverflowLink>
+        </Container>
+      );
+    },
+  },
   transaction: {
     sortField: 'transaction',
     renderFunc: (data, {location}) => {

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1210,13 +1210,13 @@ def get_snuba_translators(filter_keys, is_grouprelease=False):
         if "time" in row
         else row,
     )
-    # Extra reverse translator for bucketed_start column.
+    # Extra reverse translator for bucketed_end column.
     reverse = compose(
         reverse,
         lambda row: replace(
-            row, "bucketed_start", int(to_timestamp(parse_datetime(row["bucketed_start"])))
+            row, "bucketed_end", int(to_timestamp(parse_datetime(row["bucketed_end"])))
         )
-        if "bucketed_start" in row
+        if "bucketed_end" in row
         else row,
     )
 


### PR DESCRIPTION
Format the issue.id column as a string-y value and provide a link to the issue details. Down the road we'll format the link as a shortId but right now we don't have that data at hand as it requires reading from the groups models.

![Screen Shot 2019-10-17 at 11 31 32 AM](https://user-images.githubusercontent.com/24086/67024169-f4f46800-f0d1-11e9-9e0b-ddb9ebe4f09a.png)

I've also fixed the missing timestamp conversion for `bucketed_end` which was resulting in time series data not being formatted correctly. This was caused by switching from bucketed_start to bucketed_end as the `time` alias last week.