### PR TITLE
chore(vscode): Update config for vscode-python

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,6 +66,6 @@
   "restructuredtext.confPath": "",
   "python.linting.enabled": true,
   "python.linting.flake8Path": "${workspaceFolder}/.venv/bin/flake8",
-  "python.linting.pep8Path": "${workspaceFolder}/.venv/bin/pep8",
+  "python.linting.pycodestylePath": "${workspaceFolder}/.venv/bin/pep8",
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest"
 }


### PR DESCRIPTION
VS Code 2019.10.0-rc replaced `pep8` with `pycodestyle`. Documentation here: https://github.com/microsoft/vscode-python/blob/master/CHANGELOG.md

See "Fixes" > (1) for more information.