### PR TITLE
fix(ui): Unsubscribe from environment store correctly

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/index.tsx
@@ -27,7 +27,7 @@ export class GroupEventDetailsContainer extends React.Component<Props, State> {
   state = OrganizationEnvironmentsStore.get();
 
   componentDidMount() {
-    this.environmentSubscription = OrganizationEnvironmentsStore.listen(data =>
+    this.environmentUnsubscribe = OrganizationEnvironmentsStore.listen(data =>
       this.setState(data)
     );
     const {environments, error} = OrganizationEnvironmentsStore.get();
@@ -37,13 +37,13 @@ export class GroupEventDetailsContainer extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
-    if (this.environmentSubscription) {
-      this.environmentSubscription.unsubscribe();
+    if (this.environmentUnsubscribe) {
+      this.environmentUnsubscribe();
     }
   }
 
   // TODO(ts): reflux :(
-  environmentSubscription: any;
+  environmentUnsubscribe: any;
 
   render() {
     if (this.state.error) {

--- a/tests/js/spec/views/organizationGroupDetails/groupEventDetailsContainer.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventDetailsContainer.spec.jsx
@@ -67,4 +67,20 @@ describe('groupEventDetailsContainer', () => {
     expect(wrapper.find('LoadingError').exists()).toBe(true);
     expect(environmentsCall).toHaveBeenCalledTimes(1);
   });
+
+  it('unsubscribes on unmount', async function() {
+    const unsubscribeMock = jest.fn();
+    jest
+      .spyOn(OrganizationEnvironmentsStore, 'listen')
+      .mockImplementation(() => unsubscribeMock);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/environments/`,
+      body: TestStubs.Environments(),
+    });
+    const wrapper = mount(<GroupEventDetailsContainer organization={org} />);
+    expect(wrapper.find('LoadingIndicator').exists()).toBe(true);
+    wrapper.unmount();
+    expect(unsubscribeMock).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
After merging in https://github.com/getsentry/sentry/pull/15006, this error (https://sentry.io/organizations/sentry/issues/1267301008/?project=11276&referrer=slack) started appearing due to incorrectly unsubscribing from the environments store. It should be fixed now and added a test to ensure that unsubscribe is being called on unmount.