### PR TITLE
fix: Fix unstable incident tests.

### DIFF
--- a/tests/sentry/api/serializers/test_incident_activity.py
+++ b/tests/sentry/api/serializers/test_incident_activity.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from uuid import uuid4
 
 import six
@@ -53,7 +53,7 @@ class IncidentActivitySerializerTest(TestCase, SnubaTestCase):
         assert result["comment"] == activity.comment
         assert result["dateCreated"] == activity.date_added
 
-    @freeze_time()
+    @freeze_time(datetime(2019, 10, 16, 12, 30, 25))
     def test_event_stats(self):
         for _ in range(2):
             self.store_event(

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -114,6 +114,7 @@ class TestBuildActivityContext(BaseIncidentActivityTest, TestCase):
             kwargs={"incident_id": incident.id},
         )
 
+    @freeze_time()
     def test_simple(self):
         activity = create_incident_activity(
             self.incident, IncidentActivityType.COMMENT, user=self.user, comment="hello"


### PR DESCRIPTION
These tests were periodically failing due to time boundary issues.