### PR TITLE
feat(withApi): Support disabling inflight request clears

### DIFF
--- a/src/sentry/static/sentry/app/utils/withApi.tsx
+++ b/src/sentry/static/sentry/app/utils/withApi.tsx
@@ -9,11 +9,26 @@ type InjectedApiProps = {
 
 type WrappedProps<P> = Omit<P, keyof InjectedApiProps> & Partial<InjectedApiProps>;
 
+type OptionProps = {
+  /**
+   * Enabling this option will disable clearing in-flight requests when the
+   * component is unmounted.
+   *
+   * This may be useful in situations where your component needs to finish up
+   * some where the client was passed into some type of action creator and the
+   * component is unmounted.
+   */
+  persistInFlight?: boolean;
+};
+
 /**
  * HoC that provides "api" client when mounted, and clears API requests when
  * component is unmounted
  */
-const withApi = <P extends InjectedApiProps>(WrappedComponent: React.ComponentType<P>) =>
+const withApi = <P extends InjectedApiProps>(
+  WrappedComponent: React.ComponentType<P>,
+  {persistInFlight}: OptionProps = {}
+) =>
   class extends React.Component<WrappedProps<P>> {
     static displayName = `withApi(${getDisplayName(WrappedComponent)})`;
 
@@ -23,7 +38,9 @@ const withApi = <P extends InjectedApiProps>(WrappedComponent: React.ComponentTy
     }
 
     componentWillUnmount() {
-      this.api.clear();
+      if (!persistInFlight) {
+        this.api.clear();
+      }
     }
 
     private api: Client;

--- a/tests/js/spec/utils/withApi.spec.jsx
+++ b/tests/js/spec/utils/withApi.spec.jsx
@@ -31,4 +31,14 @@ describe('withApi', function() {
 
     apiInstance.clear.mockRestore();
   });
+
+  it('does not cancels pending API requests if persistInFlight is enabled', function() {
+    const MyComponentWithApi = withApi(MyComponent, {persistInFlight: true});
+    const wrapper = mount(<MyComponentWithApi />);
+    jest.spyOn(apiInstance, 'clear');
+    wrapper.unmount();
+    expect(apiInstance.clear).not.toHaveBeenCalled();
+
+    apiInstance.clear.mockRestore();
+  });
 });


### PR DESCRIPTION
Using this on sentry.io for reloading org data after the trial starts.  The issue is that if the trial start button which makes this API request given the API component unmounts, the request to reload the org will be killed.