### PR TITLE
feat(gitlab): Add option to search for projects in subgroups

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -129,7 +129,7 @@ class GitLabApiClient(ApiClient):
         # Really useful, because we often don't need most of the project information
         return self.get(
             GitLabApiClientPath.group_projects.format(group=group),
-            params={"search": query, "simple": simple},
+            params={"search": query, "simple": simple, "include_subgroups": self.metadata["include_subgroups"]},
         )
 
     def get_project(self, project_id):

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -129,7 +129,7 @@ class GitLabApiClient(ApiClient):
         # Really useful, because we often don't need most of the project information
         return self.get(
             GitLabApiClientPath.group_projects.format(group=group),
-            params={"search": query, "simple": simple, "include_subgroups": self.metadata["include_subgroups"]},
+            params={"search": query, "simple": simple, "include_subgroups": self.metadata.get("include_subgroups", False)},
         )
 
     def get_project(self, project_id):

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -277,6 +277,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
                     "base_url": installation_data["url"],
                     "verify_ssl": installation_data["verify_ssl"],
                     "group": installation_data["group"],
+                    "include_subgroups": installation_data["include_subgroups"],
                     "error_message": e.message,
                     "error_status": e.code,
                 },
@@ -295,6 +296,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
         oauth_data = get_oauth_data(data)
         user = get_user_info(data["access_token"], state["installation_data"])
         group = self.get_group_info(data["access_token"], state["installation_data"])
+        include_subgroups = state["installation_data"]["include_subgroups"]
         scopes = sorted(GitlabIdentityProvider.oauth_scopes)
         base_url = state["installation_data"]["url"]
 
@@ -323,6 +325,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
                 "base_url": base_url,
                 "webhook_secret": secret.hexdigest(),
                 "group_id": group["id"],
+                "include_subgroups": include_subgroups,
             },
             "user_identity": {
                 "type": "gitlab",

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -135,6 +135,15 @@ class InstallationForm(forms.Form):
         ),
         widget=forms.TextInput(attrs={"placeholder": _("my-group/my-subgroup")}),
     )
+    include_subgroups = forms.BooleanField(
+        label=_("Include Subgroups"),
+        help_text=_(
+            "Include projects in subgroups of the GitLab group."
+        ),
+        widget=forms.CheckboxInput(),
+        required=False,
+        initial=False,
+    )
     verify_ssl = forms.BooleanField(
         label=_("Verify SSL"),
         help_text=_(

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -28,6 +28,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         "verify_ssl": True,
         "client_id": "client_id",
         "client_secret": "client_secret",
+        "include_subgroups": True,
     }
 
     default_group_id = 4
@@ -122,6 +123,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
             "base_url": "https://gitlab.example.com",
             "webhook_secret": "secret-token",
             "group_id": self.default_group_id,
+            "include_subgroups": True,
         }
         oi = OrganizationIntegration.objects.get(
             integration=integration, organization=self.organization


### PR DESCRIPTION
Add an installation option to the GitLab global organization integration to include projects in subgroups of the GitLab group.

Sentry's current behaviour only allows GitLab projects that are immediate members of the group to be used. When the new “Include Subgroups” option is enabled, projects in all subgroups of the group can also be searched and added.

Contributes to #12774 and #14799. This does not handle projects across an entire GitLab instance (e.g., when self-hosted).

![Screen Shot 2019-10-18 at 12 50 45 PM](https://user-images.githubusercontent.com/27340/67121024-c34dd080-f1a7-11e9-84ee-2a651921baea.png)
