### PR TITLE
build(docker): Add e2e testing w/ onpremise

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -16,23 +16,42 @@ steps:
     '-t', 'us.gcr.io/$PROJECT_ID/sentry:latest',
     '-f', './docker/Dockerfile', '.'
   ]
+  timeout: 900s
 # Derive the -onbuild variant
 - name: 'gcr.io/cloud-builders/docker'
   args: [
     'build',
+    '--build-arg', 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA',
     '-t', 'us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA-onbuild',
     '-t', 'us.gcr.io/$PROJECT_ID/sentry:$SHORT_SHA-onbuild',
     '-t', 'us.gcr.io/$PROJECT_ID/sentry:latest-onbuild',
     '-f', './docker/onbuild/Dockerfile', '.'
   ]
 # Smoke tests
-- name: 'us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
-  args: ['config', 'get', 'system.secret-key']
+- name: 'gcr.io/$PROJECT_ID/docker-compose'
+  entrypoint: 'bash'
   env:
-    - SENTRY_SKIP_BACKEND_VALIDATION=1
-    - SENTRY_SECRET_KEY=abc
-    - SENTRY_REDIS_HOST=localhost
- # Only tag "latest" when on master
+  - 'SENTRY_IMAGE=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
+  - 'SENTRY_TEST_HOST=http://web:9000'
+  - 'CI=1'
+  args:
+  - '-e'
+  - '-c'
+  - |
+    mkdir onpremise && cd onpremise
+    # TODO(byk): This should fetch from master when the branch is merged
+    # TODO(byk): We may also build this part as a builder image everytime
+    #            there's a push to onpremise and use that image for
+    curl -L "https://github.com/getsentry/onpremise/archive/v10.tar.gz" | tar xzf - --strip-components=1
+    ./install.sh
+    docker-compose run --rm web createuser --superuser --email test@example.com --password test123TEST
+    # The following trick is from https://stackoverflow.com/a/52400857/90297 with great gratuity
+    echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
+    docker-compose up -d
+    timeout 20 bash -c 'until $(curl -Isf -o /dev/null http://web:9000); do printf "."; sleep 0.5; done' || docker-compose logs web
+    ./test.sh
+  timeout: 1200s
+# Only tag "latest" when on master
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
   args:
@@ -43,9 +62,12 @@ steps:
       docker push us.gcr.io/$PROJECT_ID/sentry:latest
       docker push us.gcr.io/$PROJECT_ID/sentry:latest-onbuild
     fi
-timeout: 1200s
 images:
 - 'us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA'
 - 'us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA-onbuild'
 - 'us.gcr.io/$PROJECT_ID/sentry:$SHORT_SHA'
 - 'us.gcr.io/$PROJECT_ID/sentry:$SHORT_SHA-onbuild'
+timeout: 2400s
+options:
+  # We need more memory for Webpack builds & e2e onpremise tests
+  machineType: 'N1_HIGHCPU_8'

--- a/docker/onbuild/Dockerfile
+++ b/docker/onbuild/Dockerfile
@@ -1,4 +1,5 @@
-FROM getsentry/sentry:latest
+ARG SENTRY_IMAGE
+FROM ${SENTRY_IMAGE:-getsentry/sentry:latest}
 
 WORKDIR /usr/src/sentry
 


### PR DESCRIPTION
Replaces the very primitive smoke tests with actual e2e tests that uses the [onpremise](https://github.com/getsentry/onpremise) repo.

We can build a full onpremise acceptance test suite on top of this foundation. We may also generate a builder image, `gcr.io/sentryio/onpremise-testbed`, from the onpremise repo and use that as a build step to skip the somewhat hacky `curl -L "https://github.com/getsentry/onpremise/archive/v10.tar.gz" | tar xzf - --strip-components=1` part.