### PR TITLE
feat(platform): Improve keypress UX for SearchDropdown

### DIFF
--- a/src/sentry/static/sentry/app/components/autoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/autoComplete.jsx
@@ -226,7 +226,7 @@ class AutoComplete extends React.Component {
     this.setState(newState);
   };
 
-  moveHighlightedIndex = (step, e) => {
+  moveHighlightedIndex = (step, _e) => {
     let newIndex = this.state.highlightedIndex + step;
 
     // when this component is in virtualized mode, only a subset of items will be passed

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -401,7 +401,7 @@ class SmartSearchBar extends React.Component {
 
   onKeyUp = evt => {
     // Other keys are managed at onKeyDown function
-    if (evt.key !== 'Escape' || evt.keyCode !== 27) {
+    if (evt.key !== 'Escape') {
       return;
     }
 
@@ -414,7 +414,9 @@ class SmartSearchBar extends React.Component {
         ? findSearchItemByIndex(searchItems, activeSearchItem)
         : [];
 
-      delete searchItems[groupIndex].children[childrenIndex].active;
+      if (groupIndex !== undefined && childrenIndex !== undefined) {
+        delete searchItems[groupIndex].children[childrenIndex].active;
+      }
 
       this.setState({
         activeSearchItem: -1,

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -261,7 +261,7 @@ describe('SmartSearchBar', function() {
         const instance = wrapper.instance();
         jest.spyOn(instance, 'blur');
 
-        wrapper.find('input').simulate('keyup', {key: 'Escape', keyCode: '27'});
+        wrapper.find('input').simulate('keyup', {key: 'Escape'});
 
         expect(instance.blur).toHaveBeenCalledTimes(1);
       });
@@ -348,7 +348,7 @@ describe('SmartSearchBar', function() {
       searchBar.updateAutoCompleteItems();
       expect(searchBar.state.searchTerm).toEqual('');
       expect(searchBar.state.searchItems).toEqual([]);
-      expect(searchBar.state.activeSearchItem).toEqual(0);
+      expect(searchBar.state.activeSearchItem).toEqual(-1);
     });
 
     it('sets state when incomplete tag', async function() {
@@ -367,7 +367,7 @@ describe('SmartSearchBar', function() {
       expect(searchBar.state.searchItems).toEqual([
         expect.objectContaining({children: []}),
       ]);
-      expect(searchBar.state.activeSearchItem).toEqual(0);
+      expect(searchBar.state.activeSearchItem).toEqual(-1);
     });
 
     it('sets state when incomplete tag has negation operator', async function() {
@@ -386,7 +386,7 @@ describe('SmartSearchBar', function() {
       expect(searchBar.state.searchItems).toEqual([
         expect.objectContaining({children: []}),
       ]);
-      expect(searchBar.state.activeSearchItem).toEqual(0);
+      expect(searchBar.state.activeSearchItem).toEqual(-1);
     });
 
     it('sets state when incomplete tag as second input', async function() {
@@ -406,7 +406,7 @@ describe('SmartSearchBar', function() {
       expect(searchBar.state.searchTerm).toEqual('fu');
       // 1 items because of headers ("Tags")
       expect(searchBar.state.searchItems).toHaveLength(1);
-      expect(searchBar.state.activeSearchItem).toEqual(0);
+      expect(searchBar.state.activeSearchItem).toEqual(-1);
     });
 
     it('does not request values when tag is environments', function() {

--- a/tests/js/spec/views/issueList/searchBar.spec.jsx
+++ b/tests/js/spec/views/issueList/searchBar.spec.jsx
@@ -194,8 +194,17 @@ describe('IssueListSearchBar', function() {
 
       wrapper.find('input').simulate('change', {target: {value: 'is:'}});
       await tick();
-      wrapper.update();
 
+      wrapper.update();
+      expect(
+        wrapper
+          .find('SearchItem')
+          .at(0)
+          .find('li')
+          .prop('className')
+      ).not.toContain('active');
+
+      wrapper.find('input').simulate('keyDown', {key: 'ArrowDown'});
       expect(
         wrapper
           .find('SearchItem')
@@ -204,8 +213,17 @@ describe('IssueListSearchBar', function() {
           .prop('className')
       ).toContain('active');
 
-      wrapper.find('input').simulate('keyDown', {key: 'ArrowUp'});
+      wrapper.find('input').simulate('keyDown', {key: 'ArrowDown'});
+      expect(
+        wrapper
+          .find('SearchItem')
+          .at(1)
+          .find('li')
+          .prop('className')
+      ).toContain('active');
 
+      wrapper.find('input').simulate('keyDown', {key: 'ArrowUp'});
+      wrapper.find('input').simulate('keyDown', {key: 'ArrowUp'});
       expect(
         wrapper
           .find('SearchItem')


### PR DESCRIPTION
### Before
- `focus` on `<input/>` will cause...
  - `Dropdown` to open
  - `DropdownItem` at the top of the list will be highlighted
- Pressing `ArrowUp`/`ArrowDown` will...
  - Go up/down the list of `DropdownItem` 
- Pressing `Tab` will...
  - Select the highlighted `DropdownItem`
- Pressing `Enter` will...
  - Run the search
- Pressing 'Escape' will...
  - `blur` on `<input/>`
- Clicking on a `DropdownItem` will..
  - Select the highlighted `DropdownItem`

### After
- `focus` on `<input/>` will cause...
  - `Dropdown` to open
  - `DropdownItem` will *not* be highlighted
- Pressing `ArrowUp`/`ArrowDown` will...
  - Highlight `DropdownItem` at the top/bottom of the list
  - Go up/down the list of `DropdownItem` 
- Pressing `Tab` will...
  - Select the highlighted `DropdownItem`
- Pressing `Enter` will...
  - If a `DropdownItem` is highlighted...
    - Select the highlighted `DropdownItem`
  - Else...
    - Run the search
- Pressing 'Escape' wil...
  - If a `DropdownItem` is highlighted...
    - Unselect the `DropdownItem`
  - Else...
    - `blur` on `<input/>`
- Clicking on a `DropdownItem` will..
  - Select the highlighted `DropdownItem`