### PR TITLE
feat(gitlab): Add support for integrating projects from entire GitLab instances

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -27,6 +27,7 @@ class GitLabApiClientPath(object):
     project_issues = u"/projects/{project}/issues"
     project_hooks = u"/projects/{project}/hooks"
     project_hook = u"/projects/{project}/hooks/{hook_id}"
+    projects = u"/projects"
     user = u"/user"
 
     @staticmethod

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -135,6 +135,7 @@ class GitLabApiClient(ApiClient):
                 params={
                     "search": query,
                     "simple": simple,
+                    "order_by": "last_activity_at",
                     "include_subgroups": self.metadata.get("include_subgroups", False)
                 },
             )
@@ -143,8 +144,9 @@ class GitLabApiClient(ApiClient):
                 GitLabApiClientPath.projects,
                 params={
                     "search": query,
-                    "simple": simple
-                }
+                    "simple": simple,
+                    "order_by": "last_activity_at"
+                },
             )
 
     def get_project(self, project_id):

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -121,21 +121,31 @@ class GitLabApiClient(ApiClient):
         """
         return self.get(GitLabApiClientPath.user)
 
-    def search_group_projects(self, group, query=None, simple=True):
-        """Get projects for a group
+    def search_projects(self, group=None, query=None, simple=True):
+        """Get projects
 
         See https://docs.gitlab.com/ee/api/groups.html#list-a-group-s-projects
+        and https://docs.gitlab.com/ee/api/projects.html#list-all-projects
         """
         # simple param returns limited fields for the project.
         # Really useful, because we often don't need most of the project information
-        return self.get(
-            GitLabApiClientPath.group_projects.format(group=group),
-            params={
-                "search": query,
-                "simple": simple,
-                "include_subgroups": self.metadata.get("include_subgroups", False),
-            },
-        )
+        if group:
+            return self.get(
+                GitLabApiClientPath.group_projects.format(group=group),
+                params={
+                    "search": query,
+                    "simple": simple,
+                    "include_subgroups": self.metadata.get("include_subgroups", False)
+                },
+            )
+        else:
+            return self.get(
+                GitLabApiClientPath.projects,
+                params={
+                    "search": query,
+                    "simple": simple
+                }
+            )
 
     def get_project(self, project_id):
         """Get project

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -145,7 +145,8 @@ class InstallationForm(forms.Form):
         help_text=_(
             "Include projects in subgroups of the GitLab group."
             "<br>"
-            "Not applicable when integrating an entire GitLab instance."
+            "Not applicable when integrating an entire GitLab instance. "
+            "All groups are included for instance-level integrations."
         ),
         widget=forms.CheckboxInput(),
         required=False,

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -295,10 +295,15 @@ class GitlabIntegrationProvider(IntegrationProvider):
         data = state["identity"]["data"]
         oauth_data = get_oauth_data(data)
         user = get_user_info(data["access_token"], state["installation_data"])
-        group = self.get_group_info(data["access_token"], state["installation_data"])
-        include_subgroups = state["installation_data"]["include_subgroups"]
         scopes = sorted(GitlabIdentityProvider.oauth_scopes)
         base_url = state["installation_data"]["url"]
+
+        if state["installation_data"]["group"]:
+            group = self.get_group_info(data["access_token"], state["installation_data"])
+            include_subgroups = state["installation_data"]["include_subgroups"]
+        else:
+            group = {}
+            include_subgroups = False
 
         hostname = urlparse(base_url).netloc
         verify_ssl = state["installation_data"]["verify_ssl"]
@@ -309,22 +314,22 @@ class GitlabIntegrationProvider(IntegrationProvider):
         secret = sha1_text("".join([hostname, state["installation_data"]["client_id"]]))
 
         integration = {
-            "name": group["full_name"],
+            "name": group.get("full_name", hostname),
             # Splice the gitlab host and project together to
             # act as unique link between a gitlab instance, group + sentry.
             # This value is embedded then in the webook token that we
             # give to gitlab to allow us to find the integration a hook came
             # from.
-            "external_id": u"{}:{}".format(hostname, group["id"]),
+            "external_id": u"{}:{}".format(hostname, group.get("id", "instance")),
             "metadata": {
-                "icon": group["avatar_url"],
+                "icon": group.get("avatar_url", None),
                 "instance": hostname,
-                "domain_name": u"{}/{}".format(hostname, group["full_path"]),
+                "domain_name": u"{}/{}".format(hostname, group.get("full_path", "")),
                 "scopes": scopes,
                 "verify_ssl": verify_ssl,
                 "base_url": base_url,
                 "webhook_secret": secret.hexdigest(),
-                "group_id": group["id"],
+                "group_id": group.get("id", None),
                 "include_subgroups": include_subgroups,
             },
             "user_identity": {

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -131,9 +131,11 @@ class InstallationForm(forms.Form):
             "This can be found in the URL of your group's GitLab page. "
             "<br>"
             "For example, if your group can be found at "
-            "https://gitlab.com/my-group/my-subgroup, enter `my-group/my-subgroup`."
+            "https://gitlab.com/my-group/my-subgroup, enter `my-group/my-subgroup`. "
+            "Leave blank to integrate an entire self-managed GitLab instance."
         ),
         widget=forms.TextInput(attrs={"placeholder": _("my-group/my-subgroup")}),
+        required=False,
     )
     include_subgroups = forms.BooleanField(
         label=_("Include Subgroups"),

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -135,7 +135,7 @@ class InstallationForm(forms.Form):
             "<br>"
             "If you are trying to integrate an entire self-managed GitLab instance, "
             "leave this empty. Doing so will also allow you to select projects in "
-            "user namespaces (such as users' personal repositories and users' forks)."
+            "all group and user namespaces (such as users' personal repositories and forks)."
         ),
         widget=forms.TextInput(attrs={"placeholder": _("my-group/my-subgroup")}),
         required=False,

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -133,7 +133,9 @@ class InstallationForm(forms.Form):
             "For example, if your group URL is "
             "https://gitlab.com/my-group/my-subgroup, enter `my-group/my-subgroup`."
             "<br>"
-            "Leave this empty to integrate an entire self-managed GitLab instance."
+            "If you are trying to integrate an entire self-managed GitLab instance, "
+            "leave this empty. Doing so will also allow you to select projects in "
+            "user namespaces (such as users' personal repositories and users' forks)."
         ),
         widget=forms.TextInput(attrs={"placeholder": _("my-group/my-subgroup")}),
         required=False,

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -88,13 +88,13 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
     def get_repositories(self, query=None):
         # Note: gitlab projects are the same things as repos everywhere else
         group = self.get_group_id()
-        resp = self.get_client().search_group_projects(group, query)
+        resp = self.get_client().search_projects(group, query)
         return [{"identifier": repo["id"], "name": repo["name_with_namespace"]} for repo in resp]
 
     def search_projects(self, query):
         client = self.get_client()
         group_id = self.get_group_id()
-        return client.search_group_projects(group_id, query)
+        return client.search_projects(group_id, query)
 
     def search_issues(self, project_id, query, iids):
         client = self.get_client()

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -141,7 +141,8 @@ class InstallationForm(forms.Form):
     include_subgroups = forms.BooleanField(
         label=_("Include Subgroups"),
         help_text=_(
-            "Include projects in subgroups of the GitLab group. "
+            "Include projects in subgroups of the GitLab group."
+            "<br>"
             "Not applicable when integrating an entire GitLab instance."
         ),
         widget=forms.CheckboxInput(),

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -119,7 +119,7 @@ class InstallationForm(forms.Form):
         label=_("GitLab URL"),
         help_text=_(
             "The base URL for your GitLab instance, including the host and protocol. "
-            "Do not include group path."
+            "Do not include the group path."
             "<br>"
             "If using gitlab.com, enter https://gitlab.com/"
         ),
@@ -128,18 +128,22 @@ class InstallationForm(forms.Form):
     group = forms.CharField(
         label=_("GitLab Group Path"),
         help_text=_(
-            "This can be found in the URL of your group's GitLab page. "
+            "This can be found in the URL of your group's GitLab page."
             "<br>"
-            "For example, if your group can be found at "
-            "https://gitlab.com/my-group/my-subgroup, enter `my-group/my-subgroup`. "
-            "Leave blank to integrate an entire self-managed GitLab instance."
+            "For example, if your group URL is "
+            "https://gitlab.com/my-group/my-subgroup, enter `my-group/my-subgroup`."
+            "<br>"
+            "Leave this empty to integrate an entire self-managed GitLab instance."
         ),
         widget=forms.TextInput(attrs={"placeholder": _("my-group/my-subgroup")}),
         required=False,
     )
     include_subgroups = forms.BooleanField(
         label=_("Include Subgroups"),
-        help_text=_("Include projects in subgroups of the GitLab group."),
+        help_text=_(
+            "Include projects in subgroups of the GitLab group. "
+            "Not applicable when integrating an entire GitLab instance."
+        ),
         widget=forms.CheckboxInput(),
         required=False,
         initial=False,

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -178,3 +178,119 @@ class GitlabIntegrationTest(IntegrationTestCase):
 
         installation = integration.get_installation(self.organization.id)
         assert self.default_group_id == installation.get_group_id()
+
+
+class GitlabIntegrationInstanceTest(IntegrationTestCase):
+    provider = GitlabIntegrationProvider
+    config = {
+        # Trailing slash is intentional to ensure that valid
+        # URLs are generated even if the user inputs a trailing /
+        "url": "https://gitlab.example.com/",
+        "name": "Test App",
+        "group": "",
+        "verify_ssl": True,
+        "client_id": "client_id",
+        "client_secret": "client_secret",
+        "include_subgroups": True,
+    }
+
+    def setUp(self):
+        super(GitlabIntegrationTest, self).setUp()
+        self.init_path_without_guide = "%s%s" % (self.init_path, "?completed_installation_guide")
+
+    def assert_setup_flow(self, user_id="user_id_1"):
+        resp = self.client.get(self.init_path)
+        assert resp.status_code == 200
+        self.assertContains(resp, "you will need to create a Sentry app in your GitLab instance")
+        resp = self.client.get(self.init_path_without_guide)
+        assert resp.status_code == 200
+        resp = self.client.post(self.init_path_without_guide, data=self.config)
+        assert resp.status_code == 302
+        redirect = urlparse(resp["Location"])
+        assert redirect.scheme == "https"
+        assert redirect.netloc == "gitlab.example.com"
+        assert redirect.path == "/oauth/authorize"
+
+        params = parse_qs(redirect.query)
+        assert params["state"]
+        assert params["redirect_uri"] == ["http://testserver/extensions/gitlab/setup/"]
+        assert params["response_type"] == ["code"]
+        assert params["client_id"] == ["client_id"]
+        # once we've asserted on it, switch to a singular values to make life
+        # easier
+        authorize_params = {k: v[0] for k, v in six.iteritems(params)}
+
+        access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+
+        responses.add(
+            responses.POST,
+            "https://gitlab.example.com/oauth/token",
+            json={"access_token": access_token},
+        )
+        responses.add(responses.GET, "https://gitlab.example.com/api/v4/user", json={"id": user_id})
+        responses.add(
+            responses.POST, "https://gitlab.example.com/api/v4/hooks", json={"id": "webhook-id-1"}
+        )
+
+        resp = self.client.get(
+            u"{}?{}".format(
+                self.setup_path,
+                urlencode({"code": "oauth-code", "state": authorize_params["state"]}),
+            )
+        )
+
+        mock_access_token_request = responses.calls[0].request
+        req_params = parse_qs(mock_access_token_request.body)
+        assert req_params["grant_type"] == ["authorization_code"]
+        assert req_params["code"] == ["oauth-code"]
+        assert req_params["redirect_uri"] == ["http://testserver/extensions/gitlab/setup/"]
+        assert req_params["client_id"] == ["client_id"]
+        assert req_params["client_secret"] == ["client_secret"]
+
+        assert resp.status_code == 200
+
+        self.assertDialogSuccess(resp)
+
+    @responses.activate
+    @patch("sentry.integrations.gitlab.integration.sha1_text")
+    def test_basic_flow(self, mock_sha):
+        sha = Mock()
+        sha.hexdigest.return_value = "secret-token"
+        mock_sha.return_value = sha
+
+        self.assert_setup_flow()
+
+        integration = Integration.objects.get(provider=self.provider.key)
+
+        assert integration.external_id == "gitlab.example.com:instance"
+        assert integration.name == "gitlab.example.com"
+        assert integration.metadata == {
+            "instance": "gitlab.example.com",
+            "scopes": ["api"],
+            "icon": None,
+            "domain_name": u"gitlab.example.com/",
+            "verify_ssl": True,
+            "base_url": "https://gitlab.example.com",
+            "webhook_secret": "secret-token",
+            "group_id": None,
+            "include_subgroups": False,
+        }
+        oi = OrganizationIntegration.objects.get(
+            integration=integration, organization=self.organization
+        )
+        assert oi.config == {}
+
+        idp = IdentityProvider.objects.get(type="gitlab")
+        identity = Identity.objects.get(
+            idp=idp, user=self.user, external_id="gitlab.example.com:user_id_1"
+        )
+        assert identity.status == IdentityStatus.VALID
+        assert identity.data == {"access_token": "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"}
+
+    @responses.activate
+    def test_get_group_id(self):
+        self.assert_setup_flow()
+        integration = Integration.objects.get(provider=self.provider.key)
+
+        installation = integration.get_installation(self.organization.id)
+        assert None == installation.get_group_id()

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -195,7 +195,7 @@ class GitlabIntegrationInstanceTest(IntegrationTestCase):
     }
 
     def setUp(self):
-        super(GitlabIntegrationTest, self).setUp()
+        super(GitlabIntegrationInstanceTest, self).setUp()
         self.init_path_without_guide = "%s%s" % (self.init_path, "?completed_installation_guide")
 
     def assert_setup_flow(self, user_id="user_id_1"):

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -293,4 +293,4 @@ class GitlabIntegrationInstanceTest(IntegrationTestCase):
         integration = Integration.objects.get(provider=self.provider.key)
 
         installation = integration.get_installation(self.organization.id)
-        assert None == installation.get_group_id()
+        assert installation.get_group_id() is None


### PR DESCRIPTION
This PR is meant to follow after #15178.

Make the *GitLab Group Path* field optional when installing a GitLab integration. If the path is empty, then the integration will allow projects from the entire instance to be added, not just projects within a specific group. The installation's metadata will have `None` as the group id.

If the path is empty, the *Include Subgroups* option will have no effect. There's some help text indicating this.

The sort ordering for projects is also changed to sort by last activity, instead of date created.

Here's a screenshot with the UI changes on the installation form highlighted.

![Screen Shot 2019-10-18 at 10 07 53 PM](https://user-images.githubusercontent.com/27340/67137532-29604500-f1f4-11e9-8013-c741a98ff95d.png)

Closes #12774 and closes #14799.