### PR TITLE
ref: Move TSDB calls from outcomes producer into consumer

### DIFF
--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -315,9 +315,26 @@ class BaseTSDB(Service):
         Increment project ID=1 and group ID=5:
 
         >>> incr_multi([(TimeSeriesModel.project, 1), (TimeSeriesModel.group, 5)])
+
+        Increment individual timestamps:
+
+        >>> incr_multi([(TimeSeriesModel.project, 1, {"timestamp": ...}),
+        ...             (TimeSeriesModel.group, 5, {"timestamp": ...})])
         """
-        for model, key in items:
-            self.incr(model, key, timestamp, count, environment_id=environment_id)
+        for item in items:
+            if len(item) == 2:
+                model, key = item
+                options = {}
+            else:
+                model, key, options = item
+
+            self.incr(
+                model,
+                key,
+                timestamp=options.get("timestamp", timestamp),
+                count=options.get("count", count),
+                environment_id=environment_id,
+            )
 
     def merge(self, model, destination, sources, timestamp=None, environment_ids=None):
         """

--- a/src/sentry/tsdb/redissnuba.py
+++ b/src/sentry/tsdb/redissnuba.py
@@ -37,7 +37,7 @@ method_specifications = {
     "get_frequency_series": (READ, single_model_argument),
     "get_frequency_totals": (READ, single_model_argument),
     "incr": (WRITE, single_model_argument),
-    "incr_multi": (WRITE, lambda callargs: {model for model, key in callargs["items"]}),
+    "incr_multi": (WRITE, lambda callargs: {item[0] for item in callargs["items"]}),
     "merge": (WRITE, single_model_argument),
     "delete": (WRITE, multiple_model_argument),
     "record": (WRITE, single_model_argument),

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -4,6 +4,7 @@ import random
 
 from datetime import datetime
 from django.conf import settings
+from django.core.cache import cache
 from enum import IntEnum
 import six
 import time
@@ -34,6 +35,67 @@ def decide_signals_in_consumer():
     return rate and rate > random.random()
 
 
+def decide_tsdb_in_consumer():
+    rate = options.get("outcomes.tsdb-in-consumer-sample-rate")
+    return rate and rate > random.random()
+
+
+def _get_tsdb_cache_key(project_id, event_id):
+    assert isinstance(project_id, six.integer_types)
+    return "is-tsdb-incremented:{}:{}".format(project_id, event_id)
+
+
+def mark_tsdb_incremented(project_id, event_id):
+    """
+    Remembers that TSDB was already called for an outcome.
+
+    Sets a boolean flag in memcached to remember that
+    tsdb_increments_from_outcome was already called for a particular
+    event/outcome.
+
+    This is used by the outcomes consumer to avoid double-emission.
+    """
+    key = _get_tsdb_cache_key(project_id, event_id)
+    cache.set(key, True, 3600)
+
+
+def is_tsdb_incremented(project_id, event_id):
+    key = _get_tsdb_cache_key(project_id, event_id)
+    return cache.get(key, None) is not None
+
+
+def tsdb_increments_from_outcome(org_id, project_id, key_id, outcome, reason):
+    if outcome != Outcome.INVALID:
+        # This simply preserves old behavior. We never counted invalid events
+        # (too large, duplicate, CORS) toward regular `received` counts.
+        if project_id is not None:
+            yield (tsdb.models.project_total_received, project_id)
+        if org_id is not None:
+            yield (tsdb.models.organization_total_received, org_id)
+        if key_id is not None:
+            yield (tsdb.models.key_total_received, key_id)
+
+    if outcome == Outcome.FILTERED:
+        if project_id is not None:
+            yield (tsdb.models.project_total_blacklisted, project_id)
+        if org_id is not None:
+            yield (tsdb.models.organization_total_blacklisted, org_id)
+        if key_id is not None:
+            yield (tsdb.models.key_total_blacklisted, key_id)
+
+    elif outcome == Outcome.RATE_LIMITED:
+        if project_id is not None:
+            yield (tsdb.models.project_total_rejected, project_id)
+        if org_id is not None:
+            yield (tsdb.models.organization_total_rejected, org_id)
+        if key_id is not None:
+            yield (tsdb.models.key_total_rejected, key_id)
+
+    if reason in FILTER_STAT_KEYS_TO_VALUES:
+        if project_id is not None:
+            yield (FILTER_STAT_KEYS_TO_VALUES[reason], project_id)
+
+
 def track_outcome(org_id, project_id, key_id, outcome, reason=None, timestamp=None, event_id=None):
     """
     This is a central point to track org/project counters per incoming event.
@@ -58,41 +120,20 @@ def track_outcome(org_id, project_id, key_id, outcome, reason=None, timestamp=No
     assert isinstance(timestamp, (type(None), datetime))
 
     timestamp = timestamp or to_datetime(time.time())
-    increment_list = []
-    if outcome != Outcome.INVALID:
-        # This simply preserves old behavior. We never counted invalid events
-        # (too large, duplicate, CORS) toward regular `received` counts.
-        increment_list.extend(
-            [
-                (tsdb.models.project_total_received, project_id),
-                (tsdb.models.organization_total_received, org_id),
-                (tsdb.models.key_total_received, key_id),
-            ]
+
+    tsdb_in_consumer = decide_tsdb_in_consumer()
+
+    if not tsdb_in_consumer:
+        increment_list = list(
+            tsdb_increments_from_outcome(
+                org_id=org_id, project_id=project_id, key_id=key_id, outcome=outcome, reason=reason
+            )
         )
 
-    if outcome == Outcome.FILTERED:
-        increment_list.extend(
-            [
-                (tsdb.models.project_total_blacklisted, project_id),
-                (tsdb.models.organization_total_blacklisted, org_id),
-                (tsdb.models.key_total_blacklisted, key_id),
-            ]
-        )
-    elif outcome == Outcome.RATE_LIMITED:
-        increment_list.extend(
-            [
-                (tsdb.models.project_total_rejected, project_id),
-                (tsdb.models.organization_total_rejected, org_id),
-                (tsdb.models.key_total_rejected, key_id),
-            ]
-        )
+        if increment_list:
+            tsdb.incr_multi(increment_list, timestamp=timestamp)
 
-    if reason in FILTER_STAT_KEYS_TO_VALUES:
-        increment_list.append((FILTER_STAT_KEYS_TO_VALUES[reason], project_id))
-
-    increment_list = [(model, key) for model, key in increment_list if key is not None]
-    if increment_list:
-        tsdb.incr_multi(increment_list, timestamp=timestamp)
+        mark_tsdb_incremented(project_id, event_id)
 
     # Send a snuba metrics payload.
     outcomes_publisher.publish(


### PR DESCRIPTION
This is analogous to the signals refactor added in https://github.com/getsentry/sentry/pull/15031. We have a sampling option to decide whether to stop calling tsdb in `track_outcome`. Depending on the sampling decision a marker is set in memcached. That marker is used in the outcomes consumer to determine whether tsdb should be (not) called.

Like with signals, the goal is to eventually stop calling tsdb in track_outcome, because Relay's version of track_outcome can't do that either. There is an independent refactoring going on that should fulfill this goal as well by removing redis tsdb in favor of snuba (which has its own outcomes consumer), but we do not want to wait for that.

Two not directly related changes:

* Add feature to `tsdb.incr_multi` interface to have per-item timestamps and counts (backwards compatible)
* Basic optimization in redis' `incr_multi` (in-memory batching of key increments)

This allows us to call `tsdb.incr_multi` exactly once for an entire batch.

---

NOTE that this renames some metrics to separate timings for tsdb stuff from signals stuff.

This has been tested manually, locally. Since all the new, weird stuff is behind a sampling option too this should be relatively safe to deploy.

#sync-getsentry