### PR TITLE
feat(ui): Display breadcrumbs with milliseconds

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/breadcrumb.jsx
@@ -42,6 +42,13 @@ class Breadcrumb extends React.Component {
     return [...classes].join(' ');
   };
 
+  getTooltipTitle = () => {
+    const {crumb} = this.props;
+    const parsedTimestamp = moment(crumb.timestamp);
+    const timestampFormat = parsedTimestamp.milliseconds() ? 'll H:mm:ss.SSS A' : 'lll';
+    return parsedTimestamp.format(timestampFormat);
+  };
+
   renderType = () => {
     const {crumb} = this.props;
     const Renderer = CUSTOM_RENDERERS[crumb.type] || DefaultRenderer;
@@ -57,7 +64,7 @@ class Breadcrumb extends React.Component {
             <span className="icon" />
           </span>
           {defined(crumb.timestamp) ? (
-            <Tooltip title={moment(crumb.timestamp).format('lll')}>
+            <Tooltip title={this.getTooltipTitle()}>
               <span className="dt">{moment(crumb.timestamp).format('HH:mm:ss')}</span>
             </Tooltip>
           ) : (


### PR DESCRIPTION
# Summary
When breadcrumb timestamp was recorded with milliseconds precision display it on the tooltip.

<img width="282" alt="image" src="https://user-images.githubusercontent.com/1544476/67228234-2904bb80-f439-11e9-8f76-1d17dc6eff94.png">

Fixes #14959

# Additional context
getsentry/sentry-java#776