### PR TITLE
feat: Add 'all projects' support to API endpoints

### DIFF
--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -242,6 +242,20 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
         result = self.endpoint.get_projects(request, self.org)
         assert [] == result
 
+    def test_all_accessible_sigil_value_no_open_join(self):
+        assert self.org.flags.allow_joinleave.number == 0, "precondition not met"
+
+        self.create_team_membership(user=self.user, team=self.team_1)
+        self.run_test([self.project_1], project_ids=[-1])
+
+    def test_all_accessible_sigil_value_allow_joinleave(self):
+        self.org.flags.allow_joinleave = True
+        self.org.save()
+
+        # With membership on only one team you get all projects
+        self.create_team_membership(user=self.user, team=self.team_1)
+        self.run_test([self.project_1, self.project_2], project_ids=[-1])
+
 
 class GetEnvironmentsTest(BaseOrganizationEndpointTest):
     def setUp(self):

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -165,6 +165,39 @@ class OrganizationReleaseListTest(APITestCase):
         assert response.data[0]["version"] == release3.version
         assert response.data[1]["version"] == release1.version
 
+    def test_all_projects_parameter(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.create_organization()
+        org.flags.allow_joinleave = True
+        org.save()
+
+        team1 = self.create_team(organization=org)
+        team2 = self.create_team(organization=org)
+
+        project1 = self.create_project(teams=[team1], organization=org)
+        project2 = self.create_project(teams=[team2], organization=org)
+
+        self.create_member(teams=[team1], user=user, organization=org)
+        self.login_as(user=user)
+
+        release1 = Release.objects.create(
+            organization_id=org.id, version="1", date_added=datetime(2013, 8, 13, 3, 8, 24, 880386)
+        )
+        release1.add_project(project1)
+
+        release2 = Release.objects.create(
+            organization_id=org.id, version="2", date_added=datetime(2013, 8, 14, 3, 8, 24, 880386)
+        )
+        release2.add_project(project2)
+
+        url = reverse("sentry-api-0-organization-releases", kwargs={"organization_slug": org.slug})
+        response = self.client.get(url, data={"project": [-1]}, format="json")
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+        assert response.data[0]["version"] == release2.version
+        assert response.data[1]["version"] == release1.version
+
     def test_new_org(self):
         user = self.create_user(is_staff=False, is_superuser=False)
         org = self.organization

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -81,6 +81,15 @@ class GroupListTest(APITestCase, SnubaTestCase):
             response = self.get_response()
             assert response.status_code == 200
 
+    def test_with_all_projects(self):
+        # ensure there are two or more projects
+        self.create_project(organization=self.project.organization)
+        self.login_as(user=self.user)
+
+        with self.feature("organizations:global-views"):
+            response = self.get_valid_response(project_id=[-1])
+            assert response.status_code == 200
+
     def test_boolean_search_feature_flag(self):
         self.login_as(user=self.user)
         response = self.get_response(sort_by="date", query="title:hello OR title:goodbye")


### PR DESCRIPTION
The global selection header and its `project` query parameter currently support an empty list/undefined value to indicate 'all projects I am a member of'. Some of our larger organizations would also like to view issues and events across all projects in their organization even those that they are not actively a member on.

I'll be adding the UI changes separately as they are more complicated.

Refs SEN-1176