### PR TITLE
build(webpack): Add plugin to build integration docs

### DIFF
--- a/build-utils/build-integration-docs-plugin.js
+++ b/build-utils/build-integration-docs-plugin.js
@@ -1,0 +1,33 @@
+/*eslint-env node*/
+/*eslint import/no-nodejs-modules:0 */
+const child_process = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const DOCS_INDEX_PATH = 'src/sentry/integration-docs/_platforms.json';
+
+class BuildIntegrationDocs {
+  constructor({basePath}) {
+    this.modulePath = path.join(basePath, DOCS_INDEX_PATH);
+  }
+
+  apply(compiler) {
+    compiler.hooks.beforeRun.tapAsync(
+      'BuildIntegrationDocs',
+      (_compilation, callback) => {
+        const moduleDir = path.dirname(this.modulePath);
+        if (!fs.existsSync(moduleDir)) {
+          fs.mkdirSync(moduleDir, {recursive: true});
+        }
+        if (!fs.existsSync(this.modulePath)) {
+          child_process.execSync('make build-platform-assets');
+          callback();
+        } else {
+          callback();
+        }
+      }
+    );
+  }
+}
+
+module.exports = BuildIntegrationDocs;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const {CleanWebpackPlugin} = require('clean-webpack-plugin'); // installed via n
 const webpack = require('webpack');
 const LastBuiltPlugin = require('./build-utils/last-built-plugin');
 const OptionalLocaleChunkPlugin = require('./build-utils/optional-locale-chunk-plugin');
+const BuildIntegrationDocs = require('./build-utils/build-integration-docs-plugin');
 const IntegrationDocsFetchPlugin = require('./build-utils/integration-docs-fetch-plugin');
 const ExtractTextPlugin = require('mini-css-extract-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
@@ -332,6 +333,11 @@ const appConfig = {
      * This removes empty js files for style only entries (e.g. sentry.less)
      */
     new FixStyleOnlyEntriesPlugin(),
+
+    /**
+     * This check if integration-docs have been built, if not, will build them
+     */
+    new BuildIntegrationDocs({basePath: __dirname}),
 
     ...localeRestrictionPlugins,
   ],


### PR DESCRIPTION
This checks if `src/sentry/integration-docs/_platforms.json` exists (which is built by python, but used in the frontend).
If it does not, it runs `make build-platform-assets` before continuing to run webpack.