### PR TITLE
build(webpack): Rename `webpackJsonp` global name

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -352,6 +352,10 @@ const appConfig = {
   output: {
     path: distPath,
     filename: '[name].js',
+
+    // Rename global that is used to async load chunks
+    // Avoids 3rd party js from overwriting the default name (webpackJsonp)
+    jsonpFunction: 'sntryWpJsonp',
     sourceMapFilename: '[name].js.map',
   },
   optimization: {


### PR DESCRIPTION
Rename the global used in webpack to load async chunks. This can be overwritten by 3rd party javascript libraries and break sentry.

See https://twitter.com/stripestatus/status/1179172007218274304