### PR TITLE
meta: Remove tkaemming-specific rules from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,12 +12,5 @@
 /src/sentry/search/snuba/       @getsentry/owners-snuba
 /src/sentry/tagstore/snuba/     @getsentry/owners-snuba
 
-# Ted stuff
-/src/sentry/similarity/              @tkaemming
-/src/sentry/receivers/similarity.py  @tkaemming
-/src/sentry/digests/                 @tkaemming
-/src/sentry/tasks/reports.py         @tkaemming
-/src/sentry/tasks/digests.py         @tkaemming
-
 # Security
 /src/sentry/net/  @getsentry/security


### PR DESCRIPTION
I'm not super worried about anybody breaking similarity (but please
don't), and other teams at this point probably own the product features
around digests and reports more than I do personally.