### PR TITLE
build(travis): Split webpack + tsc from test suite for frontend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -190,20 +190,19 @@ matrix:
       name: 'Frontend [test]'
       env: TEST_SUITE=js
       before_install:
-        - *base_install
         - find "$NODE_DIR" -type d -empty -delete
         - nvm install
       install:
         - ./bin/yarn install --frozen-lockfile
 
     - python: 2.7
-      name: 'Frontend [webpack]'
+      name: 'Frontend [build]'
       env: TEST_SUITE=js-build
       before_install:
         - find "$NODE_DIR" -type d -empty -delete
         - nvm install
       install:
-        - ./bin/yarn install --pure-lockfile
+        - ./bin/yarn install --frozen-lockfile
 
     - python: 2.7
       name: 'Command Line'

--- a/.travis.yml
+++ b/.travis.yml
@@ -187,7 +187,7 @@ matrix:
       env: TEST_SUITE=plugins DB=postgres PERCY_TOKEN=${PLUGIN_PERCY_TOKEN}
 
     - python: 2.7
-      name: 'Frontend'
+      name: 'Frontend [test]'
       env: TEST_SUITE=js
       before_install:
         - *base_install
@@ -195,6 +195,15 @@ matrix:
         - nvm install
       install:
         - ./bin/yarn install --frozen-lockfile
+
+    - python: 2.7
+      name: 'Frontend [webpack]'
+      env: TEST_SUITE=js-build
+      before_install:
+        - find "$NODE_DIR" -type d -empty -delete
+        - nvm install
+      install:
+        - ./bin/yarn install --pure-lockfile
 
     - python: 2.7
       name: 'Command Line'

--- a/Makefile
+++ b/Makefile
@@ -231,13 +231,14 @@ travis-noop:
 .PHONY: travis-test-lint
 travis-test-lint: lint-python lint-js
 
-.PHONY: travis-test-postgres travis-test-acceptance travis-test-snuba travis-test-symbolicator travis-test-js
+.PHONY: travis-test-postgres travis-test-acceptance travis-test-snuba travis-test-symbolicator travis-test-js travis-test-js-build
 .PHONY: travis-test-cli travis-test-relay-integration
 travis-test-postgres: test-python
 travis-test-acceptance: test-acceptance
 travis-test-snuba: test-snuba
 travis-test-symbolicator: test-symbolicator
 travis-test-js: test-js
+travis-test-js-build: test-js-build
 travis-test-cli: test-cli
 travis-test-plugins: test-plugins
 travis-test-relay-integration: test-relay-integration

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,8 @@ test-cli:
 	@echo ""
 
 test-js-build: node-version-check
+	@echo "--> Running type check"
+	@$(YARN) run tsc
 	@echo "--> Building static assets"
 	@$(WEBPACK) --profile --json > .artifacts/webpack-stats.json
 
@@ -217,7 +219,7 @@ lint-js:
 	@echo ""
 
 
-.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale compile-locale merge-locale-catalogs sync-transifex update-transifex build-platform-assets test-cli test-js test-js-build test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js publish
+.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale compile-locale merge-locale-catalogs sync-transifex update-transifex build-platform-assets test-cli test-js test-js-build test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js
 
 
 ############################

--- a/Makefile
+++ b/Makefile
@@ -130,9 +130,11 @@ test-cli:
 	rm -r test_cli
 	@echo ""
 
-test-js: node-version-check
+test-js-build: node-version-check
 	@echo "--> Building static assets"
 	@$(WEBPACK) --profile --json > .artifacts/webpack-stats.json
+
+test-js: node-version-check
 	@echo "--> Running JavaScript tests"
 	@$(YARN) run test-ci
 	@echo ""
@@ -215,7 +217,7 @@ lint-js:
 	@echo ""
 
 
-.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale compile-locale merge-locale-catalogs sync-transifex update-transifex build-platform-assets test-cli test-js test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js publish
+.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale compile-locale merge-locale-catalogs sync-transifex update-transifex build-platform-assets test-cli test-js test-js-build test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js publish
 
 
 ############################

--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,7 @@ travis-scan-acceptance: travis-noop
 travis-scan-snuba: travis-noop
 travis-scan-symbolicator: travis-noop
 travis-scan-js: travis-noop
+travis-scan-js-build: travis-noop
 travis-scan-cli: travis-noop
 travis-scan-lint: scan-python
 travis-scan-plugins: travis-noop

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "svg-sprite-loader": "^3.9.0",
     "svgo": "^1.0.3",
     "svgo-loader": "^2.1.0",
-    "ts-loader": "^6.2.1",
     "typescript": "3.7",
     "u2f-api": "1.0.10",
     "webpack": "4.41.6",

--- a/src/sentry/utils/distutils/commands/build_assets.py
+++ b/src/sentry/utils/distutils/commands/build_assets.py
@@ -131,6 +131,7 @@ class BuildAssetsCommand(BaseBuildCommand):
         env["NODE_OPTIONS"] = (
             (env.get("NODE_OPTIONS", "") + " --max-old-space-size=4096")
         ).lstrip()
+        self._run_yarn_command(["tsc"], env=env)
         self._run_yarn_command(["webpack", "--bail"], env=env)
 
     def _write_version_file(self, version_info):

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -206,10 +206,6 @@ const babelLoaderConfig = {
   options: babelOptions,
 };
 
-const tsLoaderConfig = {
-  loader: 'ts-loader',
-};
-
 /**
  * Main Webpack config for Sentry React SPA.
  */
@@ -237,18 +233,10 @@ let appConfig = {
   module: {
     rules: [
       {
-        test: /\.jsx?$/,
+        test: /\.[tj]sx?$/,
         include: [staticPrefix],
         exclude: /(vendor|node_modules|dist)/,
         use: babelLoaderConfig,
-      },
-      {
-        test: /\.tsx?$/,
-        include: [staticPrefix],
-        exclude: /(vendor|node_modules|dist)/,
-        // Make sure we typecheck in CI, but not for local dev since that is run with
-        // the fork-ts plugin
-        use: SHOULD_FORK_TS ? babelLoaderConfig : [babelLoaderConfig, tsLoaderConfig],
       },
       {
         test: /\.po$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -231,6 +231,10 @@ let appConfig = {
   },
   context: staticPrefix,
   module: {
+    /**
+     * XXX: Modifying the order/contents of these rules may break `getsentry`
+     * Please remember to test it.
+     */
     rules: [
       {
         test: /\.[tj]sx?$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14712,17 +14712,6 @@ ts-essentials@^1.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-1.0.4.tgz#ce3b5dade5f5d97cf69889c11bf7d2da8555b15a"
   integrity sha512-q3N1xS4vZpRouhYHDPwO0bDW3EZ6SK9CrrDHxi/D6BPReSjpVgWIOpLS2o0gSBZm+7q/wyKp6RVM1AeeW7uyfQ==
 
-ts-loader@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-6.2.1.tgz#67939d5772e8a8c6bdaf6277ca023a4812da02ef"
-  integrity sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==
-  dependencies:
-    chalk "^2.3.0"
-    enhanced-resolve "^4.0.0"
-    loader-utils "^1.0.2"
-    micromatch "^4.0.0"
-    semver "^6.0.0"
-
 ts-map@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ts-map/-/ts-map-1.0.3.tgz#1c4d218dec813d2103b7e04e4bcf348e1471c1ff"


### PR DESCRIPTION

### Changes
* For the frontend job in CI, split `webpack` off from the test suite job and also run `tsc` in CI.
* Removes `ts-loader` as it is a bit redundant since `babel-loader` can handle typescript files now.
  * This means that our cloud build will *NOT* include type checks, @BYK is this fine, or should we include a call to `tsc` before building?
