### PR TITLE
fix(app-platform): Add "type=button" to buttons in internal integration form

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -268,6 +268,7 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
               size="small"
               icon="icon-trash"
               data-test-id="token-delete"
+              type="button"
             >
               {t('Revoke')}
             </Button>
@@ -357,6 +358,7 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
                   icon="icon-circle-add"
                   onClick={evt => this.onAddToken(evt)}
                   data-test-id="token-add"
+                  type="button"
                 >
                   {t('New Token')}
                 </Button>


### PR DESCRIPTION
Before, pressing enter in the internal integration edit form would create tokens because those buttons would default to the submit buttons. I added `type=button` to these buttons so they would not be clicked when you hit enter