### PR TITLE
feat(outcomes_consumer): Make TSDB processing faster

### DIFF
--- a/src/sentry/ingest/outcomes_consumer.py
+++ b/src/sentry/ingest/outcomes_consumer.py
@@ -132,7 +132,7 @@ def _process_tsdb_batch(messages):
         project_id = int(msg.get("project_id") or 0) or None
         event_id = msg.get("event_id")
 
-        if not project_id and not event_id:
+        if not project_id or not event_id:
             continue
 
         to_increment = [

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -45,7 +45,7 @@ def _get_tsdb_cache_key(project_id, event_id):
     return "is-tsdb-incremented:{}:{}".format(project_id, event_id)
 
 
-def mark_tsdb_incremented(project_id, event_id):
+def mark_tsdb_incremented_many(items):
     """
     Remembers that TSDB was already called for an outcome.
 
@@ -55,13 +55,14 @@ def mark_tsdb_incremented(project_id, event_id):
 
     This is used by the outcomes consumer to avoid double-emission.
     """
-    key = _get_tsdb_cache_key(project_id, event_id)
-    cache.set(key, True, 3600)
+    cache.set_many(
+        dict((_get_tsdb_cache_key(project_id, event_id), True) for project_id, event_id in items),
+        3600,
+    )
 
 
-def is_tsdb_incremented(project_id, event_id):
-    key = _get_tsdb_cache_key(project_id, event_id)
-    return cache.get(key, None) is not None
+def mark_tsdb_incremented(project_id, event_id):
+    mark_tsdb_incremented_many([(project_id, event_id)])
 
 
 def tsdb_increments_from_outcome(org_id, project_id, key_id, outcome, reason):


### PR DESCRIPTION
Admittedly a lot of this is CPU-bound, but it still calls out to
memcached.

#sync-getsentry