### PR TITLE
fix(discover) Make 'All Projects' work in discover

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -173,9 +173,20 @@ class OrganizationEndpoint(Endpoint):
             project_ids = set(map(int, request.GET.getlist("project")))
         except ValueError:
             raise ParseError(detail="Invalid project parameter. Values must be numbers.")
+        return self._get_projects_by_id(
+            project_ids, request, force_global_perms, include_all_accessible
+        )
 
-        user = getattr(request, "user", None)
+    def _get_projects_by_id(
+        self,
+        project_ids,
+        request,
+        organization,
+        force_global_perms=False,
+        include_all_accessible=False,
+    ):
         qs = Project.objects.filter(organization=organization, status=ProjectStatus.VISIBLE)
+        user = getattr(request, "user", None)
 
         # A project_id of -1 means 'all projects I have access to'
         # While no project_ids means 'all projects I am a member of'.

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -174,7 +174,7 @@ class OrganizationEndpoint(Endpoint):
         except ValueError:
             raise ParseError(detail="Invalid project parameter. Values must be numbers.")
         return self._get_projects_by_id(
-            project_ids, request, force_global_perms, include_all_accessible
+            project_ids, request, organization, force_global_perms, include_all_accessible
         )
 
     def _get_projects_by_id(


### PR DESCRIPTION
Refactor the `get_projects()` method so that it is compatible with discover1. This change also makes discover1 apply the same project conditions as the rest of the application does. Previously it did not respect the allowjoin flag for orgs that turned it off.

Refs SEN-1176