### PR TITLE
feat(projects): Added query parameter for getting all projects within an organization

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -106,8 +106,8 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         get_all_projects = request.GET.get("all_projects") == "1"
 
         if get_all_projects:
-            sorted_projects = sorted(list(queryset), key=lambda x: x.slug)
-            return Response(serialize(sorted_projects, request.user, ProjectSummarySerializer()))
+            queryset = queryset.order_by("slug")
+            return Response(serialize(list(queryset), request.user, ProjectSummarySerializer()))
         else:
             return self.paginate(
                 request=request,

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -102,7 +102,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
         queryset = queryset.filter(status=ProjectStatus.VISIBLE).distinct()
 
-        # TODO(davidenwang): remove this after backend is paginated
+        # TODO(davidenwang): remove this after frontend requires only paginated projects
         get_all_projects = request.GET.get("all_projects") == "1"
 
         if get_all_projects:

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -154,13 +154,11 @@ class OrganizationProjectsTest(APITestCase):
         self.login_as(user=self.user)
         other_team = self.create_team(organization=self.org)
 
-        projects = []
-        # Create 101 projects to verify the project list is not paginated
-        for i in range(0, 101):
-            projects.append(self.create_project(teams=[other_team]))
-        sorted_projects = sorted(list(projects), key=lambda x: x.slug)
+        project_bar = self.create_project(teams=[self.team], name="bar", slug="bar")
+        project_foo = self.create_project(teams=[other_team], name="foo", slug="foo")
+        project_baz = self.create_project(teams=[other_team], name="baz", slug="baz")
+        sorted_projects = [project_bar, project_baz, project_foo]
 
-        path = u"{}?all_projects=1".format(self.path)
-        response = self.client.get(path)
-        # Verify all 101 projects are returned in sorted order
+        response = self.client.get(self.path + "?all_projects=1&per_page=1")
+        # Verify all projects in the org are returned in sorted order
         self.check_valid_response(response, sorted_projects)

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -149,3 +149,18 @@ class OrganizationProjectsTest(APITestCase):
             self.path, HTTP_AUTHORIZATION="Basic " + b64encode(u"{}:".format(key.key))
         )
         self.check_valid_response(response, [project])
+
+    def test_all_projects(self):
+        self.login_as(user=self.user)
+        other_team = self.create_team(organization=self.org)
+
+        projects = []
+        # Create 101 projects to verify the project list is not paginated
+        for i in range(0, 101):
+            projects.append(self.create_project(teams=[other_team]))
+        sorted_projects = sorted(list(projects), key=lambda x: x.slug)
+
+        path = u"{}?all_projects=1".format(self.path)
+        response = self.client.get(path)
+        # Verify all 101 projects are returned in sorted order
+        self.check_valid_response(response, sorted_projects)


### PR DESCRIPTION
Overrode some functionality in `organization_projects.py` in order to bypass pagination of projects. This is as meant as an intermediate step so that frontend components no longer have to rely on `organization.projects` from org details, but will use a new `<Projects>` utility component which will fetch data from this modified `organization_projects` endpoint. Eventually this option will go away as we push to have more elements display paginated data on the frontend. Call the `organization/projects` endpoint like this: `organization/projects?all_projects=1` to retrieve all projects.