### PR TITLE
py3(django): finish (part 3/3) deferring more model imports until after Django setup

### DIFF
--- a/src/sentry/auth/__init__.py
+++ b/src/sentry/auth/__init__.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import, print_function
 
-from .provider import *  # NOQA
 from .manager import ProviderManager
-from .view import *  # NOQA
 
 manager = ProviderManager()
 register = manager.register

--- a/src/sentry/auth/providers/dummy.py
+++ b/src/sentry/auth/providers/dummy.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, print_function
 
 from django.http import HttpResponse
 
-from sentry.auth import Provider, AuthView
-from sentry.auth.provider import MigratingIdentityId
+from sentry.auth.provider import Provider, MigratingIdentityId
+from sentry.auth.view import AuthView
 
 
 class AskEmail(AuthView):

--- a/src/sentry/auth/providers/google/__init__.py
+++ b/src/sentry/auth/providers/google/__init__.py
@@ -1,14 +1,1 @@
 from __future__ import absolute_import
-
-from sentry import auth, options
-
-from .provider import GoogleOAuth2Provider
-
-auth.register("google", GoogleOAuth2Provider)
-
-options.register(
-    "auth-google.client-id", flags=options.FLAG_ALLOW_EMPTY | options.FLAG_PRIORITIZE_DISK
-)
-options.register(
-    "auth-google.client-secret", flags=options.FLAG_ALLOW_EMPTY | options.FLAG_PRIORITIZE_DISK
-)

--- a/src/sentry/auth/providers/google/apps.py
+++ b/src/sentry/auth/providers/google/apps.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = "sentry.auth.providers.google"
+
+    def ready(self):
+        from sentry import auth, options
+
+        from .provider import GoogleOAuth2Provider
+
+        auth.register("google", GoogleOAuth2Provider)
+
+        options.register(
+            "auth-google.client-id", flags=options.FLAG_ALLOW_EMPTY | options.FLAG_PRIORITIZE_DISK
+        )
+        options.register(
+            "auth-google.client-secret",
+            flags=options.FLAG_ALLOW_EMPTY | options.FLAG_PRIORITIZE_DISK,
+        )

--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -6,7 +6,8 @@ from six.moves.urllib.parse import parse_qsl, urlencode
 from time import time
 from uuid import uuid4
 
-from sentry.auth import Provider, AuthView
+from sentry.auth.provider import Provider
+from sentry.auth.view import AuthView
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.utils import json

--- a/src/sentry/auth/providers/saml2.py
+++ b/src/sentry/auth/providers/saml2.py
@@ -12,7 +12,8 @@ from six import iteritems, add_metaclass
 from six.moves.urllib.parse import urlparse
 
 from sentry import options
-from sentry.auth import Provider, AuthView
+from sentry.auth.provider import Provider
+from sentry.auth.view import AuthView
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.models import AuthProvider, Organization, OrganizationStatus
 from sentry.utils.auth import get_login_url

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -331,8 +331,9 @@ INSTALLED_APPS = (
     "sentry.plugins.sentry_webhooks.apps.Config",
     "social_auth",
     "sudo",
+    # TODO remove before PR; temporarily unblock
     "sentry.eventstream",
-    "sentry.auth.providers.google",
+    #    "sentry.auth.providers.google",
     "django.contrib.staticfiles",
 )
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -331,9 +331,8 @@ INSTALLED_APPS = (
     "sentry.plugins.sentry_webhooks.apps.Config",
     "social_auth",
     "sudo",
-    # TODO remove before PR; temporarily unblock
     "sentry.eventstream",
-    #    "sentry.auth.providers.google",
+    "sentry.auth.providers.google.apps.Config",
     "django.contrib.staticfiles",
 )
 

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -4,7 +4,6 @@ __all__ = ["FeatureManager"]
 
 from django.conf import settings
 
-from sentry.plugins.base import plugins
 from sentry.utils.safe import safe_execute
 
 from .base import Feature
@@ -83,6 +82,8 @@ class FeatureManager(object):
         return False
 
     def _get_plugin_value(self, feature, actor):
+        from sentry.plugins.base import plugins
+
         for plugin in plugins.all(version=2):
             handlers = safe_execute(plugin.get_feature_hooks, _with_transaction=False)
             for handler in handlers or ():

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -6,13 +6,9 @@ import time
 from django.conf import settings
 
 from sentry import features
-from sentry.models import EventDict
-from sentry.utils import snuba
 from sentry.utils.cache import cache
 from sentry.exceptions import PluginError
-from sentry.plugins.base import plugins
 from sentry.signals import event_processed
-from sentry.tasks.sentry_apps import process_resource_change_bound
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.utils.redis import redis_clusters
@@ -123,6 +119,8 @@ def post_process_group(event, is_new, is_regression, is_new_group_environment, *
     """
     Fires post processing hooks for a group.
     """
+    from sentry.utils import snuba
+
     with snuba.options_override({"consistent": True}):
         if check_event_already_post_processed(event):
             logger.info(
@@ -138,7 +136,7 @@ def post_process_group(event, is_new, is_regression, is_new_group_environment, *
         # NOTE: we must pass through the full Event object, and not an
         # event_id since the Event object may not actually have been stored
         # in the database due to sampling.
-        from sentry.models import Project, Organization
+        from sentry.models import Project, Organization, EventDict
         from sentry.models.group import get_group_with_redirect
         from sentry.rules.processor import RuleProcessor
         from sentry.tasks.servicehooks import process_service_hook
@@ -192,6 +190,8 @@ def post_process_group(event, is_new, is_regression, is_new_group_environment, *
                         if any(e in allowed_events for e in events):
                             process_service_hook.delay(servicehook_id=servicehook_id, event=event)
 
+            from sentry.tasks.sentry_apps import process_resource_change_bound
+
             if event.get_event_type() == "error" and _should_send_error_created_hooks(
                 event.project
             ):
@@ -202,6 +202,8 @@ def post_process_group(event, is_new, is_regression, is_new_group_environment, *
                 process_resource_change_bound.delay(
                     action="created", sender="Group", instance_id=event.group_id
                 )
+
+            from sentry.plugins.base import plugins
 
             for plugin in plugins.for_project(event.project):
                 plugin_post_process_group(
@@ -253,6 +255,8 @@ def plugin_post_process_group(plugin_slug, event, **kwargs):
     """
     with configure_scope() as scope:
         scope.set_tag("project", event.project_id)
+
+    from sentry.plugins.base import plugins
 
     plugin = plugins.get(plugin_slug)
     safe_execute(


### PR DESCRIPTION
This is the last step, after https://github.com/getsentry/sentry/pull/15094. Django's able to finish initializing now, during pytest setup on Django 1.9.

Import changes for `sentry.auth` are required across the board again, and like last time, are blocking this being merged.

EDIT: actually, it doesn't seem too bad. See https://github.com/getsentry/getsentry/pull/3257#issue-331250168.

> It would definitely be a good step to put getsentry/sentry#15233 on staging and poke at the available plugins before going to prod. And then put that on canary so we get a good amount of prod traffic to hit a bunch of imports.
