### PR TITLE
fix(member-invite): Do not clear prev values on blur

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -56,7 +56,8 @@ const InviteRowControl = ({
         }))}
         valueComponent={props => renderEmailValue(inviteStatus[props.value.value], props)}
         onBlur={e =>
-          e.target.value && onChangeEmails([...emails, {value: e.target.value}])
+          e.target.value &&
+          onChangeEmails([...emails.map(value => ({value})), {value: e.target.value}])
         }
         shouldKeyDownEventCreateNewOption={({keyCode}) =>
           // Keycodes are ENTER, SPACE, TAB, COMMA


### PR DESCRIPTION
Because the list needs to be of {value: email} objects. Typescript
failed us here since Select controls aren't typed yet.