### PR TITLE
fix(platform): Bad links when selecting tags on GroupEventDetails to narrow search

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -113,7 +113,7 @@ numeric_filter       = search_key sep operator? ~r"[0-9]+(?=\s|$)"
 # has filter for not null type checks
 has_filter           = negation? "has" sep (search_key / search_value)
 is_filter            = negation? "is" sep search_value
-tag_filter            = negation? "tags[" search_key "]" sep search_value
+tag_filter           = negation? "tags[" search_key "]" sep search_value
 
 search_key           = key / quoted_key
 search_value         = quoted_value / value

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -804,7 +804,7 @@ SENTRY_FEATURES = {
     # is not enabled).
     "organizations:create": True,
     # Enable the 'discover' interface.
-    "organizations:discover": False,
+    "organizations:discover": True,
     # Enable attaching arbitrary files to events.
     "organizations:event-attachments": False,
     # Allow organizations to configure built-in symbol sources.
@@ -812,9 +812,9 @@ SENTRY_FEATURES = {
     # Allow organizations to configure custom external symbol sources.
     "organizations:custom-symbol-sources": True,
     # Enable the events stream interface.
-    "organizations:events": False,
+    "organizations:events": True,
     # Enable events v2 instead of the events stream
-    "organizations:events-v2": False,
+    "organizations:events-v2": True,
     # Enable multi project selection
     "organizations:global-views": False,
     # Turns on grouping info.

--- a/src/sentry/static/sentry/app/components/events/eventTags.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventTags.tsx
@@ -2,18 +2,18 @@ import React from 'react';
 import {Link} from 'react-router';
 import isEmpty from 'lodash/isEmpty';
 import queryString from 'query-string';
-
 import {Location} from 'history';
 import {Event, EventTag} from 'app/types';
-
-import EventDataSection from 'app/components/events/eventDataSection';
-import DeviceName from 'app/components/deviceName';
-import {isUrl, generateQueryWithTag} from 'app/utils';
+import {isUrl} from 'app/utils';
+import {addKeyValueToQueryString} from 'app/utils/queryString';
 import {t} from 'app/locale';
+
+import DeviceName from 'app/components/deviceName';
+import EventDataSection from 'app/components/events/eventDataSection';
+import InlineSvg from 'app/components/inlineSvg';
 import Pills from 'app/components/pills';
 import Pill from 'app/components/pill';
 import VersionHoverCard from 'app/components/versionHoverCard';
-import InlineSvg from 'app/components/inlineSvg';
 
 type EventTagsProps = {
   event: Event;
@@ -31,8 +31,14 @@ class EventTags extends React.Component<EventTagsProps> {
 
   renderPill(tag: EventTag, streamPath: string, releasesPath: string) {
     const {orgId, projectId, location} = this.props;
-    const query = generateQueryWithTag(location.query, tag);
 
+    console.log('renderPill', tag.key, tag.value);
+
+    const query = addKeyValueToQueryString(
+      location.query,
+      'query',
+      `${tag.key}:${tag.value}`
+    );
     const locationSearch = `?${queryString.stringify(query)}`;
 
     return (

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.jsx
@@ -45,7 +45,7 @@ class ExternalIssueForm extends AsyncComponent {
     this.props.onSubmitSuccess(data);
   };
 
-  onRequestSuccess({stateKey, data, jqXHR}) {
+  onRequestSuccess({stateKey, data, _jqXHR}) {
     if (stateKey === 'integrationDetails' && !this.state.dynamicFieldValues) {
       this.setState({
         dynamicFieldValues: this.getDynamicFields(data),
@@ -155,9 +155,9 @@ class ExternalIssueForm extends AsyncComponent {
       <Form
         apiEndpoint={`/groups/${group.id}/integrations/${integration.id}/`}
         apiMethod={action === 'create' ? 'POST' : 'PUT'}
-        onSubmitSuccess={this.onSubmitSuccess}
         initialData={initialData}
         onFieldChange={this.onFieldChange}
+        onSubmitSuccess={this.onSubmitSuccess}
         submitLabel={SUBMIT_LABEL_BY_ACTION[action]}
         submitDisabled={this.state.reloading}
         footerClass="modal-footer"

--- a/src/sentry/static/sentry/app/utils.tsx
+++ b/src/sentry/static/sentry/app/utils.tsx
@@ -5,7 +5,7 @@ import isString from 'lodash/isString';
 import isUndefined from 'lodash/isUndefined';
 
 import {NewQuery, Project} from 'app/types';
-import {appendTagCondition} from 'app/utils/queryString';
+import {addKeyValueToQueryString} from 'app/utils/queryString';
 
 function arrayIsEqual(arr?: any[], other?: any[], deep?: boolean): boolean {
   // if the other array is a falsy value, return
@@ -269,7 +269,7 @@ export function generateQueryWithTag(
       query.project = tag.value;
       break;
     default:
-      query.query = appendTagCondition(query.query, tag.key, tag.value);
+      query.query = addKeyValueToQueryString(query, tag.key, tag.value).query;
   }
 
   return query;

--- a/src/sentry/static/sentry/app/utils/queryString.tsx
+++ b/src/sentry/static/sentry/app/utils/queryString.tsx
@@ -1,6 +1,7 @@
 import queryString from 'query-string';
 import parseurl from 'parseurl';
 import isString from 'lodash/isString';
+import {Query} from 'history';
 
 // remove leading and trailing whitespace and remove double spaces
 export function formatQueryString(qs: string): string {
@@ -16,41 +17,197 @@ export function addQueryParamsToExistingUrl(
     return '';
   }
   // Order the query params alphabetically.
-  // Otherwise ``queryString`` orders them randomly and it's impossible to test.
+  // Otherwise `queryString` orders them randomly and it's impossible to test.
   const params = JSON.parse(JSON.stringify(queryParams));
   const query = url.query ? {...queryString.parse(url.query), ...params} : params;
 
   return `${url.protocol}//${url.host}${url.pathname}?${queryString.stringify(query)}`;
 }
 
-type QueryValue = string | string[] | undefined | null;
-
 /**
- * Append a tag key:value to a query string.
+ * Add a key-value to the queryString.
+ *
+ * If there is an existing value on the same key, this function will replace it.
+ *
+ * However, if the key is `query`, it will append the new value to the existing
+ * value, delimiting the values with a space.
  *
  * Handles spacing and quoting if necessary.
  */
-export function appendTagCondition(
-  query: QueryValue,
+export function addKeyValueToQueryString(
+  query: Query = {},
   key: string,
   value: string
-): string {
-  let currentQuery = Array.isArray(query) ? query.pop() : isString(query) ? query : '';
-
-  if (isString(value) && value.indexOf(' ') > -1) {
-    value = `"${value}"`;
-  }
-  if (currentQuery) {
-    currentQuery += ` ${key}:${value}`;
-  } else {
-    currentQuery = `${key}:${value}`;
+): Query {
+  // console.log('addKeyValueToQueryString', key, value);
+  if (key === 'query') {
+    return addKeyValueToQueryStringQuery(query, value);
   }
 
-  return currentQuery;
+  // Wrap value if there are spaces
+  return {
+    ...query,
+    [key]: value.indexOf(' ') > -1 ? `"${value}"` : value,
+  };
 }
+
+/**
+ * Used by `addKeyValueToQueryStringQuery`, `decodeQueryValueToObject` and
+ * `encodeObjectToQueryValue` as a marker when they receive a value with either
+ * no keys or the wrong format.
+ */
+const NO_KEY = '__NO_KEY__';
+
+/**
+ * Append a tag (key:value) to QueryString.query. This method ensures uniqueness
+ * of keys in QueryString.query. If there is an existing key with a value, it
+ * will be overwritten by the new value.
+ *
+ * Handles spacing and quoting if necessary.
+ */
+export function addKeyValueToQueryStringQuery(qs: Query = {}, tag: string): Query {
+  const {query} = qs;
+  const queryObject = _decodeQueryValueToObject(query);
+
+  let key, value;
+  const keyValue = tag.split(':');
+  if (keyValue.length === 2) {
+    [key, value] = keyValue;
+  } else {
+    key = NO_KEY;
+    value = tag;
+  }
+
+  // Wrap value if there are spaces
+  if (value.indexOf(' ') > -1) {
+    value = `"${value.trim()}"`;
+  }
+
+  // Add new key-value into QueryObject
+  if (key === NO_KEY) {
+    queryObject[key] = `${queryObject[key]} ${value}`.trim();
+  } else {
+    queryObject[key] = value.trim();
+  }
+
+  return {
+    ...qs,
+    // query: _encodeObjectToQueryValue(queryObject),
+  };
+}
+
+/**
+ * This method specifically parses "?query=key:value" into an object and
+ * resolves duplicate keys. In the case of duplicate keys, the last value will
+ * be used.
+ *
+ * Do not include this in `export default`. This is currently exported for
+ * testing purposes only.
+ */
+export function _decodeQueryValueToObject(
+  query: Query['query']
+): {[key: string]: string} {
+  const currQuery: string = isString(query)
+    ? query
+    : Array.isArray(query)
+    ? query.reduce((acc, q) => `${acc} ${q}`, '')
+    : '';
+
+  // There
+  // 1) Start with the QueryValue: "key1:value1 key2:value2"
+  // 2) Split it into their pairs: ["key1:value1", "key2:value2"]
+  // 3) Split it into key-values:  { key1: value1, key2: value2 }
+  return currQuery.split(' ').reduce((acc, keyValue) => {
+    const pair = keyValue.split(':');
+
+    if (pair.length === 2) {
+      acc[pair[0]] = pair[1];
+    } else {
+      acc[NO_KEY] =
+        typeof acc[NO_KEY] === 'undefined' ? keyValue : `${acc[NO_KEY]} ${keyValue}`;
+    }
+
+    return acc;
+  }, {});
+}
+
+/**
+ * This method is the opposite of `decodeQueryValueToObject`.
+ *
+ * Do not include this in `export default`. This is currently exported for
+ * testing purposes only.
+ export function _encodeObjectToQueryValue(obj: {[key: string]: string}): Query['query'] {
+   const queryValue = Object.keys(obj).reduce((acc, key) => {
+     if (key === NO_KEY) {
+       return `${acc} ${obj[key]}`;
+      }
+
+      const validatedKey = _encodeKey(key);
+      const validatedValue = _encodeValue(obj[key]);
+
+      return `${acc} ${validatedKey}:${validatedValue}`;
+    }, '');
+
+    return queryValue.trim();
+  }
+  */
+
+/**
+const regexKey = /^[a-zA-Z0-9_\.-]+$/; // myKeyToEncode
+const regexKeyWithColon = /^[a-zA-Z0-9_\.-]+:[[a-zA-Z0-9_\.:-]+$/; // myKey:ToEncode
+const regexKeyWithColonQuoted = /^"[a-zA-Z0-9_\.-]+:[[a-zA-Z0-9_\.:-]+"$/; // "myKey:ToEncode"
+ *  The 2 accepted formats for keys are
+ export function _encodeKey(key: string): string {
+   if (regexKeyWithColonQuoted.test(key)) {
+     return key;
+    }
+
+    if (regexKeyWithColon.test(key)) {
+      return `"${key}"`;
+    }
+
+    if (regexKey.test(key)) {
+      return key;
+    }
+
+    throw new Error('Invalid key');
+  }
+  */
+
+// const regexValue = /^[a-zA-Z0-9_\.-\s]+$/; // value space
+// const regexValueWithQuote = /^"[a-zA-Z0-9_\.-\s]+"$/; // "value space"
+// const regexValueNoSpace = /^[a-zA-Z0-9_\.-]+$/; // value
+// const regexValueNoSpaceWithQuote = /^"[a-zA-Z0-9_\.-]+"$/; // "value"
+// const regexValueWithNamespaceValueSpaceOuterQuoted = /^"[a-zA-Z0-9_\.-]+:[a-zA-Z0-9_\.-\s]+"$/; // "namespace:value space"
+// const regexValueWithNamespace = /^[a-zA-Z0-9_\.-]+:[a-zA-Z0-9_\.-]+$/; // namespace:value
+// const regexValueWithNamespaceWithOuterQuote = /^[a-zA-Z0-9_\.-]+:[a-zA-Z0-9_\.-]+$/; // "namespace:value"
+// const regexValueWithNamespaceWithSpaceWithInnerQuote = /^[a-zA-Z0-9_\.-]+:(\\\")[a-zA-Z0-9_\.-\s]+(\\\")$/; // namespace:\"value space\"
+// const regexValueWithNamespaceWithOuterQuote = /^[a-zA-Z0-9_\.-]+:(\\\")[a-zA-Z0-9_\.-\s]+(\\\")$/; // "namespace:value space"
+// const regexValueWithNamespaceNoSpaceWithInnerOuterQuote = /^"[a-zA-Z0-9_\.-]+:(\\\")[a-zA-Z0-9_\.-\s]+(\\\")"$/; // "namespace:\"value\""
+// const regexValueWithNamespaceWithInnerOuterQuote = /^"[a-zA-Z0-9_\.-]+:(\\\")[a-zA-Z0-9_\.-\s]+(\\\")"$/; // "namespace:\"value space\""
+/**
+ * This will add TODO(leedongwei)
+ export function _encodeValue(value: string): string {
+   const term = value.replace(/(\"\\)/, '');
+   const terms = term.split(':');
+
+   if (terms.length === 2) {
+     const key = _encodeKey(terms[0]);
+     const val = _encodeValue(terms[1]);
+     return `"${key}:${val}"`;
+    }
+
+    if (terms.length === 1) {
+      //
+    }
+
+    throw new Error('Invalid value');
+  }
+  */
 
 export default {
   formatQueryString,
   addQueryParamsToExistingUrl,
-  appendTagCondition,
+  addKeyValueToQueryString,
+  addKeyValueToQueryStringQuery,
 };

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -9,7 +9,7 @@ import {Event, Organization} from 'app/types';
 import {Client} from 'app/api';
 import {getTitle} from 'app/utils/events';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
-import {generateQueryWithTag} from 'app/utils';
+import {addKeyValueToQueryString} from 'app/utils/queryString';
 
 import {
   AGGREGATE_ALIASES,
@@ -82,6 +82,23 @@ export function isAggregateField(field: string): boolean {
   return (
     AGGREGATE_ALIASES.includes(field as any) || field.match(AGGREGATE_PATTERN) !== null
   );
+}
+
+/**
+ * This function mutates `Location.query` in a way that is specific to facets
+ * on Discover2.
+ */
+export function generateQueryWithTag(
+  currQuery: Query,
+  tag: {key: string; value: string}
+): Query {
+  switch (tag.key) {
+    case 'environment':
+    case 'project':
+      return addKeyValueToQueryString(currQuery, tag.key, tag.value);
+    default:
+      return addKeyValueToQueryString(currQuery, 'query', `${tag.key}:${tag.value}`);
+  }
 }
 
 /**

--- a/tests/js/spec/utils/queryString.spec.js
+++ b/tests/js/spec/utils/queryString.spec.js
@@ -1,4 +1,7 @@
-import utils from 'app/utils/queryString';
+import utils, {
+  _decodeQueryValueToObject,
+  _encodeObjectToQueryValue,
+} from 'app/utils/queryString';
 
 describe('addQueryParamsToExistingUrl', function() {
   it('adds new query params to existing query params', function() {
@@ -30,29 +33,299 @@ describe('addQueryParamsToExistingUrl', function() {
   });
 });
 
-describe('appendTagCondition', function() {
-  it('adds simple values', function() {
-    const result = utils.appendTagCondition('error+text', 'color', 'red');
-    expect(result).toEqual('error+text color:red');
+/*
+describe('addKeyValueToQueryString', function() {
+  let locationQuery;
+
+  it('adds to Query', function() {
+    locationQuery = {};
+
+    const result = utils.addKeyValueToQueryString(locationQuery, 'color', 'red');
+    expect(result).toEqual({color: 'red'});
   });
 
-  it('handles array current value', function() {
-    const result = utils.appendTagCondition(['', 'thing'], 'color', 'red');
-    expect(result).toEqual('thing color:red');
+  it('adds to Query with null', function() {
+    locationQuery = {color: null};
+
+    const result = utils.addKeyValueToQueryString(locationQuery, 'color', 'red');
+    expect(result).toEqual({color: 'red'});
   });
 
-  it('handles empty string current value', function() {
-    const result = utils.appendTagCondition('', 'color', 'red');
-    expect(result).toEqual('color:red');
-  });
+  it('is idempotent for Query input', function() {
+    locationQuery = {};
 
-  it('handles null current value', function() {
-    const result = utils.appendTagCondition(null, 'color', 'red');
-    expect(result).toEqual('color:red');
+    const result1 = utils.addKeyValueToQueryString(locationQuery, 'color', 'red');
+    expect(result1).toEqual({color: 'red'});
+    expect(result1).not.toBe(locationQuery);
+
+    const result2 = utils.addKeyValueToQueryString(locationQuery, 'size', 'small');
+    expect(result2).toEqual({size: 'small'});
+    expect(result2).not.toEqual(expect.objectContaining({color: 'red'}));
   });
 
   it('wraps values with spaces', function() {
-    const result = utils.appendTagCondition(null, 'color', 'purple red');
-    expect(result).toEqual('color:"purple red"');
+    locationQuery = {};
+
+    const result = utils.addKeyValueToQueryString(locationQuery, 'color', 'green red');
+    expect(result).toEqual({color: '"green red"'});
+  });
+
+  it('wraps values with colon', function() {
+    locationQuery = {};
+
+    const result1 = utils.addKeyValueToQueryString(locationQuery, 'color', 'green:red');
+    expect(result1).toEqual({color: '"green:red"'});
+
+    const result2 = utils.addKeyValueToQueryString(locationQuery, 'color', '"green:red"');
+    expect(result2).toEqual({color: '"green:red"'});
+  });
+
+  it('adds to Query by replacing existing values', function() {
+    locationQuery = {color: 'green'};
+
+    const result = utils.addKeyValueToQueryString(locationQuery, 'color', 'red');
+    expect(result).toEqual({color: 'red'});
+  });
+
+  it('uses addKeyValueToQueryStringQuery appending to Query.query', function() {
+    locationQuery = {color: 'red', query: 'red'};
+
+    const result = utils.addKeyValueToQueryString(locationQuery, 'query', 'green');
+    expect(result).toEqual({color: 'red', query: 'red green'});
+  });
+
+  it('does not error out if query is undefined', function() {
+    locationQuery = undefined;
+
+    const result = utils.addKeyValueToQueryString(locationQuery, 'color', 'red');
+    expect(result).toEqual({color: 'red'});
+  });
+});
+
+describe('addKeyValueToQueryStringQuery', function() {
+  let locationQuery;
+
+  it('adds key-value to Query.query', function() {
+    locationQuery = {};
+    const result = utils.addKeyValueToQueryStringQuery(locationQuery, 'red');
+
+    expect(result).toEqual({query: 'red'});
+  });
+
+  it('wraps key-value that has spaces', function() {
+    locationQuery = {};
+    const result = utils.addKeyValueToQueryStringQuery(locationQuery, 'green red');
+
+    expect(result).toEqual({query: '"green red"'});
+  });
+
+  it('adds key-value to Query.query, replacing existing key-value pairs with the same key', function() {
+    locationQuery = {query: 'color:green taste:sweet color:pink'};
+    const result = utils.addKeyValueToQueryStringQuery(locationQuery, 'color:red');
+
+    expect(result).toEqual({query: 'color:red taste:sweet'});
+  });
+
+  it('adds key-value to Query.query by appending if it has no keys', function() {
+    locationQuery = {query: 'green'};
+    const result = utils.addKeyValueToQueryStringQuery(locationQuery, 'red');
+
+    expect(result).toEqual({query: 'green red'});
+  });
+});
+
+describe('decodeQueryValueToObject', function() {
+  it('decodes when Query.query is a string', function() {
+    const queryQuery = 'tag:value';
+    const decodedQuery = _decodeQueryValueToObject(queryQuery);
+
+    expect(decodedQuery).toEqual({
+      tag: 'value',
+    });
+  });
+
+  it('decodes when Query.query is an array of strings', function() {
+    const queryQuery = 'tag:value';
+    const decodedQuery = _decodeQueryValueToObject(queryQuery);
+
+    expect(decodedQuery).toEqual({
+      tag: 'value',
+    });
+  });
+
+  it('decodes when Query.query is falsey', function() {
+    const queryQuery = 'tag:value';
+    const decodedQuery = _decodeQueryValueToObject(queryQuery);
+
+    expect(decodedQuery).toEqual({
+      tag: 'value',
+    });
+  });
+
+  describe('decodes when Query.query has multiple values', function() {
+    it('key0:foo key1:foo', function() {
+      const queryQuery = 'key0:foo key1:bar';
+      const decodedQuery = _decodeQueryValueToObject(queryQuery);
+
+      expect(decodedQuery).toEqual({
+        key0: 'foo',
+        key1: 'bar',
+      });
+    });
+
+    describe('decodes odd cases for keys', function() {
+      it('key.0:foo key1:foo', function() {
+        const queryQuery = 'key0:foo key1:bar';
+        const decodedQuery = _decodeQueryValueToObject(queryQuery);
+
+        expect(decodedQuery).toEqual({
+          key0: 'foo',
+          key1: 'bar',
+        });
+      });
+
+      it('"key:0":foo key1:foo', function() {
+        const queryQuery = '"key:0":foo key1:bar';
+        const decodedQuery = _decodeQueryValueToObject(queryQuery);
+
+        expect(decodedQuery).toEqual({
+          '"key:0"': 'foo',
+          key1: 'bar',
+        });
+      });
+
+      it('"k.e.y:0":foo key1:foo', function() {
+        const queryQuery = '"k.e.y:0":foo key1:bar';
+        const decodedQuery = _decodeQueryValueToObject(queryQuery);
+
+        expect(decodedQuery).toEqual({
+          '"k.e.y:0"': 'foo',
+          key1: 'bar',
+        });
+      });
+    });
+
+    describe('decodes odd cases for values', function() {
+      it('key0:foo key1:"foo bar"', function() {
+        const queryQuery = 'key0:foo key1:"foo bar"';
+        const decodedQuery = _decodeQueryValueToObject(queryQuery);
+
+        expect(decodedQuery).toEqual({
+          key0: 'foo',
+          key1: '"foo bar"',
+        });
+      });
+
+      it('key0:foo key1:"id:1"', function() {
+        const queryQuery = 'key0:foo key1:"id:1"';
+        const decodedQuery = _decodeQueryValueToObject(queryQuery);
+
+        expect(decodedQuery).toEqual({
+          key0: 'foo',
+          key1: '"id:1"',
+        });
+      });
+
+      it('key0:foo key1:"id:\\"foo bar\\""', function() {
+        const queryQuery = 'key0:foo key1:"id:\\"foo bar\\""';
+        const decodedQuery = _decodeQueryValueToObject(queryQuery);
+
+        expect(decodedQuery).toEqual({
+          key0: 'foo',
+          key1: '"id:\\"foo bar\\""',
+        });
+      });
+    });
+
+    describe('decodes odd cases for key and values', function() {
+      it('"k.e.y:0":foo key1:"id:\\"foo bar\\"" "k.e.y:2":"id:\\"foo bar\\""', function() {
+        const queryQuery =
+          '"k.e.y:0":foo key1:"id:\\"foo bar\\"" "k.e.y:2":"id:\\"foo bar\\""';
+        const decodedQuery = _decodeQueryValueToObject(queryQuery);
+
+        expect(decodedQuery).toEqual({
+          '"k.e.y:0"': 'foo',
+          key1: '"id:\\"foo bar\\""',
+          '"k.e.y:2"': '"id:\\"foo bar\\""',
+        });
+      });
+    });
+  });
+});
+*/
+
+describe('encodeObjectToQueryValue', function() {
+  it('encodes when a key-value is a string', function() {
+    const queryObject = {
+      key0: 'foo',
+      'key.1': 'foo',
+    };
+    const encodedQuery = _encodeObjectToQueryValue(queryObject);
+
+    expect(encodedQuery).toBe('key0:foo key.1:foo');
+  });
+
+  it('encodes odd cases for keys', function() {
+    const queryObject = {
+      key0: 'foo',
+      '"key:1"': 'foo',
+      '"k.e.y:2"': 'foo',
+    };
+    const encodedQuery = _encodeObjectToQueryValue(queryObject);
+
+    expect(encodedQuery).toBe('key0:foo "key:1":foo "k.e.y:2":foo');
+  });
+
+  it('encodes odd cases for keys that was not quoted', function() {
+    const queryObject = {
+      key0: 'foo',
+      'key:1': 'foo',
+      'k.e.y:2': 'foo',
+    };
+    const encodedQuery = _encodeObjectToQueryValue(queryObject);
+
+    expect(encodedQuery).toBe('key0:foo "key:1":foo "k.e.y:2":foo');
+  });
+
+  it('encodes odd cases for values', function() {
+    const queryObject = {
+      key0: 'foo',
+      key1: '"foo bar"',
+      key2: '"id:1"',
+      key3: '"id:\\"foo bar\\""',
+    };
+    const encodedQuery = _encodeObjectToQueryValue(queryObject);
+
+    expect(encodedQuery).toBe(
+      'key0:foo key1:"foo bar" key2:"id:1" key3:"id:\\"foo bar\\""'
+    );
+  });
+
+  it('encodes odd cases for values that was not quoted', function() {
+    const queryObject = {
+      key0: 'foo',
+      key1: 'foo bar',
+      key2: 'id:1',
+      key3: 'id:foo bar',
+    };
+    const encodedQuery = _encodeObjectToQueryValue(queryObject);
+
+    expect(encodedQuery).toBe(
+      'key0:foo key1:"foo bar" key2:"id:1" key3:"id:\\"foo bar\\""'
+    );
+  });
+
+  it('encodes odd cases for key and values', function() {
+    const queryObject = {
+      key0: 'foo',
+      'key:1': 'foo bar',
+      'key:2': 'id:1',
+      'k.e.y:3': 'id:foo bar',
+    };
+    const encodedQuery = _encodeObjectToQueryValue(queryObject);
+
+    expect(encodedQuery).toBe(
+      'key0:foo key1:"foo bar" key2:"id:1" key3:"id:\\"foo bar\\"" "k.e.y:3":"id:\\"foo bar\\""'
+    );
   });
 });


### PR DESCRIPTION
Fix regression introduced in #14524

On `GroupEventDetails`, the users expect to narrow down their search when clicking on the `Pill`. However, if the key-value of the `Pill` was project/environment, it would unexpectedly change the state of the GlobalSelectionHeader due to the implementation of the function `generateQueryWithTag`.

On the other hand, clicking the facets/heatmap in Discover2 uses this wrong implementation of `generateQueryWithTag` (but it resulted in the correct behaviour for Discover2). To allow for this, a separate function for this behaviour was created in `app/views/eventsV2/utils.tsx`.

There were discussions on wrapping tag's keys in this format `tag[myKey]` but Discover2 is not ready for it right now.

<img src="https://user-images.githubusercontent.com/1748388/67359121-490aac80-f517-11e9-8b8d-51369a7dbc3c.png" width="300px" margin="10px auto">


Refs SEN-1069
Refs SEN-1124