### PR TITLE
feat(discover2) Add tag keys to the field list autocomplete

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -142,7 +142,7 @@ export const FIELDS: {[key: string]: ColumnValueType} = {
   p75: 'number',
   p95: 'number',
 };
-export type Field = keyof typeof FIELDS | '';
+export type Field = keyof typeof FIELDS | string | '';
 
 // This list should be removed with the tranaction-events feature flag.
 export const TRACING_FIELDS = [

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -8,6 +8,7 @@ import {Organization} from 'app/types';
 import withApi from 'app/utils/withApi';
 
 import Pagination from 'app/components/pagination';
+import {fetchOrganizationTags} from 'app/actionCreators/tags';
 
 import {DEFAULT_EVENT_VIEW_V1} from '../data';
 import EventView, {isAPIPayloadSimilar} from '../eventView';
@@ -27,6 +28,7 @@ type TableState = {
   pageLinks: null | string;
 
   tableData: TableData | null | undefined;
+  tagKeys: null | string[];
 };
 
 /**
@@ -51,8 +53,8 @@ class Table extends React.PureComponent<TableProps, TableState> {
 
     eventView: EventView.fromLocation(this.props.location),
     pageLinks: null,
-
     tableData: null,
+    tagKeys: null,
   };
 
   componentDidMount() {
@@ -112,10 +114,18 @@ class Table extends React.PureComponent<TableProps, TableState> {
           error: err.responseJSON.detail,
         });
       });
+
+    fetchOrganizationTags(this.props.api, organization.slug)
+      .then(tags => {
+        this.setState({tagKeys: tags.map(({key}) => key)});
+      })
+      .catch(() => {
+        // Do nothing.
+      });
   };
 
   render() {
-    const {pageLinks, eventView, tableData, isLoading, error} = this.state;
+    const {pageLinks, eventView, tableData, tagKeys, isLoading, error} = this.state;
 
     return (
       <Container>
@@ -125,6 +135,7 @@ class Table extends React.PureComponent<TableProps, TableState> {
           error={error}
           eventView={eventView}
           tableData={tableData}
+          tagKeys={tagKeys}
         />
         <Pagination pageLinks={pageLinks} />
       </Container>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableModalEditColumn.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableModalEditColumn.tsx
@@ -1,5 +1,6 @@
 import React, {ReactText} from 'react';
 import styled from 'react-emotion';
+import {uniq} from 'lodash';
 
 import {t} from 'app/locale';
 import {Form, SelectField, TextField} from 'app/components/forms';
@@ -231,7 +232,7 @@ function filterFieldByAggregation(
 ): Field[] {
   let fieldList = Object.keys(FIELDS);
   if (tagKeys && tagKeys.length) {
-    fieldList = fieldList.concat(tagKeys);
+    fieldList = uniq(fieldList.concat(tagKeys));
   }
   if (!organization.features.includes('transaction-events')) {
     fieldList = fieldList.filter(item => !TRACING_FIELDS.includes(item));

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -21,6 +21,7 @@ export type TableViewProps = {
 
   eventView: EventView;
   tableData: TableData | null | undefined;
+  tagKeys: null | string[];
 };
 
 /**
@@ -170,7 +171,7 @@ class TableView extends React.Component<TableViewProps> {
   };
 
   render() {
-    const {organization, isLoading, error, tableData, eventView} = this.props;
+    const {organization, isLoading, error, tableData, tagKeys, eventView} = this.props;
 
     const columnOrder = eventView.getColumns();
     const columnSortBy = eventView.getSorts();
@@ -178,7 +179,7 @@ class TableView extends React.Component<TableViewProps> {
     const {
       renderModalBodyWithForm,
       renderModalFooter,
-    } = renderTableModalEditColumnFactory(organization, {
+    } = renderTableModalEditColumnFactory(organization, tagKeys, {
       createColumn: this._createColumn,
       updateColumn: this._updateColumn,
     });


### PR DESCRIPTION
Add an organization's tag keys to the field list autocomplete and type them all as strings. This makes it possible to build custom queries using the org's tags.

I've also improved the workflow by generating column names. If the column is unnamed and a field is picked the name will default to the field name.

Fixes SEN-1179
Fixes SEN-1181