### PR TITLE
fix(eventstore): Fix time condition for earliest/latest event

### DIFF
--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from copy import deepcopy
 from datetime import datetime
 from rest_framework.response import Response
 
@@ -64,9 +65,14 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
                 conditions=conditions, project_ids=[event.project_id], group_ids=[event.group_id]
             )
 
-            next_event = eventstore.get_next_event_id(event, filter=filter)
+            # Ignore any time params and search entire retention period
+            next_event_filter = deepcopy(filter)
+            next_event_filter.end = datetime.utcnow()
+            next_event = eventstore.get_next_event_id(event, filter=next_event_filter)
 
-            prev_event = eventstore.get_prev_event_id(event, filter=filter)
+            prev_event_filter = deepcopy(filter)
+            prev_event_filter.start = datetime.utcfromtimestamp(0)
+            prev_event = eventstore.get_prev_event_id(event, filter=prev_event_filter)
 
             next_event_id = next_event[1] if next_event else None
             prev_event_id = prev_event[1] if prev_event else None

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from datetime import datetime
 import six
 from copy import deepcopy
 
@@ -95,7 +94,6 @@ class SnubaEventStorage(EventStorage):
         filter.conditions = filter.conditions or []
         filter.conditions.extend(get_before_event_condition(event))
         filter.end = event.datetime
-        filter.start = datetime.utcfromtimestamp(0)
 
         return self.__get_event_id_from_filter(filter=filter, orderby=orderby)
 
@@ -106,7 +104,6 @@ class SnubaEventStorage(EventStorage):
         filter.conditions = filter.conditions or []
         filter.conditions.extend(get_after_event_condition(event))
         filter.start = event.datetime
-        filter.end = datetime.utcnow()
 
         return self.__get_event_id_from_filter(filter=filter, orderby=orderby)
 
@@ -124,7 +121,6 @@ class SnubaEventStorage(EventStorage):
         filter.conditions = filter.conditions or []
         filter.conditions.extend(get_after_event_condition(event))
         filter.start = event.datetime
-        filter.end = datetime.utcnow()
 
         return self.__get_event_id_from_filter(filter=filter, orderby=["timestamp", "event_id"])
 
@@ -142,7 +138,6 @@ class SnubaEventStorage(EventStorage):
         filter.conditions = filter.conditions or []
         filter.conditions.extend(get_before_event_condition(event))
         filter.end = event.datetime
-        filter.start = datetime.utcfromtimestamp(0)
 
         return self.__get_event_id_from_filter(filter=filter, orderby=["-timestamp", "-event_id"])
 

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -191,9 +191,9 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 url, format="json", data={"field": ["message", "count()"], "statsPeriod": "7d"}
             )
         assert response.data["eventID"] == "b" * 32
-        assert response.data["nextEventID"] == "c" * 32, "c is newer & matches message"
-        assert response.data["previousEventID"] == "2" * 32, "d is older & matches message"
-        assert response.data["oldestEventID"] == "3" * 32, "3 is oldest matching message"
+        assert response.data["nextEventID"] == "c" * 32, "c is newer & matches message + range"
+        assert response.data["previousEventID"] == "2" * 32, "d is older & matches message + range"
+        assert response.data["oldestEventID"] == "2" * 32, "3 is outside range, no match"
         assert response.data["latestEventID"] == "c" * 32, "c is newest matching message"
 
     def test_event_links_with_tag_fields(self):

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -191,9 +191,9 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 url, format="json", data={"field": ["message", "count()"], "statsPeriod": "7d"}
             )
         assert response.data["eventID"] == "b" * 32
-        assert response.data["nextEventID"] == "c" * 32, "c is newer & matches message + range"
-        assert response.data["previousEventID"] == "2" * 32, "d is older & matches message + range"
-        assert response.data["oldestEventID"] == "2" * 32, "3 is outside range, no match"
+        assert response.data["nextEventID"] == "c" * 32, "c is newer & matches message"
+        assert response.data["previousEventID"] == "2" * 32, "d is older & matches message"
+        assert response.data["oldestEventID"] == "3" * 32, "3 is oldest matching message"
         assert response.data["latestEventID"] == "c" * 32, "c is newest matching message"
 
     def test_event_links_with_tag_fields(self):


### PR DESCRIPTION
Aligns the time conditions for determining an earliest/latest event
with next/prev

- Events with a same timestamp are sorted by event ID
- Override any start/end time from the filter (i.e. search all of time)