### PR TITLE
fix(ui): Fix Shared Issue details w/ Apple crashes [SEN-1154]

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawExceptionContent.jsx
@@ -18,7 +18,9 @@ class RawExceptionContent extends React.Component {
     eventId: PropTypes.string,
     projectId: PropTypes.string.isRequired,
     values: PropTypes.array.isRequired,
-    organization: SentryTypes.Organization.isRequired,
+
+    // XXX: Organization is NOT available for Shared Issues!
+    organization: SentryTypes.Organization,
   };
 
   constructor(props) {
@@ -57,12 +59,20 @@ class RawExceptionContent extends React.Component {
   }
 
   fetchAppleCrashReport() {
+    const {api, organization} = this.props;
+
+    // Shared issues do not have access to organization
+    if (!organization) {
+      return;
+    }
+
     this.setState({
       loading: true,
       error: false,
       crashReport: '',
     });
-    this.props.api.request(this.getAppleCrashReportEndpoint(), {
+
+    api.request(this.getAppleCrashReportEndpoint(), {
       method: 'GET',
       success: data => {
         this.setState({


### PR DESCRIPTION
For Apple crashes, `<RawExceptionContent>` depends on `organization` which is not available for Shared Issues.
Do not attempt to show download link for Apple Crash Report for Shared Issues.

Fixes JAVASCRIPT-W80
Fixes SEN-1154