### PR TITLE
feat(ui): Show intermediate information in project settings view

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
@@ -75,7 +75,11 @@ class OrganizationProjects extends AsyncView {
   }
 
   renderLoading() {
-    const {projectList, projectListPageLinks} = this.state;
+    return this.renderBody();
+  }
+
+  renderBody() {
+    const {projectList, projectListPageLinks, projectStats} = this.state;
     const {organization} = this.props;
     const canCreateProjects = new Set(organization.access).has('project:admin');
 
@@ -117,7 +121,15 @@ class OrganizationProjects extends AsyncView {
                     <ProjectListItem project={project} organization={organization} />
                   </Box>
                   <Box w={3 / 12} p={2}>
-                    <Placeholder height="25px" />
+                    {projectStats ? (
+                      <ProjectStatsGraph
+                        key={project.id}
+                        project={project}
+                        stats={projectStats[project.id]}
+                      />
+                    ) : (
+                      <Placeholder height="25px" />
+                    )}
                   </Box>
                 </PanelItem>
               ))
@@ -125,68 +137,6 @@ class OrganizationProjects extends AsyncView {
               <LoadingIndicator />
             )}
             {projectList && projectList.length === 0 && (
-              <EmptyMessage>{t('No projects found.')}</EmptyMessage>
-            )}
-          </PanelBody>
-        </Panel>
-        {projectListPageLinks && (
-          <Pagination pageLinks={projectListPageLinks} {...this.props} />
-        )}
-      </div>
-    );
-  }
-
-  renderBody() {
-    const {projectList, projectListPageLinks, projectStats} = this.state;
-    const {organization} = this.props;
-    const canCreateProjects = new Set(organization.access).has('project:admin');
-
-    const action = (
-      <Button
-        priority="primary"
-        size="small"
-        disabled={!canCreateProjects}
-        title={
-          !canCreateProjects
-            ? t('You do not have permission to create projects')
-            : undefined
-        }
-        to={`/organizations/${organization.slug}/projects/new/`}
-        icon="icon-circle-add"
-      >
-        {t('Create Project')}
-      </Button>
-    );
-
-    return (
-      <div>
-        <SettingsPageHeader title="Projects" action={action} />
-        <Panel>
-          <PanelHeader hasButtons>
-            {t('Projects')}
-
-            {this.renderSearchInput({
-              updateRoute: true,
-              placeholder: t('Search Projects'),
-              className: 'search',
-            })}
-          </PanelHeader>
-          <PanelBody css={{width: '100%'}}>
-            {sortProjects(projectList).map(project => (
-              <PanelItem p={0} key={project.id} align="center">
-                <Box p={2} flex="1">
-                  <ProjectListItem project={project} organization={organization} />
-                </Box>
-                <Box w={3 / 12} p={2}>
-                  <ProjectStatsGraph
-                    key={project.id}
-                    project={project}
-                    stats={projectStats[project.id]}
-                  />
-                </Box>
-              </PanelItem>
-            ))}
-            {projectList.length === 0 && (
               <EmptyMessage>{t('No projects found.')}</EmptyMessage>
             )}
           </PanelBody>

--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
@@ -4,18 +4,18 @@ import React from 'react';
 
 import {sortProjects} from 'app/utils';
 import {t} from 'app/locale';
+import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
-import AsyncView from 'app/views/asyncView';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import Placeholder from 'app/components/placeholder';
 import Pagination from 'app/components/pagination';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
+import Placeholder from 'app/components/placeholder';
 import ProjectListItem from 'app/views/settings/components/settingsProjectItem';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
-import withOrganization from 'app/utils/withOrganization';
 import routeTitleGen from 'app/utils/routeTitle';
+import withOrganization from 'app/utils/withOrganization';
 
 import ProjectStatsGraph from './projectStatsGraph';
 

--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
@@ -7,6 +7,8 @@ import {t} from 'app/locale';
 import Button from 'app/components/button';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import AsyncView from 'app/views/asyncView';
+import LoadingIndicator from 'app/components/loadingIndicator';
+import Placeholder from 'app/components/placeholder';
 import Pagination from 'app/components/pagination';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import ProjectListItem from 'app/views/settings/components/settingsProjectItem';
@@ -72,6 +74,68 @@ class OrganizationProjects extends AsyncView {
     return routeTitleGen(t('Projects'), organization.slug, false);
   }
 
+  renderLoading() {
+    const {projectList, projectListPageLinks} = this.state;
+    const {organization} = this.props;
+    const canCreateProjects = new Set(organization.access).has('project:admin');
+
+    const action = (
+      <Button
+        priority="primary"
+        size="small"
+        disabled={!canCreateProjects}
+        title={
+          !canCreateProjects
+            ? t('You do not have permission to create projects')
+            : undefined
+        }
+        to={`/organizations/${organization.slug}/projects/new/`}
+        icon="icon-circle-add"
+      >
+        {t('Create Project')}
+      </Button>
+    );
+
+    return (
+      <div>
+        <SettingsPageHeader title="Projects" action={action} />
+        <Panel>
+          <PanelHeader hasButtons>
+            {t('Projects')}
+
+            {this.renderSearchInput({
+              updateRoute: true,
+              placeholder: t('Search Projects'),
+              className: 'search',
+            })}
+          </PanelHeader>
+          <PanelBody css={{width: '100%'}}>
+            {projectList ? (
+              sortProjects(projectList).map(project => (
+                <PanelItem p={0} key={project.id} align="center">
+                  <Box p={2} flex="1">
+                    <ProjectListItem project={project} organization={organization} />
+                  </Box>
+                  <Box w={3 / 12} p={2}>
+                    <Placeholder height="25px" />
+                  </Box>
+                </PanelItem>
+              ))
+            ) : (
+              <LoadingIndicator />
+            )}
+            {projectList && projectList.length === 0 && (
+              <EmptyMessage>{t('No projects found.')}</EmptyMessage>
+            )}
+          </PanelBody>
+        </Panel>
+        {projectListPageLinks && (
+          <Pagination pageLinks={projectListPageLinks} {...this.props} />
+        )}
+      </div>
+    );
+  }
+
   renderBody() {
     const {projectList, projectListPageLinks, projectStats} = this.state;
     const {organization} = this.props;
@@ -108,7 +172,7 @@ class OrganizationProjects extends AsyncView {
             })}
           </PanelHeader>
           <PanelBody css={{width: '100%'}}>
-            {sortProjects(projectList).map((project, i) => (
+            {sortProjects(projectList).map(project => (
               <PanelItem p={0} key={project.id} align="center">
                 <Box p={2} flex="1">
                   <ProjectListItem project={project} organization={organization} />


### PR DESCRIPTION
The current settings>projects page (https://sentry.io/settings/sentry/projects/) is very slow even though it is paginated. Our larger customers spend up to 5-10 seconds waiting for a list of 100 projects to load. In that time they are met with only a spinning icon even though a lot more meaningful content can be shown (such as the search bar and lists of project names). Changed the page to first show a search bar, then a list of projects, then the stats for each project. This way a user can at least interact with the page without having to wait for all api requests to resolve.

Refs SEN-1197