### PR TITLE
feat(ui): Have <Projects> utility component populate the project store

### DIFF
--- a/src/sentry/static/sentry/app/utils/projects.jsx
+++ b/src/sentry/static/sentry/app/utils/projects.jsx
@@ -171,11 +171,6 @@ class Projects extends React.Component {
         initiallyLoaded: true,
         hasMore,
       });
-
-      // populate the projects store if all projects were fetched
-      if (allProjects) {
-        ProjectActions.loadProjects(results);
-      }
     } catch (err) {
       console.error(err); // eslint-disable-line no-console
 
@@ -298,6 +293,11 @@ async function fetchProjects(api, orgId, {slugs, search, limit, allProjects} = {
     hasMore =
       paginationObject &&
       (paginationObject.next.results || paginationObject.previous.results);
+  }
+
+  // populate the projects store if all projects were fetched
+  if (allProjects) {
+    ProjectActions.loadProjects(results);
   }
 
   return {


### PR DESCRIPTION
Changed `<Projects>` to have the capability of fetching a list of all projects and populating that list into the store. This will be one of the last pieces needed for a user in the lightweight org route tree to be able to smoothly navigate to the heavyweight org tree.

Refs SEN-1195