### PR TITLE
feat: Pass type != transaction condition where we don't want transactions

### DIFF
--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -91,7 +91,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
 
     def _get_filter(self, snuba_args):
         return eventstore.Filter(
-            conditions=snuba_args["conditions"],
+            conditions=snuba_args["conditions"] + [["type", "!=", "transaction"]],
             start=snuba_args.get("start", None),
             end=snuba_args.get("end", None),
             project_ids=snuba_args["filter_keys"].get("project_id", None),

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -91,7 +91,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
 
     def _get_filter(self, snuba_args):
         return eventstore.Filter(
-            conditions=snuba_args["conditions"] + [["type", "!=", "transaction"]],
+            conditions=snuba_args["conditions"],
             start=snuba_args.get("start", None),
             end=snuba_args.get("end", None),
             project_ids=snuba_args["filter_keys"].get("project_id", None),

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -55,7 +55,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
 
         if event.group_id:
             requested_environments = set(request.GET.getlist("environment"))
-            conditions = []
+            conditions = [["type", "!=", "transaction"]]
 
             if requested_environments:
                 conditions.append(["environment", "IN", requested_environments])

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -391,6 +391,13 @@ def detect_dataset(query_args, aliased_conditions=False):
         ]:
             return Dataset.Transactions
 
+        if condition == ["event.type", "!=", "transaction"] or condition == [
+            "type",
+            "!=",
+            "transaction",
+        ]:
+            return Dataset.Events
+
     for field in query_args.get("selected_columns") or []:
         if isinstance(field, six.string_types) and field in transaction_fields:
             return Dataset.Transactions

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -546,6 +546,9 @@ class DetectDatasetTest(TestCase):
         query = {"conditions": [["type", "=", "error"]]}
         assert detect_dataset(query) == Dataset.Events
 
+        query = {"conditions": [["type", "!=", "transactions"]]}
+        assert detect_dataset(query) == Dataset.Events
+
     def test_conditions(self):
         query = {"conditions": [["transaction", "=", "api.do_thing"]]}
         assert detect_dataset(query) == Dataset.Events


### PR DESCRIPTION
This is an alternative to https://github.com/getsentry/sentry/pull/15118
which added a dataset argument (defaulting to Events) on an eventstore
query. Here we are forcing the correct dataset decision by adding a
condition "type != transaction" anywhere we do not want to look at
transactions (everything except Discover 2).

When we expand `get_events` and `get_events_by_id` to support
transactions, we will need to add the same to the callers of those functions.