### PR TITLE
fix(ci): do not install_egg_info to fix importlib_metadata not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ base_postgres: &postgres_default
     - docker run -d --network host --name snuba --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=localhost:9000 getsentry/snuba
     - docker ps -a
   install:
-    - pip install -U -e ".[dev,tests,optional]"
+    - pip install -U -e ".[dev,optional]"
   before_script:
     - psql -c 'create database sentry;' -U postgres
 
@@ -99,7 +99,7 @@ base_acceptance: &acceptance_default
     - docker ps -a
   install:
     - ./bin/yarn install --pure-lockfile
-    - pip install -U -e ".[dev,tests,optional]"
+    - pip install -U -e ".[dev,optional]"
     - |
       CHROME_MAJOR_VERSION="$(dpkg -s google-chrome-stable | sed -nr 's/Version: ([0-9]+).*/\1/p')"
       wget -N "https://chromedriver.storage.googleapis.com/$(curl https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAJOR_VERSION})/chromedriver_linux64.zip" -P ~/
@@ -121,7 +121,7 @@ matrix:
       name: 'Linter'
       env: TEST_SUITE=lint
       install:
-        - SENTRY_LIGHT_BUILD=1 pip install -U -e ".[dev,tests,optional]"
+        - SENTRY_LIGHT_BUILD=1 pip install -U -e ".[dev,optional]"
         - find "$NODE_DIR" -type d -empty -delete
         - nvm install
         - ./bin/yarn install --pure-lockfile
@@ -189,7 +189,7 @@ matrix:
         - docker run -d --network host --name snuba --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=localhost:9000 getsentry/snuba
         - docker ps -a
       install:
-        - pip install -U -e ".[dev,tests,optional]"
+        - pip install -U -e ".[dev,optional]"
         - pip install confluent-kafka
       before_script:
         - psql -c 'create database sentry;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,6 @@ base_postgres: &postgres_default
     - docker run -d --network host --name snuba --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=localhost:9000 getsentry/snuba
     - docker ps -a
   install:
-    - python setup.py install_egg_info
     - pip install -U -e ".[dev,tests,optional]"
   before_script:
     - psql -c 'create database sentry;' -U postgres
@@ -100,7 +99,6 @@ base_acceptance: &acceptance_default
     - docker ps -a
   install:
     - ./bin/yarn install --pure-lockfile
-    - python setup.py install_egg_info
     - pip install -U -e ".[dev,tests,optional]"
     - |
       CHROME_MAJOR_VERSION="$(dpkg -s google-chrome-stable | sed -nr 's/Version: ([0-9]+).*/\1/p')"
@@ -123,7 +121,6 @@ matrix:
       name: 'Linter'
       env: TEST_SUITE=lint
       install:
-        - python setup.py install_egg_info
         - SENTRY_LIGHT_BUILD=1 pip install -U -e ".[dev,tests,optional]"
         - find "$NODE_DIR" -type d -empty -delete
         - nvm install
@@ -156,7 +153,6 @@ matrix:
         - postgresql
         - redis-server
       install:
-        - python setup.py install_egg_info
         - pip install -U -e .
       before_script:
         - psql -c 'create database sentry;' -U postgres
@@ -193,7 +189,6 @@ matrix:
         - docker run -d --network host --name snuba --env SNUBA_SETTINGS=test --env CLICKHOUSE_SERVER=localhost:9000 getsentry/snuba
         - docker ps -a
       install:
-        - python setup.py install_egg_info
         - pip install -U -e ".[dev,tests,optional]"
         - pip install confluent-kafka
       before_script:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,10 +5,11 @@ exam>=0.5.1
 freezegun==0.3.11
 honcho>=1.0.0,<1.1.0
 isort>=4.3.4,<4.4.0
+# XXX(joshuarli): pip will complain about pytest needing pluggy 0.12,
+# but this is a quick fix for now to unblock ci in master.
+# See https://github.com/pytest-dev/pluggy/issues/205
+pluggy==0.11.0
 pytest==4.6.5
-# XXX(joshuarli): pytest wants importlib_metadata and should be installing it;
-# this is a quick fix and should be removed once the root issue is identified
-importlib_metadata==0.22
 pytest-cov==2.5.1
 pytest-django==3.5.1
 pytest-html==1.22.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,9 +6,6 @@ freezegun==0.3.11
 honcho>=1.0.0,<1.1.0
 isort>=4.3.4,<4.4.0
 pytest==4.6.5
-# XXX(joshuarli): pytest wants importlib_metadata and should be installing it;
-# this is a quick fix and should be removed once the root issue is identified
-importlib_metadata==0.22
 pytest-cov==2.5.1
 pytest-django==3.5.1
 pytest-html==1.22.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,11 +5,10 @@ exam>=0.5.1
 freezegun==0.3.11
 honcho>=1.0.0,<1.1.0
 isort>=4.3.4,<4.4.0
-# XXX(joshuarli): pip will complain about pytest needing pluggy 0.12,
-# but this is a quick fix for now to unblock ci in master.
-# See https://github.com/pytest-dev/pluggy/issues/205
-pluggy==0.11.0
 pytest==4.6.5
+# XXX(joshuarli): pytest wants importlib_metadata and should be installing it;
+# this is a quick fix and should be removed once the root issue is identified
+importlib_metadata==0.22
 pytest-cov==2.5.1
 pytest-django==3.5.1
 pytest-html==1.22.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,9 @@ freezegun==0.3.11
 honcho>=1.0.0,<1.1.0
 isort>=4.3.4,<4.4.0
 pytest==4.6.5
+# XXX(joshuarli): pytest wants importlib_metadata and should be installing it;
+# this is a quick fix and should be removed once the root issue is identified
+importlib_metadata==0.22
 pytest-cov==2.5.1
 pytest-django==3.5.1
 pytest-html==1.22.0


### PR DESCRIPTION
pluggy (via pytest)'s complaining about importlib_metadata again. This happened with the Riak test suite, which was removed (https://github.com/getsentry/sentry/pull/15072) after I noticed it was deprecated. Back then, that was the path of least resistance, but now the issue's come back.

Related: https://github.com/pytest-dev/pluggy/issues/205