### PR TITLE
fix: Remove trace_id and span_id as exposed columns

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -124,8 +124,6 @@ TRANSACTIONS_SENTRY_SNUBA_MAP = {
     # general
     "id": "event_id",
     "project.id": "project_id",
-    "trace_id": "trace_id",
-    "span_id": "span_id",
     "title": "transaction_name",
     "message": "transaction_name",
     "transaction": "transaction_name",

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -582,7 +582,7 @@ class DetectDatasetTest(TestCase):
         query = {"aggregations": [["quantileTiming(0.95)", "transaction.duration", "p95_duration"]]}
         assert detect_dataset(query) == Dataset.Transactions
 
-        query = {"aggregations": [["uniq", "trace_id", "uniq_trace_id"]]}
+        query = {"aggregations": [["uniq", "transaction.op", "uniq_transaction_op"]]}
         assert detect_dataset(query) == Dataset.Transactions
 
 


### PR DESCRIPTION
These columns are being picked up in issue search when customers are trying to use tracing tags. For transactions these fields require properly formatted uuid values which we currently don't have formatters for so they don't work well there either.

Fixes SENTRY-CVA