### PR TITLE
fix: Outcomes total received should just exclude invalid outcomes

### DIFF
--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -70,7 +70,7 @@ class SnubaTSDB(BaseTSDB):
             snuba.Dataset.Outcomes,
             "org_id",
             "times_seen",
-            [["outcome", "=", outcomes.Outcome.ACCEPTED]],
+            [["outcome", "!=", outcomes.Outcome.INVALID]],
         ),
         TSDBModel.organization_total_rejected: SnubaModelQuerySettings(
             snuba.Dataset.Outcomes,
@@ -88,7 +88,7 @@ class SnubaTSDB(BaseTSDB):
             snuba.Dataset.Outcomes,
             "project_id",
             "times_seen",
-            [["outcome", "=", outcomes.Outcome.ACCEPTED]],
+            [["outcome", "!=", outcomes.Outcome.INVALID]],
         ),
         TSDBModel.project_total_rejected: SnubaModelQuerySettings(
             snuba.Dataset.Outcomes,


### PR DESCRIPTION
When we ask for `organization_total_received` or `project_total_received`, we should count everything and exclude any invalid outcomes because [that's the way we are incrementing counts](https://github.com/getsentry/sentry/blob/249944108eb1d324ee9056cc72fd69a58e3f2d0c/src/sentry/utils/outcomes.py#L69-L77).

## Test plan
* Unit tests
* Running locally