### PR TITLE
feat(app-platform): adds query param option to load extra app for super users

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.tsx
@@ -272,7 +272,7 @@ class OrganizationIntegrations extends AsyncComponent<
     const {orgId} = this.props.params;
     const {reloading, orgOwnedApps, publishedApps, extraApp} = this.state;
     const published = publishedApps || [];
-    //If we have an extra app in state from query parameter, add it as org owned app
+    // If we have an extra app in state from query parameter, add it as org owned app
     if (extraApp) {
       orgOwnedApps.push(extraApp);
     }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/index.tsx
@@ -27,12 +27,13 @@ import {
   SentryApp,
   IntegrationProvider,
   SentryAppInstallation,
+  RouterProps,
 } from 'app/types';
 import {RequestOptions} from 'app/api';
 
 type AppOrProvider = SentryApp | IntegrationProvider;
 
-type Props = {
+type Props = RouterProps & {
   organization: Organization;
   hideHeader: boolean;
 };
@@ -45,6 +46,7 @@ type State = {
   orgOwnedApps: SentryApp[];
   publishedApps: SentryApp[];
   config: {providers: IntegrationProvider[]};
+  extraApp?: SentryApp;
 };
 
 function isSentryApp(integration: AppOrProvider): integration is SentryApp {
@@ -74,7 +76,7 @@ class OrganizationIntegrations extends AsyncComponent<
   getEndpoints(): ([string, string, any] | [string, string])[] {
     const {orgId} = this.props.params;
     const query = {plugins: ['vsts', 'github', 'bitbucket']};
-    return [
+    const baseEndpoints: ([string, string, any] | [string, string])[] = [
       ['config', `/organizations/${orgId}/config/integrations/`],
       ['integrations', `/organizations/${orgId}/integrations/`],
       ['plugins', `/organizations/${orgId}/plugins/`, {query}],
@@ -82,6 +84,17 @@ class OrganizationIntegrations extends AsyncComponent<
       ['publishedApps', '/sentry-apps/', {query: {status: 'published'}}],
       ['appInstalls', `/organizations/${orgId}/sentry-app-installations/`],
     ];
+    /**
+     * optional app to load for super users
+     * should only be done for unpublished integrations from another org
+     * but no checks are in place to ensure the above condition
+     */
+    const extraAppSlug = new URLSearchParams(this.props.location.search).get('extra_app');
+    if (extraAppSlug) {
+      baseEndpoints.push(['extraApp', `/sentry-apps/${extraAppSlug}/`]);
+    }
+
+    return baseEndpoints;
   }
 
   // State
@@ -257,8 +270,13 @@ class OrganizationIntegrations extends AsyncComponent<
 
   renderBody() {
     const {orgId} = this.props.params;
-    const {reloading, orgOwnedApps, publishedApps} = this.state;
+    const {reloading, orgOwnedApps, publishedApps, extraApp} = this.state;
     const published = publishedApps || [];
+    //If we have an extra app in state from query parameter, add it as org owned app
+    if (extraApp) {
+      orgOwnedApps.push(extraApp);
+    }
+
     // we dont want the app to render twice if its the org that created
     // the published app.
     const orgOwned = orgOwnedApps.filter(app => {

--- a/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationIntegrations/index.spec.jsx
@@ -27,7 +27,6 @@ describe('OrganizationIntegrations', () => {
   let githubIntegration;
   let jiraIntegration;
 
-  let params;
   let routerContext;
 
   let publishedSentryAppsRequest;
@@ -36,6 +35,7 @@ describe('OrganizationIntegrations', () => {
 
   let focus;
   let open;
+  let otherProps;
 
   beforeEach(() => {
     Client.clearMockResponses();
@@ -54,13 +54,18 @@ describe('OrganizationIntegrations', () => {
     githubIntegration = TestStubs.GitHubIntegration();
     jiraIntegration = TestStubs.JiraIntegration();
 
-    params = {orgId: org.slug};
-
     routerContext = TestStubs.routerContext();
 
     focus = jest.fn();
     open = jest.fn().mockReturnValue({focus});
     global.open = open;
+
+    otherProps = {
+      location: {
+        search: '',
+      },
+      params: {orgId: org.slug},
+    };
 
     Client.addMockResponse({
       url: `/organizations/${org.slug}/integrations/`,
@@ -98,7 +103,7 @@ describe('OrganizationIntegrations', () => {
     });
 
     wrapper = mountWithTheme(
-      <OrganizationIntegrations organization={org} params={params} />,
+      <OrganizationIntegrations organization={org} {...otherProps} />,
       routerContext
     );
   });
@@ -140,7 +145,7 @@ describe('OrganizationIntegrations', () => {
       });
 
       wrapper = mountWithTheme(
-        <OrganizationIntegrations organization={org} params={params} />,
+        <OrganizationIntegrations organization={org} {...otherProps} />,
         routerContext
       );
     });
@@ -199,7 +204,7 @@ describe('OrganizationIntegrations', () => {
         });
 
         mountWithTheme(
-          <OrganizationIntegrations organization={org} params={params} />,
+          <OrganizationIntegrations organization={org} {...otherProps} />,
           routerContext
         );
 
@@ -222,7 +227,7 @@ describe('OrganizationIntegrations', () => {
         });
 
         wrapper = mountWithTheme(
-          <OrganizationIntegrations organization={org} params={params} />,
+          <OrganizationIntegrations organization={org} {...otherProps} />,
           routerContext
         );
 
@@ -274,7 +279,7 @@ describe('OrganizationIntegrations', () => {
           body: [publishedApp],
         });
         wrapper = mountWithTheme(
-          <OrganizationIntegrations organization={org} params={params} />,
+          <OrganizationIntegrations organization={org} {...otherProps} />,
           routerContext
         );
         expect(wrapper.find('SentryAppInstallationDetail').length).toBe(1);
@@ -315,7 +320,7 @@ describe('OrganizationIntegrations', () => {
         });
 
         wrapper = mountWithTheme(
-          <OrganizationIntegrations organization={org} params={params} />,
+          <OrganizationIntegrations organization={org} {...otherProps} />,
           routerContext
         );
         const pending = wrapper.find('SentryAppInstallationDetail').at(0);
@@ -351,7 +356,7 @@ describe('OrganizationIntegrations', () => {
         });
 
         wrapper = mountWithTheme(
-          <OrganizationIntegrations organization={org} params={params} />,
+          <OrganizationIntegrations organization={org} {...otherProps} />,
           routerContext
         );
         expect(
@@ -378,7 +383,7 @@ describe('OrganizationIntegrations', () => {
         });
 
         wrapper = mountWithTheme(
-          <OrganizationIntegrations organization={org} params={params} />,
+          <OrganizationIntegrations organization={org} {...otherProps} />,
           routerContext
         );
         wrapper.instance().handleRemoveInternalSentryApp(internalApp);
@@ -398,7 +403,7 @@ describe('OrganizationIntegrations', () => {
         });
 
         wrapper = mountWithTheme(
-          <OrganizationIntegrations organization={org} params={params} />,
+          <OrganizationIntegrations organization={org} {...otherProps} />,
           routerContext
         );
 
@@ -482,7 +487,7 @@ describe('OrganizationIntegrations', () => {
         });
 
         wrapper = mountWithTheme(
-          <OrganizationIntegrations organization={org} params={params} />,
+          <OrganizationIntegrations organization={org} {...otherProps} />,
           routerContext
         );
       });
@@ -513,6 +518,34 @@ describe('OrganizationIntegrations', () => {
             .text()
         ).toBe('Install');
       });
+    });
+  });
+  describe('extra_app query parameter defined', () => {
+    it('loads and renders extraApp', () => {
+      const appSlug = 'app2';
+      const extraApp = {
+        ...sentryApp,
+        status: 'unpublished',
+        slug: appSlug,
+        name: 'another app',
+        owner: {
+          id: 43,
+          slug: 'another',
+        },
+      };
+
+      otherProps.location.search = `?extra_app=${appSlug}`;
+      const loadExtraApp = Client.addMockResponse({
+        url: `/sentry-apps/${appSlug}/`,
+        body: extraApp,
+      });
+
+      wrapper = mountWithTheme(
+        <OrganizationIntegrations organization={org} {...otherProps} />,
+        routerContext
+      );
+      expect(loadExtraApp).toHaveBeenCalled();
+      expect(wrapper.find('SentryAppName').text()).toMatch('another app');
     });
   });
 });


### PR DESCRIPTION
In order to test unpublished apps on an org that is different than the author's org, this PR allows superusers to install unpublished apps on a different org. By specifying the query parameter `extra_app` and setting the value to the slug of the app you want to install, a superuser can include that app in the list of integrations.

This query parameter should NOT be used by anyone except for the purpose of evaluating unpublished integrations for publication. If you try it as a non-super user and try to load an app your user doesn't have access to, you will get an error screen trying to load that app. And while you _can_ internal and published apps as a query parameter and it won't break, you should not.