### PR TITLE
deps: Move some dependencies to optional

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,6 +1,4 @@
 BeautifulSoup>=3.2.1
-boto3>=1.4.1,<1.4.6
-botocore<1.5.71
 celery>=3.1.8,<3.1.19
 cffi>=1.11.5,<2.0
 click>=5.0,<7.0
@@ -57,7 +55,6 @@ setproctitle>=1.1.7,<1.2.0
 simplejson>=3.2.0,<3.9.0
 six>=1.10.0,<1.11.0
 sqlparse>=0.1.16,<0.2.0
-statsd>=3.1.0,<3.2.0
 strict-rfc3339>=0.7
 structlog==16.1.0
 symbolic>=7.0.0,<8.0.0

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,5 +1,10 @@
+boto3>=1.4.1,<1.4.6
+botocore<1.5.71
+datadog==0.15.0
 google-cloud-bigtable>=0.32.1,<0.33.0
 google-cloud-pubsub>=0.35.4,<0.36.0
 google-cloud-storage>=1.13.2,<1.14
+librabbitmq==1.6.1
 maxminddb==1.4.1
 python3-saml>=1.4.0,<1.5
+statsd>=3.1.0,<3.2.0


### PR DESCRIPTION
I am torn on this and can go either way.

Our definition of "optional" is fuzzy, and I'd be more inclined if we just got rid of optional and instead included all of these in base.

I'm of the feeling at this point of taking a batteries included approach, and we actively go out of our way to install these optional dependencies anyways in every environment we deploy to. And now with docker being our expected way to run, it doesn't hurt for us to just bundle these.

So do we have opinions about just collapsing optional into base? If not, this is adding some of the dependencies we're manually installing (librabbitmq, datadog) because they're not even listed, and moving boto/statsd out as they are truly optional based on configuration.