### PR TITLE
fix(gitlab): Turn off repo renaming for GitLab (for the moment)

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -51,6 +51,12 @@ class Webhook(object):
 
     def update_repo_data(self, repo, event):
         """
+        # TODO(kmclb): the name w namespace bit is currently causing false positives
+        # for people with three or more levels in their repo names. Need to research
+        # exactly how gitlab handles these cases (what's the name, what's the namespace,
+        # does the url reliably have the info we need?) and then fix this for those
+        # cases.
+
         Given a webhook payload, update stored repo data if needed.
 
         Assumes a 'project' key in event payload, with certain subkeys. Rework
@@ -87,8 +93,9 @@ class MergeEventWebhook(Webhook):
         if repo is None:
             return
 
+        # TODO(kmclb): turn this back on once tri-level repo problem has been solved
         # while we're here, make sure repo data is up to date
-        self.update_repo_data(repo, event)
+        # self.update_repo_data(repo, event)
 
         try:
             number = event["object_attributes"]["iid"]
@@ -145,8 +152,9 @@ class PushEventWebhook(Webhook):
         if repo is None:
             return
 
+        # TODO(kmclb): turn this back on once tri-level repo problem has been solved
         # while we're here, make sure repo data is up to date
-        self.update_repo_data(repo, event)
+        # self.update_repo_data(repo, event)
 
         authors = {}
 

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -273,72 +273,74 @@ class WebhookTest(GitLabTestCase):
         self.assert_pull_request(pull, author)
         self.assert_group_link(group, pull)
 
-    def test_update_repo_name(self):
-        repo_out_of_date_name = self.create_repo(
-            name="Uncool Group / Sentry",  # name out of date
-            url="http://example.com/cool-group/sentry",
-        )
-        repo_out_of_date_name.update(
-            config=dict(repo_out_of_date_name.config, path="cool-group/sentry")
-        )
+    # TODO(kmclb): update the first test, add others back in once repo updating
+    # is fixed
+    # def test_update_repo_name(self):
+    #     repo_out_of_date_name = self.create_repo(
+    #         name="Uncool Group / Sentry",  # name out of date
+    #         url="http://example.com/cool-group/sentry",
+    #     )
+    #     repo_out_of_date_name.update(
+    #         config=dict(repo_out_of_date_name.config, path="cool-group/sentry")
+    #     )
 
-        response = self.client.post(
-            self.url,
-            data=PUSH_EVENT,
-            content_type="application/json",
-            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
-            HTTP_X_GITLAB_EVENT="Push Hook",
-        )
+    #     response = self.client.post(
+    #         self.url,
+    #         data=PUSH_EVENT,
+    #         content_type="application/json",
+    #         HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+    #         HTTP_X_GITLAB_EVENT="Push Hook",
+    #     )
 
-        assert response.status_code == 204
+    #     assert response.status_code == 204
 
-        # name has been updated
-        repo_out_of_date_name.refresh_from_db()
-        assert repo_out_of_date_name.name == "Cool Group / Sentry"
+    #     # name has been updated
+    #     repo_out_of_date_name.refresh_from_db()
+    #     assert repo_out_of_date_name.name == "Cool Group / Sentry"
 
-    def test_update_repo_path(self):
-        repo_out_of_date_path = self.create_repo(
-            name="Cool Group / Sentry", url="http://example.com/cool-group/sentry"
-        )
-        repo_out_of_date_path.update(
-            config=dict(
-                repo_out_of_date_path.config, path="uncool-group/sentry"  # path out of date
-            )
-        )
+    # def test_update_repo_path(self):
+    #     repo_out_of_date_path = self.create_repo(
+    #         name="Cool Group / Sentry", url="http://example.com/cool-group/sentry"
+    #     )
+    #     repo_out_of_date_path.update(
+    #         config=dict(
+    #             repo_out_of_date_path.config, path="uncool-group/sentry"  # path out of date
+    #         )
+    #     )
 
-        response = self.client.post(
-            self.url,
-            data=PUSH_EVENT,
-            content_type="application/json",
-            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
-            HTTP_X_GITLAB_EVENT="Push Hook",
-        )
+    #     response = self.client.post(
+    #         self.url,
+    #         data=PUSH_EVENT,
+    #         content_type="application/json",
+    #         HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+    #         HTTP_X_GITLAB_EVENT="Push Hook",
+    #     )
 
-        assert response.status_code == 204
+    #     assert response.status_code == 204
 
-        # path has been updated
-        repo_out_of_date_path.refresh_from_db()
-        assert repo_out_of_date_path.config["path"] == "cool-group/sentry"
+    #     # path has been updated
+    #     repo_out_of_date_path.refresh_from_db()
+    #     assert repo_out_of_date_path.config["path"] == "cool-group/sentry"
 
-    def test_update_repo_url(self):
-        repo_out_of_date_url = self.create_repo(
-            name="Cool Group / Sentry",
-            url="http://example.com/uncool-group/sentry",  # url out of date
-        )
-        repo_out_of_date_url.update(
-            config=dict(repo_out_of_date_url.config, path="cool-group/sentry")
-        )
+    # def test_update_repo_url(self):
+    #     repo_out_of_date_url = self.create_repo(
+    #         name="Cool Group / Sentry",
+    #         url="http://example.com/uncool-group/sentry",  # url out of date
+    #     )
+    #     repo_out_of_date_url.update(
+    #         config=dict(repo_out_of_date_url.config, path="cool-group/sentry")
+    #     )
 
-        response = self.client.post(
-            self.url,
-            data=PUSH_EVENT,
-            content_type="application/json",
-            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
-            HTTP_X_GITLAB_EVENT="Push Hook",
-        )
+    #     response = self.client.post(
+    #         self.url,
+    #         data=PUSH_EVENT,
+    #         content_type="application/json",
+    #         HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+    #         HTTP_X_GITLAB_EVENT="Push Hook",
+    #     )
 
-        assert response.status_code == 204
+    #     assert response.status_code == 204
 
-        # url has been updated
-        repo_out_of_date_url.refresh_from_db()
-        assert repo_out_of_date_url.url == "http://example.com/cool-group/sentry"
+    #     # url has been updated
+    #     repo_out_of_date_url.refresh_from_db()
+    #     assert repo_out_of_date_url.url == "http://example.com/cool-group/sentry"

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import pytest
+
 from sentry.models import Commit, CommitAuthor, PullRequest, GroupLink
 from sentry.utils import json
 from .testutils import (
@@ -275,72 +277,75 @@ class WebhookTest(GitLabTestCase):
 
     # TODO(kmclb): update the first test, add others back in once repo updating
     # is fixed
-    # def test_update_repo_name(self):
-    #     repo_out_of_date_name = self.create_repo(
-    #         name="Uncool Group / Sentry",  # name out of date
-    #         url="http://example.com/cool-group/sentry",
-    #     )
-    #     repo_out_of_date_name.update(
-    #         config=dict(repo_out_of_date_name.config, path="cool-group/sentry")
-    #     )
+    @pytest.mark.xfail(reason="renaming breaks tri-level repos")
+    def test_update_repo_name(self):
+        repo_out_of_date_name = self.create_repo(
+            name="Uncool Group / Sentry",  # name out of date
+            url="http://example.com/cool-group/sentry",
+        )
+        repo_out_of_date_name.update(
+            config=dict(repo_out_of_date_name.config, path="cool-group/sentry")
+        )
 
-    #     response = self.client.post(
-    #         self.url,
-    #         data=PUSH_EVENT,
-    #         content_type="application/json",
-    #         HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
-    #         HTTP_X_GITLAB_EVENT="Push Hook",
-    #     )
+        response = self.client.post(
+            self.url,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
 
-    #     assert response.status_code == 204
+        assert response.status_code == 204
 
-    #     # name has been updated
-    #     repo_out_of_date_name.refresh_from_db()
-    #     assert repo_out_of_date_name.name == "Cool Group / Sentry"
+        # name has been updated
+        repo_out_of_date_name.refresh_from_db()
+        assert repo_out_of_date_name.name == "Cool Group / Sentry"
 
-    # def test_update_repo_path(self):
-    #     repo_out_of_date_path = self.create_repo(
-    #         name="Cool Group / Sentry", url="http://example.com/cool-group/sentry"
-    #     )
-    #     repo_out_of_date_path.update(
-    #         config=dict(
-    #             repo_out_of_date_path.config, path="uncool-group/sentry"  # path out of date
-    #         )
-    #     )
+    @pytest.mark.xfail(reason="renaming breaks tri-level repos")
+    def test_update_repo_path(self):
+        repo_out_of_date_path = self.create_repo(
+            name="Cool Group / Sentry", url="http://example.com/cool-group/sentry"
+        )
+        repo_out_of_date_path.update(
+            config=dict(
+                repo_out_of_date_path.config, path="uncool-group/sentry"  # path out of date
+            )
+        )
 
-    #     response = self.client.post(
-    #         self.url,
-    #         data=PUSH_EVENT,
-    #         content_type="application/json",
-    #         HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
-    #         HTTP_X_GITLAB_EVENT="Push Hook",
-    #     )
+        response = self.client.post(
+            self.url,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
 
-    #     assert response.status_code == 204
+        assert response.status_code == 204
 
-    #     # path has been updated
-    #     repo_out_of_date_path.refresh_from_db()
-    #     assert repo_out_of_date_path.config["path"] == "cool-group/sentry"
+        # path has been updated
+        repo_out_of_date_path.refresh_from_db()
+        assert repo_out_of_date_path.config["path"] == "cool-group/sentry"
 
-    # def test_update_repo_url(self):
-    #     repo_out_of_date_url = self.create_repo(
-    #         name="Cool Group / Sentry",
-    #         url="http://example.com/uncool-group/sentry",  # url out of date
-    #     )
-    #     repo_out_of_date_url.update(
-    #         config=dict(repo_out_of_date_url.config, path="cool-group/sentry")
-    #     )
+    @pytest.mark.xfail(reason="renaming breaks tri-level repos")
+    def test_update_repo_url(self):
+        repo_out_of_date_url = self.create_repo(
+            name="Cool Group / Sentry",
+            url="http://example.com/uncool-group/sentry",  # url out of date
+        )
+        repo_out_of_date_url.update(
+            config=dict(repo_out_of_date_url.config, path="cool-group/sentry")
+        )
 
-    #     response = self.client.post(
-    #         self.url,
-    #         data=PUSH_EVENT,
-    #         content_type="application/json",
-    #         HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
-    #         HTTP_X_GITLAB_EVENT="Push Hook",
-    #     )
+        response = self.client.post(
+            self.url,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_TOKEN=WEBHOOK_TOKEN,
+            HTTP_X_GITLAB_EVENT="Push Hook",
+        )
 
-    #     assert response.status_code == 204
+        assert response.status_code == 204
 
-    #     # url has been updated
-    #     repo_out_of_date_url.refresh_from_db()
-    #     assert repo_out_of_date_url.url == "http://example.com/cool-group/sentry"
+        # url has been updated
+        repo_out_of_date_url.refresh_from_db()
+        assert repo_out_of_date_url.url == "http://example.com/cool-group/sentry"


### PR DESCRIPTION
The keep-repo-data-up-to-date-via-webhooks code for GitLab introduced in https://github.com/getsentry/sentry/pull/12290 works for repos whose names are of the form `one / two`, but turns out _not_ to work for repos whose names contain more than two levels. Specifically, repos named `one / two / three` are being flagged as having been renamed on the GitLab side (and therefore needing to be renamed in our database) because we're testing against `two / three` rather than the full `one / two / three`, and this is causing repos to get renamed in error.

It's not obvious (nor covered in the GitLab docs) how to reconstruct the full name of tri-level repos from the data given in the webhook payloads we examine, so fixing this is going to take some research and experimentation. In the meantime, this PR disables the renaming code for GitLab, so the number of accidentally-renamed repos doesn't keep increasing.