### PR TITLE
feat(outcomes): Support 10s granularity

### DIFF
--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -104,6 +104,39 @@ class SnubaTSDB(BaseTSDB):
         ),
     }
 
+    lower_rollup_query_settings = {
+        TSDBModel.organization_total_received: SnubaModelQuerySettings(
+            snuba.Dataset.OutcomesRaw, "org_id", None, [["outcome", "!=", outcomes.Outcome.INVALID]]
+        ),
+        TSDBModel.organization_total_rejected: SnubaModelQuerySettings(
+            snuba.Dataset.OutcomesRaw,
+            "org_id",
+            None,
+            [["outcome", "=", outcomes.Outcome.RATE_LIMITED]],
+        ),
+        TSDBModel.organization_total_blacklisted: SnubaModelQuerySettings(
+            snuba.Dataset.OutcomesRaw, "org_id", None, [["outcome", "=", outcomes.Outcome.FILTERED]]
+        ),
+        TSDBModel.project_total_received: SnubaModelQuerySettings(
+            snuba.Dataset.OutcomesRaw,
+            "project_id",
+            None,
+            [["outcome", "!=", outcomes.Outcome.INVALID]],
+        ),
+        TSDBModel.project_total_rejected: SnubaModelQuerySettings(
+            snuba.Dataset.OutcomesRaw,
+            "project_id",
+            None,
+            [["outcome", "=", outcomes.Outcome.RATE_LIMITED]],
+        ),
+        TSDBModel.project_total_blacklisted: SnubaModelQuerySettings(
+            snuba.Dataset.OutcomesRaw,
+            "project_id",
+            None,
+            [["outcome", "=", outcomes.Outcome.FILTERED]],
+        ),
+    }
+
     all_model_query_settings = dict(
         model_columns.items() + model_being_upgraded_query_settings.items()
     )
@@ -129,7 +162,10 @@ class SnubaTSDB(BaseTSDB):
         `group_on_time`: whether to add a GROUP BY clause on the 'time' field.
         `group_on_model`: whether to add a GROUP BY clause on the primary model.
         """
-        model_query_settings = self.all_model_query_settings.get(model)
+        if rollup and rollup == 10 and model in self.lower_rollup_query_settings.keys():
+            model_query_settings = self.lower_rollup_query_settings.get(model)
+        else:
+            model_query_settings = self.all_model_query_settings.get(model)
 
         if model_query_settings is None:
             raise Exception(u"Unsupported TSDBModel: {}".format(model.name))
@@ -229,7 +265,10 @@ class SnubaTSDB(BaseTSDB):
                         del result[rk]
 
     def get_range(self, model, keys, start, end, rollup=None, environment_ids=None):
-        model_query_settings = self.all_model_query_settings.get(model)
+        if rollup and rollup == 10 and model in self.lower_rollup_query_settings.keys():
+            model_query_settings = self.lower_rollup_query_settings.get(model)
+        else:
+            model_query_settings = self.all_model_query_settings.get(model)
 
         assert model_query_settings is not None, u"Unsupported TSDBModel: {}".format(model.name)
 

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -104,6 +104,8 @@ class SnubaTSDB(BaseTSDB):
         ),
     }
 
+    # The Outcomes dataset aggregates outcomes into chunks of an hour. So, for rollups less than an hour, we want to
+    # query the raw outcomes dataset, with a few different settings (defined in lower_rollup_query_settings).
     lower_rollup_query_settings = {
         TSDBModel.organization_total_received: SnubaModelQuerySettings(
             snuba.Dataset.OutcomesRaw, "org_id", None, [["outcome", "!=", outcomes.Outcome.INVALID]]
@@ -162,6 +164,7 @@ class SnubaTSDB(BaseTSDB):
         `group_on_time`: whether to add a GROUP BY clause on the 'time' field.
         `group_on_model`: whether to add a GROUP BY clause on the primary model.
         """
+        # 10s is the only rollup under an hour that we support
         if rollup and rollup == 10 and model in self.lower_rollup_query_settings.keys():
             model_query_settings = self.lower_rollup_query_settings.get(model)
         else:
@@ -265,6 +268,7 @@ class SnubaTSDB(BaseTSDB):
                         del result[rk]
 
     def get_range(self, model, keys, start, end, rollup=None, environment_ids=None):
+        # 10s is the only rollup under an hour that we support
         if rollup and rollup == 10 and model in self.lower_rollup_query_settings.keys():
             model_query_settings = self.lower_rollup_query_settings.get(model)
         else:

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -63,6 +63,7 @@ class Dataset(Enum):
     Events = "events"
     Transactions = "transactions"
     Outcomes = "outcomes"
+    OutcomesRaw = "outcomes_raw"
 
 
 DATASETS = {Dataset.Events: SENTRY_SNUBA_MAP, Dataset.Transactions: TRANSACTIONS_SENTRY_SNUBA_MAP}
@@ -618,7 +619,7 @@ def _prepare_query_params(query_params):
 
     if query_params.dataset in [Dataset.Events, Dataset.Transactions]:
         (organization_id, params_to_update) = get_query_params_to_update_for_projects(query_params)
-    elif query_params.dataset == Dataset.Outcomes:
+    elif query_params.dataset in [Dataset.Outcomes, Dataset.OutcomesRaw]:
         (organization_id, params_to_update) = get_query_params_to_update_for_organizations(
             query_params
         )

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -16,8 +16,8 @@ def floor_to_hour_epoch(value):
 
 
 def floor_to_10s_epoch(value):
-    minutes = value.second
-    floored_second = 10 * (minutes / 10)
+    seconds = value.second
+    floored_second = 10 * (seconds / 10)
 
     value = value.replace(second=floored_second, microsecond=0)
     return int(to_timestamp(value))
@@ -55,9 +55,9 @@ class SnubaTSDBTest(OutcomesSnubaTest):
 
         for tsdb_model, granularity, floor_func, start_time_count, day_later_count in [
             (TSDBModel.organization_total_received, 3600, floor_to_hour_epoch, 3 * 3, 4 * 3),
-            (TSDBModel.organization_total_received, 10, floor_to_10s_epoch, 3 * 3, 4 * 3),
             (TSDBModel.organization_total_rejected, 3600, floor_to_hour_epoch, 3, 4),
             (TSDBModel.organization_total_blacklisted, 3600, floor_to_hour_epoch, 3, 4),
+            (TSDBModel.organization_total_received, 10, floor_to_10s_epoch, 3 * 3, 4 * 3),
             (TSDBModel.organization_total_rejected, 10, floor_to_10s_epoch, 3, 4),
             (TSDBModel.organization_total_blacklisted, 10, floor_to_10s_epoch, 3, 4),
         ]:
@@ -98,9 +98,9 @@ class SnubaTSDBTest(OutcomesSnubaTest):
 
         for tsdb_model, granularity, floor_func, start_time_count, day_later_count in [
             (TSDBModel.project_total_received, 3600, floor_to_hour_epoch, 3 * 3, 4 * 3),
-            (TSDBModel.project_total_received, 10, floor_to_10s_epoch, 3 * 3, 4 * 3),
             (TSDBModel.project_total_rejected, 3600, floor_to_hour_epoch, 3, 4),
             (TSDBModel.project_total_blacklisted, 3600, floor_to_hour_epoch, 3, 4),
+            (TSDBModel.project_total_received, 10, floor_to_10s_epoch, 3 * 3, 4 * 3),
             (TSDBModel.project_total_rejected, 10, floor_to_10s_epoch, 3, 4),
             (TSDBModel.project_total_blacklisted, 10, floor_to_10s_epoch, 3, 4),
         ]:

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -15,6 +15,14 @@ def floor_to_hour_epoch(value):
     return int(to_timestamp(value))
 
 
+def floor_to_10s_epoch(value):
+    minutes = value.second
+    floored_second = 10 * (minutes / 10)
+
+    value = value.replace(second=floored_second, microsecond=0)
+    return int(to_timestamp(value))
+
+
 class SnubaTSDBTest(OutcomesSnubaTest):
     def setUp(self):
         super(SnubaTSDBTest, self).setUp()
@@ -69,6 +77,49 @@ class SnubaTSDBTest(OutcomesSnubaTest):
                 ]:
                     assert count == 0
 
+    def test_organization_outcomes_lower_resolution(self):
+        other_organization = self.create_organization()
+
+        for tsdb_model, outcome in [
+            (TSDBModel.organization_total_received, Outcome.ACCEPTED),
+            (TSDBModel.organization_total_rejected, Outcome.RATE_LIMITED),
+            (TSDBModel.organization_total_blacklisted, Outcome.FILTERED),
+        ]:
+            # Create all the outcomes we will be querying
+            self.store_outcomes(
+                self.organization.id, self.project.id, outcome.value, self.start_time, 3
+            )
+            self.store_outcomes(
+                self.organization.id, self.project.id, outcome.value, self.one_day_later, 4
+            )
+
+            # Also create some outcomes we shouldn't be querying
+            self.store_outcomes(
+                other_organization.id, self.project.id, outcome.value, self.one_day_later, 5
+            )
+            self.store_outcomes(
+                self.organization.id, self.project.id, outcome.value, self.day_before_start_time, 6
+            )
+
+            # Query SnubaTSDB
+            response = self.db.get_range(
+                tsdb_model, [self.organization.id], self.start_time, self.now, 10, None
+            )
+
+            # Assert that the response has values set for the times we expect, and nothing more
+            assert self.organization.id in response.keys()
+            response_dict = {k: v for (k, v) in response[self.organization.id]}
+
+            assert response_dict[floor_to_10s_epoch(self.start_time)] == 3
+            assert response_dict[floor_to_10s_epoch(self.one_day_later)] == 4
+
+            for time, count in response[self.organization.id]:
+                if time not in [
+                    floor_to_10s_epoch(self.start_time),
+                    floor_to_10s_epoch(self.one_day_later),
+                ]:
+                    assert count == 0
+
     def test_project_outcomes(self):
         other_project = self.create_project(organization=self.organization)
 
@@ -109,5 +160,48 @@ class SnubaTSDBTest(OutcomesSnubaTest):
                 if time not in [
                     floor_to_hour_epoch(self.start_time),
                     floor_to_hour_epoch(self.one_day_later),
+                ]:
+                    assert count == 0
+
+    def test_project_outcomes_lower_resolution(self):
+        other_project = self.create_project(organization=self.organization)
+
+        for tsdb_model, outcome in [
+            (TSDBModel.project_total_received, Outcome.ACCEPTED),
+            (TSDBModel.project_total_rejected, Outcome.RATE_LIMITED),
+            (TSDBModel.project_total_blacklisted, Outcome.FILTERED),
+        ]:
+            # Create all the outcomes we will be querying
+            self.store_outcomes(
+                self.organization.id, self.project.id, outcome.value, self.start_time, 3
+            )
+            self.store_outcomes(
+                self.organization.id, self.project.id, outcome.value, self.one_day_later, 4
+            )
+
+            # Also create some outcomes we shouldn't be querying
+            self.store_outcomes(
+                self.organization.id, other_project.id, outcome.value, self.one_day_later, 5
+            )
+            self.store_outcomes(
+                self.organization.id, self.project.id, outcome.value, self.day_before_start_time, 6
+            )
+
+            # Query SnubaTSDB
+            response = self.db.get_range(
+                tsdb_model, [self.project.id], self.start_time, self.now, 10, None
+            )
+
+            # Assert that the response has values set for the times we expect, and nothing more
+            assert self.project.id in response.keys()
+            response_dict = {k: v for (k, v) in response[self.project.id]}
+
+            assert response_dict[floor_to_10s_epoch(self.start_time)] == 3
+            assert response_dict[floor_to_10s_epoch(self.one_day_later)] == 4
+
+            for time, count in response[self.project.id]:
+                if time not in [
+                    floor_to_10s_epoch(self.start_time),
+                    floor_to_10s_epoch(self.one_day_later),
                 ]:
                     assert count == 0

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -37,12 +37,7 @@ class SnubaTSDBTest(OutcomesSnubaTest):
     def test_organization_outcomes(self):
         other_organization = self.create_organization()
 
-        for tsdb_model, outcome in [
-            (TSDBModel.organization_total_received, Outcome.ACCEPTED),
-            (TSDBModel.organization_total_rejected, Outcome.RATE_LIMITED),
-            (TSDBModel.organization_total_blacklisted, Outcome.FILTERED),
-        ]:
-            # Create all the outcomes we will be querying
+        for outcome in [Outcome.ACCEPTED, Outcome.RATE_LIMITED, Outcome.FILTERED]:
             self.store_outcomes(
                 self.organization.id, self.project.id, outcome.value, self.start_time, 3
             )
@@ -58,77 +53,34 @@ class SnubaTSDBTest(OutcomesSnubaTest):
                 self.organization.id, self.project.id, outcome.value, self.day_before_start_time, 6
             )
 
-            # Query SnubaTSDB
-            response = self.db.get_range(
-                tsdb_model, [self.organization.id], self.start_time, self.now, 3600, None
-            )
-
-            # Assert that the response has values set for the times we expect, and nothing more
-            assert self.organization.id in response.keys()
-            response_dict = {k: v for (k, v) in response[self.organization.id]}
-
-            assert response_dict[floor_to_hour_epoch(self.start_time)] == 3
-            assert response_dict[floor_to_hour_epoch(self.one_day_later)] == 4
-
-            for time, count in response[self.organization.id]:
-                if time not in [
-                    floor_to_hour_epoch(self.start_time),
-                    floor_to_hour_epoch(self.one_day_later),
-                ]:
-                    assert count == 0
-
-    def test_organization_outcomes_lower_resolution(self):
-        other_organization = self.create_organization()
-
-        for tsdb_model, outcome in [
-            (TSDBModel.organization_total_received, Outcome.ACCEPTED),
-            (TSDBModel.organization_total_rejected, Outcome.RATE_LIMITED),
-            (TSDBModel.organization_total_blacklisted, Outcome.FILTERED),
+        for tsdb_model, granularity, floor_func, start_time_count, day_later_count in [
+            (TSDBModel.organization_total_received, 3600, floor_to_hour_epoch, 3 * 3, 4 * 3),
+            (TSDBModel.organization_total_received, 10, floor_to_10s_epoch, 3 * 3, 4 * 3),
+            (TSDBModel.organization_total_rejected, 3600, floor_to_hour_epoch, 3, 4),
+            (TSDBModel.organization_total_blacklisted, 3600, floor_to_hour_epoch, 3, 4),
+            (TSDBModel.organization_total_rejected, 10, floor_to_10s_epoch, 3, 4),
+            (TSDBModel.organization_total_blacklisted, 10, floor_to_10s_epoch, 3, 4),
         ]:
-            # Create all the outcomes we will be querying
-            self.store_outcomes(
-                self.organization.id, self.project.id, outcome.value, self.start_time, 3
-            )
-            self.store_outcomes(
-                self.organization.id, self.project.id, outcome.value, self.one_day_later, 4
-            )
-
-            # Also create some outcomes we shouldn't be querying
-            self.store_outcomes(
-                other_organization.id, self.project.id, outcome.value, self.one_day_later, 5
-            )
-            self.store_outcomes(
-                self.organization.id, self.project.id, outcome.value, self.day_before_start_time, 6
-            )
-
             # Query SnubaTSDB
             response = self.db.get_range(
-                tsdb_model, [self.organization.id], self.start_time, self.now, 10, None
+                tsdb_model, [self.organization.id], self.start_time, self.now, granularity, None
             )
 
             # Assert that the response has values set for the times we expect, and nothing more
             assert self.organization.id in response.keys()
             response_dict = {k: v for (k, v) in response[self.organization.id]}
 
-            assert response_dict[floor_to_10s_epoch(self.start_time)] == 3
-            assert response_dict[floor_to_10s_epoch(self.one_day_later)] == 4
+            assert response_dict[floor_func(self.start_time)] == start_time_count
+            assert response_dict[floor_func(self.one_day_later)] == day_later_count
 
             for time, count in response[self.organization.id]:
-                if time not in [
-                    floor_to_10s_epoch(self.start_time),
-                    floor_to_10s_epoch(self.one_day_later),
-                ]:
+                if time not in [floor_func(self.start_time), floor_func(self.one_day_later)]:
                     assert count == 0
 
     def test_project_outcomes(self):
         other_project = self.create_project(organization=self.organization)
 
-        for tsdb_model, outcome in [
-            (TSDBModel.project_total_received, Outcome.ACCEPTED),
-            (TSDBModel.project_total_rejected, Outcome.RATE_LIMITED),
-            (TSDBModel.project_total_blacklisted, Outcome.FILTERED),
-        ]:
-            # Create all the outcomes we will be querying
+        for outcome in [Outcome.ACCEPTED, Outcome.RATE_LIMITED, Outcome.FILTERED]:
             self.store_outcomes(
                 self.organization.id, self.project.id, outcome.value, self.start_time, 3
             )
@@ -144,64 +96,25 @@ class SnubaTSDBTest(OutcomesSnubaTest):
                 self.organization.id, self.project.id, outcome.value, self.day_before_start_time, 6
             )
 
-            # Query SnubaTSDB
-            response = self.db.get_range(
-                tsdb_model, [self.project.id], self.start_time, self.now, 3600, None
-            )
-
-            # Assert that the response has values set for the times we expect, and nothing more
-            assert self.project.id in response.keys()
-            response_dict = {k: v for (k, v) in response[self.project.id]}
-
-            assert response_dict[floor_to_hour_epoch(self.start_time)] == 3
-            assert response_dict[floor_to_hour_epoch(self.one_day_later)] == 4
-
-            for time, count in response[self.project.id]:
-                if time not in [
-                    floor_to_hour_epoch(self.start_time),
-                    floor_to_hour_epoch(self.one_day_later),
-                ]:
-                    assert count == 0
-
-    def test_project_outcomes_lower_resolution(self):
-        other_project = self.create_project(organization=self.organization)
-
-        for tsdb_model, outcome in [
-            (TSDBModel.project_total_received, Outcome.ACCEPTED),
-            (TSDBModel.project_total_rejected, Outcome.RATE_LIMITED),
-            (TSDBModel.project_total_blacklisted, Outcome.FILTERED),
+        for tsdb_model, granularity, floor_func, start_time_count, day_later_count in [
+            (TSDBModel.project_total_received, 3600, floor_to_hour_epoch, 3 * 3, 4 * 3),
+            (TSDBModel.project_total_received, 10, floor_to_10s_epoch, 3 * 3, 4 * 3),
+            (TSDBModel.project_total_rejected, 3600, floor_to_hour_epoch, 3, 4),
+            (TSDBModel.project_total_blacklisted, 3600, floor_to_hour_epoch, 3, 4),
+            (TSDBModel.project_total_rejected, 10, floor_to_10s_epoch, 3, 4),
+            (TSDBModel.project_total_blacklisted, 10, floor_to_10s_epoch, 3, 4),
         ]:
-            # Create all the outcomes we will be querying
-            self.store_outcomes(
-                self.organization.id, self.project.id, outcome.value, self.start_time, 3
-            )
-            self.store_outcomes(
-                self.organization.id, self.project.id, outcome.value, self.one_day_later, 4
-            )
-
-            # Also create some outcomes we shouldn't be querying
-            self.store_outcomes(
-                self.organization.id, other_project.id, outcome.value, self.one_day_later, 5
-            )
-            self.store_outcomes(
-                self.organization.id, self.project.id, outcome.value, self.day_before_start_time, 6
-            )
-
-            # Query SnubaTSDB
             response = self.db.get_range(
-                tsdb_model, [self.project.id], self.start_time, self.now, 10, None
+                tsdb_model, [self.project.id], self.start_time, self.now, granularity, None
             )
 
             # Assert that the response has values set for the times we expect, and nothing more
             assert self.project.id in response.keys()
             response_dict = {k: v for (k, v) in response[self.project.id]}
 
-            assert response_dict[floor_to_10s_epoch(self.start_time)] == 3
-            assert response_dict[floor_to_10s_epoch(self.one_day_later)] == 4
+            assert response_dict[floor_func(self.start_time)] == start_time_count
+            assert response_dict[floor_func(self.one_day_later)] == day_later_count
 
             for time, count in response[self.project.id]:
-                if time not in [
-                    floor_to_10s_epoch(self.start_time),
-                    floor_to_10s_epoch(self.one_day_later),
-                ]:
+                if time not in [floor_func(self.start_time), floor_func(self.one_day_later)]:
                     assert count == 0


### PR DESCRIPTION
Here's the query it produces for a 10s granularity in Snuba for `organization_total_received`:
```
SELECT org_id, (toDateTime(intDiv(toUInt32(timestamp), 10) * 10) AS time), (count() AS aggregate) FROM test_outcomes_raw_local PREWHERE org_id IN (1) WHERE outcome != 3 AND timestamp >= toDateTime('2019-10-14T15:47:00') AND timestamp < toDateTime('2019-10-14T15:48:10') AND org_id = 1 GROUP BY (org_id, time) LIMIT 0, 7
```

## Testing plan
* Hitting the API with a 10s granularity locally
* Unit tests