### PR TITLE
ref(ui): Change projects settings pagination to 50 items and remove grid emotion

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
@@ -20,7 +20,7 @@ import withOrganization from 'app/utils/withOrganization';
 
 import ProjectStatsGraph from './projectStatsGraph';
 
-const ITEMS_PER_PAGE = 2;
+const ITEMS_PER_PAGE = 50;
 
 class OrganizationProjects extends AsyncView {
   static propTypes = {

--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
@@ -20,6 +20,8 @@ import withOrganization from 'app/utils/withOrganization';
 
 import ProjectStatsGraph from './projectStatsGraph';
 
+const ITEMS_PER_PAGE = 2;
+
 class OrganizationProjects extends AsyncView {
   static propTypes = {
     organization: SentryTypes.Organization,
@@ -39,7 +41,6 @@ class OrganizationProjects extends AsyncView {
 
   getEndpoints() {
     const {orgId} = this.props.params;
-    const itemsPerPage = 50;
     return [
       [
         'projectList',
@@ -47,7 +48,7 @@ class OrganizationProjects extends AsyncView {
         {
           query: {
             query: this.props.location.query.query,
-            per_page: itemsPerPage,
+            per_page: ITEMS_PER_PAGE,
           },
         },
       ],
@@ -59,7 +60,7 @@ class OrganizationProjects extends AsyncView {
             since: new Date().getTime() / 1000 - 3600 * 24,
             stat: 'generated',
             group: 'project',
-            per_page: itemsPerPage,
+            per_page: ITEMS_PER_PAGE,
           },
         },
       ],
@@ -121,10 +122,10 @@ class OrganizationProjects extends AsyncView {
             {projectList ? (
               sortProjects(projectList).map(project => (
                 <GridPanelItem key={project.id}>
-                  <ContainerProjectListItem>
+                  <ProjectListItemWrapper>
                     <ProjectListItem project={project} organization={organization} />
-                  </ContainerProjectListItem>
-                  <ContainerProjectStatsGraph>
+                  </ProjectListItemWrapper>
+                  <ProjectStatsGraphWrapper>
                     {projectStats ? (
                       <ProjectStatsGraph
                         key={project.id}
@@ -134,7 +135,7 @@ class OrganizationProjects extends AsyncView {
                     ) : (
                       <Placeholder height="25px" />
                     )}
-                  </ContainerProjectStatsGraph>
+                  </ProjectStatsGraphWrapper>
                 </GridPanelItem>
               ))
             ) : (
@@ -161,12 +162,13 @@ const GridPanelItem = styled(PanelItem)`
   padding: 0;
 `;
 
-const ContainerProjectListItem = styled('div')`
+const ProjectListItemWrapper = styled('div')`
   padding: ${space(2)};
   flex: 1;
 `;
 
-const ContainerProjectStatsGraph = styled('div')`
+const ProjectStatsGraphWrapper = styled('div')`
   padding: ${space(2)};
   width: 25%;
+  margin-left: ${space(2)};
 `;

--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
@@ -1,6 +1,6 @@
-import {Box} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'react-emotion';
 
 import {sortProjects} from 'app/utils';
 import {t} from 'app/locale';
@@ -15,6 +15,7 @@ import ProjectListItem from 'app/views/settings/components/settingsProjectItem';
 import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import routeTitleGen from 'app/utils/routeTitle';
+import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
 
 import ProjectStatsGraph from './projectStatsGraph';
@@ -38,6 +39,7 @@ class OrganizationProjects extends AsyncView {
 
   getEndpoints() {
     const {orgId} = this.props.params;
+    const itemsPerPage = 50;
     return [
       [
         'projectList',
@@ -45,6 +47,7 @@ class OrganizationProjects extends AsyncView {
         {
           query: {
             query: this.props.location.query.query,
+            per_page: itemsPerPage,
           },
         },
       ],
@@ -56,6 +59,7 @@ class OrganizationProjects extends AsyncView {
             since: new Date().getTime() / 1000 - 3600 * 24,
             stat: 'generated',
             group: 'project',
+            per_page: itemsPerPage,
           },
         },
       ],
@@ -116,11 +120,11 @@ class OrganizationProjects extends AsyncView {
           <PanelBody css={{width: '100%'}}>
             {projectList ? (
               sortProjects(projectList).map(project => (
-                <PanelItem p={0} key={project.id} align="center">
-                  <Box p={2} flex="1">
+                <GridPanelItem key={project.id}>
+                  <ContainerProjectListItem>
                     <ProjectListItem project={project} organization={organization} />
-                  </Box>
-                  <Box w={3 / 12} p={2}>
+                  </ContainerProjectListItem>
+                  <ContainerProjectStatsGraph>
                     {projectStats ? (
                       <ProjectStatsGraph
                         key={project.id}
@@ -130,8 +134,8 @@ class OrganizationProjects extends AsyncView {
                     ) : (
                       <Placeholder height="25px" />
                     )}
-                  </Box>
-                </PanelItem>
+                  </ContainerProjectStatsGraph>
+                </GridPanelItem>
               ))
             ) : (
               <LoadingIndicator />
@@ -150,3 +154,20 @@ class OrganizationProjects extends AsyncView {
 }
 
 export default withOrganization(OrganizationProjects);
+
+const GridPanelItem = styled(PanelItem)`
+  display: grid;
+  grid-template-columns: auto 25%;
+  align-items: center;
+  padding: 0;
+`;
+
+const ContainerProjectListItem = styled('div')`
+  padding: ${space(2)};
+  grid-area: 1 / 1;
+`;
+
+const ContainerProjectStatsGraph = styled('div')`
+  padding: ${space(2)};
+  grid-area: 1 / 2;
+`;

--- a/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationProjects/index.jsx
@@ -156,18 +156,17 @@ class OrganizationProjects extends AsyncView {
 export default withOrganization(OrganizationProjects);
 
 const GridPanelItem = styled(PanelItem)`
-  display: grid;
-  grid-template-columns: auto 25%;
+  display: flex;
   align-items: center;
   padding: 0;
 `;
 
 const ContainerProjectListItem = styled('div')`
   padding: ${space(2)};
-  grid-area: 1 / 1;
+  flex: 1;
 `;
 
 const ContainerProjectStatsGraph = styled('div')`
   padding: ${space(2)};
-  grid-area: 1 / 2;
+  width: 25%;
 `;

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -380,82 +380,116 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                   <div
                     className="css-z3t9gf-textStyles"
                   >
-                    <PanelItem
-                      align="center"
+                    <GridPanelItem
                       key="2"
-                      p={0}
+                      p={2}
                     >
                       <Base
-                        align="center"
-                        className="css-1jykl04-PanelItem eo8n7lk0"
-                        p={0}
+                        className="css-no3wd-PanelItem-GridPanelItem ew99cs00"
+                        p={2}
                       >
                         <div
-                          className="css-1jykl04-PanelItem eo8n7lk0"
+                          className="css-no3wd-PanelItem-GridPanelItem ew99cs00"
                           is={null}
                         >
-                          <Box
-                            flex="1"
-                            p={2}
-                          >
-                            <Base
-                              className="css-14o7hgh"
-                              flex="1"
-                              p={2}
+                          <ContainerProjectListItem>
+                            <div
+                              className="css-11u2sgk-ContainerProjectListItem ew99cs01"
                             >
-                              <div
-                                className="css-14o7hgh"
-                                is={null}
+                              <ProjectItem
+                                organization={
+                                  Object {
+                                    "access": Array [
+                                      "org:read",
+                                      "org:write",
+                                      "org:admin",
+                                      "org:integrations",
+                                      "project:read",
+                                      "project:write",
+                                      "project:admin",
+                                      "team:read",
+                                      "team:write",
+                                      "team:admin",
+                                    ],
+                                    "features": Array [],
+                                    "id": "3",
+                                    "name": "Organization Name",
+                                    "onboardingTasks": Array [],
+                                    "projects": Array [],
+                                    "scrapeJavaScript": true,
+                                    "slug": "org-slug",
+                                    "status": Object {
+                                      "id": "active",
+                                      "name": "active",
+                                    },
+                                    "teams": Array [],
+                                  }
+                                }
+                                project={
+                                  Object {
+                                    "environments": Array [],
+                                    "hasAccess": true,
+                                    "id": "2",
+                                    "isBookmarked": false,
+                                    "isMember": true,
+                                    "name": "Project Name",
+                                    "slug": "project-slug",
+                                    "teams": Array [],
+                                  }
+                                }
                               >
-                                <ProjectItem
-                                  organization={
-                                    Object {
-                                      "access": Array [
-                                        "org:read",
-                                        "org:write",
-                                        "org:admin",
-                                        "org:integrations",
-                                        "project:read",
-                                        "project:write",
-                                        "project:admin",
-                                        "team:read",
-                                        "team:write",
-                                        "team:admin",
-                                      ],
-                                      "features": Array [],
-                                      "id": "3",
-                                      "name": "Organization Name",
-                                      "onboardingTasks": Array [],
-                                      "projects": Array [],
-                                      "scrapeJavaScript": true,
-                                      "slug": "org-slug",
-                                      "status": Object {
-                                        "id": "active",
-                                        "name": "active",
-                                      },
-                                      "teams": Array [],
-                                    }
-                                  }
-                                  project={
-                                    Object {
-                                      "environments": Array [],
-                                      "hasAccess": true,
-                                      "id": "2",
-                                      "isBookmarked": false,
-                                      "isMember": true,
-                                      "name": "Project Name",
-                                      "slug": "project-slug",
-                                      "teams": Array [],
-                                    }
-                                  }
+                                <Container
+                                  key="2"
                                 >
-                                  <Container
-                                    key="2"
+                                  <div
+                                    className="css-9ku3o0-Container enngb6z0"
                                   >
-                                    <div
-                                      className="css-9ku3o0-Container enngb6z0"
+                                    <BookmarkLink
+                                      isBookmarked={false}
+                                      onToggle={[Function]}
+                                      organization={
+                                        Object {
+                                          "access": Array [
+                                            "org:read",
+                                            "org:write",
+                                            "org:admin",
+                                            "org:integrations",
+                                            "project:read",
+                                            "project:write",
+                                            "project:admin",
+                                            "team:read",
+                                            "team:write",
+                                            "team:admin",
+                                          ],
+                                          "features": Array [],
+                                          "id": "3",
+                                          "name": "Organization Name",
+                                          "onboardingTasks": Array [],
+                                          "projects": Array [],
+                                          "scrapeJavaScript": true,
+                                          "slug": "org-slug",
+                                          "status": Object {
+                                            "id": "active",
+                                            "name": "active",
+                                          },
+                                          "teams": Array [],
+                                        }
+                                      }
+                                      project={
+                                        Object {
+                                          "environments": Array [],
+                                          "hasAccess": true,
+                                          "id": "2",
+                                          "isBookmarked": false,
+                                          "isMember": true,
+                                          "name": "Project Name",
+                                          "slug": "project-slug",
+                                          "teams": Array [],
+                                        }
+                                      }
                                     >
-                                      <BookmarkLink
+                                      <withApi(BookmarkStar)
+                                        className="css-10z01iz-BookmarkLink enngb6z1"
                                         isBookmarked={false}
                                         onToggle={[Function]}
                                         organization={
@@ -499,7 +533,16 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                                           }
                                         }
                                       >
-                                        <withApi(BookmarkStar)
+                                        <BookmarkStar
+                                          api={
+                                            Client {
+                                              "_chain": [Function],
+                                              "_wrapRequest": [Function],
+                                              "bulkUpdate": [Function],
+                                              "handleRequestError": [Function],
+                                              "hasProjectBeenRenamed": [Function],
+                                            }
+                                          }
                                           className="css-10z01iz-BookmarkLink enngb6z1"
                                           isBookmarked={false}
                                           onToggle={[Function]}
@@ -544,47 +587,48 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                                             }
                                           }
                                         >
-                                          <BookmarkStar
-                                            api={
-                                              Client {
-                                                "_chain": [Function],
-                                                "_wrapRequest": [Function],
-                                                "bulkUpdate": [Function],
-                                                "handleRequestError": [Function],
-                                                "hasProjectBeenRenamed": [Function],
-                                              }
-                                            }
+                                          <Star
                                             className="css-10z01iz-BookmarkLink enngb6z1"
                                             isBookmarked={false}
-                                            onToggle={[Function]}
-                                            organization={
-                                              Object {
-                                                "access": Array [
-                                                  "org:read",
-                                                  "org:write",
-                                                  "org:admin",
-                                                  "org:integrations",
-                                                  "project:read",
-                                                  "project:write",
-                                                  "project:admin",
-                                                  "team:read",
-                                                  "team:write",
-                                                  "team:admin",
-                                                ],
-                                                "features": Array [],
-                                                "id": "3",
-                                                "name": "Organization Name",
-                                                "onboardingTasks": Array [],
-                                                "projects": Array [],
-                                                "scrapeJavaScript": true,
-                                                "slug": "org-slug",
-                                                "status": Object {
-                                                  "id": "active",
-                                                  "name": "active",
-                                                },
-                                                "teams": Array [],
-                                              }
-                                            }
+                                            onClick={[Function]}
+                                            src="icon-star-small-filled"
+                                          >
+                                            <ForwardRef
+                                              className="enngb6z1 css-judnc9-InlineSvg-Star-BookmarkLink e5ekdrk0"
+                                              isBookmarked={false}
+                                              onClick={[Function]}
+                                              src="icon-star-small-filled"
+                                            >
+                                              <svg
+                                                className="enngb6z1 css-judnc9-InlineSvg-Star-BookmarkLink e5ekdrk0"
+                                                height="1em"
+                                                onClick={[Function]}
+                                                viewBox={Object {}}
+                                                width="1em"
+                                              >
+                                                <use
+                                                  href="#test"
+                                                  xlinkHref="#test"
+                                                />
+                                              </svg>
+                                            </ForwardRef>
+                                          </Star>
+                                        </BookmarkStar>
+                                      </withApi(BookmarkStar)>
+                                    </BookmarkLink>
+                                    <Link
+                                      to="/settings/org-slug/projects/project-slug/"
+                                    >
+                                      <Link
+                                        onlyActiveOnIndex={false}
+                                        style={Object {}}
+                                        to="/settings/org-slug/projects/project-slug/"
+                                      >
+                                        <a
+                                          onClick={[Function]}
+                                          style={Object {}}
+                                        >
+                                          <ProjectLabel
                                             project={
                                               Object {
                                                 "environments": Array [],
@@ -598,48 +642,8 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                                               }
                                             }
                                           >
-                                            <Star
-                                              className="css-10z01iz-BookmarkLink enngb6z1"
-                                              isBookmarked={false}
-                                              onClick={[Function]}
-                                              src="icon-star-small-filled"
-                                            >
-                                              <ForwardRef
-                                                className="enngb6z1 css-judnc9-InlineSvg-Star-BookmarkLink e5ekdrk0"
-                                                isBookmarked={false}
-                                                onClick={[Function]}
-                                                src="icon-star-small-filled"
-                                              >
-                                                <svg
-                                                  className="enngb6z1 css-judnc9-InlineSvg-Star-BookmarkLink e5ekdrk0"
-                                                  height="1em"
-                                                  onClick={[Function]}
-                                                  viewBox={Object {}}
-                                                  width="1em"
-                                                >
-                                                  <use
-                                                    href="#test"
-                                                    xlinkHref="#test"
-                                                  />
-                                                </svg>
-                                              </ForwardRef>
-                                            </Star>
-                                          </BookmarkStar>
-                                        </withApi(BookmarkStar)>
-                                      </BookmarkLink>
-                                      <Link
-                                        to="/settings/org-slug/projects/project-slug/"
-                                      >
-                                        <Link
-                                          onlyActiveOnIndex={false}
-                                          style={Object {}}
-                                          to="/settings/org-slug/projects/project-slug/"
-                                        >
-                                          <a
-                                            onClick={[Function]}
-                                            style={Object {}}
-                                          >
-                                            <ProjectLabel
+                                            <span
+                                              className="project-label"
                                               project={
                                                 Object {
                                                   "environments": Array [],
@@ -654,72 +658,46 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                                               }
                                             >
                                               <span
-                                                className="project-label"
-                                                project={
-                                                  Object {
-                                                    "environments": Array [],
-                                                    "hasAccess": true,
-                                                    "id": "2",
-                                                    "isBookmarked": false,
-                                                    "isMember": true,
-                                                    "name": "Project Name",
-                                                    "slug": "project-slug",
-                                                    "teams": Array [],
-                                                  }
-                                                }
+                                                className="project-name"
                                               >
-                                                <span
-                                                  className="project-name"
-                                                >
-                                                  project-slug
-                                                </span>
+                                                project-slug
                                               </span>
-                                            </ProjectLabel>
-                                          </a>
-                                        </Link>
+                                            </span>
+                                          </ProjectLabel>
+                                        </a>
                                       </Link>
-                                    </div>
-                                  </Container>
-                                </ProjectItem>
-                              </div>
-                            </Base>
-                          </Box>
-                          <Box
-                            p={2}
-                            w={0.25}
-                          >
-                            <Base
-                              className="css-7g8agk"
-                              p={2}
-                              w={0.25}
+                                    </Link>
+                                  </div>
+                                </Container>
+                              </ProjectItem>
+                            </div>
+                          </ContainerProjectListItem>
+                          <ContainerProjectStatsGraph>
+                            <div
+                              className="css-174lc2j-ContainerProjectStatsGraph ew99cs02"
                             >
-                              <div
-                                className="css-7g8agk"
-                                is={null}
-                              >
-                                <ProjectStatsGraph
-                                  key="2"
-                                  project={
-                                    Object {
-                                      "environments": Array [],
-                                      "hasAccess": true,
-                                      "id": "2",
-                                      "isBookmarked": false,
-                                      "isMember": true,
-                                      "name": "Project Name",
-                                      "slug": "project-slug",
-                                      "teams": Array [],
-                                    }
+                              <ProjectStatsGraph
+                                key="2"
+                                project={
+                                  Object {
+                                    "environments": Array [],
+                                    "hasAccess": true,
+                                    "id": "2",
+                                    "isBookmarked": false,
+                                    "isMember": true,
+                                    "name": "Project Name",
+                                    "slug": "project-slug",
+                                    "teams": Array [],
                                   }
-                                >
-                                  <div />
-                                </ProjectStatsGraph>
-                              </div>
-                            </Base>
-                          </Box>
+                                }
+                              >
+                                <div />
+                              </ProjectStatsGraph>
+                            </div>
+                          </ContainerProjectStatsGraph>
                         </div>
                       </Base>
-                    </PanelItem>
+                    </GridPanelItem>
                   </div>
                 </PanelBody>
               </div>

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -392,9 +392,9 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                           className="css-1325ndv-PanelItem-GridPanelItem ew99cs00"
                           is={null}
                         >
-                          <ContainerProjectListItem>
+                          <ProjectListItemWrapper>
                             <div
-                              className="css-s8ligm-ContainerProjectListItem ew99cs01"
+                              className="css-uamzlo-ProjectListItemWrapper ew99cs01"
                             >
                               <ProjectItem
                                 organization={
@@ -671,10 +671,10 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                                 </Container>
                               </ProjectItem>
                             </div>
-                          </ContainerProjectListItem>
-                          <ContainerProjectStatsGraph>
+                          </ProjectListItemWrapper>
+                          <ProjectStatsGraphWrapper>
                             <div
-                              className="css-15yj6l1-ContainerProjectStatsGraph ew99cs02"
+                              className="css-gtwx22-ProjectStatsGraphWrapper ew99cs02"
                             >
                               <ProjectStatsGraph
                                 key="2"
@@ -694,7 +694,7 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                                 <div />
                               </ProjectStatsGraph>
                             </div>
-                          </ContainerProjectStatsGraph>
+                          </ProjectStatsGraphWrapper>
                         </div>
                       </Base>
                     </GridPanelItem>

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -385,16 +385,16 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                       p={2}
                     >
                       <Base
-                        className="css-no3wd-PanelItem-GridPanelItem ew99cs00"
+                        className="css-1325ndv-PanelItem-GridPanelItem ew99cs00"
                         p={2}
                       >
                         <div
-                          className="css-no3wd-PanelItem-GridPanelItem ew99cs00"
+                          className="css-1325ndv-PanelItem-GridPanelItem ew99cs00"
                           is={null}
                         >
                           <ContainerProjectListItem>
                             <div
-                              className="css-11u2sgk-ContainerProjectListItem ew99cs01"
+                              className="css-s8ligm-ContainerProjectListItem ew99cs01"
                             >
                               <ProjectItem
                                 organization={
@@ -674,7 +674,7 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                           </ContainerProjectListItem>
                           <ContainerProjectStatsGraph>
                             <div
-                              className="css-174lc2j-ContainerProjectStatsGraph ew99cs02"
+                              className="css-15yj6l1-ContainerProjectStatsGraph ew99cs02"
                             >
                               <ProjectStatsGraph
                                 key="2"


### PR DESCRIPTION
Only 567 orgs (<.1% of all sentry's orgs) have more than 50 projects which led to the decision to paginate this settings -> projects page (https://sentry.io/settings/sentry/projects/) at 50 items instead of 100. Also removed grid emotion. Thought I could be cool with some css grid stuff. But after trying both, I think flex makes more sense here, let me know if css grid would be preferred though.

**Before**
![image](https://user-images.githubusercontent.com/9372512/67596881-9c9b1700-f71e-11e9-90b7-0f15aadfa717.png)


**After**
![image](https://user-images.githubusercontent.com/9372512/67596751-504fd700-f71e-11e9-9b1a-205a41205ab4.png)

Closes SEN-1201