### PR TITLE
feat(ui): Remove legacy "Team Name" settings field

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/teamSettingsFields.jsx
+++ b/src/sentry/static/sentry/app/data/forms/teamSettingsFields.jsx
@@ -1,6 +1,4 @@
-import React from 'react';
-
-import {t, tct} from 'app/locale';
+import {t} from 'app/locale';
 import slugify from 'app/utils/slugify';
 
 // Export route to make these forms searchable by label/help
@@ -24,21 +22,6 @@ const formGroups = [
         saveOnBlur: false,
         saveMessageAlertType: 'info',
         saveMessage: t('You will be redirected to the new team slug after saving'),
-      },
-      {
-        name: 'name',
-        type: 'string',
-        required: true,
-        label: t('Legacy Name'),
-        placeholder: 'e.g. API Team',
-        disabled: ({access}) => !access.has('team:write'),
-        help: tct(
-          '[Deprecated] In the future, only [Name] will be used to identify your team',
-          {
-            Deprecated: <strong>DEPRECATED</strong>,
-            Name: <strong>Name</strong>,
-          }
-        ),
       },
     ],
   },

--- a/tests/js/spec/views/teamSettings.spec.jsx
+++ b/tests/js/spec/views/teamSettings.spec.jsx
@@ -14,7 +14,7 @@ describe('TeamSettings', function() {
     window.location.assign.mockRestore();
   });
 
-  it('can change name and slug', async function() {
+  it('can change slug', async function() {
     const team = TestStubs.Team();
     const putMock = MockApiClient.addMockResponse({
       url: `/teams/org/${team.slug}/`,
@@ -32,20 +32,6 @@ describe('TeamSettings', function() {
         onTeamChange={() => {}}
       />,
       mountOptions
-    );
-
-    wrapper
-      .find('input[name="name"]')
-      .simulate('change', {target: {value: 'New Name'}})
-      .simulate('blur');
-
-    expect(putMock).toHaveBeenCalledWith(
-      `/teams/org/${team.slug}/`,
-      expect.objectContaining({
-        data: {
-          name: 'New Name',
-        },
-      })
     );
 
     wrapper


### PR DESCRIPTION
This has been unused and marked as legacy for awhile. This PR removes the field from the team settings page.