### PR TITLE
fix(discover) Allow users to view events in non-member projects

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -54,7 +54,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         reference_event_id = request.GET.get("referenceEvent")
         if reference_event_id:
             snuba_args["conditions"] = get_reference_event_conditions(
-                snuba_args, reference_event_id
+                organization, snuba_args, reference_event_id
             )
 
         return snuba_args

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
 from sentry.api.event_search import get_reference_event_conditions
 from sentry import eventstore, features
-from sentry.models.project import Project
+from sentry.models.project import Project, ProjectStatus
 from sentry.api.serializers import serialize
 
 
@@ -23,7 +23,9 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
             return Response(status=404)
 
         try:
-            project = Project.objects.get(slug=project_slug, organization_id=organization.id)
+            project = Project.objects.get(
+                slug=project_slug, organization_id=organization.id, status=ProjectStatus.VISIBLE
+            )
         except Project.DoesNotExist:
             return Response(status=404)
 
@@ -38,7 +40,9 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         # This ensure that if a field list/groupby conditions were provided
         # that we constrain related events to the query + current event values
         event_slug = u"{}:{}".format(project.slug, event_id)
-        snuba_args["conditions"].extend(get_reference_event_conditions(snuba_args, event_slug))
+        snuba_args["conditions"].extend(
+            get_reference_event_conditions(organization, snuba_args, event_slug)
+        )
 
         data = serialize(event)
         data["nextEventID"] = self.next_event_id(snuba_args, event)

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -28,6 +28,10 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
             )
         except Project.DoesNotExist:
             return Response(status=404)
+        # Check access to the project as this endpoint doesn't use membership checks done
+        # get_filter_params().
+        if not request.access.has_project_access(project):
+            return Response(status=404)
 
         # We return the requested event if we find a match regardless of whether
         # it occurred within the range specified


### PR DESCRIPTION
If a user gets a link to an event they should be able to see it if they have access to the project. I've also added/improved the access check that is performed as the project in the eventSlug was previously not checked.

Fixes SENTRY-CX0