### PR TITLE
fix(deletions): Fix event attachment and user report deletions

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -51,8 +51,9 @@ class EventDataDeletionTask(BaseDeletionTask):
         nodestore.delete_multi(node_ids)
 
         # Remove EventAttachment and UserReport
-        EventAttachment.objects.filter(event_id=event.event_id, project_id=self.project_id).delete()
-        UserReport.objects.filter(event_id=event.event_id, project_id=self.project_id).delete()
+        event_ids = [event.event_id for event in events]
+        EventAttachment.objects.filter(event_id__in=event_ids, project_id=self.project_id).delete()
+        UserReport.objects.filter(event_id__in=event_ids, project_id=self.project_id).delete()
 
         return True
 


### PR DESCRIPTION
This went unnoticed since they are currently (temporarily) being deleted
from event deletions as well.

I reran the tests with event deletions turned off to verify this works
without relying on event deletions.