### PR TITLE
py3: bump pillow to 6.2.1, the last 2.7 compatible version

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -34,7 +34,7 @@ oauth2>=1.5.167
 parsimonious==0.8.0
 percy>=1.1.2
 petname>=2.6,<2.7
-Pillow>=3.2.0,<=4.2.1
+Pillow>=6.2.1,<7.0.0
 progressbar2>=3.10,<3.11
 psycopg2-binary>=2.7.0,<2.9.0
 PyJWT>=1.5.0,<1.6.0


### PR DESCRIPTION
[DoS vuln](https://www.cvedetails.com/cve/CVE-2019-16865/) with pillow < 6.2.0. It also [looks like 6.2.1 is the last version with 2.7 support](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst#621-2019-10-21), so I was going to bump this anyways for py3. Thanks @BYK for bringing this to my attention!

I manually tested avatar operations in a local dev sentry, things seem to be working fine. None of our (very little) API usage is described [here](https://pillow.readthedocs.io/en/stable/deprecations.html) and I tried the deprecated `PIL.VERSION` on new and old pillow and our tests errored as expected on the new.

As usual, this bump will need to be mirrored in getsentry.