### PR TITLE
fix(jira): Users not showing up in JIRA server

### DIFF
--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -66,6 +66,12 @@ class JiraCloud(object):
         """
         return "accountId"
 
+    def query_field(self):
+        """
+        Jira-Cloud requires GDPR compliant API usage so we have to use query
+        """
+        return "query"
+
 
 class JiraApiClient(ApiClient):
     COMMENTS_URL = "/rest/api/2/issue/%s/comment"
@@ -110,6 +116,9 @@ class JiraApiClient(ApiClient):
 
     def user_id_field(self):
         return self.jira_style.user_id_field()
+
+    def query_field(self):
+        return self.jira_style.query_field()
 
     def get_cached(self, url, params=None):
         """
@@ -194,13 +203,15 @@ class JiraApiClient(ApiClient):
 
     def search_users_for_project(self, project, username):
         # Jira Server wants a project key, while cloud is indifferent.
-        # Use the query parameter as our implemention follows jira's gdpr practices
         project_key = self.get_project_key_for_id(project)
-        return self.get_cached(self.USERS_URL, params={"project": project_key, "query": username})
+        return self.get_cached(
+            self.USERS_URL, params={"project": project_key, self.query_field(): username}
+        )
 
     def search_users_for_issue(self, issue_key, email):
-        # Use the query parameter as our implemention follows jira's gdpr practices
-        return self.get_cached(self.USERS_URL, params={"issueKey": issue_key, "query": email})
+        return self.get_cached(
+            self.USERS_URL, params={"issueKey": issue_key, self.query_field(): email}
+        )
 
     def create_issue(self, raw_form_data):
         data = {"fields": raw_form_data}

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -141,3 +141,9 @@ class JiraServer(object):
         Jira-Server doesn't require GDPR compliant API usage so we can use `name`
         """
         return "name"
+
+    def query_field(self):
+        """
+        Jira-Server doesn't require GDPR compliant API usage so we can use `username`
+        """
+        return "username"

--- a/tests/sentry/integrations/jira_server/test_search.py
+++ b/tests/sentry/integrations/jira_server/test_search.py
@@ -111,7 +111,7 @@ class JiraSearchEndpointTest(APITestCase):
         def responder(request):
             query = parse_qs(urlparse(request.url).query)
             assert "HSP" == query["project"][0]
-            assert "bob" == query["query"][0]
+            assert "bob" == query["username"][0]
             return (200, {}, EXAMPLE_USER_SEARCH_RESPONSE)
 
         responses.add_callback(


### PR DESCRIPTION
## Problem
When using JIRA server and creating a JIRA ticket from the Sentry issue page, some assignees don't show up even though they have the right permissions. :(

## Background
JIRA Cloud and Server used to accept the `username` parameter when searching for a list of assignable users. To become GDPR compliant, JIRA changed the parameter to be called `query`.

This change, however, was only made on JIRA cloud, and not on JIRA server. Here's the API docs for the endpoint we're hitting:
* [JIRA cloud](https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-user-assignable-search-get)
* [JIRA server](https://docs.atlassian.com/software/jira/docs/api/REST/7.6.1/#api/2/user-findAssignableUsers)

So, for JIRA server, passing in `query=blah` would not actually filter anything - it would just return all the users without filtering. And it looks like the endpoint returns a maximum of 50 users. So, if you were the 51st user, the API would not return your user.

## Solution
Make JIRA server use the `username` parameter, and make JIRA cloud use the `query` parameter.

## Test plan
* Running the JIRA client locally and executed commands
* Testing against our test JIRA server instance