### PR TITLE
chore(jest): Remove noisy stacktraces from unmocked endpoints

### DIFF
--- a/src/sentry/static/sentry/app/__mocks__/api.tsx
+++ b/src/sentry/static/sentry/app/__mocks__/api.tsx
@@ -126,7 +126,7 @@ class Client {
       // Because we are mocking an API client, we generally catch errors to show
       // user-friendly error messages, this means in tests this error gets gobbled
       // up and developer frustration ensues.
-      console.warn(err); // eslint-disable-line no-console
+      console.warn(err.message); // eslint-disable-line no-console
       throw err;
     } else {
       // has mocked response


### PR DESCRIPTION
This removes the noisy stacktraces from the unmocked API endpoint warnings so that we can read travis logs a little bit easier.