### PR TITLE
feat(ui): Fix XSS in markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "crypto-js": "3.1.5",
     "css-loader": "^2.0.1",
     "diff": "^3.5.0",
+    "dompurify": "^2.0.7",
     "echarts": "4.2.1",
     "echarts-for-react": "2.0.14",
     "emotion": "9.2.12",

--- a/src/sentry/static/sentry/app/utils/marked.jsx
+++ b/src/sentry/static/sentry/app/utils/marked.jsx
@@ -1,4 +1,5 @@
 import marked from 'marked';
+import dompurify from 'dompurify';
 
 function isSafeHref(href, pattern) {
   try {
@@ -18,7 +19,7 @@ function Renderer() {
 }
 Object.assign(Renderer.prototype, marked.Renderer.prototype);
 
-// Anythign except javascript, vbscript, data protocols
+// Only https and mailto, (e.g. no javascript, vbscript, data protocols)
 const safeLinkPattern = /^(https?:|mailto:)/i;
 
 Renderer.prototype.link = function(href, title, text) {
@@ -32,7 +33,7 @@ Renderer.prototype.link = function(href, title, text) {
     out += ' title="' + title + '"';
   }
   out += '>' + text + '</a>';
-  return out;
+  return dompurify.sanitize(out);
 };
 
 // Only allow http(s) for image tags
@@ -49,7 +50,7 @@ Renderer.prototype.image = function(href, title, text) {
     out += ' title="' + title + '"';
   }
   out += this.options.xhtml ? '/>' : '>';
-  return out;
+  return dompurify.sanitize(out);
 };
 
 marked.setOptions({

--- a/tests/js/spec/utils/marked.spec.jsx
+++ b/tests/js/spec/utils/marked.spec.jsx
@@ -30,9 +30,9 @@ describe('marked', function() {
 
   it('normal images get rendered as html', function() {
     for (const test of [
-      ['![](http://example.com)', '<img src="http://example.com" alt="">'],
-      ['![x](http://example.com)', '<img src="http://example.com" alt="x">'],
-      ['![x](https://example.com)', '<img src="https://example.com" alt="x">'],
+      ['![](http://example.com)', '<img alt="" src="http://example.com">'],
+      ['![x](http://example.com)', '<img alt="x" src="http://example.com">'],
+      ['![x](https://example.com)', '<img alt="x" src="https://example.com">'],
     ]) {
       expectMarkdown(test);
     }
@@ -42,5 +42,16 @@ describe('marked', function() {
     for (const test of [['![x](javascript:foo)', '']]) {
       expectMarkdown(test);
     }
+  });
+
+  it('escapes XSS and removes invalid attributes on img', function() {
+    [
+      [
+        `[test](http://example.com\""#><img/onerror='alert\(location\)'/src=>)
+![test](http://example.com"/onerror='alert\(location\)'/)`,
+        `<a href="http://example.com"><img src="">"&gt;test</a>
+<img alt="test" src="http://example.com">`,
+      ],
+    ].forEach(expectMarkdown);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5433,6 +5433,11 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+dompurify@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.7.tgz#f8266ad38fe1602fb5b3222f31eedbf5c16c4fd5"
+  integrity sha512-S3O0lk6rFJtO01ZTzMollCOGg+WAtCwS3U5E2WSDY/x/sy7q70RjEC4Dmrih5/UqzLLB9XoKJ8KqwBxaNvBu4A==
+
 domready@1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/domready/-/domready-1.0.8.tgz#91f252e597b65af77e745ae24dd0185d5e26d58c"


### PR DESCRIPTION
This fixes XSS issues in components that support markdown when rendering images and links.

[Uses `DOMPurify` library which is recommended by marked](https://github.com/markedjs/marked#warning--marked-does-not-sanitize-the-output-html-please-use-a-sanitize-library-like-dompurify-recommended-sanitize-html-or-insane-on-the-output-html-)