### PR TITLE
fix(db): Fix bug where running `makemigrations` in `getsentry` generates a useless migration.

### DIFF
--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import six
 from collections import defaultdict
 
+from sentry import roles
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import OrganizationMember, OrganizationMemberTeam, Team, TeamStatus
 
@@ -25,7 +26,7 @@ class OrganizationMemberSerializer(Serializer):
             "name": obj.user.get_display_name() if obj.user else obj.get_email(),
             "user": attrs["user"],
             "role": obj.role,
-            "roleName": obj.get_role_display(),
+            "roleName": roles.get(obj.role).name,
             "pending": obj.is_pending,
             "expired": obj.token_expired,
             "flags": {

--- a/src/sentry/migrations/0007_auto_20191029_0131.py
+++ b/src/sentry/migrations/0007_auto_20191029_0131.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    # This flag is used to mark that a migration shouldn't be automatically run in
+    # production. We set this to True for operations that we think are risky and want
+    # someone from ops to run manually and monitor.
+    # General advice is that if in doubt, mark your migration as `is_dangerous`.
+    # Some things you should always mark as dangerous:
+    # - Adding indexes to large tables. These indexes should be created concurrently,
+    #   unfortunately we can't run migrations outside of a transaction until Django
+    #   1.10. So until then these should be run manually.
+    # - Large data migrations. Typically we want these to be run manually by ops so that
+    #   they can be monitored. Since data migrations will now hold a transaction open
+    #   this is even more important.
+    # - Adding columns to highly active tables, even ones that are NULL.
+    is_dangerous = False
+
+
+    dependencies = [
+        ('sentry', '0006_sentryapp_date_published'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='organization',
+            name='default_role',
+            field=models.CharField(default=b'member', max_length=32),
+        ),
+        migrations.AlterField(
+            model_name='organizationmember',
+            name='role',
+            field=models.CharField(default=b'member', max_length=32),
+        ),
+    ]

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -110,9 +110,7 @@ class Organization(Model):
         related_name="org_memberships",
         through_fields=("organization", "user"),
     )
-    default_role = models.CharField(
-        choices=roles.get_choices(), max_length=32, default=roles.get_default().id
-    )
+    default_role = models.CharField(max_length=32, default=roles.get_default().id)
 
     flags = BitField(
         flags=(

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -91,9 +91,7 @@ class OrganizationMember(Model):
         settings.AUTH_USER_MODEL, null=True, blank=True, related_name="sentry_orgmember_set"
     )
     email = models.EmailField(null=True, blank=True, max_length=75)
-    role = models.CharField(
-        choices=roles.get_choices(), max_length=32, default=roles.get_default().id
-    )
+    role = models.CharField(max_length=32, default=roles.get_default().id)
     flags = BitField(
         flags=(("sso:linked", "sso:linked"), ("sso:invalid", "sso:invalid")), default=0
     )


### PR DESCRIPTION
Django migrations take into account the choices in their migrations, even though there's no sql
involved. This is so that they can keep a complete history of the states of a table.

Since `getsentry` has an extra role, and we calculate this dynamically, when we run `makemigrations`
we generate a new migration in `sentry` that has the role. This is annoying if you have sentry installed
via `-e`.

I did a quick look over the codebase and I didn't see any forms using these choices. afaik models
don't use these choices for validation, only forms, so it should be safe to remove.

The alternative is to always run `getsentry makemigrations getsentry`, which isn't too terrible but
a little annoying.

Note that the migration in this diff literally does nothing to postgres, it just stores new state.