### PR TITLE
ref(pagerduty): Add is_enabled check

### DIFF
--- a/src/sentry/integrations/pagerduty/notify_action.py
+++ b/src/sentry/integrations/pagerduty/notify_action.py
@@ -78,6 +78,9 @@ class PagerDutyNotifyServiceAction(EventAction):
         if initial_service:
             self.form_fields["service"]["initial"] = initial_service
 
+    def is_enabled(self):
+        return self.get_integrations().exists()
+
     def get_initial_service(self):
         try:
             # service_id here is the id of the PagerDutyService record, not the


### PR DESCRIPTION
I forgot to add this - we need it so that we hide it in the alert rule actions section if the PD integration has not been installed.