### PR TITLE
fix(store): Consider functions without filename for event title

### DIFF
--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -11,7 +11,7 @@ def get_crash_location(data):
     from sentry.stacktraces.processing import get_crash_frame_from_event_data
 
     frame = get_crash_frame_from_event_data(
-        data, frame_filter=lambda x: x.get("filename") or x.get("abs_path")
+        data, frame_filter=lambda x: x.get("function") not in (None, "<redacted>", "<unknown>")
     )
     if frame is not None:
         from sentry.stacktraces.functions import get_function_name_for_frame

--- a/tests/sentry/eventtypes/test_error.py
+++ b/tests/sentry/eventtypes/test_error.py
@@ -15,6 +15,31 @@ class ErrorEventTest(TestCase):
         data = {"exception": {"values": [{"type": None, "value": None, "stacktrace": {}}]}}
         assert inst.get_metadata(data) == {"type": "Error", "value": ""}
 
+    def test_get_metadata_function(self):
+        inst = ErrorEvent()
+        data = {
+            "platform": "native",
+            "exception": {
+                "values": [
+                    {
+                        "stacktrace": {
+                            "frames": [
+                                {"in_app": True, "function": "void top_func(int)"},
+                                {"in_app": False, "function": "void invalid_func(int)"},
+                                {"in_app": True, "function": "<unknown>"},
+                            ]
+                        }
+                    }
+                ]
+            },
+        }
+        assert inst.get_metadata(data) == {"type": "Error", "value": "", "function": "top_func"}
+
+    def test_get_metadata_function_none_frame(self):
+        inst = ErrorEvent()
+        data = {"exception": {"values": [{"stacktrace": {"frames": [None]}}]}}
+        assert inst.get_metadata(data) == {"type": "Error", "value": ""}
+
     def test_get_title_none_value(self):
         inst = ErrorEvent()
         result = inst.get_title({"type": "Error", "value": None})


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/10413, we introduced better rendering of event titles by considering the location (function name) of a crash. We would only look at frames, however, that also have a file name attached.

I'm not entirely sure anymore what the original thoughts behind this were. However, at the moment we report wrong event titles for customers, where the top frame does not have a file name, even if it symbolicated and is tagged as in app. 

This fix **considers all frames**, regardless of whether they have a file name. 