### PR TITLE
ref(grid-emotion): Refactor `<ProjectsDashboard>`

### DIFF
--- a/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
@@ -21,9 +21,9 @@ import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
 import withTeams from 'app/utils/withTeams';
 
-import getProjectsByTeams from './getProjectsByTeams';
 import Resources from './resources';
 import TeamSection from './teamSection';
+import getProjectsByTeams from './getProjectsByTeams';
 
 class Dashboard extends React.Component {
   static propTypes = {

--- a/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
@@ -1,4 +1,3 @@
-import {Flex} from 'grid-emotion';
 import {Link, browserHistory} from 'react-router';
 import LazyLoad from 'react-lazyload';
 import PropTypes from 'prop-types';
@@ -22,9 +21,9 @@ import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
 import withTeams from 'app/utils/withTeams';
 
+import getProjectsByTeams from './getProjectsByTeams';
 import Resources from './resources';
 import TeamSection from './teamSection';
-import getProjectsByTeams from './getProjectsByTeams';
 
 class Dashboard extends React.Component {
   static propTypes = {
@@ -131,9 +130,9 @@ class Dashboard extends React.Component {
 
 const OrganizationDashboard = props => {
   return (
-    <Flex flex="1" direction="column">
+    <OrganizationDashboardWrapper>
       <Dashboard {...props} />
-    </Flex>
+    </OrganizationDashboardWrapper>
   );
 };
 
@@ -147,6 +146,12 @@ const ProjectsHeader = styled('div')`
   display: flex;
   align-items: center;
   justify-content: space-between;
+`;
+
+const OrganizationDashboardWrapper = styled('div')`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
 `;
 
 export {Dashboard};


### PR DESCRIPTION
Getting rid of `<Flex>` here (also need it to unblock https://github.com/getsentry/sentry/pull/15311)

**Before**
![image](https://user-images.githubusercontent.com/9372512/67806156-97580800-fa4f-11e9-85d8-8f087ae4eac6.png)

**After**
![image](https://user-images.githubusercontent.com/9372512/67806192-a63eba80-fa4f-11e9-909c-edc60e4ce34f.png)
