### PR TITLE
py3(django): compatibility with Django 1.9

### DIFF
--- a/src/sentry/new_migrations/monkey/__init__.py
+++ b/src/sentry/new_migrations/monkey/__init__.py
@@ -7,7 +7,7 @@ from sentry.new_migrations.monkey.writer import SENTRY_MIGRATION_TEMPLATE
 
 from django.db.migrations import migration, executor, writer
 
-LAST_VERIFIED_DJANGO_VERSION = (1, 8)
+LAST_VERIFIED_DJANGO_VERSION = (1, 9)
 CHECK_MESSAGE = """Looks like you're trying to upgrade Django! Since we monkeypatch
 the Django migration library in several places, please verify that we have the latest
 code, and that the monkeypatching still works as expected. Currently the main things

--- a/src/sentry/plugins/sentry_mail/activity/release.py
+++ b/src/sentry/plugins/sentry_mail/activity/release.py
@@ -115,7 +115,7 @@ class ReleaseActivityEmail(ActivityEmail):
         users = list(
             User.objects.filter(
                 emails__is_verified=True,
-                sentry_orgmember_set__teams=Team.objects.filter(
+                sentry_orgmember_set__teams__in=Team.objects.filter(
                     id__in=ProjectTeam.objects.filter(project__in=self.projects).values_list(
                         "team_id", flat=True
                     )

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django.conf import settings
 from django.template import Library
+from django.utils.safestring import mark_safe
 
 from sentry import options
 from sentry.utils.assets import get_asset_url
@@ -56,4 +57,4 @@ def locale_js_include(context):
         return ""
 
     href = get_asset_url("sentry", "dist/locale/" + lang_code + ".js")
-    return u'<script src="{0}"{1}></script>'.format(href, crossorigin())
+    return mark_safe('<script src="{0}"{1}></script>'.format(href, crossorigin()))

--- a/src/sentry/templatetags/sentry_avatars.py
+++ b/src/sentry/templatetags/sentry_avatars.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from django import template
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.utils.safestring import mark_safe
 from six.moves.urllib.parse import urlencode
 
 from sentry.models import User, UserAvatar
@@ -21,7 +22,7 @@ def gravatar_url(context, email, size, default="mm"):
 
 @register.simple_tag(takes_context=True)
 def letter_avatar_svg(context, display_name, identifier, size=None):
-    return get_letter_avatar(display_name, identifier, size=size)
+    return mark_safe(get_letter_avatar(display_name, identifier, size=size))
 
 
 @register.simple_tag(takes_context=True)

--- a/src/sentry/templatetags/sentry_avatars.py
+++ b/src/sentry/templatetags/sentry_avatars.py
@@ -41,7 +41,7 @@ def profile_photo_url(context, user_id, size=None):
 # than 1-2 avatars. It will make a request for every user!
 @register.simple_tag(takes_context=True)
 def email_avatar(context, display_name, identifier, size=None, try_gravatar=True):
-    return get_email_avatar(display_name, identifier, size, try_gravatar)
+    return mark_safe(get_email_avatar(display_name, identifier, size, try_gravatar))
 
 
 @register.inclusion_tag("sentry/partial/avatar.html")

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -51,7 +51,7 @@ def _get_frame_paths(event):
 def _get_commits(releases):
     return list(
         Commit.objects.filter(
-            releasecommit=ReleaseCommit.objects.filter(release__in=releases)
+            releasecommit__in=ReleaseCommit.objects.filter(release__in=releases)
         ).select_related("author")
     )
 

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -37,8 +37,6 @@ class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
 
         self.browser.wait_until(".ref-success")
 
-        self.browser.snapshot("developer settings new public integration after success")
-
         assert self.browser.find_element_by_xpath("//div[contains(text(), 'Client ID')]")
 
     def test_create_new_internal_integration(self):

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -2,6 +2,10 @@ from __future__ import absolute_import
 
 from sentry.testutils import AcceptanceTestCase
 
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions
+
 
 class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
     """
@@ -35,9 +39,11 @@ class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
 
         self.browser.click('[aria-label="Save Changes"]')
 
-        self.browser.wait_until(".ref-success")
-
-        assert self.browser.find_element_by_xpath("//div[contains(text(), 'Client ID')]")
+        WebDriverWait(self.browser, 3).until(
+            expected_conditions.presence_of_element_located(
+                (By.XPATH, "//div[contains(text(), 'Client ID')]")
+            )
+        )
 
     def test_create_new_internal_integration(self):
         self.load_page(self.org_developer_settings_path)

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -37,6 +37,8 @@ class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
 
         self.browser.wait_until(".ref-success")
 
+        self.browser.snapshot("developer settings new public integration after success")
+
         assert self.browser.find_element_by_xpath("//div[contains(text(), 'Client ID')]")
 
     def test_create_new_internal_integration(self):

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -2,10 +2,6 @@ from __future__ import absolute_import
 
 from sentry.testutils import AcceptanceTestCase
 
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions
-
 
 class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
     """
@@ -39,11 +35,7 @@ class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
 
         self.browser.click('[aria-label="Save Changes"]')
 
-        WebDriverWait(self.browser, 3).until(
-            expected_conditions.presence_of_element_located(
-                (By.XPATH, "//div[contains(text(), 'Client ID')]")
-            )
-        )
+        self.browser.wait_until(xpath="//div[contains(text(), 'Client ID')]", timeout=3)
 
     def test_create_new_internal_integration(self):
         self.load_page(self.org_developer_settings_path)
@@ -54,9 +46,7 @@ class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
 
         self.browser.click('[aria-label="Save Changes"]')
 
-        self.browser.wait_until(".ref-success")
-
-        assert self.browser.find_element_by_xpath("//button//span[contains(text(), 'New Token')]")
+        self.browser.wait_until(xpath="//button//span[contains(text(), 'New Token')]", timeout=3)
 
 
 class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):

--- a/tests/integration/test_sso.py
+++ b/tests/integration/test_sso.py
@@ -24,7 +24,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.login_as(user)
 
         path = u"/{}/".format(organization.slug)
-        redirect_uri = u"http://testserver/auth/login/{}/".format(organization.slug)
+        redirect_uri = u"/auth/login/{}/".format(organization.slug)
 
         # we should be redirecting the user to the authentication form as they
         # haven't verified this specific organization

--- a/tests/integration/test_sso.py
+++ b/tests/integration/test_sso.py
@@ -29,14 +29,12 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         # we should be redirecting the user to the authentication form as they
         # haven't verified this specific organization
         resp = self.client.get(path)
-        assert resp.status_code == 302
-        assert resp["Location"] == redirect_uri
+        self.assertRedirects(resp, redirect_uri)
 
         # superuser should still require SSO as they're a member of the org
         user.update(is_superuser=True)
         resp = self.client.get(path)
-        assert resp.status_code == 302
-        assert resp["Location"] == redirect_uri
+        self.assertRedirects(resp, redirect_uri)
 
         # XXX(dcramer): using internal API as exposing a request object is hard
         self.session[SSO_SESSION_KEY] = six.text_type(organization.id)

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import mock
 import six
 
+import django
 from django.core.urlresolvers import reverse
 
 from sentry.constants import RESERVED_PROJECT_SLUGS
@@ -80,12 +81,13 @@ class ProjectDetailsTest(APITestCase):
             project.organization.slug,
             "foobar",
         )
+        redirect_path = "/api/0/projects/%s/%s/" % (project.organization.slug, "foobar")
+        if django.VERSION < (1, 9):
+            # Django 1.9 no longer forcefully rewrites relative redirects to absolute URIs because of RFC 7231.
+            redirect_path = "http://testserver" + redirect_path
         # XXX: AttributeError: 'Response' object has no attribute 'url'
         # (this is with self.assertRedirects(response, ...))
-        assert response["Location"] == "/api/0/projects/%s/%s/" % (
-            project.organization.slug,
-            "foobar",
-        )
+        assert response["Location"] == redirect_path
 
 
 class ProjectUpdateTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -80,7 +80,7 @@ class ProjectDetailsTest(APITestCase):
             project.organization.slug,
             "foobar",
         )
-        assert response["Location"] == "http://testserver/api/0/projects/%s/%s/" % (
+        assert response["Location"] == "/api/0/projects/%s/%s/" % (
             project.organization.slug,
             "foobar",
         )

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -80,8 +80,11 @@ class ProjectDetailsTest(APITestCase):
             project.organization.slug,
             "foobar",
         )
-        self.assertRedirects(
-            response, "/api/0/projects/%s/%s/" % (project.organization.slug, "foobar")
+        # XXX: AttributeError: 'Response' object has no attribute 'url'
+        # (this is with self.assertRedirects(response, ...))
+        assert response["Location"] == "/api/0/projects/%s/%s/" % (
+            project.organization.slug,
+            "foobar",
         )
 
 

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -80,9 +80,8 @@ class ProjectDetailsTest(APITestCase):
             project.organization.slug,
             "foobar",
         )
-        assert response["Location"] == "/api/0/projects/%s/%s/" % (
-            project.organization.slug,
-            "foobar",
+        self.assertRedirects(
+            response, "/api/0/projects/%s/%s/" % (project.organization.slug, "foobar")
         )
 
 

--- a/tests/sentry/templatetags/test_sentry_assets.py
+++ b/tests/sentry/templatetags/test_sentry_assets.py
@@ -15,13 +15,8 @@ class AssetsTest(TestCase):
     )
 
     def test_supported_foreign_lang(self):
-        # in Django 1.9+, simple_tag escapes the output by default.
-        # To keep this test readable, we set autoescape=False.
-        # If this rendering is safe, then we could mark_safe.
         result = self.TEMPLATE.render(
-            Context(
-                {"request": Mock(LANGUAGE_CODE="fr")}, autoescape=False
-            )  # French, in locale/catalogs.json
+            Context({"request": Mock(LANGUAGE_CODE="fr")})  # French, in locale/catalogs.json
         )
 
         assert '<script src="/_static/{version}/sentry/dist/locale/fr.js"></script>' in result

--- a/tests/sentry/templatetags/test_sentry_assets.py
+++ b/tests/sentry/templatetags/test_sentry_assets.py
@@ -15,8 +15,13 @@ class AssetsTest(TestCase):
     )
 
     def test_supported_foreign_lang(self):
+        # in Django 1.9+, simple_tag escapes the output by default.
+        # To keep this test readable, we set autoescape=False.
+        # If this rendering is safe, then we could mark_safe.
         result = self.TEMPLATE.render(
-            Context({"request": Mock(LANGUAGE_CODE="fr")})  # French, in locale/catalogs.json
+            Context(
+                {"request": Mock(LANGUAGE_CODE="fr")}, autoescape=False
+            )  # French, in locale/catalogs.json
         )
 
         assert '<script src="/_static/{version}/sentry/dist/locale/fr.js"></script>' in result

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -146,9 +146,17 @@ class AuthLoginTest(TestCase):
         self.client.get(self.path + "?next=" + urlquote(next))
 
         resp = self.client.post(
-            self.path, {"username": self.user.username, "password": "admin", "op": "login"}
+            self.path,
+            {"username": self.user.username, "password": "admin", "op": "login"},
+            follow=False,
         )
-        self.assertRedirects(resp, "/auth/login/")
+        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+        resp = self.client.post(
+            self.path,
+            {"username": self.user.username, "password": "admin", "op": "login"},
+            follow=True,
+        )
+        self.assertRedirects(resp, "/organizations/new/")
 
     def test_redirects_already_authed_non_superuser(self):
         self.user.update(is_superuser=False)

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -148,17 +148,14 @@ class AuthLoginTest(TestCase):
         resp = self.client.post(
             self.path, {"username": self.user.username, "password": "admin", "op": "login"}
         )
-        assert resp.status_code == 302
-        assert resp["Location"] == "/auth/login/"
+        self.assertRedirects(resp, "/auth/login/")
 
     def test_redirects_already_authed_non_superuser(self):
         self.user.update(is_superuser=False)
         self.login_as(self.user)
         with self.feature("organizations:create"):
             resp = self.client.get(self.path)
-
-        assert resp.status_code == 302
-        assert resp["Location"] == "/organizations/new/"
+            self.assertRedirects(resp, "/organizations/new/")
 
     def test_doesnt_redirect_already_authed_superuser(self):
         self.login_as(self.user, superuser=False)

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -149,8 +149,7 @@ class AuthLoginTest(TestCase):
             self.path, {"username": self.user.username, "password": "admin", "op": "login"}
         )
         assert resp.status_code == 302
-        assert next not in resp["Location"]
-        assert resp["Location"] == "http://testserver/auth/login/"
+        assert resp["Location"] == "/auth/login/"
 
     def test_redirects_already_authed_non_superuser(self):
         self.user.update(is_superuser=False)
@@ -159,7 +158,7 @@ class AuthLoginTest(TestCase):
             resp = self.client.get(self.path)
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver/organizations/new/"
+        assert resp["Location"] == "/organizations/new/"
 
     def test_doesnt_redirect_already_authed_superuser(self):
         self.login_as(self.user, superuser=False)

--- a/tests/sentry/web/frontend/test_auth_logout.py
+++ b/tests/sentry/web/frontend/test_auth_logout.py
@@ -44,5 +44,4 @@ class AuthLogoutTest(TestCase):
         self.client.post(self.path + "?next=" + quote(next))
 
         resp = self.client.post(self.path)
-        assert resp.status_code == 302
-        assert resp["Location"] == "/auth/login/"
+        self.assertRedirects(resp, "/auth/login/")

--- a/tests/sentry/web/frontend/test_auth_logout.py
+++ b/tests/sentry/web/frontend/test_auth_logout.py
@@ -45,5 +45,4 @@ class AuthLogoutTest(TestCase):
 
         resp = self.client.post(self.path)
         assert resp.status_code == 302
-        assert next not in resp["Location"]
-        assert resp["Location"] == "http://testserver/auth/login/"
+        assert resp["Location"] == "/auth/login/"

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -94,9 +94,10 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         with self.settings(
             TERMS_URL="https://example.com/terms", PRIVACY_URL="https://example.com/privacy"
         ):
-            resp = self.client.post(path, {"op": "newuser"})
-
-        self.assertRedirects(resp, reverse("sentry-login"))
+            resp = self.client.post(path, {"op": "newuser"}, follow=False)
+            self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+            resp = self.client.post(path, {"op": "newuser"}, follow=True)
+            self.assertRedirects(resp, "/organizations/foo/issues/")
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -130,9 +131,10 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(resp, "sentry/auth-confirm-link.html")
         assert resp.status_code == 200
 
-        resp = self.client.post(path, {"op": "confirm"})
-
-        self.assertRedirects(resp, reverse("sentry-login"))
+        resp = self.client.post(path, {"op": "confirm"}, follow=False)
+        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+        resp = self.client.post(path, {"op": "confirm"}, follow=True)
+        self.assertRedirects(resp, "/organizations/foo/issues/")
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
         assert user == auth_identity.user
@@ -154,9 +156,10 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert self.provider.TEMPLATE in resp.content.decode("utf-8")
 
         path = reverse("sentry-auth-sso")
-        resp = self.client.post(path, {"email": "foo@example.com"})
-
-        self.assertRedirects(resp, reverse("sentry-login"))
+        resp = self.client.post(path, {"email": "foo@example.com"}, follow=False)
+        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+        resp = self.client.post(path, {"email": "foo@example.com"}, follow=True)
+        self.assertRedirects(resp, "/organizations/foo/issues/")
 
     def test_flow_as_unauthenticated_existing_matched_user_no_merge(self):
         auth_provider = AuthProvider.objects.create(
@@ -177,9 +180,10 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.context["existing_user"] == user
         assert resp.context["login_form"]
 
-        resp = self.client.post(path, {"op": "newuser"})
-
-        self.assertRedirects(resp, reverse("sentry-login"))
+        resp = self.client.post(path, {"op": "newuser"}, follow=False)
+        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+        resp = self.client.post(path, {"op": "newuser"}, follow=True)
+        self.assertRedirects(resp, "/organizations/foo/issues/")
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
         new_user = auth_identity.user
@@ -226,9 +230,10 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(resp, "sentry/auth-confirm-link.html")
         assert resp.status_code == 200
 
-        resp = self.client.post(path, {"op": "confirm"})
-
-        self.assertRedirects(resp, reverse("sentry-login"))
+        resp = self.client.post(path, {"op": "confirm"}, follow=False)
+        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+        resp = self.client.post(path, {"op": "confirm"}, follow=True)
+        self.assertRedirects(resp, "/organizations/foo/issues/")
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -267,9 +272,10 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(resp, "sentry/auth-confirm-link.html")
         assert resp.status_code == 200
 
-        resp = self.client.post(path, {"op": "confirm"})
-
-        self.assertRedirects(resp, reverse("sentry-login"))
+        resp = self.client.post(path, {"op": "confirm"}, follow=False)
+        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+        resp = self.client.post(path, {"op": "confirm"}, follow=True)
+        self.assertRedirects(resp, "/organizations/foo/issues/")
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -308,9 +314,10 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(resp, "sentry/auth-confirm-link.html")
         assert resp.status_code == 200
 
-        resp = self.client.post(path, {"op": "confirm"})
-
-        self.assertRedirects(resp, reverse("sentry-login"))
+        resp = self.client.post(path, {"op": "confirm"}, follow=False)
+        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+        resp = self.client.post(path, {"op": "confirm"}, follow=True)
+        self.assertRedirects(resp, "/organizations/foo/issues/")
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -353,9 +360,10 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(resp, "sentry/auth-confirm-link.html")
         assert resp.status_code == 200
 
-        resp = self.client.post(path, {"op": "confirm"})
-
-        self.assertRedirects(resp, reverse("sentry-login"))
+        resp = self.client.post(path, {"op": "confirm"}, follow=False)
+        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+        resp = self.client.post(path, {"op": "confirm"}, follow=True)
+        self.assertRedirects(resp, "/organizations/foo/issues/")
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -398,9 +406,10 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert not resp.context["existing_user"]
         assert resp.context["login_form"]
 
-        resp = self.client.post(path, {"op": "newuser"})
-
-        self.assertRedirects(resp, reverse("sentry-login"))
+        resp = self.client.post(path, {"op": "newuser"}, follow=False)
+        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+        resp = self.client.post(path, {"op": "newuser"}, follow=True)
+        self.assertRedirects(resp, "/organizations/foo/issues/")
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -450,11 +459,14 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         # we're suggesting the identity changed (as if the Google ident was
         # updated to be something else)
         resp = self.client.post(
-            path, {"email": "bar@example.com", "id": "123", "email_verified": "1"}
+            path, {"email": "bar@example.com", "id": "123", "email_verified": "1"}, follow=False
         )
-
         # there should be no prompt as we auto merge the identity
-        self.assertRedirects(resp, reverse("sentry-login"))
+        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+        resp = self.client.post(
+            path, {"email": "bar@example.com", "id": "123", "email_verified": "1"}, follow=True
+        )
+        self.assertRedirects(resp, "/auth/login/foo/")
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -606,9 +618,10 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         # we're suggesting the identity changed (as if the Google ident was
         # updated to be something else)
-        resp = self.client.post(path, {"email": "adfadsf@example.com"})
-
-        self.assertRedirects(resp, reverse("sentry-login"))
+        resp = self.client.post(path, {"email": "adfadsf@example.com"}, follow=False)
+        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+        resp = self.client.post(path, {"email": "adfadsf@example.com"}, follow=True)
+        self.assertRedirects(resp, "/auth/login/foo/")
 
         assert not AuthIdentity.objects.filter(id=identity1.id).exists()
 
@@ -642,11 +655,14 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         path = reverse("sentry-auth-sso")
 
         resp = self.client.post(
-            path, {"email": "foo@new-domain.com", "legacy_email": "foo@example.com"}
+            path, {"email": "foo@new-domain.com", "legacy_email": "foo@example.com"}, follow=False
         )
+        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
+        resp = self.client.post(
+            path, {"email": "foo@new-domain.com", "legacy_email": "foo@example.com"}, follow=True
+        )
+        self.assertRedirects(resp, "/organizations/foo/issues/")
 
         # Ensure the ident was migrated from the legacy identity
         updated_ident = AuthIdentity.objects.get(id=user_ident.id)
         assert updated_ident.ident == "foo@new-domain.com"
-
-        self.assertRedirects(resp, reverse("sentry-login"))

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -96,8 +96,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         ):
             resp = self.client.post(path, {"op": "newuser"})
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-login")
+        self.assertRedirects(resp, reverse("sentry-login"))
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -133,8 +132,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         resp = self.client.post(path, {"op": "confirm"})
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-login")
+        self.assertRedirects(resp, reverse("sentry-login"))
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
         assert user == auth_identity.user
@@ -158,8 +156,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         path = reverse("sentry-auth-sso")
         resp = self.client.post(path, {"email": "foo@example.com"})
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-login")
+        self.assertRedirects(resp, reverse("sentry-login"))
 
     def test_flow_as_unauthenticated_existing_matched_user_no_merge(self):
         auth_provider = AuthProvider.objects.create(
@@ -182,8 +179,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         resp = self.client.post(path, {"op": "newuser"})
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-login")
+        self.assertRedirects(resp, reverse("sentry-login"))
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
         new_user = auth_identity.user
@@ -232,8 +228,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         resp = self.client.post(path, {"op": "confirm"})
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-login")
+        self.assertRedirects(resp, reverse("sentry-login"))
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -274,8 +269,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         resp = self.client.post(path, {"op": "confirm"})
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-login")
+        self.assertRedirects(resp, reverse("sentry-login"))
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -316,8 +310,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         resp = self.client.post(path, {"op": "confirm"})
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-login")
+        self.assertRedirects(resp, reverse("sentry-login"))
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -362,8 +355,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         resp = self.client.post(path, {"op": "confirm"})
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-login")
+        self.assertRedirects(resp, reverse("sentry-login"))
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -408,8 +400,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         resp = self.client.post(path, {"op": "newuser"})
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-login")
+        self.assertRedirects(resp, reverse("sentry-login"))
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -463,8 +454,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         )
 
         # there should be no prompt as we auto merge the identity
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-login")
+        self.assertRedirects(resp, reverse("sentry-login"))
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -618,8 +608,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         # updated to be something else)
         resp = self.client.post(path, {"email": "adfadsf@example.com"})
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-login")
+        self.assertRedirects(resp, reverse("sentry-login"))
 
         assert not AuthIdentity.objects.filter(id=identity1.id).exists()
 
@@ -660,5 +649,4 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         updated_ident = AuthIdentity.objects.get(id=user_ident.id)
         assert updated_ident.ident == "foo@new-domain.com"
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-login")
+        self.assertRedirects(resp, reverse("sentry-login"))

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -97,7 +97,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
             resp = self.client.post(path, {"op": "newuser"})
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver" + reverse("sentry-login")
+        assert resp["Location"] == reverse("sentry-login")
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -134,7 +134,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {"op": "confirm"})
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver" + reverse("sentry-login")
+        assert resp["Location"] == reverse("sentry-login")
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
         assert user == auth_identity.user
@@ -159,7 +159,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {"email": "foo@example.com"})
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver" + reverse("sentry-login")
+        assert resp["Location"] == reverse("sentry-login")
 
     def test_flow_as_unauthenticated_existing_matched_user_no_merge(self):
         auth_provider = AuthProvider.objects.create(
@@ -183,7 +183,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {"op": "newuser"})
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver" + reverse("sentry-login")
+        assert resp["Location"] == reverse("sentry-login")
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
         new_user = auth_identity.user
@@ -233,7 +233,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {"op": "confirm"})
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver" + reverse("sentry-login")
+        assert resp["Location"] == reverse("sentry-login")
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -275,7 +275,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {"op": "confirm"})
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver" + reverse("sentry-login")
+        assert resp["Location"] == reverse("sentry-login")
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -317,7 +317,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {"op": "confirm"})
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver" + reverse("sentry-login")
+        assert resp["Location"] == reverse("sentry-login")
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -363,7 +363,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {"op": "confirm"})
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver" + reverse("sentry-login")
+        assert resp["Location"] == reverse("sentry-login")
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -409,7 +409,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {"op": "newuser"})
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver" + reverse("sentry-login")
+        assert resp["Location"] == reverse("sentry-login")
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -464,7 +464,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         # there should be no prompt as we auto merge the identity
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver" + reverse("sentry-login")
+        assert resp["Location"] == reverse("sentry-login")
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -619,7 +619,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {"email": "adfadsf@example.com"})
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver" + reverse("sentry-login")
+        assert resp["Location"] == reverse("sentry-login")
 
         assert not AuthIdentity.objects.filter(id=identity1.id).exists()
 
@@ -661,4 +661,4 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert updated_ident.ident == "foo@new-domain.com"
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver" + reverse("sentry-login")
+        assert resp["Location"] == reverse("sentry-login")

--- a/tests/sentry/web/frontend/test_home.py
+++ b/tests/sentry/web/frontend/test_home.py
@@ -15,7 +15,7 @@ class HomeTest(TestCase):
         resp = self.client.get(self.path)
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver/auth/login/"
+        assert resp["Location"] == "/auth/login/"
 
     def test_redirects_to_create_org(self):
         self.login_as(self.user)
@@ -24,7 +24,7 @@ class HomeTest(TestCase):
             resp = self.client.get(self.path)
 
         assert resp.status_code == 302
-        assert resp["Location"] == "http://testserver/organizations/new/"
+        assert resp["Location"] == "/organizations/new/"
 
     def test_shows_no_access(self):
         self.login_as(self.user)
@@ -43,4 +43,4 @@ class HomeTest(TestCase):
             resp = self.client.get(self.path)
 
         assert resp.status_code == 302
-        assert resp["Location"] == u"http://testserver/organizations/{}/issues/".format(org.slug)
+        assert resp["Location"] == u"/organizations/{}/issues/".format(org.slug)

--- a/tests/sentry/web/frontend/test_home.py
+++ b/tests/sentry/web/frontend/test_home.py
@@ -14,8 +14,7 @@ class HomeTest(TestCase):
     def test_redirects_to_login(self):
         resp = self.client.get(self.path)
 
-        assert resp.status_code == 302
-        assert resp["Location"] == "/auth/login/"
+        self.assertRedirects(resp, "/auth/login/")
 
     def test_redirects_to_create_org(self):
         self.login_as(self.user)
@@ -23,8 +22,7 @@ class HomeTest(TestCase):
         with self.feature("organizations:create"):
             resp = self.client.get(self.path)
 
-        assert resp.status_code == 302
-        assert resp["Location"] == "/organizations/new/"
+        self.assertRedirects(resp, "/organizations/new/")
 
     def test_shows_no_access(self):
         self.login_as(self.user)
@@ -42,5 +40,4 @@ class HomeTest(TestCase):
         with self.feature("organizations:create"):
             resp = self.client.get(self.path)
 
-        assert resp.status_code == 302
-        assert resp["Location"] == u"/organizations/{}/issues/".format(org.slug)
+        self.assertRedirects(resp, u"/organizations/{}/issues/".format(org.slug))

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -246,7 +246,8 @@ class OAuthAuthorizeCodeTest(TestCase):
         assert grant.application == self.application
         assert not grant.get_scopes()
 
-        self.assertRedirects(resp, u"https://example.com?code={}".format(grant.code))
+        assert resp.status_code == 302
+        assert resp["Location"] == u"https://example.com?code={}".format(grant.code)
 
         authorization = ApiAuthorization.objects.get(user=self.user, application=self.application)
         assert authorization.get_scopes() == grant.get_scopes()

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -233,8 +233,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         resp = self.client.post(
             full_path, {"username": self.user.username, "password": "admin", "op": "login"}
         )
-        assert resp.status_code == 302
-        assert resp.get("Location") == full_path
+        self.assertRedirects(resp, full_path)
 
         resp = self.client.get(full_path)
         self.assertTemplateUsed("sentry/oauth-authorize.html")
@@ -247,8 +246,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         assert grant.application == self.application
         assert not grant.get_scopes()
 
-        assert resp.status_code == 302
-        assert resp["Location"] == u"https://example.com?code={}".format(grant.code)
+        self.assertRedirects(resp, u"https://example.com?code={}".format(grant.code))
 
         authorization = ApiAuthorization.objects.get(user=self.user, application=self.application)
         assert authorization.get_scopes() == grant.get_scopes()

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -234,7 +234,7 @@ class OAuthAuthorizeCodeTest(TestCase):
             full_path, {"username": self.user.username, "password": "admin", "op": "login"}
         )
         assert resp.status_code == 302
-        assert resp.get("Location") == u"http://testserver{}".format(full_path)
+        assert resp.get("Location") == full_path
 
         resp = self.client.get(full_path)
         self.assertTemplateUsed("sentry/oauth-authorize.html")

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -107,8 +107,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
             path = reverse("sentry-auth-sso")
             resp = self.client.post(path, {"email": user.email})
 
-        assert resp.status_code == 302
-        assert resp["Location"] == configure_path
+        self.assertRedirects(resp, configure_path)
 
         auth_provider = AuthProvider.objects.get(organization=organization, provider="dummy")
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -108,7 +108,7 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
             resp = self.client.post(path, {"email": user.email})
 
         assert resp.status_code == 302
-        assert resp["Location"] == u"http://testserver{}".format(configure_path)
+        assert resp["Location"] == configure_path
 
         auth_provider = AuthProvider.objects.get(organization=organization, provider="dummy")
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from django.core.urlresolvers import reverse
 from sentry.testutils import TestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
-from sentry import options
 
 
 class ProjectEventTest(SnubaTestCase, TestCase):
@@ -28,11 +27,8 @@ class ProjectEventTest(SnubaTestCase, TestCase):
             )
         )
         assert resp.status_code == 302
-        assert resp["Location"] == "{}/organizations/{}/issues/{}/events/{}/".format(
-            options.get("system.url-prefix"),
-            self.org.slug,
-            self.event.group_id,
-            self.event.event_id,
+        assert resp["Location"] == "/organizations/{}/issues/{}/events/{}/".format(
+            self.org.slug, self.event.group_id, self.event.event_id
         )
 
     def test_event_not_found(self):

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -26,9 +26,11 @@ class ProjectEventTest(SnubaTestCase, TestCase):
                 args=[self.org.slug, self.project.slug, self.event.event_id],
             )
         )
-        assert resp.status_code == 302
-        assert resp["Location"] == "/organizations/{}/issues/{}/events/{}/".format(
-            self.org.slug, self.event.group_id, self.event.event_id
+        self.assertRedirects(
+            resp,
+            "/organizations/{}/issues/{}/events/{}/".format(
+                self.org.slug, self.event.group_id, self.event.event_id
+            ),
         )
 
     def test_event_not_found(self):

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -13,8 +13,7 @@ class ReactPageViewTest(TestCase):
         path = reverse("sentry-organization-home", args=[org.slug])
         resp = self.client.get(path)
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-auth-organization", args=[org.slug])
+        self.assertRedirects(resp, reverse("sentry-auth-organization", args=[org.slug]))
         assert resp["X-Robots-Tag"] == "noindex, nofollow"
 
     def test_superuser_can_load(self):
@@ -40,8 +39,7 @@ class ReactPageViewTest(TestCase):
 
         resp = self.client.get(path)
 
-        assert resp.status_code == 302
-        assert resp["Location"] == reverse("sentry-auth-organization", args=[org.slug])
+        self.assertRedirects(resp, reverse("sentry-auth-organization", args=[org.slug]))
 
         # ensure we dont redirect to auth if its not a valid org
         path = reverse("sentry-organization-home", args=["foobar"])

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -14,9 +14,7 @@ class ReactPageViewTest(TestCase):
         resp = self.client.get(path)
 
         assert resp.status_code == 302
-        assert resp["Location"] == u"http://testserver{}".format(
-            reverse("sentry-auth-organization", args=[org.slug])
-        )
+        assert resp["Location"] == reverse("sentry-auth-organization", args=[org.slug])
         assert resp["X-Robots-Tag"] == "noindex, nofollow"
 
     def test_superuser_can_load(self):
@@ -43,9 +41,7 @@ class ReactPageViewTest(TestCase):
         resp = self.client.get(path)
 
         assert resp.status_code == 302
-        assert resp["Location"] == u"http://testserver{}".format(
-            reverse("sentry-auth-organization", args=[org.slug])
-        )
+        assert resp["Location"] == reverse("sentry-auth-organization", args=[org.slug])
 
         # ensure we dont redirect to auth if its not a valid org
         path = reverse("sentry-organization-home", args=["foobar"])
@@ -53,9 +49,7 @@ class ReactPageViewTest(TestCase):
         resp = self.client.get(path)
 
         assert resp.status_code == 302
-        assert resp["Location"] != u"http://testserver{}".format(
-            reverse("sentry-auth-organization", args=[org.slug])
-        )
+        assert resp["Location"] != reverse("sentry-auth-organization", args=[org.slug])
 
         # ensure we dont redirect with valid membership
         path = reverse("sentry-organization-home", args=[org.slug])


### PR DESCRIPTION
At this point, sentry should be compatible with Django 1.9 and still work with 1.8. We can fully make the switch in a separate PR. **Note that getsentry, and plugins, also have to be made compatible.**

Summarily, the changes required were:

https://docs.djangoproject.com/en/2.2/releases/1.9/#http-redirects-no-longer-forced-to-absolute-uris

Django 1.9 no longer forcefully rewrites relative redirects to absolute URIs because of RFC 7231. So in places where we do have relative redirects, we need to be asserting for those without the http://testserver prefix. **This was strictly a test suite change.** Because we were asserting based purely on the `Location` header, it was either one way or the other on Django 1.8 vs. 1.9, but I found that using django's `assertRedirects` removed the need for assert branching based on `django.VERSION`. Additionally it was found that we weren't fully checking the correctness of double redirects e.g. somewhere to `/auth/login` to `/auth/login/organization` - that has been fixed.

https://docs.djangoproject.com/en/2.2/releases/1.9/#simple-tag-now-wraps-tag-output-in-conditional-escape

Django's simple_tags were previously not html-autoescaped by default, but in 1.9 they are, which led one test to fail when rightfully asserting the non-escaped html rendered result of a simple tag. It's a requirement that it isn't escaped for the script to load properly. That one simple_tag which renders HTML has been changed to render a mark_safe'd string, which disables this autoescaping behavior in 1.9.

Percy was also really helpful here - the letter avatar placeholder SVGs were also rendered via simple_tag and so they also needed to be mark_safe'd.

https://docs.djangoproject.com/en/2.2/releases/1.9/#implicit-queryset-in-lookup-removed

Django 1.8 had [undocumented behavior](https://code.djangoproject.com/ticket/25284#comment:6) where queries like `Model.objects.filter(related_id=...)` would implicitly convert to `Model.objects.filter(related_id__in=...)`. In some places, we have something like `objects.filter(foo=objects.filter(bar__in=..))` where in Django 1.9 would error due to the subquery returning more than 1 row because the `foo=` isn't being implicitly converted to `foo__in` anymore.

I've changed the source code directly impacted by our test coverage, but before we flip the switch to Django 1.9, all of our similar queries need to be audited.