### PR TITLE
fix: Fix potentially recursively used lock

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -22,7 +22,7 @@ from sentry.utils.imports import import_string
 from sentry.utils.redis import get_cluster_from_options
 
 _local_buffers = None
-_local_buffers_lock = threading.Lock()
+_local_buffers_lock = threading.RLock()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
I believe there is a reasonable chance that this could actually deadlock since `batch_buffers_incr` can call back into `buffers.incr` which again tries to lock.

Since we see some things that look like deadlocks my hunch is that this might be it.