### PR TITLE
ref(ui): Remove "Is Default" option from Incident Rules form

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm.tsx
@@ -121,13 +121,6 @@ class RuleForm extends React.Component<Props> {
                 choices: Object.entries(TIME_WINDOW_MAP),
                 required: true,
               },
-              {
-                name: 'isDefault',
-                type: 'boolean',
-                label: t('Is Default'),
-                defaultValue: false,
-                help: t('Default rules will visible for all members of an organization?'),
-              },
             ],
           },
         ]}


### PR DESCRIPTION
This will not be necessary until we move Alert rules as a whole into
org-level settings.