### PR TITLE
fix(ui): Async search component now validates results before changing state

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponentSearchInput.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponentSearchInput.jsx
@@ -49,8 +49,11 @@ class AsyncComponentSearchInput extends React.Component {
         query: searchQuery,
       },
       success: (data, _, jqXHR) => {
+        // only update state if the request's query matches the current query
         this.setState({busy: false});
-        this.props.onSuccess(data, jqXHR);
+        if (this.state.query === searchQuery) {
+          this.props.onSuccess(data, jqXHR);
+        }
       },
       error: () => {
         this.setState({busy: false});

--- a/src/sentry/static/sentry/app/components/asyncComponentSearchInput.jsx
+++ b/src/sentry/static/sentry/app/components/asyncComponentSearchInput.jsx
@@ -49,8 +49,8 @@ class AsyncComponentSearchInput extends React.Component {
         query: searchQuery,
       },
       success: (data, _, jqXHR) => {
-        // only update state if the request's query matches the current query
         this.setState({busy: false});
+        // only update data if the request's query matches the current query
         if (this.state.query === searchQuery) {
           this.props.onSuccess(data, jqXHR);
         }


### PR DESCRIPTION
The AsyncComponentSearchInput overrides the parent async component with new results from a search, but doesn't check to see if the fetched results are correct. This can result in unexpected behavior:
![image](https://user-images.githubusercontent.com/9372512/67812302-194e2e00-fa5c-11e9-85d4-4d567167f3eb.png)

Even though I searched for ‘at’ a lot of incorrect projects are displayed. This is because when a user types 'a', a search is fired off for projects with 'a', lets call that "request_a". Then the user types 'at' so another request is fired off, "request_at". If "request_at" finishes before "request_a" then the above image will be the result, as request_a will come later and override the list with outdated results.

Typically this doesn't happen with smaller organizations because the queries happen faster than the debounce time inside of the async search component. However, with larger orgs, such as Square, this edge case often becomes the typical case.

To fix this I check to see if the current state of the search input matches the query used to fetch the results that are coming in from a request.

I have mocked out this unexpected behavior locally by hardcoding the first query, "i", to wait 2 seconds before firing, so that the second request, "ia", will come first and be overridden.

**Before**
![bad_async_search](https://user-images.githubusercontent.com/9372512/67811590-5d403380-fa5a-11e9-8508-7d09e0171abd.gif)


**After**
![good_async_search](https://user-images.githubusercontent.com/9372512/67811601-63361480-fa5a-11e9-81cb-4fd36448aa27.gif)

REFS SEN-1214