### PR TITLE
feat(grouping): Add support for force-overriding client fingerprints

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -133,16 +133,23 @@ def apply_server_fingerprinting(event, config):
     if not any(x in DEFAULT_FINGERPRINT_VALUES for x in fingerprint):
         return
 
-    new_values = config.get_fingerprint_values_for_event(event)
-    if new_values is None:
+    rv = config.get_fingerprint_values_for_event(event)
+    if rv is None:
         return
 
-    new_fingerprint = []
-    for value in fingerprint:
-        if value in DEFAULT_FINGERPRINT_VALUES:
-            new_fingerprint.extend(new_values)
-        else:
-            new_fingerprint.append(value)
+    # if the fingerprint is forced it replaces the values that might
+    # already be in the event from the client.  Otherwise it only replaces
+    # the `{{ default }}` values in the fingerprint.
+    new_values, force = rv
+    if force:
+        new_fingerprint = new_values
+    else:
+        new_fingerprint = []
+        for value in fingerprint:
+            if value in DEFAULT_FINGERPRINT_VALUES:
+                new_fingerprint.extend(new_values)
+            else:
+                new_fingerprint.append(value)
 
     event["fingerprint"] = new_fingerprint
 

--- a/tests/sentry/grouping/fingerprint_inputs/override-client.json
+++ b/tests/sentry/grouping/fingerprint_inputs/override-client.json
@@ -1,0 +1,15 @@
+{
+  "_fingerprinting_rules": [
+    {
+      "matchers": [
+        ["message", "*love*"]
+      ],
+      "fingerprint": ["what-is-love"],
+      "force": true
+    }
+  ],
+  "fingerprint": ["{{ default }}", "baby-dont-hurt-me"],
+  "logentry": {
+    "formatted": "Hello my sweet Love"
+  }
+}

--- a/tests/sentry/grouping/fingerprint_inputs/retain-client.json
+++ b/tests/sentry/grouping/fingerprint_inputs/retain-client.json
@@ -1,0 +1,14 @@
+{
+  "_fingerprinting_rules": [
+    {
+      "matchers": [
+        ["message", "*love*"]
+      ],
+      "fingerprint": ["what-is-love"]
+    }
+  ],
+  "fingerprint": ["{{ default }}", "baby-dont-hurt-me"],
+  "logentry": {
+    "formatted": "Hello my sweet Love"
+  }
+}

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-07-23T21:55:25.846335Z'
+created: '2019-10-29T21:47:59.113703Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -7,6 +7,7 @@ config:
   rules:
   - fingerprint:
     - database-unavailable
+    force: false
     matchers:
     - - type
       - DatabaseUnavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-07-23T21:55:25.855738Z'
+created: '2019-10-29T21:47:59.122857Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -7,6 +7,7 @@ config:
   rules:
   - fingerprint:
     - database-unavailable
+    force: false
     matchers:
     - - type
       - DatabaseUnavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-07-23T21:55:25.868386Z'
+created: '2019-10-29T21:47:59.136040Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -7,6 +7,7 @@ config:
   rules:
   - fingerprint:
     - database-unavailable
+    force: false
     matchers:
     - - type
       - DatabaseUnavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-07-23T21:55:25.877113Z'
+created: '2019-10-29T21:47:59.144335Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -7,6 +7,7 @@ config:
   rules:
   - fingerprint:
     - something-went-wrong
+    force: false
     matchers:
     - - value
       - '*went wrong*'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-08-05T10:20:54.371341Z'
+created: '2019-10-29T21:47:59.153579Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -8,6 +8,7 @@ config:
   - fingerprint:
     - database-unavailable
     - '{{ function }}'
+    force: false
     matchers:
     - - type
       - DatabaseUnavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-07-23T21:55:25.885546Z'
+created: '2019-10-29T21:47:59.162978Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -7,6 +7,7 @@ config:
   rules:
   - fingerprint:
     - what-is-love
+    force: false
     matchers:
     - - message
       - '*love*'

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-07-23T21:55:25.902949Z'
+created: '2019-10-29T21:47:59.179764Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -7,6 +7,7 @@ config:
   rules:
   - fingerprint:
     - symcache-error
+    force: false
     matchers:
     - - type
       - SymCacheError

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-07-23T21:55:25.921295Z'
+created: '2019-10-29T21:47:59.196077Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -7,6 +7,7 @@ config:
   rules:
   - fingerprint:
     - symcache-error
+    force: false
     matchers:
     - - function
       - symbolicator::actors::symcaches::*

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_non_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_non_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-07-23T21:55:26.014346Z'
+created: '2019-10-29T21:47:59.462494Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -7,6 +7,7 @@ config:
   rules:
   - fingerprint:
     - symcache-error
+    force: false
     matchers:
     - - function
       - symbolicator::actors::symcaches::*

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-08-05T10:21:51.469194Z'
+created: '2019-10-29T21:47:59.471080Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -8,6 +8,7 @@ config:
   - fingerprint:
     - database-unavailable
     - '{{ function }}'
+    force: false
     matchers:
     - - type
       - DatabaseUnavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-07-23T21:55:26.024104Z'
+created: '2019-10-29T21:47:59.483230Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -7,6 +7,7 @@ config:
   rules:
   - fingerprint:
     - database-unavailable
+    force: false
     matchers:
     - - type
       - DatabaseUnavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-08-05T12:11:28.476796Z'
+created: '2019-10-29T21:47:59.491208Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -7,6 +7,7 @@ config:
   rules:
   - fingerprint:
     - '{{ package }}'
+    force: false
     matchers:
     - - type
       - DatabaseUnavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-08-05T10:21:51.486852Z'
+created: '2019-10-29T21:47:59.499641Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -8,6 +8,7 @@ config:
   - fingerprint:
     - database-unavailable
     - '{{ transaction }}'
+    force: false
     matchers:
     - - type
       - DatabaseUnavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-08-05T10:26:51.809104Z'
+created: '2019-10-29T21:47:59.511441Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -9,6 +9,7 @@ config:
     - '{{ type }}'
     - '{{ module }}'
     - '{{ function }}'
+    force: false
     matchers:
     - - function
       - main

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-08-05T12:11:53.473003Z'
+created: '2019-10-29T21:47:59.524365Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -7,6 +7,7 @@ config:
   rules:
   - fingerprint:
     - '{{ package }}'
+    force: false
     matchers:
     - - type
       - DatabaseUnavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-07-23T22:00:33.106276Z'
+created: '2019-10-29T21:47:59.546176Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -8,6 +8,7 @@ config:
   - fingerprint:
     - database-unavailable
     - '{{ transaction }}'
+    force: false
     matchers:
     - - type
       - DatabaseUnavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-08-05T10:24:07.792310Z'
+created: '2019-10-29T21:47:59.556377Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -8,6 +8,7 @@ config:
   - fingerprint:
     - '{{ type }}'
     - '{{ module }}'
+    force: false
     matchers:
     - - type
       - DatabaseUnavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/override_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/override_client.pysnap
@@ -1,23 +1,21 @@
 ---
-created: '2019-10-29T21:47:59.536238Z'
+created: '2019-10-29T22:02:02.552074Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
 config:
   rules:
   - fingerprint:
-    - timeout-in-requests
-    force: false
+    - what-is-love
+    force: true
     matchers:
-    - - type
-      - ReadTimeout
-    - - path
-      - '**/requests/adapters.py'
+    - - message
+      - '*love*'
   version: 1
 fingerprint:
-- timeout-in-requests
+- what-is-love
 variants:
   custom-fingerprint:
     type: custom-fingerprint
     values:
-    - timeout-in-requests
+    - what-is-love

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/retain_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/retain_client.pysnap
@@ -1,23 +1,23 @@
 ---
-created: '2019-10-29T21:47:59.536238Z'
+created: '2019-10-29T22:02:02.561769Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
 config:
   rules:
   - fingerprint:
-    - timeout-in-requests
+    - what-is-love
     force: false
     matchers:
-    - - type
-      - ReadTimeout
-    - - path
-      - '**/requests/adapters.py'
+    - - message
+      - '*love*'
   version: 1
 fingerprint:
-- timeout-in-requests
+- what-is-love
+- baby-dont-hurt-me
 variants:
   custom-fingerprint:
     type: custom-fingerprint
     values:
-    - timeout-in-requests
+    - what-is-love
+    - baby-dont-hurt-me

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -19,18 +19,23 @@ def test_basic_parsing(insta_snapshot):
 type:DatabaseUnavailable                        -> DatabaseUnavailable
 function:assertion_failed module:foo            -> AssertionFailed, foo
 app:true                                        -> aha
-app:true                                        -> {{ default }}
+app:true                                        -> {{ default }}!
 """
     )
     assert rules._to_config_structure() == {
         "rules": [
-            {"matchers": [["type", "DatabaseUnavailable"]], "fingerprint": ["DatabaseUnavailable"]},
+            {
+                "matchers": [["type", "DatabaseUnavailable"]],
+                "fingerprint": ["DatabaseUnavailable"],
+                "force": False,
+            },
             {
                 "matchers": [["function", "assertion_failed"], ["module", "foo"]],
                 "fingerprint": ["AssertionFailed", "foo"],
+                "force": False,
             },
-            {"matchers": [["app", "true"]], "fingerprint": ["aha"]},
-            {"matchers": [["app", "true"]], "fingerprint": ["{{ default }}"]},
+            {"matchers": [["app", "true"]], "fingerprint": ["aha"], "force": False},
+            {"matchers": [["app", "true"]], "fingerprint": ["{{ default }}"], "force": True},
         ],
         "version": 1,
     }


### PR DESCRIPTION
This adds support for a flag that force overrides the client fingerprint
instead of extending it.  By adding an exclamation mark at the end of the
fingerprint value it overrides.

Example:

    message:Timeout* -> timeout-hit!