### PR TITLE
feat(hooks): Add log experiment analytics hook

### DIFF
--- a/src/sentry/static/sentry/app/stores/hookStore.tsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.tsx
@@ -13,6 +13,7 @@ const validHookNames = new Set<HookName>([
   'analytics:init-user',
   'analytics:track-adhoc-event',
   'analytics:track-event',
+  'analytics:log-experiment',
   'component:header-date-range',
   'component:header-selector-items',
   'component:org-members-view',

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -68,6 +68,7 @@ export type AnalyticsHooks = {
   'analytics:init-user': AnalyticsInitUser;
   'analytics:track-event': AnalyticsTrackEvent;
   'analytics:track-adhoc-event': AnalyticsTrackAdhocEvent;
+  'analytics:log-experiment': AnalyticsLogExperiment;
   'metrics:event': MetricsEvent;
 
   // TODO(epurkhiser): This is deprecated and should be replaced
@@ -190,6 +191,32 @@ type AnalyticsTrackEvent = (opts: {
 type AnalyticsTrackAdhocEvent = (
   opts: Omit<Parameters<AnalyticsTrackEvent>[0], 'eventName'>
 ) => void;
+
+/**
+ * Trigger experiment observed logging.
+ */
+type AnalyticsLogExperiment = (opts: {
+  /**
+   * The organiation with the experiment
+   */
+  organization: Organization;
+  /**
+   * The experiment key
+   */
+  key: string;
+  /**
+   * The name of the exposed unit
+   */
+  unitName: string;
+  /**
+   * The value of the unit to group by
+   */
+  unitId: string | number;
+  /**
+   * The parameter name used for the exposed key
+   */
+  param: string;
+}) => void;
 
 /**
  * Trigger analytics tracking in the hook store.

--- a/src/sentry/static/sentry/app/utils/analytics.tsx
+++ b/src/sentry/static/sentry/app/utils/analytics.tsx
@@ -44,6 +44,16 @@ export const trackAdhocEvent: Hooks['analytics:track-adhoc-event'] = options =>
   HookStore.get('analytics:track-adhoc-event').forEach(cb => cb(options));
 
 /**
+ * This should be used to log when a `organization.experiments` experiment
+ * variant is checked in the application.
+ *
+ * Refer for the backend implementation provided through HookStore for more
+ * details.
+ */
+export const logExperiment: Hooks['analytics:log-experiment'] = options =>
+  HookStore.get('analytics:track-adhoc-event').forEach(cb => cb(options));
+
+/**
  * Legacy analytics tracking.
  *
  * @deprecated Prefer `trackAnalyticsEvent` and `trackAdhocEvent`.


### PR DESCRIPTION
Sentry is already relatively aware of organization experiments.