### PR TITLE
chore(ci): simplify matching of tests allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -230,8 +230,8 @@ matrix:
         - psql -c 'create database sentry;' -U postgres
 
     # Deploy 'storybook' (component & style guide) - allowed to fail
-    - language: node_js
-      name: 'Storybook Deploy'
+    - name: 'Storybook Deploy'
+      language: node_js
       env: STORYBOOK_BUILD=1
       before_install:
         # Decrypt the credentials we added to the repo using the key we added with the Travis command line tool
@@ -248,14 +248,11 @@ matrix:
       after_success: skip
       after_failure: skip
 
-# jobs are defined in matrix/include
-# to specify which jobs are allowed to fail, match the env exactly in matrix/allow_failures
   allow_failures:
-    - language: node_js
-      env: STORYBOOK_BUILD=1
-    - env: DJANGO_VERSION=">=1.9,<1.10" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0
-    - env: DJANGO_VERSION=">=1.9,<1.10" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1
-    - env: DJANGO_VERSION=">=1.9,<1.10" TEST_SUITE=acceptance USE_SNUBA=1
+    - name: 'Storybook Deploy'
+    - name: 'Django 1.9 Backend [Postgres] (1/2)'
+    - name: 'Django 1.9 Backend [Postgres] (2/2)'
+    - name: 'Django 1.9 Acceptance'
 
 notifications:
   webhooks:


### PR DESCRIPTION
I recently found out that only matching the `name` of a travis matrix job was enough to mark it as allowed to fail, so this makes the config more readable.