### PR TITLE
feat(discover2): Add "save as", "update", and "delete" saved queries into the discover dashboard

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
@@ -4,12 +4,7 @@ import {browserHistory} from 'react-router';
 
 import {Client} from 'app/api';
 import AutoComplete from 'app/components/autoComplete';
-import Button from 'app/components/button';
-import ButtonBar from 'app/components/buttonBar';
-import {
-  fetchSavedQueries,
-  deleteSavedQuery,
-} from 'app/actionCreators/discoverSavedQueries';
+import {fetchSavedQueries} from 'app/actionCreators/discoverSavedQueries';
 import Highlight from 'app/components/highlight';
 import InlineSvg from 'app/components/inlineSvg';
 import {t} from 'app/locale';
@@ -67,24 +62,6 @@ class Discover2Item extends React.Component<Props, State> {
     browserHistory.push(target);
   };
 
-  handleEdit = (event: React.MouseEvent<Element>, item: SavedQuery) => {
-    event.preventDefault();
-    event.stopPropagation();
-    const {organization} = this.props;
-    const target = {
-      pathname: `/organizations/${organization.slug}/eventsv2/`,
-      query: {...EventView.fromSavedQuery(item).generateQueryStringObject()},
-    };
-    browserHistory.push(target);
-  };
-
-  handleDelete = (event: React.MouseEvent<Element>, item: SavedQuery) => {
-    const {organization, api} = this.props;
-    event.preventDefault();
-    event.stopPropagation();
-    deleteSavedQuery(api, organization.slug, item.id);
-  };
-
   renderSavedQueries({inputValue, getItemProps, highlightedIndex}) {
     const {savedQueries} = this.props;
     if (!savedQueries || savedQueries.length === 0) {
@@ -112,20 +89,6 @@ class Discover2Item extends React.Component<Props, State> {
             <QueryName>
               <Highlight text={inputValue}>{item.name}</Highlight>
             </QueryName>
-            <ButtonBar>
-              <MenuItemButton
-                borderless
-                size="xxsmall"
-                icon="icon-edit"
-                onClick={event => this.handleEdit(event, item)}
-              />
-              <MenuItemButton
-                borderless
-                size="xxsmall"
-                icon="icon-trash"
-                onClick={event => this.handleDelete(event, item)}
-              />
-            </ButtonBar>
           </MenuItem>
         );
       });
@@ -251,11 +214,6 @@ const StyledLabel = styled('label')<{htmlFor: string}>`
   margin: 0;
   color: ${p => p.theme.gray2};
   padding: ${space(1.5)} ${space(1)} ${space(1.5)} ${space(2)};
-`;
-
-const MenuItemButton = styled(Button)`
-  color: ${p => p.theme.gray3};
-  margin-left: ${space(0.5)};
 `;
 
 const InputContainer = styled('div')`

--- a/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/discover2Item.tsx
@@ -73,7 +73,7 @@ class Discover2Item extends React.Component<Props, State> {
     const {organization} = this.props;
     const target = {
       pathname: `/organizations/${organization.slug}/eventsv2/`,
-      query: {...EventView.fromSavedQuery(item).generateQueryStringObject(), edit: true},
+      query: {...EventView.fromSavedQuery(item).generateQueryStringObject()},
     };
     browserHistory.push(target);
   };

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -456,11 +456,7 @@ class EventView {
         const currentDateTime = moment.utc(currentValue);
         const othereDateTime = moment.utc(otherValue);
 
-        if (
-          currentDateTime.isValid() &&
-          othereDateTime.isValid() &&
-          !currentDateTime.isSame(othereDateTime)
-        ) {
+        if (!currentDateTime.isSame(othereDateTime)) {
           return false;
         }
       }

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -421,6 +421,33 @@ class EventView {
     });
   }
 
+  isEqualTo(other: EventView): boolean {
+    const fluidKeys = [
+      'id',
+      'name',
+      'query',
+      'start',
+      'end',
+      'statsPeriod',
+      'fields',
+      'sorts',
+      'tags',
+      'project',
+      'environment',
+    ];
+
+    for (const key of fluidKeys) {
+      const currentValue = this[key];
+      const otherValue = other[key];
+
+      if (!isEqual(currentValue, otherValue)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   toNewQuery(): NewQuery {
     const orderby = this.sorts.length > 0 ? encodeSorts(this.sorts)[0] : undefined;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -422,7 +422,7 @@ class EventView {
   }
 
   isEqualTo(other: EventView): boolean {
-    const fluidKeys = [
+    const keys = [
       'id',
       'name',
       'query',
@@ -436,7 +436,7 @@ class EventView {
       'environment',
     ];
 
-    for (const key of fluidKeys) {
+    for (const key of keys) {
       const currentValue = this[key];
       const otherValue = other[key];
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -1,5 +1,6 @@
 import {Location, Query} from 'history';
 import {isString, cloneDeep, pick, isEqual} from 'lodash';
+import moment from 'moment';
 
 import {DEFAULT_PER_PAGE} from 'app/constants';
 import {EventViewv1} from 'app/types';
@@ -426,8 +427,6 @@ class EventView {
       'id',
       'name',
       'query',
-      'start',
-      'end',
       'statsPeriod',
       'fields',
       'sorts',
@@ -442,6 +441,28 @@ class EventView {
 
       if (!isEqual(currentValue, otherValue)) {
         return false;
+      }
+    }
+
+    // compare datetime selections using moment
+
+    const dateTimeKeys = ['start', 'end'];
+
+    for (const key of dateTimeKeys) {
+      const currentValue = this[key];
+      const otherValue = other[key];
+
+      if (currentValue && otherValue) {
+        const currentDateTime = moment.utc(currentValue);
+        const othereDateTime = moment.utc(otherValue);
+
+        if (
+          currentDateTime.isValid() &&
+          othereDateTime.isValid() &&
+          !currentDateTime.isSame(othereDateTime)
+        ) {
+          return false;
+        }
       }
     }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -272,7 +272,7 @@ function isLegacySavedQuery(
 
 const queryStringFromSavedQuery = (saved: LegacySavedQuery | SavedQuery): string => {
   if (!isLegacySavedQuery(saved) && saved.query) {
-    return saved.query;
+    return saved.query || '';
   }
   if (isLegacySavedQuery(saved) && saved.conditions) {
     const conditions = saved.conditions.map(item => {
@@ -295,7 +295,7 @@ class EventView {
   fields: Readonly<Field[]>;
   sorts: Readonly<Sort[]>;
   tags: Readonly<string[]>;
-  query: string | undefined;
+  query: string;
   project: Readonly<number[]>;
   start: string | undefined;
   end: string | undefined;
@@ -308,7 +308,7 @@ class EventView {
     fields: Readonly<Field[]>;
     sorts: Readonly<Sort[]>;
     tags: Readonly<string[]>;
-    query?: string | undefined;
+    query: string;
     project: Readonly<number[]>;
     start: string | undefined;
     end: string | undefined;
@@ -340,7 +340,7 @@ class EventView {
     this.fields = props.fields;
     this.sorts = sorts;
     this.tags = props.tags;
-    this.query = props.query;
+    this.query = typeof props.query === 'string' ? props.query : '';
     this.project = props.project;
     this.start = props.start;
     this.end = props.end;
@@ -355,7 +355,7 @@ class EventView {
       fields: decodeFields(location),
       sorts: decodeSorts(location),
       tags: collectQueryStringByKey(location.query, 'tag'),
-      query: decodeQuery(location),
+      query: decodeQuery(location) || '',
       project: decodeProjects(location),
       start: decodeScalar(location.query.start),
       end: decodeScalar(location.query.end),
@@ -377,7 +377,7 @@ class EventView {
       name: eventViewV1.name,
       sorts: fromSorts(eventViewV1.data.sort),
       tags: eventViewV1.tags,
-      query: eventViewV1.data.query,
+      query: eventViewV1.data.query || '',
       project: [],
       id: undefined,
       start: undefined,

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -21,7 +21,7 @@ import withOrganization from 'app/utils/withOrganization';
 
 import Events from './events';
 import EventDetails from './eventDetails';
-import EventsSaveQueryButton from './saveQueryButton';
+import SavedQueryButtonGroup from './savedQueryButtonGroup';
 import {getFirstQueryString} from './utils';
 import {ALL_VIEWS, TRANSACTION_VIEWS} from './data';
 import EventView from './eventView';
@@ -84,8 +84,7 @@ class EventsV2 extends React.Component<Props> {
     const eventSlug = getFirstQueryString(location.query, 'eventSlug');
     const eventView = EventView.fromLocation(location);
 
-    const hasQuery =
-      location.query.field || location.query.eventSlug || location.query.view;
+    const hasQuery = location.query.field || location.query.eventSlug;
 
     const documentTitle = this.getEventViewName()
       .reverse()
@@ -103,8 +102,7 @@ class EventsV2 extends React.Component<Props> {
                     {pageTitle} <BetaTag />
                   </PageHeading>
                   {hasQuery && (
-                    <EventsSaveQueryButton
-                      isEditing={!!location.query.edit}
+                    <SavedQueryButtonGroup
                       location={location}
                       organization={organization}
                       eventView={eventView}

--- a/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
@@ -25,6 +25,7 @@ type Props = {
   eventView: EventView;
   location: Location;
   savedQueries: SavedQuery[];
+  isEditingExistingQuery: boolean;
 };
 
 type State = {
@@ -73,18 +74,8 @@ class EventsSaveQueryButton extends React.Component<Props, State> {
     this.setState({queryName: value});
   };
 
-  isEditingExistingQuery = (): boolean => {
-    const {savedQueries, eventView} = this.props;
-
-    const index = savedQueries.findIndex(needle => {
-      return needle.id === eventView.id;
-    });
-
-    return index >= 0;
-  };
-
   render() {
-    const newQueryLabel = this.isEditingExistingQuery()
+    const newQueryLabel = this.props.isEditingExistingQuery
       ? t('Save as...')
       : t('Save Query');
 

--- a/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
@@ -110,7 +110,7 @@ class EventsSaveQueryButton extends React.Component<Props, State> {
             showChevron={false}
           >
             <StyledInlineSvg src="icon-bookmark" size="14" />
-            {t('Save Search')}
+            {t('Save Query')}
           </StyledDropdownButton>
         )}
       >

--- a/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
@@ -18,6 +18,8 @@ import Input from 'app/components/forms/input';
 import InlineSvg from 'app/components/inlineSvg';
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
+import {SavedQuery} from 'app/stores/discoverSavedQueriesStore';
+import withDiscoverSavedQueries from 'app/utils/withDiscoverSavedQueries';
 
 import EventView from './eventView';
 
@@ -27,6 +29,7 @@ type Props = {
   eventView: EventView;
   location: Location;
   isEditing: boolean;
+  savedQueries: SavedQuery[];
 };
 
 type State = {
@@ -95,9 +98,23 @@ class EventsSaveQueryButton extends React.Component<Props, State> {
     this.setState({queryName: value});
   };
 
+  isEditingExistingQuery = (): boolean => {
+    const {savedQueries, eventView} = this.props;
+
+    const index = savedQueries.findIndex(needle => {
+      return needle.id === eventView.id;
+    });
+
+    return index >= 0;
+  };
+
   render() {
     const {isEditing} = this.props;
     const buttonText = isEditing ? t('Update') : t('Save');
+
+    const newQueryLabel = this.isEditingExistingQuery()
+      ? t('Save as...')
+      : t('Save Query');
 
     return (
       <DropdownControl
@@ -110,7 +127,7 @@ class EventsSaveQueryButton extends React.Component<Props, State> {
             showChevron={false}
           >
             <StyledInlineSvg src="icon-bookmark" size="14" />
-            {t('Save Query')}
+            {newQueryLabel}
           </StyledDropdownButton>
         )}
       >
@@ -148,4 +165,4 @@ const StyledDropdownButton = styled(DropdownButton)`
   white-space: nowrap;
 `;
 
-export default withApi(EventsSaveQueryButton);
+export default withApi(withDiscoverSavedQueries(EventsSaveQueryButton));

--- a/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
@@ -16,7 +16,6 @@ import InlineSvg from 'app/components/inlineSvg';
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 import {SavedQuery} from 'app/stores/discoverSavedQueriesStore';
-import withDiscoverSavedQueries from 'app/utils/withDiscoverSavedQueries';
 
 import EventView from './eventView';
 
@@ -138,4 +137,4 @@ const StyledDropdownButton = styled(DropdownButton)`
   white-space: nowrap;
 `;
 
-export default withApi(withDiscoverSavedQueries(EventsSaveQueryButton));
+export default withApi(EventsSaveQueryButton);

--- a/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
@@ -6,10 +6,7 @@ import {Location} from 'history';
 import {Client} from 'app/api';
 import {Organization} from 'app/types';
 import {t} from 'app/locale';
-import {
-  createSavedQuery,
-  updateSavedQuery,
-} from 'app/actionCreators/discoverSavedQueries';
+import {createSavedQuery} from 'app/actionCreators/discoverSavedQueries';
 import {addSuccessMessage} from 'app/actionCreators/indicator';
 import DropdownControl from 'app/components/dropdownControl';
 import DropdownButton from 'app/components/dropdownButton';
@@ -28,7 +25,6 @@ type Props = {
   organization: Organization;
   eventView: EventView;
   location: Location;
-  isEditing: boolean;
   savedQueries: SavedQuery[];
 };
 
@@ -40,21 +36,6 @@ class EventsSaveQueryButton extends React.Component<Props, State> {
   state = {
     queryName: '',
   };
-
-  componentDidUpdate(prevProps: Props) {
-    // Going from one query to another whilst not leaving edit mode
-    if (
-      (this.props.isEditing === true &&
-        this.props.eventView.id !== prevProps.eventView.id) ||
-      this.props.isEditing !== prevProps.isEditing
-    ) {
-      const queryName =
-        this.props.isEditing === true ? this.props.eventView.name || '' : '';
-
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({queryName});
-    }
-  }
 
   swallowEvent = (event: React.MouseEvent) => {
     // Stop propagation for the input and container so
@@ -70,19 +51,14 @@ class EventsSaveQueryButton extends React.Component<Props, State> {
   };
 
   handleSave = () => {
-    const {api, eventView, organization, location, isEditing} = this.props;
+    const {api, eventView, organization, location} = this.props;
 
     const payload = eventView.toNewQuery();
     if (this.state.queryName) {
       payload.name = this.state.queryName;
     }
-    let promise;
-    if (isEditing) {
-      promise = updateSavedQuery(api, organization.slug, payload);
-    } else {
-      promise = createSavedQuery(api, organization.slug, payload);
-    }
-    promise.then(saved => {
+
+    createSavedQuery(api, organization.slug, payload).then(saved => {
       const view = EventView.fromSavedQuery(saved);
       addSuccessMessage(t('Query saved'));
 
@@ -109,9 +85,6 @@ class EventsSaveQueryButton extends React.Component<Props, State> {
   };
 
   render() {
-    const {isEditing} = this.props;
-    const buttonText = isEditing ? t('Update') : t('Save');
-
     const newQueryLabel = this.isEditingExistingQuery()
       ? t('Save as...')
       : t('Save Query');
@@ -139,7 +112,7 @@ class EventsSaveQueryButton extends React.Component<Props, State> {
             onChange={this.handleInputChange}
           />
           <Button size="small" onClick={this.handleSave} priority="primary">
-            {buttonText}
+            {t('Save')}
           </Button>
         </SaveQueryContainer>
       </DropdownControl>

--- a/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
@@ -77,7 +77,7 @@ class EventsSaveQueryButton extends React.Component<Props, State> {
   render() {
     const newQueryLabel = this.props.isEditingExistingQuery
       ? t('Save as...')
-      : t('Save Query');
+      : t('Save query');
 
     return (
       <DropdownControl

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
@@ -65,6 +65,14 @@ class SavedQueryButtonGroup extends React.Component<Props> {
     return <Button icon="icon-trash" onClick={this.deleteQuery} />;
   };
 
+  renderSaveButton = () => {
+    if (!this.isEditingExistingQuery()) {
+      return null;
+    }
+
+    return <Button>{t('Update query')}</Button>;
+  };
+
   render() {
     const {location, organization, eventView, savedQueries} = this.props;
 
@@ -78,6 +86,7 @@ class SavedQueryButtonGroup extends React.Component<Props> {
           savedQueries={savedQueries}
           isEditingExistingQuery={this.isEditingExistingQuery()}
         />
+        {this.renderSaveButton()}
       </ButtonGroup>
     );
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {Location} from 'history';
+
+import {Organization} from 'app/types';
+
+import EventView from './eventView';
+import EventsSaveQueryButton from './saveQueryButton';
+
+type Props = {
+  eventView: EventView;
+  location: Location;
+  organization: Organization;
+};
+
+const SavedQueryButtonGroup = (props: Props) => {
+  const {location, organization, eventView} = props;
+
+  return (
+    <EventsSaveQueryButton
+      location={location}
+      organization={organization}
+      eventView={eventView}
+    />
+  );
+};
+
+export default SavedQueryButtonGroup;

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {Location} from 'history';
 
 import {Organization} from 'app/types';
+import {SavedQuery} from 'app/stores/discoverSavedQueriesStore';
+import withDiscoverSavedQueries from 'app/utils/withDiscoverSavedQueries';
 
 import EventView from './eventView';
 import EventsSaveQueryButton from './saveQueryButton';
@@ -10,18 +12,20 @@ type Props = {
   eventView: EventView;
   location: Location;
   organization: Organization;
+  savedQueries: SavedQuery[];
 };
 
 const SavedQueryButtonGroup = (props: Props) => {
-  const {location, organization, eventView} = props;
+  const {location, organization, eventView, savedQueries} = props;
 
   return (
     <EventsSaveQueryButton
       location={location}
       organization={organization}
       eventView={eventView}
+      savedQueries={savedQueries}
     />
   );
 };
 
-export default SavedQueryButtonGroup;
+export default withDiscoverSavedQueries(SavedQueryButtonGroup);

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
@@ -1,16 +1,23 @@
 import React from 'react';
 import {Location} from 'history';
 import styled from 'react-emotion';
+import {browserHistory} from 'react-router';
 
+import {Client} from 'app/api';
+import {t} from 'app/locale';
 import Button from 'app/components/button';
 import {Organization} from 'app/types';
+import {deleteSavedQuery} from 'app/actionCreators/discoverSavedQueries';
 import {SavedQuery} from 'app/stores/discoverSavedQueriesStore';
+import withApi from 'app/utils/withApi';
 import withDiscoverSavedQueries from 'app/utils/withDiscoverSavedQueries';
+import {addSuccessMessage} from 'app/actionCreators/indicator';
 
 import EventView from './eventView';
 import EventsSaveQueryButton from './saveQueryButton';
 
 type Props = {
+  api: Client;
   eventView: EventView;
   location: Location;
   organization: Organization;
@@ -21,11 +28,33 @@ class SavedQueryButtonGroup extends React.Component<Props> {
   isEditingExistingQuery = (): boolean => {
     const {savedQueries, eventView} = this.props;
 
+    const isValidId = typeof eventView.id === 'string';
+
     const index = savedQueries.findIndex(needle => {
       return needle.id === eventView.id;
     });
 
-    return index >= 0;
+    return index >= 0 && isValidId;
+  };
+
+  deleteQuery = (event: React.MouseEvent<Element>) => {
+    if (!this.isEditingExistingQuery()) {
+      return;
+    }
+
+    const {organization, api, eventView} = this.props;
+    event.preventDefault();
+    event.stopPropagation();
+    deleteSavedQuery(api, organization.slug, eventView.id!).then(() => {
+      addSuccessMessage(t('Query deleted'));
+
+      // redirect to the primary discover2 page
+
+      browserHistory.push({
+        pathname: location.pathname,
+        query: {},
+      });
+    });
   };
 
   renderDeleteButton = () => {
@@ -33,7 +62,7 @@ class SavedQueryButtonGroup extends React.Component<Props> {
       return null;
     }
 
-    return <Button icon="icon-trash" />;
+    return <Button icon="icon-trash" onClick={this.deleteQuery} />;
   };
 
   render() {
@@ -60,4 +89,4 @@ const ButtonGroup = styled('div')`
   }
 `;
 
-export default withDiscoverSavedQueries(SavedQueryButtonGroup);
+export default withApi(withDiscoverSavedQueries(SavedQueryButtonGroup));

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
@@ -17,21 +17,34 @@ type Props = {
   savedQueries: SavedQuery[];
 };
 
-const SavedQueryButtonGroup = (props: Props) => {
-  const {location, organization, eventView, savedQueries} = props;
+class SavedQueryButtonGroup extends React.Component<Props> {
+  isEditingExistingQuery = (): boolean => {
+    const {savedQueries, eventView} = this.props;
 
-  return (
-    <ButtonGroup>
-      <Button icon="icon-trash" />
-      <EventsSaveQueryButton
-        location={location}
-        organization={organization}
-        eventView={eventView}
-        savedQueries={savedQueries}
-      />
-    </ButtonGroup>
-  );
-};
+    const index = savedQueries.findIndex(needle => {
+      return needle.id === eventView.id;
+    });
+
+    return index >= 0;
+  };
+
+  render() {
+    const {location, organization, eventView, savedQueries} = this.props;
+
+    return (
+      <ButtonGroup>
+        <Button icon="icon-trash" />
+        <EventsSaveQueryButton
+          location={location}
+          organization={organization}
+          eventView={eventView}
+          savedQueries={savedQueries}
+          isEditingExistingQuery={this.isEditingExistingQuery()}
+        />
+      </ButtonGroup>
+    );
+  }
+}
 
 const ButtonGroup = styled('div')`
   > * + * {

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
@@ -38,13 +38,15 @@ class SavedQueryButtonGroup extends React.Component<Props> {
   };
 
   deleteQuery = (event: React.MouseEvent<Element>) => {
+    event.preventDefault();
+    event.stopPropagation();
+
     if (!this.isEditingExistingQuery()) {
       return;
     }
 
     const {organization, api, eventView} = this.props;
-    event.preventDefault();
-    event.stopPropagation();
+
     deleteSavedQuery(api, organization.slug, eventView.id!).then(() => {
       addSuccessMessage(t('Query deleted'));
 

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
@@ -28,12 +28,20 @@ class SavedQueryButtonGroup extends React.Component<Props> {
     return index >= 0;
   };
 
+  renderDeleteButton = () => {
+    if (!this.isEditingExistingQuery()) {
+      return null;
+    }
+
+    return <Button icon="icon-trash" />;
+  };
+
   render() {
     const {location, organization, eventView, savedQueries} = this.props;
 
     return (
       <ButtonGroup>
-        <Button icon="icon-trash" />
+        {this.renderDeleteButton()}
         <EventsSaveQueryButton
           location={location}
           organization={organization}

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import {Location} from 'history';
+import styled from 'react-emotion';
 
+import Button from 'app/components/button';
 import {Organization} from 'app/types';
 import {SavedQuery} from 'app/stores/discoverSavedQueriesStore';
 import withDiscoverSavedQueries from 'app/utils/withDiscoverSavedQueries';
@@ -19,13 +21,22 @@ const SavedQueryButtonGroup = (props: Props) => {
   const {location, organization, eventView, savedQueries} = props;
 
   return (
-    <EventsSaveQueryButton
-      location={location}
-      organization={organization}
-      eventView={eventView}
-      savedQueries={savedQueries}
-    />
+    <ButtonGroup>
+      <Button icon="icon-trash" />
+      <EventsSaveQueryButton
+        location={location}
+        organization={organization}
+        eventView={eventView}
+        savedQueries={savedQueries}
+      />
+    </ButtonGroup>
   );
 };
+
+const ButtonGroup = styled('div')`
+  > * + * {
+    margin-left: 8px;
+  }
+`;
 
 export default withDiscoverSavedQueries(SavedQueryButtonGroup);

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
@@ -84,6 +84,8 @@ class SavedQueryButtonGroup extends React.Component<Props> {
 }
 
 const ButtonGroup = styled('div')`
+  display: flex;
+
   > * + * {
     margin-left: 8px;
   }

--- a/tests/js/spec/components/sidebar/discover2Item.spec.jsx
+++ b/tests/js/spec/components/sidebar/discover2Item.spec.jsx
@@ -81,39 +81,4 @@ describe('Sidebar > Discover2Item', function() {
     const menuItems = menu.find('MenuItem');
     expect(menuItems).toHaveLength(2);
   });
-
-  it('handles delete buttons', async function() {
-    const deleteRequest = Client.addMockResponse({
-      url: '/organizations/org-slug/discover/saved/1/',
-      method: 'DELETE',
-    });
-    const wrapper = makeWrapper({organization, client});
-    // Wait for reflux
-    await tick();
-    await tick();
-
-    const nav = wrapper.find('nav');
-    nav.simulate('mouseEnter');
-    await wrapper.update();
-
-    const item = wrapper.find('Menu MenuItem').first();
-    item.find('MenuItemButton[icon="icon-trash"]').simulate('click');
-
-    expect(deleteRequest).toHaveBeenCalled();
-  });
-
-  it('handles edit buttons', async function() {
-    const wrapper = makeWrapper({organization, client});
-    // Wait for reflux
-    await tick();
-    await tick();
-
-    const nav = wrapper.find('nav');
-    nav.simulate('mouseEnter');
-    await wrapper.update();
-
-    const item = wrapper.find('Menu MenuItem').first();
-    item.find('MenuItemButton[icon="icon-edit"]').simulate('click');
-    expect(browserHistory.push).toHaveBeenCalled();
-  });
 });

--- a/tests/js/spec/components/sidebar/discover2Item.spec.jsx
+++ b/tests/js/spec/components/sidebar/discover2Item.spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
-import {browserHistory} from 'react-router';
 
 import {Client} from 'app/api';
 import Discover2Item from 'app/components/sidebar/discover2Item';

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -57,6 +57,28 @@ describe('EventView.fromLocation()', function() {
       environment: ['staging'],
     });
   });
+
+  it('generates event view when there are no query strings', function() {
+    const location = {
+      query: {},
+    };
+
+    const eventView = EventView.fromLocation(location);
+
+    expect(eventView).toMatchObject({
+      id: void 0,
+      name: void 0,
+      fields: [],
+      sorts: [],
+      tags: [],
+      query: '',
+      project: [],
+      start: void 0,
+      end: void 0,
+      statsPeriod: void 0,
+      environment: [],
+    });
+  });
 });
 
 describe('EventView.fromSavedQuery()', function() {

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -173,6 +173,34 @@ describe('EventView.fromSavedQuery()', function() {
     expect(eventView.start).toEqual('');
     expect(eventView.end).toEqual('');
   });
+
+  it('saved queries are equal when start and end datetime differ in format', function() {
+    const saved = {
+      orderby: '-count_timestamp',
+      end: '2019-10-23T19:27:04+0000',
+      name: 'release query',
+      fields: ['release', 'count(timestamp)'],
+      fieldnames: ['release', 'counts'],
+      dateCreated: '2019-10-30T05:10:23.718937Z',
+      environment: ['dev', 'production'],
+      start: '2019-10-20T21:02:51+0000',
+      version: 2,
+      createdBy: '1',
+      dateUpdated: '2019-10-30T07:25:58.291917Z',
+      id: '3',
+      projects: [1],
+    };
+
+    const eventView = EventView.fromSavedQuery(saved);
+
+    const eventView2 = EventView.fromSavedQuery({
+      ...saved,
+      start: '2019-10-20T21:02:51Z',
+      end: '2019-10-23T19:27:04Z',
+    });
+
+    expect(eventView.isEqualTo(eventView2)).toBe(true);
+  });
 });
 
 describe('EventView.generateQueryStringObject()', function() {

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -201,6 +201,41 @@ describe('EventView.fromSavedQuery()', function() {
 
     expect(eventView.isEqualTo(eventView2)).toBe(true);
   });
+
+  it('saved queries are not equal when datetime selection are invalid', function() {
+    const saved = {
+      orderby: '-count_timestamp',
+      end: '2019-10-23T19:27:04+0000',
+      name: 'release query',
+      fields: ['release', 'count(timestamp)'],
+      fieldnames: ['release', 'counts'],
+      dateCreated: '2019-10-30T05:10:23.718937Z',
+      environment: ['dev', 'production'],
+      start: '2019-10-20T21:02:51+0000',
+      version: 2,
+      createdBy: '1',
+      dateUpdated: '2019-10-30T07:25:58.291917Z',
+      id: '3',
+      projects: [1],
+    };
+
+    const eventView = EventView.fromSavedQuery(saved);
+
+    const eventView2 = EventView.fromSavedQuery({
+      ...saved,
+      start: 'invalid',
+    });
+
+    expect(eventView.isEqualTo(eventView2)).toBe(false);
+
+    const eventView3 = EventView.fromSavedQuery({
+      ...saved,
+      end: 'invalid',
+    });
+
+    expect(eventView.isEqualTo(eventView3)).toBe(false);
+    expect(eventView2.isEqualTo(eventView3)).toBe(false);
+  });
 });
 
 describe('EventView.generateQueryStringObject()', function() {

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -1408,6 +1408,9 @@ describe('EventView.isEqualTo()', function() {
     expect(eventView).toMatchObject(state);
     expect(eventView2).toMatchObject(state);
     expect(eventView.isEqualTo(eventView2)).toBe(true);
+
+    // commutativity property holds
+    expect(eventView2.isEqualTo(eventView)).toBe(true);
   });
 
   it('should be false when not equal', function() {

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -1292,7 +1292,7 @@ describe('EventView.isEqualTo()', function() {
     expect(eventView.isEqualTo(eventView2)).toBe(true);
   });
 
-  it.only('should be false when not equal', function() {
+  it('should be false when not equal', function() {
     const state = {
       id: '1234',
       name: 'best query',

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -200,6 +200,20 @@ describe('EventView.fromSavedQuery()', function() {
     });
 
     expect(eventView.isEqualTo(eventView2)).toBe(true);
+
+    const eventView3 = EventView.fromSavedQuery({
+      ...saved,
+      start: '2019-10-20T21:02:51Z',
+    });
+
+    expect(eventView.isEqualTo(eventView3)).toBe(true);
+
+    const eventView4 = EventView.fromSavedQuery({
+      ...saved,
+      end: '2019-10-23T19:27:04Z',
+    });
+
+    expect(eventView.isEqualTo(eventView4)).toBe(true);
   });
 
   it('saved queries are not equal when datetime selection are invalid', function() {
@@ -1411,6 +1425,33 @@ describe('EventView.isEqualTo()', function() {
 
     // commutativity property holds
     expect(eventView2.isEqualTo(eventView)).toBe(true);
+  });
+
+  it('should be true when datetime are equal but differ in format', function() {
+    const state = {
+      id: '1234',
+      name: 'best query',
+      fields: [
+        {field: 'count()', title: 'events'},
+        {field: 'project.id', title: 'project'},
+      ],
+      sorts: generateSorts(['count']),
+      tags: ['foo', 'bar'],
+      query: 'event.type:error',
+      project: [42],
+      start: '2019-10-20T21:02:51+0000',
+      end: '2019-10-23T19:27:04+0000',
+      environment: ['staging'],
+    };
+
+    const eventView = new EventView(state);
+    const eventView2 = new EventView({
+      ...state,
+      start: '2019-10-20T21:02:51Z',
+      end: '2019-10-23T19:27:04Z',
+    });
+
+    expect(eventView.isEqualTo(eventView2)).toBe(true);
   });
 
   it('should be false when not equal', function() {

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -90,6 +90,39 @@ describe('EventView.fromSavedQuery()', function() {
     });
   });
 
+  it('maps saved query with no conditions', function() {
+    const saved = {
+      orderby: '-count_id',
+      name: 'foo bar',
+      fields: ['release', 'count(id)'],
+      fieldnames: ['Release tags', 'counts'],
+      dateCreated: '2019-10-30T06:13:17.632078Z',
+      environment: ['dev', 'production'],
+      version: 2,
+      createdBy: '1',
+      dateUpdated: '2019-10-30T06:13:17.632096Z',
+      id: '5',
+      projects: [1],
+    };
+
+    const eventView = EventView.fromSavedQuery(saved);
+
+    const expected = {
+      id: '5',
+      name: 'foo bar',
+      fields: [
+        {field: 'release', title: 'Release tags'},
+        {field: 'count(id)', title: 'counts'},
+      ],
+      sorts: generateSorts(['count_id']),
+      query: '',
+      project: [1],
+      environment: ['dev', 'production'],
+    };
+
+    expect(eventView).toMatchObject(expected);
+  });
+
   it('maps equality conditions', function() {
     const saved = {
       fields: ['count()', 'id'],

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -608,6 +608,7 @@ describe('EventView.clone()', function() {
 
     expect(eventView).toMatchObject(state);
     expect(eventView2).toMatchObject(state);
+    expect(eventView.isEqualTo(eventView2)).toBe(true);
   });
 });
 
@@ -1259,6 +1260,144 @@ describe('EventView.sortOnField()', function() {
     };
 
     expect(eventView2).toMatchObject(nextState);
+  });
+});
+
+describe('EventView.isEqualTo()', function() {
+  it('should be true when equal', function() {
+    const state = {
+      id: '1234',
+      name: 'best query',
+      fields: [
+        {field: 'count()', title: 'events'},
+        {field: 'project.id', title: 'project'},
+      ],
+      sorts: generateSorts(['count']),
+      tags: ['foo', 'bar'],
+      query: 'event.type:error',
+      project: [42],
+      start: '2019-10-01T00:00:00',
+      end: '2019-10-02T00:00:00',
+      statsPeriod: '14d',
+      environment: ['staging'],
+    };
+
+    const eventView = new EventView(state);
+    const eventView2 = new EventView(state);
+
+    expect(eventView2 !== eventView).toBeTruthy();
+
+    expect(eventView).toMatchObject(state);
+    expect(eventView2).toMatchObject(state);
+    expect(eventView.isEqualTo(eventView2)).toBe(true);
+  });
+
+  it.only('should be false when not equal', function() {
+    const state = {
+      id: '1234',
+      name: 'best query',
+      fields: [
+        {field: 'count()', title: 'events'},
+        {field: 'project.id', title: 'project'},
+      ],
+      sorts: generateSorts(['count']),
+      tags: ['foo', 'bar'],
+      query: 'event.type:error',
+      project: [42],
+      start: '2019-10-01T00:00:00',
+      end: '2019-10-02T00:00:00',
+      statsPeriod: '14d',
+      environment: ['staging'],
+    };
+
+    const eventView = new EventView(state);
+
+    // id differs
+
+    let eventView2 = new EventView({...state, id: '12'});
+    expect(eventView.isEqualTo(eventView2)).toBe(false);
+
+    // name differs
+
+    eventView2 = new EventView({...state, name: 'new query'});
+    expect(eventView.isEqualTo(eventView2)).toBe(false);
+
+    // field differs
+
+    eventView2 = new EventView({
+      ...state,
+      fields: [
+        // swapped columns
+        {field: 'project.id', title: 'project'},
+        {field: 'count()', title: 'events'},
+      ],
+    });
+    expect(eventView.isEqualTo(eventView2)).toBe(false);
+
+    // sort differs
+
+    eventView2 = new EventView({
+      ...state,
+      sorts: [
+        {
+          field: 'count',
+          kind: 'asc',
+        },
+      ],
+    });
+    expect(eventView.isEqualTo(eventView2)).toBe(false);
+
+    // tags differs
+
+    eventView2 = new EventView({
+      ...state,
+      tags: ['foo', 'baz'],
+    });
+    expect(eventView.isEqualTo(eventView2)).toBe(false);
+
+    // query differs
+
+    eventView2 = new EventView({
+      ...state,
+      query: 'event.type:transaction',
+    });
+    expect(eventView.isEqualTo(eventView2)).toBe(false);
+
+    // project differs
+
+    eventView2 = new EventView({
+      ...state,
+      project: [24],
+    });
+    expect(eventView.isEqualTo(eventView2)).toBe(false);
+
+    // date time differs
+
+    eventView2 = new EventView({
+      ...state,
+      start: '2019-09-01T00:00:00',
+    });
+    expect(eventView.isEqualTo(eventView2)).toBe(false);
+
+    eventView2 = new EventView({
+      ...state,
+      end: '2020-09-01T00:00:00',
+    });
+    expect(eventView.isEqualTo(eventView2)).toBe(false);
+
+    eventView2 = new EventView({
+      ...state,
+      statsPeriod: '24d',
+    });
+    expect(eventView.isEqualTo(eventView2)).toBe(false);
+
+    // environment differs
+
+    eventView2 = new EventView({
+      ...state,
+      environment: [],
+    });
+    expect(eventView.isEqualTo(eventView2)).toBe(false);
   });
 });
 

--- a/tests/js/spec/views/eventsV2/saveQueryButton.spec.jsx
+++ b/tests/js/spec/views/eventsV2/saveQueryButton.spec.jsx
@@ -30,7 +30,7 @@ describe('EventsV2 > SaveQueryButton', function() {
       TestStubs.routerContext()
     );
     const button = wrapper.find('StyledDropdownButton');
-    expect(button.text()).toEqual('Save Search');
+    expect(button.text()).toEqual('Save Query');
   });
 
   it('renders a popover for a new query', function() {

--- a/tests/js/spec/views/eventsV2/saveQueryButton.spec.jsx
+++ b/tests/js/spec/views/eventsV2/saveQueryButton.spec.jsx
@@ -30,7 +30,7 @@ describe('EventsV2 > SaveQueryButton', function() {
       TestStubs.routerContext()
     );
     const button = wrapper.find('StyledDropdownButton');
-    expect(button.text()).toEqual('Save Query');
+    expect(button.text()).toEqual('Save query');
   });
 
   it('renders a popover for a new query', function() {

--- a/tests/js/spec/views/eventsV2/saveQueryButton.spec.jsx
+++ b/tests/js/spec/views/eventsV2/saveQueryButton.spec.jsx
@@ -69,7 +69,7 @@ describe('EventsV2 > SaveQueryButton', function() {
 
     const submit = wrapper.find('SaveQueryContainer Button');
     expect(submit).toHaveLength(1);
-    expect(submit.text()).toEqual('Update');
+    expect(submit.text()).toEqual('Save');
   });
 
   it('sets input value based on props', function() {
@@ -85,22 +85,6 @@ describe('EventsV2 > SaveQueryButton', function() {
     button.simulate('click');
 
     // Creating a new query
-    expect(wrapper.find('StyledInput').props().value).toEqual('');
-
-    // Enter edit mode
-    wrapper.setProps({isEditing: true});
-    wrapper.update();
-    expect(wrapper.find('StyledInput').props().value).toEqual(errorsView.name);
-
-    // Edit a different view
-    const otherView = {...errorsView, name: 'other view', id: 99};
-    wrapper.setProps({isEditing: true, eventView: otherView});
-    wrapper.update();
-    expect(wrapper.find('StyledInput').props().value).toEqual(otherView.name);
-
-    // Leave edit mode
-    wrapper.setProps({isEditing: false});
-    wrapper.update();
     expect(wrapper.find('StyledInput').props().value).toEqual('');
   });
 
@@ -142,58 +126,6 @@ describe('EventsV2 > SaveQueryButton', function() {
       query: {
         field: ['title', 'count()'],
         id: '2',
-        fieldnames: ['title', 'total'],
-        name: 'my query',
-        query: '',
-        sort: [],
-        tag: [],
-      },
-    });
-  });
-
-  it('updates an existing query', async function() {
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/discover/saved/1/',
-      method: 'PUT',
-      body: {
-        id: '1',
-        name: 'my query',
-        fields: ['title', 'count()'],
-        fieldnames: ['title', 'total'],
-      },
-    });
-    const errors = EventView.fromEventViewv1(
-      ALL_VIEWS.find(view => view.name === 'Errors')
-    );
-    errors.id = '1';
-    const wrapper = mountWithTheme(
-      <EventSaveQueryButton
-        organization={organization}
-        location={location}
-        eventView={errors}
-        isEditing
-      />,
-      TestStubs.routerContext()
-    );
-    const button = wrapper.find('StyledDropdownButton');
-    button.simulate('click');
-
-    const input = wrapper.find('SaveQueryContainer input');
-    input.simulate('change', {target: {value: 'my query'}});
-
-    const submit = wrapper.find('button[aria-label="Update"]');
-    submit.simulate('click');
-
-    // Wait for reflux
-    await tick();
-    await tick();
-
-    // should redirect to query
-    expect(browserHistory.push).toHaveBeenCalledWith({
-      pathname: location.pathname,
-      query: {
-        field: ['title', 'count()'],
-        id: '1',
         fieldnames: ['title', 'total'],
         name: 'my query',
         query: '',


### PR DESCRIPTION
## TODO

- [x] remove edit link from popout menu
- [x] remove delete link from popout menu
- [x] add `EventView` equality
- [x] add "save as" button
- [x] add "update query" button
- [x] add "delete query" button
- [ ] test: create saved query
- [ ] test: save a saved query as a new query
- [ ] test: delete a saved query
- [ ] test: update a saved query
- [ ] percy tests (may be delegated to a separate PR)

-------


Closes SEN-1030