### PR TITLE
feat(ui): Change `<SmartSearchBar>` to simulate "search" on Enter

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -332,6 +332,7 @@ class SmartSearchBar extends React.Component {
       return;
     }
 
+    const {useFormWrapper} = this.props;
     const {key} = evt;
     const isSelectingDropdownItems = this.state.activeSearchItem !== -1;
 
@@ -396,6 +397,12 @@ class SmartSearchBar extends React.Component {
       if (item && !this.isDefaultDropdownItem(item)) {
         this.onAutoComplete(item.value, item);
       }
+    } else if (key === 'Enter' && !useFormWrapper && !isSelectingDropdownItems) {
+      // If enter is pressed, and we are not wrapping input in a `<form>`, and
+      // we are not selecting an item from the dropdown, then we should consider
+      // the user as finished selecting and perform a "search" since there is no
+      // `<form>` to catch and call `this.onSubmit`
+      this.doSearch();
     }
   };
 

--- a/tests/js/spec/views/events/searchBar.spec.jsx
+++ b/tests/js/spec/views/events/searchBar.spec.jsx
@@ -41,6 +41,12 @@ describe('SearchBar', function() {
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/recent-searches/',
+      method: 'POST',
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
       body: [],
     });
 
@@ -95,6 +101,37 @@ describe('SearchBar', function() {
     selectFirstAutocompleteItem(wrapper);
     wrapper.update();
     expect(wrapper.find('input').prop('value')).toBe('gpu:"Nvidia 1080ti" ');
+  });
+
+  it('if `useFormWrapper` is false, pressing enter when there are no dropdown items selected should blur and call `onSearch` callback', async function() {
+    const onBlur = jest.fn();
+    const onSearch = jest.fn();
+    const wrapper = mountWithTheme(
+      <SearchBar {...props} useFormWrapper={false} onSearch={onSearch} onBlur={onBlur} />,
+      options
+    );
+    await tick();
+    setQuery(wrapper, 'gpu:');
+
+    expect(tagValuesMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/tags/gpu/values/',
+      expect.objectContaining({query: {}})
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('');
+    expect(
+      wrapper
+        .find('SearchDropdown Description')
+        .first()
+        .text()
+    ).toEqual('"Nvidia 1080ti"');
+
+    wrapper.find('input').simulate('keydown', {key: 'Enter'});
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
   });
 
   it('does not requery for event field values if query does not change', async function() {


### PR DESCRIPTION
...keypress when we use the prop `useFormWrapper=false` and there are no dropdown items selected. When it is wrapped in a `<form>`, the enter keypress gets captured by the form and submits the form. When it is not wrapped, we should call the search bar `onSearch` callback when enter is pressed. I think there is an argument that this should be default behavior regardless of the `useFormWrapper` prop.