### PR TITLE
fix(discover) Fetch the first series instead of count

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/events.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.tsx
@@ -16,7 +16,7 @@ type Options = {
   includePrevious?: boolean;
   limit?: number;
   query?: string;
-  yAxis?: 'event_count' | 'user_count';
+  yAxis?: string;
   field?: string[];
   referenceEvent?: string;
 };

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -101,9 +101,17 @@ class EventsChart extends React.Component {
     yAxisOptions: PropTypes.array,
   };
 
-  state = {
-    yAxis: 'event_count',
-  };
+  constructor(props) {
+    super(props);
+    const value =
+      props.yAxisOptions && props.yAxisOptions.length
+        ? props.yAxisOptions[0].value
+        : undefined;
+
+    this.state = {
+      yAxis: value,
+    };
+  }
 
   handleYAxisChange = value => {
     this.setState({yAxis: value});

--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
@@ -47,7 +47,7 @@ type EventsRequestPartialProps = {
   includeTransformedData?: boolean;
   loading?: boolean;
   showLoading?: boolean;
-  yAxis?: 'event_count' | 'user_count';
+  yAxis?: string;
   children: (renderProps: RenderProps) => React.ReactNode;
 };
 


### PR DESCRIPTION
Instead of always fetching count(id) on first load, select the first series in the option list. I've also fixed some downstream typing problems that didn't come up earlier as yAxisSelector is a jsx file.