### PR TITLE
feat(member-invites): Track modal usage analytics

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
@@ -4,6 +4,8 @@ import styled, {css} from 'react-emotion';
 import {t, tn, tct} from 'app/locale';
 import {MEMBER_ROLES} from 'app/constants';
 import {ModalRenderProps} from 'app/actionCreators/modal';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
+import {uniqueId} from 'app/utils/guid';
 import InlineSvg from 'app/components/inlineSvg';
 import Button from 'app/components/button';
 import HookOrDefault from 'app/components/hookOrDefault';
@@ -20,6 +22,7 @@ import InviteRowControl from './inviteRowControl';
 type Props = AsyncComponent['props'] &
   ModalRenderProps & {
     organization: Organization;
+    source?: string;
   };
 
 type State = AsyncComponent['state'] & {
@@ -44,6 +47,26 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
     return {emails: new Set(), teams: new Set(), role: DEFAULT_ROLE};
   }
 
+  /**
+   * Used for analytics tracking of the modals usage.
+   */
+  sessionId = '';
+
+  componentDidMount() {
+    this.sessionId = uniqueId();
+
+    const {organization, source} = this.props;
+
+    trackAnalyticsEvent({
+      eventKey: 'invite_modal.opened',
+      eventName: 'Invite Modal: Opened',
+      organization_id: organization.id,
+      modal_session: this.sessionId,
+      can_invite: this.willInvite,
+      source,
+    });
+  }
+
   getEndpoints(): [string, string][] {
     const orgId = this.props.organization.slug;
 
@@ -65,13 +88,21 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
     };
   }
 
-  reset = () =>
+  reset = () => {
     this.setState({
       pendingInvites: [this.inviteTemplate],
       inviteStatus: {},
       complete: false,
       sendingInvites: false,
     });
+
+    trackAnalyticsEvent({
+      eventKey: 'invite_modal.add_more',
+      eventName: 'Invite Modal: Add More',
+      organization_id: this.props.organization.id,
+      modal_session: this.sessionId,
+    });
+  };
 
   sendInvite = async (invite: NormalizedInvite) => {
     const {slug} = this.props.organization;
@@ -120,6 +151,17 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
     this.setState({sendingInvites: true});
     await Promise.all(this.invites.map(this.sendInvite));
     this.setState({sendingInvites: false, complete: true});
+
+    trackAnalyticsEvent({
+      eventKey: this.willInvite
+        ? 'invite_modal.invites_sent'
+        : 'invite_modal.requests_sent',
+      eventName: this.willInvite
+        ? 'Invite Modal: Invites Sent'
+        : 'Invite Modal: Requests Sent',
+      organization_id: this.props.organization.id,
+      modal_session: this.sessionId,
+    });
   };
 
   addInviteRow = () =>
@@ -325,7 +367,15 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
                   data-test-id="close"
                   priority="primary"
                   size="small"
-                  onClick={closeModal}
+                  onClick={() => {
+                    trackAnalyticsEvent({
+                      eventKey: 'invite_modal.closed',
+                      eventName: 'Invite Modal: Closed',
+                      organization_id: this.props.organization.id,
+                      modal_session: this.sessionId,
+                    });
+                    closeModal();
+                  }}
                 >
                   {t('Close')}
                 </Button>

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersWrapper.tsx
@@ -149,7 +149,7 @@ class OrganizationMembersWrapper extends AsyncView<Props> {
           <Button
             priority="primary"
             size="small"
-            onClick={openInviteMembersModal}
+            onClick={() => openInviteMembersModal({source: 'members_settings'})}
             disabled={!this.canOpeninviteModal}
             title={
               !this.canOpeninviteModal


### PR DESCRIPTION
Tracks:
 - Open Modal (w/ member role, source)
 - Sent invites (w/ num sent, member role)
 - Clicked to add more (w/ num sent, member role)
 - Closed modal (w/ num sent, member role)