### PR TITLE
feat(constants): Import VALID_PLATFORMS from libsemaphore

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -18,10 +18,10 @@ email-reply-parser>=0.2.0,<0.3.0
 enum34>=1.1.6,<1.2.0
 functools32>=3.2.3,<3.3
 futures>=3.2.0,<4.0.0
-# optional but needed for google stuff below
-google-cloud-core==0.29.1
 # optional
 google-cloud-bigtable>=0.32.1,<0.33.0
+# optional but needed for google stuff below
+google-cloud-core==0.29.1
 # optional
 google-cloud-pubsub>=0.35.4,<0.36.0
 # optional
@@ -63,7 +63,7 @@ redis>=2.10.3,<2.10.6
 requests-oauthlib==0.3.3
 requests[security]>=2.20.0,<2.21.0
 selenium==3.141.0
-semaphore>=0.4.57,<0.5.0
+semaphore>=0.4.59,<0.5.0
 sentry-sdk>=0.13.1
 setproctitle>=1.1.7,<1.2.0
 simplejson>=3.2.0,<3.9.0

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -16,6 +16,8 @@ from django.utils.translation import ugettext_lazy as _
 from sentry.utils.integrationdocs import load_doc
 from sentry.utils.geo import rust_geoip
 
+import semaphore
+
 
 def get_all_languages():
     results = []
@@ -224,29 +226,8 @@ SENTRY_RULES = (
 # methods as defined by http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html + PATCH
 HTTP_METHODS = ("GET", "POST", "PUT", "OPTIONS", "HEAD", "DELETE", "TRACE", "CONNECT", "PATCH")
 
-VALID_PLATFORMS = set(
-    [
-        "as3",
-        "c",
-        "cfml",
-        "cocoa",
-        "csharp",
-        "go",
-        "java",
-        "javascript",
-        "node",
-        "objc",
-        "other",
-        "perl",
-        "php",
-        "python",
-        "ruby",
-        "elixir",
-        "haskell",
-        "groovy",
-        "native",
-    ]
-)
+# See https://github.com/getsentry/semaphore/blob/master/general/src/protocol/constants.rs
+VALID_PLATFORMS = semaphore.VALID_PLATFORMS
 
 OK_PLUGIN_ENABLED = _("The {name} integration has been enabled.")
 
@@ -469,7 +450,6 @@ DEFAULT_STORE_NORMALIZER_ARGS = dict(
     geoip_lookup=rust_geoip,
     stacktrace_frames_hard_limit=settings.SENTRY_STACKTRACE_FRAMES_HARD_LIMIT,
     max_stacktrace_frames=settings.SENTRY_MAX_STACKTRACE_FRAMES,
-    valid_platforms=list(VALID_PLATFORMS),
     max_secs_in_future=MAX_SECS_IN_FUTURE,
     max_secs_in_past=MAX_SECS_IN_PAST,
     enable_trimming=True,


### PR DESCRIPTION
`VALID_PLATFORMS` is now owned by Relay, which also performs normalization. We previously used to inject this list into store normalization, but now Relay has to run this independently of Sentry.
