### PR TITLE
feat(discover) Persist the overview chart state in saved queries

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -66,7 +66,10 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
             resolved = resolve_field_list([y_axis], {})
         except InvalidSearchQuery as err:
             raise ParseError(detail=six.text_type(err))
-        aggregate = resolved["aggregations"][0]
+        try:
+            aggregate = resolved["aggregations"][0]
+        except IndexError:
+            raise ParseError(detail="Invalid yAxis value requested.")
         aggregate[2] = "count"
         snuba_args["aggregations"] = [aggregate]
 

--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -24,6 +24,7 @@ class DiscoverSavedQuerySerializer(Serializer):
             "limit",
             "version",
             "tags",
+            "yAxis",
         ]
 
         data = {

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -161,9 +161,10 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
     fieldnames = ListField(child=serializers.CharField(), required=False, allow_null=True)
     query = serializers.CharField(required=False, allow_null=True)
     tags = ListField(child=serializers.CharField(), required=False, allow_null=True)
+    yAxis = serializers.CharField(required=False, allow_null=True)
 
     disallowed_fields = {
-        1: set(["environment", "fieldnames", "query", "tags"]),
+        1: set(["environment", "fieldnames", "query", "tags", "yAxis"]),
         2: set(["groupby", "rollup", "aggregations", "conditions", "limit"]),
     }
 
@@ -200,6 +201,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
             "orderby",
             "limit",
             "tags",
+            "yAxis",
         ]
 
         for key in query_keys:

--- a/src/sentry/static/sentry/app/stores/discoverSavedQueriesStore.tsx
+++ b/src/sentry/static/sentry/app/stores/discoverSavedQueriesStore.tsx
@@ -17,6 +17,7 @@ export type NewQuery = {
   end?: string;
   environment?: Readonly<string[]>;
   tags?: Readonly<string[]>;
+  yAxis?: string;
 };
 
 export type SavedQuery = NewQuery & {

--- a/src/sentry/static/sentry/app/views/events/eventsChart.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsChart.jsx
@@ -12,6 +12,7 @@ import ReleaseSeries from 'app/components/charts/releaseSeries';
 import SentryTypes from 'app/sentryTypes';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
+import {callIfFunction} from 'app/utils/callIfFunction';
 
 import EventsRequest from './utils/eventsRequest';
 import YAxisSelector from './yAxisSelector';
@@ -99,23 +100,26 @@ class EventsChart extends React.Component {
     router: PropTypes.object,
     showLegend: PropTypes.bool,
     yAxisOptions: PropTypes.array,
+    yAxisValue: PropTypes.string,
+    onYAxisChange: PropTypes.func,
   };
-
-  constructor(props) {
-    super(props);
-    const value =
-      props.yAxisOptions && props.yAxisOptions.length
-        ? props.yAxisOptions[0].value
-        : undefined;
-
-    this.state = {
-      yAxis: value,
-    };
-  }
 
   handleYAxisChange = value => {
-    this.setState({yAxis: value});
+    const {onYAxisChange} = this.props;
+    callIfFunction(onYAxisChange, value);
   };
+
+  getYAxisValue() {
+    const {yAxisValue, yAxisOptions} = this.props;
+    if (yAxisValue) {
+      return yAxisValue;
+    }
+    if (yAxisOptions && yAxisOptions.length) {
+      return yAxisOptions[0].value;
+    }
+
+    return undefined;
+  }
 
   render() {
     const {
@@ -134,6 +138,7 @@ class EventsChart extends React.Component {
     } = this.props;
     // Include previous only on relative dates (defaults to relative if no start and end)
     const includePrevious = !start && !end;
+    const yAxis = this.getYAxisValue();
 
     return (
       <ChartZoom
@@ -157,7 +162,7 @@ class EventsChart extends React.Component {
             showLoading={false}
             query={query}
             includePrevious={includePrevious}
-            yAxis={this.state.yAxis}
+            yAxis={yAxis}
           >
             {({loading, reloading, timeseriesData, previousTimeseriesData}) => {
               return (
@@ -172,7 +177,7 @@ class EventsChart extends React.Component {
                         <TransparentLoadingMask visible={reloading} />
                         {yAxisOptions && (
                           <YAxisSelector
-                            selected={this.state.yAxis}
+                            selected={yAxis}
                             options={yAxisOptions}
                             onChange={this.handleYAxisChange}
                           />

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -25,6 +25,7 @@ type LocationQuery = {
   utc?: string | string[];
   statsPeriod?: string | string[];
   cursor?: string | string[];
+  yAxis?: string | string[];
 };
 
 const EXTERNAL_QUERY_STRING_KEYS: Readonly<Array<keyof LocationQuery>> = [
@@ -302,6 +303,7 @@ class EventView {
   end: string | undefined;
   statsPeriod: string | undefined;
   environment: Readonly<string[]>;
+  yAxis: string | undefined;
 
   constructor(props: {
     id: string | undefined;
@@ -315,6 +317,7 @@ class EventView {
     end: string | undefined;
     statsPeriod: string | undefined;
     environment: Readonly<string[]>;
+    yAxis: string | undefined;
   }) {
     // only include sort keys that are included in the fields
 
@@ -347,6 +350,7 @@ class EventView {
     this.end = props.end;
     this.statsPeriod = props.statsPeriod;
     this.environment = props.environment;
+    this.yAxis = props.yAxis;
   }
 
   static fromLocation(location: Location): EventView {
@@ -362,6 +366,7 @@ class EventView {
       end: decodeScalar(location.query.end),
       statsPeriod: decodeScalar(location.query.statsPeriod),
       environment: collectQueryStringByKey(location.query, 'environment'),
+      yAxis: decodeScalar(location.query.yAxis),
     });
   }
 
@@ -385,21 +390,24 @@ class EventView {
       end: undefined,
       statsPeriod: undefined,
       environment: [],
+      yAxis: undefined,
     });
   }
 
   static fromSavedQuery(saved: SavedQuery | LegacySavedQuery): EventView {
-    let fields;
+    let fields, yAxis;
     if (isLegacySavedQuery(saved)) {
       fields = saved.fields.map(field => {
         return {field, title: field};
       });
+      yAxis = undefined;
     } else {
       fields = saved.fields.map((field, i) => {
         const title =
           saved.fieldnames && saved.fieldnames[i] ? saved.fieldnames[i] : field;
         return {field, title};
       });
+      yAxis = saved.yAxis;
     }
 
     return new EventView({
@@ -424,6 +432,7 @@ class EventView {
         },
         'environment'
       ),
+      yAxis,
     });
   }
 
@@ -487,6 +496,7 @@ class EventView {
       end: this.end,
       range: this.statsPeriod,
       environment: this.environment,
+      yAxis: this.yAxis,
     };
 
     if (!newQuery.query) {
@@ -507,6 +517,7 @@ class EventView {
       sort: encodeSorts(this.sorts),
       tag: this.tags,
       query: this.query,
+      yAxis: this.yAxis,
     };
 
     for (const field of EXTERNAL_QUERY_STRING_KEYS) {
@@ -576,6 +587,7 @@ class EventView {
       end: this.end,
       statsPeriod: this.statsPeriod,
       environment: this.environment,
+      yAxis: this.yAxis,
     });
   }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/events.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/events.tsx
@@ -30,7 +30,7 @@ type EventsProps = {
 };
 
 export default class Events extends React.Component<EventsProps> {
-  handleSearch = query => {
+  handleSearch = (query: string) => {
     const {router, location} = this.props;
 
     const queryParams = getParams({
@@ -44,6 +44,20 @@ export default class Events extends React.Component<EventsProps> {
     router.push({
       pathname: location.pathname,
       query: searchQueryParams,
+    });
+  };
+
+  handleYAxisChange = (value: string) => {
+    const {router, location} = this.props;
+
+    const newQuery = {
+      ...location.query,
+      yAxis: value,
+    };
+
+    router.push({
+      pathname: location.pathname,
+      query: newQuery,
     });
   };
 
@@ -83,6 +97,8 @@ export default class Events extends React.Component<EventsProps> {
                 organization={organization}
                 showLegend
                 yAxisOptions={yAxisOptions}
+                yAxisValue={eventView.yAxis}
+                onYAxisChange={this.handleYAxisChange}
               />
             ),
             fixed: 'events chart',

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -38,6 +38,7 @@ describe('EventView.fromLocation()', function() {
         end: '2019-10-02T00:00:00',
         statsPeriod: '14d',
         environment: ['staging'],
+        yAxis: 'p95',
       },
     };
 
@@ -55,6 +56,7 @@ describe('EventView.fromLocation()', function() {
       end: '2019-10-02T00:00:00',
       statsPeriod: '14d',
       environment: ['staging'],
+      yAxis: 'p95',
     });
   });
 
@@ -77,12 +79,13 @@ describe('EventView.fromLocation()', function() {
       end: void 0,
       statsPeriod: void 0,
       environment: [],
+      yAxis: void 0,
     });
   });
 });
 
 describe('EventView.fromSavedQuery()', function() {
-  it('maps basic properties', function() {
+  it('maps basic properties of legacy query', function() {
     const saved = {
       id: '42',
       name: 'best query',
@@ -109,6 +112,7 @@ describe('EventView.fromSavedQuery()', function() {
       end: '2019-10-02T00:00:00',
       statsPeriod: '14d',
       environment: ['staging'],
+      yAxis: undefined,
     });
   });
 
@@ -125,6 +129,7 @@ describe('EventView.fromSavedQuery()', function() {
       dateUpdated: '2019-10-30T06:13:17.632096Z',
       id: '5',
       projects: [1],
+      yAxis: 'count(id)',
     };
 
     const eventView = EventView.fromSavedQuery(saved);
@@ -140,6 +145,7 @@ describe('EventView.fromSavedQuery()', function() {
       query: '',
       project: [1],
       environment: ['dev', 'production'],
+      yAxis: 'count(id)',
     };
 
     expect(eventView).toMatchObject(expected);
@@ -263,6 +269,7 @@ describe('EventView.generateQueryStringObject()', function() {
       statsPeriod: '',
       start: null,
       end: undefined,
+      yAxis: undefined,
     });
     const query = eventView.generateQueryStringObject();
     expect(query.environment).toBeUndefined();
@@ -270,6 +277,7 @@ describe('EventView.generateQueryStringObject()', function() {
     expect(query.start).toBeUndefined();
     expect(query.end).toBeUndefined();
     expect(query.project).toBeUndefined();
+    expect(query.yAxis).toBeUndefined();
   });
 
   it('generates query string object', function() {
@@ -288,6 +296,7 @@ describe('EventView.generateQueryStringObject()', function() {
       end: '2019-10-02T00:00:00',
       statsPeriod: '14d',
       environment: ['staging'],
+      yAxis: 'count(id)',
     };
 
     const eventView = new EventView(state);
@@ -305,6 +314,7 @@ describe('EventView.generateQueryStringObject()', function() {
       end: '2019-10-02T00:00:00',
       statsPeriod: '14d',
       environment: ['staging'],
+      yAxis: 'count(id)',
     };
 
     expect(eventView.generateQueryStringObject()).toEqual(expected);
@@ -435,6 +445,7 @@ describe('EventView.getEventsAPIPayload()', function() {
         utc: 'utc',
         statsPeriod: 'statsPeriod',
         cursor: 'some cursor',
+        yAxis: 'count(id)',
 
         // non-relevant query strings
         bestCountry: 'canada',

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -170,6 +170,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
                     "query": "event.type:error browser.name:Firefox",
                     "range": "24h",
                     "tags": ["release", "environment"],
+                    "yAxis": "count(id)",
                     "version": 2,
                 },
             )
@@ -181,6 +182,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
         assert data["environment"] == ["dev"]
         assert data["query"] == "event.type:error browser.name:Firefox"
         assert data["tags"] == ["release", "environment"]
+        assert data["yAxis"] == "count(id)"
 
     def test_post_success_no_fieldnames(self):
         with self.feature(self.feature_name):

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -171,6 +171,20 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             [{"count": 2}],
         ]
 
+    def test_invalid_aggregate(self):
+        with self.feature("organizations:events-v2"):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
+                    "interval": "1h",
+                    "yAxis": "rubbish",
+                },
+            )
+        assert response.status_code == 400, response.content
+
     def test_aggregate_function_user_count(self):
         with self.feature("organizations:events-v2"):
             response = self.client.get(


### PR DESCRIPTION
Include the overview chart state in URL state and saved queries. I've also fixed a problem in the event-stats endpoint where invalid aggregates would result in 500s.