### PR TITLE
feat(discover2): Add initial metrics for Discover2 (Alberto's list)

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -34,6 +34,8 @@ import {
 } from './styles';
 
 type GridEditableProps<DataRow, ColumnKey> = {
+  onToggleEdit?: (nextValue: boolean) => void;
+
   gridHeadCellButtonProps?: {[prop: string]: any};
 
   isEditable?: boolean;
@@ -130,7 +132,13 @@ class GridEditable<
   }
 
   toggleEdit = () => {
-    this.setState({isEditing: !this.state.isEditing});
+    const nextValue = !this.state.isEditing;
+
+    if (this.props.onToggleEdit) {
+      this.props.onToggleEdit(nextValue);
+    }
+
+    this.setState({isEditing: nextValue});
   };
 
   openModalAddColumnAt = (insertIndex: number) => {

--- a/src/sentry/static/sentry/app/components/tagDistributionMeter/index.jsx
+++ b/src/sentry/static/sentry/app/components/tagDistributionMeter/index.jsx
@@ -27,6 +27,7 @@ export default class TagDistributionMeter extends React.Component {
     renderEmpty: PropTypes.func,
     renderLoading: PropTypes.func,
     renderError: PropTypes.func,
+    onTagClick: PropTypes.func,
   };
 
   static defaultProps = {
@@ -38,7 +39,7 @@ export default class TagDistributionMeter extends React.Component {
   };
 
   renderSegments() {
-    const {segments, totalValues} = this.props;
+    const {segments, totalValues, onTagClick, title} = this.props;
 
     const totalVisible = segments.reduce((sum, value) => sum + value.count, 0);
     const hasOther = totalVisible < totalValues;
@@ -72,6 +73,11 @@ export default class TagDistributionMeter extends React.Component {
                   to={value.isOther ? null : value.url}
                   index={index}
                   isOther={!!value.isOther}
+                  onClick={() => {
+                    if (onTagClick) {
+                      onTagClick(title, value);
+                    }
+                  }}
                 >
                   <Description first={index === 0}>
                     <Percentage>{pctLabel}%</Percentage>

--- a/src/sentry/static/sentry/app/views/eventsV2/eventModalContent.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventModalContent.tsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
+import {Location} from 'history';
 
 import SentryTypes from 'app/sentryTypes';
 import DateTime from 'app/components/dateTime';
@@ -11,7 +12,7 @@ import space from 'app/styles/space';
 import getDynamicText from 'app/utils/getDynamicText';
 import {getMessage, getTitle} from 'app/utils/events';
 import {Event, Organization} from 'app/types';
-import {Location} from 'history';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 
 import EventInterfaces from './eventInterfaces';
 import LinkedIssuePreview from './linkedIssuePreview';
@@ -34,57 +35,74 @@ type EventModalContentProps = {
  * Render the columns and navigation elements inside the event modal view.
  * Controlled by the EventDetails View.
  */
-const EventModalContent = (props: EventModalContentProps) => {
-  const {event, projectId, organization, location, eventView} = props;
+class EventModalContent extends React.Component<EventModalContentProps> {
+  static propTypes = {
+    event: SentryTypes.Event.isRequired,
+    projectId: PropTypes.string.isRequired,
+    organization: SentryTypes.Organization.isRequired,
+    location: PropTypes.object.isRequired,
+  };
 
-  // Having an aggregate field means we want to show pagination/graphs
-  const isGroupedView = hasAggregateField(eventView);
-  const eventJsonUrl = `/api/0/projects/${organization.slug}/${projectId}/events/${
-    event.eventID
-  }/json/`;
+  componentDidMount() {
+    const {event} = this.props;
+    // metrics
+    trackAnalyticsEvent({
+      eventKey: 'discover_v2.event_details',
+      eventName: 'Discoverv2: Opened Event Details',
+      event_type: event.type,
+    });
+  }
 
-  return (
-    <ColumnGrid>
-      <HeaderBox>
-        <EventHeader event={event} />
-        {isGroupedView && <ModalPagination event={event} location={location} />}
-        {isGroupedView &&
-          getDynamicText({
-            value: (
-              <ModalLineGraph
-                organization={organization}
-                currentEvent={event}
-                location={location}
-                eventView={eventView}
-              />
-            ),
-            fixed: 'events chart',
-          })}
-      </HeaderBox>
-      <ContentColumn>
-        <EventInterfaces event={event} projectId={projectId} />
-      </ContentColumn>
-      <SidebarColumn>
-        {event.groupID && (
-          <LinkedIssuePreview groupId={event.groupID} eventId={event.eventID} />
-        )}
-        {event.type === 'transaction' && (
-          <RelatedEvents organization={organization} event={event} location={location} />
-        )}
-        <EventMetadata event={event} eventJsonUrl={eventJsonUrl} />
-        <SidebarBlock>
-          <TagsTable tags={event.tags} />
-        </SidebarBlock>
-      </SidebarColumn>
-    </ColumnGrid>
-  );
-};
-EventModalContent.propTypes = {
-  event: SentryTypes.Event.isRequired,
-  projectId: PropTypes.string.isRequired,
-  organization: SentryTypes.Organization.isRequired,
-  location: PropTypes.object.isRequired,
-};
+  render() {
+    const {event, projectId, organization, location, eventView} = this.props;
+
+    // Having an aggregate field means we want to show pagination/graphs
+    const isGroupedView = hasAggregateField(eventView);
+    const eventJsonUrl = `/api/0/projects/${organization.slug}/${projectId}/events/${
+      event.eventID
+    }/json/`;
+
+    return (
+      <ColumnGrid>
+        <HeaderBox>
+          <EventHeader event={event} />
+          {isGroupedView && <ModalPagination event={event} location={location} />}
+          {isGroupedView &&
+            getDynamicText({
+              value: (
+                <ModalLineGraph
+                  organization={organization}
+                  currentEvent={event}
+                  location={location}
+                  eventView={eventView}
+                />
+              ),
+              fixed: 'events chart',
+            })}
+        </HeaderBox>
+        <ContentColumn>
+          <EventInterfaces event={event} projectId={projectId} />
+        </ContentColumn>
+        <SidebarColumn>
+          {event.groupID && (
+            <LinkedIssuePreview groupId={event.groupID} eventId={event.eventID} />
+          )}
+          {event.type === 'transaction' && (
+            <RelatedEvents
+              organization={organization}
+              event={event}
+              location={location}
+            />
+          )}
+          <EventMetadata event={event} eventJsonUrl={eventJsonUrl} />
+          <SidebarBlock>
+            <TagsTable tags={event.tags} />
+          </SidebarBlock>
+        </SidebarColumn>
+      </ColumnGrid>
+    );
+  }
+}
 
 /**
  * Render the header of the modal content

--- a/src/sentry/static/sentry/app/views/eventsV2/eventModalContent.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventModalContent.tsx
@@ -44,12 +44,13 @@ class EventModalContent extends React.Component<EventModalContentProps> {
   };
 
   componentDidMount() {
-    const {event} = this.props;
+    const {event, organization} = this.props;
     // metrics
     trackAnalyticsEvent({
       eventKey: 'discover_v2.event_details',
       eventName: 'Discoverv2: Opened Event Details',
       event_type: event.type,
+      organization_id: organization.id,
     });
   }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableModalEditColumn.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableModalEditColumn.tsx
@@ -91,7 +91,7 @@ class TableModalEditColumnBodyForm extends React.Component<
   };
 
   componentDidMount() {
-    const {column, indexColumnOrder} = this.props;
+    const {column, indexColumnOrder, organization} = this.props;
 
     const isEditing = !!column;
     const focusedColumnIndex =
@@ -106,6 +106,7 @@ class TableModalEditColumnBodyForm extends React.Component<
           eventKey: 'discover_v2.edit_column.open_modal',
           eventName: 'Discoverv2: Opened modal to edit a column',
           index: focusedColumnIndex,
+          organization_id: organization.id,
         });
       }
     } else {
@@ -114,6 +115,7 @@ class TableModalEditColumnBodyForm extends React.Component<
         eventKey: 'discover_v2.add_column.open_modal',
         eventName: 'Discoverv2: Opened modal to add a column',
         index: focusedColumnIndex,
+        organization_id: organization.id,
       });
     }
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableModalEditColumn.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableModalEditColumn.tsx
@@ -2,6 +2,7 @@ import React, {ReactText} from 'react';
 import styled from 'react-emotion';
 import {uniq} from 'lodash';
 
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {t} from 'app/locale';
 import {Form, SelectField, TextField} from 'app/components/forms';
 import InlineSvg from 'app/components/inlineSvg';
@@ -88,6 +89,34 @@ class TableModalEditColumnBodyForm extends React.Component<
     ),
     name: this.props.column ? this.props.column.name : '',
   };
+
+  componentDidMount() {
+    const {column, indexColumnOrder} = this.props;
+
+    const isEditing = !!column;
+    const focusedColumnIndex =
+      typeof indexColumnOrder === 'number' && indexColumnOrder >= 0
+        ? indexColumnOrder
+        : -1;
+
+    if (isEditing) {
+      if (typeof indexColumnOrder === 'number') {
+        // metrics
+        trackAnalyticsEvent({
+          eventKey: 'discover_v2.edit_column.open_modal',
+          eventName: 'Discoverv2: Opened modal to edit a column',
+          index: focusedColumnIndex,
+        });
+      }
+    } else {
+      // metrics
+      trackAnalyticsEvent({
+        eventKey: 'discover_v2.add_column.open_modal',
+        eventName: 'Discoverv2: Opened modal to add a column',
+        index: focusedColumnIndex,
+      });
+    }
+  }
 
   onChangeAggregation = (value: Aggregation) => {
     const {organization, tagKeys} = this.props;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -141,7 +141,7 @@ class TableView extends React.Component<TableViewProps> {
     // metrics
     trackAnalyticsEvent({
       eventKey: 'discover_v2.delete_column',
-      eventName: 'Discoverv2: A column was updated',
+      eventName: 'Discoverv2: A column was deleted',
       deleted_at: columnIndex,
     });
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -125,7 +125,7 @@ class TableView extends React.Component<TableViewProps> {
     );
 
     if (nextEventView !== eventView) {
-      let changed: 'some' | 'all' | 'aggregate' | 'field' | 'fieldname' = 'some';
+      const changed: string[] = [];
 
       const prevField = explodeField(eventView.fields[columnIndex]);
       const nextField = explodeField(nextEventView.fields[columnIndex]);
@@ -134,20 +134,16 @@ class TableView extends React.Component<TableViewProps> {
       const fieldChanged = prevField.field !== nextField.field;
       const fieldnameChanged = prevField.fieldname !== nextField.fieldname;
 
-      if (aggregationChanged && fieldChanged && fieldnameChanged) {
-        changed = 'all';
+      if (aggregationChanged) {
+        changed.push('aggregate');
       }
 
-      if (aggregationChanged && !fieldChanged && !fieldnameChanged) {
-        changed = 'aggregate';
+      if (fieldChanged) {
+        changed.push('field');
       }
 
-      if (!aggregationChanged && fieldChanged && !fieldnameChanged) {
-        changed = 'field';
-      }
-
-      if (!aggregationChanged && !fieldChanged && fieldnameChanged) {
-        changed = 'fieldname';
+      if (fieldnameChanged) {
+        changed.push('fieldname');
       }
 
       // metrics

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -54,7 +54,7 @@ class TableView extends React.Component<TableViewProps> {
     nextColumn: TableColumn<keyof TableDataRow>,
     insertAt: number | undefined
   ) => {
-    const {location, eventView} = this.props;
+    const {location, eventView, organization} = this.props;
 
     let nextEventView: EventView;
 
@@ -73,6 +73,7 @@ class TableView extends React.Component<TableViewProps> {
         eventKey: 'discover_v2.add_column',
         eventName: 'Discoverv2: Add a new column at an index',
         insert_at_index: insertAt,
+        organization_id: organization.id,
         ...payload,
       });
     } else {
@@ -89,6 +90,7 @@ class TableView extends React.Component<TableViewProps> {
       trackAnalyticsEvent({
         eventKey: 'discover_v2.add_column.right_end',
         eventName: 'Discoverv2: Add a new column at the right end of the table',
+        organization_id: organization.id,
         ...payload,
       });
     }
@@ -104,7 +106,7 @@ class TableView extends React.Component<TableViewProps> {
    * Please read the comment on `_createColumn`
    */
   _updateColumn = (columnIndex: number, nextColumn: TableColumn<keyof TableDataRow>) => {
-    const {location, eventView, tableData} = this.props;
+    const {location, eventView, tableData, organization} = this.props;
 
     if (!tableData || !tableData.meta) {
       return;
@@ -154,6 +156,7 @@ class TableView extends React.Component<TableViewProps> {
         eventName: 'Discoverv2: A column was updated',
         updated_at_index: columnIndex,
         changed,
+        organization_id: organization.id,
         ...payload,
       });
     }
@@ -169,7 +172,7 @@ class TableView extends React.Component<TableViewProps> {
    * Please read the comment on `_createColumn`
    */
   _deleteColumn = (columnIndex: number) => {
-    const {location, eventView, tableData} = this.props;
+    const {location, eventView, tableData, organization} = this.props;
 
     if (!tableData || !tableData.meta) {
       return;
@@ -182,6 +185,7 @@ class TableView extends React.Component<TableViewProps> {
       eventKey: 'discover_v2.delete_column',
       eventName: 'Discoverv2: A column was deleted',
       deleted_at_index: columnIndex,
+      organization_id: organization.id,
     });
 
     pushEventViewToLocation({
@@ -195,7 +199,7 @@ class TableView extends React.Component<TableViewProps> {
    * Please read the comment on `_createColumn`
    */
   _moveColumnCommit = (fromIndex: number, toIndex: number) => {
-    const {location, eventView} = this.props;
+    const {location, eventView, organization} = this.props;
 
     const nextEventView = eventView.withMovedColumn({fromIndex, toIndex});
 
@@ -205,6 +209,7 @@ class TableView extends React.Component<TableViewProps> {
       eventName: 'Discoverv2: A column was moved',
       from_index: fromIndex,
       to_index: toIndex,
+      organization_id: organization.id,
     });
 
     pushEventViewToLocation({
@@ -311,17 +316,21 @@ class TableView extends React.Component<TableViewProps> {
   };
 
   onToggleEdit = (isEditing: boolean) => {
+    const {organization} = this.props;
+
     if (isEditing) {
       // metrics
       trackAnalyticsEvent({
         eventKey: 'discover_v2.table.column_header.edit_mode.enter',
         eventName: 'Discoverv2: Enter column header edit mode',
+        organization_id: organization.id,
       });
     } else {
       // metrics
       trackAnalyticsEvent({
         eventKey: 'discover_v2.table.column_header.edit_mode.exit',
         eventName: 'Discoverv2: Exit column header edit mode',
+        organization_id: organization.id,
       });
     }
   };

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -202,6 +202,7 @@ class TableView extends React.Component<TableViewProps> {
   _moveColumnCommit = (fromIndex: number, toIndex: number) => {
     const {location, eventView, organization} = this.props;
 
+    const prevField = explodeField(eventView.fields[fromIndex]);
     const nextEventView = eventView.withMovedColumn({fromIndex, toIndex});
 
     // metrics
@@ -211,6 +212,9 @@ class TableView extends React.Component<TableViewProps> {
       from_index: fromIndex,
       to_index: toIndex,
       organization_id: organization.id,
+      aggregation: prevField.aggregation,
+      field: prevField.field,
+      fieldname: prevField.fieldname,
     });
 
     pushEventViewToLocation({

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -67,7 +67,7 @@ class TableView extends React.Component<TableViewProps> {
       trackAnalyticsEvent({
         eventKey: 'discover_v2.add_column',
         eventName: 'Discoverv2: Add a new column at an index',
-        index: insertAt,
+        insert_at: insertAt,
       });
     } else {
       // create and insert a column at the right end of the table

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -105,13 +105,15 @@ class TableView extends React.Component<TableViewProps> {
       return;
     }
 
+    const payload = {
+      aggregation: String(nextColumn.aggregation),
+      field: String(nextColumn.field),
+      fieldname: nextColumn.name,
+    };
+
     const nextEventView = eventView.withUpdatedColumn(
       columnIndex,
-      {
-        aggregation: String(nextColumn.aggregation),
-        field: String(nextColumn.field),
-        fieldname: nextColumn.name,
-      },
+      payload,
       tableData.meta
     );
 
@@ -120,6 +122,7 @@ class TableView extends React.Component<TableViewProps> {
       eventKey: 'discover_v2.update_column',
       eventName: 'Discoverv2: A column was updated',
       updated_at: columnIndex,
+      ...payload,
     });
 
     pushEventViewToLocation({

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -67,7 +67,7 @@ class TableView extends React.Component<TableViewProps> {
       trackAnalyticsEvent({
         eventKey: 'discover_v2.add_column',
         eventName: 'Discoverv2: Add a new column at an index',
-        insert_at: insertAt,
+        insert_at_index: insertAt,
         ...payload,
       });
     } else {
@@ -121,7 +121,7 @@ class TableView extends React.Component<TableViewProps> {
     trackAnalyticsEvent({
       eventKey: 'discover_v2.update_column',
       eventName: 'Discoverv2: A column was updated',
-      updated_at: columnIndex,
+      updated_at_index: columnIndex,
       ...payload,
     });
 
@@ -148,7 +148,7 @@ class TableView extends React.Component<TableViewProps> {
     trackAnalyticsEvent({
       eventKey: 'discover_v2.delete_column',
       eventName: 'Discoverv2: A column was deleted',
-      deleted_at: columnIndex,
+      deleted_at_index: columnIndex,
     });
 
     pushEventViewToLocation({

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -138,6 +138,13 @@ class TableView extends React.Component<TableViewProps> {
 
     const nextEventView = eventView.withDeletedColumn(columnIndex, tableData.meta);
 
+    // metrics
+    trackAnalyticsEvent({
+      eventKey: 'discover_v2.delete_column',
+      eventName: 'Discoverv2: A column was updated',
+      deleted_at: columnIndex,
+    });
+
     pushEventViewToLocation({
       location,
       nextEventView,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -78,7 +78,7 @@ class TableView extends React.Component<TableViewProps> {
       });
 
       trackAnalyticsEvent({
-        eventKey: 'discover_v2.add_column_right_side',
+        eventKey: 'discover_v2.add_column.right_end',
         eventName: 'Discoverv2: Add a new column at the right end of the table',
       });
     }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -160,6 +160,14 @@ class TableView extends React.Component<TableViewProps> {
 
     const nextEventView = eventView.withMovedColumn({fromIndex, toIndex});
 
+    // metrics
+    trackAnalyticsEvent({
+      eventKey: 'discover_v2.move_column',
+      eventName: 'Discoverv2: A column was moved',
+      from_index: fromIndex,
+      to_index: toIndex,
+    });
+
     pushEventViewToLocation({
       location,
       nextEventView,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -112,6 +112,13 @@ class TableView extends React.Component<TableViewProps> {
       tableData.meta
     );
 
+    // metrics
+    trackAnalyticsEvent({
+      eventKey: 'discover_v2.update_column',
+      eventName: 'Discoverv2: A column was updated',
+      updated_at: columnIndex,
+    });
+
     pushEventViewToLocation({
       location,
       nextEventView,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -117,13 +117,15 @@ class TableView extends React.Component<TableViewProps> {
       tableData.meta
     );
 
-    // metrics
-    trackAnalyticsEvent({
-      eventKey: 'discover_v2.update_column',
-      eventName: 'Discoverv2: A column was updated',
-      updated_at_index: columnIndex,
-      ...payload,
-    });
+    if (nextEventView !== eventView) {
+      // metrics
+      trackAnalyticsEvent({
+        eventKey: 'discover_v2.update_column',
+        eventName: 'Discoverv2: A column was updated',
+        updated_at_index: columnIndex,
+        ...payload,
+      });
+    }
 
     pushEventViewToLocation({
       location,

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -277,6 +277,22 @@ class TableView extends React.Component<TableViewProps> {
     return nextColumnOrder;
   };
 
+  onToggleEdit = (isEditing: boolean) => {
+    if (isEditing) {
+      // metrics
+      trackAnalyticsEvent({
+        eventKey: 'discover_v2.table.column_header.edit_mode.enter',
+        eventName: 'Discoverv2: Enter column header edit mode',
+      });
+    } else {
+      // metrics
+      trackAnalyticsEvent({
+        eventKey: 'discover_v2.table.column_header.edit_mode.exit',
+        eventName: 'Discoverv2: Exit column header edit mode',
+      });
+    }
+  };
+
   render() {
     const {organization, isLoading, error, tableData, tagKeys, eventView} = this.props;
 
@@ -313,6 +329,7 @@ class TableView extends React.Component<TableViewProps> {
           return (
             <GridEditable
               isEditable
+              onToggleEdit={this.onToggleEdit}
               isColumnDragging={isColumnDragging}
               gridHeadCellButtonProps={{className: DRAGGABLE_COLUMN_CLASSNAME_IDENTIFIER}}
               isLoading={isLoading}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {Location} from 'history';
 
 import {Organization} from 'app/types';
-
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import GridEditable from 'app/components/gridEditable';
 
 import {getFieldRenderer, getAggregateAlias, pushEventViewToLocation} from '../utils';
@@ -63,12 +63,23 @@ class TableView extends React.Component<TableViewProps> {
         },
         insertAt
       );
+
+      trackAnalyticsEvent({
+        eventKey: 'discover_v2.add_column',
+        eventName: 'Discoverv2: Add a new column at an index',
+        index: insertAt,
+      });
     } else {
       // create and insert a column at the right end of the table
       nextEventView = eventView.withNewColumn({
         aggregation: String(nextColumn.aggregation),
         field: String(nextColumn.field),
         fieldname: nextColumn.name,
+      });
+
+      trackAnalyticsEvent({
+        eventKey: 'discover_v2.add_column_right_side',
+        eventName: 'Discoverv2: Add a new column at the right end of the table',
       });
     }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -64,6 +64,7 @@ class TableView extends React.Component<TableViewProps> {
         insertAt
       );
 
+      // metrics
       trackAnalyticsEvent({
         eventKey: 'discover_v2.add_column',
         eventName: 'Discoverv2: Add a new column at an index',
@@ -77,6 +78,7 @@ class TableView extends React.Component<TableViewProps> {
         fieldname: nextColumn.name,
       });
 
+      // metrics
       trackAnalyticsEvent({
         eventKey: 'discover_v2.add_column.right_end',
         eventName: 'Discoverv2: Add a new column at the right end of the table',

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -174,6 +174,8 @@ class TableView extends React.Component<TableViewProps> {
       return;
     }
 
+    const prevField = explodeField(eventView.fields[columnIndex]);
+
     const nextEventView = eventView.withDeletedColumn(columnIndex, tableData.meta);
 
     // metrics
@@ -182,6 +184,9 @@ class TableView extends React.Component<TableViewProps> {
       eventName: 'Discoverv2: A column was deleted',
       deleted_at_index: columnIndex,
       organization_id: organization.id,
+      aggregation: prevField.aggregation,
+      field: prevField.field,
+      fieldname: prevField.fieldname,
     });
 
     pushEventViewToLocation({

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -54,34 +54,37 @@ class TableView extends React.Component<TableViewProps> {
     let nextEventView: EventView;
 
     if (typeof insertAt === 'number') {
+      const payload = {
+        aggregation: String(nextColumn.aggregation),
+        field: String(nextColumn.field),
+        fieldname: nextColumn.name,
+      };
+
       // create and insert a column at a specific index
-      nextEventView = eventView.withNewColumnAt(
-        {
-          aggregation: String(nextColumn.aggregation),
-          field: String(nextColumn.field),
-          fieldname: nextColumn.name,
-        },
-        insertAt
-      );
+      nextEventView = eventView.withNewColumnAt(payload, insertAt);
 
       // metrics
       trackAnalyticsEvent({
         eventKey: 'discover_v2.add_column',
         eventName: 'Discoverv2: Add a new column at an index',
         insert_at: insertAt,
+        ...payload,
       });
     } else {
-      // create and insert a column at the right end of the table
-      nextEventView = eventView.withNewColumn({
+      const payload = {
         aggregation: String(nextColumn.aggregation),
         field: String(nextColumn.field),
         fieldname: nextColumn.name,
-      });
+      };
+
+      // create and insert a column at the right end of the table
+      nextEventView = eventView.withNewColumn(payload);
 
       // metrics
       trackAnalyticsEvent({
         eventKey: 'discover_v2.add_column.right_end',
         eventName: 'Discoverv2: Add a new column at the right end of the table',
+        ...payload,
       });
     }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -11,6 +11,7 @@ import Placeholder from 'app/components/placeholder';
 import TagDistributionMeter from 'app/components/tagDistributionMeter';
 import withApi from 'app/utils/withApi';
 import {Organization} from 'app/types';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 
 import {
   fetchTagDistribution,
@@ -100,6 +101,16 @@ class Tags extends React.Component<Props, State> {
     }
   };
 
+  onTagClick = (tag: string, segment: TagTopValue) => {
+    // metrics
+    trackAnalyticsEvent({
+      eventKey: 'discover_v2.facet_map.clicked',
+      eventName: 'Discoverv2: Clicked on a tag on the facet map',
+      tag,
+      value: segment.value,
+    });
+  };
+
   renderTag(tag) {
     const {location} = this.props;
     const {tags, totalValues} = this.state;
@@ -123,6 +134,7 @@ class Tags extends React.Component<Props, State> {
         totalValues={totalValues}
         isLoading={isLoading}
         renderLoading={() => <StyledPlaceholder height="16px" />}
+        onTagClick={this.onTagClick}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -102,12 +102,14 @@ class Tags extends React.Component<Props, State> {
   };
 
   onTagClick = (tag: string, segment: TagTopValue) => {
+    const {organization} = this.props;
     // metrics
     trackAnalyticsEvent({
       eventKey: 'discover_v2.facet_map.clicked',
       eventName: 'Discoverv2: Clicked on a tag on the facet map',
       tag,
       value: segment.value,
+      organization_id: organization.id,
     });
   };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -35,6 +35,22 @@ export type EventQuery = {
 const AGGREGATE_PATTERN = /^([^\(]+)\(([a-z\._+]*)\)$/;
 const ROUND_BRACKETS_PATTERN = /[\(\)]/;
 
+export function explodeField(
+  field: FieldType
+): {aggregation: string; field: string; fieldname: string} {
+  const results = field.field.match(AGGREGATE_PATTERN);
+
+  if (!results) {
+    return {aggregation: '', field: field.field, fieldname: field.title};
+  }
+
+  if (results.length >= 3) {
+    return {aggregation: results[1], field: results[2], fieldname: field.title};
+  }
+
+  return {aggregation: '', field: field.field, fieldname: field.title};
+}
+
 /**
  * Takes a view and determines if there are any aggregate fields in it.
  *

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -85,6 +85,7 @@ export function getEventTagSearchUrl(
 }
 
 export type TagTopValue = {
+  name: string;
   url: {
     pathname: string;
     query: any;


### PR DESCRIPTION
## TODO

- [ ] add necessary events to https://github.com/getsentry/reload/blob/master/reload_app/events.py
- [x] usage of facet maps (which tag was clicked)
- [x] track insertion index of a new column
- [x] track CTA of add column (opening the modal)
- [x] track CTA of edit column (opening the modal)
- [x] track updated column index
- [ ] ~track CTA "Update column" button on editing a column~ already tracked in add/edit column event
- [x] track clicks of delete column
- [x] track adding columns
- [x] track re-ordering of a column
- [x] track opening of the events detail 
- [ ] reload: https://github.com/getsentry/reload/pull/126