### PR TITLE
feat(discover2): Add initial metrics for Discover2 (Dwang's list)

### DIFF
--- a/src/sentry/static/sentry/app/utils.tsx
+++ b/src/sentry/static/sentry/app/utils.tsx
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import {Query} from 'history';
 
+import {NewQuery} from 'app/stores/discoverSavedQueriesStore';
 import {Project} from 'app/types/index';
 import {appendTagCondition} from 'app/utils/queryString';
 
@@ -270,4 +271,15 @@ export function generateQueryWithTag(
   }
 
   return query;
+}
+
+export function extractAnalyticsQueryFields(payload: NewQuery): Partial<NewQuery> {
+  const {projects, fields, fieldnames, query, tags} = payload;
+  return {
+    projects,
+    fields,
+    fieldnames,
+    query,
+    tags,
+  };
 }

--- a/src/sentry/static/sentry/app/utils.tsx
+++ b/src/sentry/static/sentry/app/utils.tsx
@@ -273,6 +273,10 @@ export function generateQueryWithTag(
   return query;
 }
 
+/**
+ * Takes in a DiscoverV2 NewQuery object and returns a Partial containing
+ * the desired fields to populate into reload analytics
+ */
 export function extractAnalyticsQueryFields(payload: NewQuery): Partial<NewQuery> {
   const {projects, fields, fieldnames, query, tags} = payload;
   return {

--- a/src/sentry/static/sentry/app/views/eventsV2/events.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/events.tsx
@@ -4,6 +4,7 @@ import * as ReactRouter from 'react-router';
 import {Location} from 'history';
 import {omit, uniqBy} from 'lodash';
 
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {Organization} from 'app/types';
 import space from 'app/styles/space';
 import SearchBar from 'app/views/events/searchBar';
@@ -58,6 +59,13 @@ export default class Events extends React.Component<EventsProps> {
     router.push({
       pathname: location.pathname,
       query: newQuery,
+    });
+
+    trackAnalyticsEvent({
+      eventKey: 'discover_v2.y_axis_change',
+      eventName: "Discoverv2: Change chart's y axis",
+      organization_id: this.props.organization.id,
+      y_axis_value: value,
     });
   };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -8,6 +8,7 @@ import {Location} from 'history';
 
 import {Organization} from 'app/types';
 import {t} from 'app/locale';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import SentryTypes from 'app/sentryTypes';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import {PageContent, PageHeader} from 'app/styles/organization';
@@ -59,7 +60,19 @@ class EventsV2 extends React.Component<Props> {
 
       return (
         <LinkContainer key={index}>
-          <Link to={to}>{eventView.name}</Link>
+          <Link
+            to={to}
+            onClick={() => {
+              trackAnalyticsEvent({
+                eventKey: 'discover_v2.prebuilt_query_click',
+                eventName: 'Discoverv2: Click a pre-built query',
+                organization_id: this.props.organization.id,
+                query_name: eventView.name,
+              });
+            }}
+          >
+            {eventView.name}
+          </Link>
         </LinkContainer>
       );
     });

--- a/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/saveQueryButton.tsx
@@ -118,8 +118,8 @@ class EventsSaveQueryButton extends React.Component<Props, State> {
   ) {
     const eventKey =
       (editingExistingQuery
-        ? 'discover_v2.save_existing_query'
-        : 'discover_v2.save_new_query') + type;
+        ? 'discover_v2.save_existing_query_'
+        : 'discover_v2.save_new_query_') + type;
 
     const eventName = editingExistingQuery
       ? EVENT_NAME_EXISTING_MAP[type]

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQueryButtonGroup.tsx
@@ -6,6 +6,8 @@ import {browserHistory} from 'react-router';
 import space from 'app/styles/space';
 import {Client} from 'app/api';
 import {t} from 'app/locale';
+import {extractAnalyticsQueryFields} from 'app/utils';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import Button from 'app/components/button';
 import {Organization} from 'app/types';
 import {
@@ -72,6 +74,13 @@ class SavedQueryButtonGroup extends React.Component<Props> {
         pathname: location.pathname,
         query: {},
       });
+
+      trackAnalyticsEvent({
+        eventKey: 'discover_v2.delete_query',
+        eventName: 'Discoverv2: Deleting a saved query',
+        organization_id: organization.id,
+        ...extractAnalyticsQueryFields(eventView.toNewQuery()),
+      });
     });
   };
 
@@ -98,6 +107,12 @@ class SavedQueryButtonGroup extends React.Component<Props> {
     updateSavedQuery(api, organization.slug, payload).then(_saved => {
       addSuccessMessage(t('Query updated'));
 
+      trackAnalyticsEvent({
+        eventKey: 'discover_v2.update_query',
+        eventName: 'Discoverv2: Updating a saved query',
+        organization_id: organization.id,
+        ...extractAnalyticsQueryFields(payload),
+      });
       // NOTE: there is no need to convert _saved into an EventView and push it
       //       to the browser history, since this.props.eventView already
       //       derives from location.


### PR DESCRIPTION
Added metrics to track the following events happening in discover 2
- track which pre-built queries are clicked on the most
- track how many users are saving searches (saved query)
- track usage of deleted saved query
- track usage of saving a saved query as a new query
- track usage of updating a query
- track what yAxis was clicked

More details here: https://www.notion.so/sentry/0d7d602c42ef4f388d4c0bc4f549d91d?v=8f19a9f88f24474e82f2a690336d1d52