### PR TITLE
feat(outcomes) Support key tsdb models

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -850,20 +850,20 @@ class OutcomesSnubaTest(TestCase):
         super(OutcomesSnubaTest, self).setUp()
         assert requests.post(settings.SENTRY_SNUBA + "/tests/outcomes/drop").status_code == 200
 
-    def __format(self, org_id, project_id, outcome, timestamp):
+    def __format(self, org_id, project_id, outcome, timestamp, key_id):
         return {
             "project_id": project_id,
             "timestamp": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "org_id": org_id,
             "reason": None,
-            "key_id": 1,
+            "key_id": key_id,
             "outcome": outcome,
         }
 
-    def store_outcomes(self, org_id, project_id, outcome, timestamp, num_times):
+    def store_outcomes(self, org_id, project_id, outcome, timestamp, key_id, num_times):
         outcomes = []
         for _ in range(num_times):
-            outcomes.append(self.__format(org_id, project_id, outcome, timestamp))
+            outcomes.append(self.__format(org_id, project_id, outcome, timestamp, key_id))
 
         assert (
             requests.post(

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -23,6 +23,7 @@ from sentry.models import (
     GroupRelease,
     Organization,
     Project,
+    ProjectKey,
     Release,
     ReleaseProject,
 )
@@ -582,6 +583,10 @@ def get_query_params_to_update_for_organizations(query_params):
         organization_id = organization_ids[0]
     elif "project_id" in query_params.filter_keys:
         organization_id, _ = get_query_params_to_update_for_projects(query_params)
+    elif "key_id" in query_params.filter_keys:
+        key_ids = list(set(query_params.filter_keys["key_id"]))
+        project_key = ProjectKey.objects.get(pk=key_ids[0])
+        organization_id = project_key.project.organization_id
     else:
         organization_id = None
 

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import pytz
+import six
 from datetime import datetime, timedelta
 
 from sentry.testutils.cases import OutcomesSnubaTest
@@ -39,18 +40,23 @@ class SnubaTSDBTest(OutcomesSnubaTest):
 
         for outcome in [Outcome.ACCEPTED, Outcome.RATE_LIMITED, Outcome.FILTERED]:
             self.store_outcomes(
-                self.organization.id, self.project.id, outcome.value, self.start_time, 3
+                self.organization.id, self.project.id, outcome.value, self.start_time, 1, 3
             )
             self.store_outcomes(
-                self.organization.id, self.project.id, outcome.value, self.one_day_later, 4
+                self.organization.id, self.project.id, outcome.value, self.one_day_later, 1, 4
             )
 
             # Also create some outcomes we shouldn't be querying
             self.store_outcomes(
-                other_organization.id, self.project.id, outcome.value, self.one_day_later, 5
+                other_organization.id, self.project.id, outcome.value, self.one_day_later, 1, 5
             )
             self.store_outcomes(
-                self.organization.id, self.project.id, outcome.value, self.day_before_start_time, 6
+                self.organization.id,
+                self.project.id,
+                outcome.value,
+                self.day_before_start_time,
+                1,
+                6,
             )
 
         for tsdb_model, granularity, floor_func, start_time_count, day_later_count in [
@@ -82,18 +88,23 @@ class SnubaTSDBTest(OutcomesSnubaTest):
 
         for outcome in [Outcome.ACCEPTED, Outcome.RATE_LIMITED, Outcome.FILTERED]:
             self.store_outcomes(
-                self.organization.id, self.project.id, outcome.value, self.start_time, 3
+                self.organization.id, self.project.id, outcome.value, self.start_time, 1, 3
             )
             self.store_outcomes(
-                self.organization.id, self.project.id, outcome.value, self.one_day_later, 4
+                self.organization.id, self.project.id, outcome.value, self.one_day_later, 1, 4
             )
 
             # Also create some outcomes we shouldn't be querying
             self.store_outcomes(
-                self.organization.id, other_project.id, outcome.value, self.one_day_later, 5
+                self.organization.id, other_project.id, outcome.value, self.one_day_later, 1, 5
             )
             self.store_outcomes(
-                self.organization.id, self.project.id, outcome.value, self.day_before_start_time, 6
+                self.organization.id,
+                self.project.id,
+                outcome.value,
+                self.day_before_start_time,
+                1,
+                6,
             )
 
         for tsdb_model, granularity, floor_func, start_time_count, day_later_count in [
@@ -116,5 +127,76 @@ class SnubaTSDBTest(OutcomesSnubaTest):
             assert response_dict[floor_func(self.one_day_later)] == day_later_count
 
             for time, count in response[self.project.id]:
+                if time not in [floor_func(self.start_time), floor_func(self.one_day_later)]:
+                    assert count == 0
+
+    def test_key_outcomes(self):
+        project_key = self.create_project_key(project=self.project)
+        other_project = self.create_project(organization=self.organization)
+        other_project_key = self.create_project_key(project=other_project)
+
+        for outcome in [Outcome.ACCEPTED, Outcome.RATE_LIMITED, Outcome.FILTERED]:
+            self.store_outcomes(
+                self.organization.id,
+                self.project.id,
+                outcome.value,
+                self.start_time,
+                project_key.id,
+                3,
+            )
+            self.store_outcomes(
+                self.organization.id,
+                self.project.id,
+                outcome.value,
+                self.one_day_later,
+                project_key.id,
+                4,
+            )
+
+            # Also create some outcomes we shouldn't be querying
+            self.store_outcomes(
+                self.organization.id,
+                self.project.id,
+                outcome.value,
+                self.one_day_later,
+                other_project_key.id,
+                5,
+            )
+            self.store_outcomes(
+                self.organization.id,
+                self.project.id,
+                outcome.value,
+                self.day_before_start_time,
+                project_key.id,
+                6,
+            )
+
+        for tsdb_model, granularity, floor_func, start_time_count, day_later_count in [
+            (TSDBModel.key_total_received, 3600, floor_to_hour_epoch, 3 * 3, 4 * 3),
+            (TSDBModel.key_total_rejected, 3600, floor_to_hour_epoch, 3, 4),
+            (TSDBModel.key_total_blacklisted, 3600, floor_to_hour_epoch, 3, 4),
+            (TSDBModel.key_total_received, 10, floor_to_10s_epoch, 3 * 3, 4 * 3),
+            (TSDBModel.key_total_rejected, 10, floor_to_10s_epoch, 3, 4),
+            (TSDBModel.key_total_blacklisted, 10, floor_to_10s_epoch, 3, 4),
+        ]:
+            response = self.db.get_range(
+                # with [project_key.id, six.text_type(project_key.id)], we are imitating the hack in
+                # project_key_stats.py cause that is what `get_range` will be called with.
+                tsdb_model,
+                [project_key.id, six.text_type(project_key.id)],
+                self.start_time,
+                self.now,
+                granularity,
+                None,
+            )
+
+            # Assert that the response has values set for the times we expect, and nothing more
+            assert project_key.id in response.keys()
+            response_dict = {k: v for (k, v) in response[project_key.id]}
+
+            assert response_dict[floor_func(self.start_time)] == start_time_count
+            assert response_dict[floor_func(self.one_day_later)] == day_later_count
+
+            for time, count in response[project_key.id]:
                 if time not in [floor_func(self.start_time), floor_func(self.one_day_later)]:
                     assert count == 0

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -614,6 +614,13 @@ class PrepareQueryParamsTest(TestCase):
         kwargs, _, _ = _prepare_query_params(query_params)
         assert kwargs["organization"] == self.organization.id
 
+    def test_outcomes_dataset_with_key_id(self):
+        key = self.create_project_key(project=self.project)
+        query_params = SnubaQueryParams(dataset=Dataset.Outcomes, filter_keys={"key_id": [key.id]})
+
+        kwargs, _, _ = _prepare_query_params(query_params)
+        assert kwargs["organization"] == self.organization.id
+
     def test_outcomes_dataset_with_no_org_id_given(self):
         query_params = SnubaQueryParams(dataset=Dataset.Outcomes)
 


### PR DESCRIPTION
In addition to `project` and `organization` tsdb models, outcomes should also support the follow project key tsdb models:
* `key_total_received`
* `key_total_rejected`
* `key_total_blacklisted`

I missed this in the initial implementation so adding it now.

## Test plan
* Hitting the key details page locally
* Unit tests