### PR TITLE
feat(ui): Add render prop for `<Form>`

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/createIncidentModal.jsx
+++ b/src/sentry/static/sentry/app/components/modals/createIncidentModal.jsx
@@ -20,10 +20,10 @@ class CreateIncidentModal extends React.Component {
     organization: SentryTypes.Organization.isRequired,
   };
 
-  handleSubmit = async (data, onSuccess, onError, _e, setFormSavingState) => {
+  handleSubmit = async (data, onSuccess, onError, _e, model) => {
     const {api, organization, issues} = this.props;
 
-    setFormSavingState();
+    model.setFormSaving();
 
     try {
       const incident = await createIncident(api, organization, data.title, issues);

--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -18,12 +18,17 @@ type RenderProps = {
   model: FormModel;
 };
 
-type RenderFunction = (props: RenderProps) => React.ReactNode;
+type RenderFunc = (props: RenderProps) => React.ReactNode;
+
+// Type guard for render func.
+function isRenderFunc(func: React.ReactNode | Function): func is RenderFunc {
+  return typeof func === 'function';
+}
 
 type Props = {
   apiMethod: APIRequestMethod;
   apiEndpoint: string;
-  children: React.ReactNode | RenderFunction;
+  children: React.ReactNode | RenderFunc;
   className?: string;
   cancelLabel?: string;
   submitDisabled?: boolean;
@@ -60,7 +65,7 @@ type Context = {
 };
 
 export default class Form extends React.Component<Props> {
-  static propTypes = {
+  static propTypes: any = {
     cancelLabel: PropTypes.string,
     onCancel: PropTypes.func,
     onSubmit: PropTypes.func,
@@ -206,9 +211,7 @@ export default class Form extends React.Component<Props> {
         className={className}
         data-test-id={this.props['data-test-id']}
       >
-        <div>
-          {typeof children === 'function' ? children({model: this.model}) : children}
-        </div>
+        <div>{isRenderFunc(children) ? children({model: this.model}) : children}</div>
 
         {shouldShowFooter && (
           <StyledFooter

--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -55,7 +55,7 @@ type Props = {
     onSubmitSuccess: (data: Data) => void,
     onSubmitError: (error: any) => void,
     e: React.FormEvent,
-    setFormSaving: FormModel['setFormSaving']
+    model: FormModel
   ) => void;
 } & Pick<FormOptions, 'onSubmitSuccess' | 'onSubmitError' | 'onFieldChange'>;
 
@@ -161,7 +161,7 @@ export default class Form extends React.Component<Props> {
         this.onSubmitSuccess,
         this.onSubmitError,
         e,
-        this.model.setFormSaving.bind(this.model)
+        this.model
       );
     } else {
       this.model.saveForm();

--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -14,11 +14,16 @@ import Panel from 'app/components/panels/panel';
 
 type Data = {};
 
+type RenderProps = {
+  model: FormModel;
+};
+
+type RenderFunction = (props: RenderProps) => React.ReactNode;
+
 type Props = {
   apiMethod: APIRequestMethod;
   apiEndpoint: string;
-  children: React.ReactNode;
-
+  children: React.ReactNode | RenderFunction;
   className?: string;
   cancelLabel?: string;
   submitDisabled?: boolean;
@@ -201,7 +206,9 @@ export default class Form extends React.Component<Props> {
         className={className}
         data-test-id={this.props['data-test-id']}
       >
-        <div>{children}</div>
+        <div>
+          {typeof children === 'function' ? children({model: this.model}) : children}
+        </div>
 
         {shouldShowFooter && (
           <StyledFooter


### PR DESCRIPTION
This allows `children` to be a render prop so that we can pass the form
`model` to children components.

Also expose the form model in the `onSubmit` callback.