### PR TITLE
fix(discover2) Don't offer ungraphable aliases.

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/events.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/events.tsx
@@ -79,6 +79,10 @@ export default class Events extends React.Component<EventsProps> {
     const yAxisOptions = uniqBy(
       eventView
         .getAggregateFields()
+        // Exclude last_seen and latest_event as they don't produce useful graphs.
+        .filter(
+          (field: Field) => ['last_seen', 'latest_event'].includes(field.field) === false
+        )
         .map((field: Field) => {
           return {label: field.title, value: field.field};
         })


### PR DESCRIPTION
These fields are 'aggregates' but don't produce useful graphs.