### PR TITLE
feat(pagerduty): Make service_id column nullable

### DIFF
--- a/src/sentry/migrations/0009_auto_20191101_1608.py
+++ b/src/sentry/migrations/0009_auto_20191101_1608.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    # This flag is used to mark that a migration shouldn't be automatically run in
+    # production. We set this to True for operations that we think are risky and want
+    # someone from ops to run manually and monitor.
+    # General advice is that if in doubt, mark your migration as `is_dangerous`.
+    # Some things you should always mark as dangerous:
+    # - Adding indexes to large tables. These indexes should be created concurrently,
+    #   unfortunately we can't run migrations outside of a transaction until Django
+    #   1.10. So until then these should be run manually.
+    # - Large data migrations. Typically we want these to be run manually by ops so that
+    #   they can be monitored. Since data migrations will now hold a transaction open
+    #   this is even more important.
+    # - Adding columns to highly active tables, even ones that are NULL.
+    is_dangerous = False
+
+
+    dependencies = [
+        ('sentry', '0008_auto_20191030_0016'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="pagerdutyservice",
+            name="service_id",
+            field=models.CharField(max_length=255, null=True)
+        )
+    ]


### PR DESCRIPTION
The `pagerdutyservice` table has a column called `service_id`. This was made to store the service IDs that would come from the automated integration flow.

However, keeping the list of services in sync between PD and Sentry was proving hard. So, we want to allow users to be able to change the service name to integration key mapping in case they get into a funky state. In those cases, having them enter a service ID is just adding more friction.

So, we want to drop the service ID column.

To drop that column safely, we have to go through the three steps defined here: https://www.notion.so/sentry/Django-migrations-103e5994029d4345b5b6f5f6f9cac9c7

This is step 1 of those three steps. After this, we will stop using the column in code, and then we'll drop the column entirely.

## Notes to the reviewer
The column has 1 row, so...not very dangerous.

Here's the SQL it will run:
```
BEGIN;
ALTER TABLE "sentry_pagerdutyservice" ALTER COLUMN "service_id" DROP NOT NULL;

COMMIT;
```

## Test plan
* Running the integration flow locally.