### PR TITLE
fix(discover1) Accept all projects in discover1 saved queries as well

### DIFF
--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -219,9 +219,9 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
                     "You must provide an equal number of field names and fields"
                 )
 
-            if data["projects"] == ALL_ACCESS_PROJECTS:
-                data["projects"] = []
-                query["all_projects"] = True
+        if data["projects"] == ALL_ACCESS_PROJECTS:
+            data["projects"] = []
+            query["all_projects"] = True
 
         return {"name": data["name"], "project_ids": data["projects"], "query": query}
 

--- a/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
+++ b/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
@@ -349,7 +349,8 @@ export default function createQueryBuilder(
    */
   function reset(q: any) {
     const [validProjects, invalidProjects] = partition(q.projects || [], project =>
-      defaultProjectIds.includes(project)
+      // -1 means all projects
+      project === -1 ? true : defaultProjectIds.includes(project)
     );
 
     if (invalidProjects.length) {

--- a/tests/js/spec/views/discover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/discover/queryBuilder.spec.jsx
@@ -297,6 +297,14 @@ describe('Query Builder', function() {
       });
       expect(openModal).not.toHaveBeenCalled();
     });
+
+    it('does not display warning for -1 (all projects)', function() {
+      queryBuilder.reset({
+        fields: ['id'],
+        projects: [-1],
+      });
+      expect(openModal).not.toHaveBeenCalled();
+    });
   });
 
   describe('getColumns()', function() {

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -82,6 +82,24 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
             )
         assert response.status_code == 403, response.content
 
+    def test_post_all_projects(self):
+        with self.feature(self.feature_name):
+            url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
+            response = self.client.post(
+                url,
+                {
+                    "name": "All projects",
+                    "projects": [-1],
+                    "conditions": [],
+                    "fields": ["title", "count()"],
+                    "range": "24h",
+                    "orderby": "time",
+                },
+            )
+        assert response.status_code == 201, response.content
+        assert response.data["projects"] == [-1]
+        assert response.data["name"] == "All projects"
+
     def test_post_cannot_use_version_two_fields(self):
         with self.feature(self.feature_name):
             url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])


### PR DESCRIPTION
Previously 'all projects' could only be saved in a discover2 query. This allows all projects for discover 1 saved queries.