### PR TITLE
fix(pagerduty): Make service_id column nullable

### DIFF
--- a/src/sentry/models/integration.py
+++ b/src/sentry/models/integration.py
@@ -18,7 +18,7 @@ class PagerDutyService(Model):
 
     organization_integration = FlexibleForeignKey("sentry.OrganizationIntegration")
     integration_key = models.CharField(max_length=255)
-    service_id = models.CharField(max_length=255)
+    service_id = models.CharField(max_length=255, null=True)
     service_name = models.CharField(max_length=255)
     date_added = models.DateTimeField(default=timezone.now)
 


### PR DESCRIPTION
I'm supposed to make the column nullable in the model, not in the migration.