### PR TITLE
fix(discoverv1): Normalize datetime payload when generating API payload for Discover v1

### DIFF
--- a/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
+++ b/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
@@ -6,6 +6,7 @@ import {Client} from 'app/api';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {t} from 'app/locale';
 import {Project, Organization} from 'app/types';
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 
 import {openModal} from 'app/actionCreators/modal';
 import ConfigStore from 'app/stores/configStore';
@@ -148,11 +149,11 @@ export default function createQueryBuilder(
     const projects = query.projects.length ? query.projects : defaultProjectIds;
 
     // Default to DEFAULT_STATS_PERIOD when no date range selected (either relative or absolute)
-    const {range, start, end} = query;
+    const {statsPeriod, start, end} = getParams(query);
     const hasAbsolute = start && end;
     const daterange = {
       ...(hasAbsolute && {start, end}),
-      ...(range ? {range} : !hasAbsolute && {range: DEFAULT_STATS_PERIOD}),
+      ...(statsPeriod && {range: statsPeriod}),
     };
 
     // Default to all fields if there are none selected, and no aggregation is

--- a/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
+++ b/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
@@ -246,6 +246,17 @@ export default function createQueryBuilder(
       return Promise.reject(new Error('Start date cannot be after end date'));
     }
 
+    const {start, end, statsPeriod} = getParams(data);
+
+    if (start && end) {
+      data.start = start;
+      data.end = end;
+    }
+
+    if (statsPeriod) {
+      data.range = statsPeriod;
+    }
+
     return api
       .requestPromise(endpoint, {includeAllArgs: true, method: 'POST', data} as any)
       .then(([responseData, _, utils]) => {
@@ -282,6 +293,17 @@ export default function createQueryBuilder(
 
     if (moment.utc(data.start).isAfter(moment.utc(data.end))) {
       return Promise.reject(new Error('Start date cannot be after end date'));
+    }
+
+    const {start, end, statsPeriod} = getParams(data);
+
+    if (start && end) {
+      data.start = start;
+      data.end = end;
+    }
+
+    if (statsPeriod) {
+      data.range = statsPeriod;
     }
 
     return api.requestPromise(endpoint, {method: 'POST', data} as any).catch(() => {

--- a/tests/js/spec/views/dashboards/overviewDashboard.spec.jsx
+++ b/tests/js/spec/views/dashboards/overviewDashboard.spec.jsx
@@ -202,7 +202,7 @@ describe('OverviewDashboard', function() {
         data: expect.objectContaining({
           environments: [],
           projects: [2, 3],
-          range: '7d',
+          range: '14d',
 
           fields: [],
           conditions: [],

--- a/tests/js/spec/views/discover/discover.spec.jsx
+++ b/tests/js/spec/views/discover/discover.spec.jsx
@@ -680,8 +680,8 @@ describe('Discover', function() {
         expect.anything(),
         expect.objectContaining({
           data: expect.objectContaining({
-            start: '2017-10-03T02:41:20',
-            end: '2017-10-17T02:41:20',
+            start: '2017-10-03T02:41:20.000',
+            end: '2017-10-17T02:41:20.000',
             utc: false,
           }),
         })
@@ -709,8 +709,8 @@ describe('Discover', function() {
         expect.anything(),
         expect.objectContaining({
           data: expect.objectContaining({
-            start: '2017-10-01T04:00:00',
-            end: '2017-10-02T03:59:59',
+            start: '2017-10-01T04:00:00.000',
+            end: '2017-10-02T03:59:59.000',
             utc: false,
           }),
         })
@@ -729,8 +729,8 @@ describe('Discover', function() {
         expect.anything(),
         expect.objectContaining({
           data: expect.objectContaining({
-            start: '2017-10-01T00:00:00',
-            end: '2017-10-01T23:59:59',
+            start: '2017-10-01T00:00:00.000',
+            end: '2017-10-01T23:59:59.000',
             utc: true,
           }),
         })
@@ -747,8 +747,8 @@ describe('Discover', function() {
         expect.anything(),
         expect.objectContaining({
           data: expect.objectContaining({
-            start: '2017-10-01T04:00:00',
-            end: '2017-10-02T03:59:59',
+            start: '2017-10-01T04:00:00.000',
+            end: '2017-10-02T03:59:59.000',
             utc: false,
           }),
         })

--- a/tests/js/spec/views/discover/index.spec.jsx
+++ b/tests/js/spec/views/discover/index.spec.jsx
@@ -101,8 +101,8 @@ describe('DiscoverContainer', function() {
         TestStubs.DiscoverSavedQuery({
           id: '2',
           name: 'two',
-          start: '2019-04-01T07:00:00.000Z',
-          end: '2019-04-04T06:59:59.000Z',
+          start: '2019-04-01T07:00:00.000',
+          end: '2019-04-04T06:59:59.000',
         }),
       ];
 
@@ -196,8 +196,8 @@ describe('DiscoverContainer', function() {
             data: {
               aggregations: [],
               conditions: [],
-              start: '2019-04-01T07:00:00.000Z',
-              end: '2019-04-04T06:59:59.000Z',
+              start: '2019-04-01T07:00:00.000',
+              end: '2019-04-04T06:59:59.000',
               fields: ['test'],
               limit: expect.any(Number),
               orderby: expect.any(String),
@@ -232,7 +232,7 @@ describe('DiscoverContainer', function() {
         expect.anything(),
         expect.objectContaining({
           data: expect.objectContaining({
-            range: '7d',
+            range: '14d',
             start: null,
             end: null,
             utc: null,

--- a/tests/js/spec/views/discover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/discover/queryBuilder.spec.jsx
@@ -65,7 +65,8 @@ describe('Query Builder', function() {
             aggregations: [['count()', null, 'count']],
             orderby: '-count',
             projects: [2],
-            range: '90d',
+            range: '14d',
+            turbo: true,
           }),
         })
       );
@@ -109,7 +110,8 @@ describe('Query Builder', function() {
             aggregations: [['count()', null, 'count']],
             orderby: '-count',
             projects: [1, 2],
-            range: '90d',
+            range: '14d',
+            turbo: true,
           }),
         })
       );
@@ -154,7 +156,8 @@ describe('Query Builder', function() {
             aggregations: [['count()', null, 'count']],
             orderby: '-count',
             projects: [1, 2],
-            range: '90d',
+            range: '14d',
+            turbo: true,
           }),
         })
       );


### PR DESCRIPTION
1. Choose an absolute datetime thru the global selection header (or thru a graph selection from elsewhere such as Discover v2)

2. Generate and save a query on Discover v1

3. Reload the page.

4. Reload the query saved in step 2. Discover v1 breaks.

------

The cause is that the discover endpoint for saved queries returns datetime strings in a different format. And these datetime strings passed back to another endpoint thru the frontend, and that endpoint doesn't like those datetime strings.