### PR TITLE
ref(ts): Convert `actionCreators/indicator` to typescript

### DIFF
--- a/src/sentry/static/sentry/app/views/monitors/monitorHeaderActions.jsx
+++ b/src/sentry/static/sentry/app/views/monitors/monitorHeaderActions.jsx
@@ -1,17 +1,17 @@
+import {browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {browserHistory} from 'react-router';
 
-import {t} from 'app/locale';
 import {
   addErrorMessage,
   addLoadingMessage,
-  removeIndicator,
+  clearIndicators,
 } from 'app/actionCreators/indicator';
 import {logException} from 'app/utils/logging';
-import SentryTypes from 'app/sentryTypes';
+import {t} from 'app/locale';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
+import SentryTypes from 'app/sentryTypes';
 import withApi from 'app/utils/withApi';
 
 class MonitorHeaderActions extends React.Component {
@@ -35,7 +35,6 @@ class MonitorHeaderActions extends React.Component {
         browserHistory.push(redirectPath);
       })
       .catch(() => {
-        removeIndicator();
         addErrorMessage(t('Unable to remove monitor.'));
       });
   };
@@ -49,12 +48,11 @@ class MonitorHeaderActions extends React.Component {
         data,
       })
       .then(resp => {
-        removeIndicator();
+        clearIndicators();
         this.props.onUpdate && this.props.onUpdate(resp);
       })
       .catch(err => {
         logException(err);
-        removeIndicator();
         addErrorMessage(t('Unable to update monitor.'));
       });
   };

--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {Panel, PanelAlert} from 'app/components/panels';
-import {addLoadingMessage, removeIndicator} from 'app/actionCreators/indicator';
+import {addLoadingMessage, clearIndicators} from 'app/actionCreators/indicator';
 import {t, tn} from 'app/locale';
 import Access from 'app/components/acl/access';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
@@ -118,7 +118,7 @@ class ProjectProcessingIssues extends React.Component {
     this.setState({
       reprocessing: true,
     });
-    const loadingIndicator = addLoadingMessage(t('Started reprocessing..'));
+    addLoadingMessage(t('Started reprocessing..'));
     const {orgId, projectId} = this.props.params;
     this.props.api.request(`/projects/${orgId}/${projectId}/reprocessing/`, {
       method: 'POST',
@@ -134,7 +134,7 @@ class ProjectProcessingIssues extends React.Component {
         });
       },
       complete: () => {
-        removeIndicator(loadingIndicator);
+        clearIndicators();
       },
     });
   };

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
@@ -13,7 +13,6 @@ import {
   addSuccessMessage,
   addErrorMessage,
   addLoadingMessage,
-  removeIndicator,
 } from 'app/actionCreators/indicator';
 import {getDisplayName} from 'app/utils/environment';
 import {t, tct} from 'app/locale';
@@ -64,13 +63,12 @@ class RuleRow extends React.Component<Props, State> {
       return;
     }
 
-    const loadingIndicator = addLoadingMessage();
+    addLoadingMessage();
     const {api, orgId, projectId, data} = this.props;
     api.request(`/projects/${orgId}/${projectId}/rules/${data.id}/`, {
       method: 'DELETE',
       success: () => {
         this.props.onDelete();
-        removeIndicator(loadingIndicator);
         addSuccessMessage(tct('Successfully deleted "[alert]"', {alert: data.name}));
       },
       error: () => {
@@ -78,7 +76,6 @@ class RuleRow extends React.Component<Props, State> {
           error: true,
           loading: false,
         });
-        removeIndicator(loadingIndicator);
         addErrorMessage(t('Unable to save changes. Please try again.'));
       },
     });


### PR DESCRIPTION
This converts `actionCreators/indicator` to typescript as well as fixing
incorrect usages of `removeIndicator()`

Requires:
- [x] https://github.com/getsentry/sentry/pull/15404
- [x] https://github.com/getsentry/sentry/pull/15414
