### PR TITLE
feat(pagerduty): Remove uniqueness constraint on service_id cause we droppin it

### DIFF
--- a/src/sentry/migrations/0010_auto_20191104_1641.py
+++ b/src/sentry/migrations/0010_auto_20191104_1641.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    # This flag is used to mark that a migration shouldn't be automatically run in
+    # production. We set this to True for operations that we think are risky and want
+    # someone from ops to run manually and monitor.
+    # General advice is that if in doubt, mark your migration as `is_dangerous`.
+    # Some things you should always mark as dangerous:
+    # - Adding indexes to large tables. These indexes should be created concurrently,
+    #   unfortunately we can't run migrations outside of a transaction until Django
+    #   1.10. So until then these should be run manually.
+    # - Large data migrations. Typically we want these to be run manually by ops so that
+    #   they can be monitored. Since data migrations will now hold a transaction open
+    #   this is even more important.
+    # - Adding columns to highly active tables, even ones that are NULL.
+    is_dangerous = False
+
+
+    dependencies = [
+        ('sentry', '0009_auto_20191101_1608'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='pagerdutyservice',
+            unique_together=set([]),
+        ),
+    ]

--- a/src/sentry/models/integration.py
+++ b/src/sentry/models/integration.py
@@ -25,7 +25,6 @@ class PagerDutyService(Model):
     class Meta:
         app_label = "sentry"
         db_table = "sentry_pagerdutyservice"
-        unique_together = (("service_id", "organization_integration"),)
 
 
 class PagerDutyServiceProject(Model):


### PR DESCRIPTION
Since we are dropping the service ID column in `pagerdutyservice`, first remove the uniqueness constraint.

## What's the SQL?
```
BEGIN;
ALTER TABLE "sentry_pagerdutyservice" DROP CONSTRAINT "sentry_pagerdutyservice_service_id_314dc4dbbd1c82f9_uniq";

COMMIT;
```