### PR TITLE
feat: Register options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -160,6 +160,12 @@ register("store.empty-interface-sample-rate", default=0.0)
 # regards to filter responses.
 register("store.lie-about-filter-status", default=False)
 
+# Skip nodestore save when saving an event
+register("store.save-event-skips-nodestore", default=False, flags=FLAG_PRIORITIZE_DISK)
+
+# Check postgres for duplicates before saving an event
+register("store.check-duplicates", default=True, flags=FLAG_PRIORITIZE_DISK)
+
 # Symbolicator refactors
 # - Disabling minidump stackwalking in endpoints
 register("symbolicator.minidump-refactor-projects-opt-in", type=Sequence, default=[])  # unused


### PR DESCRIPTION
Register options to be used for
https://github.com/getsentry/sentry/pull/15004 and
https://github.com/getsentry/sentry/pull/15044.

These need to be set on disk before shipping the rest of the changes.