### PR TITLE
feat(pagerduty): Step 2 of dropping the service_id column

### DIFF
--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -79,7 +79,6 @@ class PagerDutyIntegrationProvider(IntegrationProvider):
                 PagerDutyService.objects.create_or_update(
                     organization_integration=org_integration,
                     integration_key=service["integration_key"],
-                    service_id=service["id"],
                     service_name=service["name"],
                 )
 

--- a/src/sentry/migrations/0011_remove_pagerdutyservice_service_id_from_state.py
+++ b/src/sentry/migrations/0011_remove_pagerdutyservice_service_id_from_state.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    # This flag is used to mark that a migration shouldn't be automatically run in
+    # production. We set this to True for operations that we think are risky and want
+    # someone from ops to run manually and monitor.
+    # General advice is that if in doubt, mark your migration as `is_dangerous`.
+    # Some things you should always mark as dangerous:
+    # - Adding indexes to large tables. These indexes should be created concurrently,
+    #   unfortunately we can't run migrations outside of a transaction until Django
+    #   1.10. So until then these should be run manually.
+    # - Large data migrations. Typically we want these to be run manually by ops so that
+    #   they can be monitored. Since data migrations will now hold a transaction open
+    #   this is even more important.
+    # - Adding columns to highly active tables, even ones that are NULL.
+    is_dangerous = False
+
+    dependencies = [("sentry", "0010_auto_20191104_1641")]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[
+                migrations.RemoveField(model_name="pagerdutyservice", name="service_id"),
+            ],
+        )
+    ]

--- a/src/sentry/models/integration.py
+++ b/src/sentry/models/integration.py
@@ -18,7 +18,6 @@ class PagerDutyService(Model):
 
     organization_integration = FlexibleForeignKey("sentry.OrganizationIntegration")
     integration_key = models.CharField(max_length=255)
-    service_id = models.CharField(max_length=255, null=True)
     service_name = models.CharField(max_length=255)
     date_added = models.DateTimeField(default=timezone.now)
 

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -35,7 +35,6 @@ class PagerDutyClientTest(APITestCase):
         )
         self.integration.add_organization(self.organization, self.user)
         self.service = PagerDutyService.objects.create(
-            service_id=SERVICES[0]["service_id"],
             service_name=SERVICES[0]["service_name"],
             integration_key=SERVICES[0]["integration_key"],
             organization_integration=self.integration.organizationintegration_set.first(),

--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -33,7 +33,6 @@ class PagerDutyNotifyActionTest(RuleTestCase):
         )
         self.integration.add_organization(self.organization, self.user)
         self.service = PagerDutyService.objects.create(
-            service_id=SERVICES[0]["service_id"],
             service_name=SERVICES[0]["service_name"],
             integration_key=SERVICES[0]["integration_key"],
             organization_integration=self.integration.organizationintegration_set.first(),
@@ -103,7 +102,6 @@ class PagerDutyNotifyActionTest(RuleTestCase):
         )
         integration.add_organization(self.organization, self.user)
         service = PagerDutyService.objects.create(
-            service_id=service_info["service_id"],
             service_name=service_info["service_name"],
             integration_key=service_info["integration_key"],
             organization_integration=integration.organizationintegration_set.first(),


### PR DESCRIPTION
This is step 2 in https://www.notion.so/sentry/Django-migrations-103e5994029d4345b5b6f5f6f9cac9c7 to remove the service_id column from the pagerdutyservice table.

For more context around why we're removing this column, see: https://github.com/getsentry/sentry/pull/15394

## Test plan
- Tested manually