### PR TITLE
fix(security): Fix XSS in `marked` usage

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/note/input.jsx
+++ b/src/sentry/static/sentry/app/components/activity/note/input.jsx
@@ -1,13 +1,13 @@
 import {MentionsInput, Mention} from 'react-mentions';
 import PropTypes from 'prop-types';
 import React from 'react';
-import marked from 'marked';
 import styled from 'react-emotion';
 
 import {t} from 'app/locale';
 import Button from 'app/components/button';
 import ConfigStore from 'app/stores/configStore';
 import NavTabs from 'app/components/navTabs';
+import marked from 'app/utils/marked';
 import space from 'app/styles/space';
 import textStyles from 'app/styles/text';
 

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.jsx
@@ -1,6 +1,7 @@
+// TODO(grid-emotion): Refactor
+// eslint-disable-next-line no-restricted-imports
 import {Flex} from 'grid-emotion';
 import React from 'react';
-import marked from 'marked';
 import styled from 'react-emotion';
 
 import {extractMultilineFields} from 'app/utils';
@@ -8,6 +9,7 @@ import {t, tct, tn} from 'app/locale';
 import HintPanelItem from 'app/components/panels/hintPanelItem';
 import PlatformIcon from 'app/components/platformIcon';
 import getDynamicText from 'app/utils/getDynamicText';
+import marked from 'app/utils/marked';
 import platforms from 'app/data/platforms';
 import slugify from 'app/utils/slugify';
 import space from 'app/styles/space';

--- a/src/sentry/static/sentry/app/utils/marked.jsx
+++ b/src/sentry/static/sentry/app/utils/marked.jsx
@@ -1,4 +1,4 @@
-import marked from 'marked';
+import marked from 'marked'; // eslint-disable-line no-restricted-imports
 import dompurify from 'dompurify';
 
 function isSafeHref(href, pattern) {
@@ -50,12 +50,11 @@ Renderer.prototype.image = function(href, title, text) {
     out += ' title="' + title + '"';
   }
   out += this.options.xhtml ? '/>' : '>';
-  return dompurify.sanitize(out);
+  return out;
 };
 
 marked.setOptions({
   renderer: new Renderer(),
-  // Disable all HTML input and only accept Markdown
   sanitize: true,
 });
 
@@ -63,7 +62,9 @@ const noParagraphRenderer = new Renderer();
 noParagraphRenderer.paragraph = s => s;
 
 const singleLineRenderer = (text, options) =>
-  marked(text, {...options, renderer: noParagraphRenderer});
+  dompurify.sanitize(marked(text, {...options, renderer: noParagraphRenderer}));
 
-export default marked;
+const sanitizedMarked = (...args) => dompurify.sanitize(marked(...args));
+
 export {singleLineRenderer};
+export default sanitizedMarked;

--- a/src/sentry/static/sentry/app/views/organizationActivity/activityFeedItem.jsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity/activityFeedItem.jsx
@@ -1,7 +1,6 @@
 import {Link} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
-import marked from 'marked';
 import styled from 'react-emotion';
 
 import {t, tn, tct} from 'app/locale';
@@ -16,6 +15,7 @@ import TeamStore from 'app/stores/teamStore';
 import TimeSince from 'app/components/timeSince';
 import Version from 'app/components/version';
 import VersionHoverCard from 'app/components/versionHoverCard';
+import marked from 'app/utils/marked';
 import space from 'app/styles/space';
 
 class ActivityItem extends React.Component {

--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
-import marked from 'marked';
 
 import Alert from 'app/components/alert';
 import {Panel, PanelAlert, PanelHeader} from 'app/components/panels';
@@ -29,6 +28,7 @@ import TextBlock from 'app/views/settings/components/text/textBlock';
 import TextField from 'app/views/settings/components/forms/textField';
 import BetaTag from 'app/components/betaTag';
 import handleXhrErrorResponse from 'app/utils/handleXhrErrorResponse';
+import marked from 'app/utils/marked';
 import recreateRoute from 'app/utils/recreateRoute';
 import routeTitleGen from 'app/utils/routeTitle';
 

--- a/tests/js/spec/utils/marked.spec.jsx
+++ b/tests/js/spec/utils/marked.spec.jsx
@@ -52,6 +52,10 @@ describe('marked', function() {
         `<a href="http://example.com"><img src="">"&gt;test</a>
 <img alt="test" src="http://example.com">`,
       ],
+      [
+        '<script> <img <script> src=x onerror=alert(1) />',
+        '&lt;script&gt; <img src="x">',
+      ],
     ].forEach(expectMarkdown);
   });
 });


### PR DESCRIPTION
Export a wrapped `mark` that sanitizes output. We can ensure future uses of marked use our wrapped util by adding an eslint rule to restrict direct imports of the `marked` library.