### PR TITLE
fix(api): Filter invite requests from teams list

### DIFF
--- a/src/sentry/api/endpoints/team_members.py
+++ b/src/sentry/api/endpoints/team_members.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import OrganizationMember
+from sentry.models import InviteStatus, OrganizationMember
 
 
 class TeamMembersEndpoint(TeamEndpoint):
@@ -13,6 +13,7 @@ class TeamMembersEndpoint(TeamEndpoint):
         queryset = OrganizationMember.objects.filter(
             Q(user__is_active=True) | Q(user__isnull=True),
             organization=team.organization,
+            invite_status=InviteStatus.APPROVED.value,
             teams=team,
         ).select_related("user")
 

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -11,6 +11,7 @@ from sentry.app import env
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
+    InviteStatus,
     OrganizationAccessRequest,
     OrganizationMember,
     OrganizationMemberTeam,
@@ -34,7 +35,10 @@ def get_member_totals(team_list, user):
     """Get the total number of members in each team"""
     if user.is_authenticated():
         query = (
-            Team.objects.filter(id__in=[t.pk for t in team_list])
+            Team.objects.filter(
+                id__in=[t.pk for t in team_list],
+                organizationmember__invite_status=InviteStatus.APPROVED.value,
+            )
             .annotate(member_count=Count("organizationmemberteam"))
             .values("id", "member_count")
         )

--- a/tests/sentry/api/endpoints/test_team_members.py
+++ b/tests/sentry/api/endpoints/test_team_members.py
@@ -2,25 +2,51 @@ from __future__ import absolute_import
 
 import six
 
-from django.core.urlresolvers import reverse
-
 from sentry.testutils import APITestCase
+from sentry.models import InviteStatus
 
 
 class TeamMembersTest(APITestCase):
-    def test_simple(self):
-        org = self.create_organization(owner=self.user)
-        foo = self.create_user("foo@example.com")
-        bar = self.create_user("bar@example.com")
-        team = self.create_team(organization=org)
-        member = self.create_member(organization=org, user=foo, teams=[team])
-        self.create_member(organization=org, user=bar, teams=[])
-        self.login_as(user=self.user)
-        url = reverse(
-            "sentry-api-0-team-members",
-            kwargs={"organization_slug": org.slug, "team_slug": team.slug},
+    endpoint = "sentry-api-0-team-members"
+
+    def setUp(self):
+        self.org = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.org)
+        self.member = self.create_member(organization=self.org, user=self.create_user(), teams=[])
+        self.team_member = self.create_member(
+            organization=self.org, user=self.create_user("1@example.com"), teams=[self.team]
         )
-        response = self.client.get(url)
+
+    def test_simple(self):
+        self.login_as(user=self.user)
+
+        response = self.get_response(self.org.slug, self.team.slug)
         assert response.status_code == 200
         assert len(response.data) == 1
-        assert response.data[0]["id"] == six.text_type(member.id)
+        assert response.data[0]["id"] == six.text_type(self.team_member.id)
+
+    def test_team_members_list_does_not_include_invite_requests(self):
+        pending_invite = self.create_member(
+            email="a@example.com", organization=self.org, teams=[self.team]
+        )
+
+        # invite requests
+        self.create_member(
+            email="b@example.com",
+            organization=self.org,
+            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
+            teams=[self.team],
+        )
+        self.create_member(
+            email="c@example.com",
+            organization=self.org,
+            invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
+            teams=[self.team],
+        )
+        self.login_as(user=self.user)
+
+        response = self.get_response(self.org.slug, self.team.slug)
+        assert response.status_code == 200
+        assert len(response.data) == 2
+        assert response.data[0]["id"] == six.text_type(self.team_member.id)
+        assert response.data[1]["id"] == six.text_type(pending_invite.id)


### PR DESCRIPTION
Exclude invite requests from the team memberCount and list of members within an organization. Related to JAVASCRIPT-4EK