### PR TITLE
fix(invite-requests): Add invite request notification task

### DIFF
--- a/src/sentry/api/endpoints/organization_invite_request_index.py
+++ b/src/sentry/api/endpoints/organization_invite_request_index.py
@@ -10,6 +10,7 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPerm
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize, OrganizationMemberWithTeamsSerializer
 from sentry.models import AuditLogEntryEvent, OrganizationMember, InviteStatus
+from sentry.tasks.members import send_invite_request_notification_email
 from sentry.utils.retries import TimedRetryPolicy
 
 from .organization_member_index import OrganizationMemberSerializer, save_team_assignments
@@ -95,6 +96,6 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
                 event=AuditLogEntryEvent.INVITE_REQUEST_ADD,
             )
 
-        om.send_request_notification_email()
+        send_invite_request_notification_email.delay(om.id)
 
         return Response(serialize(om), status=201)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -533,6 +533,7 @@ CELERY_IMPORTS = (
     "sentry.tasks.deletion",
     "sentry.tasks.digests",
     "sentry.tasks.email",
+    "sentry.tasks.members",
     "sentry.tasks.merge",
     "sentry.tasks.options",
     "sentry.tasks.ping",

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -233,60 +233,6 @@ class OrganizationMember(Model):
             logger = get_logger(name="sentry.mail")
             logger.exception(e)
 
-    def send_request_notification_email(self):
-        from sentry.utils.email import MessageBuilder
-
-        link_args = {"organization_slug": self.organization.slug}
-
-        context = {
-            "email": self.email,
-            "inviter": self.inviter,
-            "organization": self.organization,
-            "organization_link": absolute_uri(
-                reverse("sentry-organization-index", args=[self.organization.slug])
-            ),
-            "pending_requests_link": absolute_uri(
-                reverse("sentry-organization-members-requests", kwargs=link_args)
-            ),
-            "settings_link": absolute_uri(
-                reverse("sentry-organization-settings", args=[self.organization.slug])
-            ),
-        }
-
-        if self.requested_to_join:
-            email_args = {
-                "template": "sentry/emails/organization-join-request.txt",
-                "html_template": "sentry/emails/organization-join-request.html",
-            }
-        elif self.requested_to_be_invited:
-            email_args = {
-                "template": "sentry/emails/organization-invite-request.txt",
-                "html_template": "sentry/emails/organization-invite-request.html",
-            }
-        else:
-            raise RuntimeError("This member is not pending invitation")
-
-        recipients = OrganizationMember.objects.select_related("user").filter(
-            organization_id=self.organization_id,
-            user__isnull=False,
-            invite_status=InviteStatus.APPROVED.value,
-            role__in=(r.id for r in roles.get_all() if r.has_scope("member:write")),
-        )
-
-        msg = MessageBuilder(
-            subject="Access request to %s" % (self.organization.name,),
-            type="organization.invite-request",
-            context=context,
-            **email_args
-        )
-
-        for recipient in recipients:
-            try:
-                msg.send_async([recipient.get_email()])
-            except Exception as e:
-                logger = get_logger(name="sentry.mail")
-                logger.exception(e)
-
     def send_sso_link_email(self, actor, provider):
         from sentry.utils.email import MessageBuilder
 

--- a/src/sentry/tasks/members.py
+++ b/src/sentry/tasks/members.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import, print_function
+
+from django.core.urlresolvers import reverse
+from structlog import get_logger
+
+from sentry import roles
+from sentry.models import OrganizationMember
+from sentry.tasks.base import instrumented_task
+from sentry.utils.email import MessageBuilder
+from sentry.utils.http import absolute_uri
+
+
+@instrumented_task(name="sentry.tasks.send_invite_request_notification_email", queue="email")
+def send_invite_request_notification_email(member_id):
+    try:
+        om = OrganizationMember.objects.get(id=member_id)
+    except OrganizationMember.DoesNotExist:
+        return
+
+    link_args = {"organization_slug": om.organization.slug}
+
+    context = {
+        "email": om.email,
+        "organization_name": om.organization.name,
+        "pending_requests_link": absolute_uri(
+            reverse("sentry-organization-members-requests", kwargs=link_args)
+        ),
+    }
+
+    if om.requested_to_join:
+        email_args = {
+            "template": "sentry/emails/organization-join-request.txt",
+            "html_template": "sentry/emails/organization-join-request.html",
+        }
+        context["settings_link"] = absolute_uri(
+            reverse("sentry-organization-settings", args=[om.organization.slug])
+        )
+
+    elif om.requested_to_be_invited:
+        email_args = {
+            "template": "sentry/emails/organization-invite-request.txt",
+            "html_template": "sentry/emails/organization-invite-request.html",
+        }
+        context["inviter_name"] = om.inviter.get_salutation_name
+    else:
+        raise RuntimeError("This member is not pending invitation")
+
+    recipients = OrganizationMember.objects.select_related("user").filter(
+        organization_id=om.organization_id,
+        user__isnull=False,
+        role__in=(r.id for r in roles.get_all() if r.has_scope("member:write")),
+    )
+
+    msg = MessageBuilder(
+        subject="Access request to %s" % (om.organization.name,),
+        type="organization.invite-request",
+        context=context,
+        **email_args
+    )
+
+    for recipient in recipients:
+        try:
+            msg.send_async([recipient.get_email()])
+        except Exception as e:
+            logger = get_logger(name="sentry.mail")
+            logger.exception(e)

--- a/src/sentry/templates/sentry/emails/organization-invite-request.html
+++ b/src/sentry/templates/sentry/emails/organization-invite-request.html
@@ -5,7 +5,7 @@
 {% block main %}
   <h3>Request for Access</h3>
 
-  <p><strong>{{ inviter.get_salutation_name }}</strong> has requested to invite <strong>{{ email }}</strong> to the <a href="{{ organization_link }}">{{ organization.name }}</a> organization.</p>
+  <p><strong>{{ inviter_name }}</strong> has requested to invite <strong>{{ email }}</strong> to the {{ organization_name }} organization.</p>
 
   <a href="{{ pending_requests_link }}" class="btn">View access requests</a>
 

--- a/src/sentry/templates/sentry/emails/organization-invite-request.txt
+++ b/src/sentry/templates/sentry/emails/organization-invite-request.txt
@@ -1,6 +1,6 @@
 Request for Access
 
-{{ inviter.get_salutation_name }} has requested to invite {{ email }} to the {{ organization.name }} organization.
+{{ inviter_name }} has requested to invite {{ email }} to the {{ organization_name }} organization.
 
 View access requests by clicking the link below:
 

--- a/src/sentry/templates/sentry/emails/organization-join-request.html
+++ b/src/sentry/templates/sentry/emails/organization-join-request.html
@@ -5,7 +5,7 @@
 {% block main %}
   <h3>Request for Access</h3>
 
-  <p><strong>{{ email }}</strong> is requesting to join the <a href="{{ organization_link }}">{{ organization.name }}</a> organization.</p>
+  <p><strong>{{ email }}</strong> is requesting to join the {{ organization_name }} organization.</p>
 
   <a href="{{ pending_requests_link }}" class="btn">View access requests</a>
 

--- a/src/sentry/templates/sentry/emails/organization-join-request.txt
+++ b/src/sentry/templates/sentry/emails/organization-join-request.txt
@@ -1,6 +1,6 @@
 Request for Access
 
-{{ email }} is requesting to join the {{ organization.name }} organization.
+{{ email }} is requesting to join the {{ organization_name }} organization.
 
 View access requests by clicking the link below:
 

--- a/src/sentry/web/frontend/debug/debug_organization_invite_request.py
+++ b/src/sentry/web/frontend/debug/debug_organization_invite_request.py
@@ -15,12 +15,9 @@ class DebugOrganizationInviteRequestEmailView(View):
         user = User(name="Rick Swan")
 
         context = {
-            "organization": org,
-            "inviter": user,
+            "organization_name": org.name,
+            "inviter_name": user.get_salutation_name,
             "email": "test@gmail.com",
-            "organization_link": absolute_uri(
-                reverse("sentry-organization-index", args=[org.slug])
-            ),
             "pending_requests_link": absolute_uri(
                 reverse("sentry-organization-members-requests", args=[org.slug])
             ),

--- a/src/sentry/web/frontend/debug/debug_organization_join_request.py
+++ b/src/sentry/web/frontend/debug/debug_organization_join_request.py
@@ -13,13 +13,10 @@ class DebugOrganizationJoinRequestEmailView(View):
     def get(self, request):
         org = Organization(id=1, slug="default", name="Default")
         context = {
-            "organization": org,
+            "organization_name": org.name,
             "email": "test@gmail.com",
             "pending_requests_link": absolute_uri(
-                reverse("sentry-organization-members", args=[org.slug])
-            ),
-            "organization_link": absolute_uri(
-                reverse("sentry-organization-index", args=[org.slug])
+                reverse("sentry-organization-members-requests", args=[org.slug])
             ),
             "settings_link": absolute_uri(reverse("sentry-organization-settings", args=[org.slug])),
         }

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -127,9 +127,8 @@ class OrganizationJoinRequestTest(APITestCase):
         assert not any(c[0][0] == "join_request.created" for c in mock_record.call_args_list)
 
     @patch("sentry.analytics.record")
-    @patch("sentry.api.endpoints.organization_join_request.logger")
     @patch("sentry.experiments.get", return_value="join_request")
-    def test_request_to_join(self, mock_experiment, mock_log, mock_record):
+    def test_request_to_join(self, mock_experiment, mock_record):
         with self.tasks():
             resp = self.get_response(self.org.slug, email=self.email)
 
@@ -141,16 +140,6 @@ class OrganizationJoinRequestTest(APITestCase):
         assert join_request.user is None
         assert join_request.role == "member"
         assert not join_request.invite_approved
-
-        mock_log.info.assert_called_once_with(
-            "org-join-request.created",
-            extra={
-                "organization_id": self.org.id,
-                "member_id": join_request.id,
-                "email": self.email,
-                "ip_address": "127.0.0.1",
-            },
-        )
 
         mock_record.assert_called_with(
             "join_request.created", member_id=join_request.id, organization_id=self.org.id

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -10,7 +10,6 @@ from mock import patch
 from sentry.auth import manager
 from sentry.models import InviteStatus, OrganizationMember, INVITE_DAYS_VALID
 from sentry.testutils import TestCase
-from sentry.tasks.members import send_invite_request_notification_email
 
 
 class OrganizationMemberTest(TestCase):
@@ -40,36 +39,6 @@ class OrganizationMemberTest(TestCase):
         msg = mail.outbox[0]
 
         assert msg.to == ["foo@example.com"]
-
-    def test_send_invite_request_notification_email(self):
-        organization = self.create_organization()
-
-        user1 = self.create_user(email="manager@localhost")
-        user2 = self.create_user(email="owner@localhost")
-        user3 = self.create_user(email="member@localhost")
-
-        self.create_member(organization=organization, user=user1, role="manager")
-        self.create_member(organization=organization, user=user2, role="owner")
-        self.create_member(organization=organization, user=user3, role="member")
-
-        member = OrganizationMember.objects.create(
-            id=1,
-            role="manager",
-            organization=organization,
-            email="foo@example.com",
-            inviter=user3,
-            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
-        )
-        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
-            send_invite_request_notification_email(member.id)
-
-        assert len(mail.outbox) == 2
-
-        assert mail.outbox[0].to == ["manager@localhost"]
-        assert mail.outbox[1].to == ["owner@localhost"]
-
-        expected_subject = "Access request to %s" % (organization.name,)
-        assert mail.outbox[0].subject == expected_subject
 
     def test_send_sso_link_email(self):
         organization = self.create_organization()

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -10,6 +10,7 @@ from mock import patch
 from sentry.auth import manager
 from sentry.models import InviteStatus, OrganizationMember, INVITE_DAYS_VALID
 from sentry.testutils import TestCase
+from sentry.tasks.members import send_invite_request_notification_email
 
 
 class OrganizationMemberTest(TestCase):
@@ -40,7 +41,7 @@ class OrganizationMemberTest(TestCase):
 
         assert msg.to == ["foo@example.com"]
 
-    def test_send_request_notification_email(self):
+    def test_send_invite_request_notification_email(self):
         organization = self.create_organization()
 
         user1 = self.create_user(email="manager@localhost")
@@ -51,7 +52,7 @@ class OrganizationMemberTest(TestCase):
         self.create_member(organization=organization, user=user2, role="owner")
         self.create_member(organization=organization, user=user3, role="member")
 
-        member = OrganizationMember(
+        member = OrganizationMember.objects.create(
             id=1,
             role="manager",
             organization=organization,
@@ -60,7 +61,7 @@ class OrganizationMemberTest(TestCase):
             invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
         )
         with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
-            member.send_request_notification_email()
+            send_invite_request_notification_email(member.id)
 
         assert len(mail.outbox) == 2
 

--- a/tests/sentry/tasks/test_members.py
+++ b/tests/sentry/tasks/test_members.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, print_function
+
+from django.core import mail
+
+from sentry.models import InviteStatus, OrganizationMember
+from sentry.testutils import TestCase
+from sentry.tasks.members import send_invite_request_notification_email
+
+
+class InviteRequestNotificationTest(TestCase):
+    def test_send_notification(self):
+        organization = self.create_organization()
+
+        user1 = self.create_user(email="manager@localhost")
+        user2 = self.create_user(email="owner@localhost")
+        user3 = self.create_user(email="member@localhost")
+
+        self.create_member(organization=organization, user=user1, role="manager")
+        self.create_member(organization=organization, user=user2, role="owner")
+        self.create_member(organization=organization, user=user3, role="member")
+
+        member = OrganizationMember.objects.create(
+            role="manager",
+            organization=organization,
+            email="foo@example.com",
+            inviter=user3,
+            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
+        )
+        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
+            send_invite_request_notification_email(member.id)
+
+        assert len(mail.outbox) == 2
+
+        assert mail.outbox[0].to == ["manager@localhost"]
+        assert mail.outbox[1].to == ["owner@localhost"]
+
+        expected_subject = "Access request to %s" % (organization.name,)
+        assert mail.outbox[0].subject == expected_subject


### PR DESCRIPTION
There is a noticeable lag (~2+ seconds) when requesting to join, so moving the notification email to an async task. Almost all of that time is spent rendering the css for the emails, which happens synchronously before the emails are sent async.