### PR TITLE
perf(db): fetch existing groups from cache.

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -913,7 +913,7 @@ class EventManager(object):
             )
 
         else:
-            group = Group.objects.get(id=existing_group_id)
+            group = Group.objects.get_from_cache(id=existing_group_id)
 
             group_is_new = False
 


### PR DESCRIPTION
There are a few references to `group.*` after we rebind it from `GroupHash`:
 - Assigning the id to any `GroupHash`es that are locked in migration.
 - Passing arguments to `buffers.incr`
   - Calculating ScoreClause ( bespoke priority-o-meter)
   - Selecting a date that is `max(event.datetime, group.last_seen)`
 - Setting `max(event.datetime, group.last_seen)` for `acvite_at/last_seen` during regression.
 - `group.is_resolved()` during `_handle_regression`.

The only thing I can possibly see being problematic is the status not atomically updating. I'm unsure if this is a realistic problem or if there is anything we can do without it.

If anyone else thinks this is un-doable, I'll change this PR to add comments to why we can't cache it.