### PR TITLE
fix(app-platform): don't send issue_ignored webhook for issue unresolved action

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -710,20 +710,20 @@ def update_groups(request, projects, organization_id, search_fn):
                     "ignoreWindow": ignore_window,
                 }
 
-            groups_by_project_id = defaultdict(list)
-            for group in group_list:
-                groups_by_project_id[group.project_id].append(group)
+                groups_by_project_id = defaultdict(list)
+                for group in group_list:
+                    groups_by_project_id[group.project_id].append(group)
 
-            for project in projects:
-                project_groups = groups_by_project_id.get(project.id)
-                if project_groups:
-                    issue_ignored.send_robust(
-                        project=project,
-                        user=acting_user,
-                        group_list=project_groups,
-                        activity_data=activity_data,
-                        sender=update_groups,
-                    )
+                for project in projects:
+                    project_groups = groups_by_project_id.get(project.id)
+                    if project_groups:
+                        issue_ignored.send_robust(
+                            project=project,
+                            user=acting_user,
+                            group_list=project_groups,
+                            activity_data=activity_data,
+                            sender=update_groups,
+                        )
 
             for group in group_list:
                 group.status = new_status

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1,8 +1,14 @@
 from __future__ import absolute_import
 
-from mock import patch
+from mock import patch, Mock
+from django.http import QueryDict
 
-from sentry.api.helpers.group_index import validate_search_filter_permissions, ValidationError
+from sentry.models import GroupStatus
+from sentry.api.helpers.group_index import (
+    validate_search_filter_permissions,
+    ValidationError,
+    update_groups,
+)
 from sentry.api.issue_search import parse_search_query
 from sentry.testutils import TestCase
 
@@ -58,3 +64,58 @@ class ValidateSearchFilterPermissionsTest(TestCase):
 
         self.run_test(query)
         self.assert_analytics_recorded(mock_record)
+
+
+class UpdateGroupsTest(TestCase):
+    @patch("sentry.signals.issue_ignored.send_robust")
+    def test_unresolving_resolved_group(self, send_robust):
+        resolved_group = self.create_group(status=GroupStatus.RESOLVED)
+        assert resolved_group.status == GroupStatus.RESOLVED
+
+        request = self.make_request(user=self.user, method="GET")
+        request.user = self.user
+        request.data = {"status": "unresolved"}
+        request.GET = QueryDict(query_string="id={}".format(resolved_group.id))
+
+        search_fn = Mock()
+        update_groups(request, [self.project], self.organization.id, search_fn)
+
+        resolved_group.refresh_from_db()
+
+        assert resolved_group.status == GroupStatus.UNRESOLVED
+        assert not send_robust.called
+
+    @patch("sentry.signals.issue_resolved.send_robust")
+    def test_resolving_unresolved_group(self, send_robust):
+        unresolved_group = self.create_group(status=GroupStatus.UNRESOLVED)
+        assert unresolved_group.status == GroupStatus.UNRESOLVED
+
+        request = self.make_request(user=self.user, method="GET")
+        request.user = self.user
+        request.data = {"status": "resolved"}
+        request.GET = QueryDict(query_string="id={}".format(unresolved_group.id))
+
+        search_fn = Mock()
+        update_groups(request, [self.project], self.organization.id, search_fn)
+
+        unresolved_group.refresh_from_db()
+
+        assert unresolved_group.status == GroupStatus.RESOLVED
+        assert send_robust.called
+
+    @patch("sentry.signals.issue_ignored.send_robust")
+    def test_ignoring_group(self, send_robust):
+        group = self.create_group()
+
+        request = self.make_request(user=self.user, method="GET")
+        request.user = self.user
+        request.data = {"status": "ignored"}
+        request.GET = QueryDict(query_string="id={}".format(group.id))
+
+        search_fn = Mock()
+        update_groups(request, [self.project], self.organization.id, search_fn)
+
+        group.refresh_from_db()
+
+        assert group.status == GroupStatus.IGNORED
+        assert send_robust.called


### PR DESCRIPTION
The code for sending `issue_ignored` webhooks was indented incorrectly so the `issue_ignored` webhooks were being sent when an issue was unresolved