### PR TITLE
perf: Cache UserIp.log calls

### DIFF
--- a/src/sentry/models/userip.py
+++ b/src/sentry/models/userip.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.conf import settings
+from django.core.cache import cache
 from django.db import models
 from django.utils import timezone
 
@@ -27,6 +28,12 @@ class UserIP(Model):
 
     @classmethod
     def log(cls, user, ip_address):
+        # Only log once every 5 minutes for the same user/ip_address pair
+        # since this is hit pretty frequently by all API calls in the UI, etc.
+        cache_key = "userip.log:%d:%s" % (user.id, ip_address)
+        if cache.get(cache_key):
+            return
+
         try:
             geo = geo_by_addr(ip_address)
         except Exception:
@@ -37,3 +44,4 @@ class UserIP(Model):
             values.update({"country_code": geo["country_code"], "region_code": geo["region"]})
 
         UserIP.objects.create_or_update(user=user, ip_address=ip_address, values=values)
+        cache.set(cache_key, 1, 300)

--- a/tests/sentry/lang/java/test_plugin.py
+++ b/tests/sentry/lang/java/test_plugin.py
@@ -98,7 +98,6 @@ class BasicResolvingIntegrationTest(TestCase):
                 "sentry_eventuser": 1,
                 "sentry_groupedmessage": 1,
                 "sentry_message": 1,
-                "sentry_userip": 1,
                 "sentry_userreport": 1,
             }
         ):


### PR DESCRIPTION
We call this very frequently and can cause Postgres row contention with
concurrent requests. There's arguably little value in UPDATEing the row
more than once every so often rather than on every single request.

In theory, this is something that can go through buffers too if we want
to go that approach in the future.