### PR TITLE
feat: Skip EventDataDeletionTask in scheduled cleanup

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function
 
+import os
 from sentry import eventstore, nodestore
 from sentry.models import Event, EventAttachment, UserReport
 
@@ -91,14 +92,16 @@ class GroupDeletionTask(ModelDeletionTask):
 
         relations.extend([ModelRelation(m, {"group_id": instance.id}) for m in model_list])
 
-        relations.extend(
-            [
-                BaseRelation(
-                    {"group_id": instance.id, "project_id": instance.project_id},
-                    EventDataDeletionTask,
-                )
-            ]
-        )
+        # Skip EventDataDeletionTask if this is being called from cleanup.py
+        if not os.environ.get("_SENTRY_CLEANUP"):
+            relations.extend(
+                [
+                    BaseRelation(
+                        {"group_id": instance.id, "project_id": instance.project_id},
+                        EventDataDeletionTask,
+                    )
+                ]
+            )
 
         return relations
 

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import mock
+import os
 from uuid import uuid4
 
 from sentry.models import (
@@ -11,98 +13,105 @@ from sentry.models import (
     GroupHash,
     GroupMeta,
     GroupRedirect,
-    GroupStatus,
-    ScheduledDeletion,
     UserReport,
 )
 from sentry import nodestore
 from sentry.deletions.defaults.group import EventDataDeletionTask
-from sentry.tasks.deletion import run_deletion
-
-from sentry.testutils import TestCase, SnubaTestCase
+from sentry.tasks.deletion import delete_groups
+from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class DeleteGroupTest(TestCase, SnubaTestCase):
-    def test_simple(self):
-        EventDataDeletionTask.DEFAULT_CHUNK_SIZE = 1  # test chunking logic
-        event_id = "a" * 32
-        event_id2 = "b" * 32
-        event_id3 = "c" * 32
-        project = self.create_project()
-        node_id = Event.generate_node_id(project.id, event_id)
-        node_id2 = Event.generate_node_id(project.id, event_id2)
-        node_id3 = Event.generate_node_id(project.id, event_id3)
+    def setUp(self):
+        super(DeleteGroupTest, self).setUp()
+        self.event_id = "a" * 32
+        self.event_id2 = "b" * 32
+        self.event_id3 = "c" * 32
 
-        event = self.store_event(
+        self.project = self.create_project()
+
+        self.event = self.store_event(
             data={
-                "event_id": event_id,
+                "event_id": self.event_id,
                 "tags": {"foo": "bar"},
                 "timestamp": iso_format(before_now(minutes=1)),
                 "fingerprint": ["group1"],
             },
-            project_id=project.id,
+            project_id=self.project.id,
         )
 
         self.store_event(
             data={
-                "event_id": event_id2,
+                "event_id": self.event_id2,
                 "timestamp": iso_format(before_now(minutes=1)),
                 "fingerprint": ["group1"],
             },
-            project_id=project.id,
+            project_id=self.project.id,
         )
 
         self.store_event(
             data={
-                "event_id": event_id3,
+                "event_id": self.event_id3,
                 "timestamp": iso_format(before_now(minutes=1)),
                 "fingerprint": ["group2"],
             },
-            project_id=project.id,
+            project_id=self.project.id,
         )
-
-        group = event.group
-        group.update(status=GroupStatus.PENDING_DELETION)
-
-        project = self.create_project()
+        group = self.event.group
 
         UserReport.objects.create(
-            group_id=group.id, project_id=event.project_id, name="With group id"
+            group_id=group.id, project_id=self.event.project_id, name="With group id"
         )
         UserReport.objects.create(
-            event_id=event.event_id, project_id=event.project_id, name="With event id"
+            event_id=self.event.event_id, project_id=self.event.project_id, name="With event id"
         )
         EventAttachment.objects.create(
-            event_id=event.event_id,
-            project_id=event.project_id,
+            event_id=self.event.event_id,
+            project_id=self.event.project_id,
             file=File.objects.create(name="hello.png", type="image/png"),
             name="hello.png",
         )
-
-        GroupAssignee.objects.create(group=group, project=project, user=self.user)
-        GroupHash.objects.create(project=project, group=group, hash=uuid4().hex)
+        GroupAssignee.objects.create(group=group, project=self.project, user=self.user)
+        GroupHash.objects.create(project=self.project, group=group, hash=uuid4().hex)
         GroupMeta.objects.create(group=group, key="foo", value="bar")
         GroupRedirect.objects.create(group_id=group.id, previous_group_id=1)
 
-        deletion = ScheduledDeletion.schedule(group, days=0)
-        deletion.update(in_progress=True)
+        self.node_id = Event.generate_node_id(self.project.id, self.event_id)
+        self.node_id2 = Event.generate_node_id(self.project.id, self.event_id2)
+        self.node_id3 = Event.generate_node_id(self.project.id, self.event_id3)
 
-        assert nodestore.get(node_id)
-        assert nodestore.get(node_id2)
-        assert nodestore.get(node_id3)
+    def test_simple(self):
+        EventDataDeletionTask.DEFAULT_CHUNK_SIZE = 1  # test chunking logic
+        group = self.event.group
+        assert nodestore.get(self.node_id)
+        assert nodestore.get(self.node_id2)
+        assert nodestore.get(self.node_id3)
 
         with self.tasks():
-            run_deletion(deletion.id)
+            delete_groups(object_ids=[group.id])
 
-        assert not Event.objects.filter(id=event.id).exists()
+        assert not Event.objects.filter(id=self.event.id).exists()
         assert not UserReport.objects.filter(group_id=group.id).exists()
-        assert not UserReport.objects.filter(event_id=event.event_id).exists()
-        assert not EventAttachment.objects.filter(event_id=event.event_id).exists()
+        assert not UserReport.objects.filter(event_id=self.event.event_id).exists()
+        assert not EventAttachment.objects.filter(event_id=self.event.event_id).exists()
 
         assert not GroupRedirect.objects.filter(group_id=group.id).exists()
         assert not GroupHash.objects.filter(group_id=group.id).exists()
         assert not Group.objects.filter(id=group.id).exists()
-        assert not nodestore.get(node_id)
-        assert not nodestore.get(node_id2)
-        assert nodestore.get(node_id3), "Does not remove from second group"
+        assert not nodestore.get(self.node_id)
+        assert not nodestore.get(self.node_id2)
+        assert nodestore.get(self.node_id3), "Does not remove from second group"
+
+    @mock.patch("sentry.nodestore.delete_multi")
+    def test_cleanup(self, nodestore_delete_multi):
+        # Skip EventDataDeletionTask if _SENTRY_CLEANUP is set
+        os.environ["_SENTRY_CLEANUP"] = "1"
+        group = self.event.group
+
+        with self.tasks():
+            delete_groups(object_ids=[group.id])
+
+        # Eventually this will be 0, nodestore deletions are currently still
+        # being triggered from event deletions
+        assert nodestore_delete_multi.call_count == 1


### PR DESCRIPTION
Avoid calling Snuba during scheduled cleanup.

We only need perform EventDataDeletionTask when it's been triggered
from a group_deletion action, not as part of scheduled deletion of
expired items as this is already being handled.