### PR TITLE
feat(api): Create an alert rule action for sending alerts to slack (SEN-961)

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_trigger_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_trigger_action_index.py
@@ -9,7 +9,7 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.incidents.endpoints.bases import OrganizationAlertRuleTriggerEndpoint
 from sentry.incidents.endpoints.serializers import AlertRuleTriggerActionSerializer
-from sentry.incidents.logic import get_actions_for_trigger
+from sentry.incidents.logic import get_actions_for_trigger, InvalidTriggerActionError
 
 
 class OrganizationAlertRuleTriggerActionIndexEndpoint(OrganizationAlertRuleTriggerEndpoint):
@@ -47,7 +47,10 @@ class OrganizationAlertRuleTriggerActionIndexEndpoint(OrganizationAlertRuleTrigg
         )
 
         if serializer.is_valid():
-            action = serializer.save()
+            try:
+                action = serializer.save()
+            except InvalidTriggerActionError as e:
+                return Response(e.message, status=status.HTTP_400_BAD_REQUEST)
             return Response(serialize(action, request.user), status=status.HTTP_201_CREATED)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -5,6 +5,7 @@ import logging
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 
+from sentry import http
 from sentry import tagstore
 from sentry.api.fields.actor import Actor
 from sentry.incidents.logic import get_incident_aggregates
@@ -20,6 +21,7 @@ from sentry.models import (
     Project,
     User,
     Identity,
+    Integration,
     Team,
     ReleaseProject,
 )
@@ -35,6 +37,9 @@ LEVEL_TO_COLOR = {
     "error": "#E03E2F",
     "fatal": "#d20f2a",
 }
+MEMBER_PREFIX = "@"
+CHANNEL_PREFIX = "#"
+strip_channel_chars = "".join([MEMBER_PREFIX, CHANNEL_PREFIX])
 
 
 def format_actor_option(actor):
@@ -308,3 +313,56 @@ def build_incident_attachment(incident):
         "color": LEVEL_TO_COLOR["error"],
         "actions": [],
     }
+
+
+# Different list types in slack that we'll use to resolve a channel name. Format is
+# (<list_name>, <result_name>, <prefix>).
+LIST_TYPES = [
+    ("channels", "channels", CHANNEL_PREFIX),
+    ("groups", "groups", CHANNEL_PREFIX),
+    ("users", "members", MEMBER_PREFIX),
+]
+
+
+def get_channel_id(organization, integration_id, name):
+    """
+    Fetches the internal slack id of a channel.
+    :param organization: The organization that is using this integration
+    :param integration_id: The integration id of this slack integration
+    :param name: The name of the channel
+    :return:
+    """
+    name = name.lstrip(strip_channel_chars)
+    try:
+        integration = Integration.objects.get(
+            provider="slack", organizations=organization, id=integration_id
+        )
+    except Integration.DoesNotExist:
+        return None
+
+    token_payload = {"token": integration.metadata["access_token"]}
+
+    # Look for channel ID
+    payload = dict(token_payload, **{"exclude_archived": False, "exclude_members": True})
+
+    session = http.build_session()
+    for list_type, result_name, prefix in LIST_TYPES:
+        # Slack limits the response of `<list_type>.list` to 1000 channels, paginate if
+        # needed
+        cursor = ""
+        while cursor is not None:
+            items = session.get(
+                "https://slack.com/api/%s.list" % list_type,
+                params=dict(payload, **{"cursor": cursor}),
+            )
+            items = items.json()
+            if not items.get("ok"):
+                logger.info(
+                    "rule.slack.%s_list_failed" % list_type, extra={"error": items.get("error")}
+                )
+                return None
+
+            cursor = items.get("response_metadata", {}).get("next_cursor", None)
+            item_id = {c["name"]: c["id"] for c in items[result_name]}.get(name)
+            if item_id:
+                return prefix, item_id

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -959,9 +959,8 @@ class Factories(object):
         type=AlertRuleTriggerAction.Type.EMAIL,
         target_type=AlertRuleTriggerAction.TargetType.USER,
         target_identifier=None,
-        target_display=None,
         integration=None,
     ):
         return create_alert_rule_trigger_action(
-            trigger, type, target_type, target_identifier, target_display, integration
+            trigger, type, target_type, target_identifier, integration
         )

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -13,8 +13,10 @@ from sentry.incidents.logic import (
     create_alert_rule,
     create_alert_rule_trigger,
     create_alert_rule_trigger_action,
+    InvalidTriggerActionError,
 )
 from sentry.incidents.models import AlertRuleThresholdType, AlertRuleTriggerAction
+from sentry.models import Integration
 from sentry.snuba.models import QueryAggregations
 from sentry.testutils import TestCase
 
@@ -367,10 +369,17 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
         )
 
         self._run_changed_fields_test(action, {"type": type.value}, {})
+        integration = Integration.objects.create(external_id="1", provider="slack", metadata={})
+
         self._run_changed_fields_test(
             action,
-            {"type": AlertRuleTriggerAction.Type.SLACK.value},
-            {"type": AlertRuleTriggerAction.Type.SLACK},
+            {
+                "type": AlertRuleTriggerAction.Type.SLACK.value,
+                "targetIdentifier": "hello",
+                "targetType": AlertRuleTriggerAction.TargetType.SPECIFIC.value,
+                "integration": integration.id,
+            },
+            {"type": AlertRuleTriggerAction.Type.SLACK, "integration": integration},
         )
         self._run_changed_fields_test(
             action, {"target_type": target_type.value, "target_identifier": identifier}, {}
@@ -403,3 +412,41 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
             },
             {"nonFieldErrors": ["User does not belong to this organization"]},
         )
+
+    def test_slack(self):
+        self.run_fail_validation_test(
+            {
+                "type": AlertRuleTriggerAction.Type.SLACK.value,
+                "target_type": AlertRuleTriggerAction.TargetType.USER.value,
+                "target_identifier": "123",
+            },
+            {"targetType": ["Must provide a specific channel for slack"]},
+        )
+        self.run_fail_validation_test(
+            {
+                "type": AlertRuleTriggerAction.Type.SLACK.value,
+                "targetType": AlertRuleTriggerAction.TargetType.SPECIFIC.value,
+                "targetIdentifier": "123",
+            },
+            {"integration": ["Integration must be provided for slack"]},
+        )
+        integration = Integration.objects.create(
+            external_id="1",
+            provider="slack",
+            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+        )
+        integration.add_organization(self.organization, self.user)
+
+        base_params = self.valid_params.copy()
+        base_params.update(
+            {
+                "type": AlertRuleTriggerAction.Type.SLACK.value,
+                "targetType": AlertRuleTriggerAction.TargetType.SPECIFIC.value,
+                "targetIdentifier": "123",
+                "integration": six.text_type(integration.id),
+            }
+        )
+        serializer = AlertRuleTriggerActionSerializer(context=self.context, data=base_params)
+        assert serializer.is_valid()
+        with self.assertRaises(InvalidTriggerActionError):
+            serializer.save()

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1,10 +1,12 @@
 from __future__ import absolute_import
 
+import json
+from uuid import uuid4
+
+import responses
 from datetime import timedelta
 from exam import fixture, patcher
 from freezegun import freeze_time
-
-from uuid import uuid4
 
 import six
 from django.utils import timezone
@@ -73,6 +75,7 @@ from sentry.incidents.models import (
 )
 from sentry.snuba.models import QueryAggregations, QueryDatasets, QuerySubscription
 from sentry.models.commit import Commit
+from sentry.models.integration import Integration
 from sentry.models.repository import Repository
 from sentry.testutils import TestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
@@ -1280,19 +1283,45 @@ class CreateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
         type = AlertRuleTriggerAction.Type.EMAIL
         target_type = AlertRuleTriggerAction.TargetType.USER
         target_identifier = six.text_type(self.user.id)
-        target_display = "hello"
         action = create_alert_rule_trigger_action(
-            self.trigger,
-            type,
-            target_type,
-            target_identifier=target_identifier,
-            target_display=target_display,
+            self.trigger, type, target_type, target_identifier=target_identifier
         )
         assert action.alert_rule_trigger == self.trigger
         assert action.type == type.value
         assert action.target_type == target_type.value
         assert action.target_identifier == target_identifier
-        assert action.target_display == target_display
+
+    @responses.activate
+    def test_slack(self):
+        integration = Integration.objects.create(
+            external_id="1",
+            provider="slack",
+            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+        )
+        integration.add_organization(self.organization, self.user)
+        type = AlertRuleTriggerAction.Type.SLACK
+        target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
+        channel_name = "#some_channel"
+        channel_id = "s_c"
+        responses.add(
+            method=responses.GET,
+            url="https://slack.com/api/channels.list",
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {"ok": "true", "channels": [{"name": channel_name[1:], "id": channel_id}]}
+            ),
+        )
+
+        action = create_alert_rule_trigger_action(
+            self.trigger, type, target_type, target_identifier=channel_name, integration=integration
+        )
+        assert action.alert_rule_trigger == self.trigger
+        assert action.type == type.value
+        assert action.target_type == target_type.value
+        assert action.target_identifier == channel_id
+        assert action.target_display == channel_name
+        assert action.integration == integration
 
 
 class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
@@ -1303,25 +1332,50 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
             AlertRuleTriggerAction.Type.EMAIL,
             AlertRuleTriggerAction.TargetType.USER,
             target_identifier=six.text_type(self.user.id),
-            target_display="hello",
         )
 
     def test(self):
-        type = AlertRuleTriggerAction.Type.SLACK
-        target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
-        target_identifier = "#ruhroh"
-        target_display = "Alert Channel"
+        type = AlertRuleTriggerAction.Type.EMAIL
+        target_type = AlertRuleTriggerAction.TargetType.TEAM
+        target_identifier = six.text_type(self.team.id)
         update_alert_rule_trigger_action(
-            self.action,
-            type=type,
-            target_type=target_type,
-            target_identifier=target_identifier,
-            target_display=target_display,
+            self.action, type=type, target_type=target_type, target_identifier=target_identifier
         )
         assert self.action.type == type.value
         assert self.action.target_type == target_type.value
         assert self.action.target_identifier == target_identifier
-        assert self.action.target_display == target_display
+
+    @responses.activate
+    def test_slack(self):
+        integration = Integration.objects.create(
+            external_id="1",
+            provider="slack",
+            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+        )
+        integration.add_organization(self.organization, self.user)
+        type = AlertRuleTriggerAction.Type.SLACK
+        target_type = AlertRuleTriggerAction.TargetType.SPECIFIC
+        channel_name = "#some_channel"
+        channel_id = "s_c"
+        responses.add(
+            method=responses.GET,
+            url="https://slack.com/api/channels.list",
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {"ok": "true", "channels": [{"name": channel_name[1:], "id": channel_id}]}
+            ),
+        )
+
+        action = update_alert_rule_trigger_action(
+            self.action, type, target_type, target_identifier=channel_name, integration=integration
+        )
+        assert action.alert_rule_trigger == self.trigger
+        assert action.type == type.value
+        assert action.target_type == target_type.value
+        assert action.target_identifier == channel_id
+        assert action.target_display == channel_name
+        assert action.integration == integration
 
 
 class DeleteAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
@@ -1332,7 +1386,6 @@ class DeleteAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
             AlertRuleTriggerAction.Type.EMAIL,
             AlertRuleTriggerAction.TargetType.USER,
             target_identifier=six.text_type(self.user.id),
-            target_display="hello",
         )
 
     def test(self):
@@ -1350,6 +1403,5 @@ class GetActionsForTriggerTest(BaseAlertRuleTriggerActionTest, TestCase):
             AlertRuleTriggerAction.Type.EMAIL,
             AlertRuleTriggerAction.TargetType.USER,
             target_identifier=six.text_type(self.user.id),
-            target_display="hello",
         )
         assert list(get_actions_for_trigger(self.trigger)) == [action]

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -1,17 +1,80 @@
 from __future__ import absolute_import
 import six
 
+import responses
 from django.core.urlresolvers import reverse
 
 from sentry.integrations.slack.utils import (
-    build_incident_attachment,
     build_group_attachment,
+    build_incident_attachment,
+    CHANNEL_PREFIX,
+    get_channel_id,
     LEVEL_TO_COLOR,
+    MEMBER_PREFIX,
 )
+from sentry.models import Integration
 from sentry.testutils import TestCase
+from sentry.utils import json
 from sentry.utils.assets import get_asset_url
 from sentry.utils.dates import to_timestamp
 from sentry.utils.http import absolute_uri
+
+
+class GetChannelIdTest(TestCase):
+    def setUp(self):
+        self.resp = responses.mock
+        self.resp.__enter__()
+
+        self.integration = Integration.objects.create(
+            provider="slack",
+            name="Awesome Team",
+            external_id="TXXXXXXX1",
+            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+        )
+        self.integration.add_organization(self.event.project.organization, self.user)
+        self.add_list_response(
+            "channels",
+            [{"name": "my-channel", "id": "m-c"}, {"name": "other-chann", "id": "o-c"}],
+            result_name="channels",
+        )
+        self.add_list_response(
+            "groups", [{"name": "my-private-channel", "id": "m-p-c"}], result_name="groups"
+        )
+        self.add_list_response(
+            "users",
+            [{"name": "morty", "id": "m"}, {"name": "other-user", "id": "o-u"}],
+            result_name="members",
+        )
+
+    def tearDown(self):
+        self.resp.__exit__(None, None, None)
+
+    def add_list_response(self, list_type, channels, result_name="channels"):
+        self.resp.add(
+            method=responses.GET,
+            url="https://slack.com/api/%s.list" % list_type,
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ok": "true", result_name: channels}),
+        )
+
+    def run_valid_test(self, channel, expected_prefix, expected_id):
+        assert (expected_prefix, expected_id) == get_channel_id(
+            self.organization, self.integration.id, channel
+        )
+
+    def test_valid_channel_selected(self):
+        self.run_valid_test("#my-channel", CHANNEL_PREFIX, "m-c")
+
+    def test_valid_private_channel_selected(self):
+        self.run_valid_test("#my-private-channel", CHANNEL_PREFIX, "m-p-c")
+
+    def test_valid_member_selected(self):
+        self.run_valid_test("@morty", MEMBER_PREFIX, "m")
+
+    def test_invalid_channel_selected(self):
+        assert get_channel_id(self.organization, self.integration.id, "#fake-channel") is None
+        assert get_channel_id(self.organization, self.integration.id, "@fake-user") is None
 
 
 class BuildIncidentAttachmentTest(TestCase):


### PR DESCRIPTION
This updates our api to allow us to create slack actions. I refactored the slack integration so we
could re-use the code for fetching channels from slack. Code for sending messages to slack, and for
getting a list of installed integrations that can be used coming in a separate pr.