### PR TITLE
logging(events): log the group_id on duplicates.

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -493,6 +493,7 @@ class EventManager(object):
                 extra={
                     "event_uuid": data["event_id"],
                     "project_id": project.id,
+                    "group_id": event.group_id,
                     "platform": data.get("platform"),
                     "model": Event.__name__,
                 },


### PR DESCRIPTION
This will help to identify any patterns in a specific project's over-sending.

/cc @lobsterkatie 