### PR TITLE
feat(outcomes): Remove writes to redis

### DIFF
--- a/src/sentry/tsdb/redissnuba.py
+++ b/src/sentry/tsdb/redissnuba.py
@@ -59,7 +59,7 @@ assert (
 
 model_backends = {
     # model: (read, write)
-    model: ("redis", "redis") if model not in SnubaTSDB.model_columns else ("snuba", "dummy")
+    model: ("redis", "redis") if model not in SnubaTSDB.model_query_settings else ("snuba", "dummy")
     for model in BaseTSDB.models
 }
 

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -30,10 +30,7 @@ class SnubaTSDB(BaseTSDB):
     will return empty results for unsupported models.
     """
 
-    # The ``model_query_settings`` and ``model_being_upgraded_query_settings`` are translations of
-    # TSDB models into required settings for querying snuba. Queries for ``model_columns``
-    # directly hit snuba, while queries for ``model_columns_being_upgraded`` hit
-    # redis in the main thread and snuba in a background thread.
+    # ``model_query_settings`` is a translation of TSDB models into required settings for querying snuba
     model_query_settings = {
         TSDBModel.project: SnubaModelQuerySettings(snuba.Dataset.Events, "project_id", None, None),
         TSDBModel.group: SnubaModelQuerySettings(snuba.Dataset.Events, "issue", None, None),


### PR DESCRIPTION
Alright, alright, alright. Remove writes to Redis for outcomes.

In this PR, we are basically moving items from `model_being_upgraded_query_settings` and `model_being_upgraded_query_settings2` into `model_query_settings` so that it stops writes to redis.

## Test plan
- Tested manually by hitting the stats pages and the main issues page
- Unit tests

## Next steps
- Clean up tsdb.py
- [Remove `incr_multi` for outcomes](https://github.com/getsentry/sentry/blob/master/src/sentry/utils/outcomes.py#L135). Why not do this in this PR? Admittedly, I'm being a little cautious here cause I don't know that area of the codebase well. So, going to do that separately.
- Clean up some lingering code from the upgrade in [tsdb/snuba](https://github.com/getsentry/sentry/blob/e98f2cb61dbe28abf75ca3caf045c65ab977b508/src/sentry/tsdb/snuba.py#L111-L115)
- Remove hack from [`project_key_stats.py`](https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/project_key_stats.py#L36-L38)