### PR TITLE
feat(pagerduty): Alas, remove service_id column

### DIFF
--- a/src/sentry/migrations/0012_remove_pagerdutyservice_service_id.py
+++ b/src/sentry/migrations/0012_remove_pagerdutyservice_service_id.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    # This flag is used to mark that a migration shouldn't be automatically run in
+    # production. We set this to True for operations that we think are risky and want
+    # someone from ops to run manually and monitor.
+    # General advice is that if in doubt, mark your migration as `is_dangerous`.
+    # Some things you should always mark as dangerous:
+    # - Adding indexes to large tables. These indexes should be created concurrently,
+    #   unfortunately we can't run migrations outside of a transaction until Django
+    #   1.10. So until then these should be run manually.
+    # - Large data migrations. Typically we want these to be run manually by ops so that
+    #   they can be monitored. Since data migrations will now hold a transaction open
+    #   this is even more important.
+    # - Adding columns to highly active tables, even ones that are NULL.
+    is_dangerous = False
+
+    dependencies = [
+        ('sentry', '0011_remove_pagerdutyservice_service_id_from_state'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    """
+                    ALTER TABLE "sentry_pagerdutyservice" DROP COLUMN "service_id";
+                    """,
+                    reverse_sql="""
+                        ALTER TABLE "sentry_pagerdutyservice" ADD COLUMN "service_id" varchar(255) NULL;
+                        """,
+                )
+            ],
+            state_operations=[],
+        )
+    ]


### PR DESCRIPTION
This is the last step in in https://www.notion.so/sentry/Django-migrations-103e5994029d4345b5b6f5f6f9cac9c7 to remove the service_id column from the pagerdutyservice table.

For more context around why we're removing this column, see: https://github.com/getsentry/sentry/pull/15394

## What's the SQL
```
ALTER TABLE "sentry_pagerdutyservice" DROP COLUMN "service_id";
```

## Previous steps
1. Make `service_id` nullable ([this](https://github.com/getsentry/sentry/pull/15394) and [this](https://github.com/getsentry/sentry/pull/15396)) 
1. [Remove uniqueness constraints](https://github.com/getsentry/sentry/pull/15423)
1. [Remove service_id from state and code](https://github.com/getsentry/sentry/pull/15434/files)