### PR TITLE
ref(apm): Change how apm data sampling/collection is triggered

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.jsx
+++ b/src/sentry/static/sentry/app/bootstrap.jsx
@@ -67,9 +67,7 @@ const config = ConfigStore.getConfig();
 // This is just a simple gatekeeper to not enable apm for whole sentry.io at first
 if (
   config &&
-  ((config.userIdentity &&
-    config.userIdentity.email &&
-    config.userIdentity.email.includes('sentry')) ||
+  (config.isApmDataSamplingEnabled ||
     (config.urlPrefix &&
       (config.urlPrefix.includes('localhost') ||
         config.urlPrefix.includes('127.0.0.1') ||


### PR DESCRIPTION
Changed the condition for startApm() to be a flag within the config that is populated by the server (code in `getsentry`)