### PR TITLE
chore: bump sqlparse to 0.2.x

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -70,7 +70,7 @@ sentry-sdk>=0.13.1
 setproctitle>=1.1.7,<1.2.0
 simplejson>=3.2.0,<3.9.0
 six>=1.10.0,<1.11.0
-sqlparse>=0.1.16,<0.2.0
+sqlparse>=0.2.0,<0.3.0
 statsd>=3.1.0,<3.2.0
 strict-rfc3339>=0.7
 structlog==16.1.0


### PR DESCRIPTION
sqlparse [improves Python2/3 compat in 0.2.x](https://github.com/andialbrecht/sqlparse/blob/master/CHANGELOG#L134). 0.2.x is also required by django-debug-toolbar 1.9.1 in getsentry (I forgot to bump sqlparse in https://github.com/getsentry/getsentry/pull/3301).