### PR TITLE
feat(ui): Added loading state to ProjectsStore and withProjects

### DIFF
--- a/src/sentry/static/sentry/app/stores/projectsStore.jsx
+++ b/src/sentry/static/sentry/app/stores/projectsStore.jsx
@@ -21,6 +21,7 @@ const ProjectsStore = Reflux.createStore({
 
   reset() {
     this.itemsById = {};
+    this.loading = true;
   },
 
   loadInitialData(items) {
@@ -28,6 +29,7 @@ const ProjectsStore = Reflux.createStore({
       map[project.id] = project;
       return map;
     }, {});
+    this.loading = false;
     this.trigger(new Set(Object.keys(this.itemsById)));
   },
 
@@ -166,6 +168,13 @@ const ProjectsStore = Reflux.createStore({
 
   getBySlug(slug) {
     return this.getAll().find(project => project.slug === slug);
+  },
+
+  getState() {
+    return {
+      projects: this.getAll(),
+      loading: this.loading,
+    };
   },
 });
 

--- a/src/sentry/static/sentry/app/utils/withProjects.tsx
+++ b/src/sentry/static/sentry/app/utils/withProjects.tsx
@@ -32,18 +32,20 @@ const withProjects = <P extends InjectedProjectsProps>(
     },
     mixins: [Reflux.listenTo(ProjectsStore, 'onProjectUpdate') as any],
     getInitialState() {
-      return {
-        projects: ProjectsStore.getAll() as Project[],
-      };
+      return ProjectsStore.getState();
     },
 
     onProjectUpdate() {
-      this.setState({
-        projects: ProjectsStore.getAll() as Project[],
-      });
+      this.setState(ProjectsStore.getState());
     },
     render() {
-      return <WrappedComponent {...this.props} projects={this.state.projects} />;
+      return (
+        <WrappedComponent
+          {...this.props}
+          projects={this.state.projects}
+          loadingProjects={this.state.loading}
+        />
+      );
     },
   });
 

--- a/tests/js/spec/stores/projectsStore.spec.jsx
+++ b/tests/js/spec/stores/projectsStore.spec.jsx
@@ -40,7 +40,7 @@ describe('ProjectsStore', function() {
     });
   });
 
-  describe('updates data', function() {
+  describe('updating data', function() {
     beforeEach(function() {
       ProjectsStore.reset();
       ProjectsStore.loadInitialData([projectFoo, projectBar]);

--- a/tests/js/spec/stores/projectsStore.spec.jsx
+++ b/tests/js/spec/stores/projectsStore.spec.jsx
@@ -22,114 +22,134 @@ describe('ProjectsStore', function() {
     teams: [teamFoo, teamBar],
   });
 
-  beforeEach(function() {
-    ProjectsStore.reset();
-    ProjectsStore.loadInitialData([projectFoo, projectBar]);
-  });
+  describe('setting data', function() {
+    beforeEach(function() {
+      ProjectsStore.reset();
+    });
 
-  it('updates when slug changes', async function() {
-    ProjectActions.changeSlug('foo', 'new-project');
-    await tick();
-    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
-      slug: 'new-project',
-    });
-    expect(ProjectsStore.itemsById[projectBar.id]).toBeDefined();
-  });
-
-  it('adds project to store on "create success"', async function() {
-    const project = TestStubs.Project({id: '11', slug: 'created-project'});
-    ProjectActions.createSuccess(project);
-    await tick();
-    expect(ProjectsStore.itemsById[project.id]).toMatchObject({
-      id: '11',
-      slug: 'created-project',
-    });
-    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
-      id: '2',
-      slug: 'foo',
-      name: 'Foo',
-    });
-    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
-      id: '10',
-      slug: 'bar',
+    it('correctly manages loading state', function() {
+      expect(ProjectsStore.getState()).toMatchObject({
+        projects: [],
+        loading: true,
+      });
+      ProjectsStore.loadInitialData([projectFoo, projectBar]);
+      expect(ProjectsStore.getState()).toMatchObject({
+        projects: [projectBar, projectFoo], // projects are returned sorted
+        loading: false,
+      });
     });
   });
 
-  it('updates a project in store', async function() {
-    // Create a new project, but should have same id as `projectBar`
-    const project = TestStubs.Project({id: '10', slug: 'bar', name: 'New Name'});
-    ProjectActions.updateSuccess(project);
-    await tick();
-    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
-      id: '10',
-      slug: 'bar',
-      name: 'New Name',
-    });
-    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
-      id: '2',
-      slug: 'foo',
-      name: 'Foo',
-    });
-  });
-
-  it('can remove a team from a single project', async function() {
-    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
-      teams: [
-        expect.objectContaining({slug: 'team-foo'}),
-        expect.objectContaining({slug: 'team-bar'}),
-      ],
-    });
-    ProjectActions.removeTeamSuccess('team-foo', 'bar');
-    await tick();
-
-    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
-      teams: [expect.objectContaining({slug: 'team-bar'})],
-    });
-    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
-      teams: [expect.objectContaining({slug: 'team-foo'})],
-    });
-  });
-
-  it('removes a team from all projects when team is deleted', async function() {
-    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
-      teams: [
-        expect.objectContaining({slug: 'team-foo'}),
-        expect.objectContaining({slug: 'team-bar'}),
-      ],
-    });
-    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
-      teams: [expect.objectContaining({slug: 'team-foo'})],
+  describe('updates data', function() {
+    beforeEach(function() {
+      ProjectsStore.reset();
+      ProjectsStore.loadInitialData([projectFoo, projectBar]);
     });
 
-    TeamActions.removeTeamSuccess('team-foo');
-    await tick();
+    it('updates when slug changes', async function() {
+      ProjectActions.changeSlug('foo', 'new-project');
+      await tick();
+      expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+        slug: 'new-project',
+      });
+      expect(ProjectsStore.itemsById[projectBar.id]).toBeDefined();
+    });
 
-    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
-      teams: [expect.objectContaining({slug: 'team-bar'})],
+    it('adds project to store on "create success"', async function() {
+      const project = TestStubs.Project({id: '11', slug: 'created-project'});
+      ProjectActions.createSuccess(project);
+      await tick();
+      expect(ProjectsStore.itemsById[project.id]).toMatchObject({
+        id: '11',
+        slug: 'created-project',
+      });
+      expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+        id: '2',
+        slug: 'foo',
+        name: 'Foo',
+      });
+      expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+        id: '10',
+        slug: 'bar',
+      });
     });
-    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
-      teams: [],
-    });
-  });
 
-  it('can add a team to a project', async function() {
-    const team = TestStubs.Team({
-      slug: 'new-team',
+    it('updates a project in store', async function() {
+      // Create a new project, but should have same id as `projectBar`
+      const project = TestStubs.Project({id: '10', slug: 'bar', name: 'New Name'});
+      ProjectActions.updateSuccess(project);
+      await tick();
+      expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+        id: '10',
+        slug: 'bar',
+        name: 'New Name',
+      });
+      expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+        id: '2',
+        slug: 'foo',
+        name: 'Foo',
+      });
     });
-    ProjectActions.addTeamSuccess(team, 'foo');
-    await tick();
 
-    expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
-      teams: [
-        expect.objectContaining({slug: 'team-foo'}),
-        expect.objectContaining({slug: 'team-bar'}),
-      ],
+    it('can remove a team from a single project', async function() {
+      expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+        teams: [
+          expect.objectContaining({slug: 'team-foo'}),
+          expect.objectContaining({slug: 'team-bar'}),
+        ],
+      });
+      ProjectActions.removeTeamSuccess('team-foo', 'bar');
+      await tick();
+
+      expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+        teams: [expect.objectContaining({slug: 'team-bar'})],
+      });
+      expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+        teams: [expect.objectContaining({slug: 'team-foo'})],
+      });
     });
-    expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
-      teams: [
-        expect.objectContaining({slug: 'team-foo'}),
-        expect.objectContaining({slug: 'new-team'}),
-      ],
+
+    it('removes a team from all projects when team is deleted', async function() {
+      expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+        teams: [
+          expect.objectContaining({slug: 'team-foo'}),
+          expect.objectContaining({slug: 'team-bar'}),
+        ],
+      });
+      expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+        teams: [expect.objectContaining({slug: 'team-foo'})],
+      });
+
+      TeamActions.removeTeamSuccess('team-foo');
+      await tick();
+
+      expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+        teams: [expect.objectContaining({slug: 'team-bar'})],
+      });
+      expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+        teams: [],
+      });
+    });
+
+    it('can add a team to a project', async function() {
+      const team = TestStubs.Team({
+        slug: 'new-team',
+      });
+      ProjectActions.addTeamSuccess(team, 'foo');
+      await tick();
+
+      expect(ProjectsStore.itemsById[projectBar.id]).toMatchObject({
+        teams: [
+          expect.objectContaining({slug: 'team-foo'}),
+          expect.objectContaining({slug: 'team-bar'}),
+        ],
+      });
+      expect(ProjectsStore.itemsById[projectFoo.id]).toMatchObject({
+        teams: [
+          expect.objectContaining({slug: 'team-foo'}),
+          expect.objectContaining({slug: 'new-team'}),
+        ],
+      });
     });
   });
 });

--- a/tests/js/spec/utils/withProjects.spec.jsx
+++ b/tests/js/spec/utils/withProjects.spec.jsx
@@ -15,14 +15,17 @@ describe('withProjects HoC', function() {
     const wrapper = mount(<Container />);
 
     expect(wrapper.find('MyComponent').prop('projects')).toEqual([]);
+    expect(wrapper.find('MyComponent').prop('loadingProjects')).toEqual(true);
 
     // Insert into projects store
     const project = TestStubs.Project();
     ProjectsStore.loadInitialData([project]);
 
     wrapper.update();
-    const props = wrapper.find('MyComponent').prop('projects');
-    expect(props).toHaveLength(1);
-    expect(props[0].id).toBe(project.id);
+    const projectProp = wrapper.find('MyComponent').prop('projects');
+    expect(projectProp).toHaveLength(1);
+    expect(projectProp[0].id).toBe(project.id);
+    const loadingProp = wrapper.find('MyComponent').prop('loadingProjects');
+    expect(loadingProp).toBe(false);
   });
 });


### PR DESCRIPTION
Because pages are being switched over to lightweight organization context they must be displayed without all the projects loaded in the store. However because the store only holds an array of projects it is impossible to tell if the organization has no projects or is simply waiting for them to be loaded. I added a loading flag to the state of the store so that, when appropriate, certain pages (e.g. user-feedback) can show loading states while waiting for projects to come in. This loading flag is also propagated through the withProjects HOC.