### PR TITLE
feat(ui): Added LightWeightNoProjectMessage

### DIFF
--- a/src/sentry/static/sentry/app/components/lightWeightNoProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/lightWeightNoProjectMessage.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import {Organization} from 'app/types';
+import NoProjectMessage from 'app/components/noProjectMessage';
+import Projects from 'app/utils/projects';
+
+type Props = {
+  organization: Organization;
+};
+
+export default class LightWeightNoProjectMessage extends React.Component<Props> {
+  renderChildren = ({projects, fetching}) => {
+    if (fetching) {
+      return this.props.children;
+    }
+    return <NoProjectMessage {...this.props} projects={projects} />;
+  };
+
+  render() {
+    return (
+      <Projects orgId={this.props.organization.slug} allProjects>
+        {this.renderChildren}
+      </Projects>
+    );
+  }
+}

--- a/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
+
+describe('LightWeightNoProjectMessage', function() {
+  it('renders', async function() {
+    const project1 = TestStubs.Project();
+    const project2 = TestStubs.Project();
+    const organization = TestStubs.Organization({slug: 'org-slug'});
+    const getProjectsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project1, project2],
+    });
+    const wrapper = mountWithTheme(
+      <LightWeightNoProjectMessage organization={organization}>
+        {null}
+      </LightWeightNoProjectMessage>,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.prop('children')).toBe(null);
+    // await fetching projects
+    await tick();
+    wrapper.update();
+    expect(getProjectsMock).toHaveBeenCalled();
+    expect(wrapper.find('NoProjectMessage').exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
The NoProjectMessage component relies on `organization.projects` which will not exist in a lightweight organization context. Alternatively, the NoProjectMessage can accept a list of projects instead of using `organization.projects`. I created a lightweight wrapper around NoProjectMessage which uses the `<Projects>` utility render props component to pass down projects to NoProjectMessage.