### PR TITLE
feat(api): Implement Slack ActionHandler for alert rules (SEN-961)

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -30,6 +30,7 @@ logger = logging.getLogger("sentry.integrations.slack")
 
 # Attachment colors used for issues with no actions take
 ACTIONED_ISSUE_COLOR = "#EDEEEF"
+RESOLVED_COLOR = "#0cbd4d"
 LEVEL_TO_COLOR = {
     "debug": "#fbe14f",
     "info": "#2788ce",
@@ -280,7 +281,13 @@ def build_incident_attachment(incident):
     logo_url = absolute_uri(get_asset_url("sentry", "images/sentry-email-avatar.png"))
 
     aggregates = get_incident_aggregates(incident)
-    status = "Closed" if incident.status == IncidentStatus.CLOSED.value else "Open"
+
+    if incident.status == IncidentStatus.CLOSED.value:
+        status = "Resolved"
+        color = RESOLVED_COLOR
+    else:
+        status = "Fired"
+        color = LEVEL_TO_COLOR["error"]
 
     fields = [
         {"title": "Status", "value": status, "short": True},
@@ -310,7 +317,7 @@ def build_incident_attachment(incident):
         "footer_icon": logo_url,
         "footer": "Sentry Incident",
         "ts": to_timestamp(ts),
-        "color": LEVEL_TO_COLOR["error"],
+        "color": color,
         "actions": [],
     }
 
@@ -366,3 +373,20 @@ def get_channel_id(organization, integration_id, name):
             item_id = {c["name"]: c["id"] for c in items[result_name]}.get(name)
             if item_id:
                 return prefix, item_id
+
+
+def send_incident_alert_notification(integration, incident, channel):
+    attachment = build_incident_attachment(incident)
+
+    payload = {
+        "token": integration.metadata["access_token"],
+        "channel": channel,
+        "attachments": json.dumps([attachment]),
+    }
+
+    session = http.build_session()
+    resp = session.post("https://slack.com/api/chat.postMessage", data=payload, timeout=5)
+    resp.raise_for_status()
+    resp = resp.json()
+    if not resp.get("ok"):
+        logger.info("rule.fail.slack_post", extra={"error": resp.get("error")})

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -1,14 +1,25 @@
 from __future__ import absolute_import
 
+import json
+
+import responses
 import six
 from django.core import mail
 from django.core.urlresolvers import reverse
 from exam import fixture
 from freezegun import freeze_time
+from six.moves.urllib.parse import parse_qs
 
-from sentry.incidents.action_handlers import EmailActionHandler
-from sentry.incidents.models import AlertRuleTriggerAction, QueryAggregations, TriggerStatus
-from sentry.models import UserOption
+from sentry.incidents.action_handlers import EmailActionHandler, SlackActionHandler
+from sentry.incidents.logic import update_incident_status
+from sentry.incidents.models import (
+    AlertRuleTriggerAction,
+    IncidentStatus,
+    QueryAggregations,
+    TriggerStatus,
+)
+from sentry.integrations.slack.utils import build_incident_attachment
+from sentry.models import Integration, UserOption
 from sentry.testutils import TestCase
 from sentry.utils.http import absolute_uri
 
@@ -129,3 +140,58 @@ class EmailActionHandlerResolveTest(TestCase):
         out = mail.outbox[0]
         assert out.to == [self.user.email]
         assert out.subject.startswith("Incident Alert Rule Resolved")
+
+
+@freeze_time()
+class SlackActionHandlerBaseTest(object):
+    @responses.activate
+    def run_test(self, incident, method):
+        token = "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+        integration = Integration.objects.create(
+            external_id="1", provider="slack", metadata={"access_token": token}
+        )
+        integration.add_organization(self.organization, self.user)
+        channel_id = "some_id"
+        channel_name = "#hello"
+        responses.add(
+            method=responses.GET,
+            url="https://slack.com/api/channels.list",
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {"ok": "true", "channels": [{"name": channel_name[1:], "id": channel_id}]}
+            ),
+        )
+
+        action = self.create_alert_rule_trigger_action(
+            target_identifier=channel_name,
+            type=AlertRuleTriggerAction.Type.SLACK,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            integration=integration,
+        )
+        responses.add(
+            method=responses.POST,
+            url="https://slack.com/api/chat.postMessage",
+            status=200,
+            content_type="application/json",
+            body='{"ok": true}',
+        )
+        handler = SlackActionHandler(action, incident, self.project)
+        with self.tasks():
+            getattr(handler, method)()
+        data = parse_qs(responses.calls[1].request.body)
+        assert data["channel"] == [channel_id]
+        assert data["token"] == [token]
+        assert json.loads(data["attachments"][0])[0] == build_incident_attachment(incident)
+
+
+class SlackActionHandlerFireTest(SlackActionHandlerBaseTest, TestCase):
+    def test(self):
+        self.run_test(self.create_incident(), "fire")
+
+
+class SlackActionHandlerResolveTest(SlackActionHandlerBaseTest, TestCase):
+    def test(self):
+        incident = self.create_incident()
+        update_incident_status(incident, IncidentStatus.CLOSED)
+        self.run_test(incident, "resolve")

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -97,7 +97,7 @@ class BuildIncidentAttachmentTest(TestCase):
             ),
             "text": " ",
             "fields": [
-                {"title": "Status", "value": "Open", "short": True},
+                {"title": "Status", "value": "Fired", "short": True},
                 {"title": "Events", "value": 0, "short": True},
                 {"title": "Users", "value": 0, "short": True},
             ],


### PR DESCRIPTION
This implements the handler for slack actions. This will be called for any actions that are
fired/resolved via the subscription processor.