### PR TITLE
chore(tsdb): explicitly deprecate frequent_projects_by_organization.

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -712,18 +712,7 @@ class EventManager(object):
 
         tsdb.incr_multi(counters, timestamp=event.datetime, environment_id=environment.id)
 
-        frequencies = [
-            # (tsdb.models.frequent_projects_by_organization, {
-            #     project.organization_id: {
-            #         project.id: 1,
-            #     },
-            # }),
-            # (tsdb.models.frequent_issues_by_project, {
-            #     project.id: {
-            #         group.id: 1,
-            #     },
-            # })
-        ]
+        frequencies = []
 
         if group:
             frequencies.append(

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -52,7 +52,7 @@ class TSDBModel(Enum):
     # frequent_values_by_issue_tag = 405
 
     # number of events seen for a project, by organization
-    frequent_projects_by_organization = 403
+    # frequent_projects_by_organization = 403  # DEPRECATED
     # number of issues seen for a project, by project
     frequent_issues_by_project = 404
     # number of events seen for a release, by issue

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -629,12 +629,6 @@ class EventManagerTest(TestCase):
             tsdb.models.frequent_issues_by_project, (event.project.id,), event.datetime
         ) == {event.project.id: [(event.group_id, 1.0)]}
 
-        assert tsdb.get_most_frequent(
-            tsdb.models.frequent_projects_by_organization,
-            (event.project.organization_id,),
-            event.datetime,
-        ) == {event.project.organization_id: [(event.project_id, 1.0)]}
-
     def test_event_user(self):
         manager = EventManager(
             make_event(

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -318,7 +318,7 @@ class RedisTSDBTest(TestCase):
 
     def test_frequency_tables(self):
         now = datetime.utcnow().replace(tzinfo=pytz.UTC)
-        model = TSDBModel.frequent_projects_by_organization
+        model = TSDBModel.frequent_issues_by_project
 
         # None of the registered frequency tables actually support
         # environments, so we have to pretend like one actually does


### PR DESCRIPTION
This model was deprecated three years ago.
https://github.com/getsentry/sentry/commit/5ff3dc73a28582a32c885107d1c4e91eb8cca523