### PR TITLE
fix(ui): Ensure projects are loaded before setting GlobalSelectionStore

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -191,6 +191,7 @@ const OrganizationContext = createReactClass({
       // lead to very confusing behavior.
       if (
         this.props.detailed &&
+        organization.projects &&
         !this.props.routes.find(
           ({path}) => path && path.includes('/organizations/:orgId/issues/:groupId/')
         )


### PR DESCRIPTION
https://sentry.io/organizations/sentry/issues/1309332036/?project=11276&query=is%3Aunassigned+is%3Aunresolved+level%3Aerror+%21error.type%3ABadGatewayError++%21error.type%3AForbiddenError+%21error.type%3AUnauthorizedError++%21error.type%3ACancelledError+%21error.type%3ANotFoundError+%21error.type%3ABadRequestError+%21error.type%3AGatewayTimeoutError+%21error.type%3ATooManyRequestsError

This error will happen when a user starts in the lighweight org context (projects page) which will trigger a request for /teams. If the user then navigates to a heavyweight org while the /projects haven't loaded, a new request for a detailed org will be requested and the sentry loading gif will show. During this time if the /teams endpoint were to return then the app will wrongly assume that the detailed org context has been returned when the org context that has come back only has teams and no projects.

TLDR: Check for the existence of projects before using it in global selection store.