### PR TITLE
build(webpack): Add webpack speed measure plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "prettier": "1.16.4",
     "react-test-renderer": "16.7.0",
     "source-map-loader": "^0.2.4",
+    "speed-measure-webpack-plugin": "^1.3.1",
     "stylelint": "10.1.0",
     "stylelint-config-prettier": "^5.2.0",
     "stylelint-config-recommended": "^2.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
 const CopyPlugin = require('copy-webpack-plugin');
+const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
 
 const babelConfig = require('./babel.config');
 
@@ -460,4 +461,5 @@ if (IS_PRODUCTION) {
   });
 }
 
-module.exports = appConfig;
+const smp = new SpeedMeasurePlugin();
+module.exports = smp.wrap(appConfig);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -461,5 +461,5 @@ if (IS_PRODUCTION) {
   });
 }
 
-const smp = new SpeedMeasurePlugin();
+const smp = new SpeedMeasurePlugin({disable: !process.env.MEASURE});
 module.exports = smp.wrap(appConfig);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,6 @@ const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
 const CopyPlugin = require('copy-webpack-plugin');
-const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
 
 const babelConfig = require('./babel.config');
 
@@ -188,7 +187,7 @@ const babelOptions = {...babelConfig, cacheDirectory: true};
 /**
  * Main Webpack config for Sentry React SPA.
  */
-const appConfig = {
+let appConfig = {
   mode: WEBPACK_MODE,
   entry: {
     /**
@@ -461,5 +460,10 @@ if (IS_PRODUCTION) {
   });
 }
 
-const smp = new SpeedMeasurePlugin({disable: !process.env.MEASURE});
-module.exports = smp.wrap(appConfig);
+if (process.env.MEASURE) {
+  const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
+  const smp = new SpeedMeasurePlugin();
+  appConfig = smp.wrap(appConfig);
+}
+
+module.exports = appConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13787,6 +13787,13 @@ specificity@^0.4.1:
   resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.1.tgz#aab5e645012db08ba182e151165738d00887b019"
   integrity sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==
 
+speed-measure-webpack-plugin@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.3.1.tgz#69840a5cdc08b4638697dac7db037f595d7f36a0"
+  integrity sha512-qVIkJvbtS9j/UeZumbdfz0vg+QfG/zxonAjzefZrqzkr7xOncLVXkeGbTpzd1gjCBM4PmVNkWlkeTVhgskAGSQ==
+  dependencies:
+    chalk "^2.0.1"
+
 split-on-first@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"


### PR DESCRIPTION
Running webpack with the enviroment variable `MEASURE` set will produce some debug output with timings for webpack plugins.