### PR TITLE
build(webpack): Only use `CopyPlugin` when `DEPLOY_PREVIEW_CONFIG` is set

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -307,13 +307,6 @@ const appConfig = {
     new ExtractTextPlugin(),
 
     /**
-     * Generate a index.html file used for running the app in pure client mode.
-     * This is currently used for PR deploy previews, where only the frontend
-     * is deployed.
-     */
-    new CopyPlugin([{from: path.join(staticPrefix, 'app', 'index.html')}]),
-
-    /**
      * Defines environment specific flags.
      */
     new webpack.DefinePlugin({
@@ -371,6 +364,17 @@ const appConfig = {
   },
   devtool: IS_PRODUCTION ? 'source-map' : 'cheap-module-eval-source-map',
 };
+
+if (DEPLOY_PREVIEW_CONFIG) {
+  /**
+   * Generate a index.html file used for running the app in pure client mode.
+   * This is currently used for PR deploy previews, where only the frontend
+   * is deployed.
+   */
+  appConfig.plugins.push(
+    new CopyPlugin([{from: path.join(staticPrefix, 'app', 'index.html')}])
+  );
+}
 
 if (IS_TEST || IS_STORYBOOK) {
   appConfig.resolve.alias['integration-docs-platforms'] = path.join(


### PR DESCRIPTION
We currently only need the `CopyPlugin` when we have a deploy preview config set.