### PR TITLE
feat(ui): <Projects> utility component does not refetch all projects unnecessarily

### DIFF
--- a/src/sentry/static/sentry/app/utils/projects.jsx
+++ b/src/sentry/static/sentry/app/utils/projects.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import ProjectActions from 'app/actions/projectActions';
+import ProjectsStore from 'app/stores/projectsStore';
 import SentryTypes from 'app/sentryTypes';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
 import withApi from 'app/utils/withApi';
@@ -274,6 +275,15 @@ async function fetchProjects(api, orgId, {slugs, search, limit, allProjects} = {
   }
 
   if (allProjects) {
+    const {loading, projects} = ProjectsStore.getState();
+    // If the projects store is loaded then return all projects from the store
+    if (!loading) {
+      return {
+        results: projects,
+        hasMore: false,
+      };
+    }
+    // Otherwise mark the query to fetch all projects from the API
     query.all_projects = 1;
   }
 

--- a/tests/js/spec/utils/projects.spec.jsx
+++ b/tests/js/spec/utils/projects.spec.jsx
@@ -435,10 +435,14 @@ describe('utils.projects', function() {
         })
       );
     });
+  });
 
-    it('can query for a list of all projects and save it to the store', async function() {
-      const loadProjects = jest.spyOn(ProjectActions, 'loadProjects');
-      const mockProjects = [
+  describe('with all projects prop', function() {
+    let request;
+    let mockProjects;
+
+    beforeEach(async function() {
+      mockProjects = [
         TestStubs.Project({
           id: '100',
           slug: 'a',
@@ -453,7 +457,6 @@ describe('utils.projects', function() {
         }),
       ];
 
-      request.mockClear();
       request = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/projects/',
         query: {
@@ -461,9 +464,13 @@ describe('utils.projects', function() {
         },
         body: mockProjects,
       });
+      ProjectsStore.reset();
+    });
+
+    it('can query for a list of all projects and save it to the store', async function() {
+      const loadProjects = jest.spyOn(ProjectActions, 'loadProjects');
 
       const wrapper = createWrapper({allProjects: true});
-
       // This is initial state
       expect(renderer).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -495,6 +502,23 @@ describe('utils.projects', function() {
 
       // expect the store action to be called
       expect(loadProjects).toHaveBeenCalledWith(mockProjects);
+    });
+
+    it('does not refetch projects that are already loaded in the store', async function() {
+      ProjectsStore.loadInitialData(mockProjects);
+
+      const wrapper = createWrapper({allProjects: true});
+      wrapper.update();
+
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fetching: false,
+          isIncomplete: null,
+          hasMore: false,
+          projects: mockProjects,
+        })
+      );
+      expect(request).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/js/spec/utils/projects.spec.jsx
+++ b/tests/js/spec/utils/projects.spec.jsx
@@ -438,8 +438,9 @@ describe('utils.projects', function() {
   });
 
   describe('with all projects prop', function() {
-    let request;
+    const loadProjects = jest.spyOn(ProjectActions, 'loadProjects');
     let mockProjects;
+    let request;
 
     beforeEach(async function() {
       mockProjects = [
@@ -464,12 +465,11 @@ describe('utils.projects', function() {
         },
         body: mockProjects,
       });
+      loadProjects.mockReset();
       ProjectsStore.reset();
     });
 
     it('can query for a list of all projects and save it to the store', async function() {
-      const loadProjects = jest.spyOn(ProjectActions, 'loadProjects');
-
       const wrapper = createWrapper({allProjects: true});
       // This is initial state
       expect(renderer).toHaveBeenCalledWith(
@@ -519,6 +519,7 @@ describe('utils.projects', function() {
         })
       );
       expect(request).not.toHaveBeenCalled();
+      expect(loadProjects).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
@@ -5,6 +5,7 @@ import OrganizationDetails, {
   LightWeightOrganizationDetails,
 } from 'app/views/organizationDetails';
 import OrganizationStore from 'app/stores/organizationStore';
+import ProjectsStore from 'app/stores/projectsStore';
 
 let tree;
 
@@ -115,6 +116,7 @@ describe('OrganizationDetails', function() {
     });
   });
   it('can render a lightweight version of itself and fetches teams', async function() {
+    ProjectsStore.reset();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/',
       body: TestStubs.Organization({


### PR DESCRIPTION
Now that `<Projects>` will be used across multiple lightweight org pages (projects and user-feedback pages) as a way to pass projects information to `<NoProjectMessage>` we should not have the utility component unnecessarily refetch all projects (as the user navigates between lightweight pages) if the data is already in the store.