### PR TITLE
ref(app-platform): remove SentryAppWebhookError model from DB

### DIFF
--- a/src/sentry/migrations/0015_delete_sentryappwebhookerror_db.py
+++ b/src/sentry/migrations/0015_delete_sentryappwebhookerror_db.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    # This flag is used to mark that a migration shouldn't be automatically run in
+    # production. We set this to True for operations that we think are risky and want
+    # someone from ops to run manually and monitor.
+    # General advice is that if in doubt, mark your migration as `is_dangerous`.
+    # Some things you should always mark as dangerous:
+    # - Adding indexes to large tables. These indexes should be created concurrently,
+    #   unfortunately we can't run migrations outside of a transaction until Django
+    #   1.10. So until then these should be run manually.
+    # - Large data migrations. Typically we want these to be run manually by ops so that
+    #   they can be monitored. Since data migrations will now hold a transaction open
+    #   this is even more important.
+    # - Adding columns to highly active tables, even ones that are NULL.
+    is_dangerous = False
+
+
+    dependencies = [
+        ('sentry', '0014_delete_sentryappwebhookerror'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    """
+                    DROP TABLE "sentry_sentryappwebhookerror";
+                    """
+                )
+            ],
+            state_operations=[],
+        )
+    ]


### PR DESCRIPTION
Step 3 in removing SentryAppWebhookError: Actually run migration to remove the table

merge after #15528