### PR TITLE
feat(app-platform): UI tweaks to request log 

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.tsx
@@ -16,10 +16,21 @@ import BarChart from 'app/components/charts/barChart';
 import DateTime from 'app/components/dateTime';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import Link from 'app/components/links/link';
+import Tag from 'app/views/settings/components/tag';
 
 import space from 'app/styles/space';
 import {SentryApp, SentryAppWebhookRequest} from 'app/types';
 import {t} from 'app/locale';
+
+const ResponseCode = ({code}: {code: number}) => {
+  return (
+    <div>
+      <Tag priority={code >= 100 && code <= 399 ? 'success' : 'error'}>
+        {code === 0 ? 'timeout' : code}
+      </Tag>
+    </div>
+  );
+};
 
 type Props = AsyncView['props'];
 
@@ -155,7 +166,7 @@ export default class SentryApplicationDashboard extends AsyncView<Props, State> 
                 <PanelItem key={idx}>
                   <TableLayout>
                     <DateTime date={request.date} />
-                    <div>{request.responseCode}</div>
+                    <ResponseCode code={request.responseCode} />
                     {app.status !== 'internal' && request.organization && (
                       <div>{request.organization.name}</div>
                     )}

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'react-emotion';
 
+import moment from 'moment-timezone';
+
 import AsyncView from 'app/views/asyncView';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import LineChart from 'app/components/charts/lineChart';
@@ -29,6 +31,16 @@ const ResponseCode = ({code}: {code: number}) => {
         {code === 0 ? 'timeout' : code}
       </Tag>
     </div>
+  );
+};
+
+const TimestampLink = ({date, link}: {date: moment.MomentInput; link?: string}) => {
+  return link ? (
+    <Link to={link}>
+      <DateTime date={date} />
+    </Link>
+  ) : (
+    <DateTime date={date} />
   );
 };
 
@@ -165,7 +177,7 @@ export default class SentryApplicationDashboard extends AsyncView<Props, State> 
               requests.map((request, idx) => (
                 <PanelItem key={idx}>
                   <TableLayout>
-                    <DateTime date={request.date} />
+                    <TimestampLink date={request.date} />
                     <ResponseCode code={request.responseCode} />
                     {app.status !== 'internal' && request.organization && (
                       <div>{request.organization.name}</div>

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.tsx
@@ -25,11 +25,16 @@ import {SentryApp, SentryAppWebhookRequest} from 'app/types';
 import {t} from 'app/locale';
 
 const ResponseCode = ({code}: {code: number}) => {
+  let priority = 'error';
+  if (code <= 399 && code >= 300) {
+    priority = 'warning';
+  } else if (code <= 299 && code >= 100) {
+    priority = 'success';
+  }
+
   return (
     <div>
-      <Tag priority={code >= 100 && code <= 399 ? 'success' : 'error'}>
-        {code === 0 ? 'timeout' : code}
-      </Tag>
+      <Tag priority={priority}>{code === 0 ? 'timeout' : code}</Tag>
     </div>
   );
 };

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {Client} from 'app/api';
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import SentryApplicationDashboard from 'app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard';
 
 describe('Sentry Application Dashboard', function() {
@@ -63,7 +63,7 @@ describe('Sentry Application Dashboard', function() {
         body: sentryApp,
       });
 
-      wrapper = mount(
+      wrapper = mountWithTheme(
         <SentryApplicationDashboard params={{appSlug: sentryApp.slug, orgId}} />,
         TestStubs.routerContext()
       );
@@ -120,7 +120,7 @@ describe('Sentry Application Dashboard', function() {
         body: [],
       });
 
-      wrapper = mount(
+      wrapper = mountWithTheme(
         <SentryApplicationDashboard params={{appSlug: sentryApp.slug, orgId}} />,
         TestStubs.routerContext()
       );
@@ -203,7 +203,7 @@ describe('Sentry Application Dashboard', function() {
         body: sentryApp,
       });
 
-      wrapper = mount(
+      wrapper = mountWithTheme(
         <SentryApplicationDashboard params={{appSlug: sentryApp.slug, orgId}} />,
         TestStubs.routerContext()
       );
@@ -233,7 +233,7 @@ describe('Sentry Application Dashboard', function() {
         body: [],
       });
 
-      wrapper = mount(
+      wrapper = mountWithTheme(
         <SentryApplicationDashboard params={{appSlug: sentryApp.slug, orgId}} />,
         TestStubs.routerContext()
       );


### PR DESCRIPTION
- display the status codes as colored tags
- add potential to have a link on the timestamp (this will come in handy when we link Sentry errors)
![image](https://user-images.githubusercontent.com/16789393/68903900-53246300-06f1-11ea-883d-217ade783bde.png)
![image](https://user-images.githubusercontent.com/16789393/68903906-56b7ea00-06f1-11ea-9b14-897f6a0e2f82.png)
