### PR TITLE
fix(app-platform): ensures that repo deletion rollback is atomic

### DIFF
--- a/src/sentry/api/endpoints/organization_repository_details.py
+++ b/src/sentry/api/endpoints/organization_repository_details.py
@@ -5,6 +5,7 @@ import logging
 from rest_framework import serializers
 from rest_framework.response import Response
 from uuid import uuid4
+from django.db import transaction
 
 from sentry.api.base import DocSection
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationRepositoryPermission
@@ -74,10 +75,14 @@ class OrganizationRepositoryDetailsEndpoint(OrganizationEndpoint):
 
         if update_kwargs:
             old_status = repo.status
-            repo.update(**update_kwargs)
-            if old_status == ObjectStatus.PENDING_DELETION and repo.status == ObjectStatus.VISIBLE:
-                repo.reset_pending_deletion_field_names()
-                repo.delete_pending_deletion_option()
+            with transaction.atomic():
+                repo.update(**update_kwargs)
+                if (
+                    old_status == ObjectStatus.PENDING_DELETION
+                    and repo.status == ObjectStatus.VISIBLE
+                ):
+                    repo.reset_pending_deletion_field_names()
+                    repo.delete_pending_deletion_option()
 
         return Response(serialize(repo, request.user))
 

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
 from mock import patch
-
 from django.core.urlresolvers import reverse
+
 
 from sentry.constants import ObjectStatus
 from sentry.models import Commit, Integration, OrganizationOption, Repository
@@ -209,6 +209,51 @@ class OrganizationRepositoryDeleteTest(APITestCase):
         assert not OrganizationOption.objects.filter(
             organization_id=org.id, key=repo.build_pending_deletion_key()
         ).exists()
+
+    def test_put_cancel_deletion_dupliate_exists(self):
+        self.login_as(user=self.user)
+
+        org = self.create_organization(owner=self.user, name="baz")
+        integration = Integration.objects.create(provider="example", name="example")
+        integration.add_organization(org)
+
+        repo = Repository.objects.create(
+            name="uuid-name",
+            external_id="uuid-external-id",
+            organization_id=org.id,
+            status=ObjectStatus.PENDING_DELETION,
+            config={"pending_deletion_name": "example-name"},
+        )
+
+        repo2 = Repository.objects.create(
+            name="example_name",
+            external_id="uuid-external-id",
+            organization_id=org.id,
+            status=ObjectStatus.VISIBLE,
+        )
+
+        OrganizationOption.objects.create(
+            organization_id=org.id,
+            key=repo.build_pending_deletion_key(),
+            value={
+                "name": "example_name",
+                "external_id": "example-external-id",
+                "id": repo.id,
+                "model": Repository.__name__,
+            },
+        )
+
+        url = reverse("sentry-api-0-organization-repository-details", args=[org.slug, repo.id])
+        response = self.client.put(url, data={"status": "visible", "integrationId": integration.id})
+        assert response.status_code == 500
+
+        repo = Repository.objects.get(id=repo.id)
+        assert repo.status == ObjectStatus.PENDING_DELETION
+        assert repo.name == "uuid-name"
+
+        repo2 = Repository.objects.get(id=repo2.id)
+        assert repo2.status == ObjectStatus.VISIBLE
+        assert repo2.name == "example_name"
 
     def test_put_bad_integration_org(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
 from mock import patch
-from django.core.urlresolvers import reverse
 
+from django.core.urlresolvers import reverse
 
 from sentry.constants import ObjectStatus
 from sentry.models import Commit, Integration, OrganizationOption, Repository


### PR DESCRIPTION
Use `transaction.atomic()` when changing fields of the Repository when cancelling a deletion in case there is a DB error.