### PR TITLE
feat(ui): Add description to `<RadioGroup>`

### DIFF
--- a/docs-ui/components/form.stories.js
+++ b/docs-ui/components/form.stories.js
@@ -372,8 +372,8 @@ storiesOf('Forms|Fields', module)
               label={label}
               value={value}
               choices={[
-                ['choice_one', 'Choice One'],
-                ['choice_two', 'Choice Two'],
+                ['choice_one', 'Choice One', 'Description for Choice One'],
+                ['choice_two', 'Choice Two', 'Description for Choice Two'],
                 ['choice_three', 'Choice Three'],
               ]}
             />

--- a/docs-ui/components/form.stories.js
+++ b/docs-ui/components/form.stories.js
@@ -348,7 +348,7 @@ storiesOf('Forms|Fields', module)
         <SelectField
           name="select"
           label="Multi Select"
-          multiple={true}
+          multiple
           choices={[
             ['choice_one', 'Choice One'],
             ['choice_two', 'Choice Two'],

--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/radioGroup.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/radioGroup.tsx
@@ -5,46 +5,64 @@ import isPropValid from '@emotion/is-prop-valid';
 
 import {growIn} from 'app/styles/animations';
 
-const RadioGroup = ({value, disabled, choices, label, onChange, ...props}) => {
-  const isSelected = id => {
-    return value ? value === id : id === 0;
-  };
+type Props = {
+  value: string | number | null;
 
+  // An array of [id, name, description]
+  choices: [string, string, string?][];
+  disabled?: boolean;
+  label: string;
+  onChange: (id: string, e: React.MouseEvent) => void;
+};
+
+const RadioGroup: React.FC<Props> = ({
+  value,
+  disabled,
+  choices,
+  label,
+  onChange,
+  ...props
+}) => {
   return (
     <div {...props} role="radiogroup" aria-labelledby={label}>
-      {(choices || []).map(([id, name, description], index) => (
-        <RadioLineItem
-          key={index}
-          onClick={e => !disabled && onChange(id, e)}
-          role="radio"
-          index={index}
-          aria-checked={isSelected(id)}
-          disabled={disabled}
-        >
-          <RadioLineButton type="button" disabled={disabled}>
-            {isSelected(id) && (
-              <RadioLineButtonFill disabled={disabled} animate={value !== ''} />
+      {(choices || []).map(([id, name, description], index) => {
+        const isSelected = value === id;
+
+        return (
+          <RadioLineItem
+            key={index}
+            onClick={e => !disabled && onChange(id, e)}
+            role="radio"
+            index={index}
+            aria-checked={isSelected}
+            disabled={disabled}
+          >
+            <RadioLineButton type="button" disabled={disabled}>
+              {isSelected && (
+                <RadioLineButtonFill disabled={disabled} animate={value !== ''} />
+              )}
+            </RadioLineButton>
+            <RadioLineText disabled={disabled}>{name}</RadioLineText>
+            {description && (
+              <React.Fragment>
+                <div />
+                <Description>{description}</Description>
+              </React.Fragment>
             )}
-          </RadioLineButton>
-          <RadioLineText disabled={disabled}>{name}</RadioLineText>
-          {description && (
-            <React.Fragment>
-              <div />
-              <Description>{description}</Description>
-            </React.Fragment>
-          )}
-        </RadioLineItem>
-      ))}
+          </RadioLineItem>
+        );
+      })}
     </div>
   );
 };
 
 RadioGroup.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  choices: PropTypes.arrayOf(PropTypes.array),
+  // TODO(ts): This is causing issues with ts
+  choices: PropTypes.any.isRequired,
   disabled: PropTypes.bool,
-  label: PropTypes.string,
-  onChange: PropTypes.func,
+  label: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 const RadioLineButton = styled('button')`
@@ -70,17 +88,23 @@ const RadioLineButton = styled('button')`
 
 const shouldForwardProp = p => !['disabled', 'animate'].includes(p) && isPropValid(p);
 
-const RadioLineItem = styled('div', {shouldForwardProp})`
+const RadioLineItem = styled('div', {shouldForwardProp})<{
+  disabled?: boolean;
+  index: number;
+}>`
   display: grid;
   grid-gap: 0.25em 0.5em;
   grid-template-columns: max-content auto;
   align-items: center;
   cursor: ${p => (p.disabled ? 'default' : 'pointer')};
-  margin-top: ${p => (p.index ? '0.5em' : '0')};
+  margin-top: ${p => (p.index > 0 ? '0.5em' : '0')};
   outline: none;
 `;
 
-const RadioLineButtonFill = styled('div', {shouldForwardProp})`
+const RadioLineButtonFill = styled('div', {shouldForwardProp})<{
+  animate: boolean;
+  disabled?: boolean;
+}>`
   width: 1rem;
   height: 1rem;
   border-radius: 50%;
@@ -89,7 +113,7 @@ const RadioLineButtonFill = styled('div', {shouldForwardProp})`
   opacity: ${p => (p.disabled ? 0.4 : null)};
 `;
 
-const RadioLineText = styled('div', {shouldForwardProp})`
+const RadioLineText = styled('div', {shouldForwardProp})<{disabled?: boolean}>`
   opacity: ${p => (p.disabled ? 0.4 : null)};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/radioGroup.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/radioGroup.tsx
@@ -45,6 +45,7 @@ const RadioGroup: React.FC<Props> = ({
             <RadioLineText disabled={disabled}>{name}</RadioLineText>
             {description && (
               <React.Fragment>
+                {/* If there is a description then we want to have a 2x2 grid so the first column width aligns with Radio Button */}
                 <div />
                 <Description>{description}</Description>
               </React.Fragment>

--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/radioGroup.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/radioGroup.tsx
@@ -12,7 +12,7 @@ const RadioGroup = ({value, disabled, choices, label, onChange, ...props}) => {
 
   return (
     <div {...props} role="radiogroup" aria-labelledby={label}>
-      {(choices || []).map(([id, name], index) => (
+      {(choices || []).map(([id, name, description], index) => (
         <RadioLineItem
           key={index}
           onClick={e => !disabled && onChange(id, e)}
@@ -27,6 +27,12 @@ const RadioGroup = ({value, disabled, choices, label, onChange, ...props}) => {
             )}
           </RadioLineButton>
           <RadioLineText disabled={disabled}>{name}</RadioLineText>
+          {description && (
+            <React.Fragment>
+              <div />
+              <Description>{description}</Description>
+            </React.Fragment>
+          )}
         </RadioLineItem>
       ))}
     </div>
@@ -65,7 +71,9 @@ const RadioLineButton = styled('button')`
 const shouldForwardProp = p => !['disabled', 'animate'].includes(p) && isPropValid(p);
 
 const RadioLineItem = styled('div', {shouldForwardProp})`
-  display: flex;
+  display: grid;
+  grid-gap: 0.25em 0.5em;
+  grid-template-columns: max-content auto;
   align-items: center;
   cursor: ${p => (p.disabled ? 'default' : 'pointer')};
   margin-top: ${p => (p.index ? '0.5em' : '0')};
@@ -82,10 +90,13 @@ const RadioLineButtonFill = styled('div', {shouldForwardProp})`
 `;
 
 const RadioLineText = styled('div', {shouldForwardProp})`
-  margin-left: 0.5em;
-  font-size: 0.875em;
-  font-weight: bold;
   opacity: ${p => (p.disabled ? 0.4 : null)};
+`;
+
+const Description = styled('div')`
+  color: ${p => p.theme.gray1};
+  font-size: ${p => p.theme.fontSizeRelativeSmall};
+  line-height: 1.25em;
 `;
 
 export default RadioGroup;

--- a/tests/js/spec/components/forms/__snapshots__/radioGroup.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/radioGroup.spec.jsx.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RadioGroup render() can select a different item 1`] = `
+exports[`RadioGroup can select a different item 1`] = `
 <div
+  aria-labelledby="test"
   name="radio"
   role="radiogroup"
 >
@@ -54,8 +55,9 @@ exports[`RadioGroup render() can select a different item 1`] = `
 </div>
 `;
 
-exports[`RadioGroup render() renders 1`] = `
+exports[`RadioGroup renders 1`] = `
 <div
+  aria-labelledby="test"
   name="radio"
   role="radiogroup"
 >
@@ -108,7 +110,7 @@ exports[`RadioGroup render() renders 1`] = `
 </div>
 `;
 
-exports[`RadioGroup render() renders disabled 1`] = `
+exports[`RadioGroup renders disabled 1`] = `
 <RadioGroup
   choices={
     Array [
@@ -119,10 +121,13 @@ exports[`RadioGroup render() renders disabled 1`] = `
     ]
   }
   disabled={true}
+  label="test"
   name="radio"
+  onChange={[MockFunction]}
   value="choice_one"
 >
   <div
+    aria-labelledby="test"
     name="radio"
     role="radiogroup"
   >

--- a/tests/js/spec/components/forms/__snapshots__/radioGroup.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/radioGroup.spec.jsx.snap
@@ -136,7 +136,7 @@ exports[`RadioGroup render() renders disabled 1`] = `
     >
       <div
         aria-checked={true}
-        className="css-1ujnufh-RadioLineItem eeb3g7x1"
+        className="css-7bssrx-RadioLineItem e1r42lk41"
         onClick={[Function]}
         role="radio"
       >
@@ -145,7 +145,7 @@ exports[`RadioGroup render() renders disabled 1`] = `
           type="button"
         >
           <button
-            className="css-1ovwgkh-RadioLineButton eeb3g7x0"
+            className="css-1ovwgkh-RadioLineButton e1r42lk40"
             disabled={true}
             type="button"
           >
@@ -154,7 +154,7 @@ exports[`RadioGroup render() renders disabled 1`] = `
               disabled={true}
             >
               <div
-                className="css-14bkqla-RadioLineButtonFill eeb3g7x2"
+                className="css-14bkqla-RadioLineButtonFill e1r42lk42"
               />
             </RadioLineButtonFill>
           </button>
@@ -163,7 +163,7 @@ exports[`RadioGroup render() renders disabled 1`] = `
           disabled={true}
         >
           <div
-            className="css-fr9tlv-RadioLineText eeb3g7x3"
+            className="css-1lmu4rv-RadioLineText e1r42lk43"
           >
             Choice One
           </div>

--- a/tests/js/spec/components/forms/radioGroup.spec.jsx
+++ b/tests/js/spec/components/forms/radioGroup.spec.jsx
@@ -4,72 +4,80 @@ import {mount, shallow} from 'sentry-test/enzyme';
 import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup';
 
 describe('RadioGroup', function() {
-  describe('render()', function() {
-    it('renders', function() {
-      const wrapper = shallow(
-        <RadioGroup
-          name="radio"
-          value="choice_one"
-          choices={[
-            ['choice_one', 'Choice One'],
-            ['choice_two', 'Choice Two'],
-            ['choice_three', 'Choice Three'],
-          ]}
-        />
-      );
-      expect(wrapper).toMatchSnapshot();
-    });
+  it('renders', function() {
+    const mock = jest.fn();
+    const wrapper = shallow(
+      <RadioGroup
+        name="radio"
+        label="test"
+        value="choice_one"
+        choices={[
+          ['choice_one', 'Choice One'],
+          ['choice_two', 'Choice Two'],
+          ['choice_three', 'Choice Three'],
+        ]}
+        onChange={mock}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 
-    it('renders disabled', function() {
-      const wrapper = mount(
-        <RadioGroup
-          name="radio"
-          value="choice_one"
-          disabled
-          choices={[['choice_one', 'Choice One']]}
-        />
-      );
-      expect(wrapper).toMatchSnapshot();
+  it('renders disabled', function() {
+    const mock = jest.fn();
+    const wrapper = mount(
+      <RadioGroup
+        name="radio"
+        label="test"
+        value="choice_one"
+        disabled
+        choices={[['choice_one', 'Choice One']]}
+        onChange={mock}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
 
-      expect(wrapper.find('RadioLineText').props().disabled).toBe(true);
-      expect(wrapper.find('RadioLineButtonFill').props().disabled).toBe(true);
-    });
+    expect(wrapper.find('RadioLineText').props().disabled).toBe(true);
+    expect(wrapper.find('RadioLineButtonFill').props().disabled).toBe(true);
+  });
 
-    it('can select a different item', function() {
-      const wrapper = shallow(
-        <RadioGroup
-          name="radio"
-          value="choice_three"
-          choices={[
-            ['choice_one', 'Choice One'],
-            ['choice_two', 'Choice Two'],
-            ['choice_three', 'Choice Three'],
-          ]}
-        />
-      );
-      expect(wrapper).toMatchSnapshot();
-    });
+  it('can select a different item', function() {
+    const mock = jest.fn();
+    const wrapper = shallow(
+      <RadioGroup
+        name="radio"
+        label="test"
+        value="choice_three"
+        choices={[
+          ['choice_one', 'Choice One'],
+          ['choice_two', 'Choice Two'],
+          ['choice_three', 'Choice Three'],
+        ]}
+        onChange={mock}
+      />
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
 
-    it('calls onChange when clicked', function() {
-      const mock = jest.fn();
+  it('calls onChange when clicked', function() {
+    const mock = jest.fn();
 
-      const wrapper = mount(
-        <RadioGroup
-          name="radio"
-          value="choice_one"
-          choices={[
-            ['choice_one', 'Choice One'],
-            ['choice_two', 'Choice Two'],
-            ['choice_three', 'Choice Three'],
-          ]}
-          onChange={mock}
-        />
-      );
-      wrapper
-        .find('[role="radio"]')
-        .last()
-        .simulate('click');
-      expect(mock).toHaveBeenCalledWith(expect.any(String), expect.any(Object));
-    });
+    const wrapper = mount(
+      <RadioGroup
+        name="radio"
+        label="test"
+        value="choice_one"
+        choices={[
+          ['choice_one', 'Choice One'],
+          ['choice_two', 'Choice Two'],
+          ['choice_three', 'Choice Three'],
+        ]}
+        onChange={mock}
+      />
+    );
+    wrapper
+      .find('[role="radio"]')
+      .last()
+      .simulate('click');
+    expect(mock).toHaveBeenCalledWith(expect.any(String), expect.any(Object));
   });
 });


### PR DESCRIPTION
This allows `<RadioGroup>`s to have a description, but also changes the
styling a bit. Options are no longer bold, and font size is slightly
larger, description has smaller text and a lighter color.

Also converts to typescript.

Old:
![image](https://user-images.githubusercontent.com/79684/68622686-99768980-0487-11ea-99fb-04632962389e.png)


New:
![image](https://user-images.githubusercontent.com/79684/68622675-9085b800-0487-11ea-85e3-bc73296d7cf7.png)



With Description:
![image](https://user-images.githubusercontent.com/79684/68622902-0f7af080-0488-11ea-8478-ff9cba3da166.png)
