### PR TITLE
py3(django): use override_settings for ROOT_URLCONF instead of deprecated SimpleTestCase.urls

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -40,7 +40,7 @@ from django.core.cache import cache
 from django.core.urlresolvers import reverse
 from django.db import connections, DEFAULT_DB_ALIAS
 from django.http import HttpRequest
-from django.test import TestCase, TransactionTestCase
+from django.test import override_settings, TestCase, TransactionTestCase
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from exam import before, fixture, Exam
@@ -99,8 +99,6 @@ DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, li
 
 
 class BaseTestCase(Fixtures, Exam):
-    urls = "sentry.web.urls"
-
     def assertRequiresAuthentication(self, path, method="GET"):
         resp = getattr(self.client, method.lower())(path)
         assert resp.status_code == 302
@@ -436,6 +434,7 @@ class _AssertQueriesContext(CaptureQueriesContext):
             )
 
 
+@override_settings(ROOT_URLCONF="sentry.web.urls")
 class TestCase(BaseTestCase, TestCase):
     pass
 

--- a/tests/sentry/api/test_handlers.py
+++ b/tests/sentry/api/test_handlers.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.conf.urls import patterns, url
+from django.test import override_settings
 from rest_framework.permissions import AllowAny
 
 from sentry.api.base import Endpoint
@@ -18,9 +19,9 @@ class RateLimitedEndpoint(Endpoint):
 urlpatterns = patterns("", url(r"^/$", RateLimitedEndpoint.as_view(), name="sentry-test"))
 
 
+@override_settings(ROOT_URLCONF="tests.sentry.api.test_handlers")
 class TestRateLimited(APITestCase):
     endpoint = "sentry-test"
-    urls = "tests.sentry.api.test_handlers"
 
     def test_simple(self):
         self.login_as(self.user)

--- a/tests/sentry/web/frontend/test_csrf_failure.py
+++ b/tests/sentry/web/frontend/test_csrf_failure.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 
 from sentry.testutils import TestCase
 
 
+@override_settings(ROOT_URLCONF="sentry.conf.urls")
 class CsrfFailureTest(TestCase):
-    urls = "sentry.conf.urls"
-
     def test_simple(self):
         path = reverse("error-403-csrf-failure")
 

--- a/tests/sentry/web/frontend/test_error_404.py
+++ b/tests/sentry/web/frontend/test_error_404.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 
 from sentry.testutils import TestCase
 
 
+@override_settings(ROOT_URLCONF="sentry.conf.urls")
 class Error404Test(TestCase):
-    urls = "sentry.conf.urls"
-
     def test_renders(self):
         resp = self.client.get(reverse("error-404"))
         assert resp.status_code == 404

--- a/tests/sentry/web/frontend/test_error_500.py
+++ b/tests/sentry/web/frontend/test_error_500.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 
 from sentry.testutils import TestCase
 
 
+@override_settings(ROOT_URLCONF="sentry.conf.urls")
 class Error500Test(TestCase):
-    urls = "sentry.conf.urls"
-
     def test_renders(self):
         resp = self.client.get(reverse("error-500"))
         assert resp.status_code == 500

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 from six.moves.urllib.parse import quote
 from uuid import uuid4
 import logging
@@ -10,9 +11,8 @@ from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
+@override_settings(ROOT_URLCONF="sentry.conf.urls")
 class ErrorPageEmbedTest(TestCase):
-    urls = "sentry.conf.urls"
-
     def setUp(self):
         super(ErrorPageEmbedTest, self).setUp()
         self.project = self.create_project()
@@ -140,10 +140,8 @@ class ErrorPageEmbedTest(TestCase):
         assert resp.status_code == 400, resp.content
 
 
+@override_settings(ROOT_URLCONF="sentry.conf.urls")
 class ErrorPageEmbedEnvironmentTest(TestCase):
-
-    urls = "sentry.conf.urls"
-
     def setUp(self):
         self.project = self.create_project()
         self.project.update_option("sentry:origins", ["example.com"])


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.9/topics/testing/tools/#django.test.SimpleTestCase.urls is deprecated since 1.8.

See also https://github.com/getsentry/getsentry/pull/3265#issuecomment-552629960.
