### PR TITLE
fix(ui): Moved routing logic out of projects dashboard

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -999,26 +999,9 @@ function routes() {
           </Route>
         </Route>
       </Route>
-      {/* A route tree for lightweight organizational detail views */}
-      <Route path="/:orgId/" component={errorHandler(LightWeightOrganizationDetails)}>
-        <IndexRoute
-          componentPromise={() =>
-            import(/* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard')
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route
-          path="/organizations/:orgId/projects/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard')
-          }
-          component={errorHandler(LazyLoad)}
-        />
-      </Route>
       <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
         <Route component={errorHandler(OrganizationRoot)}>
           {hook('routes:organization-root')}
-          />
           <Route
             path="/organizations/:orgId/stats/"
             componentPromise={() =>
@@ -1622,6 +1605,16 @@ function routes() {
         <Route
           path=":projectId/events/:eventId/"
           component={errorHandler(ProjectEventRedirect)}
+        />
+      </Route>
+      {/* A route tree for lightweight organizational detail views */}
+      <Route component={errorHandler(LightWeightOrganizationDetails)}>
+        <Route
+          path="/organizations/:orgId/projects/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard')
+          }
+          component={errorHandler(LazyLoad)}
         />
       </Route>
       {hook('routes')}

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1292,7 +1292,6 @@ function routes() {
             component={errorHandler(LazyLoad)}
           />
           <Route path="/organizations/:orgId/">
-            <Redirect from="/organizations/:orgId/projects/" to="/:orgId/" />
             {hook('routes:organization')}
             <Redirect path="/organizations/:orgId/teams/" to="/settings/:orgId/teams/" />
             <Redirect

--- a/src/sentry/static/sentry/app/views/organizationDetails/index.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDetails/index.jsx
@@ -1,9 +1,11 @@
 import React, {Component} from 'react';
+import {browserHistory} from 'react-router';
 import PropTypes from 'prop-types';
 
 import {Client} from 'app/api';
 import {switchOrganization} from 'app/actionCreators/organizations';
 import {t, tct} from 'app/locale';
+import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 import AlertActions from 'app/actions/alertActions';
 import Button from 'app/components/button';
 import ErrorBoundary from 'app/components/errorBoundary';
@@ -164,6 +166,19 @@ class OrganizationDetailsBody extends Component {
 }
 
 export default class OrganizationDetails extends Component {
+  static propTypes = {
+    routes: PropTypes.array,
+  };
+
+  componentDidMount() {
+    const {routes} = this.props;
+    const isOldRoute = getRouteStringFromRoutes(routes) === '/:orgId/';
+
+    if (isOldRoute) {
+      browserHistory.replace(`/organizations/${this.props.params.orgId}/`);
+    }
+  }
+
   componentDidUpdate(prevProps) {
     if (
       prevProps.params &&

--- a/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/index.jsx
@@ -1,4 +1,4 @@
-import {Link, browserHistory} from 'react-router';
+import {Link} from 'react-router';
 import LazyLoad from 'react-lazyload';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -15,7 +15,6 @@ import PageHeading from 'app/components/pageHeading';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import ProjectsStatsStore from 'app/stores/projectsStatsStore';
 import SentryTypes from 'app/sentryTypes';
-import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 import profiler from 'app/utils/profiler';
 import space from 'app/styles/space';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -28,7 +27,6 @@ import TeamSection from './teamSection';
 
 class Dashboard extends React.Component {
   static propTypes = {
-    routes: PropTypes.array,
     teams: PropTypes.array,
     organization: SentryTypes.Organization,
     finishProfile: PropTypes.func,
@@ -37,12 +35,7 @@ class Dashboard extends React.Component {
   };
 
   componentDidMount() {
-    const {organization, routes, finishProfile} = this.props;
-    const isOldRoute = getRouteStringFromRoutes(routes) === '/:orgId/';
-
-    if (isOldRoute) {
-      browserHistory.replace(`/organizations/${organization.slug}/`);
-    }
+    const {finishProfile} = this.props;
 
     if (finishProfile) {
       finishProfile();


### PR DESCRIPTION
Currently the projectsDashboard takes on the responsibility of navigating users from `sentry.io/:orgId/` to `sentry.io/organizations/:orgId/` which will eventually lead to the issues page. This was fine until after the projectDashboard moved to a lightweight organization context causing some problems to crop up. Now the application will not only switch URLs but will also cause the user to navigate through lightweight and heavyweight organization contexts which causes some weird side effects and race conditions. We will do what we can to make navigation tolerant to these race conditions, but it probably makes sense to not have projectsDashboard managing redirects for now.