### PR TITLE
ref: Always use event.event_id instead of event.id

### DIFF
--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -60,7 +60,7 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
                     "organizationSlug": organization.slug,
                     "projectSlug": project_slugs_by_id[event.project_id],
                     "groupId": six.text_type(event.group_id),
-                    "eventId": six.text_type(event.id),
+                    "eventId": six.text_type(event.event_id),
                     "event": serialize(event, request.user),
                 }
             )

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -232,9 +232,9 @@ class EventSerializer(Serializer):
                 received = None
 
         d = {
-            "id": six.text_type(obj.id),
+            "id": obj.event_id,
             "groupID": six.text_type(obj.group_id) if obj.group_id else None,
-            "eventID": six.text_type(obj.event_id),
+            "eventID": obj.event_id,
             "projectID": six.text_type(obj.project_id),
             "size": obj.size,
             "entries": attrs["entries"],

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -41,7 +41,7 @@ class EventStream(Service):
         skip_consume=False,
     ):
         if skip_consume:
-            logger.info("post_process.skip.raw_event", extra={"event_id": event.id})
+            logger.info("post_process.skip.raw_event", extra={"event_id": event.event_id})
         else:
             post_process_group.delay(
                 event=event,

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -74,7 +74,7 @@ class NotificationPlugin(Plugin):
 
     def rule_notify(self, event, futures):
         rules = []
-        extra = {"event_id": event.id, "group_id": event.group_id, "plugin": self.slug}
+        extra = {"event_id": event.event_id, "group_id": event.group_id, "plugin": self.slug}
         log_event = "dispatched"
         for future in futures:
             rules.append(future.rule)

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -42,7 +42,7 @@ class NotifyEventServiceAction(EventAction):
     def after(self, event, state):
         service = self.get_option("service")
 
-        extra = {"event_id": event.id}
+        extra = {"event_id": event.event_id}
         if not service:
             self.logger.info("rules.fail.is_configured", extra=extra)
             return

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -296,7 +296,7 @@ class BaseTestCase(Fixtures, Exam):
     def _postEventAttachmentWithHeader(self, attachment, **extra):
         path = reverse(
             "sentry-api-event-attachment",
-            kwargs={"project_id": self.project.id, "event_id": self.event.id},
+            kwargs={"project_id": self.project.id, "event_id": self.event.event_id},
         )
 
         key = self.projectkey.public_key

--- a/src/sentry/web/frontend/project_event.py
+++ b/src/sentry/web/frontend/project_event.py
@@ -25,6 +25,6 @@ class ProjectEventRedirect(ProjectView):
         return HttpResponseRedirect(
             reverse(
                 "sentry-organization-event-detail",
-                args=[organization.slug, event.group_id, event.id],
+                args=[organization.slug, event.group_id, event.event_id],
             )
         )

--- a/tests/acceptance/test_project_user_feedback.py
+++ b/tests/acceptance/test_project_user_feedback.py
@@ -21,7 +21,10 @@ class ProjectUserFeedbackTest(AcceptanceTestCase):
     def test(self):
         group = self.create_group(project=self.project, message="Foo bar")
         self.create_userreport(
-            date_added=timezone.now(), group=group, project=self.project, event_id=self.event.id
+            date_added=timezone.now(),
+            group=group,
+            project=self.project,
+            event_id=self.event.event_id,
         )
         self.browser.get(self.path)
         self.browser.wait_until_not(".loading")

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -9,15 +9,19 @@ from sentry.api.serializers.models.event import SharedEventSerializer, SnubaEven
 from sentry.models import EventError
 from sentry.testutils import TestCase
 from sentry.utils.samples import load_data
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
 class EventSerializerTest(TestCase):
     def test_simple(self):
-        event = self.create_event(event_id="a")
-
+        event_id = "a" * 32
+        event = self.store_event(
+            data={"event_id": event_id, "timestamp": iso_format(before_now(minutes=1))},
+            project_id=self.project.id,
+        )
         result = serialize(event)
-        assert result["id"] == six.text_type(event.id)
-        assert result["eventID"] == "a"
+        assert result["id"] == event_id
+        assert result["eventID"] == event_id
 
     def test_eventerror(self):
         event = self.create_event(
@@ -186,7 +190,7 @@ class SharedEventSerializerTest(TestCase):
         event = self.create_event(event_id="a")
 
         result = serialize(event, None, SharedEventSerializer())
-        assert result["id"] == six.text_type(event.id)
+        assert result["id"] == six.text_type(event.event_id)
         assert result["eventID"] == "a"
         assert result.get("context") is None
         assert result.get("contexts") is None

--- a/tests/sentry/deletions/test_event.py
+++ b/tests/sentry/deletions/test_event.py
@@ -29,7 +29,7 @@ class DeleteEventTest(TestCase):
         with self.tasks():
             run_deletion(deletion.id)
 
-        assert not Event.objects.filter(id=event.id).exists()
+        assert not Event.objects.filter(event_id=event.event_id).exists()
         assert not EventAttachment.objects.filter(
             event_id=event.event_id, project_id=project.id
         ).exists()

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -91,7 +91,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         with self.tasks():
             delete_groups(object_ids=[group.id])
 
-        assert not Event.objects.filter(id=self.event.id).exists()
+        assert not Event.objects.filter(event_id=self.event.event_id).exists()
         assert not UserReport.objects.filter(group_id=group.id).exists()
         assert not UserReport.objects.filter(event_id=self.event.event_id).exists()
         assert not EventAttachment.objects.filter(event_id=self.event.event_id).exists()

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -61,7 +61,8 @@ class GroupRecordsTestCase(TestCase):
     def test_success(self):
         events = [self.create_event(group=self.group) for _ in range(3)]
         records = [
-            Record(event.id, Notification(event, [self.rule]), event.datetime) for event in events
+            Record(event.event_id, Notification(event, [self.rule]), event.datetime)
+            for event in events
         ]
         assert reduce(group_records, records, defaultdict(lambda: defaultdict(list))) == {
             self.rule: {self.group: records}

--- a/tests/sentry/rules/conditions/test_level_event.py
+++ b/tests/sentry/rules/conditions/test_level_event.py
@@ -59,7 +59,7 @@ class LevelConditionTest(RuleTestCase):
         eevent = self.create_event(tags={"level": "error"})
         wevent = self.create_event(tags={"level": "warning"})
 
-        assert wevent.id != eevent.id
+        assert wevent.event_id != eevent.event_id
         assert wevent.group.id == eevent.group.id
 
         wevent.group.level = logging.WARNING

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -217,7 +217,7 @@ class DeleteGroupTest(TestCase):
         with self.tasks():
             delete_groups(object_ids=[group.id])
 
-        assert not Event.objects.filter(id=event.id).exists()
+        assert not Event.objects.filter(event_id=event.event_id).exists()
         assert not GroupRedirect.objects.filter(group_id=group.id).exists()
         assert not GroupHash.objects.filter(group_id=group.id).exists()
         assert not Group.objects.filter(id=group.id).exists()

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -684,7 +684,7 @@ class EventAttachmentStoreViewTest(TestCase):
 
     def has_attachment(self):
         return EventAttachment.objects.filter(
-            project_id=self.project.id, event_id=self.event.id
+            project_id=self.project.id, event_id=self.event.event_id
         ).exists()
 
     def test_event_attachments_feature_creates_attachment(self):

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -56,7 +56,7 @@ class ProjectEventTest(SnubaTestCase, TestCase):
         )
 
         url = reverse(
-            "sentry-project-event-redirect", args=[self.org.slug, self.project.slug, event.id]
+            "sentry-project-event-redirect", args=[self.org.slug, self.project.slug, event.event_id]
         )
         resp = self.client.get(url)
         assert resp.status_code == 404


### PR DESCRIPTION
Ensure that we are always using event.event_id not event.id (which is
different for Event, but not for SnubaEvent). I don't think we were actually
exposing the deprecated ID anywhere however this will help with
https://github.com/getsentry/sentry/pull/15544 since event.id will
become None during post processing when we stop saving events.