### PR TITLE
fix(discover): Flaky test

### DIFF
--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -45,7 +45,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == six.text_type(self.query_id)
-        assert response.data["projects"] == self.project_ids
+        assert set(response.data["projects"]) == set(self.project_ids)
         assert response.data["fields"] == ["test"]
         assert response.data["conditions"] == []
         assert response.data["limit"] == 10


### PR DESCRIPTION
Have seen this test flake out a few times:
```
____________________ DiscoverSavedQueryDetailTest.test_get _____________________
Traceback (most recent call last):
  File "/home/travis/build/getsentry/sentry/tests/snuba/api/endpoints/test_discover_saved_query_detail.py", line 48, in test_get
    assert response.data["projects"] == self.project_ids
AssertionError: assert [96, 95] == [95, 96]
  At index 0 diff: 96 != 95
  Full diff:
  - [96, 95]
  + [95, 96]
```