### PR TITLE
feat(ui): Adapt user-feedback page to lightweight organization context

### DIFF
--- a/src/sentry/static/sentry/app/components/lightWeightNoProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/lightWeightNoProjectMessage.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import {Organization} from 'app/types';
+import {LightWeightOrganization, Organization} from 'app/types';
 import NoProjectMessage from 'app/components/noProjectMessage';
 import Projects from 'app/utils/projects';
 
 type Props = {
-  organization: Organization;
+  organization: LightWeightOrganization | Organization;
 };
 
 export default class LightWeightNoProjectMessage extends React.Component<Props> {
@@ -19,7 +19,7 @@ export default class LightWeightNoProjectMessage extends React.Component<Props> 
   render() {
     const {organization} = this.props;
 
-    return organization.projects ? (
+    return 'projects' in organization ? (
       <NoProjectMessage {...this.props} />
     ) : (
       <Projects orgId={this.props.organization.slug} allProjects>

--- a/src/sentry/static/sentry/app/components/lightWeightNoProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/lightWeightNoProjectMessage.tsx
@@ -1,30 +1,26 @@
 import React from 'react';
 
-import {LightWeightOrganization, Organization} from 'app/types';
+import {LightWeightOrganization, Organization, Project} from 'app/types';
 import NoProjectMessage from 'app/components/noProjectMessage';
-import Projects from 'app/utils/projects';
+import withProjects from 'app/utils/withProjects';
 
 type Props = {
   organization: LightWeightOrganization | Organization;
+  projects: Project[];
+  loadingProjects: boolean;
 };
 
-export default class LightWeightNoProjectMessage extends React.Component<Props> {
-  renderChildren = ({projects, fetching}) => {
-    if (fetching) {
+class LightWeightNoProjectMessage extends React.Component<Props> {
+  render() {
+    const {organization, projects, loadingProjects} = this.props;
+    if ('projects' in organization) {
+      return <NoProjectMessage {...this.props} />;
+    }
+    if (loadingProjects) {
       return this.props.children;
     }
     return <NoProjectMessage {...this.props} projects={projects} />;
-  };
-
-  render() {
-    const {organization} = this.props;
-
-    return 'projects' in organization ? (
-      <NoProjectMessage {...this.props} />
-    ) : (
-      <Projects orgId={this.props.organization.slug} allProjects>
-        {this.renderChildren}
-      </Projects>
-    );
   }
 }
+
+export default withProjects(LightWeightNoProjectMessage);

--- a/src/sentry/static/sentry/app/components/lightWeightNoProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/lightWeightNoProjectMessage.tsx
@@ -17,7 +17,11 @@ export default class LightWeightNoProjectMessage extends React.Component<Props> 
   };
 
   render() {
-    return (
+    const {organization} = this.props;
+
+    return organization.projects ? (
+      <NoProjectMessage {...this.props} />
+    ) : (
       <Projects orgId={this.props.organization.slug} allProjects>
         {this.renderChildren}
       </Projects>

--- a/src/sentry/static/sentry/app/components/noProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/noProjectMessage.tsx
@@ -3,7 +3,7 @@ import styled from 'react-emotion';
 import PropTypes from 'prop-types';
 
 import {t} from 'app/locale';
-import {Organization, Project} from 'app/types';
+import {LightWeightOrganization, Organization, Project} from 'app/types';
 import Button from 'app/components/button';
 import PageHeading from 'app/components/pageHeading';
 import Tooltip from 'app/components/tooltip';
@@ -14,7 +14,7 @@ import ConfigStore from 'app/stores/configStore';
 import img from '../../images/dashboard/hair-on-fire.svg';
 
 type Props = {
-  organization: Organization;
+  organization: LightWeightOrganization | Organization;
   projects?: Project[];
 };
 
@@ -34,14 +34,14 @@ export default class NoProjectMessage extends React.Component<Props> {
     const canJoinTeam = organization.access.includes('team:read');
 
     let hasProjects;
-    if (projects) {
-      hasProjects = projects.length > 0;
-    } else {
+    if ('projects' in organization) {
       const {isSuperuser} = ConfigStore.get('user');
 
       hasProjects = isSuperuser
         ? organization.projects.some(p => p.hasAccess)
         : organization.projects.some(p => p.isMember && p.hasAccess);
+    } else {
+      hasProjects = projects && projects.length > 0;
     }
 
     return hasProjects ? (

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -51,6 +51,11 @@ class GlobalSelectionHeader extends React.Component {
     projects: PropTypes.arrayOf(SentryTypes.Project).isRequired,
 
     /**
+     * Whether or not the projects are currently being loaded in
+     */
+    loadingProjects: PropTypes.bool,
+
+    /**
      * A project will be forced from parent component (selection is disabled, and if user
      * does not have multi-project support enabled, it will not try to auto select a project).
      *
@@ -487,6 +492,7 @@ class GlobalSelectionHeader extends React.Component {
       className,
       shouldForceProject,
       forceProject,
+      loadingProjects,
       organization,
       showAbsolute,
       showRelative,
@@ -510,6 +516,7 @@ class GlobalSelectionHeader extends React.Component {
             shouldForceProject={shouldForceProject}
             forceProject={forceProject}
             projects={projects}
+            loadingProjects={loadingProjects}
             nonMemberProjects={nonMemberProjects}
             value={this.state.projects || this.props.selection.projects}
             onChange={this.handleChangeProjects}
@@ -524,6 +531,8 @@ class GlobalSelectionHeader extends React.Component {
             <HeaderItemPosition>
               <MultipleEnvironmentSelector
                 organization={organization}
+                projects={projects}
+                loadingProjects={loadingProjects}
                 selectedProjects={selectedProjects}
                 value={this.state.environments || this.props.selection.environments}
                 onChange={this.handleChangeEnvironments}

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
@@ -17,7 +17,7 @@ type Props = {
   hasSelected: boolean;
   isOpen: boolean;
   locked: boolean;
-  loadingProjects: boolean;
+  loading: boolean;
   innerRef: React.Ref<HTMLDivElement>;
   onClear: () => void;
 } & HTMLDivElement;
@@ -56,7 +56,7 @@ class HeaderItem extends React.Component<Props> {
       lockedMessage,
       settingsLink,
       onClear, // eslint-disable-line no-unused-vars
-      loadingProjects,
+      loading,
       ...props
     } = this.props;
     return (
@@ -65,7 +65,7 @@ class HeaderItem extends React.Component<Props> {
         isOpen={isOpen}
         hasSelected={hasSelected}
         locked={locked}
-        loadingProjects={loadingProjects}
+        loading={loading}
         {...props}
       >
         <IconContainer hasSelected={hasSelected} locked={locked}>
@@ -85,7 +85,7 @@ class HeaderItem extends React.Component<Props> {
             <SettingsIcon src="icon-settings" />
           </SettingsIconLink>
         )}
-        {!locked && !loadingProjects && (
+        {!locked && !loading && (
           <StyledChevron isOpen={isOpen}>
             <InlineSvg src="icon-chevron-down" />
           </StyledChevron>
@@ -111,7 +111,7 @@ const StyledHeaderItem = styled('div')`
   display: flex;
   padding: 0 ${space(4)};
   align-items: center;
-  cursor: ${p => (p.loadingProjects ? 'progress' : p.locked ? 'text' : 'pointer')};
+  cursor: ${p => (p.loading ? 'progress' : p.locked ? 'text' : 'pointer')};
   color: ${getColor};
   transition: 0.1s color;
   user-select: none;

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
@@ -17,6 +17,7 @@ type Props = {
   hasSelected: boolean;
   isOpen: boolean;
   locked: boolean;
+  loadingProjects: boolean;
   innerRef: React.Ref<HTMLDivElement>;
   onClear: () => void;
 } & HTMLDivElement;
@@ -55,15 +56,16 @@ class HeaderItem extends React.Component<Props> {
       lockedMessage,
       settingsLink,
       onClear, // eslint-disable-line no-unused-vars
+      loadingProjects,
       ...props
     } = this.props;
-
     return (
       <StyledHeaderItem
         className={className}
         isOpen={isOpen}
         hasSelected={hasSelected}
         locked={locked}
+        loadingProjects={loadingProjects}
         {...props}
       >
         <IconContainer hasSelected={hasSelected} locked={locked}>
@@ -83,7 +85,7 @@ class HeaderItem extends React.Component<Props> {
             <SettingsIcon src="icon-settings" />
           </SettingsIconLink>
         )}
-        {!locked && (
+        {!locked && !loadingProjects && (
           <StyledChevron isOpen={isOpen}>
             <InlineSvg src="icon-chevron-down" />
           </StyledChevron>
@@ -109,7 +111,7 @@ const StyledHeaderItem = styled('div')`
   display: flex;
   padding: 0 ${space(4)};
   align-items: center;
-  cursor: ${p => (p.locked ? 'text' : 'pointer')};
+  cursor: ${p => (p.loadingProjects ? 'progress' : p.locked ? 'text' : 'pointer')};
   color: ${getColor};
   transition: 0.1s color;
   user-select: none;

--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -35,6 +35,10 @@ class MultipleEnvironmentSelector extends React.PureComponent {
 
     organization: SentryTypes.Organization,
 
+    projects: PropTypes.arrayOf(SentryTypes.Project),
+
+    loadingProjects: PropTypes.bool,
+
     selectedProjects: PropTypes.arrayOf(PropTypes.number),
 
     // This component must be controlled using a value array
@@ -183,9 +187,9 @@ class MultipleEnvironmentSelector extends React.PureComponent {
   };
 
   getEnvironments() {
-    const {organization, selectedProjects} = this.props;
+    const {projects, selectedProjects} = this.props;
     let environments = [];
-    organization.projects.forEach(function(project) {
+    projects.forEach(function(project) {
       const projectId = parseInt(project.id, 10);
 
       // Include environments from:
@@ -207,7 +211,7 @@ class MultipleEnvironmentSelector extends React.PureComponent {
   }
 
   render() {
-    const {value} = this.props;
+    const {value, loadingProjects} = this.props;
     const environments = this.getEnvironments();
 
     const validatedValue = value.filter(env => environments.includes(env));
@@ -215,7 +219,15 @@ class MultipleEnvironmentSelector extends React.PureComponent {
       ? `${validatedValue.join(', ')}`
       : t('All Environments');
 
-    return (
+    return loadingProjects ? (
+      <StyledHeaderItem
+        data-test-id="global-header-project-selector"
+        icon={<StyledInlineSvg src="icon-project" />}
+        loadingProjects
+      >
+        Loading...
+      </StyledHeaderItem>
+    ) : (
       <StyledDropdownAutoComplete
         alignMenu="left"
         allowActorToggle

--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -222,7 +222,7 @@ class MultipleEnvironmentSelector extends React.PureComponent {
     return loadingProjects ? (
       <StyledHeaderItem
         data-test-id="global-header-environment-selector"
-        icon={<StyledInlineSvg src="icon-project" />}
+        icon={<StyledInlineSvg src="icon-window" />}
         loadingProjects
       >
         Loading...

--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -225,7 +225,7 @@ class MultipleEnvironmentSelector extends React.PureComponent {
         icon={<StyledInlineSvg src="icon-window" />}
         loadingProjects
       >
-        Loading...
+        {t('Loading...')}
       </StyledHeaderItem>
     ) : (
       <StyledDropdownAutoComplete

--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -221,7 +221,7 @@ class MultipleEnvironmentSelector extends React.PureComponent {
 
     return loadingProjects ? (
       <StyledHeaderItem
-        data-test-id="global-header-project-selector"
+        data-test-id="global-header-environment-selector"
         icon={<StyledInlineSvg src="icon-project" />}
         loadingProjects
       >

--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -223,9 +223,9 @@ class MultipleEnvironmentSelector extends React.PureComponent {
       <StyledHeaderItem
         data-test-id="global-header-environment-selector"
         icon={<StyledInlineSvg src="icon-window" />}
-        loadingProjects
+        loading={loadingProjects}
       >
-        {t('Loading...')}
+        {t('Loading\u2026')}
       </StyledHeaderItem>
     ) : (
       <StyledDropdownAutoComplete

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -25,6 +25,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     value: PropTypes.array,
     projects: PropTypes.array.isRequired,
     nonMemberProjects: PropTypes.array.isRequired,
+    loadingProjects: PropTypes.bool,
     onChange: PropTypes.func,
     onUpdate: PropTypes.func,
     multi: PropTypes.bool,
@@ -155,7 +156,15 @@ export default class MultipleProjectSelector extends React.PureComponent {
     // `forceProject` can be undefined if it is loading the project
     // We are intentionally using an empty string as its "loading" state
 
-    return shouldForceProject ? (
+    return this.props.loadingProjects ? (
+      <StyledHeaderItem
+        data-test-id="global-header-project-selector"
+        icon={<StyledInlineSvg src="icon-project" />}
+        loadingProjects
+      >
+        Loading...
+      </StyledHeaderItem>
+    ) : shouldForceProject ? (
       <StyledHeaderItem
         data-test-id="global-header-project-selector"
         icon={<StyledInlineSvg src="icon-project" />}

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -140,6 +140,7 @@ export default class MultipleProjectSelector extends React.PureComponent {
     const {
       value,
       projects,
+      loadingProjects,
       nonMemberProjects,
       multi,
       organization,
@@ -156,13 +157,13 @@ export default class MultipleProjectSelector extends React.PureComponent {
     // `forceProject` can be undefined if it is loading the project
     // We are intentionally using an empty string as its "loading" state
 
-    return this.props.loadingProjects ? (
+    return loadingProjects ? (
       <StyledHeaderItem
         data-test-id="global-header-project-selector"
         icon={<StyledInlineSvg src="icon-project" />}
         loadingProjects
       >
-        Loading...
+        {t('Loading...')}
       </StyledHeaderItem>
     ) : shouldForceProject ? (
       <StyledHeaderItem

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -161,9 +161,9 @@ export default class MultipleProjectSelector extends React.PureComponent {
       <StyledHeaderItem
         data-test-id="global-header-project-selector"
         icon={<StyledInlineSvg src="icon-project" />}
-        loadingProjects
+        loading={loadingProjects}
       >
-        {t('Loading...')}
+        {t('Loading\u2026')}
       </StyledHeaderItem>
     ) : shouldForceProject ? (
       <StyledHeaderItem

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -1229,13 +1229,6 @@ function routes() {
             />
           </Route>
           <Route
-            path="/organizations/:orgId/user-feedback/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "OrganizationUserFeedback" */ 'app/views/userFeedback/organizationUserFeedback')
-            }
-            component={errorHandler(LazyLoad)}
-          />
-          <Route
             path="/organizations/:orgId/releases/"
             componentPromise={() =>
               import(/* webpackChunkName: "Releases" */ 'app/views/releases/list')
@@ -1612,6 +1605,13 @@ function routes() {
           path="/organizations/:orgId/projects/"
           componentPromise={() =>
             import(/* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard')
+          }
+          component={errorHandler(LazyLoad)}
+        />
+        <Route
+          path="/organizations/:orgId/user-feedback/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "OrganizationUserFeedback" */ 'app/views/userFeedback/organizationUserFeedback')
           }
           component={errorHandler(LazyLoad)}
         />

--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -999,6 +999,27 @@ function routes() {
           </Route>
         </Route>
       </Route>
+      {/* A route tree for lightweight organizational detail views. We place
+      this above the heavyweight organization detail views because there
+      exist some redirects from deprecated routes which should not take
+      precedence over these lightweight routes*/}
+      <Route component={errorHandler(LightWeightOrganizationDetails)}>
+        <Route
+          path="/organizations/:orgId/projects/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard')
+          }
+          component={errorHandler(LazyLoad)}
+        />
+        <Route
+          path="/organizations/:orgId/user-feedback/"
+          componentPromise={() =>
+            import(/* webpackChunkName: "OrganizationUserFeedback" */ 'app/views/userFeedback/organizationUserFeedback')
+          }
+          component={errorHandler(LazyLoad)}
+        />
+      </Route>
+      {/* The heavyweight organization detail views */}
       <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
         <Route component={errorHandler(OrganizationRoot)}>
           {hook('routes:organization-root')}
@@ -1597,23 +1618,6 @@ function routes() {
         <Route
           path=":projectId/events/:eventId/"
           component={errorHandler(ProjectEventRedirect)}
-        />
-      </Route>
-      {/* A route tree for lightweight organizational detail views */}
-      <Route component={errorHandler(LightWeightOrganizationDetails)}>
-        <Route
-          path="/organizations/:orgId/projects/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard')
-          }
-          component={errorHandler(LazyLoad)}
-        />
-        <Route
-          path="/organizations/:orgId/user-feedback/"
-          componentPromise={() =>
-            import(/* webpackChunkName: "OrganizationUserFeedback" */ 'app/views/userFeedback/organizationUserFeedback')
-          }
-          component={errorHandler(LazyLoad)}
         />
       </Route>
       {hook('routes')}

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -10,12 +10,15 @@ export type ObjectStatus =
   | 'pending_deletion'
   | 'deletion_in_progress';
 
-export type Organization = {
+export type LightWeightOrganization = {
   id: string;
   slug: string;
-  projects: Project[];
   access: string[];
   features: string[];
+};
+
+export type Organization = LightWeightOrganization & {
+  projects: Project[];
   teams: Team[];
 };
 

--- a/src/sentry/static/sentry/app/utils/withProjects.tsx
+++ b/src/sentry/static/sentry/app/utils/withProjects.tsx
@@ -9,10 +9,12 @@ import {Project} from 'app/types';
 
 type InjectedProjectsProps = {
   projects: Project[];
+  loadingProjects?: boolean;
 };
 
 type State = {
   projects: Project[];
+  loadingProjects: boolean;
 };
 
 /**

--- a/src/sentry/static/sentry/app/utils/withProjects.tsx
+++ b/src/sentry/static/sentry/app/utils/withProjects.tsx
@@ -14,7 +14,7 @@ type InjectedProjectsProps = {
 
 type State = {
   projects: Project[];
-  loadingProjects: boolean;
+  loading: boolean;
 };
 
 /**

--- a/src/sentry/static/sentry/app/views/userFeedback/organizationUserFeedback.tsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/organizationUserFeedback.tsx
@@ -10,7 +10,7 @@ import CompactIssue from 'app/components/issues/compactIssue';
 import EventUserFeedback from 'app/components/events/userFeedback';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import NoProjectMessage from 'app/components/noProjectMessage';
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import withOrganization from 'app/utils/withOrganization';
@@ -112,7 +112,7 @@ class OrganizationUserFeedback extends AsyncView<Props, State> {
       <React.Fragment>
         <GlobalSelectionHeader organization={organization} />
         <PageContent>
-          <NoProjectMessage organization={organization}>
+          <LightWeightNoProjectMessage organization={organization}>
             <UserFeedbackContainer
               pageLinks={reportListPageLinks}
               status={status}
@@ -120,7 +120,7 @@ class OrganizationUserFeedback extends AsyncView<Props, State> {
             >
               {this.renderStreamBody()}
             </UserFeedbackContainer>
-          </NoProjectMessage>
+          </LightWeightNoProjectMessage>
         </PageContent>
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/views/userFeedback/userFeedbackEmpty.tsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/userFeedbackEmpty.tsx
@@ -3,7 +3,7 @@ import styled from 'react-emotion';
 import PropTypes from 'prop-types';
 import * as Sentry from '@sentry/browser';
 
-import {Organization} from 'app/types';
+import {Organization, Project} from 'app/types';
 import {t} from 'app/locale';
 import {trackAnalyticsEvent, trackAdhocEvent} from 'app/utils/analytics';
 import Button from 'app/components/button';
@@ -12,9 +12,13 @@ import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import userFeedback from 'sentry-dreamy-components/dist/user-feedback.svg';
 import withOrganization from 'app/utils/withOrganization';
+import withProjects from 'app/utils/withProjects';
+import LoadingIndicator from 'app/components/loadingIndicator';
 
 type Props = {
   organization: Organization;
+  projects: Project[];
+  loadingProjects: boolean;
   projectIds?: string[];
 };
 
@@ -59,10 +63,7 @@ class UserFeedbackEmpty extends React.Component<Props> {
   }
 
   get hasAnyFeedback() {
-    const {
-      organization: {projects},
-      projectIds,
-    } = this.props;
+    const {projects, projectIds} = this.props;
 
     const selectedProjects =
       projectIds && projectIds.length
@@ -84,6 +85,10 @@ class UserFeedbackEmpty extends React.Component<Props> {
   }
 
   render() {
+    if (this.props.loadingProjects) {
+      return <LoadingIndicator />;
+    }
+
     if (this.hasAnyFeedback !== false) {
       return (
         <EmptyStateWarning>
@@ -200,4 +205,6 @@ const ButtonList = styled('div')`
   grid-gap: ${space(1)};
 `;
 
-export default withOrganization(UserFeedbackEmpty);
+export {UserFeedbackEmpty};
+
+export default withOrganization(withProjects(UserFeedbackEmpty));

--- a/src/sentry/static/sentry/app/views/userFeedback/userFeedbackEmpty.tsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/userFeedbackEmpty.tsx
@@ -13,7 +13,6 @@ import space from 'app/styles/space';
 import userFeedback from 'sentry-dreamy-components/dist/user-feedback.svg';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
-import LoadingIndicator from 'app/components/loadingIndicator';
 
 type Props = {
   organization: Organization;
@@ -85,18 +84,15 @@ class UserFeedbackEmpty extends React.Component<Props> {
   }
 
   render() {
-    if (this.props.loadingProjects) {
-      return <LoadingIndicator />;
-    }
-
-    if (this.hasAnyFeedback !== false) {
+    // Show no user reports if waiting for projects to load or if there is no feedback
+    if (this.props.loadingProjects || this.hasAnyFeedback !== false) {
       return (
         <EmptyStateWarning>
           <p>{t('Sorry, no user reports match your filters.')}</p>
         </EmptyStateWarning>
       );
     }
-
+    // Show landing page after projects have loaded and it is confirmed no projects have feedback
     return (
       <UserFeedbackLanding>
         <IllustrationContainer>

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -54,7 +54,10 @@ describe('GlobalSelectionHeader', function() {
   });
 
   beforeEach(function() {
-    jest.spyOn(ProjectsStore, 'getAll').mockImplementation(() => organization.projects);
+    jest.spyOn(ProjectsStore, 'getState').mockImplementation(() => ({
+      projects: organization.projects,
+      loadingProjects: false,
+    }));
     GlobalSelectionStore.reset();
     [
       globalActions.updateDateTime,
@@ -453,7 +456,9 @@ describe('GlobalSelectionHeader', function() {
     it('selects first project if none (i.e. all) is requested', function() {
       const project = TestStubs.Project({id: '3'});
       const org = TestStubs.Organization({projects: [project]});
-      jest.spyOn(ProjectsStore, 'getAll').mockImplementation(() => org.projects);
+      jest
+        .spyOn(ProjectsStore, 'getState')
+        .mockImplementation(() => ({projects: org.projects, loadingProjects: false}));
 
       const initializationObj = initializeOrg({
         organization: org,
@@ -483,6 +488,10 @@ describe('GlobalSelectionHeader', function() {
         location: {query: {}},
       },
     });
+    jest.spyOn(ProjectsStore, 'getState').mockImplementation(() => ({
+      projects: initialData.organization.projects,
+      loadingProjects: false,
+    }));
 
     const wrapper = mountWithTheme(
       <GlobalSelectionHeader
@@ -536,9 +545,10 @@ describe('GlobalSelectionHeader', function() {
       };
 
       beforeEach(function() {
-        jest
-          .spyOn(ProjectsStore, 'getAll')
-          .mockImplementation(() => initialData.organization.projects);
+        jest.spyOn(ProjectsStore, 'getState').mockImplementation(() => ({
+          projects: initialData.organization.projects,
+          loadingProjects: false,
+        }));
         initialData.router.push.mockClear();
         initialData.router.replace.mockClear();
       });
@@ -668,7 +678,9 @@ describe('GlobalSelectionHeader', function() {
       memberProject = TestStubs.Project({id: '3', isMember: true});
       nonMemberProject = TestStubs.Project({id: '4', isMember: false});
       const org = TestStubs.Organization({projects: [memberProject, nonMemberProject]});
-      jest.spyOn(ProjectsStore, 'getAll').mockImplementation(() => org.projects);
+      jest
+        .spyOn(ProjectsStore, 'getState')
+        .mockImplementation(() => ({projects: org.projects, loadingProjects: false}));
 
       initialData = initializeOrg({
         organization: org,

--- a/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
@@ -10,26 +10,25 @@ describe('MultipleEnvironmentSelector', function() {
   const onUpdate = jest.fn();
 
   const envs = ['production', 'staging', 'dev'];
-  const organization = TestStubs.Organization({
-    projects: [
-      TestStubs.Project({
-        id: '1',
-        slug: 'first',
-        environments: ['production', 'staging'],
-      }),
-      TestStubs.Project({
-        id: '2',
-        slug: 'second',
-        environments: ['dev'],
-      }),
-      TestStubs.Project({
-        id: '3',
-        slug: 'no member',
-        environments: ['no-env'],
-        isMember: false,
-      }),
-    ],
-  });
+  const projects = [
+    TestStubs.Project({
+      id: '1',
+      slug: 'first',
+      environments: ['production', 'staging'],
+    }),
+    TestStubs.Project({
+      id: '2',
+      slug: 'second',
+      environments: ['dev'],
+    }),
+    TestStubs.Project({
+      id: '3',
+      slug: 'no member',
+      environments: ['no-env'],
+      isMember: false,
+    }),
+  ];
+  const organization = TestStubs.Organization({projects});
   const selectedProjects = [1, 2];
   const routerContext = TestStubs.routerContext([
     {
@@ -43,6 +42,8 @@ describe('MultipleEnvironmentSelector', function() {
     wrapper = mountWithTheme(
       <MultipleEnvironmentSelector
         organization={organization}
+        projects={projects}
+        loadingProjects={false}
         selectedProjects={selectedProjects}
         onChange={onChange}
         onUpdate={onUpdate}

--- a/tests/js/spec/views/events/events.spec.jsx
+++ b/tests/js/spec/views/events/events.spec.jsx
@@ -383,6 +383,8 @@ describe('EventsContainer', function() {
 
   it('updates when changing projects', async function() {
     ProjectsStore.loadInitialData(organization.projects);
+    // ensure that the wrapper gets new project values from withProjects HOC
+    wrapper.update();
 
     expect(wrapper.find('MultipleProjectSelector').prop('value')).toEqual([]);
 

--- a/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
 
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
+import ProjectsStore from 'app/stores/projectsStore';
 
 describe('LightWeightNoProjectMessage', function() {
   it('renders', async function() {
@@ -9,10 +10,7 @@ describe('LightWeightNoProjectMessage', function() {
     const project2 = TestStubs.Project();
     const organization = TestStubs.Organization({slug: 'org-slug'});
     delete organization.projects;
-    const getProjectsMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/projects/',
-      body: [project1, project2],
-    });
+    ProjectsStore.loadInitialData([project1, project2]);
     const wrapper = mountWithTheme(
       <LightWeightNoProjectMessage organization={organization}>
         {null}
@@ -20,10 +18,6 @@ describe('LightWeightNoProjectMessage', function() {
       TestStubs.routerContext()
     );
     expect(wrapper.prop('children')).toBe(null);
-    // await fetching projects
-    await tick();
-    wrapper.update();
-    expect(getProjectsMock).toHaveBeenCalled();
     expect(wrapper.find('NoProjectMessage').exists()).toBe(true);
   });
 });

--- a/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
@@ -8,6 +8,7 @@ describe('LightWeightNoProjectMessage', function() {
     const project1 = TestStubs.Project();
     const project2 = TestStubs.Project();
     const organization = TestStubs.Organization({slug: 'org-slug'});
+    delete organization.projects;
     const getProjectsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
       body: [project1, project2],

--- a/tests/js/spec/views/userFeedback/userFeedbackEmpty.spec.jsx
+++ b/tests/js/spec/views/userFeedback/userFeedbackEmpty.spec.jsx
@@ -1,22 +1,25 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
-import UserFeedbackEmpty from 'app/views/userFeedback/userFeedbackEmpty';
+import {UserFeedbackEmpty} from 'app/views/userFeedback/userFeedbackEmpty';
 
 describe('UserFeedbackEmpty', function() {
   const routerContext = TestStubs.routerContext();
   const project = TestStubs.Project({id: '1'});
   const projectWithReports = TestStubs.Project({id: '2', hasUserReports: true});
+  const projectWithoutReports = TestStubs.Project({id: '3'});
+  const organization = TestStubs.Organization();
 
   it('renders empty', function() {
-    const organization = TestStubs.Organization();
-    mountWithTheme(<UserFeedbackEmpty organization={organization} />, routerContext);
+    mountWithTheme(
+      <UserFeedbackEmpty projects={[]} organization={organization} />,
+      routerContext
+    );
   });
 
   it('renders landing for project with no user feedback', function() {
-    const organization = TestStubs.Organization({projects: [TestStubs.Project()]});
     const wrapper = mountWithTheme(
-      <UserFeedbackEmpty organization={organization} />,
+      <UserFeedbackEmpty projects={[project]} organization={organization} />,
       routerContext
     );
 
@@ -24,11 +27,8 @@ describe('UserFeedbackEmpty', function() {
   });
 
   it('renders warning for project with any user feedback', function() {
-    const organization = TestStubs.Organization({
-      projects: [projectWithReports],
-    });
     const wrapper = mountWithTheme(
-      <UserFeedbackEmpty organization={organization} />,
+      <UserFeedbackEmpty projects={[projectWithReports]} organization={organization} />,
       routerContext
     );
 
@@ -36,11 +36,11 @@ describe('UserFeedbackEmpty', function() {
   });
 
   it('renders warning for projects with any user feedback', function() {
-    const organization = TestStubs.Organization({
-      projects: [TestStubs.Project(), TestStubs.Project({hasUserReports: true})],
-    });
     const wrapper = mountWithTheme(
-      <UserFeedbackEmpty organization={organization} />,
+      <UserFeedbackEmpty
+        projects={[project, projectWithReports]}
+        organization={organization}
+      />,
       routerContext
     );
 
@@ -48,11 +48,9 @@ describe('UserFeedbackEmpty', function() {
   });
 
   it('renders warning for project query with user feedback', function() {
-    const organization = TestStubs.Organization({
-      projects: [project, projectWithReports],
-    });
     const wrapper = mountWithTheme(
       <UserFeedbackEmpty
+        projects={[project, projectWithReports]}
         organization={organization}
         projectIds={[projectWithReports.id]}
       />,
@@ -63,11 +61,12 @@ describe('UserFeedbackEmpty', function() {
   });
 
   it('renders landing for project query without any user feedback', function() {
-    const organization = TestStubs.Organization({
-      projects: [project, projectWithReports],
-    });
     const wrapper = mountWithTheme(
-      <UserFeedbackEmpty organization={organization} projectIds={[project.id]} />,
+      <UserFeedbackEmpty
+        projects={[project, projectWithReports]}
+        organization={organization}
+        projectIds={[project.id]}
+      />,
       routerContext
     );
 
@@ -75,11 +74,9 @@ describe('UserFeedbackEmpty', function() {
   });
 
   it('renders warning for multi project query with any user feedback', function() {
-    const organization = TestStubs.Organization({
-      projects: [project, projectWithReports],
-    });
     const wrapper = mountWithTheme(
       <UserFeedbackEmpty
+        projects={[project, projectWithReports]}
         organization={organization}
         projectIds={[project.id, projectWithReports.id]}
       />,
@@ -90,12 +87,9 @@ describe('UserFeedbackEmpty', function() {
   });
 
   it('renders landing for multi project query without any user feedback', function() {
-    const projectWithoutReports = TestStubs.Project({id: '3'});
-    const organization = TestStubs.Organization({
-      projects: [project, projectWithoutReports],
-    });
     const wrapper = mountWithTheme(
       <UserFeedbackEmpty
+        projects={[project, projectWithoutReports]}
         organization={organization}
         projectIds={[project.id, projectWithoutReports.id]}
       />,


### PR DESCRIPTION
Moving the user-feedback page to the lightweight organization context (without projects/teams) to improve first time (cold start) load of the page. This should contribute to a large performance benefit to this page as teams and projects are both not required to show information on the user-feedback page. In order to do this I
- Introduced a loading state to GlobalSelectionHeader
- Made the GlobalSelectionHeader listen to the loading flag surfaced by withProjects HOC
- Replaced NoProjectMessage with a LightWeightNoProjectMessage that does not rely on projects to exist within organization

This is what the loading state looks like: 
![image](https://user-images.githubusercontent.com/9372512/68720381-dd3ec100-0563-11ea-9d77-c20a60e66fa9.png)

