### PR TITLE
fix(apm): Do not enable APM by default for on-premise Sentry installations

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.jsx
+++ b/src/sentry/static/sentry/app/bootstrap.jsx
@@ -65,14 +65,7 @@ if (window.__initialData) {
 // APM -------------------------------------------------------------
 const config = ConfigStore.getConfig();
 // This is just a simple gatekeeper to not enable apm for whole sentry.io at first
-if (
-  config &&
-  config.isApmDataSamplingEnabled &&
-  (config.urlPrefix &&
-    (config.urlPrefix.includes('localhost') ||
-      config.urlPrefix.includes('127.0.0.1') ||
-      config.urlPrefix.includes('dev.getsentry.net')))
-) {
+if (config && config.isApmDataSamplingEnabled) {
   startApm();
 }
 // -----------------------------------------------------------------

--- a/src/sentry/static/sentry/app/bootstrap.jsx
+++ b/src/sentry/static/sentry/app/bootstrap.jsx
@@ -67,11 +67,11 @@ const config = ConfigStore.getConfig();
 // This is just a simple gatekeeper to not enable apm for whole sentry.io at first
 if (
   config &&
-  (config.isApmDataSamplingEnabled ||
-    (config.urlPrefix &&
-      (config.urlPrefix.includes('localhost') ||
-        config.urlPrefix.includes('127.0.0.1') ||
-        config.urlPrefix.includes('dev.getsentry.net'))))
+  config.isApmDataSamplingEnabled &&
+  (config.urlPrefix &&
+    (config.urlPrefix.includes('localhost') ||
+      config.urlPrefix.includes('127.0.0.1') ||
+      config.urlPrefix.includes('dev.getsentry.net')))
 ) {
   startApm();
 }


### PR DESCRIPTION
Let `isApmDataSamplingEnabled` be not set by default, and therefore APM isn't enabled by default.

We enable `isApmDataSamplingEnabled` to be `true`for SaaS and local development as per https://github.com/getsentry/getsentry/pull/3305

