### PR TITLE
feat(api): Refactor trigger actions api to accept strings for type/target_type

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -29,7 +29,11 @@ class ActionHandler(object):
         pass
 
 
-@AlertRuleTriggerAction.register_type_handler(AlertRuleTriggerAction.Type.EMAIL)
+@AlertRuleTriggerAction.register_type(
+    "email",
+    AlertRuleTriggerAction.Type.EMAIL,
+    [AlertRuleTriggerAction.TargetType.USER, AlertRuleTriggerAction.TargetType.TEAM],
+)
 class EmailActionHandler(ActionHandler):
     query_aggregations_display = {
         QueryAggregations.TOTAL: "Total Events",
@@ -125,7 +129,12 @@ class EmailActionHandler(ActionHandler):
         }
 
 
-@AlertRuleTriggerAction.register_type_handler(AlertRuleTriggerAction.Type.SLACK)
+@AlertRuleTriggerAction.register_type(
+    "slack",
+    AlertRuleTriggerAction.Type.SLACK,
+    [AlertRuleTriggerAction.TargetType.SPECIFIC],
+    integration_provider="slack",
+)
 class SlackActionHandler(ActionHandler):
     def fire(self):
         self.send_alert()

--- a/src/sentry/incidents/endpoints/organization_alert_rule_trigger_action_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_trigger_action_details.py
@@ -29,7 +29,6 @@ class OrganizationAlertRuleTriggerActionDetailsEndpoint(OrganizationAlertRuleTri
             },
             instance=alert_rule_trigger_action,
             data=request.data,
-            partial=True,
         )
 
         if serializer.is_valid():

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_trigger_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_trigger_action_index.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import
 
+import six
 from exam import fixture
 from freezegun import freeze_time
 
 from sentry.api.serializers import serialize
+from sentry.incidents.endpoints.serializers import action_target_type_to_string
 from sentry.incidents.logic import create_alert_rule_trigger, create_alert_rule_trigger_action
 from sentry.incidents.models import AlertRuleThresholdType, AlertRuleTriggerAction
 from sentry.testutils import APITestCase
@@ -73,9 +75,11 @@ class AlertRuleTriggerActionCreateEndpointTest(AlertRuleTriggerActionIndexBase, 
                 self.organization.slug,
                 self.alert_rule.id,
                 self.trigger.id,
-                type=AlertRuleTriggerAction.Type.EMAIL.value,
-                targetType=AlertRuleTriggerAction.TargetType.SPECIFIC.value,
-                targetIdentifier="hello",
+                type=AlertRuleTriggerAction.get_registered_type(
+                    AlertRuleTriggerAction.Type.EMAIL
+                ).slug,
+                target_type=action_target_type_to_string[AlertRuleTriggerAction.TargetType.USER],
+                target_identifier=six.text_type(self.user.id),
                 status_code=201,
             )
         assert "id" in resp.data

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -167,11 +167,11 @@ class AlertRuleTriggerActionActivateTest(object):
     method = None
 
     def setUp(self):
-        self.old_handlers = AlertRuleTriggerAction.handlers
-        AlertRuleTriggerAction.handlers = {}
+        self.old_handlers = AlertRuleTriggerAction._type_registrations
+        AlertRuleTriggerAction._type_registrations = {}
 
     def tearDown(self):
-        AlertRuleTriggerAction.handlers = self.old_handlers
+        AlertRuleTriggerAction._type_registrations = self.old_handlers
 
     def test_no_handler(self):
         trigger = AlertRuleTriggerAction(type=AlertRuleTriggerAction.Type.EMAIL.value)
@@ -182,7 +182,7 @@ class AlertRuleTriggerActionActivateTest(object):
         mock_method = getattr(mock_handler.return_value, self.method)
         mock_method.return_value = "test"
         type = AlertRuleTriggerAction.Type.EMAIL
-        AlertRuleTriggerAction.register_type_handler(type)(mock_handler)
+        AlertRuleTriggerAction.register_type("something", type, [])(mock_handler)
         trigger = AlertRuleTriggerAction(type=type.value)
         assert getattr(trigger, self.method)(Mock(), Mock()) == mock_method.return_value
 
@@ -199,11 +199,11 @@ class AlertRuleTriggerActionActivateTest(TestCase):
     metrics = patcher("sentry.incidents.models.metrics")
 
     def setUp(self):
-        self.old_handlers = AlertRuleTriggerAction.handlers
-        AlertRuleTriggerAction.handlers = {}
+        self.old_handlers = AlertRuleTriggerAction._type_registrations
+        AlertRuleTriggerAction._type_registrations = {}
 
     def tearDown(self):
-        AlertRuleTriggerAction.handlers = self.old_handlers
+        AlertRuleTriggerAction._type_registrations = self.old_handlers
 
     def test_unhandled(self):
         trigger = AlertRuleTriggerAction(type=AlertRuleTriggerAction.Type.EMAIL.value)
@@ -213,7 +213,7 @@ class AlertRuleTriggerActionActivateTest(TestCase):
     def test_handled(self):
         mock_handler = Mock()
         type = AlertRuleTriggerAction.Type.EMAIL
-        AlertRuleTriggerAction.register_type_handler(type)(mock_handler)
+        AlertRuleTriggerAction.register_type("something", type, [])(mock_handler)
 
         trigger = AlertRuleTriggerAction(type=AlertRuleTriggerAction.Type.EMAIL.value)
         incident = Mock()

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -50,10 +50,10 @@ class ProcessUpdateTest(TestCase):
 
     def setUp(self):
         super(ProcessUpdateTest, self).setUp()
-        self.old_handlers = AlertRuleTriggerAction.handlers
-        AlertRuleTriggerAction.handlers = {}
+        self.old_handlers = AlertRuleTriggerAction._type_registrations
+        AlertRuleTriggerAction._type_registrations = {}
         self.email_action_handler = Mock()
-        AlertRuleTriggerAction.register_type_handler(AlertRuleTriggerAction.Type.EMAIL)(
+        AlertRuleTriggerAction.register_type("email", AlertRuleTriggerAction.Type.EMAIL, [])(
             self.email_action_handler
         )
         self._run_tasks = self.tasks()
@@ -61,7 +61,7 @@ class ProcessUpdateTest(TestCase):
 
     def tearDown(self):
         super(ProcessUpdateTest, self).tearDown()
-        AlertRuleTriggerAction.handlers = self.old_handlers
+        AlertRuleTriggerAction._type_registrations = self.old_handlers
         self._run_tasks.__exit__(None, None, None)
 
     @fixture

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -220,9 +220,9 @@ class HandleTriggerActionTest(TestCase):
         self.metrics.incr.assert_called_once_with("incidents.alert_rules.skipping_missing_project")
 
     def test(self):
-        with patch.object(AlertRuleTriggerAction, "handlers", new={}):
+        with patch.object(AlertRuleTriggerAction, "_type_registrations", new={}):
             mock_handler = Mock()
-            AlertRuleTriggerAction.register_type_handler(AlertRuleTriggerAction.Type.EMAIL)(
+            AlertRuleTriggerAction.register_type("email", AlertRuleTriggerAction.Type.EMAIL, [])(
                 mock_handler
             )
             incident = self.create_incident()


### PR DESCRIPTION
This refactors the trigger actions endpoint to accept strings for type/target_type, which makes it
easier for frontend to work with.

We also refactor the registration of action handlers to help support this, and other things in the
future. We store a slug which we use to return from the endpoint, and also list the supported target
types for each handler. This will be used as part of returning a list of available actions to the
frontend as well in a future pr.