### PR TITLE
feat(ui): Update existing Alert Rules UI for new Alerts

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -262,7 +262,7 @@ function routes() {
       </Route>
 
       <Route
-        name="Alerts"
+        name="Alert Rules"
         path="alerts-v2/"
         component={errorHandler(LazyLoad)}
         componentPromise={() =>
@@ -278,7 +278,16 @@ function routes() {
             import(/* webpackChunkName: "ProjectAlertSettings" */ 'app/views/settings/projectAlerts/projectAlertSettings')
           }
         />
-        <Route path="issue-rules/" name="Rules" component={null}>
+        <Route
+          path="new/"
+          name="New Alert Rule"
+          component={errorHandler(LazyLoad)}
+          componentPromise={() =>
+            import(/* webpackChunkName: "ProjectAlertsRuleDetails" */ 'app/views/settings/projectAlerts/ruleDetailsNew')
+          }
+        />
+
+        <Route path="issue-rules/" component={null}>
           <IndexRoute
             component={errorHandler(LazyLoad)}
             componentPromise={() =>
@@ -287,23 +296,23 @@ function routes() {
           />
           <Route
             path="new/"
-            name="New"
+            name="New Alert Rule"
             component={errorHandler(LazyLoad)}
             componentPromise={() =>
-              import(/* webpackChunkName: "ProjectAlertRuleDetails" */ 'app/views/settings/projectAlerts/projectAlertRuleDetails')
+              import(/* webpackChunkName: "ProjectAlertRuleDetails" */ 'app/views/settings/projectAlerts/ruleDetailsNew')
             }
           />
           <Route
             path=":ruleId/"
-            name="Edit"
+            name="Edit Alert Rule"
             componentPromise={() =>
-              import(/* webpackChunkName: "ProjectAlertRuleDetails" */ 'app/views/settings/projectAlerts/projectAlertRuleDetails')
+              import(/* webpackChunkName: "ProjectAlertRuleDetails" */ 'app/views/settings/projectAlerts/ruleDetailsNew')
             }
             component={errorHandler(LazyLoad)}
           />
         </Route>
 
-        <Route path="event-rules/" name="Event Rules" component={null}>
+        <Route path="metric-rules/" name="Metric Rules" component={null}>
           <IndexRoute
             componentPromise={() =>
               import(/* webpackChunkName: "IncidentRulesList" */ 'app/views/settings/incidentRules/list')

--- a/src/sentry/static/sentry/app/types/alerts.tsx
+++ b/src/sentry/static/sentry/app/types/alerts.tsx
@@ -1,11 +1,47 @@
-export type IssueAlertRuleAction = {
+/**
+ * These templates that tell the UI how to render the action or condition
+ * and what fields it needs
+ */
+export type IssueAlertRuleActionTemplate = {
   id: string;
-  name: string;
+  label: string;
+  enabled: boolean;
+  formFields?: {
+    [key: string]:
+      | {
+          type: 'choice';
+          choices: [string, string][];
+          placeholder?: string;
+        }
+      | {
+          type: 'string';
+          placeholder?: string;
+        }
+      | {
+          type: 'number';
+          placeholder?: number | string;
+        };
+  };
+};
+export type IssueAlertRuleConditionTemplate = IssueAlertRuleActionTemplate;
+
+/**
+ * These are the action or condition data that the user is editing or has saved.
+ */
+export type IssueAlertRuleAction = Omit<
+  IssueAlertRuleActionTemplate,
+  'formFields' | 'enabled'
+> & {
+  // These are the same values as the keys in `formFields` for a template
+  [key: string]: number | string;
 };
 
-export type IssueAlertRuleCondition = {
-  id: string;
-  name: string;
+export type IssueAlertRuleCondition = Omit<
+  IssueAlertRuleConditionTemplate,
+  'formFields' | 'enabled'
+> & {
+  // These are the same values as the keys in `formFields` for a template
+  [key: string]: number | string;
 };
 
 // Issue-based alert rule

--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -102,7 +102,7 @@ export default class Form extends React.Component<Props> {
     cancelLabel: t('Cancel'),
     submitLabel: t('Save Changes'),
     submitDisabled: false,
-    submitPriority: 'primary',
+    submitPriority: 'primary' as 'primary',
     className: 'form-stacked',
     requireChanges: false,
     allowUndo: false,

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/create.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/create.tsx
@@ -4,8 +4,6 @@ import React from 'react';
 import {AlertRuleAggregations} from 'app/views/settings/incidentRules/types';
 import {Organization, Project} from 'app/types';
 import recreateRoute from 'app/utils/recreateRoute';
-import withOrganization from 'app/utils/withOrganization';
-import withProject from 'app/utils/withProject';
 
 import RuleForm from './ruleForm';
 
@@ -42,4 +40,4 @@ class IncidentRulesCreate extends React.Component<RouteComponentProps<{}, {}> & 
   }
 }
 
-export default withOrganization(withProject(IncidentRulesCreate));
+export default IncidentRulesCreate;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/create.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/create.tsx
@@ -21,10 +21,10 @@ type Props = {
 };
 
 class IncidentRulesCreate extends React.Component<RouteComponentProps<{}, {}> & Props> {
-  handleSubmitSuccess = data => {
+  handleSubmitSuccess = () => {
     const {params, routes, router, location} = this.props;
 
-    router.push(recreateRoute(`${data.id}/`, {params, routes, location, stepBack: -1}));
+    router.push(recreateRoute('metric-rules/', {params, routes, location, stepBack: -1}));
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -1,0 +1,409 @@
+import {RouteComponentProps} from 'react-router/lib/Router';
+import {browserHistory} from 'react-router';
+import React from 'react';
+import classNames from 'classnames';
+import styled from 'react-emotion';
+
+import {ALL_ENVIRONMENTS_KEY} from 'app/constants';
+import {Client} from 'app/api';
+import {Environment, Organization, Project} from 'app/types';
+import {
+  IssueAlertRule,
+  IssueAlertRuleActionTemplate,
+  IssueAlertRuleConditionTemplate,
+} from 'app/types/alerts';
+import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'app/actionCreators/indicator';
+import {getDisplayName} from 'app/utils/environment';
+import {t} from 'app/locale';
+import Form from 'app/views/settings/components/forms/form';
+import LoadingMask from 'app/components/loadingMask';
+import PanelAlert from 'app/components/panels/panelAlert';
+import PanelItem from 'app/components/panels/panelItem';
+import SelectField from 'app/views/settings/components/forms/selectField';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
+import TextField from 'app/views/settings/components/forms/textField';
+import recreateRoute from 'app/utils/recreateRoute';
+import space from 'app/styles/space';
+import withApi from 'app/utils/withApi';
+
+import RuleNodeList from './ruleNodeList';
+
+const FREQUENCY_CHOICES = [
+  ['5', t('5 minutes')],
+  ['10', t('10 minutes')],
+  ['30', t('30 minutes')],
+  ['60', t('60 minutes')],
+  ['180', t('3 hours')],
+  ['720', t('12 hours')],
+  ['1440', t('24 hours')],
+  ['10080', t('one week')],
+  ['43200', t('30 days')],
+];
+
+const ACTION_MATCH_CHOICES = [['all', t('all')], ['any', t('any')], ['none', t('none')]];
+
+// TODO(ts): I can't get this to work if I'm specific -- should be: 'condition' | 'action';
+type ConditionOrAction = string;
+
+type Props = {
+  api: Client;
+  actions: IssueAlertRuleActionTemplate[] | null;
+  conditions: IssueAlertRuleConditionTemplate[] | null;
+  project: Project;
+  organization: Organization;
+} & RouteComponentProps<{orgId: string; projectId: string; ruleId: string}, {}>;
+
+type State = {
+  rule: IssueAlertRule | null;
+  loading: boolean;
+  error: null | {
+    [key: string]: string[];
+  };
+  environments: Environment[];
+};
+
+class IssueRuleEditor extends React.Component<Props, State> {
+  state: State = {
+    rule: null,
+    loading: false,
+    error: null,
+    environments: [],
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  async fetchData() {
+    const {
+      api,
+      params: {ruleId, projectId, orgId},
+    } = this.props;
+
+    const defaultRule = {
+      actionMatch: 'all',
+      actions: [],
+      conditions: [],
+      name: '',
+      frequency: 30,
+      environment: ALL_ENVIRONMENTS_KEY,
+    };
+
+    const promises = [
+      api.requestPromise(`/projects/${orgId}/${projectId}/environments/`),
+      ruleId
+        ? api.requestPromise(`/projects/${orgId}/${projectId}/rules/${ruleId}/`)
+        : Promise.resolve(defaultRule),
+    ];
+
+    try {
+      const [environments, rule] = await Promise.all(promises);
+      this.setState({environments, rule});
+    } catch (_err) {
+      addErrorMessage(t('Unable to fetch data'));
+    }
+  }
+
+  handleSubmit = async () => {
+    const {rule} = this.state;
+    const isNew = !rule || !rule.id;
+    const {project, organization} = this.props;
+
+    const endpoint = `/projects/${organization.slug}/${project.slug}/rules/${
+      rule && rule.id ? `${rule.id}/` : ''
+    }`;
+
+    if (rule && rule.environment === ALL_ENVIRONMENTS_KEY) {
+      delete rule.environment;
+    }
+
+    addLoadingMessage(t('Saving...'));
+
+    try {
+      const resp = await this.props.api.requestPromise(endpoint, {
+        method: isNew ? 'POST' : 'PUT',
+        data: rule,
+      });
+
+      this.setState({error: null, loading: false, rule: resp});
+
+      // Redirect to correct ID if new
+      if (isNew) {
+        browserHistory.replace(
+          recreateRoute(`${resp.id}/`, {...this.props, stepBack: -1})
+        );
+      }
+      addSuccessMessage(isNew ? t('Created alert rule') : t('Updated alert rule'));
+    } catch (err) {
+      this.setState({
+        error: err.responseJSON || {__all__: 'Unknown error'},
+        loading: false,
+      });
+      addErrorMessage(t('An error occurred'));
+    }
+  };
+
+  handleCancel = () => {
+    const {router} = this.props;
+
+    router.push(recreateRoute('', {...this.props, stepBack: -1}));
+  };
+
+  hasError = (field: string) => {
+    const {error} = this.state;
+
+    if (!error) {
+      return false;
+    }
+
+    return error.hasOwnProperty(field);
+  };
+
+  handleEnvironmentChange = val => {
+    // If 'All Environments' is selected the value should be null
+    if (val === ALL_ENVIRONMENTS_KEY) {
+      this.handleChange('environment', null);
+    } else {
+      this.handleChange('environment', val);
+    }
+  };
+
+  handleChange = (prop: string, val: string | null) => {
+    this.setState(state => {
+      const rule = {...state.rule} as IssueAlertRule;
+      rule[prop] = val;
+      return {rule};
+    });
+  };
+
+  handlePropertyChange = (type: ConditionOrAction) => {
+    return (idx: number) => {
+      return (prop: string, val: string) => {
+        const rule = {...this.state.rule} as IssueAlertRule;
+        rule[type][idx][prop] = val;
+        this.setState({rule});
+      };
+    };
+  };
+
+  handleAddRow = (type: ConditionOrAction) => {
+    return id => {
+      this.setState(state => {
+        const rule = {
+          ...state.rule,
+          [type]: [...(state.rule ? state.rule[type] : []), {id}],
+        } as IssueAlertRule;
+
+        return {
+          rule,
+        };
+      });
+    };
+  };
+
+  handleDeleteRow = (type: ConditionOrAction) => {
+    return (idx: number) => {
+      this.setState(prevState => {
+        const newTypeList = prevState.rule ? [...prevState.rule[type]] : [];
+
+        if (prevState.rule) {
+          newTypeList.splice(idx, 1);
+        }
+
+        const rule = {
+          ...prevState.rule,
+          [type]: newTypeList,
+        } as IssueAlertRule;
+
+        return {
+          rule,
+        };
+      });
+    };
+  };
+
+  render() {
+    const {projectId, ruleId} = this.props.params;
+    const {environments} = this.state;
+    const environmentChoices = [
+      [ALL_ENVIRONMENTS_KEY, t('All Environments')],
+      ...environments.map(env => [env.name, getDisplayName(env)]),
+    ];
+
+    const {rule, error} = this.state;
+    const {actionMatch, actions, conditions, frequency, name} = rule || {};
+
+    const environment =
+      !rule || !rule.environment ? ALL_ENVIRONMENTS_KEY : rule.environment;
+
+    const title = ruleId ? t('Edit Alert Rule') : t('New Alert Rule');
+
+    // Note `key` on `<Form>` below is so that on initial load, we show
+    // the form with a loading mask on top of it, but force a re-render by using
+    // a different key when we have fetched the rule so that form inputs are filled in
+    return (
+      <React.Fragment>
+        <SentryDocumentTitle title={title} objSlug={projectId} />
+        <StyledForm
+          key={rule ? rule.id : undefined}
+          onCancel={this.handleCancel}
+          onSubmit={this.handleSubmit}
+          initialData={rule as object}
+          submitLabel={t('Save Rule')}
+        >
+          {ruleId && !this.state.rule && <SemiTransparentLoadingMask />}
+          <Panel>
+            <PanelHeader>{t('Configure Rule Conditions')}</PanelHeader>
+            <PanelBody>
+              {error && (
+                <PanelAlert type="error">
+                  {t(
+                    'There was an error saving your changes. Make sure all fields are valid and try again.'
+                  )}
+                </PanelAlert>
+              )}
+              <SelectField
+                className={classNames({
+                  error: this.hasError('environment'),
+                })}
+                label={t('Environment')}
+                help={t('Choose an environment for these conditions to apply to')}
+                placeholder={t('Select an Environment')}
+                clearable={false}
+                name="environment"
+                value={environment}
+                choices={environmentChoices}
+                onChange={val => this.handleEnvironmentChange(val)}
+              />
+
+              <PanelSubHeader>
+                {t(
+                  'Whenever %s of these conditions are met',
+                  <EmbeddedWrapper>
+                    <EmbeddedSelectField
+                      className={classNames({
+                        error: this.hasError('actionMatch'),
+                      })}
+                      inline={false}
+                      height="20"
+                      clearable={false}
+                      search={false}
+                      name="actionMatch"
+                      value={actionMatch}
+                      required
+                      flexibleControlStateSize
+                      choices={ACTION_MATCH_CHOICES}
+                      onChange={val => this.handleChange('actionMatch', val)}
+                    />
+                  </EmbeddedWrapper>
+                )}
+              </PanelSubHeader>
+
+              {this.hasError('conditions') && (
+                <PanelAlert type="error">{this.state.error!.conditions[0]}</PanelAlert>
+              )}
+
+              <PanelRuleItem>
+                <RuleNodeList
+                  nodes={this.props.conditions}
+                  items={conditions || []}
+                  placeholder={t('Add a condition...')}
+                  onPropertyChange={this.handlePropertyChange('conditions')}
+                  onAddRow={this.handleAddRow('conditions')}
+                  onDeleteRow={this.handleDeleteRow('conditions' as const)}
+                />
+              </PanelRuleItem>
+
+              <PanelSubHeader>{t('Perform these actions')}</PanelSubHeader>
+
+              {this.hasError('actions') && (
+                <PanelAlert type="error">{this.state.error!.actions[0]}</PanelAlert>
+              )}
+
+              <PanelRuleItem>
+                <RuleNodeList
+                  nodes={this.props.actions}
+                  items={actions || []}
+                  placeholder={t('Add an action...')}
+                  onPropertyChange={this.handlePropertyChange('actions')}
+                  onAddRow={this.handleAddRow('actions')}
+                  onDeleteRow={this.handleDeleteRow('actions')}
+                />
+              </PanelRuleItem>
+            </PanelBody>
+          </Panel>
+
+          <Panel>
+            <PanelHeader>{t('Rate Limit')}</PanelHeader>
+            <PanelBody>
+              <SelectField
+                label={t('Action Interval')}
+                help={t('Perform these actions once this often for an issue')}
+                clearable={false}
+                name="frequency"
+                className={this.hasError('frequency') ? ' error' : ''}
+                value={frequency}
+                required
+                choices={FREQUENCY_CHOICES}
+                onChange={val => this.handleChange('frequency', val)}
+              />
+            </PanelBody>
+          </Panel>
+
+          <Panel>
+            <PanelHeader>{t('Give your rule a name')}</PanelHeader>
+            <PanelBody>
+              <TextField
+                label={t('Rule name')}
+                help={t('Give your rule a name so it is easy to manage later')}
+                name="name"
+                defaultValue={name}
+                required
+                placeholder={t('My Rule Name')}
+                onChange={val => this.handleChange('name', val)}
+              />
+            </PanelBody>
+          </Panel>
+        </StyledForm>
+      </React.Fragment>
+    );
+  }
+}
+
+export default withApi(IssueRuleEditor);
+
+const StyledForm = styled(Form)`
+  position: relative;
+`;
+
+const PanelSubHeader = styled(PanelHeader)`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding: ${space(1)} ${space(2)};
+`;
+
+const PanelRuleItem = styled(PanelItem)`
+  flex-direction: column;
+`;
+
+const EmbeddedWrapper = styled('div')`
+  margin: 0 ${space(1)};
+  width: 72px;
+`;
+
+const EmbeddedSelectField = styled(SelectField)`
+  padding: 0;
+  font-weight: normal;
+  text-transform: none;
+`;
+
+const SemiTransparentLoadingMask = styled(LoadingMask)`
+  opacity: 0.6;
+  z-index: 1; /* Needed so that it sits above form elements */
+`;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -132,13 +132,8 @@ class IssueRuleEditor extends React.Component<Props, State> {
 
       this.setState({error: null, loading: false, rule: resp});
 
-      // Redirect to correct ID if new
-      if (isNew) {
-        browserHistory.replace(
-          recreateRoute(`${resp.id}/`, {...this.props, stepBack: -1})
-        );
-      }
       addSuccessMessage(isNew ? t('Created alert rule') : t('Updated alert rule'));
+      browserHistory.replace(recreateRoute('', {...this.props, stepBack: -1}));
     } catch (err) {
       this.setState({
         error: err.responseJSON || {__all__: 'Unknown error'},

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import styled from 'react-emotion';
+
+import {
+  IssueAlertRuleAction,
+  IssueAlertRuleActionTemplate,
+  IssueAlertRuleCondition,
+  IssueAlertRuleConditionTemplate,
+} from 'app/types/alerts';
+import {t} from 'app/locale';
+import Button from 'app/components/button';
+import Input from 'app/views/settings/components/forms/controls/input';
+import SelectControl from 'app/components/forms/selectControl';
+import space from 'app/styles/space';
+
+type FormField = {
+  // Type of form fields
+  type: string;
+  // The rest is configuration for the form field
+  [key: string]: any;
+};
+
+type Props = {
+  node?: IssueAlertRuleActionTemplate | IssueAlertRuleConditionTemplate | null;
+  data?: IssueAlertRuleAction | IssueAlertRuleCondition;
+  onDelete: () => void;
+  onPropertyChange: (name: string, value: string) => void;
+};
+
+class RuleNode extends React.Component<Props> {
+  getChoiceField = (name: string, fieldConfig: FormField) => {
+    // Select the first item on this list
+    // If it's not yet defined, call onPropertyChange to make sure the value is set on state
+    const {data, onPropertyChange} = this.props;
+    let initialVal;
+
+    if (data) {
+      if (data[name] === undefined && !!fieldConfig.choices.length) {
+        if (fieldConfig.initial) {
+          initialVal = fieldConfig.initial;
+        } else {
+          initialVal = fieldConfig.choices[0][0];
+        }
+        onPropertyChange(name, initialVal);
+      } else {
+        initialVal = data[name];
+      }
+    }
+
+    return (
+      <SelectWrapper>
+        <SelectControl
+          clearable={false}
+          placeholder={t('Select integration')}
+          noResultsText={t('No integrations available')}
+          height="35"
+          name={name}
+          value={initialVal}
+          choices={fieldConfig.choices}
+          key={name}
+          onChange={val => this.props.onPropertyChange(name, val)}
+        />
+      </SelectWrapper>
+    );
+  };
+
+  getTextField = (name: string, fieldConfig: FormField) => {
+    const {data, onPropertyChange} = this.props;
+
+    return (
+      <InlineInput
+        type="text"
+        name={name}
+        value={data && data[name]}
+        placeholder={`${fieldConfig.placeholder}`}
+        key={name}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          onPropertyChange(name, e.target.value)
+        }
+      />
+    );
+  };
+
+  getNumberField = (name: string, fieldConfig: FormField) => {
+    const {data, onPropertyChange} = this.props;
+
+    return (
+      <InlineInput
+        type="number"
+        name={name}
+        value={data && data[name]}
+        placeholder={`${fieldConfig.placeholder}`}
+        key={name}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          onPropertyChange(name, e.target.value)
+        }
+      />
+    );
+  };
+
+  getField = (name: string, fieldConfig: FormField) => {
+    const getFieldTypes = {
+      choice: this.getChoiceField,
+      number: this.getNumberField,
+      string: this.getTextField,
+    };
+    return getFieldTypes[fieldConfig.type](name, fieldConfig);
+  };
+
+  getComponent() {
+    const {data, node} = this.props;
+
+    if (!node) {
+      return null;
+    }
+
+    const {label, formFields} = node;
+
+    const parts = label.split(/({\w+})/).map(part => {
+      if (!/^{\w+}$/.test(part)) {
+        return part;
+      }
+
+      const key = part.slice(1, -1);
+
+      // If matcher is "is set" or "is not set", then we do not want to show the value input
+      // because it is not required
+      if (key === 'value' && (data && (data.match === 'is' || data.match === 'ns'))) {
+        return null;
+      }
+
+      return formFields && formFields.hasOwnProperty(key)
+        ? this.getField(key, formFields[key])
+        : part;
+    });
+
+    const [title, ...inputs] = parts;
+
+    // We return this so that it can be a grid
+    return (
+      <React.Fragment>
+        <div>{title}</div>
+        <RuleNodeForm>{inputs}</RuleNodeForm>
+      </React.Fragment>
+    );
+  }
+
+  render() {
+    const {data, onDelete} = this.props;
+
+    const component = this.getComponent();
+
+    return (
+      <React.Fragment>
+        {data && <input type="hidden" name="id" value={data.id} />}
+        {component}
+        <div>
+          <Button onClick={onDelete} type="button" size="small" icon="icon-trash" />
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+
+export default RuleNode;
+
+const SelectWrapper = styled('div')`
+  width: 204px;
+`;
+
+const InlineInput = styled(Input)`
+  width: auto;
+`;
+
+const RuleNodeForm = styled('div')`
+  display: grid;
+  grid-gap: ${space(1)};
+  grid-auto-flow: column;
+  grid-auto-columns: min-content;
+  align-items: center;
+  white-space: nowrap;
+`;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import styled from 'react-emotion';
+
+import {
+  IssueAlertRuleAction,
+  IssueAlertRuleActionTemplate,
+  IssueAlertRuleCondition,
+  IssueAlertRuleConditionTemplate,
+} from 'app/types/alerts';
+import SelectControl from 'app/components/forms/selectControl';
+import space from 'app/styles/space';
+
+import RuleNode from './ruleNode';
+
+type Props = {
+  // All available actions or conditions
+  nodes: IssueAlertRuleActionTemplate[] | IssueAlertRuleConditionTemplate[] | null;
+
+  // actions/conditions that have been added to the rule
+  items?: IssueAlertRuleAction[] | IssueAlertRuleCondition[];
+
+  // Placeholder for select control
+  placeholder: string;
+
+  onPropertyChange: (ruleIndex: number) => (prop: string, val: string) => void;
+
+  // TODO(ts): Type value
+  onAddRow: (value: unknown) => void;
+
+  onDeleteRow: (ruleIndex: number) => void;
+};
+
+class RuleNodeList extends React.Component<Props> {
+  getNode = (
+    id: string
+  ):
+    | IssueAlertRuleActionTemplate
+    | IssueAlertRuleConditionTemplate
+    | null
+    | undefined => {
+    const {nodes} = this.props;
+    return nodes ? nodes.find(node => node.id === id) : null;
+  };
+
+  render() {
+    const {
+      onAddRow,
+      onDeleteRow,
+      onPropertyChange,
+      nodes,
+      placeholder,
+      items,
+    } = this.props;
+
+    const options = nodes
+      ? nodes
+          .filter(({enabled}) => enabled)
+          .map(node => ({
+            value: node.id,
+            label: node.label,
+          }))
+      : [];
+
+    return (
+      <React.Fragment>
+        {items && !!items.length && (
+          <RuleNodes>
+            {items.map((item, idx) => {
+              return (
+                <RuleNode
+                  key={idx}
+                  node={this.getNode(item.id)}
+                  onDelete={() => onDeleteRow(idx)}
+                  data={item}
+                  onPropertyChange={onPropertyChange(idx)}
+                />
+              );
+            })}
+          </RuleNodes>
+        )}
+        <StyledSelectControl
+          placeholder={placeholder}
+          onChange={obj => onAddRow(obj ? obj.value : obj)}
+          options={options}
+        />
+      </React.Fragment>
+    );
+  }
+}
+
+export default RuleNodeList;
+
+const StyledSelectControl = styled(SelectControl)`
+  width: 100%;
+`;
+
+const RuleNodes = styled('div')`
+  display: grid;
+  grid-template-columns: max-content auto min-content;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: ${space(2)};
+  grid-gap: ${space(1)};
+`;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/new.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/new.tsx
@@ -1,12 +1,11 @@
+import {RouteComponentProps} from 'react-router/lib/Router';
 import React from 'react';
-
-import {RouterProps} from 'app/types';
 
 import ProjectAlertHeader from './projectAlertHeaderNew';
 
-type Props = RouterProps & {
+type Props = {
   children: React.ReactNode;
-};
+} & RouteComponentProps<{organizationId: string; projectId: string}, {}>;
 
 function ProjectAlerts({children, ...props}: Props) {
   return (

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertHeaderNew.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertHeaderNew.tsx
@@ -1,11 +1,10 @@
+import {RouteComponentProps} from 'react-router/lib/Router';
 import React from 'react';
 import styled from 'react-emotion';
 
-import {Organization, RouterProps} from 'app/types';
+import {Organization} from 'app/types';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
-import ListLink from 'app/components/links/listLink';
-import NavTabs from 'app/components/navTabs';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import Tooltip from 'app/components/tooltip';
 import space from 'app/styles/space';
@@ -13,17 +12,16 @@ import withOrganization from 'app/utils/withOrganization';
 
 type Props = {
   organization: Organization;
-} & RouterProps;
+} & Pick<RouteComponentProps<{projectId: string}, {}>, 'params'>;
 
 class ProjectAlertHeader extends React.Component<Props> {
   render() {
-    const {location, params, organization} = this.props;
+    const {params, organization} = this.props;
     const {projectId} = params;
 
     const canEditRule = organization.access.includes('project:write');
 
     const basePath = `/settings/${organization.slug}/projects/${projectId}/alerts-v2/`;
-    const isIssues = location.pathname.includes('issue-rules');
 
     return (
       <SettingsPageHeader
@@ -38,7 +36,7 @@ class ProjectAlertHeader extends React.Component<Props> {
               title={t('You do not have permission to edit alert rules.')}
             >
               <Button
-                to={`${basePath}${isIssues ? 'issue' : 'event'}-rules/new/`}
+                to={`${basePath}new/`}
                 disabled={!canEditRule}
                 priority="primary"
                 size="small"
@@ -48,12 +46,6 @@ class ProjectAlertHeader extends React.Component<Props> {
               </Button>
             </Tooltip>
           </Actions>
-        }
-        tabs={
-          <NavTabs underlined>
-            <ListLink to={`${basePath}issue-rules/`}>{t('Issue Rules')}</ListLink>
-            <ListLink to={`${basePath}event-rules/`}>{t('Event Rules')}</ListLink>
-          </NavTabs>
         }
       />
     );

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleDetailsNew/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleDetailsNew/index.tsx
@@ -1,0 +1,113 @@
+import {RouteComponentProps} from 'react-router/lib/Router';
+import React from 'react';
+
+import {
+  IssueAlertRuleActionTemplate,
+  IssueAlertRuleConditionTemplate,
+} from 'app/types/alerts';
+import {Organization, Project} from 'app/types';
+import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import {t} from 'app/locale';
+import AsyncView from 'app/views/asyncView';
+import IssueEditor from 'app/views/settings/projectAlerts/issueEditor';
+import IncidentRulesCreate from 'app/views/settings/incidentRules/create';
+import PanelItem from 'app/components/panels/panelItem';
+import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup';
+import withOrganization from 'app/utils/withOrganization';
+import withProject from 'app/utils/withProject';
+
+type Props = {
+  organization: Organization;
+  project: Project;
+} & RouteComponentProps<{organizationId: string; projectId: string}, {}> &
+  AsyncView['props'];
+
+type State = {
+  alertType: string | null;
+  configs: {
+    actions: IssueAlertRuleActionTemplate[];
+    conditions: IssueAlertRuleConditionTemplate[];
+  } | null;
+} & AsyncView['state'];
+
+class RuleDetails extends AsyncView<Props, State> {
+  getDefaultState() {
+    const {router} = this.props;
+    const {pathname} = router.location;
+
+    return {
+      ...super.getDefaultState(),
+      alertType: pathname.includes('issue-rules')
+        ? 'issue'
+        : pathname.includes('metric-rules')
+        ? 'metric'
+        : null,
+      configs: null,
+    };
+  }
+
+  getEndpoints(): [string, string][] {
+    const {orgId, projectId} = this.props.params;
+
+    return [['configs', `/projects/${orgId}/${projectId}/rules/configuration/`]];
+  }
+
+  handleChangeAlertType = (alertType: string) => {
+    // alertType should be `issue` or `metric`
+    this.setState({
+      alertType,
+    });
+  };
+
+  renderLoading() {
+    return this.renderBody();
+  }
+
+  renderBody() {
+    const {alertType, configs} = this.state;
+    return (
+      <React.Fragment>
+        <Panel>
+          <PanelHeader>{t('Choose an Alert Type')}</PanelHeader>
+          <PanelBody>
+            <PanelItem>
+              <RadioGroup
+                label={t('Select an Alert Type')}
+                value={this.state.alertType}
+                choices={[
+                  [
+                    'issue',
+                    t('Issue Alert'),
+                    t(
+                      'Alert when any issue satisfies a set of conditions. For example, a new issue is seen, an issue occurs more than 100 times, an issue affects more than 100 users.'
+                    ),
+                  ],
+                  [
+                    'metric',
+                    t('Metric Alert'),
+                    t(
+                      'Alert on conditions defined over all events in the project. For example, more than 10 users affected by signup-page errors, database errors exceed 10 per minute, errors seen by our largest customers exceed 500 per hour.'
+                    ),
+                  ],
+                ]}
+                onChange={this.handleChangeAlertType}
+              />
+            </PanelItem>
+          </PanelBody>
+        </Panel>
+
+        {alertType === 'issue' ? (
+          <IssueEditor
+            {...this.props}
+            actions={configs && configs.actions}
+            conditions={configs && configs.conditions}
+          />
+        ) : alertType === 'metric' ? (
+          <IncidentRulesCreate {...this.props} />
+        ) : null}
+      </React.Fragment>
+    );
+  }
+}
+
+export default withProject(withOrganization(RuleDetails));

--- a/tests/js/spec/views/settings/incidentRules/create.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/create.spec.jsx
@@ -14,11 +14,12 @@ describe('Incident Rules Create', function() {
   });
 
   it('renders', function() {
-    const {organization, routerContext} = initializeOrg();
+    const {organization, project, routerContext} = initializeOrg();
     mountWithTheme(
       <IncidentRulesCreate
         params={{orgId: organization.slug}}
         organization={organization}
+        project={project}
       />,
       routerContext
     );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -397,7 +397,7 @@ if (USE_HOT_MODULE_RELOAD && !NO_DEV_SERVER) {
     hotOnly: true,
     port: SENTRY_WEBPACK_PROXY_PORT,
     stats: 'errors-only',
-    overlay: true,
+    overlay: false,
     watchOptions: {
       ignored: ['node_modules'],
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -397,7 +397,7 @@ if (USE_HOT_MODULE_RELOAD && !NO_DEV_SERVER) {
     hotOnly: true,
     port: SENTRY_WEBPACK_PROXY_PORT,
     stats: 'errors-only',
-    overlay: false,
+    overlay: true,
     watchOptions: {
       ignored: ['node_modules'],
     },


### PR DESCRIPTION
This updates our new Alert Rules editor view (note this is internal only, the existing alert rule editor is still the default) that has the combined alert
rule types (issue and metric) to be able to select between the two
types and be able to edit the corresponding rule type.

This also has a slight refresh to the Issue (existing) alert rules.

![localhost_8000_settings_sentry_projects_internal_alerts-v2_issue-rules_19_ (2)](https://user-images.githubusercontent.com/79684/68722188-9227ac80-0569-11ea-94eb-064bc749ea43.png)

Old UI for reference:
![image](https://user-images.githubusercontent.com/79684/68799553-34e53700-060d-11ea-9e47-7db3886ca332.png)
