### PR TITLE
feat: Register option "store.skip-pg-save"

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -163,8 +163,8 @@ register("store.lie-about-filter-status", default=False)
 # Skip nodestore save when saving an event
 register("store.save-event-skips-nodestore", default=False, flags=FLAG_PRIORITIZE_DISK)
 
-# Check postgres for duplicates before saving an event
-register("store.check-duplicates", default=True, flags=FLAG_PRIORITIZE_DISK)
+# Skip saving an event to postgres
+register("store.skip-pg-save", default=True, flags=FLAG_PRIORITIZE_DISK)
 
 # Symbolicator refactors
 # - Disabling minidump stackwalking in endpoints


### PR DESCRIPTION
Register option to be used in
https://github.com/getsentry/sentry/pull/15544.
We should set this to False in production before rolling out these
changes. Defaults to True so that we run tests against the new behavior.

Also removes "store.check-duplicates" which is now unused.