### PR TITLE
feat(api): Add endpoint to list trigger actions that are available for an organization (SEN-961)

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -282,6 +282,9 @@ from .endpoints.useravatar import UserAvatarEndpoint
 from sentry.discover.endpoints.discover_query import DiscoverQueryEndpoint
 from sentry.discover.endpoints.discover_saved_queries import DiscoverSavedQueriesEndpoint
 from sentry.discover.endpoints.discover_saved_query_detail import DiscoverSavedQueryDetailEndpoint
+from sentry.incidents.endpoints.organization_alert_rule_available_action_index import (
+    OrganizationAlertRuleAvailableActionIndexEndpoint,
+)
 from sentry.incidents.endpoints.organization_alert_rule_details import (
     OrganizationAlertRuleDetailsEndpoint,
 )
@@ -555,6 +558,11 @@ urlpatterns = [
                     name="sentry-api-0-organization-details",
                 ),
                 # Alert Rules
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/alert-rules/available-actions/$",
+                    OrganizationAlertRuleAvailableActionIndexEndpoint.as_view(),
+                    name="sentry-api-0-organization-alert-rule-available-actions",
+                ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/alert-rules/(?P<alert_rule_id>[^\/]+)/$",
                     OrganizationAlertRuleDetailsEndpoint.as_view(),

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -1,0 +1,52 @@
+from __future__ import absolute_import
+
+from collections import defaultdict
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.incidents.endpoints.bases import OrganizationEndpoint
+from sentry.incidents.endpoints.serializers import action_target_type_to_string
+from sentry.incidents.logic import get_available_action_integrations_for_org
+from sentry.incidents.models import AlertRuleTriggerAction
+
+
+class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
+    def build_action_response(self, registered_type, integration=None):
+        return {
+            "type": registered_type.slug,
+            "allowedTargetTypes": [
+                action_target_type_to_string[target_type]
+                for target_type in registered_type.supported_target_types
+            ],
+            "integrationName": integration.name if integration else None,
+            "integrationId": integration.id if integration else None,
+        }
+
+    def get(self, request, organization):
+        """
+        Fetches actions that an alert rule can perform for an organization
+        """
+        if not features.has("organizations:incidents", organization, actor=request.user):
+            raise ResourceDoesNotExist
+
+        actions = []
+
+        integrations = get_available_action_integrations_for_org(organization).order_by("id")
+        provider_integrations = defaultdict(list)
+        for integration in integrations:
+            provider_integrations[integration.provider].append(integration)
+
+        registered_types = AlertRuleTriggerAction.get_registered_types()
+        registered_types.sort(key=lambda x: x.slug)
+
+        for registered_type in AlertRuleTriggerAction.get_registered_types():
+            if registered_type.integration_provider:
+                for integration in provider_integrations[registered_type.integration_provider]:
+                    actions.append(self.build_action_response(registered_type, integration))
+            else:
+                actions.append(self.build_action_response(registered_type))
+
+        return Response(actions, status=status.HTTP_200_OK)

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -465,7 +465,7 @@ class AlertRuleTriggerAction(Model):
         def inner(handler):
             if type not in cls._type_registrations:
                 cls._type_registrations[type] = cls.TypeRegistration(
-                    handler, slug, type, set(supported_target_types), integration_provider
+                    handler, slug, type, frozenset(supported_target_types), integration_provider
                 )
             else:
                 raise Exception(u"Handler already registered for type %s" % type)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import
+
+from sentry.models import Integration
+from sentry.testutils import APITestCase
+
+
+class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-organization-alert-rule-available-actions"
+
+    def setUp(self):
+        super(OrganizationAlertRuleAvailableActionIndexEndpointTest, self).setUp()
+        self.login_as(self.user)
+
+    def create_integration_response(self, type, integration=None):
+        return {
+            "type": type,
+            "allowedTargetTypes": ["user", "team"] if type == "email" else ["specific"],
+            "integrationName": integration.name if integration else None,
+            "integrationId": integration.id if integration else None,
+        }
+
+    def test_no_integrations(self):
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(self.organization.slug)
+
+        assert resp.data == [self.create_integration_response("email")]
+
+    def test_simple(self):
+        integration = Integration.objects.create(external_id="1", provider="slack")
+        integration.add_organization(self.organization)
+
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(self.organization.slug)
+
+        assert resp.data == [
+            self.create_integration_response("email"),
+            self.create_integration_response("slack", integration),
+        ]
+
+    def test_duplicate_integrations(self):
+        integration = Integration.objects.create(external_id="1", provider="slack", name="slack 1")
+        integration.add_organization(self.organization)
+        other_integration = Integration.objects.create(
+            external_id="2", provider="slack", name="slack 2"
+        )
+        other_integration.add_organization(self.organization)
+
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(self.organization.slug)
+
+        assert resp.data == [
+            self.create_integration_response("email"),
+            self.create_integration_response("slack", integration),
+            self.create_integration_response("slack", other_integration),
+        ]
+
+    def test_no_feature(self):
+        self.create_team(organization=self.organization, members=[self.user])
+        resp = self.get_response(self.organization.slug)
+        assert resp.status_code == 404


### PR DESCRIPTION
This endpoint returns actions that can be set up on triggers in alert rules. Each action is a dict
with the following keys:
- type: one of 'email', 'slack' ('pagerduty' in the future)
- allowedTargetTypes: list of strings. valid values are 'user', 'team', 'specific'. Specific
  basically means free text for the moment.
- integrationName: Name of the integration. This is a text field that differentiates integrations
  from the same provider from each other
- integrationId: integration id for this type. Should be passed to the backend as integrationId
  when creating an action if not null