### PR TITLE
ref: Remove "store.save-event-skips-nodestore" option from code

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -15,7 +15,7 @@ from django.db.models import Func
 from django.utils import timezone
 from django.utils.encoding import force_text
 
-from sentry import buffer, eventtypes, eventstream, options, tsdb
+from sentry import buffer, eventtypes, eventstream, tsdb
 from sentry.constants import (
     DEFAULT_STORE_NORMALIZER_ARGS,
     LOG_LEVELS,
@@ -722,8 +722,7 @@ class EventManager(object):
         # save the event
         try:
             with transaction.atomic(using=router.db_for_write(Event)):
-                if options.get("store.save-event-skips-nodestore", True):
-                    event.data.save()
+                event.data.save()
                 event.save()
         except IntegrityError:
             logger.info(

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -14,7 +14,7 @@ from hashlib import md5
 
 from semaphore.processing import StoreNormalizer
 
-from sentry import eventtypes, options
+from sentry import eventtypes
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedIntegerField,
@@ -619,7 +619,7 @@ class Event(EventCommon, Model):
         ref_func=lambda x: x.project_id or x.project.id,
         ref_version=2,
         wrapper=EventDict,
-        skip_nodestore_save=options.get("store.save-event-skips-nodestore", True),
+        skip_nodestore_save=True,
     )
 
     objects = EventManager()


### PR DESCRIPTION
This was a temporary option that has now been set to True in production.