### PR TITLE
fix(api): Fix failing snuba test in Django 1.9

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -5,6 +5,7 @@ import six
 from datetime import timedelta
 from uuid import uuid4
 
+import django
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 from mock import patch, Mock
@@ -1180,7 +1181,15 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         response = self.get_valid_response(
             qs_params={"id": [group1.id, group2.id]}, isPublic="false"
         )
-        assert response.data == {"isPublic": False}
+        if django.VERSION < (1, 9):
+            assert response.data == {"isPublic": False}
+        else:
+            # In Django < 1.9 `.delete()` returns nothing, even if it manages to delete
+            # rows. In 1.9+ it returns information about how many rows were deleted.
+            # We use `.delete()` in an if statement when setting `isPublic`, and it was
+            # always returning False due to this. Since this is fixed we now have this
+            # extra attribute.
+            assert response.data == {"isPublic": False, "shareId": None}
 
         new_group1 = Group.objects.get(id=group1.id)
         assert not bool(new_group1.get_share_id())


### PR DESCRIPTION
This test is failing because django 1.9 fixes how `.delete()` works, and now returns deletion counts
from this method. I checked for other uses of `.delete` with `if` and this was the only one.