### PR TITLE
fix: Fix `get_participants` to use `__in` correctly.

### DIFF
--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -135,7 +135,7 @@ class GroupSubscriptionManager(BaseManager):
         users = {
             user.id: user
             for user in User.objects.filter(
-                sentry_orgmember_set__teams=group.project.teams.all(), is_active=True
+                sentry_orgmember_set__teams__in=group.project.teams.all(), is_active=True
             )
         }
 

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -84,7 +84,9 @@ class GetParticipantsTest(TestCase):
     def test_simple(self):
         org = self.create_organization()
         team = self.create_team(organization=org)
-        project = self.create_project(teams=[team], organization=org)
+        # Include an extra team here to prove the subquery works
+        team_2 = self.create_team(organization=org)
+        project = self.create_project(teams=[team, team_2], organization=org)
         group = self.create_group(project=project)
         user = self.create_user("foo@example.com")
         user2 = self.create_user("bar@example.com")


### PR DESCRIPTION
This will break in some cases in Django 1.9, since it no longer implicitly assumes `__in`.