### PR TITLE
fix(app-platform): Component Interactions fixes

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_interaction.py
+++ b/src/sentry/api/endpoints/sentry_app_interaction.py
@@ -44,7 +44,7 @@ class SentryAppInteractionEndpoint(SentryAppBaseEndpoint, StatsMixin):
         return Response(
             {
                 "views": views,
-                "component_interactions": {
+                "componentInteractions": {
                     k.split(":")[1]: v for k, v in component_interactions.items()
                 },
             }

--- a/src/sentry/api/endpoints/sentry_app_stats.py
+++ b/src/sentry/api/endpoints/sentry_app_stats.py
@@ -46,10 +46,10 @@ class SentryAppStatsEndpoint(SentryAppBaseEndpoint, StatsMixin):
                     uninstall_stats[uninstall_norm_epoch] += 1
 
         result = {
-            "total_installs": install_count,
-            "total_uninstalls": uninstall_count,
-            "install_stats": sorted(install_stats.items(), key=lambda x: x[0]),
-            "uninstall_stats": sorted(uninstall_stats.items(), key=lambda x: x[0]),
+            "totalInstalls": install_count,
+            "totalUninstalls": uninstall_count,
+            "installStats": sorted(install_stats.items(), key=lambda x: x[0]),
+            "uninstallStats": sorted(uninstall_stats.items(), key=lambda x: x[0]),
         }
 
         return Response(result)

--- a/src/sentry/static/sentry/app/components/events/interfaces/openInContextLine.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/openInContextLine.jsx
@@ -48,6 +48,7 @@ class OpenInContextLine extends React.Component {
         data-test-id={`stacktrace-link-${slug}`}
         href={url}
         onClick={recordStacktraceLinkInteraction}
+        onContextMenu={recordStacktraceLinkInteraction}
       >
         <OpenInIcon slug={slug} />
         <OpenInName>{t(`${component.sentryApp.name}`)}</OpenInName>

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.tsx
@@ -25,14 +25,14 @@ type Props = AsyncView['props'];
 
 type State = AsyncView['state'] & {
   stats: {
-    total_uninstalls: number;
-    total_installs: number;
-    install_stats: [number, number][];
-    uninstall_stats: [number, number][];
+    totalUninstalls: number;
+    totalInstalls: number;
+    installStats: [number, number][];
+    uninstallStats: [number, number][];
   };
   requests: SentryAppWebhookRequest[];
   interactions: {
-    component_interactions: {
+    componentInteractions: {
       [key: string]: [number, number][];
     };
     views: [number, number][];
@@ -67,18 +67,18 @@ export default class SentryApplicationDashboard extends AsyncView<Props, State> 
   }
 
   renderInstallData() {
-    const {total_uninstalls, total_installs} = this.state.stats;
+    const {totalUninstalls, totalInstalls} = this.state.stats;
     return (
       <React.Fragment>
         <h5>{t('Installation Data')}</h5>
         <Row>
           <StatsSection>
             <StatsHeader>{t('Total installs')}</StatsHeader>
-            <p>{total_installs}</p>
+            <p>{totalInstalls}</p>
           </StatsSection>
           <StatsSection>
             <StatsHeader>{t('Total uninstalls')}</StatsHeader>
-            <p>{total_uninstalls}</p>
+            <p>{totalUninstalls}</p>
           </StatsSection>
         </Row>
         {this.renderInstallCharts()}
@@ -87,17 +87,17 @@ export default class SentryApplicationDashboard extends AsyncView<Props, State> 
   }
 
   renderInstallCharts() {
-    const {install_stats, uninstall_stats} = this.state.stats;
+    const {installStats, uninstallStats} = this.state.stats;
 
     const installSeries = {
-      data: install_stats.map(point => ({
+      data: installStats.map(point => ({
         name: point[0] * 1000,
         value: point[1],
       })),
       seriesName: t('installed'),
     };
     const uninstallSeries = {
-      data: uninstall_stats.map(point => ({
+      data: uninstallStats.map(point => ({
         name: point[0] * 1000,
         value: point[1],
       })),
@@ -201,14 +201,14 @@ export default class SentryApplicationDashboard extends AsyncView<Props, State> 
   }
 
   renderComponentInteractions() {
-    const {component_interactions} = this.state.interactions;
+    const {componentInteractions} = this.state.interactions;
 
     return (
       <Panel>
         <PanelHeader>{t('Component Interactions')}</PanelHeader>
 
         <PanelBody>
-          <InteractionsChart data={component_interactions} />
+          <InteractionsChart data={componentInteractions} />
         </PanelBody>
 
         <PanelFooter>

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.tsx
@@ -202,6 +202,12 @@ export default class SentryApplicationDashboard extends AsyncView<Props, State> 
 
   renderComponentInteractions() {
     const {componentInteractions} = this.state.interactions;
+    const componentInteractionsDetails = {
+      'stacktrace-link': t(
+        'Each link click or context menu open counts as one interaction'
+      ),
+      'issue-link': t('Each open of the issue link modal counts as one interaction'),
+    };
 
     return (
       <Panel>
@@ -213,11 +219,16 @@ export default class SentryApplicationDashboard extends AsyncView<Props, State> 
 
         <PanelFooter>
           <StyledFooter>
-            <strong>{t('stacktrace-link:')}</strong>{' '}
-            {t('Each click on the link counts as one interaction')}
-            <br />
-            <strong>{t('issue-link:')}</strong>{' '}
-            {t('Each open of the issue link modal counts as one interaction')}
+            {Object.keys(componentInteractions).map(
+              (component, idx) =>
+                componentInteractionsDetails[component] && (
+                  <React.Fragment key={idx}>
+                    <strong>{`${component}: `}</strong>
+                    {componentInteractionsDetails[component]}
+                    <br />
+                  </React.Fragment>
+                )
+            )}
           </StyledFooter>
         </PanelFooter>
       </Panel>

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/sentryApplicationDashboard.spec.jsx
@@ -35,10 +35,10 @@ describe('Sentry Application Dashboard', function() {
       Client.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/stats/`,
         body: {
-          total_installs: NUM_INSTALLS,
-          total_uninstalls: NUM_UNINSTALLS,
-          install_stats: [[1569783600, NUM_INSTALLS]],
-          uninstall_stats: [[1569783600, NUM_UNINSTALLS]],
+          totalInstalls: NUM_INSTALLS,
+          totalUninstalls: NUM_UNINSTALLS,
+          installStats: [[1569783600, NUM_INSTALLS]],
+          uninstallStats: [[1569783600, NUM_UNINSTALLS]],
         },
       });
 
@@ -50,7 +50,7 @@ describe('Sentry Application Dashboard', function() {
       Client.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/interaction/`,
         body: {
-          component_interactions: {
+          componentInteractions: {
             'stacktrace-link': [[1569783600, 1]],
             'issue-link': [[1569783600, 1]],
           },
@@ -176,10 +176,10 @@ describe('Sentry Application Dashboard', function() {
       Client.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/stats/`,
         body: {
-          total_installs: 1,
-          total_uninstalls: 0,
-          install_stats: [[1569783600, 1]],
-          uninstall_stats: [[1569783600, 0]],
+          totalInstalls: 1,
+          totalUninstalls: 0,
+          installStats: [[1569783600, 1]],
+          uninstallStats: [[1569783600, 0]],
         },
       });
 
@@ -191,7 +191,7 @@ describe('Sentry Application Dashboard', function() {
       Client.addMockResponse({
         url: `/sentry-apps/${sentryApp.slug}/interaction/`,
         body: {
-          component_interactions: {
+          componentInteractions: {
             'stacktrace-link': [[1569783600, 1]],
           },
           views: [[1569783600, 1]],

--- a/tests/sentry/api/endpoints/test_sentry_app_interaction.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_interaction.py
@@ -35,7 +35,7 @@ class GetSentryAppInteractionTest(SentryAppInteractionTest):
         response = self.client.get(self.unowned_url, format="json")
         assert response.status_code == 200
         assert len(response.data["views"]) > 0
-        assert response.data["component_interactions"] == {}
+        assert response.data["componentInteractions"] == {}
 
     def test_user_sees_owned_interactions(self):
         self.login_as(user=self.user)
@@ -43,7 +43,7 @@ class GetSentryAppInteractionTest(SentryAppInteractionTest):
         response = self.client.get(self.owned_url, format="json")
         assert response.status_code == 200
         assert len(response.data["views"]) > 0
-        assert "issue-link" in response.data["component_interactions"]
+        assert "issue-link" in response.data["componentInteractions"]
 
     def test_user_does_not_see_unowned_interactions(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_sentry_app_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_stats.py
@@ -42,8 +42,8 @@ class GetSentryAppStatsTest(SentryAppStatsTest):
         url = reverse("sentry-api-0-sentry-app-stats", args=[self.unowned_published_app.slug])
         response = self.client.get(url, format="json")
         assert response.status_code == 200
-        assert response.data["total_installs"] == 1
-        assert response.data["total_uninstalls"] == 0
+        assert response.data["totalInstalls"] == 1
+        assert response.data["totalUninstalls"] == 0
         install_epoch = int(
             to_timestamp(
                 self.unowned_published_app_install.date_added.replace(
@@ -51,7 +51,7 @@ class GetSentryAppStatsTest(SentryAppStatsTest):
                 )
             )
         )
-        assert (install_epoch, 1) in response.data["install_stats"]
+        assert (install_epoch, 1) in response.data["installStats"]
 
     def test_superuser_sees_unowned_unpublished_stats(self):
         self.login_as(user=self.superuser, superuser=True)
@@ -59,8 +59,8 @@ class GetSentryAppStatsTest(SentryAppStatsTest):
         url = reverse("sentry-api-0-sentry-app-stats", args=[self.unowned_unpublished_app.slug])
         response = self.client.get(url, format="json")
         assert response.status_code == 200
-        assert response.data["total_installs"] == 0
-        assert response.data["total_uninstalls"] == 0
+        assert response.data["totalInstalls"] == 0
+        assert response.data["totalUninstalls"] == 0
 
     def test_user_sees_owned_published_stats(self):
         self.login_as(self.user)
@@ -68,14 +68,14 @@ class GetSentryAppStatsTest(SentryAppStatsTest):
         url = reverse("sentry-api-0-sentry-app-stats", args=[self.published_app.slug])
         response = self.client.get(url, format="json")
         assert response.status_code == 200
-        assert response.data["total_installs"] == 1
-        assert response.data["total_uninstalls"] == 0
+        assert response.data["totalInstalls"] == 1
+        assert response.data["totalUninstalls"] == 0
         install_epoch = int(
             to_timestamp(
                 self.published_app_install.date_added.replace(microsecond=0, second=0, minute=0)
             )
         )
-        assert (install_epoch, 1) in response.data["install_stats"]
+        assert (install_epoch, 1) in response.data["installStats"]
 
     def test_user_does_not_see_unowned_published_stats(self):
         self.login_as(self.user)
@@ -91,8 +91,8 @@ class GetSentryAppStatsTest(SentryAppStatsTest):
         url = reverse("sentry-api-0-sentry-app-stats", args=[self.unpublished_app.slug])
         response = self.client.get(url, format="json")
         assert response.status_code == 200
-        assert response.data["total_installs"] == 0
-        assert response.data["total_uninstalls"] == 0
+        assert response.data["totalInstalls"] == 0
+        assert response.data["totalUninstalls"] == 0
 
     def test_user_sees_internal_stats(self):
         self.login_as(self.user)
@@ -100,8 +100,8 @@ class GetSentryAppStatsTest(SentryAppStatsTest):
         url = reverse("sentry-api-0-sentry-app-stats", args=[self.internal_app.slug])
         response = self.client.get(url, format="json")
         assert response.status_code == 200
-        assert response.data["total_installs"] == 1
-        assert response.data["total_uninstalls"] == 0
+        assert response.data["totalInstalls"] == 1
+        assert response.data["totalUninstalls"] == 0
 
     def test_invalid_startend_throws_error(self):
         self.login_as(self.user)


### PR DESCRIPTION
3 things:

1. rename all the sentry app stats endpoints to be camelcase fields
2. count context menu opens (right clicks) as 1 interaction for stacktrace-link UI components (this change is in src/sentry/static/sentry/app/components/events/interfaces/openInContextLine.jsx)
3. only show info in the dashboard about the UI component interactions if the component actually exists in the app (https://github.com/getsentry/sentry/pull/15576/files#diff-1c3cbd450bd69f8a27ff10ab3d079234R222-R231)