### PR TITLE
fix(discover) Don't show v2 queries in discover1

### DIFF
--- a/src/sentry/static/sentry/app/views/discover/sidebar/savedQueryList.tsx
+++ b/src/sentry/static/sentry/app/views/discover/sidebar/savedQueryList.tsx
@@ -75,6 +75,7 @@ export default class SavedQueries extends React.Component<
   fetchAll() {
     fetchSavedQueries(this.props.organization)
       .then((data: SavedQuery[]) => {
+        data = data.filter(item => item.version === 1 || item.version === undefined);
         this.setState({isLoading: false, data});
       })
       .catch(() => {

--- a/tests/js/spec/views/discover/sidebar/savedQueryList.spec.jsx
+++ b/tests/js/spec/views/discover/sidebar/savedQueryList.spec.jsx
@@ -30,7 +30,7 @@ describe('savedQueryList', function() {
     const savedQueries = [
       TestStubs.DiscoverSavedQuery({id: '1', name: 'one'}),
       TestStubs.DiscoverSavedQuery({id: '2', name: '2two'}),
-      TestStubs.DiscoverSavedQuery({id: '2', name: 'three v2', version: 2}),
+      TestStubs.DiscoverSavedQuery({id: '3', name: 'three v2', version: 2}),
     ];
     mockResponse.push(...savedQueries);
     const wrapper = mount(<SavedQueryList organization={organization} />);

--- a/tests/js/spec/views/discover/sidebar/savedQueryList.spec.jsx
+++ b/tests/js/spec/views/discover/sidebar/savedQueryList.spec.jsx
@@ -30,13 +30,17 @@ describe('savedQueryList', function() {
     const savedQueries = [
       TestStubs.DiscoverSavedQuery({id: '1', name: 'one'}),
       TestStubs.DiscoverSavedQuery({id: '2', name: '2two'}),
+      TestStubs.DiscoverSavedQuery({id: '2', name: 'three v2', version: 2}),
     ];
     mockResponse.push(...savedQueries);
     const wrapper = mount(<SavedQueryList organization={organization} />);
     await tick();
-    savedQueries.forEach(query => {
-      expect(wrapper.text()).toContain(query.name);
-      expect(wrapper.text()).toContain('Updated Sep 24 00:00:00 (UTC)');
-    });
+
+    const text = wrapper.text();
+    expect(text).toContain('Updated Sep 24 00:00:00 (UTC)');
+    expect(text).toContain(savedQueries[0].name);
+    expect(text).toContain(savedQueries[1].name);
+    // v2 queries should not be present.
+    expect(text).not.toContain(savedQueries[2].name);
   });
 });


### PR DESCRIPTION
Filter saved queries client side to hide discover 2 queries from discover1. Ideally this would be done in the API endpoint but with the query being stored in a text field that is more challenging to do.