### PR TITLE
build(webpack): Use `fork-ts` webpack plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "emotion-theming": "10.0.27",
     "file-loader": "^3.0.1",
     "focus-visible": "^5.0.2",
+    "fork-ts-checker-webpack-plugin": "^1.5.1",
     "fuse.js": "^3.4.6",
     "gettext-parser": "1.3.1",
     "intersection-observer": "^0.7.0",

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -17,10 +17,6 @@ export type UnsavedTrigger = {
   // UnsavedTrigger can be apart of an Unsaved Alert Rule that does not have an id yet
   alertRuleId?: string;
   label: string;
-  thresholdType: AlertRuleThresholdType;
-  alertThreshold: number;
-  resolveThreshold: number | '';
-  actions: Action[];
 };
 
 export type ThresholdControlValue = {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -17,6 +17,10 @@ export type UnsavedTrigger = {
   // UnsavedTrigger can be apart of an Unsaved Alert Rule that does not have an id yet
   alertRuleId?: string;
   label: string;
+  thresholdType: AlertRuleThresholdType;
+  alertThreshold: number;
+  resolveThreshold: number | '';
+  actions: Action[];
 };
 
 export type ThresholdControlValue = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "lib": ["esnext", "dom"],
     "module": "esnext",
     "moduleResolution": "node",
+    "noEmit": true,
     "noEmitHelpers": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "lib": ["esnext", "dom"],
     "module": "esnext",
     "moduleResolution": "node",
-    "noEmit": true,
     "noEmitHelpers": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     "experimentalDecorators": true,
 
     "esModuleInterop": true,
-    "jsx": "react",
+    "jsx": "preserve",
     "baseUrl": ".",
     "outDir": "src/sentry/static/sentry/dist",
     "paths": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ const CompressionPlugin = require('compression-webpack-plugin');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const FixStyleOnlyEntriesPlugin = require('webpack-fix-style-only-entries');
 const CopyPlugin = require('copy-webpack-plugin');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 const babelConfig = require('./babel.config');
 
@@ -231,7 +232,7 @@ let appConfig = {
           {
             loader: 'ts-loader',
             options: {
-              transpileOnly: false,
+              transpileOnly: true,
             },
           },
         ],
@@ -319,6 +320,10 @@ let appConfig = {
     new FixStyleOnlyEntriesPlugin(),
 
     new SentryInstrumentation(),
+
+    new ForkTsCheckerWebpackPlugin({
+      tsconfig: path.resolve(__dirname, './tsconfig.json'),
+    }),
 
     ...localeRestrictionPlugins,
   ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -185,6 +185,14 @@ const cacheGroups = {
 };
 
 const babelOptions = {...babelConfig, cacheDirectory: true};
+const babelLoaderConfig = {loader: 'babel-loader', options: babelOptions};
+
+const tsLoaderConfig = {
+  loader: 'ts-loader',
+  options: {
+    transpileOnly: false,
+  },
+};
 
 /**
  * Main Webpack config for Sentry React SPA.
@@ -225,23 +233,7 @@ let appConfig = {
         test: /\.tsx?$/,
         include: [staticPrefix],
         exclude: /(vendor|node_modules|dist)/,
-        use: [
-          ...(!IS_CI
-            ? [
-                {
-                  loader: 'babel-loader',
-                  options: babelOptions,
-                },
-              ]
-            : [
-                {
-                  loader: 'ts-loader',
-                  options: {
-                    transpileOnly: false,
-                  },
-                },
-              ]),
-        ],
+        use: [!IS_CI ? babelLoaderConfig : tsLoaderConfig],
       },
       {
         test: /\.po$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -230,12 +230,8 @@ let appConfig = {
         test: /\.tsx?$/,
         include: [staticPrefix],
         exclude: /(vendor|node_modules|dist)/,
-
-        // Note there is an emotion bug if we run babel-loader in conjunction with ts-loader
-        // See https://github.com/emotion-js/emotion/issues/1748
-        //
-        // However, we don't want to lose typechecking in CI, so we have a CI task
-        // that will run explicitly ts-loader
+        // Make sure we typecheck in CI, but not for local dev since that is run with
+        // the fork-ts plugin
         use: !IS_CI ? babelLoaderConfig : [babelLoaderConfig, tsLoaderConfig],
       },
       {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,9 +33,6 @@ const USE_HOT_MODULE_RELOAD =
 const NO_DEV_SERVER = env.NO_DEV_SERVER;
 const IS_CI = !!env.CI || !!env.TRAVIS;
 
-// We only use ts-loader directly in CI for a specific job
-const USE_TS_LOADER = env.TEST_SUITE === 'js-build';
-
 // Deploy previews are built using netlify. We can check if we're in netlifys
 // build process by checking the existence of the PULL_REQUEST env var.
 //
@@ -239,7 +236,7 @@ let appConfig = {
         //
         // However, we don't want to lose typechecking in CI, so we have a CI task
         // that will run explicitly ts-loader
-        use: USE_TS_LOADER ? [babelLoaderConfig, tsLoaderConfig] : babelLoaderConfig,
+        use: !IS_CI ? babelLoaderConfig : [babelLoaderConfig, tsLoaderConfig],
       },
       {
         test: /\.po$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6749,6 +6749,20 @@ fork-ts-checker-webpack-plugin@1.5.0:
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
 
+fork-ts-checker-webpack-plugin@^1.5.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.6.0.tgz#a81fd1c6bf5258fa5318cf3e9a7e9bac006f7917"
+  integrity sha512-vqOY5gakcoon2s12V7MMe01OPwfgqulUWFzm+geQaPPOBKjW1I7aqqoBVlU0ECn97liMB0ECs16pRdIGe9qdRw==
+  dependencies:
+    babel-code-frame "^6.22.0"
+    chalk "^2.4.1"
+    chokidar "^2.0.4"
+    micromatch "^3.1.10"
+    minimatch "^3.0.4"
+    semver "^5.6.0"
+    tapable "^1.0.0"
+    worker-rpc "^0.1.0"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"


### PR DESCRIPTION
This should decrease build times since we are only running either
babel-loader or ts-loader and not both. We should skip typechecking for
local dev (and instead run type checking in a forked process) and always
run type checking in CI.

This will also skip typechecking when building prod assets (which should
be fine since we run them in CI).

👀👀