### PR TITLE
fix(sso): Handle existing invite requests

### DIFF
--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -108,6 +108,10 @@ class ApiInviteHelper(object):
                 extra={"organization_id": self.om.organization.id, "user_id": self.request.user.id},
             )
 
+    def handle_invite_not_approved(self):
+        if not self.invite_approved:
+            self.om.delete()
+
     @property
     def organization_member(self):
         return OrganizationMember.objects.select_related("organization").get(pk=self.member_id)
@@ -115,6 +119,10 @@ class ApiInviteHelper(object):
     @property
     def member_pending(self):
         return self.om.is_pending
+
+    @property
+    def invite_approved(self):
+        return self.om.invite_approved
 
     @property
     def valid_token(self):
@@ -147,7 +155,7 @@ class ApiInviteHelper(object):
     def valid_request(self):
         return (
             self.member_pending
-            and self.om.invite_approved
+            and self.invite_approved
             and self.valid_token
             and self.user_authenticated
             and not self.needs_2fa

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -167,8 +167,14 @@ def handle_new_membership(auth_provider, organization, request, auth_identity):
     # If we are able to accept an existing invite for the user for this
     # organization, do so, otherwise handle new membership
     if invite_helper:
-        invite_helper.accept_invite(user)
-        return
+        if invite_helper.invite_approved:
+            invite_helper.accept_invite(user)
+            return
+
+        # It's possible the user has an _invite request_ that hasn't been approved yet,
+        # and is able to join the organization without an invite through the SSO flow.
+        # In that case, delete the invite request and create a new membership.
+        invite_helper.handle_invite_not_approved()
 
     # Otherwise create a new membership
     om = OrganizationMember.objects.create(

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -4,7 +4,7 @@ from six.moves.urllib.parse import urlencode
 from django.test import RequestFactory
 from django.contrib.auth.models import AnonymousUser
 
-from sentry.models import AuthProvider, OrganizationMember
+from sentry.models import AuthProvider, InviteStatus, OrganizationMember
 from sentry.testutils import TestCase
 from sentry.auth.helper import handle_new_user
 
@@ -42,6 +42,29 @@ class HandleNewUserTest(TestCase):
         )
 
         assert assigned_member.id == member.id
+
+    def test_associated_existing_member_invite_request(self):
+        request = RequestFactory().post("/auth/sso/")
+        request.user = AnonymousUser()
+
+        provider = AuthProvider.objects.create(organization=self.organization, provider="dummy")
+        identity = {"id": "1234", "email": "test@example.com", "name": "Morty"}
+
+        member = self.create_member(
+            organization=self.organization,
+            email=identity["email"],
+            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
+        )
+
+        auth_identity = handle_new_user(provider, self.organization, request, identity)
+
+        assert OrganizationMember.objects.filter(
+            organization=self.organization,
+            user=auth_identity.user,
+            invite_status=InviteStatus.APPROVED.value,
+        ).exists()
+
+        assert not OrganizationMember.objects.filter(id=member.id).exists()
 
     def test_associate_pending_invite(self):
         provider = AuthProvider.objects.create(organization=self.organization, provider="dummy")


### PR DESCRIPTION
A user could have an invite request that's not yet accepted and join the organization without an invite through the SSO flow. In that case, we'll delete the invite request and create a new membership, so the user gets the default SSO role and team(s), rather than the roles and teams on the invite request.