### PR TITLE
feat(eventstore): Run the Discover dataset and log differences

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1046,6 +1046,24 @@ SENTRY_SEARCH_OPTIONS = {}
 SENTRY_TSDB = "sentry.tsdb.dummy.DummyTSDB"
 SENTRY_TSDB_OPTIONS = {}
 
+# Event storage backend
+SENTRY_EVENTSTORE = "sentry.utils.services.ServiceDelegator"
+SENTRY_EVENTSTORE_OPTIONS = {
+    "backend_base": "sentry.eventstore.base.EventStorage",
+    "backends": {
+        "snuba": {
+            "path": "sentry.eventstore.snuba.SnubaEventStorage",
+            "executor": {"path": "sentry.utils.concurrent.SynchronousExecutor"},
+        },
+        "snuba_discover": {
+            "path": "sentry.eventstore.snuba_discover.SnubaDiscoverEventStorage",
+            "executor": {"path": "sentry.utils.services.ThreadedExecutor"},
+        },
+    },
+    "selector_func": "sentry.eventstore.utils.selector_func",
+    "callback_func": "sentry.eventstore.utils.callback_func",
+}
+
 SENTRY_NEWSLETTER = "sentry.newsletter.base.Newsletter"
 SENTRY_NEWSLETTER_OPTIONS = {}
 

--- a/src/sentry/eventstore/__init__.py
+++ b/src/sentry/eventstore/__init__.py
@@ -1,10 +1,15 @@
 from __future__ import absolute_import
 
+from django.conf import settings
+
 from sentry.utils.services import LazyServiceWrapper
 
 from .base import EventStorage, Columns, Filter, get_columns_from_aliases  # NOQA
 
 backend = LazyServiceWrapper(
-    EventStorage, "sentry.eventstore.snuba.SnubaEventStorage", {}, metrics_path="eventstore"
+    EventStorage,
+    settings.SENTRY_EVENTSTORE,
+    settings.SENTRY_EVENTSTORE_OPTIONS,
+    metrics_path="eventstore",
 )
 backend.expose(locals())

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -181,7 +181,15 @@ class EventStorage(Service):
         Columns.USER_USERNAME,
     ]
 
-    def get_events(self, filter, additional_columns, orderby, limit, offset, referrer):
+    def get_events(
+        self,
+        filter,
+        additional_columns=None,
+        orderby=None,
+        limit=100,
+        offset=0,
+        referrer="eventstore.get_events",
+    ):
         """
         Fetches a list of events given a set of criteria.
 
@@ -195,7 +203,7 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
-    def get_event_by_id(self, project_id, event_id, additional_columns):
+    def get_event_by_id(self, project_id, event_id, additional_columns=None):
         """
         Gets a single event given a project_id and event_id.
 

--- a/src/sentry/eventstore/snuba_discover/__init__.py
+++ b/src/sentry/eventstore/snuba_discover/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .backend import SnubaDiscoverEventStorage  # NOQA

--- a/src/sentry/eventstore/snuba_discover/backend.py
+++ b/src/sentry/eventstore/snuba_discover/backend.py
@@ -76,14 +76,6 @@ class SnubaDiscoverEventStorage(EventStorage):
 
         return self.__get_event_id_from_filter(filter=filter, orderby=DESC_ORDERING)
 
-    def __get_columns(self, additional_columns):
-        columns = EventStorage.minimal_columns
-
-        if additional_columns:
-            columns = set(columns + additional_columns)
-
-        return [col.value.event_name for col in columns]
-
     def __get_event_id_from_filter(self, filter=None, orderby=None):
         columns = ["event_id", "project_id", "timestamp"]
         result = snuba.raw_query(

--- a/src/sentry/eventstore/utils.py
+++ b/src/sentry/eventstore/utils.py
@@ -2,12 +2,14 @@ from __future__ import absolute_import
 
 import logging
 
-methods_to_test = [
+get_by_id_methods = [
     "get_next_event_id",
     "get_prev_event_id",
     "get_earliest_event_id",
     "get_latest_event_id",
 ]
+
+methods_to_test = get_by_id_methods
 
 logger = logging.getLogger("sentry.eventstore")
 
@@ -23,14 +25,15 @@ def callback_func(context, method, callargs, backends, results):
     """
     Log if results are different
     """
-    if backends == ["snuba", "snuba_discover"] and method in methods_to_test:
-        if results[0].result() != results[1].result():
-            logger.info(
-                "discover.result-mismatch",
-                extra={
-                    "method": method,
-                    "callargs": callargs,
-                    "snuba": results[0].result(),
-                    "snuba_discover": results[1].result(),
-                },
-            )
+    if backends == ["snuba", "snuba_discover"]:
+        if method in get_by_id_methods:
+            if results[0].result() != results[1].result():
+                logger.info(
+                    "discover.result-mismatch",
+                    extra={
+                        "method": method,
+                        "callargs": callargs,
+                        "snuba": results[0].result(),
+                        "snuba_discover": results[1].result(),
+                    },
+                )

--- a/src/sentry/eventstore/utils.py
+++ b/src/sentry/eventstore/utils.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+import logging
+
+methods_to_test = [
+    "get_next_event_id",
+    "get_prev_event_id",
+    "get_earliest_event_id",
+    "get_latest_event_id",
+]
+
+logger = logging.getLogger("sentry.eventstore")
+
+
+def selector_func(context, method, callargs):
+    if method in methods_to_test:
+        return ["snuba", "snuba_discover"]
+
+    return ["snuba"]
+
+
+def callback_func(context, method, callargs, backends, results):
+    """
+    Log if results are different
+    """
+    if backends == ["snuba", "snuba_discover"] and method in methods_to_test:
+        if results[0].result() != results[1].result():
+            logger.info(
+                "discover.result-mismatch",
+                extra={"snuba": results[0].result(), "snuba_discover": results[1].result()},
+            )

--- a/src/sentry/eventstore/utils.py
+++ b/src/sentry/eventstore/utils.py
@@ -27,5 +27,10 @@ def callback_func(context, method, callargs, backends, results):
         if results[0].result() != results[1].result():
             logger.info(
                 "discover.result-mismatch",
-                extra={"snuba": results[0].result(), "snuba_discover": results[1].result()},
+                extra={
+                    "method": method,
+                    "callargs": callargs,
+                    "snuba": results[0].result(),
+                    "snuba_discover": results[1].result(),
+                },
             )

--- a/src/sentry/eventstore/utils.py
+++ b/src/sentry/eventstore/utils.py
@@ -27,13 +27,18 @@ def callback_func(context, method, callargs, backends, results):
     """
     if backends == ["snuba", "snuba_discover"]:
         if method in get_by_id_methods:
-            if results[0].result() != results[1].result():
+            snuba_result = results[0].result()
+            snuba_discover_reuslt = results[1].result()
+
+            if snuba_result != snuba_discover_reuslt:
                 logger.info(
                     "discover.result-mismatch",
                     extra={
                         "method": method,
-                        "callargs": callargs,
-                        "snuba": results[0].result(),
-                        "snuba_discover": results[1].result(),
+                        "event_id": callargs["event"].event_id,
+                        "filter_keys": callargs["filter"].filter_keys,
+                        "conditions": callargs["filter"].conditions,
+                        "snuba_result": results[0].result(),
+                        "snuba_discover_result": results[1].result(),
                     },
                 )

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -104,7 +104,7 @@ def pytest_configure(config):
         settings.SENTRY_TSDB = "sentry.tsdb.redissnuba.RedisSnubaTSDB"
         settings.SENTRY_EVENTSTREAM = "sentry.eventstream.snuba.SnubaEventStream"
 
-    # Use the synchronous executor to make backends easier to test
+    # Use the synchronous executor to make multiple backends easier to test
     eventstore_options = deepcopy(settings.SENTRY_EVENTSTORE_OPTIONS)
     eventstore_options["backends"]["snuba_discover"]["executor"][
         "path"

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from copy import deepcopy
 import mock
 import os
 
@@ -102,6 +103,13 @@ def pytest_configure(config):
         settings.SENTRY_SEARCH = "sentry.search.snuba.SnubaSearchBackend"
         settings.SENTRY_TSDB = "sentry.tsdb.redissnuba.RedisSnubaTSDB"
         settings.SENTRY_EVENTSTREAM = "sentry.eventstream.snuba.SnubaEventStream"
+
+    # Use the synchronous executor to make backends easier to test
+    eventstore_options = deepcopy(settings.SENTRY_EVENTSTORE_OPTIONS)
+    eventstore_options["backends"]["snuba_discover"]["executor"][
+        "path"
+    ] = "sentry.utils.concurrent.SynchronousExecutor"
+    settings.SENTRY_EVENTSTORE_OPTIONS = eventstore_options
 
     if not hasattr(settings, "SENTRY_OPTIONS"):
         settings.SENTRY_OPTIONS = {}

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -63,6 +63,7 @@ TRANSACTIONS_SENTRY_SNUBA_MAP = {
 class Dataset(Enum):
     Events = "events"
     Transactions = "transactions"
+    Discover = "discover"
     Outcomes = "outcomes"
     OutcomesRaw = "outcomes_raw"
 
@@ -609,7 +610,7 @@ def _prepare_query_params(query_params):
             query_params.filter_keys, is_grouprelease=query_params.is_grouprelease
         )
 
-    if query_params.dataset in [Dataset.Events, Dataset.Transactions]:
+    if query_params.dataset in [Dataset.Events, Dataset.Transactions, Dataset.Discover]:
         (organization_id, params_to_update) = get_query_params_to_update_for_projects(query_params)
     elif query_params.dataset in [Dataset.Outcomes, Dataset.OutcomesRaw]:
         (organization_id, params_to_update) = get_query_params_to_update_for_organizations(

--- a/tests/sentry/eventstore/snuba/__init__.py
+++ b/tests/sentry/eventstore/snuba/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/eventstore/snuba_discover/__init__.py
+++ b/tests/sentry/eventstore/snuba_discover/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/eventstore/snuba_discover/test_backend.py
+++ b/tests/sentry/eventstore/snuba_discover/test_backend.py
@@ -1,0 +1,175 @@
+from __future__ import absolute_import
+
+import six
+import pytest
+
+from sentry.testutils import TestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
+from sentry.eventstore.snuba_discover.backend import SnubaDiscoverEventStorage
+from sentry.eventstore.base import Filter
+
+from sentry.utils.samples import load_data
+
+
+class SnubaDiscoverEventStorageTest(TestCase, SnubaTestCase):
+    """
+    This is just a temporary copy/paste of eventstore.snuba.test_backend
+    """
+
+    def setUp(self):
+        super(SnubaDiscoverEventStorageTest, self).setUp()
+        self.min_ago = iso_format(before_now(minutes=1))
+        self.two_min_ago = iso_format(before_now(minutes=2))
+        self.project1 = self.create_project()
+        self.project2 = self.create_project()
+
+        self.event1 = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "type": "default",
+                "platform": "python",
+                "fingerprint": ["group1"],
+                "timestamp": self.two_min_ago,
+                "tags": {"foo": "1"},
+            },
+            project_id=self.project1.id,
+        )
+        self.event2 = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "type": "default",
+                "platform": "python",
+                "fingerprint": ["group1"],
+                "timestamp": self.min_ago,
+                "tags": {"foo": "1"},
+            },
+            project_id=self.project2.id,
+        )
+        self.event3 = self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "type": "default",
+                "platform": "python",
+                "fingerprint": ["group2"],
+                "timestamp": self.min_ago,
+                "tags": {"foo": "1"},
+            },
+            project_id=self.project2.id,
+        )
+
+        event_data = load_data("transaction")
+        event_data["timestamp"] = iso_format(before_now(minutes=1))
+        event_data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=1))
+        event_data["event_id"] = "d" * 32
+
+        self.transaction_event = self.store_event(data=event_data, project_id=self.project2.id)
+
+        event_data_2 = load_data("transaction")
+        event_data_2["timestamp"] = iso_format(before_now(seconds=30))
+        event_data_2["start_timestamp"] = iso_format(before_now(seconds=31))
+
+        event_data_2["event_id"] = "e" * 32
+
+        self.transaction_event_2 = self.store_event(data=event_data_2, project_id=self.project2.id)
+
+        self.eventstore = SnubaDiscoverEventStorage()
+
+    def test_get_events(self):
+        events = self.eventstore.get_events(
+            filter=Filter(project_ids=[self.project1.id, self.project2.id])
+        )
+        assert len(events) == 5
+        # Default sort is timestamp desc, event_id desc
+        assert events[0].id == "e" * 32
+        assert events[1].id == "d" * 32
+        assert events[2].id == "c" * 32
+        assert events[3].id == "b" * 32
+        assert events[4].id == "a" * 32
+
+        # No events found
+        project = self.create_project()
+        events = self.eventstore.get_events(filter=Filter(project_ids=[project.id]))
+        assert events == []
+
+    def test_get_event_by_id(self):
+        # Get event with default columns
+        event = self.eventstore.get_event_by_id(self.project1.id, "a" * 32)
+
+        assert event.id == "a" * 32
+        assert event.event_id == "a" * 32
+        assert event.project_id == self.project1.id
+        assert len(event.snuba_data.keys()) == 4
+
+        # Get all columns
+        event = self.eventstore.get_event_by_id(
+            self.project2.id, "b" * 32, self.eventstore.full_columns
+        )
+        assert event.id == "b" * 32
+        assert event.event_id == "b" * 32
+        assert event.project_id == self.project2.id
+        assert len(event.snuba_data.keys()) == 17
+
+        # Get non existent event
+        event = self.eventstore.get_event_by_id(self.project2.id, "f" * 32)
+        assert event is None
+
+    def test_get_next_prev_event_id(self):
+        event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
+
+        filter = Filter(project_ids=[self.project1.id, self.project2.id])
+
+        prev_event = self.eventstore.get_prev_event_id(event, filter=filter)
+
+        next_event = self.eventstore.get_next_event_id(event, filter=filter)
+
+        assert prev_event == (six.text_type(self.project1.id), "a" * 32)
+
+        # Events with the same timestamp are sorted by event_id
+        assert next_event == (six.text_type(self.project2.id), "c" * 32)
+
+        # Returns None if no event
+        assert self.eventstore.get_prev_event_id(None, filter=filter) is None
+        assert self.eventstore.get_next_event_id(None, filter=filter) is None
+
+    def test_get_latest_or_oldest_event_id(self):
+        # Returns a latest/oldest event
+        event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
+        filter = Filter(project_ids=[self.project1.id, self.project2.id])
+        oldest_event = self.eventstore.get_earliest_event_id(event, filter=filter)
+        latest_event = self.eventstore.get_latest_event_id(event, filter=filter)
+        assert oldest_event == (six.text_type(self.project1.id), "a" * 32)
+        assert latest_event == (six.text_type(self.project2.id), "e" * 32)
+
+        # Returns none when no latest/oldest event that meets conditions
+        event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
+        filter = Filter(project_ids=[self.project1.id], group_ids=[self.event2.group_id])
+        oldest_event = self.eventstore.get_earliest_event_id(event, filter=filter)
+        latest_event = self.eventstore.get_latest_event_id(event, filter=filter)
+        assert oldest_event is None
+        assert latest_event is None
+
+    def test_transaction_get_event_by_id(self):
+        event = self.eventstore.get_event_by_id(self.project2.id, self.transaction_event.event_id)
+
+        assert event.id == "d" * 32
+        assert event.get_event_type() == "transaction"
+        assert event.project_id == self.project2.id
+
+    @pytest.mark.skip(reason="Not yet implemented")
+    def test_transaction_get_next_prev_event_id(self):
+        filter = Filter(
+            project_ids=[self.project1.id, self.project2.id],
+            conditions=[["type", "=", "transaction"]],
+        )
+
+        event = self.eventstore.get_event_by_id(self.project2.id, "e" * 32)
+        prev_event = self.eventstore.get_prev_event_id(event, filter=filter)
+        next_event = self.eventstore.get_next_event_id(event, filter=filter)
+        assert prev_event == (six.text_type(self.project2.id), "d" * 32)
+        assert next_event is None
+
+        event = self.eventstore.get_event_by_id(self.project2.id, "d" * 32)
+        prev_event = self.eventstore.get_prev_event_id(event, filter=filter)
+        next_event = self.eventstore.get_next_event_id(event, filter=filter)
+        assert prev_event is None
+        assert next_event == (six.text_type(self.project2.id), "e" * 32)

--- a/tests/sentry/eventstore/test_base.py
+++ b/tests/sentry/eventstore/test_base.py
@@ -91,9 +91,11 @@ class ServiceDelegationTest(TestCase, SnubaTestCase):
             mock_logger.assert_called_with(
                 "discover.result-mismatch",
                 extra={
-                    "snuba": None,
-                    "snuba_discover": (six.text_type(self.project.id), "b" * 32),
+                    "snuba_result": None,
+                    "snuba_discover_result": (six.text_type(self.project.id), "b" * 32),
                     "method": "get_next_event_id",
-                    "callargs": {"self": None, "filter": filter, "event": event},
+                    "event_id": event.event_id,
+                    "filter_keys": filter.filter_keys,
+                    "conditions": filter.conditions,
                 },
             )

--- a/tests/sentry/eventstore/test_base.py
+++ b/tests/sentry/eventstore/test_base.py
@@ -90,5 +90,10 @@ class ServiceDelegationTest(TestCase, SnubaTestCase):
             assert mock_logger.call_count == 1
             mock_logger.assert_called_with(
                 "discover.result-mismatch",
-                extra={"snuba": None, "snuba_discover": (six.text_type(self.project.id), "b" * 32)},
+                extra={
+                    "snuba": None,
+                    "snuba_discover": (six.text_type(self.project.id), "b" * 32),
+                    "method": "get_next_event_id",
+                    "callargs": {"self": None, "filter": filter, "event": event},
+                },
             )


### PR DESCRIPTION
This PR introduces the SnubaDiscover eventstore backend.

This alternative eventstore backend skips dataset detection in Sentry
and simply routes the query to the Discover dataset in Snuba for the
following methods:
- get_next_event_by_id
- get_prev_event_by_id
- get_latest_event_by_id
- get_earliest_event_by_id

Currently results are not being returned from this dataset, we are just
using this backend to log any differences in results with the primary
Snuba backend.