### PR TITLE
feat(backend): Create an endpoint to return if a user has access to projects

### DIFF
--- a/src/sentry/api/endpoints/organization_has_projects.py
+++ b/src/sentry/api/endpoints/organization_has_projects.py
@@ -18,7 +18,7 @@ class OrganizationHasProjectsEndpoint(OrganizationEndpoint):
         ``````````````````````````````````````````````````````````
 
         Returns true if there are any projects within the organization that
-        the user has access to via team membership
+        the user has access to via team membership or superuser access
 
         :pparam string organization_slug: the slug of the organization
                                           to check

--- a/src/sentry/api/endpoints/organization_has_projects.py
+++ b/src/sentry/api/endpoints/organization_has_projects.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.base import DocSection
+from sentry.api.serializers import serialize
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.auth.superuser import is_active_superuser
+from sentry.models import Project
+
+
+class OrganizationHasProjectsEndpoint(OrganizationEndpoint):
+    doc_section = DocSection.ORGANIZATIONS
+
+    def get(self, request, organization):
+        """
+        Verify If A User Has Access to Projects In An Organization
+        ``````````````````````````````````````````````````````````
+
+        Returns true if there are any projects within the organization that
+        the user has access to via team membership
+
+        :pparam string organization_slug: the slug of the organization
+                                          to check
+        :auth: required
+        """
+        if is_active_superuser(request):
+            # retrieve all projects within the organization
+            queryset = Project.objects.filter(organization=organization)
+            return Response(serialize({"hasProjects": queryset.count() > 0}, request.user))
+        else:
+            return Response(
+                serialize({"hasProjects": len(request.access.projects) > 0}, request.user)
+            )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -93,6 +93,7 @@ from .endpoints.organization_events_distribution import OrganizationEventsDistri
 from .endpoints.organization_events_meta import OrganizationEventsMetaEndpoint
 from .endpoints.organization_events_stats import OrganizationEventsStatsEndpoint
 from .endpoints.organization_group_index import OrganizationGroupIndexEndpoint
+from .endpoints.organization_has_projects import OrganizationHasProjectsEndpoint
 from .endpoints.organization_incident_activity_index import (
     OrganizationIncidentActivityIndexEndpoint,
 )
@@ -774,6 +775,11 @@ urlpatterns = patterns(
                     r"^(?P<organization_slug>[^\/]+)/events-meta/$",
                     OrganizationEventsMetaEndpoint.as_view(),
                     name="sentry-api-0-organization-events-meta",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/has-projects/$",
+                    OrganizationHasProjectsEndpoint.as_view(),
+                    name="sentry-api-0-organization-has-projects",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/issues/new/$",

--- a/tests/sentry/api/endpoints/test_organization_has_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_has_projects.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase
+
+
+class OrganizationHasProjectsTest(APITestCase):
+    def setUp(self):
+        self.foo = self.create_user("foo@example.com")
+        self.bar = self.create_user("bar@example.com", is_superuser=True)
+        self.org = self.create_organization(owner=self.user)
+        self.team = self.create_team(organization=self.org)
+        self.url = reverse(
+            "sentry-api-0-organization-has-projects", kwargs={"organization_slug": self.org.slug}
+        )
+
+    def test_simple_has_projects(self):
+        # there are projects within a team that the user belongs to
+        self.create_project(teams=[self.team])
+        self.create_member(organization=self.org, user=self.foo, teams=[self.team])
+
+        self.login_as(user=self.foo)
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+        assert response.data["hasProjects"]
+
+    def test_simple_has_no_projects(self):
+        # there are no projects in the organization
+        self.create_member(organization=self.org, user=self.foo, teams=[self.team])
+
+        self.login_as(user=self.foo)
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+        assert not response.data["hasProjects"]
+
+    def test_user_belongs_to_no_projects(self):
+        # there are projects in the org, but the user doesn't belong to it
+        self.create_project(teams=[self.team])
+        self.create_member(organization=self.org, user=self.foo)
+
+        self.login_as(user=self.foo)
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+        assert not response.data["hasProjects"]
+
+    def test_super_user_belongs_to_no_projects(self):
+        # there are projects in the org, and the user is super user
+        self.create_project(teams=[self.team])
+        self.create_member(organization=self.org, user=self.foo)
+
+        self.login_as(user=self.bar, superuser=True)
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+        assert response.data["hasProjects"]

--- a/tests/sentry/api/endpoints/test_organization_has_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_has_projects.py
@@ -51,7 +51,7 @@ class OrganizationHasProjectsTest(APITestCase):
         assert not response.data["hasProjects"]
 
     def test_super_user_belongs_to_no_projects(self):
-        # there are projects in the org, and the user is super user
+        # there are projects in the org, and the user is superuser
         self.create_project(teams=[self.team])
         self.create_member(organization=self.org, user=self.foo)
 


### PR DESCRIPTION
On all of the frontend pages there is a `<NoProjectMessage>` component which uses `organization.projects` to detect if a user has access to any projects. With the change to make organization details lighter (exclude `teams` and `projects` inside organization) it would be useful for an endpoint to return the information necessary to render `<NoProjectMessage>` instead of having to wait for all projects in the organization to load. I tried to mimic the functionality of `<NoProjectMessage>` with this endpoint.

https://github.com/getsentry/sentry/blob/ea2dfd3f078848a8b1864637a839eedc941108ba/src/sentry/static/sentry/app/components/noProjectMessage.tsx#L37-L42