### PR TITLE
fix(discover2): Fix duplicated error messages

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {t} from 'app/locale';
 import {openModal} from 'app/actionCreators/modal';
 
-import Alert from 'app/components/alert';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import InlineSvg from 'app/components/inlineSvg';
 import LoadingContainer from 'app/components/loading/loadingContainer';
@@ -29,6 +28,7 @@ import {
   GridBodyCell,
   GridBodyCellSpan,
   GridBodyCellLoading,
+  GridBodyErrorAlert,
   GridEditGroup,
   GridEditGroupButton,
 } from './styles';
@@ -169,9 +169,6 @@ class GridEditable<
 
     return (
       <React.Fragment>
-        <Alert type="error" icon="icon-circle-exclamation">
-          {error}
-        </Alert>
         <GridPanel>
           <Grid
             isEditable={this.props.isEditable}
@@ -181,7 +178,11 @@ class GridEditable<
             {this.renderGridHead()}
             <GridBody>
               <GridRow>
-                <GridBodyCellSpan>{error}</GridBodyCellSpan>
+                <GridBodyCellSpan>
+                  <GridBodyErrorAlert type="error" icon="icon-circle-exclamation">
+                    {error}
+                  </GridBodyErrorAlert>
+                </GridBodyCellSpan>
               </GridRow>
             </GridBody>
           </Grid>

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -1,5 +1,6 @@
 import styled from 'react-emotion';
 
+import Alert from 'app/components/alert';
 import InlineSvg from 'app/components/inlineSvg';
 import {Panel, PanelBody} from 'app/components/panels';
 import space from 'app/styles/space';
@@ -291,6 +292,10 @@ export const GridBodyCellSpan = styled(GridBodyCell)`
 `;
 export const GridBodyCellLoading = styled('div')`
   min-height: 220px;
+`;
+
+export const GridBodyErrorAlert = styled(Alert)`
+  margin: 0;
 `;
 
 /**


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/1748388/68819792-03389400-063e-11ea-820a-bf6d9f873e24.png)

## After
![image](https://user-images.githubusercontent.com/1748388/68819811-151a3700-063e-11ea-9a33-bd762bfa895f.png)

Tagging @doralchan because error states were not part of the design for Table.