### PR TITLE
feat(discover2) Promote version to a schema column

### DIFF
--- a/src/sentry/discover/models.py
+++ b/src/sentry/discover/models.py
@@ -29,6 +29,7 @@ class DiscoverSavedQuery(Model):
     created_by = FlexibleForeignKey("sentry.User", null=True, on_delete=models.SET_NULL)
     name = models.CharField(max_length=255)
     query = JSONField()
+    version = models.IntegerField(null=True)
     date_created = models.DateTimeField(auto_now_add=True)
     date_updated = models.DateTimeField(auto_now=True)
 

--- a/src/sentry/migrations/0018_discoversavedquery_version.py
+++ b/src/sentry/migrations/0018_discoversavedquery_version.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    # This flag is used to mark that a migration shouldn't be automatically run in
+    # production. We set this to True for operations that we think are risky and want
+    # someone from ops to run manually and monitor.
+    # General advice is that if in doubt, mark your migration as `is_dangerous`.
+    # Some things you should always mark as dangerous:
+    # - Adding indexes to large tables. These indexes should be created concurrently,
+    #   unfortunately we can't run migrations outside of a transaction until Django
+    #   1.10. So until then these should be run manually.
+    # - Large data migrations. Typically we want these to be run manually by ops so that
+    #   they can be monitored. Since data migrations will now hold a transaction open
+    #   this is even more important.
+    # - Adding columns to highly active tables, even ones that are NULL.
+    is_dangerous = False
+
+
+    dependencies = [
+        ('sentry', '0017_incident_aggregation'),
+    ]
+
+    """
+    Generated SQL:
+    ALTER TABLE "sentry_discoversavedquery" ADD COLUMN "version" integer NULL;
+    ALTER TABLE "sentry_discoversavedquery" ALTER COLUMN "version" DROP DEFAULT;
+    """
+
+    operations = [
+        migrations.AddField(
+            model_name='discoversavedquery',
+            name='version',
+            field=models.IntegerField(null=True),
+        ),
+    ]


### PR DESCRIPTION
We want saved queries from discover2 to not show up in discover1. Right now we are doing filtering client side but that's a bit janky. If we promote the version field out of the query blob and into the schema we can add an API parameter to filter by version and remove the client side code.

I'm going to follow this up with a datamigration to populate the column and update how version is stored, but first we need the column in place.