### PR TITLE
feat(discover) Enable searching saved queries

### DIFF
--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -1,13 +1,15 @@
 from __future__ import absolute_import
 
+import six
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.serializers import serialize
 from sentry.api.bases import OrganizationEndpoint
 from sentry.discover.models import DiscoverSavedQuery
-from sentry import features
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
+from sentry.search.utils import tokenize_query
 
 
 class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
@@ -25,13 +27,22 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         if not self.has_feature(organization, request):
             return self.respond(status=404)
 
-        saved_queries = list(
+        queryset = (
             DiscoverSavedQuery.objects.filter(organization=organization)
-            .all()
             .prefetch_related("projects")
             .order_by("name")
         )
+        query = request.query_params.get("query")
+        if query:
+            tokens = tokenize_query(query)
+            for key, value in six.iteritems(tokens):
+                if key == "name" or key == "query":
+                    value = " ".join(value)
+                    queryset = queryset.filter(name__icontains=value)
+                else:
+                    queryset = queryset.none()
 
+        saved_queries = list(queryset.all())
         return Response(serialize(saved_queries), status=200)
 
     def post(self, request, organization):


### PR DESCRIPTION
We want to enable users to seach through their saved queries. In order to do that we need to have filtering in the API endpoint. This reuses the filtering conventions we have in other API endpoints like organization_projects and organization_teams.