### PR TITLE
fix(ui) Reduce overflows in settings

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/index.jsx
@@ -106,5 +106,6 @@ export {CrumbLink};
 
 const Breadcrumbs = styled('div')`
   display: flex;
+  flex: 1;
   align-items: center;
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsHeader.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsHeader.jsx
@@ -8,6 +8,8 @@ const SettingsHeader = styled('div')`
   padding: ${space(3)} ${space(4)};
   border-bottom: 1px solid ${p => p.theme.borderLight};
   background: #fff;
+  display: flex;
+  align-items: center;
 `;
 
 export default SettingsHeader;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsLayout.jsx
@@ -1,4 +1,3 @@
-import {Box, Flex} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
@@ -27,16 +26,8 @@ class SettingsLayout extends React.Component {
       <React.Fragment>
         <SettingsColumn>
           <SettingsHeader>
-            <Flex align="center" width={1}>
-              <Box flex="1">
-                <SettingsBreadcrumb
-                  params={params}
-                  routes={childRoutes}
-                  route={childRoute}
-                />
-              </Box>
-              <SettingsSearch routes={routes} router={router} params={params} />
-            </Flex>
+            <SettingsBreadcrumb params={params} routes={childRoutes} route={childRoute} />
+            <SettingsSearch routes={routes} router={router} params={params} />
           </SettingsHeader>
 
           <MaxWidthContainer>
@@ -67,6 +58,7 @@ const SidebarWrapper = styled('div')`
 
 const SettingsColumn = styled('div')`
   display: flex;
+  max-width: 100%;
   flex-direction: column;
   flex: 1; /* so this stretches vertically so that footer is fixed at bottom */
   footer {

--- a/tests/js/spec/components/__snapshots__/settingsLayout.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/settingsLayout.spec.jsx.snap
@@ -4,22 +4,13 @@ exports[`SettingsLayout renders 1`] = `
 <Fragment>
   <SettingsColumn>
     <SettingsHeader>
-      <Flex
-        align="center"
-        width={1}
-      >
-        <Box
-          flex="1"
-        >
-          <ConnectedSettingsBreadcrumb
-            route={Object {}}
-            routes={Array []}
-          />
-        </Box>
-        <StyledSettingsSearch
-          routes={Array []}
-        />
-      </Flex>
+      <ConnectedSettingsBreadcrumb
+        route={Object {}}
+        routes={Array []}
+      />
+      <StyledSettingsSearch
+        routes={Array []}
+      />
     </SettingsHeader>
     <MaxWidthContainer>
       <Content />


### PR DESCRIPTION
Add a max-width to the settings layout so that wide pages like discarded issues don't overflow. I've also opportunistically removed grid-emotion usage.