### PR TITLE
feat(discover) Allow saved queries to be filtered by version

### DIFF
--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -39,6 +39,9 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
                 if key == "name" or key == "query":
                     value = " ".join(value)
                     queryset = queryset.filter(name__icontains=value)
+                elif key == "version":
+                    value = " ".join(value)
+                    queryset = queryset.filter(version=value)
                 else:
                     queryset = queryset.none()
 


### PR DESCRIPTION
Enable saved queries to be filtered by their schema version. We don't yet have values in this column but I'll be fixing that soon and there are no consumers of this version filter yet.