### PR TITLE
feat(discover) Store version on saved queries

### DIFF
--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -22,7 +22,6 @@ class DiscoverSavedQuerySerializer(Serializer):
             "end",
             "orderby",
             "limit",
-            "version",
             "tags",
             "yAxis",
         ]
@@ -31,6 +30,7 @@ class DiscoverSavedQuerySerializer(Serializer):
             "id": six.text_type(obj.id),
             "name": obj.name,
             "projects": [project.id for project in obj.projects.all()],
+            "version": obj.version or obj.query.get("version", 1),
             "dateCreated": obj.date_created,
             "dateUpdated": obj.date_updated,
             "createdBy": six.text_type(obj.created_by_id) if obj.created_by_id else None,

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -65,6 +65,7 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
             organization=organization,
             name=data["name"],
             query=data["query"],
+            version=data["version"],
             created_by=request.user if request.user.is_authenticated() else None,
         )
 

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -53,7 +53,12 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
 
         data = serializer.validated_data
 
-        model.update(organization=organization, name=data["name"], query=data["query"])
+        model.update(
+            organization=organization,
+            name=data["name"],
+            query=data["query"],
+            version=data["version"],
+        )
 
         model.set_projects(data["project_ids"])
 

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -191,7 +191,6 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
             "fieldnames",
             "environment",
             "query",
-            "version",
             "fields",
             "conditions",
             "aggregations",
@@ -208,7 +207,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
             if data.get(key) is not None:
                 query[key] = data[key]
 
-        version = query.get("version", 1)
+        version = data.get("version", 1)
         self.validate_version_fields(version, query)
         if version == 2:
             if len(query["fields"]) < 1:
@@ -223,7 +222,12 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
             data["projects"] = []
             query["all_projects"] = True
 
-        return {"name": data["name"], "project_ids": data["projects"], "query": query}
+        return {
+            "name": data["name"],
+            "project_ids": data["projects"],
+            "query": query,
+            "version": version,
+        }
 
     def validate_version_fields(self, version, query):
         try:

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -40,6 +40,7 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
         assert response.data[0]["fields"] == ["test"]
         assert response.data[0]["conditions"] == []
         assert response.data[0]["limit"] == 10
+        assert response.data[0]["version"] == 1
 
     def test_get_name_filter(self):
         url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
@@ -224,6 +225,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
         assert data["query"] == "event.type:error browser.name:Firefox"
         assert data["tags"] == ["release", "environment"]
         assert data["yAxis"] == "count(id)"
+        assert data["version"] == 2
 
     def test_post_success_no_fieldnames(self):
         with self.feature(self.feature_name):


### PR DESCRIPTION
Start saving the version field for newly created/updated saved queries. This will let us start filtering on the version later on. Existing queries will need a separate backfill migration to fully synchronize the new column data.