### PR TITLE
ref(py3): bump BeautifulSoup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,6 @@ repos:
     - id: trailing-whitespace
       exclude_types: [svg]
     - id: debug-statements
-    - id: requirements-txt-fixer
 # -   repo: git://github.com/getsentry/pre-commit-hooks
 #     rev: f3237d2d65af81d435c49dee3593dc8f03d23c2d
 #     hooks:

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -34,7 +34,7 @@ ipaddress>=1.0.16,<1.1.0
 jsonschema==2.6.0
 kombu==3.0.35
 loremipsum>=1.0.5,<1.1.0
-lxml>=3.4.1
+lxml>=4.3.3,<4.4.0
 # optional
 maxminddb==1.4.1
 # for vsts repo

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,9 +1,6 @@
 BeautifulSoup>=3.2.1
 boto3>=1.4.1,<1.4.6
 botocore<1.5.71
-
-# sentry-plugins specific dependencies
-cached-property
 celery>=3.1.8,<3.1.19
 cffi>=1.11.5,<2.0
 click>=5.0,<7.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,4 +1,4 @@
-BeautifulSoup>=3.2.1
+beautifulsoup4>=4.7.1,<4.8
 boto3>=1.4.1,<1.4.6
 botocore<1.5.71
 celery>=3.1.8,<3.1.19

--- a/src/new_sentry_plugins/client.py
+++ b/src/new_sentry_plugins/client.py
@@ -5,7 +5,7 @@ import logging
 import json
 import requests
 
-from BeautifulSoup import BeautifulStoneSoup
+from bs4 import BeautifulSoup
 from cached_property import cached_property
 from requests.exceptions import ConnectionError, HTTPError
 
@@ -85,7 +85,7 @@ class TextApiResponse(BaseApiResponse):
 
 class XmlApiResponse(BaseApiResponse):
     def __init__(self, text, *args, **kwargs):
-        self.xml = BeautifulStoneSoup(text)
+        self.xml = BeautifulSoup(text, "xml")
         super(XmlApiResponse, self).__init__(*args, **kwargs)
 
 

--- a/src/new_sentry_plugins/exceptions.py
+++ b/src/new_sentry_plugins/exceptions.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from BeautifulSoup import BeautifulStoneSoup
+from bs4 import BeautifulSoup
 from collections import OrderedDict
 from simplejson.decoder import JSONDecodeError
 from six.moves.urllib.parse import urlparse
@@ -24,7 +24,7 @@ class ApiError(Exception):
             except (JSONDecodeError, ValueError):
                 if self.text[:5] == "<?xml":
                     # perhaps it's XML?
-                    self.xml = BeautifulStoneSoup(self.text)
+                    self.xml = BeautifulSoup(self.text, "xml")
                 # must be an awful code.
                 self.json = None
         else:

--- a/src/sentry/integrations/client.py
+++ b/src/sentry/integrations/client.py
@@ -7,7 +7,7 @@ import requests
 from collections import OrderedDict
 from time import time
 
-from BeautifulSoup import BeautifulStoneSoup
+from bs4 import BeautifulSoup
 from django.utils.functional import cached_property
 from requests.exceptions import ConnectionError, Timeout, HTTPError
 from sentry.exceptions import InvalidIdentity
@@ -93,7 +93,7 @@ class TextApiResponse(BaseApiResponse):
 
 class XmlApiResponse(BaseApiResponse):
     def __init__(self, text, *args, **kwargs):
-        self.xml = BeautifulStoneSoup(text)
+        self.xml = BeautifulSoup(text, "xml")
         super(XmlApiResponse, self).__init__(*args, **kwargs)
 
 

--- a/src/sentry/integrations/exceptions.py
+++ b/src/sentry/integrations/exceptions.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from BeautifulSoup import BeautifulStoneSoup
+from bs4 import BeautifulSoup
 from collections import OrderedDict
 from simplejson.decoder import JSONDecodeError
 from six.moves.urllib.parse import urlparse
@@ -24,7 +24,7 @@ class ApiError(Exception):
             except (JSONDecodeError, ValueError):
                 if self.text[:5] == "<?xml":
                     # perhaps it's XML?
-                    self.xml = BeautifulStoneSoup(self.text)
+                    self.xml = BeautifulSoup(self.text, "xml")
                 # must be an awful code.
                 self.json = None
         else:


### PR DESCRIPTION
beautifulsoup 3 doesn't support Python 3.

While it seems that 4.x supports Python 2 + 3, 4.8+ doesn't look too enticing at the moment.
4.7.1 fixes performance regressions in 4.7.0, so let's make that clear in the pin range too.

Also, I fixed a recent mistake in the requirements file, and removed the requirements fixer pre-commit hook so it doesn't happen again; we need the comments for annotations.

Finally, I'm bumping lxml too. 4.3.3 is currently used in getsentry, so should be safe.

As always these bumps will have to be mirrored in getsentry (but not plugins anymore!)

Supersedes https://github.com/getsentry/sentry/pull/13123.