### PR TITLE
feat(projects): Added query option to allow for filtering of user projects

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -97,7 +97,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                 elif key == "!team":
                     team_list = list(Team.objects.filter(slug__in=value))
                     queryset = queryset.exclude(teams__in=team_list)
-                elif key == "user_projects":
+                elif key == "is_member":
                     queryset = queryset.filter(teams__organizationmember__user=request.user)
                 else:
                     queryset = queryset.none()

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -97,6 +97,8 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                 elif key == "!team":
                     team_list = list(Team.objects.filter(slug__in=value))
                     queryset = queryset.exclude(teams__in=team_list)
+                elif key == "user_projects":
+                    queryset = queryset.filter(teams__organizationmember__user=request.user)
                 else:
                     queryset = queryset.none()
 

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -162,3 +162,22 @@ class OrganizationProjectsTest(APITestCase):
         response = self.client.get(self.path + "?all_projects=1&per_page=1")
         # Verify all projects in the org are returned in sorted order
         self.check_valid_response(response, sorted_projects)
+
+    def test_user_projects(self):
+        self.foo_user = self.create_user("foo@example.com")
+        self.login_as(user=self.foo_user)
+
+        other_team = self.create_team(organization=self.org)
+
+        project_bar = self.create_project(teams=[self.team], name="bar", slug="bar")
+        self.create_project(teams=[other_team], name="foo", slug="foo")
+        self.create_project(teams=[other_team], name="baz", slug="baz")
+
+        # Make foo_user a part of the org and self.team
+        self.create_member(organization=self.org, user=self.foo_user, teams=[self.team])
+
+        foo_user_projects = [project_bar]
+
+        response = self.client.get(self.path + "?query=user_projects:1")
+        # Verify projects were returned were foo_users projects
+        self.check_valid_response(response, foo_user_projects)

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -178,6 +178,6 @@ class OrganizationProjectsTest(APITestCase):
 
         foo_user_projects = [project_bar]
 
-        response = self.client.get(self.path + "?query=user_projects:1")
+        response = self.client.get(self.path + "?query=is_member:1")
         # Verify projects that were returned were foo_users projects
         self.check_valid_response(response, foo_user_projects)

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -179,5 +179,5 @@ class OrganizationProjectsTest(APITestCase):
         foo_user_projects = [project_bar]
 
         response = self.client.get(self.path + "?query=user_projects:1")
-        # Verify projects were returned were foo_users projects
+        # Verify projects that were returned were foo_users projects
         self.check_valid_response(response, foo_user_projects)


### PR DESCRIPTION
Modified the OrganizationProjectsEndpoint to support returning just the projects that a user is a member of via team membership. This will eventually be used in the logic of `<NoProjectMessage>` instead of having it look through all of `organization.projects`.