### PR TITLE
feat(ui): Persist teams/ and projects/ across lightweight - heavyweight navigation

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/organization.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organization.jsx
@@ -32,9 +32,14 @@ export async function fetchOrganizationDetails(api, slug, detailed, silent) {
       return;
     }
 
-    // create a request for all teams and all projects if in lightweight org
-    if (!detailed) {
-      // create a new client so when this context unmounts the requests continue
+    OrganizationActions.update(org);
+    setActiveOrganization(org);
+
+    if (detailed) {
+      TeamStore.loadInitialData(org.teams);
+      ProjectsStore.loadInitialData(org.projects);
+    } else {
+      // create a new client so the request is not cancelled
       const uncancelableApi = new Client();
       const [projects, teams] = await Promise.all([
         uncancelableApi.requestPromise(`/organizations/${slug}/projects/`, {
@@ -46,14 +51,6 @@ export async function fetchOrganizationDetails(api, slug, detailed, silent) {
       ]);
       ProjectActions.loadProjects(projects);
       TeamActions.loadTeams(teams);
-    }
-
-    OrganizationActions.update(org);
-    setActiveOrganization(org);
-
-    if (detailed) {
-      TeamStore.loadInitialData(org.teams);
-      ProjectsStore.loadInitialData(org.projects);
     }
   } catch (err) {
     OrganizationActions.fetchOrgError(err);

--- a/src/sentry/static/sentry/app/actionCreators/organization.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organization.jsx
@@ -35,17 +35,17 @@ export async function fetchOrganizationDetails(api, slug, detailed, silent) {
     // create a request for all teams and all projects if in lightweight org
     if (!detailed) {
       // create a new client so when this context unmounts the requests continue
-      const persistedAPI = new Client();
-      persistedAPI
-        .requestPromise(`/organizations/${slug}/projects/`, {
+      const uncancelableApi = new Client();
+      const [projects, teams] = await Promise.all([
+        uncancelableApi.requestPromise(`/organizations/${slug}/projects/`, {
           query: {
             all_projects: 1,
           },
-        })
-        .then(ProjectActions.loadProjects);
-      persistedAPI
-        .requestPromise(`/organizations/${slug}/teams/`)
-        .then(TeamActions.loadTeams);
+        }),
+        uncancelableApi.requestPromise(`/organizations/${slug}/teams/`),
+      ]);
+      ProjectActions.loadProjects(projects);
+      TeamActions.loadTeams(teams);
     }
 
     OrganizationActions.update(org);

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -140,7 +140,7 @@ const OrganizationContext = createReactClass({
   },
 
   isLoading() {
-    // In the absence of an organization slug, then the loading state should be
+    // In the absence of an organization slug, the loading state should be
     // derived from this.props.organizationsLoading from OrganizationsStore
     if (!this.getOrganizationSlug()) {
       return this.props.organizationsLoading;

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -140,11 +140,13 @@ const OrganizationContext = createReactClass({
   },
 
   isLoading() {
-    // A custom loading function because we could either by waiting for the
-    // whole organization object to come in or just the teams and projects
+    // In the absence of an organization slug, then the loading state should be
+    // derived from this.props.organizationsLoading from OrganizationsStore
     if (!this.getOrganizationSlug()) {
       return this.props.organizationsLoading;
     }
+    // The following loading logic exists because we could either be waiting for
+    // the whole organization object to come in or just the teams and projects.
     const {loading, error, organization} = this.state;
     const {detailed} = this.props;
     return (
@@ -167,7 +169,7 @@ const OrganizationContext = createReactClass({
       this.props.api,
       this.getOrganizationSlug(),
       this.props.detailed,
-      true // silent
+      true // silent, to not reset a lightweight org that was fetched
     );
   },
 

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -7,7 +7,6 @@ import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
 import {ORGANIZATION_FETCH_ERROR_TYPES} from 'app/constants';
-import {Client} from 'app/api';
 import {fetchOrganizationDetails} from 'app/actionCreators/organization';
 import {metric, logExperiment} from 'app/utils/analytics';
 import {openSudo} from 'app/actionCreators/modal';
@@ -20,7 +19,6 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import OrganizationStore from 'app/stores/organizationStore';
 import ProjectActions from 'app/actions/projectActions';
-import TeamActions from 'app/actions/teamActions';
 import SentryTypes from 'app/sentryTypes';
 import Sidebar from 'app/components/sidebar';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
@@ -169,24 +167,6 @@ const OrganizationContext = createReactClass({
       this.props.detailed,
       true // silent
     );
-    // create a request for all teams and all projects if in lightweight org
-    if (!this.props.detailed) {
-      // create a new client so when this context unmounts the requests continue
-      const persistedAPI = new Client();
-      const projects = await persistedAPI.requestPromise(
-        this.getOrganizationProjectsEndpoint(),
-        {
-          query: {
-            all_projects: 1,
-          },
-        }
-      );
-      ProjectActions.loadProjects(projects);
-      const teams = await persistedAPI.requestPromise(
-        this.getOrganizationTeamsEndpoint()
-      );
-      TeamActions.loadTeams(teams);
-    }
   },
 
   loadOrganization(orgData) {
@@ -256,14 +236,6 @@ const OrganizationContext = createReactClass({
 
   getOrganizationDetailsEndpoint() {
     return `/organizations/${this.getOrganizationSlug()}/`;
-  },
-
-  getOrganizationTeamsEndpoint() {
-    return `/organizations/${this.getOrganizationSlug()}/teams/`;
-  },
-
-  getOrganizationProjectsEndpoint() {
-    return `/organizations/${this.getOrganizationSlug()}/projects/`;
   },
 
   getTitle() {

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -142,6 +142,9 @@ const OrganizationContext = createReactClass({
   isLoading() {
     // A custom loading function because we could either by waiting for the
     // whole organization object to come in or just the teams and projects
+    if (!this.getOrganizationSlug()) {
+      return this.props.organizationsLoading;
+    }
     const {loading, error, organization} = this.state;
     const {detailed} = this.props;
     return (
@@ -153,7 +156,6 @@ const OrganizationContext = createReactClass({
 
   async fetchData() {
     if (!this.getOrganizationSlug()) {
-      this.setState({loading: this.props.organizationsLoading});
       return;
     }
     // fetch from the store, then fetch from the API if necessary

--- a/src/sentry/static/sentry/app/views/organizationDetails/lightWeightInstallPromptBanner.jsx
+++ b/src/sentry/static/sentry/app/views/organizationDetails/lightWeightInstallPromptBanner.jsx
@@ -4,30 +4,22 @@ import React from 'react';
 import InstallPromptBanner from 'app/views/organizationDetails/installPromptBanner';
 
 import SentryTypes from 'app/sentryTypes';
-import Projects from 'app/utils/projects';
+import withProjects from 'app/utils/withProjects';
 
 class LightWeightInstallPromptBanner extends React.Component {
   static propTypes = {
     organization: SentryTypes.Organization,
-    teams: PropTypes.arrayOf(SentryTypes.Team),
-    loadingTeams: PropTypes.bool,
-    error: PropTypes.instanceOf(Error),
-  };
-
-  renderChildren = ({projects, fetching}) => {
-    if (fetching) {
-      return null;
-    }
-    return <InstallPromptBanner {...this.props} projects={projects} />;
+    projects: PropTypes.arrayOf(SentryTypes.Team),
+    loadingProjects: PropTypes.bool,
   };
 
   render() {
-    return (
-      <Projects orgId={this.props.organization.slug} allProjects>
-        {this.renderChildren}
-      </Projects>
-    );
+    const {projects, loadingProjects} = this.props;
+    if (loadingProjects) {
+      return null;
+    }
+    return <InstallPromptBanner {...this.props} projects={projects} />;
   }
 }
 
-export default LightWeightInstallPromptBanner;
+export default withProjects(LightWeightInstallPromptBanner);

--- a/tests/acceptance/test_api.py
+++ b/tests/acceptance/test_api.py
@@ -7,6 +7,7 @@ class ApiTokensTest(AcceptanceTestCase):
     def setUp(self):
         super(ApiTokensTest, self).setUp()
         self.user = self.create_user(email="foo@example.com", name="User Name")
+        self.org = self.create_organization(owner=self.user, name="foo")
         self.login_as(self.user)
         self.path = "/api/"
 
@@ -28,6 +29,7 @@ class ApiApplicationTest(AcceptanceTestCase):
     def setUp(self):
         super(ApiApplicationTest, self).setUp()
         self.user = self.create_user(email="foo@example.com", name="User Name")
+        self.org = self.create_organization(owner=self.user, name="foo")
         self.login_as(self.user)
         self.path = "/api/applications/"
 

--- a/tests/acceptance/test_api.py
+++ b/tests/acceptance/test_api.py
@@ -7,7 +7,6 @@ class ApiTokensTest(AcceptanceTestCase):
     def setUp(self):
         super(ApiTokensTest, self).setUp()
         self.user = self.create_user(email="foo@example.com", name="User Name")
-        self.org = self.create_organization(owner=self.user, name="foo")
         self.login_as(self.user)
         self.path = "/api/"
 
@@ -29,7 +28,6 @@ class ApiApplicationTest(AcceptanceTestCase):
     def setUp(self):
         super(ApiApplicationTest, self).setUp()
         self.user = self.create_user(email="foo@example.com", name="User Name")
-        self.org = self.create_organization(owner=self.user, name="foo")
         self.login_as(self.user)
         self.path = "/api/applications/"
 

--- a/tests/js/spec/actionCreators/organization.spec.jsx
+++ b/tests/js/spec/actionCreators/organization.spec.jsx
@@ -57,6 +57,14 @@ describe('OrganizationActionCreator', function() {
       url: `/organizations/${lightOrg.slug}/`,
       body: lightOrg,
     });
+    const getProjectsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${lightOrg.slug}/projects/`,
+      body: [],
+    });
+    const getTeamsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${lightOrg.slug}/teams/`,
+      body: [],
+    });
 
     fetchOrganizationDetails(api, lightOrg.slug, false);
     await tick();
@@ -64,6 +72,14 @@ describe('OrganizationActionCreator', function() {
 
     expect(getOrgMock).toHaveBeenCalledWith(
       `/organizations/${lightOrg.slug}/`,
+      expect.anything()
+    );
+    expect(getProjectsMock).toHaveBeenCalledWith(
+      `/organizations/${lightOrg.slug}/projects/`,
+      expect.anything()
+    );
+    expect(getTeamsMock).toHaveBeenCalledWith(
+      `/organizations/${lightOrg.slug}/teams/`,
       expect.anything()
     );
     expect(OrganizationActions.update).toHaveBeenCalledWith(lightOrg);

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -86,6 +86,7 @@ describe('OrganizationContext', function() {
     expect(OrganizationActionCreator.fetchOrganizationDetails).toHaveBeenCalledWith(
       api,
       'org-slug',
+      true,
       true
     );
     expect(GlobalSelectionStore.loadInitialData).toHaveBeenCalledWith(org, {});

--- a/tests/js/spec/views/organizationDetails/lightWeightInstallPromptBanner.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/lightWeightInstallPromptBanner.spec.jsx
@@ -1,23 +1,20 @@
 import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import LightWeightInstallPromptBanner from 'app/views/organizationDetails/lightWeightInstallPromptBanner';
+import ProjectsStore from 'app/stores/projectsStore';
 
 describe('LightWeightInstallPromptBanner', function() {
   it('renders', async function() {
     const project1 = TestStubs.Project();
     const project2 = TestStubs.Project({firstEvent: null});
     const organization = TestStubs.Organization({slug: 'org-slug'});
-    const getProjectsMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/projects/',
-      body: [project1, project2],
-    });
+    ProjectsStore.loadInitialData([project1, project2]);
     const wrapper = mountWithTheme(
       <LightWeightInstallPromptBanner organization={organization} />,
       TestStubs.routerContext()
     );
     await tick();
     wrapper.update();
-    expect(getProjectsMock).toHaveBeenCalled();
     expect(wrapper.find('StyledAlert').exists()).toBe(true);
     expect(wrapper.find('a').text()).toContain('Start capturing errors');
   });


### PR DESCRIPTION
When a user navigates to a lightweight organization page they will be able to see content a lot faster. However to navigate into a heavyweight organization page the user will need to have `organization.projects` and `organization.teams` which are backgrounded requests. If you navigated out of the lightweight org page and those projects/ and teams/ requests hadn't finished then you would be forced to sit through a complete heavyweight organization fetch (~10 sec for large customers) even if projects/ and teams/ were maybe a second or two from finishing. With these changes, that api request is persisted and the organization context has a more complex condition for loading. 

I also moved the logic to fetch all projects away from InstallPromptBanner and gave that responsibility to OrganizationContext.

There is also one small problem. Because I am loading teams and projects and lightweight org details all at the same time there is a possibility the data comes back in some order like this
1) Projects
2) Teams
3) Lightweight Org Details

This is unfortunate because the projects and teams have no organization to fit themselves into and if a user now navigates to any heavyweight page they are forced to load heavyweight organization details. This ordering is most likely to happen if the projects or teams endpoint are very fast though, faster than light weight org details (~0.5 seconds) so it may not be a big deal as this is an indicator that the heavyweight org details would probably only take a second to load.

If we would like to solve this it would be reasonable to just block the projects endpoint and teams endpoint from firing until after lightweight org details comes back with an organization. But now we have slowed down those endpoints and the main customers that would be affected are enterprise customers where projects/ and teams/ takes a significant amount of time. This could add 0.5-1 second to the load time for them.

There are some hacks we can do such as save the projects and teams information into an empty organization, but I'm unsure how recommended that is.