### PR TITLE
Hack POC for getting tests running on Django 1.10

### DIFF
--- a/src/new_sentry_plugins/bitbucket/urls.py
+++ b/src/new_sentry_plugins/bitbucket/urls.py
@@ -1,12 +1,9 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .endpoints.webhook import BitbucketWebhookEndpoint
 
-urlpatterns = patterns(
-    "",
-    url(
-        r"^organizations/(?P<organization_id>[^\/]+)/webhook/$", BitbucketWebhookEndpoint.as_view()
-    ),
-)
+urlpatterns = [
+    url(r"^organizations/(?P<organization_id>[^\/]+)/webhook/$", BitbucketWebhookEndpoint.as_view())
+]

--- a/src/new_sentry_plugins/github/urls.py
+++ b/src/new_sentry_plugins/github/urls.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .endpoints.webhook import GithubIntegrationsWebhookEndpoint, GithubWebhookEndpoint
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^organizations/(?P<organization_id>[^\/]+)/webhook/$", GithubWebhookEndpoint.as_view()),
     url(r"^installations/webhook/$", GithubIntegrationsWebhookEndpoint.as_view()),
-)
+]

--- a/src/new_sentry_plugins/jira_ac/urls.py
+++ b/src/new_sentry_plugins/jira_ac/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from new_sentry_plugins.jira_ac.views import (
     JiraConfigView,
@@ -9,10 +9,9 @@ from new_sentry_plugins.jira_ac.views import (
     JiraUIWidgetView,
 )
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^plugin$", JiraUIWidgetView.as_view()),
     url(r"^config$", JiraConfigView.as_view()),
     url(r"^atlassian-connect\.json$", JiraDescriptorView.as_view()),
     url(r"^installed$", JiraInstalledCallback.as_view()),
-)
+]

--- a/src/sentry/admin.py
+++ b/src/sentry/admin.py
@@ -224,14 +224,10 @@ class UserAdmin(admin.ModelAdmin):
         return super(UserAdmin, self).get_form(request, obj, **defaults)
 
     def get_urls(self):
-        from django.conf.urls import patterns
-
-        return (
-            patterns(
-                "", (r"^(\d+)/password/$", self.admin_site.admin_view(self.user_change_password))
-            )
-            + super(UserAdmin, self).get_urls()
-        )
+        return [
+            "",
+            (r"^(\d+)/password/$", self.admin_site.admin_view(self.user_change_password)),
+        ] + super(UserAdmin, self).get_urls()
 
     def lookup_allowed(self, lookup, value):
         # See #20078: we don't want to allow any lookups involving passwords.

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 
 from .endpoints.accept_project_transfer import AcceptProjectTransferEndpoint
 from .endpoints.api_application_details import ApiApplicationDetailsEndpoint
@@ -339,8 +339,7 @@ GROUP_URLS = [
     url(r"^(?P<issue_id>[^\/]+)/plugins?/", include("sentry.plugins.base.group_api_urls")),
 ]
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     # Relay
     url(
         r"^relays/",
@@ -1555,4 +1554,4 @@ urlpatterns = patterns(
     url(r"^$", IndexEndpoint.as_view(), name="sentry-api-index"),
     url(r"^", CatchallEndpoint.as_view(), name="sentry-api-catchall"),
     # url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
-)
+]

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -293,8 +293,8 @@ TEMPLATE_DIRS = (
 TEMPLATE_CONTEXT_PROCESSORS = (
     "django.contrib.auth.context_processors.auth",
     "django.contrib.messages.context_processors.messages",
-    "django.core.context_processors.csrf",
-    "django.core.context_processors.request",
+    "django.template.context_processors.csrf",
+    "django.template.context_processors.request",
     "social_auth.context_processors.social_auth_by_name_backends",
     "social_auth.context_processors.social_auth_backends",
     "social_auth.context_processors.social_auth_by_type_backends",

--- a/src/sentry/conf/urls.py
+++ b/src/sentry/conf/urls.py
@@ -10,7 +10,7 @@ These are additional urls used by the Sentry-provided web server
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 
 from sentry.web.urls import urlpatterns as web_urlpatterns
@@ -21,12 +21,11 @@ from sentry.web.frontend.error_500 import Error500View
 handler404 = Error404View.as_view()
 handler500 = Error500View.as_view()
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^500/", handler500, name="error-500"),
     url(r"^404/", handler404, name="error-404"),
     url(r"^403-csrf-failure/", CsrfFailureView.as_view(), name="error-403-csrf-failure"),
-)
+]
 
 if "django.contrib.admin" in settings.INSTALLED_APPS:
     from sentry import django_admin

--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -86,7 +86,7 @@ class BulkDeleteQuery(object):
             cutoff = timezone.now() - timedelta(days=self.days)
             qs = qs.filter(**{u"{}__lte".format(self.dtfield): cutoff})
         if self.project_id:
-            if "project" in self.model._meta.get_all_field_names():
+            if "project" in [f.name for f in self.model._meta.get_fields()]:
                 qs = qs.filter(project=self.project_id)
             else:
                 qs = qs.filter(project_id=self.project_id)

--- a/src/sentry/django_admin.py
+++ b/src/sentry/django_admin.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from copy import copy
 from django.contrib import admin
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 
 from sentry.auth.superuser import is_active_superuser
 
@@ -33,4 +33,4 @@ def make_site():
 
 site = make_site()
 
-urlpatterns = patterns("", url(r"^admin/", include(site.urls)))
+urlpatterns = [url(r"^admin/", include(site.urls))]

--- a/src/sentry/integrations/bitbucket/urls.py
+++ b/src/sentry/integrations/bitbucket/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .descriptor import BitbucketDescriptorEndpoint
 from .installed import BitbucketInstalledEndpoint
@@ -8,8 +8,7 @@ from .uninstalled import BitbucketUninstalledEndpoint
 from .webhook import BitbucketWebhookEndpoint
 from .search import BitbucketSearchEndpoint
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^descriptor/$", BitbucketDescriptorEndpoint.as_view()),
     url(r"^installed/$", BitbucketInstalledEndpoint.as_view()),
     url(r"^uninstalled/$", BitbucketUninstalledEndpoint.as_view()),
@@ -21,4 +20,4 @@ urlpatterns = patterns(
         BitbucketSearchEndpoint.as_view(),
         name="sentry-extensions-bitbucket-search",
     ),
-)
+]

--- a/src/sentry/integrations/cloudflare/urls.py
+++ b/src/sentry/integrations/cloudflare/urls.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .metadata import CloudflareMetadataEndpoint
 from .webhook import CloudflareWebhookEndpoint
 
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^metadata/$", CloudflareMetadataEndpoint.as_view()),
     url(r"^webhook/$", CloudflareWebhookEndpoint.as_view()),
-)
+]

--- a/src/sentry/integrations/github/urls.py
+++ b/src/sentry/integrations/github/urls.py
@@ -1,16 +1,15 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .webhook import GitHubIntegrationsWebhookEndpoint
 from .search import GitHubSearchEndpoint
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^webhook/$", GitHubIntegrationsWebhookEndpoint.as_view()),
     url(
         r"^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$",
         GitHubSearchEndpoint.as_view(),
         name="sentry-extensions-github-search",
     ),
-)
+]

--- a/src/sentry/integrations/github_enterprise/urls.py
+++ b/src/sentry/integrations/github_enterprise/urls.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .webhook import GitHubEnterpriseWebhookEndpoint
 
 
-urlpatterns = patterns("", url(r"^webhook/$", GitHubEnterpriseWebhookEndpoint.as_view()))
+urlpatterns = [url(r"^webhook/$", GitHubEnterpriseWebhookEndpoint.as_view())]

--- a/src/sentry/integrations/gitlab/urls.py
+++ b/src/sentry/integrations/gitlab/urls.py
@@ -1,16 +1,15 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .webhooks import GitlabWebhookEndpoint
 from .search import GitlabIssueSearchEndpoint
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(
         r"^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$",
         GitlabIssueSearchEndpoint.as_view(),
         name="sentry-extensions-gitlab-search",
     ),
     url(r"^webhook/$", GitlabWebhookEndpoint.as_view(), name="sentry-extensions-gitlab-webhook"),
-)
+]

--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .configure import JiraConfigureView
 from .descriptor import JiraDescriptorEndpoint
@@ -10,8 +10,7 @@ from .uninstalled import JiraUninstalledEndpoint
 from .webhooks import JiraIssueUpdatedWebhook
 
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^configure/$", JiraConfigureView.as_view()),
     url(r"^descriptor/$", JiraDescriptorEndpoint.as_view()),
     url(r"^installed/$", JiraInstalledEndpoint.as_view()),
@@ -26,4 +25,4 @@ urlpatterns = patterns(
         JiraSearchEndpoint.as_view(),
         name="sentry-extensions-jira-search",
     ),
-)
+]

--- a/src/sentry/integrations/jira_server/urls.py
+++ b/src/sentry/integrations/jira_server/urls.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .search import JiraServerSearchEndpoint
 from .webhooks import JiraIssueUpdatedWebhook
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(
         r"^issue-updated/(?P<token>[^\/]+)/$",
         JiraIssueUpdatedWebhook.as_view(),
@@ -17,4 +16,4 @@ urlpatterns = patterns(
         JiraServerSearchEndpoint.as_view(),
         name="sentry-extensions-jiraserver-search",
     ),
-)
+]

--- a/src/sentry/integrations/slack/urls.py
+++ b/src/sentry/integrations/slack/urls.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .action_endpoint import SlackActionEndpoint
 from .event_endpoint import SlackEventEndpoint
 from .link_identity import SlackLinkIdentityView
 
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^action/$", SlackActionEndpoint.as_view()),
     url(r"^event/$", SlackEventEndpoint.as_view()),
     url(
@@ -16,4 +15,4 @@ urlpatterns = patterns(
         SlackLinkIdentityView.as_view(),
         name="sentry-integration-slack-link-identity",
     ),
-)
+]

--- a/src/sentry/integrations/vsts/urls.py
+++ b/src/sentry/integrations/vsts/urls.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from .search import VstsSearchEndpoint
 from .webhooks import WorkItemWebhook
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(
         r"^issue-updated/$", WorkItemWebhook.as_view(), name="sentry-extensions-vsts-issue-updated"
     ),
@@ -14,4 +13,4 @@ urlpatterns = patterns(
         VstsSearchEndpoint.as_view(),
         name="sentry-extensions-vsts-search",
     ),
-)
+]

--- a/src/sentry/new_migrations/monkey/__init__.py
+++ b/src/sentry/new_migrations/monkey/__init__.py
@@ -7,7 +7,7 @@ from sentry.new_migrations.monkey.writer import SENTRY_MIGRATION_TEMPLATE
 
 from django.db.migrations import migration, executor, writer
 
-LAST_VERIFIED_DJANGO_VERSION = (1, 9)
+LAST_VERIFIED_DJANGO_VERSION = (1, 10)
 CHECK_MESSAGE = """Looks like you're trying to upgrade Django! Since we monkeypatch
 the Django migration library in several places, please verify that we have the latest
 code, and that the monkeypatching still works as expected. Currently the main things

--- a/src/sentry/plugins/base/group_api_urls.py
+++ b/src/sentry/plugins/base/group_api_urls.py
@@ -4,7 +4,7 @@ import logging
 import re
 
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from sentry.plugins.base import plugins
 
@@ -22,7 +22,7 @@ def ensure_url(u):
 
 
 def load_plugin_urls(plugins):
-    urlpatterns = patterns("")
+    urlpatterns = []
     for plugin in plugins:
         try:
             urls = plugin.get_group_urls()

--- a/src/sentry/plugins/base/project_api_urls.py
+++ b/src/sentry/plugins/base/project_api_urls.py
@@ -4,7 +4,7 @@ import logging
 import re
 
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from sentry.plugins.base import plugins
 
@@ -22,7 +22,7 @@ def ensure_url(u):
 
 
 def load_plugin_urls(plugins):
-    urlpatterns = patterns("")
+    urlpatterns = []
     for plugin in plugins:
         try:
             urls = plugin.get_project_urls()

--- a/src/sentry/plugins/base/response.py
+++ b/src/sentry/plugins/base/response.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, print_function
 
 __all__ = ("Response", "JSONResponse")
 
-from django.core.context_processors import csrf
 from django.http import HttpResponse
+from django.template.context_processors import csrf
 
 from sentry.utils import json
 

--- a/src/sentry/plugins/base/urls.py
+++ b/src/sentry/plugins/base/urls.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 
 import re
 
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from sentry.plugins.base import plugins
 
-urlpatterns = patterns("")
+urlpatterns = []
 
 for _plugin in plugins.all():
     _plugin_url_module = _plugin.get_url_module()

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -223,7 +223,7 @@ def _get_event_environment(event, project, cache):
 def merge_objects(models, group, new_group, limit=1000, logger=None, transaction_id=None):
     has_more = False
     for model in models:
-        all_fields = model._meta.get_all_field_names()
+        all_fields = [f.name for f in model._meta.get_fields()]
 
         # not all models have a 'project' or 'project_id' field, but we make a best effort
         # to filter on one if it is available

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.generic import TemplateView
 
 import sentry.web.frontend.debug.mail
@@ -62,8 +62,7 @@ from sentry.web.frontend.debug.debug_oauth_authorize import (
     DebugOAuthAuthorizeErrorView,
 )
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^debug/mail/alert/$", sentry.web.frontend.debug.mail.alert),
     url(r"^debug/mail/note/$", DebugNoteEmailView.as_view()),
     url(r"^debug/mail/new-release/$", DebugNewReleaseEmailView.as_view()),
@@ -118,4 +117,4 @@ urlpatterns = patterns(
     url(r"^debug/sudo/$", TemplateView.as_view(template_name="sentry/account/sudo.html")),
     url(r"^debug/oauth/authorize/$", DebugOAuthAuthorizeView.as_view()),
     url(r"^debug/oauth/authorize/error/$", DebugOAuthAuthorizeErrorView.as_view()),
-)
+]

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -8,10 +8,10 @@ import six
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login as login_user, authenticate
-from django.core.context_processors import csrf
 from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.http import HttpResponseRedirect, Http404, HttpResponse
+from django.template.context_processors import csrf
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import logging
 import six
 
-from django.core.context_processors import csrf
 from django.core.urlresolvers import reverse
 from django.http import (
     HttpResponse,
@@ -12,6 +11,7 @@ from django.http import (
     HttpResponseRedirect,
 )
 from django.middleware.csrf import CsrfViewMiddleware
+from django.template.context_processors import csrf
 from django.views.generic import View
 from django.views.decorators.csrf import csrf_exempt
 from sudo.views import redirect_to_sudo

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.http import HttpResponse
 from django.views.generic import RedirectView
 
@@ -53,7 +53,7 @@ __all__ = ("urlpatterns",)
 generic_react_page_view = GenericReactPageView.as_view()
 react_page_view = ReactPageView.as_view()
 
-urlpatterns = patterns("")
+urlpatterns = []
 
 if getattr(settings, "DEBUG_VIEWS", settings.DEBUG):
     from sentry.web.debug_urls import urlpatterns as debug_urls
@@ -62,16 +62,16 @@ if getattr(settings, "DEBUG_VIEWS", settings.DEBUG):
 
 # Special favicon in debug mode
 if settings.DEBUG:
-    urlpatterns += patterns(
+    urlpatterns += [
         "",
         url(
             r"^_static/[^/]+/[^/]+/images/favicon\.ico$",
             generic.dev_favicon,
             name="sentry-dev-favicon",
         ),
-    )
+    ]
 
-urlpatterns += patterns(
+urlpatterns += [
     "",
     # Store endpoints first since they are the most active
     url(r"^api/store/$", api.StoreView.as_view(), name="sentry-api-store"),
@@ -695,4 +695,4 @@ urlpatterns += patterns(
     ),
     # Legacy
     url(r"/$", react_page_view),
-)
+]

--- a/src/social_auth/admin.py
+++ b/src/social_auth/admin.py
@@ -14,7 +14,7 @@ else:
     username_field = None
 
 fieldnames = ("first_name", "last_name", "email") + (username_field,)
-all_names = _User._meta.get_all_field_names()
+all_names = [f.name for f in _User._meta.get_fields()]
 user_search_fields = ["user__" + name for name in fieldnames if name in all_names]
 
 

--- a/src/social_auth/backends/pipeline/user.py
+++ b/src/social_auth/backends/pipeline/user.py
@@ -87,7 +87,7 @@ def django_orm_maxlength_truncate(backend, details, user=None, is_new=False, *ar
     if user is None:
         return
     out = {}
-    names = user._meta.get_all_field_names()
+    names = [f.name for f in user._meta.get_fields()]
     for name, value in six.iteritems(details):
         if name in names and not _ignore_field(name, is_new):
             max_length = user._meta.get_field(name).max_length

--- a/src/social_auth/fields.py
+++ b/src/social_auth/fields.py
@@ -7,12 +7,22 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.encoding import smart_text
 
+from sentry.db.models.utils import Creator
 
-@six.add_metaclass(models.SubfieldBase)
+
+# @six.add_metaclass(models.SubfieldBase)
 class JSONField(models.TextField):
     """Simple JSON field that stores python structures as JSON strings
     on database.
     """
+
+    def contribute_to_class(self, cls, name):
+        """
+        Add a descriptor for backwards compatibility
+        with previous Django behavior.
+        """
+        super(JSONField, self).contribute_to_class(cls, name)
+        setattr(cls, name, Creator(self))
 
     def to_python(self, value):
         """

--- a/src/social_auth/urls.py
+++ b/src/social_auth/urls.py
@@ -1,19 +1,18 @@
 from __future__ import absolute_import
 
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:
     # for Django version less then 1.4
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 
 from social_auth.views import auth, complete
 
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     # authentication
     url(
         r"^associate/complete/(?P<backend>[^/]+)/$", complete, name="socialauth_associate_complete"
     ),
     url(r"^associate/(?P<backend>[^/]+)/$", auth, name="socialauth_associate"),
-)
+]

--- a/tests/sentry/api/test_handlers.py
+++ b/tests/sentry/api/test_handlers.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.test import override_settings
 from rest_framework.permissions import AllowAny
 
@@ -16,7 +16,7 @@ class RateLimitedEndpoint(Endpoint):
         raise RateLimitExceeded()
 
 
-urlpatterns = patterns("", url(r"^/$", RateLimitedEndpoint.as_view(), name="sentry-test"))
+urlpatterns = [url(r"^/$", RateLimitedEndpoint.as_view(), name="sentry-test")]
 
 
 @override_settings(ROOT_URLCONF="tests.sentry.api.test_handlers")


### PR DESCRIPTION
Main changes here:

- `patterns` is deprecated. We need to replace it with a list instead from the docs: https://docs.djangoproject.com/en/2.2/releases/1.8/#django-conf-urls-patterns (looks like we don't need the empty string, so this should be an easy enough drop in replacement, which should be 1.8 compatible)
- `django.core.context_processors` was moved to `django.template.context_processors`. Looks like a drop in replacement: https://docs.djangoproject.com/en/2.2/releases/1.8/#django-core-context-processors
- Internal api `Model._meta.get_all_field_names` was removed as part of standardising the _meta api: https://docs.djangoproject.com/en/1.10/ref/models/meta/#migrating-from-the-old-api. My change to use `get_fields` may not be correct in all cases, we need to understand the implications of the change.
- Did not verify `LAST_VERIFIED_DJANGO_VERSION`, just bumped it as a test.
- `@six.add_metaclass(models.SubfieldBase)` is used in social_auth. @markstory already fixed this for a bunch of fields in his `Creator` class. It might be fine to just drop this in here too.

That's all we needed to make tests run. Probably each of these changes can be a separate pr.