### PR TITLE
fix(ui): Fix double fetching of Organization details in settings

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -89,12 +89,16 @@ const OrganizationContext = createReactClass({
     // protect against the case where we finish fetching org details
     // and then `OrganizationsStore` finishes loading:
     // only fetch in the case where we don't have an orgId
+    //
+    // Compare `getOrganizationSlug`  because we may have a last used org from server
+    // if there is no orgId in the URL
     const organizationLoadingChanged =
       prevProps.organizationsLoading !== this.props.organizationsLoading &&
       this.props.organizationsLoading === false;
 
     if (
-      hasOrgIdAndChanged ||
+      (hasOrgIdAndChanged &&
+        this.getOrganizationSlug(prevProps) !== this.getOrganizationSlug(this.props)) ||
       (!this.props.params.orgId && organizationLoadingChanged) ||
       (this.props.location.state === 'refresh' && prevProps.location.state !== 'refresh')
     ) {
@@ -117,14 +121,14 @@ const OrganizationContext = createReactClass({
     fetchOrganizationDetails(this.props.api, this.getOrganizationSlug(), true);
   },
 
-  getOrganizationSlug() {
+  getOrganizationSlug(props = this.props) {
     return (
-      this.props.params.orgId ||
-      (this.props.useLastOrganization &&
+      props.params.orgId ||
+      (props.useLastOrganization &&
         (ConfigStore.get('lastOrganization') ||
-          (this.props.organizations &&
-            this.props.organizations.length &&
-            this.props.organizations[0].slug)))
+          (props.organizations &&
+            props.organizations.length &&
+            props.organizations[0].slug)))
     );
   },
 

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -86,7 +86,7 @@ const OrganizationContext = createReactClass({
       this.props.params.orgId &&
       prevProps.params.orgId !== this.props.params.orgId;
     const hasOrgId =
-      this.props.params.org ||
+      this.props.params.orgId ||
       (this.props.useLastOrganization && ConfigStore.get('lastOrganization'));
 
     // protect against the case where we finish fetching org details

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -85,6 +85,9 @@ const OrganizationContext = createReactClass({
       prevProps.params.orgId &&
       this.props.params.orgId &&
       prevProps.params.orgId !== this.props.params.orgId;
+    const hasOrgId =
+      this.props.params.org ||
+      (this.props.useLastOrganization && ConfigStore.get('lastOrganization'));
 
     // protect against the case where we finish fetching org details
     // and then `OrganizationsStore` finishes loading:
@@ -97,9 +100,8 @@ const OrganizationContext = createReactClass({
       this.props.organizationsLoading === false;
 
     if (
-      (hasOrgIdAndChanged &&
-        this.getOrganizationSlug(prevProps) !== this.getOrganizationSlug(this.props)) ||
-      (!this.props.params.orgId && organizationLoadingChanged) ||
+      hasOrgIdAndChanged ||
+      (!hasOrgId && organizationLoadingChanged) ||
       (this.props.location.state === 'refresh' && prevProps.location.state !== 'refresh')
     ) {
       this.remountComponent();
@@ -121,14 +123,14 @@ const OrganizationContext = createReactClass({
     fetchOrganizationDetails(this.props.api, this.getOrganizationSlug(), true);
   },
 
-  getOrganizationSlug(props = this.props) {
+  getOrganizationSlug() {
     return (
-      props.params.orgId ||
-      (props.useLastOrganization &&
+      this.props.params.orgId ||
+      (this.props.useLastOrganization &&
         (ConfigStore.get('lastOrganization') ||
-          (props.organizations &&
-            props.organizations.length &&
-            props.organizations[0].slug)))
+          (this.props.organizations &&
+            this.props.organizations.length &&
+            this.props.organizations[0].slug)))
     );
   },
 

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -196,6 +196,39 @@ describe('OrganizationContext', function() {
     expect(getOrgMock).toHaveBeenLastCalledWith('/organizations/foo/', expect.anything());
   });
 
+  it('uses last organization when no orgId in URL - and fetches org details once', async function() {
+    ConfigStore.get.mockImplementation(() => 'my-last-org');
+    getOrgMock = MockApiClient.addMockResponse({
+      url: '/organizations/my-last-org/',
+      body: TestStubs.Organization({slug: 'my-last-org'}),
+    });
+
+    wrapper = createWrapper({
+      params: {},
+      useLastOrganization: true,
+      organizations: [],
+    });
+    // await dispatching action
+    await tick();
+    // await resolving api, and updating component
+    await tick();
+    wrapper.update();
+    expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
+    expect(getOrgMock).toHaveBeenCalledTimes(1);
+
+    // Simulate OrganizationsStore being loaded *after* `OrganizationContext` finishes
+    // org details fetch
+    wrapper.setProps({
+      organizationsLoading: false,
+      organizations: [
+        TestStubs.Organization({slug: 'foo'}),
+        TestStubs.Organization({slug: 'bar'}),
+      ],
+    });
+
+    expect(getOrgMock).toHaveBeenCalledTimes(1);
+  });
+
   it('fetches org details only once if organizations loading store changes', async function() {
     wrapper = createWrapper({
       params: {orgId: 'org-slug'},


### PR DESCRIPTION
This fixes a bug with double fetching of organization details when
navigating to a URL without an org slug (e.g. account settings).

I was looking through our APM data and noticed some URLs had unusually high load times:


![image](https://user-images.githubusercontent.com/79684/68913280-9e4d6e80-070f-11ea-8ee7-30168e1c3a9f.png)


After diving in you can see that the organization details endpoint was called twice:

![image](https://user-images.githubusercontent.com/79684/68913024-d1433280-070e-11ea-8b29-7d9c69e4321c.png)
