### PR TITLE
feat(discover) Add pagination and sorting to saved queries

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/discoverSavedQueries.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/discoverSavedQueries.tsx
@@ -12,6 +12,7 @@ export function fetchSavedQueries(api: Client, orgId: string): Promise<SavedQuer
     `/organizations/${orgId}/discover/saved/`,
     {
       method: 'GET',
+      query: {query: 'version:2'},
     }
   );
 

--- a/src/sentry/static/sentry/app/views/discover/sidebar/savedQueryList.tsx
+++ b/src/sentry/static/sentry/app/views/discover/sidebar/savedQueryList.tsx
@@ -75,7 +75,6 @@ export default class SavedQueries extends React.Component<
   fetchAll() {
     fetchSavedQueries(this.props.organization)
       .then((data: SavedQuery[]) => {
-        data = data.filter(item => item.version === 1 || item.version === undefined);
         this.setState({isLoading: false, data});
       })
       .catch(() => {

--- a/src/sentry/static/sentry/app/views/discover/utils.tsx
+++ b/src/sentry/static/sentry/app/views/discover/utils.tsx
@@ -146,6 +146,7 @@ export function fetchSavedQueries(organization: any): Promise<any> {
 
   return api.requestPromise(endpoint, {
     method: 'GET',
+    query: {all: 1, query: 'version:1'},
   } as any); // TODO: Remove as any
 }
 

--- a/tests/js/spec/views/discover/sidebar/savedQueryList.spec.jsx
+++ b/tests/js/spec/views/discover/sidebar/savedQueryList.spec.jsx
@@ -30,7 +30,6 @@ describe('savedQueryList', function() {
     const savedQueries = [
       TestStubs.DiscoverSavedQuery({id: '1', name: 'one'}),
       TestStubs.DiscoverSavedQuery({id: '2', name: '2two'}),
-      TestStubs.DiscoverSavedQuery({id: '3', name: 'three v2', version: 2}),
     ];
     mockResponse.push(...savedQueries);
     const wrapper = mount(<SavedQueryList organization={organization} />);
@@ -40,7 +39,5 @@ describe('savedQueryList', function() {
     expect(text).toContain('Updated Sep 24 00:00:00 (UTC)');
     expect(text).toContain(savedQueries[0].name);
     expect(text).toContain(savedQueries[1].name);
-    // v2 queries should not be present.
-    expect(text).not.toContain(savedQueries[2].name);
   });
 });

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -65,7 +65,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == six.text_type(model.id)
-        assert response.data["projects"] == self.project_ids
+        assert set(response.data["projects"]) == set(self.project_ids)
         assert response.data["fields"] == ["event_id"]
         assert response.data["query"] == "event.type:error"
         assert response.data["limit"] == 10


### PR DESCRIPTION
Enable saved queries to be sorted and paginated. This helps future proof the discover query list so that we don't have unbounded result sets in the future. I've included an escape hatch for discover1 which expects that it will receive *all* saved queries at once.