### PR TITLE
Revert "fix(ui) Reduce overflows in settings (#15609)"

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/index.jsx
@@ -106,6 +106,5 @@ export {CrumbLink};
 
 const Breadcrumbs = styled('div')`
   display: flex;
-  flex: 1;
   align-items: center;
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsHeader.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsHeader.jsx
@@ -8,8 +8,6 @@ const SettingsHeader = styled('div')`
   padding: ${space(3)} ${space(4)};
   border-bottom: 1px solid ${p => p.theme.borderLight};
   background: #fff;
-  display: flex;
-  align-items: center;
 `;
 
 export default SettingsHeader;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsLayout.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsLayout.jsx
@@ -1,3 +1,4 @@
+import {Box, Flex} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
@@ -26,8 +27,16 @@ class SettingsLayout extends React.Component {
       <React.Fragment>
         <SettingsColumn>
           <SettingsHeader>
-            <SettingsBreadcrumb params={params} routes={childRoutes} route={childRoute} />
-            <SettingsSearch routes={routes} router={router} params={params} />
+            <Flex align="center" width={1}>
+              <Box flex="1">
+                <SettingsBreadcrumb
+                  params={params}
+                  routes={childRoutes}
+                  route={childRoute}
+                />
+              </Box>
+              <SettingsSearch routes={routes} router={router} params={params} />
+            </Flex>
           </SettingsHeader>
 
           <MaxWidthContainer>
@@ -58,7 +67,6 @@ const SidebarWrapper = styled('div')`
 
 const SettingsColumn = styled('div')`
   display: flex;
-  max-width: 100%;
   flex-direction: column;
   flex: 1; /* so this stretches vertically so that footer is fixed at bottom */
   footer {

--- a/tests/js/spec/components/__snapshots__/settingsLayout.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/settingsLayout.spec.jsx.snap
@@ -4,13 +4,22 @@ exports[`SettingsLayout renders 1`] = `
 <Fragment>
   <SettingsColumn>
     <SettingsHeader>
-      <ConnectedSettingsBreadcrumb
-        route={Object {}}
-        routes={Array []}
-      />
-      <StyledSettingsSearch
-        routes={Array []}
-      />
+      <Flex
+        align="center"
+        width={1}
+      >
+        <Box
+          flex="1"
+        >
+          <ConnectedSettingsBreadcrumb
+            route={Object {}}
+            routes={Array []}
+          />
+        </Box>
+        <StyledSettingsSearch
+          routes={Array []}
+        />
+      </Flex>
     </SettingsHeader>
     <MaxWidthContainer>
       <Content />


### PR DESCRIPTION
This reverts commit e668c0119fa6955a42434a9f90ae4b280f0f9a47.

The squished content is visually alarming on a few pages. Going back restores the optics but re-opens the problems with not being able to reach UI that is out of viewport.