### PR TITLE
fix(ui): Added comment explaining usage of loadInitialData vs store actions

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/organization.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organization.jsx
@@ -36,6 +36,9 @@ export async function fetchOrganizationDetails(api, slug, detailed, silent) {
     setActiveOrganization(org);
 
     if (detailed) {
+      // TODO(davidenwang): Change these to actions after organization.projects
+      // and organization.teams no longer exists. Currently if they were changed
+      // to actions it would cause OrganizationContext to rerender many times
       TeamStore.loadInitialData(org.teams);
       ProjectsStore.loadInitialData(org.projects);
     } else {


### PR DESCRIPTION
The Projects and Teams store are currently populated via direct calls to `loadInitialData`. Ideally we would use ProjectActions.loadProjects and TeamActions.loadTeams, but because OrganizationStore listens to those actions it would `trigger` multiple copies of the same organization and cause OrganizationContext to unnecessarily rerender multiple times. Once `organization.projects` and `organization.teams` does not exist we can safely change these store calls to use actions.