### PR TITLE
feat(dif): Add hidden sources and aliases

### DIFF
--- a/src/sentry/api/endpoints/builtin_symbol_sources.py
+++ b/src/sentry/api/endpoints/builtin_symbol_sources.py
@@ -9,7 +9,12 @@ from sentry.api.serializers import serialize
 
 
 def normalize_symbol_source(key, source):
-    return {"sentry_key": key, "id": source["id"], "name": source["name"]}
+    return {
+        "sentry_key": key,
+        "id": source["id"],
+        "name": source["name"],
+        "hidden": bool(source.get("hidden")),
+    }
 
 
 class BuiltinSymbolSourcesEndpoint(Endpoint):

--- a/src/sentry/static/sentry/app/data/forms/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectDebugFiles.jsx
@@ -46,7 +46,9 @@ export const fields = {
     ),
     choices: ({builtinSymbolSources}) =>
       builtinSymbolSources &&
-      builtinSymbolSources.map(source => [source.sentry_key, t(source.name)]),
+      builtinSymbolSources
+        .filter(source => !source.hidden)
+        .map(source => [source.sentry_key, t(source.name)]),
   },
   symbolSources: {
     name: 'symbolSources',


### PR DESCRIPTION
This adds support for hidden sources that cannot be selected and an alias.
This lets us configure multiple internal sources for things like iOS/tvOS
and other symbols.