### PR TITLE
ref(pagerduty): Add ExternalEventSerializer

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -382,8 +382,7 @@ class SimpleEventSerializer(EventSerializer):
 class ExternalEventSerializer(EventSerializer):
     """
     Event serializer for the minimum event data needed to send to an external service. This
-    can be used for Integrations and the Integration Platform. If the full event is needed,
-    use `event.as_dict()` instead.
+    should be used for Integrations that need to include event data.
     """
 
     def serialize(self, obj, attrs, user):
@@ -396,8 +395,8 @@ class ExternalEventSerializer(EventSerializer):
         user = obj.get_minimal_user()
 
         return {
-            "group_id": six.text_type(obj.group_id) if obj.group_id else None,
-            "event_id": six.text_type(obj.event_id),
+            "groupID": six.text_type(obj.group_id) if obj.group_id else None,
+            "eventID": six.text_type(obj.event_id),
             "project": six.text_type(obj.project_id),
             # XXX for 'message' this doesn't do the proper resolution of logentry
             # etc. that _get_legacy_message_with_meta does.

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -6,11 +6,11 @@ from sentry.models import EventCommon
 from sentry.api.serializers import serialize, ExternalEventSerializer
 
 LEVEL_SEVERITY_MAP = {
-    "debug": "Info",
-    "info": "Info",
-    "warning": "Warning",
-    "error": "Error",
-    "fatal": "Critical",
+    "debug": "info",
+    "info": "info",
+    "warning": "warning",
+    "error": "error",
+    "fatal": "critical",
 }
 
 

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -5,6 +5,7 @@ import copy
 from sentry.utils import json
 from mock import patch
 
+from sentry.api.serializers import serialize, ExternalEventSerializer
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.models import Integration, PagerDutyService
@@ -57,6 +58,7 @@ class PagerDutyClientTest(APITestCase):
 
         integration_key = self.service.integration_key
         client = self.installation.get_client(integration_key=integration_key)
+        custom_details = serialize(event, None, ExternalEventSerializer())
 
         client.send_trigger(event)
         data = {
@@ -65,10 +67,10 @@ class PagerDutyClientTest(APITestCase):
             "dedup_key": group.qualified_short_id,
             "payload": {
                 "summary": event.message,
-                "severity": "error",
+                "severity": "Error",
                 "source": event.transaction or event.culprit,
                 "component": self.project.slug,
-                "custom_details": event.as_dict(),
+                "custom_details": custom_details,
             },
             "links": [
                 {

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -67,7 +67,7 @@ class PagerDutyClientTest(APITestCase):
             "dedup_key": group.qualified_short_id,
             "payload": {
                 "summary": event.message,
-                "severity": "Error",
+                "severity": "error",
                 "source": event.transaction or event.culprit,
                 "component": self.project.slug,
                 "custom_details": custom_details,

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import copy
 
-from sentry.utils import json
 from mock import patch
 
 from sentry.api.serializers import serialize, ExternalEventSerializer
@@ -79,4 +78,4 @@ class PagerDutyClientTest(APITestCase):
                 }
             ],
         }
-        mock_request.assert_called_once_with("POST", "/", data=json.dumps(data))
+        mock_request.assert_called_once_with("POST", "/", data=data)


### PR DESCRIPTION
**Why another Serializer?**
For the Integration Platform webhooks we've stuck to using `event.as_dict` which so far has been the normalized event representation for external services. However, it doesn't always make sense to send the whole event, especially in Integrations that we are building (e.g. PagerDuty).

I'm hoping to add a version of event data that is essentially the same as the `event.as_dict()` just without the stack trace and breadcrumbs - since in almost all cases I'm assuming we'd send a link back to Sentry where a user could view this information. 

**Note:** We use camel case for our API in almost all places and while I introduced (potentially mistakenly) snake case for the Integration Platform, this serializer will use the camel case convention we used in the past. It's possible in the future we should have another serializer that basically translates the `event.as_dict()` data to follow camel case as well.

cc @lynnagara 