### PR TITLE
build(git-hooks): Change to always suggest `make` when dependencies are out of date

### DIFF
--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -9,26 +9,38 @@ trap "rm -f ${files_changed_upstream}" EXIT
 
 git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD > "$files_changed_upstream"
 
-grep -E --quiet 'requirements.*\.txt' "$files_changed_upstream" && py=true
-grep -E --quiet 'yarn.lock' "$files_changed_upstream"           && js=true
-grep -E --quiet 'south_migrations' "$files_changed_upstream"    && migrations=true
+grep -E --quiet 'requirements.*\.txt' "$files_changed_upstream" && py="install-sentry-dev "
+grep -E --quiet 'yarn.lock' "$files_changed_upstream"           && js="install-yarn-pkgs "
+grep -E --quiet 'migrations' "$files_changed_upstream"          && migrations="apply-migrations "
+
+update_command="make ${py}${js}${migrations}"
 
 [[ "$py" || "$js" || "$migrations" ]] && cat <<EOF
 
-[${red}${bold}!!!${reset}] ${red}It looks like some dependencies have changed that will require your intervention.${reset}
-
+[${red}${bold}!!!${reset}] ${red}The following dependencies have changed and require your intervention${reset}
 EOF
 
 [[ "$py" ]] && cat <<EOF
-    ${red}Run "${bold}make install-sentry-dev${reset}${red}" to refresh your python virtual environment${reset}
+    ${red}* python virtual environment${reset}
 EOF
 
 [[ "$js" ]] && cat <<EOF
-    ${red}Run "${bold}yarn${reset}${red}" to update your javascript dependencies${reset}
+    ${red}* javascript dependencies${reset}
 EOF
 
 [[ "$migrations" ]] && cat <<EOF
-    ${red}Run "${bold}sentry upgrade${reset}${red}" to run database migrations${reset}
+    ${red}* database migrations${reset}
 EOF
 
-echo
+[[ "$py" || "$js" || "$migrations" ]] && cat <<EOF
+
+${red}Run ${bold}${update_command}${reset}${red}to update necessary dependencies${reset}
+
+EOF
+
+
+echo "Do you want to run updates now? [y/n] "
+read answer
+if [ "$answer" = "y" ]; then
+  $update_command
+fi

--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -17,30 +17,12 @@ update_command="make ${py}${js}${migrations}"
 
 [[ "$py" || "$js" || "$migrations" ]] && cat <<EOF
 
-[${red}${bold}!!!${reset}] ${red}The following dependencies have changed and require your intervention${reset}
-EOF
+[${red}${bold}!!!${reset}] ${red} It looks like some dependencies have changed that will require your intervention. Run the following to update:${reset}
 
-[[ "$py" ]] && cat <<EOF
-    ${red}* python virtual environment${reset}
-EOF
-
-[[ "$js" ]] && cat <<EOF
-    ${red}* javascript dependencies${reset}
-EOF
-
-[[ "$migrations" ]] && cat <<EOF
-    ${red}* database migrations${reset}
-EOF
-
-[[ "$py" || "$js" || "$migrations" ]] && cat <<EOF
-
-${red}Run ${bold}${update_command}${reset}${red}to update necessary dependencies${reset}
+    ${red}${bold}${update_command}${reset}
 
 EOF
 
-
-echo "Do you want to run updates now? [y/n] "
-read answer
-if [ "$answer" = "y" ]; then
+if [[ "$SENTRY_POST_MERGE_AUTO_UPDATE" ]]; then
   $update_command
 fi


### PR DESCRIPTION
This changes the post-merge git hook to allow users to copy a single command to update their dependencies.
Also fixes check for migrations (was previously checking for
`south_migrations`)

![image](https://user-images.githubusercontent.com/79684/69084171-83714780-09f8-11ea-81c4-874af6529a86.png)

