### PR TITLE
chore(cfg): Cleanup references to `south` in configs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,9 +17,7 @@ coverage:
   - src/sentry/runner/.*
   - src/sentry/debug/.*
   - src/.*?/migrations/.*
-  - src/.*?/south_migrations/.*
   - src/bitfield/.*
   - src/social_auth/.*
-  - src/south/.*
   - src/sentry/static/sentry/app/routes.jsx
 comment: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ exclude='''
 (
       \.venv/
     | node_modules/
-    | south_migrations/
     | migrations/
 )
 '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ markers =
 # E203 false positive, see https://github.com/PyCQA/pycodestyle/issues/373
 # W605 false positive until python3.8: https://github.com/PyCQA/pycodestyle/issues/755
 ignore = F999,E203,E501,E128,E124,E402,W503,W504,W605,E731,C901,B007,B306,B009,B010
-exclude = .venv/.git,*/migrations/*,*/south_migrations/*,node_modules/*,src/sentry/static/sentry/vendor/*,docs/*,src/south/*,examples/*
+exclude = .venv/.git,*/migrations/*,node_modules/*,src/sentry/static/sentry/vendor/*,docs/*,src/south/*,examples/*
 
 # XXX: E501 is ignored, which disables line length checking.
 # Currently, the black formatter doesn't wrap long strings: https://github.com/psf/black/issues/182#issuecomment-385325274
@@ -23,7 +23,6 @@ python-tag = py27
 
 [coverage:run]
 omit =
-    src/sentry/south_migrations/*
     src/sentry/migrations/*
 source =
     src


### PR DESCRIPTION
This cleans up some remaining configuration options relating to `south` and `south_migrations`.