### PR TITLE
logging(app-platform): adds leg message before slack.action.api-error

### DIFF
--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -32,6 +32,7 @@ class SlackActionEndpoint(Endpoint):
     permission_classes = ()
 
     def api_error(self, error, action_type, logging_data):
+        logger.info("slack.action.api-error-pre-message")
         logging_data = logging_data.copy()
         logging_data["response"] = error.body
         logging_data["action_type"] = action_type

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import
 
+import six
+
 from sentry import analytics
 from sentry import http
 from sentry.api import client
 from sentry.api.base import Endpoint
 from sentry.models import Group, Project, Identity, IdentityProvider, ApiKey
 from sentry.utils import json
-import six
 
 from .link_identity import build_linking_url
 from .requests import SlackActionRequest, SlackRequestError

--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -6,6 +6,7 @@ from sentry.api import client
 from sentry.api.base import Endpoint
 from sentry.models import Group, Project, Identity, IdentityProvider, ApiKey
 from sentry.utils import json
+import six
 
 from .link_identity import build_linking_url
 from .requests import SlackActionRequest, SlackRequestError
@@ -32,10 +33,10 @@ class SlackActionEndpoint(Endpoint):
     permission_classes = ()
 
     def api_error(self, error, action_type, logging_data):
-        logger.info("slack.action.api-error-pre-message")
         logging_data = logging_data.copy()
         logging_data["response"] = error.body
         logging_data["action_type"] = action_type
+        logger.info("slack.action.api-error-pre-message: %s" % six.text_type(logging_data))
         logger.info("slack.action.api-error", extra=logging_data)
         return self.respond(
             {


### PR DESCRIPTION
It seems the log message `slack.action.api-error` isn't showing up in our logs anymore. We think it might be because it is having issues serializing the dictionary. We can test this by adding a simple log message before it and see if that shows up.