### PR TITLE
fix(api): Fix double prefix after adding a slack channel/user

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -8,7 +8,7 @@ from sentry.rules.actions.base import EventAction
 from sentry.utils import metrics, json
 from sentry.models import Integration
 
-from .utils import build_group_attachment, get_channel_id
+from .utils import build_group_attachment, get_channel_id, strip_channel_name
 
 
 class SlackNotifyServiceForm(forms.Form):
@@ -37,6 +37,7 @@ class SlackNotifyServiceForm(forms.Form):
         channel = cleaned_data.get("channel", "")
 
         channel_id = self.channel_transformer(workspace, channel)
+        channel = strip_channel_name(channel)
 
         if channel_id is None and workspace is not None:
             params = {

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -324,6 +324,10 @@ LIST_TYPES = [
 ]
 
 
+def strip_channel_name(name):
+    return name.lstrip(strip_channel_chars)
+
+
 def get_channel_id(organization, integration_id, name):
     """
     Fetches the internal slack id of a channel.
@@ -332,7 +336,7 @@ def get_channel_id(organization, integration_id, name):
     :param name: The name of the channel
     :return:
     """
-    name = name.lstrip(strip_channel_chars)
+    name = strip_channel_name(name)
     try:
         integration = Integration.objects.get(
             provider="slack", organizations=organization, id=integration_id

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -24,6 +24,11 @@ class SlackNotifyActionTest(RuleTestCase):
         )
         self.integration.add_organization(event.project.organization, self.user)
 
+    def assert_form_valid(self, form, expected_channel_id, expected_channel):
+        assert form.is_valid()
+        assert form.cleaned_data["channel_id"] == expected_channel_id
+        assert form.cleaned_data["channel"] == expected_channel
+
     @responses.activate
     def test_applies_correctly(self):
         event = self.get_event()
@@ -98,6 +103,7 @@ class SlackNotifyActionTest(RuleTestCase):
 
         form = rule.get_form_instance()
         assert form.is_valid()
+        self.assert_form_valid(form, "chan-id", "#my-channel")
 
     @responses.activate
     def test_valid_private_channel_selected(self):
@@ -132,7 +138,7 @@ class SlackNotifyActionTest(RuleTestCase):
         )
 
         form = rule.get_form_instance()
-        assert form.is_valid()
+        self.assert_form_valid(form, "chan-id", "#my-private-channel")
 
     @responses.activate
     def test_valid_member_selected(self):
@@ -183,7 +189,7 @@ class SlackNotifyActionTest(RuleTestCase):
         )
 
         form = rule.get_form_instance()
-        assert form.is_valid()
+        self.assert_form_valid(form, "morty-id", "@morty")
 
     @responses.activate
     def test_invalid_channel_selected(self):


### PR DESCRIPTION
This fixes a bug in https://github.com/getsentry/sentry/pull/15460 that causes the api to return a
double prefix after saving a slack alert rule. This shouldn't have cause problems with actually
creating rules, since we store the internal slack id after we save.