### PR TITLE
py3(django): remove patterns which is removed in Django 1.10

### DIFF
--- a/src/new_sentry_plugins/bitbucket/urls.py
+++ b/src/new_sentry_plugins/bitbucket/urls.py
@@ -1,12 +1,9 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .endpoints.webhook import BitbucketWebhookEndpoint
 
-urlpatterns = patterns(
-    "",
-    url(
-        r"^organizations/(?P<organization_id>[^\/]+)/webhook/$", BitbucketWebhookEndpoint.as_view()
-    ),
-)
+urlpatterns = [
+    url(r"^organizations/(?P<organization_id>[^\/]+)/webhook/$", BitbucketWebhookEndpoint.as_view())
+]

--- a/src/new_sentry_plugins/github/urls.py
+++ b/src/new_sentry_plugins/github/urls.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .endpoints.webhook import GithubIntegrationsWebhookEndpoint, GithubWebhookEndpoint
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^organizations/(?P<organization_id>[^\/]+)/webhook/$", GithubWebhookEndpoint.as_view()),
     url(r"^installations/webhook/$", GithubIntegrationsWebhookEndpoint.as_view()),
-)
+]

--- a/src/new_sentry_plugins/jira_ac/urls.py
+++ b/src/new_sentry_plugins/jira_ac/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from new_sentry_plugins.jira_ac.views import (
     JiraConfigView,
@@ -9,10 +9,9 @@ from new_sentry_plugins.jira_ac.views import (
     JiraUIWidgetView,
 )
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^plugin$", JiraUIWidgetView.as_view()),
     url(r"^config$", JiraConfigView.as_view()),
     url(r"^atlassian-connect\.json$", JiraDescriptorView.as_view()),
     url(r"^installed$", JiraInstalledCallback.as_view()),
-)
+]

--- a/src/sentry/admin.py
+++ b/src/sentry/admin.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from django import forms
 from django.conf import settings
+from django.conf.urls import url
 from django.contrib import admin, messages
 from django.contrib.auth.forms import UserCreationForm, UserChangeForm, AdminPasswordChangeForm
 from django.core.exceptions import PermissionDenied
@@ -225,8 +226,7 @@ class UserAdmin(admin.ModelAdmin):
 
     def get_urls(self):
         return [
-            "",
-            (r"^(\d+)/password/$", self.admin_site.admin_view(self.user_change_password)),
+            url(r"^(\d+)/password/$", self.admin_site.admin_view(self.user_change_password))
         ] + super(UserAdmin, self).get_urls()
 
     def lookup_allowed(self, lookup, value):

--- a/src/sentry/admin.py
+++ b/src/sentry/admin.py
@@ -224,14 +224,10 @@ class UserAdmin(admin.ModelAdmin):
         return super(UserAdmin, self).get_form(request, obj, **defaults)
 
     def get_urls(self):
-        from django.conf.urls import patterns
-
-        return (
-            patterns(
-                "", (r"^(\d+)/password/$", self.admin_site.admin_view(self.user_change_password))
-            )
-            + super(UserAdmin, self).get_urls()
-        )
+        return [
+            "",
+            (r"^(\d+)/password/$", self.admin_site.admin_view(self.user_change_password)),
+        ] + super(UserAdmin, self).get_urls()
 
     def lookup_allowed(self, lookup, value):
         # See #20078: we don't want to allow any lookups involving passwords.

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 
 from .endpoints.accept_project_transfer import AcceptProjectTransferEndpoint
 from .endpoints.api_application_details import ApiApplicationDetailsEndpoint
@@ -339,8 +339,7 @@ GROUP_URLS = [
     url(r"^(?P<issue_id>[^\/]+)/plugins?/", include("sentry.plugins.base.group_api_urls")),
 ]
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     # Relay
     url(
         r"^relays/",
@@ -1555,4 +1554,4 @@ urlpatterns = patterns(
     url(r"^$", IndexEndpoint.as_view(), name="sentry-api-index"),
     url(r"^", CatchallEndpoint.as_view(), name="sentry-api-catchall"),
     # url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
-)
+]

--- a/src/sentry/conf/urls.py
+++ b/src/sentry/conf/urls.py
@@ -10,7 +10,7 @@ These are additional urls used by the Sentry-provided web server
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 
 from sentry.web.urls import urlpatterns as web_urlpatterns
@@ -21,12 +21,11 @@ from sentry.web.frontend.error_500 import Error500View
 handler404 = Error404View.as_view()
 handler500 = Error500View.as_view()
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^500/", handler500, name="error-500"),
     url(r"^404/", handler404, name="error-404"),
     url(r"^403-csrf-failure/", CsrfFailureView.as_view(), name="error-403-csrf-failure"),
-)
+]
 
 if "django.contrib.admin" in settings.INSTALLED_APPS:
     from sentry import django_admin

--- a/src/sentry/django_admin.py
+++ b/src/sentry/django_admin.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from copy import copy
 from django.contrib import admin
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 
 from sentry.auth.superuser import is_active_superuser
 
@@ -33,4 +33,4 @@ def make_site():
 
 site = make_site()
 
-urlpatterns = patterns("", url(r"^admin/", include(site.urls)))
+urlpatterns = [url(r"^admin/", include(site.urls))]

--- a/src/sentry/integrations/bitbucket/urls.py
+++ b/src/sentry/integrations/bitbucket/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .descriptor import BitbucketDescriptorEndpoint
 from .installed import BitbucketInstalledEndpoint
@@ -8,8 +8,7 @@ from .uninstalled import BitbucketUninstalledEndpoint
 from .webhook import BitbucketWebhookEndpoint
 from .search import BitbucketSearchEndpoint
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^descriptor/$", BitbucketDescriptorEndpoint.as_view()),
     url(r"^installed/$", BitbucketInstalledEndpoint.as_view()),
     url(r"^uninstalled/$", BitbucketUninstalledEndpoint.as_view()),
@@ -21,4 +20,4 @@ urlpatterns = patterns(
         BitbucketSearchEndpoint.as_view(),
         name="sentry-extensions-bitbucket-search",
     ),
-)
+]

--- a/src/sentry/integrations/cloudflare/urls.py
+++ b/src/sentry/integrations/cloudflare/urls.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .metadata import CloudflareMetadataEndpoint
 from .webhook import CloudflareWebhookEndpoint
 
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^metadata/$", CloudflareMetadataEndpoint.as_view()),
     url(r"^webhook/$", CloudflareWebhookEndpoint.as_view()),
-)
+]

--- a/src/sentry/integrations/github/urls.py
+++ b/src/sentry/integrations/github/urls.py
@@ -1,16 +1,15 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .webhook import GitHubIntegrationsWebhookEndpoint
 from .search import GitHubSearchEndpoint
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^webhook/$", GitHubIntegrationsWebhookEndpoint.as_view()),
     url(
         r"^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$",
         GitHubSearchEndpoint.as_view(),
         name="sentry-extensions-github-search",
     ),
-)
+]

--- a/src/sentry/integrations/github_enterprise/urls.py
+++ b/src/sentry/integrations/github_enterprise/urls.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .webhook import GitHubEnterpriseWebhookEndpoint
 
 
-urlpatterns = patterns("", url(r"^webhook/$", GitHubEnterpriseWebhookEndpoint.as_view()))
+urlpatterns = [url(r"^webhook/$", GitHubEnterpriseWebhookEndpoint.as_view())]

--- a/src/sentry/integrations/gitlab/urls.py
+++ b/src/sentry/integrations/gitlab/urls.py
@@ -1,16 +1,15 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .webhooks import GitlabWebhookEndpoint
 from .search import GitlabIssueSearchEndpoint
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(
         r"^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$",
         GitlabIssueSearchEndpoint.as_view(),
         name="sentry-extensions-gitlab-search",
     ),
     url(r"^webhook/$", GitlabWebhookEndpoint.as_view(), name="sentry-extensions-gitlab-webhook"),
-)
+]

--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .configure import JiraConfigureView
 from .descriptor import JiraDescriptorEndpoint
@@ -10,8 +10,7 @@ from .uninstalled import JiraUninstalledEndpoint
 from .webhooks import JiraIssueUpdatedWebhook
 
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^configure/$", JiraConfigureView.as_view()),
     url(r"^descriptor/$", JiraDescriptorEndpoint.as_view()),
     url(r"^installed/$", JiraInstalledEndpoint.as_view()),
@@ -26,4 +25,4 @@ urlpatterns = patterns(
         JiraSearchEndpoint.as_view(),
         name="sentry-extensions-jira-search",
     ),
-)
+]

--- a/src/sentry/integrations/jira_server/urls.py
+++ b/src/sentry/integrations/jira_server/urls.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .search import JiraServerSearchEndpoint
 from .webhooks import JiraIssueUpdatedWebhook
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(
         r"^issue-updated/(?P<token>[^\/]+)/$",
         JiraIssueUpdatedWebhook.as_view(),
@@ -17,4 +16,4 @@ urlpatterns = patterns(
         JiraServerSearchEndpoint.as_view(),
         name="sentry-extensions-jiraserver-search",
     ),
-)
+]

--- a/src/sentry/integrations/slack/urls.py
+++ b/src/sentry/integrations/slack/urls.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .action_endpoint import SlackActionEndpoint
 from .event_endpoint import SlackEventEndpoint
 from .link_identity import SlackLinkIdentityView
 
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^action/$", SlackActionEndpoint.as_view()),
     url(r"^event/$", SlackEventEndpoint.as_view()),
     url(
@@ -16,4 +15,4 @@ urlpatterns = patterns(
         SlackLinkIdentityView.as_view(),
         name="sentry-integration-slack-link-identity",
     ),
-)
+]

--- a/src/sentry/integrations/vsts/urls.py
+++ b/src/sentry/integrations/vsts/urls.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import, print_function
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from .search import VstsSearchEndpoint
 from .webhooks import WorkItemWebhook
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(
         r"^issue-updated/$", WorkItemWebhook.as_view(), name="sentry-extensions-vsts-issue-updated"
     ),
@@ -14,4 +13,4 @@ urlpatterns = patterns(
         VstsSearchEndpoint.as_view(),
         name="sentry-extensions-vsts-search",
     ),
-)
+]

--- a/src/sentry/plugins/base/group_api_urls.py
+++ b/src/sentry/plugins/base/group_api_urls.py
@@ -4,7 +4,7 @@ import logging
 import re
 
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from sentry.plugins.base import plugins
 
@@ -22,7 +22,7 @@ def ensure_url(u):
 
 
 def load_plugin_urls(plugins):
-    urlpatterns = patterns("")
+    urlpatterns = []
     for plugin in plugins:
         try:
             urls = plugin.get_group_urls()

--- a/src/sentry/plugins/base/project_api_urls.py
+++ b/src/sentry/plugins/base/project_api_urls.py
@@ -4,7 +4,7 @@ import logging
 import re
 
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from sentry.plugins.base import plugins
 
@@ -22,7 +22,7 @@ def ensure_url(u):
 
 
 def load_plugin_urls(plugins):
-    urlpatterns = patterns("")
+    urlpatterns = []
     for plugin in plugins:
         try:
             urls = plugin.get_project_urls()

--- a/src/sentry/plugins/base/response.py
+++ b/src/sentry/plugins/base/response.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, print_function
 
 __all__ = ("Response", "JSONResponse")
 
-from django.core.context_processors import csrf
 from django.http import HttpResponse
+from django.template.context_processors import csrf
 
 from sentry.utils import json
 

--- a/src/sentry/plugins/base/urls.py
+++ b/src/sentry/plugins/base/urls.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 
 import re
 
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from sentry.plugins.base import plugins
 
-urlpatterns = patterns("")
+urlpatterns = []
 
 for _plugin in plugins.all():
     _plugin_url_module = _plugin.get_url_module()

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.generic import TemplateView
 
 import sentry.web.frontend.debug.mail
@@ -62,8 +62,7 @@ from sentry.web.frontend.debug.debug_oauth_authorize import (
     DebugOAuthAuthorizeErrorView,
 )
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     url(r"^debug/mail/alert/$", sentry.web.frontend.debug.mail.alert),
     url(r"^debug/mail/note/$", DebugNoteEmailView.as_view()),
     url(r"^debug/mail/new-release/$", DebugNewReleaseEmailView.as_view()),
@@ -118,4 +117,4 @@ urlpatterns = patterns(
     url(r"^debug/sudo/$", TemplateView.as_view(template_name="sentry/account/sudo.html")),
     url(r"^debug/oauth/authorize/$", DebugOAuthAuthorizeView.as_view()),
     url(r"^debug/oauth/authorize/error/$", DebugOAuthAuthorizeErrorView.as_view()),
-)
+]

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 from django.http import HttpResponse
 from django.views.generic import RedirectView
 
@@ -53,7 +53,7 @@ __all__ = ("urlpatterns",)
 generic_react_page_view = GenericReactPageView.as_view()
 react_page_view = ReactPageView.as_view()
 
-urlpatterns = patterns("")
+urlpatterns = []
 
 if getattr(settings, "DEBUG_VIEWS", settings.DEBUG):
     from sentry.web.debug_urls import urlpatterns as debug_urls
@@ -62,16 +62,16 @@ if getattr(settings, "DEBUG_VIEWS", settings.DEBUG):
 
 # Special favicon in debug mode
 if settings.DEBUG:
-    urlpatterns += patterns(
+    urlpatterns += [
         "",
         url(
             r"^_static/[^/]+/[^/]+/images/favicon\.ico$",
             generic.dev_favicon,
             name="sentry-dev-favicon",
         ),
-    )
+    ]
 
-urlpatterns += patterns(
+urlpatterns += [
     "",
     # Store endpoints first since they are the most active
     url(r"^api/store/$", api.StoreView.as_view(), name="sentry-api-store"),
@@ -695,4 +695,4 @@ urlpatterns += patterns(
     ),
     # Legacy
     url(r"/$", react_page_view),
-)
+]

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -63,16 +63,14 @@ if getattr(settings, "DEBUG_VIEWS", settings.DEBUG):
 # Special favicon in debug mode
 if settings.DEBUG:
     urlpatterns += [
-        "",
         url(
             r"^_static/[^/]+/[^/]+/images/favicon\.ico$",
             generic.dev_favicon,
             name="sentry-dev-favicon",
-        ),
+        )
     ]
 
 urlpatterns += [
-    "",
     # Store endpoints first since they are the most active
     url(r"^api/store/$", api.StoreView.as_view(), name="sentry-api-store"),
     url(r"^api/(?P<project_id>[\w_-]+)/store/$", api.StoreView.as_view(), name="sentry-api-store"),

--- a/src/social_auth/urls.py
+++ b/src/social_auth/urls.py
@@ -1,19 +1,18 @@
 from __future__ import absolute_import
 
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:
     # for Django version less then 1.4
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 
 from social_auth.views import auth, complete
 
 
-urlpatterns = patterns(
-    "",
+urlpatterns = [
     # authentication
     url(
         r"^associate/complete/(?P<backend>[^/]+)/$", complete, name="socialauth_associate_complete"
     ),
     url(r"^associate/(?P<backend>[^/]+)/$", auth, name="socialauth_associate"),
-)
+]

--- a/tests/sentry/api/test_handlers.py
+++ b/tests/sentry/api/test_handlers.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.test import override_settings
 from rest_framework.permissions import AllowAny
 
@@ -16,7 +16,7 @@ class RateLimitedEndpoint(Endpoint):
         raise RateLimitExceeded()
 
 
-urlpatterns = patterns("", url(r"^/$", RateLimitedEndpoint.as_view(), name="sentry-test"))
+urlpatterns = [url(r"^/$", RateLimitedEndpoint.as_view(), name="sentry-test")]
 
 
 @override_settings(ROOT_URLCONF="tests.sentry.api.test_handlers")


### PR DESCRIPTION
`django.conf.urls.patterns()` is removed in Django 1.10. Since this is a large blanket change, it's decoupled from https://github.com/getsentry/sentry/pull/15627, which should be rebased once this lands in master.
