### PR TITLE
test(plugins): add option to raise error if plugin fails to load

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -36,7 +36,7 @@ def install_sentry_plugins():
 
     from sentry.runner.initializer import register_plugins
 
-    register_plugins(settings, test_plugins=True)
+    register_plugins(settings, test_plugins=True, raise_on_plugin_load_failure=True)
 
     settings.ASANA_CLIENT_ID = "abc"
     settings.ASANA_CLIENT_SECRET = "123"

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -11,7 +11,7 @@ from sentry.utils.sdk import configure_sdk
 from sentry.utils.warnings import DeprecatedSettingWarning
 
 
-def register_plugins(settings, test_plugins=False):
+def register_plugins(settings, test_plugins=False, raise_on_plugin_load_failure=False):
     from pkg_resources import iter_entry_points
     from sentry.plugins.base import plugins
 
@@ -35,6 +35,8 @@ def register_plugins(settings, test_plugins=False):
                 click.echo(
                     "Failed to load plugin %r:\n%s" % (ep.name, traceback.format_exc()), err=True
                 )
+                if raise_on_plugin_load_failure:
+                    raise
             else:
                 plugins.register(plugin)
 


### PR DESCRIPTION
This will help us catch bugs if the entry point of a plugin is incorrect 