### PR TITLE
feat(outcomes): Support single tenant

### DIFF
--- a/src/sentry/tsdb/redissnuba.py
+++ b/src/sentry/tsdb/redissnuba.py
@@ -59,7 +59,9 @@ assert (
 
 model_backends = {
     # model: (read, write)
-    model: ("redis", "redis") if model not in SnubaTSDB.model_query_settings else ("snuba", "dummy")
+    model: ("redis", "redis")
+    if model not in SnubaTSDB.non_outcomes_query_settings
+    else ("snuba", "dummy")
     for model in BaseTSDB.models
 }
 

--- a/tests/sentry/tsdb/test_redissnuba.py
+++ b/tests/sentry/tsdb/test_redissnuba.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+from sentry.tsdb.base import TSDBModel
+from sentry.tsdb.snuba import SnubaTSDB
+from sentry.tsdb.redissnuba import selector_func, method_specifications, READ
+
+
+def get_callargs(model):
+    """
+    Represents for all possible ways that a model could be passed to ``selector_func`` through the callargs
+    """
+    return {
+        "model": model,
+        "models": [model],
+        "items": [(model, "key", ["values"])],
+        "requests": [(model, "data")],
+    }
+
+
+def test_redissnuba_connects_to_correct_backend():
+    should_resolve_to_redis = set(list(TSDBModel)) - set(
+        SnubaTSDB.non_outcomes_query_settings.keys()
+    )
+    should_resolve_to_snuba = SnubaTSDB.non_outcomes_query_settings.keys()
+
+    methods = set(method_specifications.keys()) - set(["flush"])
+
+    for method in methods:
+        for model in should_resolve_to_redis:
+            assert "redis" == selector_func(method, get_callargs(model))
+
+        for model in should_resolve_to_snuba:
+            read_or_write, _ = method_specifications.get(method)
+
+            if read_or_write == READ:
+                assert "snuba" == selector_func(method, get_callargs(model))
+            else:
+                assert "dummy" == selector_func(method, get_callargs(model))


### PR DESCRIPTION
For outcomes based TSDB models, sentry.io now reads from `SnubaTSDB` and writes to `DummyTSDB`.

This doesn't work for single tenant. For single tenant we still want to use `RedisTSDB` for outcomes based TSDB models. Single tenant uses `RedisSnubaTSDB`. 

So, this PR makes it such that `RedisSnubaTSDB` does the following:
* Reads and writes to `RedisTSDB` for outcomes based TSDB models
* Reads from `SnubaTSDB` and writes to `DummyTSDB` for events based TSDB models (i.e. the same as before we starting moving outcomes to use Snuba - [call site](https://github.com/getsentry/sentry/blob/95767d455b8004ec4b4c5026d84b64b6348e6d37/src/sentry/tsdb/redissnuba.py#L62) and [settings](https://github.com/getsentry/sentry/blob/95767d455b8004ec4b4c5026d84b64b6348e6d37/src/sentry/tsdb/snuba.py#L26-L35))
* Reads and writes to `RedisTSDB` for everything else.

## Test plan
* Wrote a unit test
* Tested locally