### PR TITLE
feat(discover2): Add caching for the events graphs

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -5,15 +5,15 @@ import six
 from datetime import timedelta
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
-from sentry.utils.hashlib import sha1_text
 
 from sentry import features
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
 from sentry.api.event_search import resolve_field_list, InvalidSearchQuery
 from sentry.api.serializers.snuba import SnubaTSResultSerializer
-from sentry.cache import default_cache
+from sentry.utils.cache import cache
 from sentry.utils.dates import parse_stats_period
 from sentry.utils import snuba, json
+from sentry.utils.hashlib import sha1_text
 
 
 class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
@@ -41,7 +41,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
         cache_key = cache_key_for_snuba_args(organization, request) if should_cache else ""
 
         if should_cache:
-            snuba_data = default_cache.get(cache_key)
+            snuba_data = cache.get(cache_key)
 
             import logging
 
@@ -69,7 +69,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
 
         if should_cache:
             cache_timeout = 900  # 15 minutes = 900 seconds
-            default_cache.set(cache_key, snuba_data, cache_timeout)
+            cache.set(cache_key, snuba_data, cache_timeout)
             logging.info("foo cache miss: %s", cache_key)
 
         return Response(snuba_data, status=200)

--- a/src/sentry/static/sentry/app/actionCreators/events.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.tsx
@@ -19,6 +19,7 @@ type Options = {
   yAxis?: string;
   field?: string[];
   referenceEvent?: string;
+  shouldCache?: boolean;
 };
 
 /**
@@ -50,6 +51,7 @@ export const doEventsRequest = (
     yAxis,
     field,
     referenceEvent,
+    shouldCache,
   }: Options
 ): Promise<EventsStats> => {
   const shouldDoublePeriod = canIncludePreviousPeriod(includePrevious, period);
@@ -64,6 +66,10 @@ export const doEventsRequest = (
       referenceEvent,
     }).filter(([, value]) => typeof value !== 'undefined')
   );
+
+  if (shouldCache === true) {
+    urlQuery.cache = '1';
+  }
 
   // Doubling period for absolute dates is not accurate unless starting and
   // ending times are the same (at least for daily intervals). This is

--- a/src/sentry/static/sentry/app/actionCreators/events.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.tsx
@@ -76,6 +76,10 @@ export const doEventsRequest = (
   // the tradeoff for now.
   const periodObj = getPeriod({period, start, end}, {shouldDoublePeriod});
 
+  const foo = {...urlQuery, ...periodObj};
+
+  console.log('foo', JSON.stringify(foo));
+
   return api.requestPromise(`${getBaseUrl(organization)}`, {
     query: {
       ...urlQuery,

--- a/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/events/utils/eventsRequest.tsx
@@ -50,6 +50,8 @@ type EventsRequestPartialProps = {
   showLoading?: boolean;
   yAxis?: string;
   children: (renderProps: RenderProps) => React.ReactNode;
+
+  shouldCache?: boolean;
 };
 
 type TimeAggregationProps =
@@ -69,6 +71,8 @@ const omitIgnoredProps = (props: EventsRequestProps) =>
 
 class EventsRequest extends React.PureComponent<EventsRequestProps, EventsRequestState> {
   static propTypes = {
+    shouldCache: PropTypes.bool,
+
     /**
      * API client instance
      */

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -381,6 +381,22 @@ class EventView {
     });
   }
 
+  static fromSavedQueryWithLocation(
+    saved: NewQuery | LegacySavedQuery,
+    location: Location
+  ): EventView {
+    const query = location.query;
+
+    saved = {
+      ...saved,
+      start: saved.start || decodeScalar(query.start),
+      end: saved.end || decodeScalar(query.end),
+      range: saved.range || decodeScalar(query.statsPeriod),
+    };
+
+    return EventView.fromSavedQuery(saved);
+  }
+
   static fromSavedQuery(saved: NewQuery | LegacySavedQuery): EventView {
     let fields, yAxis;
     if (isLegacySavedQuery(saved)) {
@@ -883,10 +899,10 @@ class EventView {
     // normalize datetime selection
 
     const normalizedTimeWindowParams = getParams({
-      start: this.start,
-      end: this.end,
+      start: this.start || picked.start,
+      end: this.end || picked.end,
       period: decodeScalar(query.period),
-      statsPeriod: this.statsPeriod,
+      statsPeriod: this.statsPeriod || picked.statsPeriod,
       utc: decodeScalar(query.utc),
     });
 

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -143,7 +143,9 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
       return null;
     }
 
-    const eventView = EventView.fromSavedQuery(DEFAULT_EVENT_VIEW);
+    const {location} = this.props;
+
+    const eventView = EventView.fromSavedQueryWithLocation(DEFAULT_EVENT_VIEW, location);
 
     const to = {
       pathname: location.pathname,

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -46,6 +46,8 @@ class MiniGraph extends React.Component<Props> {
         end={end}
         period={period}
         interval={getInterval({start, end, period}, true)}
+        project={selection.projects || []}
+        environment={selection.environments || []}
       >
         {({loading, timeseriesData}) => {
           if (loading) {

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -48,6 +48,7 @@ class MiniGraph extends React.Component<Props> {
         interval={getInterval({start, end, period}, true)}
         project={selection.projects || []}
         environment={selection.environments || []}
+        includePrevious={false}
       >
         {({loading, timeseriesData}) => {
           if (loading) {

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -42,8 +42,11 @@ class MiniGraph extends React.Component<Props> {
     const end = getUtcToLocalDateObject(apiPayload.end);
     const period: string | undefined = apiPayload.statsPeriod as any;
 
+    const shouldCache = !!(location.query.cache && location.query.cache.length);
+
     return (
       <EventsRequest
+        shouldCache={shouldCache}
         organization={organization}
         api={api}
         query={query}

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -99,7 +99,7 @@ class QueryList extends React.Component<Props> {
           renderGraph={() => {
             return (
               <MiniGraph
-                query={eventView.getEventsAPIPayload(location).query}
+                location={location}
                 eventView={eventView}
                 organization={organization}
               />
@@ -155,7 +155,7 @@ class QueryList extends React.Component<Props> {
           renderGraph={() => {
             return (
               <MiniGraph
-                query={eventView.getEventsAPIPayload(location).query}
+                location={location}
                 eventView={eventView}
                 organization={organization}
               />

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -80,7 +80,7 @@ class QueryList extends React.Component<Props> {
     const views = getPrebuiltQueries(organization);
 
     const list = views.map((view, index) => {
-      const eventView = EventView.fromSavedQuery(view);
+      const eventView = EventView.fromSavedQueryWithLocation(view, location);
       const to = {
         pathname: location.pathname,
         query: {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -53,7 +53,10 @@ class Table extends React.PureComponent<TableProps, TableState> {
     const {location, eventView} = this.props;
 
     if (!eventView.isValid()) {
-      const nextEventView = EventView.fromSavedQuery(DEFAULT_EVENT_VIEW);
+      const nextEventView = EventView.fromSavedQueryWithLocation(
+        DEFAULT_EVENT_VIEW,
+        location
+      );
 
       browserHistory.replace({
         pathname: location.pathname,


### PR DESCRIPTION
WORK IN PROGRESS

## TODO

- [x] figure out the start, end, statsPeriod situation 
- [x] use `sentry.utils.cache` instead
- [x] add `cache=1` query param so that caching isn't default
- [x] consider using params for the cache keys
- [ ] revert https://github.com/getsentry/sentry/pull/15659/commits/79eccda021cee50905f94015cc5dac3d4146324e