### PR TITLE
fix(global-header): Fix default values for the datetime prop of the global selection store

### DIFF
--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -8,20 +8,23 @@ import {
   LOCAL_STORAGE_KEY,
 } from 'app/constants/globalSelectionHeader';
 import {getStateFromQuery} from 'app/components/organizations/globalSelectionHeader/utils';
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {isEqualWithDates} from 'app/utils/isEqualWithDates';
 import OrganizationsStore from 'app/stores/organizationsStore';
 import GlobalSelectionActions from 'app/actions/globalSelectionActions';
 import localStorage from 'app/utils/localStorage';
+
+const DEFAULT_PARAMS = getParams({});
 
 const getDefaultSelection = () => {
   return {
     projects: [],
     environments: [],
     datetime: {
-      [DATE_TIME.START]: null,
-      [DATE_TIME.END]: null,
-      [DATE_TIME.PERIOD]: null,
-      [DATE_TIME.UTC]: null,
+      [DATE_TIME.START]: DEFAULT_PARAMS.start,
+      [DATE_TIME.END]: DEFAULT_PARAMS.end,
+      [DATE_TIME.PERIOD]: DEFAULT_PARAMS.statsPeriod,
+      [DATE_TIME.UTC]: DEFAULT_PARAMS.utc,
     },
   };
 };

--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -21,10 +21,10 @@ const getDefaultSelection = () => {
     projects: [],
     environments: [],
     datetime: {
-      [DATE_TIME.START]: DEFAULT_PARAMS.start,
-      [DATE_TIME.END]: DEFAULT_PARAMS.end,
-      [DATE_TIME.PERIOD]: DEFAULT_PARAMS.statsPeriod,
-      [DATE_TIME.UTC]: DEFAULT_PARAMS.utc,
+      [DATE_TIME.START]: DEFAULT_PARAMS.start || null,
+      [DATE_TIME.END]: DEFAULT_PARAMS.end || null,
+      [DATE_TIME.PERIOD]: DEFAULT_PARAMS.statsPeriod || null,
+      [DATE_TIME.UTC]: DEFAULT_PARAMS.utc || null,
     },
   };
 };
@@ -80,10 +80,10 @@ const GlobalSelectionStore = Reflux.createStore({
         projects: parsed.project || [],
         environments: parsed.environment || [],
         datetime: {
-          [DATE_TIME.START]: parsed.start || undefined,
-          [DATE_TIME.END]: parsed.end || undefined,
-          [DATE_TIME.PERIOD]: parsed.period || undefined,
-          [DATE_TIME.UTC]: parsed.utc || undefined,
+          [DATE_TIME.START]: parsed.start || null,
+          [DATE_TIME.END]: parsed.end || null,
+          [DATE_TIME.PERIOD]: parsed.period || null,
+          [DATE_TIME.UTC]: parsed.utc || null,
         },
       };
     } else {

--- a/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
+++ b/src/sentry/static/sentry/app/stores/globalSelectionStore.jsx
@@ -80,10 +80,10 @@ const GlobalSelectionStore = Reflux.createStore({
         projects: parsed.project || [],
         environments: parsed.environment || [],
         datetime: {
-          [DATE_TIME.START]: parsed.start || null,
-          [DATE_TIME.END]: parsed.end || null,
-          [DATE_TIME.PERIOD]: parsed.period || null,
-          [DATE_TIME.UTC]: parsed.utc || null,
+          [DATE_TIME.START]: parsed.start || undefined,
+          [DATE_TIME.END]: parsed.end || undefined,
+          [DATE_TIME.PERIOD]: parsed.period || undefined,
+          [DATE_TIME.UTC]: parsed.utc || undefined,
         },
       };
     } else {

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -214,9 +214,9 @@ describe('GlobalSelectionHeader', function() {
     expect(GlobalSelectionStore.get()).toEqual({
       datetime: {
         period: '14d',
-        utc: undefined,
-        start: undefined,
-        end: undefined,
+        utc: null,
+        start: null,
+        end: null,
       },
       environments: ['staging'],
       projects: [2, 3],
@@ -243,9 +243,9 @@ describe('GlobalSelectionHeader', function() {
     expect(GlobalSelectionStore.get()).toEqual({
       datetime: {
         period: '14d',
-        utc: undefined,
-        start: undefined,
-        end: undefined,
+        utc: null,
+        start: null,
+        end: null,
       },
       environments: [],
       projects: [2],
@@ -304,9 +304,9 @@ describe('GlobalSelectionHeader', function() {
     expect(GlobalSelectionStore.get()).toEqual({
       datetime: {
         period: '14d',
-        utc: undefined,
-        start: undefined,
-        end: undefined,
+        utc: null,
+        start: null,
+        end: null,
       },
       environments: ['prod'],
       projects: [],

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -214,9 +214,9 @@ describe('GlobalSelectionHeader', function() {
     expect(GlobalSelectionStore.get()).toEqual({
       datetime: {
         period: '14d',
-        utc: null,
-        start: null,
-        end: null,
+        utc: undefined,
+        start: undefined,
+        end: undefined,
       },
       environments: ['staging'],
       projects: [2, 3],
@@ -243,9 +243,9 @@ describe('GlobalSelectionHeader', function() {
     expect(GlobalSelectionStore.get()).toEqual({
       datetime: {
         period: '14d',
-        utc: null,
-        start: null,
-        end: null,
+        utc: undefined,
+        start: undefined,
+        end: undefined,
       },
       environments: [],
       projects: [2],
@@ -304,9 +304,9 @@ describe('GlobalSelectionHeader', function() {
     expect(GlobalSelectionStore.get()).toEqual({
       datetime: {
         period: '14d',
-        utc: null,
-        start: null,
-        end: null,
+        utc: undefined,
+        start: undefined,
+        end: undefined,
       },
       environments: ['prod'],
       projects: [],

--- a/tests/js/spec/stores/globalSelectionStore.spec.jsx
+++ b/tests/js/spec/stores/globalSelectionStore.spec.jsx
@@ -26,7 +26,7 @@ describe('GlobalSelectionStore', function() {
     expect(GlobalSelectionStore.get()).toEqual({
       projects: [],
       environments: [],
-      datetime: {period: null, start: null, end: null, utc: null},
+      datetime: {period: '14d', start: undefined, end: undefined, utc: undefined},
     });
   });
 
@@ -39,10 +39,10 @@ describe('GlobalSelectionStore', function() {
 
   it('updateDateTime()', async function() {
     expect(GlobalSelectionStore.get().datetime).toEqual({
-      period: null,
-      start: null,
-      end: null,
-      utc: null,
+      period: '14d',
+      start: undefined,
+      end: undefined,
+      utc: undefined,
     });
     updateDateTime({period: '2h', start: null, end: null});
     await tick();

--- a/tests/js/spec/stores/globalSelectionStore.spec.jsx
+++ b/tests/js/spec/stores/globalSelectionStore.spec.jsx
@@ -26,7 +26,7 @@ describe('GlobalSelectionStore', function() {
     expect(GlobalSelectionStore.get()).toEqual({
       projects: [],
       environments: [],
-      datetime: {period: '14d', start: undefined, end: undefined, utc: undefined},
+      datetime: {period: '14d', start: null, end: null, utc: null},
     });
   });
 
@@ -40,9 +40,9 @@ describe('GlobalSelectionStore', function() {
   it('updateDateTime()', async function() {
     expect(GlobalSelectionStore.get().datetime).toEqual({
       period: '14d',
-      start: undefined,
-      end: undefined,
-      utc: undefined,
+      start: null,
+      end: null,
+      utc: null,
     });
     updateDateTime({period: '2h', start: null, end: null});
     await tick();

--- a/tests/js/spec/utils/withGlobalSelection.spec.jsx
+++ b/tests/js/spec/utils/withGlobalSelection.spec.jsx
@@ -29,9 +29,9 @@ describe('withGlobalSelection HoC', function() {
     const wrapper = mount(<Container />);
 
     selection = wrapper.find('MyComponent').prop('selection');
-    expect(selection.datetime.period).toEqual(null);
-    expect(selection.datetime.start).toEqual(null);
-    expect(selection.datetime.end).toEqual(null);
+    expect(selection.datetime.period).toEqual('14d');
+    expect(selection.datetime.start).toEqual(undefined);
+    expect(selection.datetime.end).toEqual(undefined);
 
     GlobalSelectionStore.updateDateTime({
       period: '7d',

--- a/tests/js/spec/utils/withGlobalSelection.spec.jsx
+++ b/tests/js/spec/utils/withGlobalSelection.spec.jsx
@@ -30,8 +30,8 @@ describe('withGlobalSelection HoC', function() {
 
     selection = wrapper.find('MyComponent').prop('selection');
     expect(selection.datetime.period).toEqual('14d');
-    expect(selection.datetime.start).toEqual(undefined);
-    expect(selection.datetime.end).toEqual(undefined);
+    expect(selection.datetime.start).toEqual(null);
+    expect(selection.datetime.end).toEqual(null);
 
     GlobalSelectionStore.updateDateTime({
       period: '7d',

--- a/tests/js/spec/views/events/index.spec.jsx
+++ b/tests/js/spec/views/events/index.spec.jsx
@@ -259,8 +259,8 @@ describe('EventsContainer', function() {
     });
 
     it('updates router when changing periods', async function() {
-      expect(wrapper.find('TimeRangeSelector').prop('start')).toEqual(undefined);
-      expect(wrapper.find('TimeRangeSelector').prop('end')).toEqual(undefined);
+      expect(wrapper.find('TimeRangeSelector').prop('start')).toEqual(null);
+      expect(wrapper.find('TimeRangeSelector').prop('end')).toEqual(null);
       expect(wrapper.find('TimeRangeSelector').prop('relative')).toEqual('14d');
 
       wrapper.find('TimeRangeSelector HeaderItem').simulate('click');

--- a/tests/js/spec/views/events/index.spec.jsx
+++ b/tests/js/spec/views/events/index.spec.jsx
@@ -259,9 +259,9 @@ describe('EventsContainer', function() {
     });
 
     it('updates router when changing periods', async function() {
-      expect(wrapper.find('TimeRangeSelector').prop('start')).toEqual(null);
-      expect(wrapper.find('TimeRangeSelector').prop('end')).toEqual(null);
-      expect(wrapper.find('TimeRangeSelector').prop('relative')).toEqual(null);
+      expect(wrapper.find('TimeRangeSelector').prop('start')).toEqual(undefined);
+      expect(wrapper.find('TimeRangeSelector').prop('end')).toEqual(undefined);
+      expect(wrapper.find('TimeRangeSelector').prop('relative')).toEqual('14d');
 
       wrapper.find('TimeRangeSelector HeaderItem').simulate('click');
 

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -475,6 +475,7 @@ describe('IssueList,', function() {
             environment: [],
             project: [],
             sort: 'freq',
+            statsPeriod: '14d',
           },
         })
       );
@@ -514,6 +515,7 @@ describe('IssueList,', function() {
             environment: [],
             project: [],
             query: 'dogs',
+            statsPeriod: '14d',
           },
         })
       );
@@ -656,6 +658,7 @@ describe('IssueList,', function() {
           query: {
             environment: [],
             project: ['3559'],
+            statsPeriod: '14d',
           },
         })
       );
@@ -711,6 +714,7 @@ describe('IssueList,', function() {
           query: {
             project: [],
             environment: [],
+            statsPeriod: '14d',
           },
         })
       );
@@ -913,6 +917,7 @@ describe('IssueList,', function() {
           environment: [],
           project: [],
           query: 'is:unresolved',
+          statsPeriod: '14d',
         },
       };
       expect(browserHistory.push).toHaveBeenLastCalledWith(pushArgs);
@@ -940,6 +945,7 @@ describe('IssueList,', function() {
           environment: [],
           project: [],
           query: 'is:unresolved',
+          statsPeriod: '14d',
         },
       };
       expect(browserHistory.push).toHaveBeenLastCalledWith(pushArgs);
@@ -960,6 +966,7 @@ describe('IssueList,', function() {
           environment: [],
           project: [],
           query: 'is:unresolved',
+          statsPeriod: '14d',
         },
       };
       expect(browserHistory.push).toHaveBeenLastCalledWith(pushArgs);
@@ -977,9 +984,12 @@ describe('IssueList,', function() {
       expect(browserHistory.push).toHaveBeenLastCalledWith({
         pathname: '/organizations/org-slug/issues/',
         query: {
+          cursor: undefined,
           environment: [],
+          page: undefined,
           project: [],
           query: 'is:unresolved',
+          statsPeriod: '14d',
         },
       });
     });


### PR DESCRIPTION
On initial load, React components that are wrapped by the `withGlobalSelection()` HOC can be re-rendered unnecessarily. 

------

## Context

When investigating the HTTP requests profile for the graphs on the Discover 2 landing page, I've noticed that there was an extra HTTP request for every graph. Despite setting a `shouldComponentUpdate()` lifecycle method: https://github.com/getsentry/sentry/blob/98b5bedc880dcbfe34282a2609334c5fe451b6fc/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx#L28-L34

This is due to the datetime selection props changing from `null` values to the preferred defaults on initial load in the global selection header reflux store. 

Before: 
<img width="1440" alt="Screen Shot 2019-11-18 at 11 33 28 PM" src="https://user-images.githubusercontent.com/139499/69117210-ff04e000-0a5c-11ea-8275-34eb1cc8697c.png">

After

<img width="1440" alt="Screen Shot 2019-11-18 at 11 32 29 PM" src="https://user-images.githubusercontent.com/139499/69117220-04fac100-0a5d-11ea-944b-f5c86cfb8d88.png">

