### PR TITLE
feat(dif): Improved update message for symbol sources

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/projectDebugFiles.jsx
+++ b/src/sentry/static/sentry/app/data/forms/projectDebugFiles.jsx
@@ -44,6 +44,17 @@ export const fields = {
     help: t(
       'Configures which built-in repositories Sentry should use to resolve debug files.'
     ),
+    formatMessageValue: (value, {builtinSymbolSources}) => {
+      const rv = [];
+      value.forEach(key => {
+        builtinSymbolSources.forEach(source => {
+          if (source.sentry_key === key) {
+            rv.push(source.name);
+          }
+        });
+      });
+      return rv.join(', ');
+    },
     choices: ({builtinSymbolSources}) =>
       builtinSymbolSources &&
       builtinSymbolSources


### PR DESCRIPTION
This fixes the rendering bugs when selecting builtin symbol sources.  Previously we rendered
the internal array to string.

![image](https://user-images.githubusercontent.com/7396/69138085-525b4a80-0abe-11ea-90ad-b44e7f1170bb.png)
