### PR TITLE
ref(discover) Remove special casing in frontend by adding duration type

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -6,6 +6,7 @@ from functools import partial
 from rest_framework.response import Response
 
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
+from sentry.api.event_search import get_json_meta_type
 from sentry.api.helpers.events import get_direct_hit_response
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import EventSerializer, serialize, SimpleEventSerializer
@@ -140,7 +141,10 @@ class OrganizationEventsV2Endpoint(OrganizationEventsEndpointBase):
         if not data:
             return {"data": [], "meta": {}}
 
-        meta = {value["name"]: snuba.get_json_type(value["type"]) for value in results["meta"]}
+        meta = {
+            value["name"]: get_json_meta_type(value["name"], value["type"])
+            for value in results["meta"]
+        }
         # Ensure all columns in the result have types.
         for key in data[0]:
             if key not in meta:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -22,7 +22,7 @@ from sentry.search.utils import (
 )
 from sentry.snuba.events import get_columns_from_aliases
 from sentry.utils.dates import to_timestamp
-from sentry.utils.snuba import Dataset, DATASETS, get_snuba_column_name
+from sentry.utils.snuba import Dataset, DATASETS, get_snuba_column_name, get_json_type
 
 WILDCARD_CHARS = re.compile(r"[\*]")
 
@@ -683,10 +683,19 @@ FIELD_ALIASES = {
     "user": {"fields": ["user.id", "user.name", "user.username", "user.email", "user.ip"]},
     # Long term these will become more complex functions but these are
     # field aliases.
-    "apdex": {"aggregations": [["apdex(duration, 300)", "", "apdex"]]},
-    "p75": {"aggregations": [["quantileTiming(0.75)(duration)", "", "p75"]]},
-    "p95": {"aggregations": [["quantileTiming(0.95)(duration)", "", "p95"]]},
-    "p99": {"aggregations": [["quantileTiming(0.99)(duration)", "", "p99"]]},
+    "apdex": {"result_type": "number", "aggregations": [["apdex(duration, 300)", "", "apdex"]]},
+    "p75": {
+        "result_type": "duration",
+        "aggregations": [["quantileTiming(0.75)(duration)", "", "p75"]],
+    },
+    "p95": {
+        "result_type": "duration",
+        "aggregations": [["quantileTiming(0.95)(duration)", "", "p95"]],
+    },
+    "p99": {
+        "result_type": "duration",
+        "aggregations": [["quantileTiming(0.99)(duration)", "", "p99"]],
+    },
 }
 
 VALID_AGGREGATES = {
@@ -698,6 +707,15 @@ VALID_AGGREGATES = {
 }
 
 AGGREGATE_PATTERN = re.compile(r"^(?P<function>[^\(]+)\((?P<column>[a-z\._]*)\)$")
+
+
+def get_json_meta_type(field, snuba_type):
+    alias_definition = FIELD_ALIASES.get(field)
+    if alias_definition and alias_definition.get("result_type"):
+        return alias_definition.get("result_type")
+    if "duration" in field:
+        return "duration"
+    return get_json_type(snuba_type)
 
 
 def validate_aggregate(field, match):

--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -19,7 +19,13 @@ import {QueryLink} from './styles';
 import {generateEventDetailsRoute, generateEventSlug} from './eventDetails/utils';
 
 export const PIN_ICON = `image://${pinIcon}`;
-export const AGGREGATE_ALIASES = ['p95', 'p75', 'last_seen', 'latest_event'] as const;
+export const AGGREGATE_ALIASES = [
+  'apdex',
+  'p95',
+  'p75',
+  'last_seen',
+  'latest_event',
+] as const;
 
 export const DEFAULT_EVENT_VIEW: Readonly<NewQuery> = {
   id: undefined,

--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -141,10 +141,11 @@ export const FIELDS: {[key: string]: ColumnValueType} = {
   'transaction.duration': 'duration',
   'transaction.op': 'string',
   apdex: 'number',
+
   // duration aliases
-  p75: 'number',
-  p95: 'number',
-  p99: 'number',
+  p75: 'duration',
+  p95: 'duration',
+  p99: 'duration',
 };
 export type Field = keyof typeof FIELDS | string | '';
 
@@ -159,9 +160,3 @@ export const TRACING_FIELDS = [
   'p95',
   'p75',
 ];
-
-// list of fields that are duration-like
-export const DURATION_FIELDS = ['transaction.duration', 'p99', 'p95', 'p75'];
-// acceptable list of aggregate functions, that, when applied to any of the duration-like
-// fields in DURATION_FIELDS, the resulting expression is still duration-like
-export const DURATION_AGGREGATION_WHITELIST = ['min', 'max', 'sum', 'avg'];

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -27,8 +27,6 @@ import {
   AGGREGATIONS,
   FIELDS,
   ColumnValueType,
-  DURATION_FIELDS,
-  DURATION_AGGREGATION_WHITELIST,
 } from './eventQueryParams';
 import {TableColumn} from './table/types';
 
@@ -59,16 +57,6 @@ export function explodeField(
   const results = explodeFieldString(field.field);
 
   return {aggregation: results.aggregation, field: results.field, fieldname: field.title};
-}
-
-function isDuration(input: {aggregation: string; field: string}): boolean {
-  if (input.aggregation !== '') {
-    if (!DURATION_AGGREGATION_WHITELIST.includes(input.aggregation)) {
-      return false;
-    }
-  }
-
-  return DURATION_FIELDS.includes(input.field);
 }
 
 /**
@@ -212,12 +200,6 @@ export function getFieldRenderer(
   // use a different formatter set based on the type.
   if (forceLink && LINK_FORMATTERS.hasOwnProperty(fieldType)) {
     return partial(LINK_FORMATTERS[fieldType], fieldName);
-  }
-
-  const explodedField = explodeFieldString(field);
-
-  if (isDuration(explodedField)) {
-    return partial(FIELD_FORMATTERS.duration.renderFunc, fieldName);
   }
 
   if (FIELD_FORMATTERS.hasOwnProperty(fieldType)) {

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -15,6 +15,7 @@ from sentry.api.event_search import (
     resolve_field_list,
     get_reference_event_conditions,
     parse_search_query,
+    get_json_meta_type,
     InvalidSearchQuery,
     SearchBoolean,
     SearchFilter,
@@ -25,6 +26,25 @@ from sentry.api.event_search import (
 from sentry.utils.samples import load_data
 from sentry.testutils import TestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+
+
+def test_get_json_meta_type():
+    assert get_json_meta_type("project_id", "UInt8") == "boolean"
+    assert get_json_meta_type("project_id", "UInt16") == "integer"
+    assert get_json_meta_type("project_id", "UInt32") == "integer"
+    assert get_json_meta_type("project_id", "UInt64") == "integer"
+    assert get_json_meta_type("project_id", "Float32") == "number"
+    assert get_json_meta_type("project_id", "Float64") == "number"
+    assert get_json_meta_type("value", "Nullable(Float64)") == "number"
+    assert get_json_meta_type("exception_stacks.type", "Array(String)") == "array"
+    assert get_json_meta_type("transaction", "Char") == "string"
+    assert get_json_meta_type("foo", "unknown") == "string"
+    assert get_json_meta_type("other", "") == "string"
+    assert get_json_meta_type("p99", "number") == "duration"
+    assert get_json_meta_type("p95", "number") == "duration"
+    assert get_json_meta_type("p75", "number") == "duration"
+    assert get_json_meta_type("avg_duration", "number") == "duration"
+    assert get_json_meta_type("duration", "number") == "duration"
 
 
 class ParseSearchQueryTest(unittest.TestCase):

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -571,3 +571,4 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             )
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
+        assert response.data["meta"]["transaction_duration"] == "duration"

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -571,4 +571,4 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             )
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
-        assert response.data["meta"]["transaction_duration"] == "duration"
+        assert response.data["meta"]["transaction.duration"] == "duration"


### PR DESCRIPTION
Add a new 'type' to the API responses for duration values. This lets us remove a bunch of special casing in the front-end code to work around number types that need duration formatting.

I've also added apdex as an aggregate alias which allows it to be plotted on the graph.