### PR TITLE
feat(discover2): Remove overflow:hidden and update borders for QueryBuilder

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -29,7 +29,7 @@ type GridEditableProps = {
 };
 
 export const GridPanel = styled(Panel)`
-  overflow: hidden;
+  /* overflow: hidden; */
 `;
 export const GridPanelBody = styled(PanelBody)``;
 
@@ -57,8 +57,8 @@ export const Grid = styled('table')<GridEditableProps>`
   border-collapse: collapse;
   margin: 0;
 
-  background-color: ${p => p.theme.offWhite};
-  overflow: hidden;
+  /* background-color: ${p => p.theme.offWhite}; */
+  /* overflow: hidden; */
 
   /* For the last column, we want to have some space on the right if column
      is editable.
@@ -80,6 +80,13 @@ export const Grid = styled('table')<GridEditableProps>`
 `;
 export const GridRow = styled('tr')`
   display: contents;
+
+  &:last-child,
+  &:last-child > td:first-child,
+  &:last-child > td:last-child {
+    border-bottom-left-radius: ${p => p.theme.borderRadius};
+    border-bottom-right-radius: ${p => p.theme.borderRadius};
+  }
 `;
 
 /**
@@ -99,8 +106,13 @@ export const GridHeadCell = styled('th')`
   min-width: 0;
   height: ${GRID_HEADER_HEIGHT}px;
 
-  border-bottom: 1px solid ${p => p.theme.borderDark};
   background: ${p => p.theme.offWhite};
+  border-bottom: 1px solid ${p => p.theme.borderDark};
+  border-right: 1px solid ${p => p.theme.borderDark};
+
+  &:last-child {
+    border-right: none;
+  }
 `;
 export const GridHeadCellButton = styled('div')<GridEditableProps>`
   position: relative;
@@ -282,10 +294,16 @@ export const GridBodyCell = styled('td')`
      We override this by setting min-width to be 0. */
   min-width: 0;
   padding: ${space(2)} ${space(2)};
+
   background-color: ${p => p.theme.white};
   border-bottom: 1px solid ${p => p.theme.borderLight};
+  border-right: 1px solid ${p => p.theme.borderDark};
 
   font-size: ${p => p.theme.fontSizeMedium};
+
+  &:last-child {
+    border-right: none;
+  }
 `;
 export const GridBodyCellSpan = styled(GridBodyCell)`
   grid-column: 1 / -1;
@@ -313,6 +331,7 @@ export const GridEditGroup = styled('th')`
 
   background-color: ${p => p.theme.offWhite};
   border-bottom: 1px solid ${p => p.theme.borderDark};
+  border-top-right-radius: ${p => p.theme.borderRadius};
 
   z-index: ${Z_INDEX_EDITABLE};
 `;


### PR DESCRIPTION
- This commit is part of a series of small changes that'll bring the table UIUX closer to its intended design

### Before
![image](https://user-images.githubusercontent.com/1748388/69192030-9a876680-0ad8-11ea-8f0e-0c07374bbcf1.png)

### After
![image](https://user-images.githubusercontent.com/1748388/69192037-9f4c1a80-0ad8-11ea-941d-427d2a8c008f.png)

I'm aware that the border radius on the top-left top-right of the table are covered and they will be fixed in a soon-to-come PR where the "Add Column" button will be moved entirely out of the table.