### PR TITLE
feat(sdk): Improve organization context

### DIFF
--- a/src/sentry/api/bases/monitor.py
+++ b/src/sentry/api/bases/monitor.py
@@ -5,7 +5,7 @@ from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.bases.project import ProjectPermission
 from sentry.models import Monitor, Project, ProjectStatus
-from sentry.utils.sdk import configure_scope
+from sentry.utils.sdk import configure_scope, bind_organization_context
 
 
 class MonitorEndpoint(Endpoint):
@@ -30,8 +30,9 @@ class MonitorEndpoint(Endpoint):
         self.check_object_permissions(request, project)
 
         with configure_scope() as scope:
-            scope.set_tag("organization", project.organization_id)
             scope.set_tag("project", project.id)
+
+        bind_organization_context(project.organization)
 
         request._request.organization = project.organization
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -21,7 +21,7 @@ from sentry.models import (
 )
 from sentry.utils import auth
 from sentry.utils.hashlib import hash_values
-from sentry.utils.sdk import configure_scope
+from sentry.utils.sdk import bind_organization_context
 
 
 class OrganizationEventsError(Exception):
@@ -266,8 +266,7 @@ class OrganizationEndpoint(Endpoint):
 
         self.check_object_permissions(request, organization)
 
-        with configure_scope() as scope:
-            scope.set_tag("organization", organization.id)
+        bind_organization_context(organization)
 
         request._request.organization = organization
 

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -8,7 +8,7 @@ from sentry.api.exceptions import ResourceDoesNotExist, ProjectMoved
 from sentry.auth.superuser import is_active_superuser
 from sentry.auth.system import is_system_auth
 from sentry.models import OrganizationMember, Project, ProjectStatus, ProjectRedirect
-from sentry.utils.sdk import configure_scope
+from sentry.utils.sdk import configure_scope, bind_organization_context
 
 from .organization import OrganizationPermission
 from .team import has_team_permission
@@ -147,7 +147,8 @@ class ProjectEndpoint(Endpoint):
 
         with configure_scope() as scope:
             scope.set_tag("project", project.id)
-            scope.set_tag("organization", project.organization_id)
+
+        bind_organization_context(project.organization)
 
         request._request.organization = project.organization
 

--- a/src/sentry/api/bases/team.py
+++ b/src/sentry/api/bases/team.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.models import Team, TeamStatus
-from sentry.utils.sdk import configure_scope
+from sentry.utils.sdk import bind_organization_context
 
 from .organization import OrganizationPermission
 
@@ -47,8 +47,7 @@ class TeamEndpoint(Endpoint):
 
         self.check_object_permissions(request, team)
 
-        with configure_scope() as scope:
-            scope.set_tag("organization", team.organization_id)
+        bind_organization_context(team.organization)
 
         request._request.organization = team.organization
 

--- a/src/sentry/api/endpoints/monitor_checkin_details.py
+++ b/src/sentry/api/endpoints/monitor_checkin_details.py
@@ -20,7 +20,7 @@ from sentry.models import (
     ProjectKey,
     ProjectStatus,
 )
-from sentry.utils.sdk import configure_scope
+from sentry.utils.sdk import configure_scope, bind_organization_context
 
 
 class CheckInSerializer(serializers.Serializer):
@@ -59,8 +59,9 @@ class MonitorCheckInDetailsEndpoint(Endpoint):
         self.check_object_permissions(request, project)
 
         with configure_scope() as scope:
-            scope.set_tag("organization", project.organization_id)
             scope.set_tag("project", project.id)
+
+        bind_organization_context(project.organization)
 
         try:
             checkin = MonitorCheckIn.objects.get(monitor=monitor, guid=checkin_id)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1405,6 +1405,14 @@ def get_sentry_sdk_config():
 
 SENTRY_SDK_CONFIG = get_sentry_sdk_config()
 
+# Callable to bind additional context for the Sentry SDK
+#
+# def get_org_context(scope, organization, **kwargs):
+#    scope.set_tag('organization.cool', '1')
+#
+# SENTRY_ORGANIZATION_CONTEXT_HELPER = get_org_context
+SENTRY_ORGANIZATION_CONTEXT_HELPER = None
+
 # Config options that are explicitly disabled from Django
 DEAD = object()
 

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -13,7 +13,7 @@ from sentry.cache import default_cache
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json
 from sentry.utils.files import get_max_file_size
-from sentry.utils.sdk import configure_scope
+from sentry.utils.sdk import configure_scope, bind_organization_context
 
 logger = logging.getLogger(__name__)
 
@@ -167,10 +167,10 @@ def assemble_artifacts(org_id, version, checksum, chunks, **kwargs):
     from sentry.utils.zip import safe_extract_zip
     from sentry.models import File, Organization, Release, ReleaseFile
 
-    with configure_scope() as scope:
-        scope.set_tag("organization", org_id)
+    organization = Organization.objects.get(id=org_id)
 
-    organization = Organization.objects.filter(id=org_id).get()
+    bind_organization_context(organization)
+
     set_assemble_status(AssembleTask.ARTIFACTS, org_id, checksum, ChunkFileState.ASSEMBLING)
 
     # Assemble the chunks into a temporary file

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -235,3 +235,20 @@ class RavenShim(object):
             scope.set_tag(key, value)
         if fingerprint is not None:
             scope.fingerprint = fingerprint
+
+
+def bind_organization_context(organization):
+    helper = settings.SENTRY_ORGANIZATION_CONTEXT_HELPER
+
+    with sentry_sdk.configure_scope() as scope:
+        scope.set_tag("organization", organization.id)
+        scope.set_tag("organization.slug", organization.slug)
+        scope.set_context("organization", {"id": organization.id, "slug": organization.slug})
+        if helper:
+            try:
+                helper(scope=scope, organization=organization)
+            except Exception:
+                sdk_logger.exception(
+                    "internal-error.organization-context",
+                    extra={"organization_id": organization.id},
+                )


### PR DESCRIPTION
- Add organization.slug tag
- Add organization context (id, slug)
- Add SENTRY_ORGANIZATION_CONTEXT_HELPER setting

The SENTRY_ORGANIZATION_CONTEXT_HELPER will allow our saas service to define additional subscription-related context.