### PR TITLE
feat(discover2): Move buttons to add/edit columns out of the Grid

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/gridHeadCell.tsx
@@ -13,7 +13,6 @@ import {
   GridHeadCellResizer,
 } from './styles';
 import {GridColumnHeader} from './types';
-import AddColumnButton from './addColumnButton';
 
 export type GridHeadCellProps<Column> = {
   isColumnDragging: boolean;
@@ -132,31 +131,6 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
     return <GridHeadCellResizer isEditing={isEditing} />;
   };
 
-  renderAddColumnButton = () => {
-    const {
-      isEditing,
-      isLast,
-      openModalAddColumnAt,
-      indexColumnOrder,
-      isColumnDragging,
-    } = this.props;
-
-    if (isLast || !isEditing || isColumnDragging) {
-      return null;
-    }
-
-    return (
-      <AddColumnButton
-        align="right"
-        onClick={() => {
-          const insertIndex = indexColumnOrder + 1;
-          openModalAddColumnAt(insertIndex);
-        }}
-        data-test-id={`grid-add-column-${indexColumnOrder}`}
-      />
-    );
-  };
-
   render() {
     const {isEditing, children, column, gridHeadCellButtonProps} = this.props;
 
@@ -179,7 +153,6 @@ class GridHeadCell<Column extends GridColumnHeader> extends React.Component<
           to ensure that it is will always
           float on top of everything else */
         this.renderResizeGrabbable()}
-        {this.renderAddColumnButton()}
       </GridHeadCellWrapper>
     );
   }

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -30,8 +30,6 @@ import {
   GridBodyCellSpan,
   GridBodyCellLoading,
   GridBodyErrorAlert,
-  GridEditGroup,
-  GridEditGroupButton,
 } from './styles';
 
 type GridEditableProps<DataRow, ColumnKey> = {
@@ -179,7 +177,7 @@ class GridEditable<
     return (
       <HeaderButton onClick={() => this.openModalAddColumnAt()}>
         <InlineSvg src="icon-circle-add" />
-        Add Column
+        {t('Add Column')}
       </HeaderButton>
     );
   };
@@ -189,31 +187,31 @@ class GridEditable<
       return null;
     }
 
+    const sorryMessage = t('This will be improved soon! Please bear with us!');
+
     if (!this.state.isEditing) {
       return (
-        <GridEditGroup>
-          <GridEditGroupButton onClick={this.toggleEdit} data-test-id="grid-edit-enable">
-            <ToolTip title={t('Edit Columns')}>
-              <InlineSvg src="icon-edit-pencil" />
-            </ToolTip>
-          </GridEditGroupButton>
-        </GridEditGroup>
+        <ToolTip title={sorryMessage}>
+          <HeaderButton onClick={this.toggleEdit}>
+            <InlineSvg src="icon-edit-pencil" />
+            Edit Columns
+          </HeaderButton>
+        </ToolTip>
       );
     }
 
     return (
-      <GridEditGroup>
-        <GridEditGroupButton onClick={this.toggleEdit}>
-          <ToolTip title={t('Exit Edit')}>
-            <InlineSvg src="icon-close" />
-          </ToolTip>
-        </GridEditGroupButton>
-      </GridEditGroup>
+      <ToolTip title={sorryMessage}>
+        <HeaderButton onClick={this.toggleEdit}>
+          <InlineSvg src="icon-circle-close" />
+          Exit Edit
+        </HeaderButton>
+      </ToolTip>
     );
   };
 
   renderGridHead = () => {
-    const {isEditable, columnOrder, actions, grid} = this.props;
+    const {columnOrder, actions, grid} = this.props;
     const {isEditing} = this.state;
 
     // Ensure that the last column cannot be removed
@@ -222,25 +220,6 @@ class GridEditable<
     return (
       <GridHead>
         <GridRow>
-          {/* GridHeadEdit must come first.
-
-              It is a <th> that uses `position: absolute` to set its placement.
-              The CSS selectors captures the last GridHeadCell and put a
-              padding-right to provide space for GridHeadEdit to be displayed.
-
-              FAQ:
-              Instead of using `position: absolute`, why can't we just put
-              GridHeadEdit at the end so it appears on the right?
-              Because CSS Grids need to have the same number of Head/Body cells
-              for everything to align properly. Sub-grids are new and may not be
-              well supported in older browsers/
-
-              Why can't we just put GridHeadEdit somewhere else?
-              Because HTML rules mandate that <div> cannot be a nested child of
-              a <table>. This seems the best way to make it correct to satisfy
-              HTML semantics. */
-          isEditable && this.renderGridHeadEditButtons()}
-
           {columnOrder.map((column, columnIndex) => (
             <GridHeadCell
               openModalAddColumnAt={this.openModalAddColumnAt}
@@ -346,7 +325,7 @@ class GridEditable<
   };
 
   render() {
-    const {title} = this.props;
+    const {title, isEditable} = this.props;
 
     return (
       <React.Fragment>
@@ -354,7 +333,16 @@ class GridEditable<
           {/* TODO(leedongwei): Check with Bowen/Dora on what they want the
           default title to be */}
           <HeaderTitle>{title || 'Query Builder'}</HeaderTitle>
-          {this.renderHeaderButton()}
+
+          {/* TODO(leedongwei): This is ugly but I need to move it to work on
+          resizing columns. It will be refactored in a upcoming PR */}
+          <div style={{display: 'flex', flexDirection: 'row'}}>
+            {this.renderHeaderButton()}
+
+            <div style={{marginLeft: '16px'}}>
+              {isEditable && this.renderGridHeadEditButtons()}
+            </div>
+          </div>
         </Header>
 
         <Body>

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -6,7 +6,6 @@ import {openModal} from 'app/actionCreators/modal';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import InlineSvg from 'app/components/inlineSvg';
 import LoadingContainer from 'app/components/loading/loadingContainer';
-import ToolTip from 'app/components/tooltip';
 
 import {
   GridColumn,

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -212,33 +212,31 @@ class GridEditable<
     const enableEdit = isEditing && columnOrder.length > 1;
 
     return (
-      <GridHead>
-        <GridRow>
-          {columnOrder.map((column, columnIndex) => (
-            <GridHeadCell
-              openModalAddColumnAt={this.openModalAddColumnAt}
-              isLast={columnOrder.length - 1 === columnIndex}
-              key={`${columnIndex}.${column.key}`}
-              isColumnDragging={this.props.isColumnDragging}
-              isPrimary={column.isPrimary}
-              isEditing={enableEdit}
-              indexColumnOrder={columnIndex}
-              column={column}
-              gridHeadCellButtonProps={this.props.gridHeadCellButtonProps || {}}
-              actions={{
-                moveColumnCommit: actions.moveColumnCommit,
-                onDragStart: actions.onDragStart,
-                deleteColumn: actions.deleteColumn,
-                toggleModalEditColumn: this.toggleModalEditColumn,
-              }}
-            >
-              {grid.renderHeaderCell
-                ? grid.renderHeaderCell(column, columnIndex)
-                : column.name}
-            </GridHeadCell>
-          ))}
-        </GridRow>
-      </GridHead>
+      <GridRow>
+        {columnOrder.map((column, columnIndex) => (
+          <GridHeadCell
+            openModalAddColumnAt={this.openModalAddColumnAt}
+            isLast={columnOrder.length - 1 === columnIndex}
+            key={`${columnIndex}.${column.key}`}
+            isColumnDragging={this.props.isColumnDragging}
+            isPrimary={column.isPrimary}
+            isEditing={enableEdit}
+            indexColumnOrder={columnIndex}
+            column={column}
+            gridHeadCellButtonProps={this.props.gridHeadCellButtonProps || {}}
+            actions={{
+              moveColumnCommit: actions.moveColumnCommit,
+              onDragStart: actions.onDragStart,
+              deleteColumn: actions.deleteColumn,
+              toggleModalEditColumn: this.toggleModalEditColumn,
+            }}
+          >
+            {grid.renderHeaderCell
+              ? grid.renderHeaderCell(column, columnIndex)
+              : column.name}
+          </GridHeadCell>
+        ))}
+      </GridRow>
     );
   };
 
@@ -257,7 +255,7 @@ class GridEditable<
       return this.renderEmptyData();
     }
 
-    return <GridBody>{data.map(this.renderGridBodyRow)}</GridBody>;
+    return data.map(this.renderGridBodyRow);
   };
 
   renderGridBodyRow = (dataRow: DataRow, row: number) => {
@@ -278,43 +276,37 @@ class GridEditable<
     const {error} = this.props;
 
     return (
-      <GridBody>
-        <GridRow>
-          <GridBodyCellSpan>
-            <GridBodyErrorAlert type="error" icon="icon-circle-exclamation">
-              {error}
-            </GridBodyErrorAlert>
-          </GridBodyCellSpan>
-        </GridRow>
-      </GridBody>
+      <GridRow>
+        <GridBodyCellSpan>
+          <GridBodyErrorAlert type="error" icon="icon-circle-exclamation">
+            {error}
+          </GridBodyErrorAlert>
+        </GridBodyCellSpan>
+      </GridRow>
     );
   };
 
   renderLoading = () => {
     return (
-      <GridBody>
-        <GridRow>
-          <GridBodyCellSpan>
-            <GridBodyCellLoading>
-              <LoadingContainer isLoading />
-            </GridBodyCellLoading>
-          </GridBodyCellSpan>
-        </GridRow>
-      </GridBody>
+      <GridRow>
+        <GridBodyCellSpan>
+          <GridBodyCellLoading>
+            <LoadingContainer isLoading />
+          </GridBodyCellLoading>
+        </GridBodyCellSpan>
+      </GridRow>
     );
   };
 
   renderEmptyData = () => {
     return (
-      <GridBody>
-        <GridRow>
-          <GridBodyCellSpan>
-            <EmptyStateWarning>
-              <p>{t('No results found')}</p>
-            </EmptyStateWarning>
-          </GridBodyCellSpan>
-        </GridRow>
-      </GridBody>
+      <GridRow>
+        <GridBodyCellSpan>
+          <EmptyStateWarning>
+            <p>{t('No results found')}</p>
+          </EmptyStateWarning>
+        </GridBodyCellSpan>
+      </GridRow>
     );
   };
 
@@ -345,8 +337,8 @@ class GridEditable<
             isEditing={this.state.isEditing}
             numColumn={this.state.numColumn}
           >
-            {this.renderGridHead()}
-            {this.renderGridBody()}
+            <GridHead>{this.renderGridHead()}</GridHead>
+            <GridBody>{this.renderGridBody()}</GridBody>
           </Grid>
         </Body>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -187,26 +187,20 @@ class GridEditable<
       return null;
     }
 
-    const sorryMessage = t('This will be improved soon! Please bear with us!');
-
     if (!this.state.isEditing) {
       return (
-        <ToolTip title={sorryMessage}>
-          <HeaderButton onClick={this.toggleEdit}>
-            <InlineSvg src="icon-edit-pencil" />
-            Edit Columns
-          </HeaderButton>
-        </ToolTip>
+        <HeaderButton onClick={this.toggleEdit}>
+          <InlineSvg src="icon-edit-pencil" />
+          {t('Edit Columns')}
+        </HeaderButton>
       );
     }
 
     return (
-      <ToolTip title={sorryMessage}>
-        <HeaderButton onClick={this.toggleEdit}>
-          <InlineSvg src="icon-circle-close" />
-          Exit Edit
-        </HeaderButton>
-      </ToolTip>
+      <HeaderButton onClick={this.toggleEdit}>
+        <InlineSvg src="icon-circle-close" />
+        {t('Exit Edit')}
+      </HeaderButton>
     );
   };
 
@@ -332,7 +326,7 @@ class GridEditable<
         <Header>
           {/* TODO(leedongwei): Check with Bowen/Dora on what they want the
           default title to be */}
-          <HeaderTitle>{title || 'Query Builder'}</HeaderTitle>
+          <HeaderTitle>{title || t('Query Builder')}</HeaderTitle>
 
           {/* TODO(leedongwei): This is ugly but I need to move it to work on
           resizing columns. It will be refactored in a upcoming PR */}

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -174,7 +174,10 @@ class GridEditable<
     }
 
     return (
-      <HeaderButton onClick={() => this.openModalAddColumnAt()}>
+      <HeaderButton
+        onClick={() => this.openModalAddColumnAt()}
+        data-test-id="grid-add-column"
+      >
         <InlineSvg src="icon-circle-add" />
         {t('Add Column')}
       </HeaderButton>
@@ -188,7 +191,7 @@ class GridEditable<
 
     if (!this.state.isEditing) {
       return (
-        <HeaderButton onClick={this.toggleEdit}>
+        <HeaderButton onClick={this.toggleEdit} data-test-id="grid-edit-enable">
           <InlineSvg src="icon-edit-pencil" />
           {t('Edit Columns')}
         </HeaderButton>
@@ -196,7 +199,7 @@ class GridEditable<
     }
 
     return (
-      <HeaderButton onClick={this.toggleEdit}>
+      <HeaderButton onClick={this.toggleEdit} data-test-id="grid-edit-disable">
         <InlineSvg src="icon-circle-close" />
         {t('Exit Edit')}
       </HeaderButton>

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import styled from 'react-emotion';
 
 import Alert from 'app/components/alert';
@@ -28,10 +29,48 @@ type GridEditableProps = {
   isDragging?: boolean;
 };
 
-export const GridPanel = styled(Panel)`
-  /* overflow: hidden; */
+/**
+ *
+ * As
+ *
+ */
+export const Header = styled('div')`
+  display: flex;
+  /* flex-direction: ; */
+  justify-content: space-between;
+  align-items: center;
+
+  margin-bottom: ${space(1)};
 `;
-export const GridPanelBody = styled(PanelBody)``;
+export const HeaderTitle = styled('h2')`
+  margin: 0;
+
+  font-size: 20px;
+  font-weight: normal;
+  color: ${p => p.theme.gray3};
+`;
+export const HeaderButton = styled('div')`
+  display: flex;
+  align-items: center;
+
+  color: ${p => p.theme.gray3};
+  cursor: pointer;
+
+  > svg {
+    margin-right: ${space(1)};
+  }
+
+  &:hover,
+  &:active {
+    color: ${p => p.theme.gray4};
+  }
+`;
+
+export const Body: React.FC = props => (
+  <Panel>
+    <PanelBody>{props.children}</PanelBody>
+  </Panel>
+);
 
 /**
  *

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -8,9 +8,6 @@ import space from 'app/styles/space';
 
 export const ADD_BUTTON_SIZE = 16; // this is an even number
 export const GRID_HEADER_HEIGHT = 45;
-const GRID_EDIT_WIDTH = 35;
-const GRID_EDIT_WIDTH_EDIT_MODE =
-  GRID_EDIT_WIDTH + ADD_BUTTON_SIZE / 2 + (12 - ADD_BUTTON_SIZE / 2);
 
 /**
  * Explanation of z-index:
@@ -18,8 +15,7 @@ const GRID_EDIT_WIDTH_EDIT_MODE =
  *  - Editable needs to float above Resizer to hide the right-most Resizer,
  */
 const Z_INDEX_RESIZER = '1';
-const Z_INDEX_EDITABLE = '10';
-export const Z_INDEX_ADD_COLUMN = '20';
+export const Z_INDEX_ADD_COLUMN = '20'; // TODO(leedongwei): Remove with addColumnButton.tsx
 
 type GridEditableProps = {
   numColumn?: number;
@@ -29,11 +25,6 @@ type GridEditableProps = {
   isDragging?: boolean;
 };
 
-/**
- *
- * As
- *
- */
 export const Header = styled('div')`
   display: flex;
   /* flex-direction: ; */
@@ -97,25 +88,6 @@ export const Grid = styled('table')<GridEditableProps>`
   margin: 0;
 
   /* background-color: ${p => p.theme.offWhite}; */
-  /* overflow: hidden; */
-
-  /* For the last column, we want to have some space on the right if column
-     is editable.
-
-     For the header, we set padding for 1 or 2 buttons depending on state
-     For the body, use "td:last-child" */
-  th:last-child {
-    ${p => {
-      if (!p.isEditable) {
-        return 'padding-right: 0px';
-      }
-      if (!p.isEditing) {
-        return `padding-right: ${GRID_EDIT_WIDTH}px;`;
-      }
-
-      return `padding-right: ${GRID_EDIT_WIDTH_EDIT_MODE}px;`;
-    }}
-  }
 `;
 export const GridRow = styled('tr')`
   display: contents;
@@ -353,53 +325,4 @@ export const GridBodyCellLoading = styled('div')`
 
 export const GridBodyErrorAlert = styled(Alert)`
   margin: 0;
-`;
-
-/**
- *
- * GridEditGroup are the buttons that are on the top right of the Grid that
- * allows the user to add/remove/resize the columns of the Grid
- *
- */
-export const GridEditGroup = styled('th')`
-  position: absolute;
-  top: 0;
-  right: 0;
-  display: flex;
-  height: ${GRID_HEADER_HEIGHT}px;
-
-  background-color: ${p => p.theme.offWhite};
-  border-bottom: 1px solid ${p => p.theme.borderDark};
-  border-top-right-radius: ${p => p.theme.borderRadius};
-
-  z-index: ${Z_INDEX_EDITABLE};
-`;
-export const GridEditGroupButton = styled('div')`
-  display: block;
-  width: ${GRID_EDIT_WIDTH}px;
-  height: ${GRID_HEADER_HEIGHT}px;
-
-  color: ${p => p.theme.gray2};
-  font-size: 16px;
-  cursor: pointer;
-
-  &:hover {
-    color: ${p => p.theme.gray3};
-  }
-  &:active {
-    color: ${p => p.theme.gray4};
-  }
-  &:last-child {
-    border-left: 1px solid ${p => p.theme.borderDark};
-  }
-
-  /* Targets ToolTip to ensure that it will fill up the parent element and
-     its child elements will float in its center */
-  > span {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    height: 100%;
-  }
 `;

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -35,7 +35,7 @@ export const Header = styled('div')`
 export const HeaderTitle = styled('h2')`
   margin: 0;
 
-  font-size: 20px;
+  font-size: ${p => p.theme.headerFontSize};
   font-weight: normal;
   color: ${p => p.theme.gray3};
 `;

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -27,7 +27,6 @@ type GridEditableProps = {
 
 export const Header = styled('div')`
   display: flex;
-  /* flex-direction: ; */
   justify-content: space-between;
   align-items: center;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -4,6 +4,7 @@ import {browserHistory} from 'react-router';
 import styled from 'react-emotion';
 
 import {Client} from 'app/api';
+import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import withApi from 'app/utils/withApi';
 
@@ -166,4 +167,5 @@ export default withApi<TableProps>(Table);
 const Container = styled('div')`
   min-width: 0;
   overflow: hidden;
+  margin-top: ${space(1.5)};
 `;

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -215,7 +215,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
                 "events-v2 - errors query - empty state - querybuilder - column edit state"
             )
 
-            self.browser.click_when_visible('[data-test-id="grid-add-column-right-end"]')
+            self.browser.click_when_visible('[data-test-id="grid-add-column"]')
             self.browser.snapshot(
                 "events-v2 - errors query - empty state - querybuilder - add column"
             )


### PR DESCRIPTION
- This commit is part of a series of small changes that'll bring the table UIUX closer to its intended design
- This commit is dependent on dc058b0 or #15682 to be merged

### Before
![image](https://user-images.githubusercontent.com/1748388/69205555-1bf1ef80-0aff-11ea-8f4f-6f9e2f51e573.png)


### After
![image](https://user-images.githubusercontent.com/1748388/69208094-27491900-0b07-11ea-86a2-0675a84a0138.png)
![image](https://user-images.githubusercontent.com/1748388/69208095-2adca000-0b07-11ea-880e-0d718efb1e10.png)


