### PR TITLE
Custom paginator for Discover 2 landing page

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -371,8 +371,8 @@ class FooOffsetPaginator(object):
 
         assert limit > 0
 
-        # offset is page #
-        # value is page limit
+        # cursors are:
+        #   (identifier(integer), row offset, is_prev)
         if cursor is None:
             cursor = Cursor(0, 0, 0)
 

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.serializers import serialize
 from sentry.api.bases import OrganizationEndpoint
-from sentry.api.paginator import DateTimePaginator, OffsetPaginator
+from sentry.api.paginator import FooOffsetPaginator
 from sentry.discover.models import DiscoverSavedQuery
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
@@ -47,16 +47,16 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         sort_by = request.query_params.get("sortBy")
         if sort_by in ("name", "-name"):
             order_by = sort_by
-            paginator_cls = OffsetPaginator
+            paginator_cls = FooOffsetPaginator
         elif sort_by in ("dateCreated", "-dateCreated"):
             order_by = "-date_created" if sort_by.startswith("-") else "date_created"
-            paginator_cls = DateTimePaginator
+            paginator_cls = FooOffsetPaginator
         elif sort_by in ("dateUpdated", "-dateUpdated"):
             order_by = "-date_updated" if sort_by.startswith("-") else "date_updated"
-            paginator_cls = DateTimePaginator
+            paginator_cls = FooOffsetPaginator
         else:
             order_by = "name"
-            paginator_cls = OffsetPaginator
+            paginator_cls = FooOffsetPaginator
 
         # Old discover expects all queries and uses this parameter.
         if request.query_params.get("all") == "1":

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -30,7 +30,7 @@ import EventInputName from './eventInputName';
 import {DEFAULT_EVENT_VIEW} from './data';
 import QueryList from './queryList';
 import DiscoverBreadcrumb from './breadcrumb';
-import {generateTitle} from './utils';
+import {getPrebuiltQueries, generateTitle} from './utils';
 
 const DISPLAY_SEARCH_BAR_FLAG = false;
 const BANNER_DISMISSED_KEY = 'discover-banner-dismissed';
@@ -48,6 +48,7 @@ type Props = {
 
 type State = {
   savedQueries: SavedQuery[];
+  savedQueriesPageLinks: string;
 } & AsyncComponent['state'];
 
 class DiscoverLanding extends AsyncComponent<Props, State> {
@@ -64,28 +65,57 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     errors: [],
     isBannerHidden: checkIsBannerHidden(),
     savedQueries: [],
+    savedQueriesPageLinks: '',
   };
 
   shouldReload = true;
 
   getEndpoints(): [string, string, any][] {
-    const {organization} = this.props;
+    const {organization, location} = this.props;
+    const views = getPrebuiltQueries(organization);
+    const cursor = location.query.cursor;
+    // XXX(mark) Pagination here is a bit wonky as we include the pre-built queries
+    // on the first page and aim to always have 9 results showing. If there are more than
+    // 9 pre-built queries we'll have more results on the first page. Furthermore, going
+    // back and forth between the first and second page is non-determinsitic due to the shifting
+    // per_page value.
+    let perPage = 9;
+    if (!cursor) {
+      perPage = Math.max(1, perPage - views.length);
+    }
+
+    const queryParams = {
+      cursor,
+      query: 'version:2',
+      per_page: perPage,
+      sortBy: '-dateUpdated',
+    };
+    if (!cursor) {
+      delete queryParams.cursor;
+    }
+
     return [
       [
         'savedQueries',
         `/organizations/${organization.slug}/discover/saved/`,
-        {query: {query: 'version:2'}},
+        {
+          query: queryParams,
+        },
       ],
     ];
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: Props) {
     const isBannerHidden = checkIsBannerHidden();
     if (isBannerHidden !== this.state.isBannerHidden) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
         isBannerHidden,
       });
+    }
+
+    if (prevProps.location.query.cursor !== this.props.location.query.cursor) {
+      this.fetchData();
     }
   }
 
@@ -154,86 +184,72 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     );
   }
 
-  renderNewQuery() {
+  renderQueryList() {
     const {location, organization} = this.props;
-    const {savedQueries} = this.state;
+    const {loading, savedQueries, savedQueriesPageLinks} = this.state;
 
     return (
       <div>
         {this.renderBanner()}
         {DISPLAY_SEARCH_BAR_FLAG && this.renderActions()}
-        <QueryList
-          savedQueries={savedQueries}
-          location={location}
-          organization={organization}
-        />
+        {loading && this.renderLoading()}
+        {!loading && (
+          <QueryList
+            pageLinks={savedQueriesPageLinks}
+            savedQueries={savedQueries}
+            location={location}
+            organization={organization}
+          />
+        )}
       </div>
     );
   }
 
-  renderQueryRename = (hasQuery: boolean, eventView: EventView) => {
-    if (!hasQuery) {
-      return null;
-    }
-
-    const {organization} = this.props;
+  renderResults(eventView: EventView) {
+    const {organization, location, router} = this.props;
     const {savedQueries} = this.state;
 
     return (
-      <div>
-        <EventInputName
-          savedQueries={savedQueries}
+      <React.Fragment>
+        <div>
+          <EventInputName
+            savedQueries={savedQueries}
+            organization={organization}
+            eventView={eventView}
+            onQuerySave={this.handleQuerySave}
+          />
+        </div>
+        <Events
           organization={organization}
+          location={location}
+          router={router}
           eventView={eventView}
-          onQuerySave={this.handleQuerySave}
         />
-      </div>
+      </React.Fragment>
     );
-  };
+  }
 
-  renderBody() {
-    const {organization, location, router} = this.props;
-    const eventView = EventView.fromLocation(location);
+  renderSavedQueryControls(eventView: EventView) {
+    const {organization, location} = this.props;
     const {savedQueries, reloading} = this.state;
 
-    const hasQuery = eventView.isValid();
-
     return (
-      <React.Fragment>
-        <PageHeader>
-          <DiscoverBreadcrumb
-            eventView={eventView}
-            organization={organization}
-            location={location}
-          />
-          {hasQuery && (
-            <SavedQueryButtonGroup
-              location={location}
-              organization={organization}
-              eventView={eventView}
-              savedQueries={savedQueries}
-              savedQueriesLoading={reloading}
-              onQuerySave={this.handleQuerySave}
-            />
-          )}
-        </PageHeader>
-        {this.renderQueryRename(hasQuery, eventView)}
-        {!hasQuery && this.renderNewQuery()}
-        {hasQuery && (
-          <Events
-            organization={organization}
-            location={location}
-            router={router}
-            eventView={eventView}
-          />
-        )}
-      </React.Fragment>
+      <SavedQueryButtonGroup
+        location={location}
+        organization={organization}
+        eventView={eventView}
+        savedQueries={savedQueries}
+        savedQueriesLoading={reloading}
+        onQuerySave={this.handleQuerySave}
+      />
     );
   }
 
   render() {
     const {organization, location} = this.props;
+
     const eventView = EventView.fromLocation(location);
+    const hasQuery = eventView.isValid();
 
     return (
       <Feature features={['events-v2']} organization={organization} renderDisabled>
@@ -245,7 +261,16 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
             <GlobalSelectionHeader organization={organization} />
             <PageContent>
               <NoProjectMessage organization={organization}>
-                {super.render()}
+                <PageHeader>
+                  <DiscoverBreadcrumb
+                    eventView={eventView}
+                    organization={organization}
+                    location={location}
+                  />
+                  {hasQuery && this.renderSavedQueryControls(eventView)}
+                </PageHeader>
+                {!hasQuery && this.renderQueryList()}
+                {hasQuery && this.renderResults(eventView)}
               </NoProjectMessage>
             </PageContent>
           </React.Fragment>

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -14,12 +14,14 @@ import {Client} from 'app/api';
 import InlineSvg from 'app/components/inlineSvg';
 import DropdownMenu from 'app/components/dropdownMenu';
 import MenuItem from 'app/components/menuItem';
+import Pagination from 'app/components/pagination';
 import withApi from 'app/utils/withApi';
+import parseLinkHeader from 'app/utils/parseLinkHeader';
 
 import EventView from './eventView';
-import {ALL_VIEWS, TRANSACTION_VIEWS} from './data';
 import QueryCard from './querycard';
 import MiniGraph from './miniGraph';
+import {getPrebuiltQueries} from './utils';
 import {handleDeleteQuery, handleCreateQuery} from './savedQuery/utils';
 
 type Props = {
@@ -27,6 +29,7 @@ type Props = {
   organization: Organization;
   location: Location;
   savedQueries: SavedQuery[];
+  pageLinks: string;
 };
 
 class QueryList extends React.Component<Props> {
@@ -59,15 +62,24 @@ class QueryList extends React.Component<Props> {
     });
   };
 
-  renderPrebuiltQueries = () => {
-    const {location, organization} = this.props;
-    let views = ALL_VIEWS;
-    if (organization.features.includes('transaction-events')) {
-      // insert transactions queries at index 2
-      const cloned = [...ALL_VIEWS];
-      cloned.splice(2, 0, ...TRANSACTION_VIEWS);
-      views = cloned;
+  renderQueries() {
+    const {pageLinks} = this.props;
+    const links = parseLinkHeader(pageLinks);
+    let cards: React.ReactNode[] = [];
+
+    // If we're on the first page (no-previous page exists)
+    // include the pre-built queries.
+    if (!links.previous || links.previous.results === false) {
+      cards = cards.concat(this.renderPrebuiltQueries());
     }
+    cards = cards.concat(this.renderSavedQueries());
+
+    return cards;
+  }
+
+  renderPrebuiltQueries() {
+    const {location, organization} = this.props;
+    const views = getPrebuiltQueries(organization);
 
     const list = views.map((view, index) => {
       const eventView = EventView.fromSavedQuery(view);
@@ -108,9 +120,9 @@ class QueryList extends React.Component<Props> {
     });
 
     return list;
-  };
+  }
 
-  renderSavedQueries = () => {
+  renderSavedQueries() {
     const {savedQueries, location, organization} = this.props;
 
     if (!savedQueries || !Array.isArray(savedQueries) || savedQueries.length === 0) {
@@ -172,14 +184,15 @@ class QueryList extends React.Component<Props> {
         />
       );
     });
-  };
+  }
 
   render() {
+    const {pageLinks} = this.props;
     return (
-      <QueryGrid>
-        {this.renderPrebuiltQueries()}
-        {this.renderSavedQueries()}
-      </QueryGrid>
+      <React.Fragment>
+        <QueryGrid>{this.renderQueries()}</QueryGrid>
+        <Pagination pageLinks={pageLinks} />
+      </React.Fragment>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -191,7 +191,23 @@ class QueryList extends React.Component<Props> {
     return (
       <React.Fragment>
         <QueryGrid>{this.renderQueries()}</QueryGrid>
-        <Pagination pageLinks={pageLinks} />
+        <Pagination
+          pageLinks={pageLinks}
+          onCursor={(cursor, path, query, direction) => {
+            const offset = Number(cursor.split(':')[1]);
+
+            const isPrevious = direction === -1;
+
+            if (offset <= 0 && isPrevious) {
+              cursor = undefined;
+            }
+
+            browserHistory.push({
+              pathname: path,
+              query: {...query, cursor},
+            });
+          }}
+        />
       </React.Fragment>
     );
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -4,7 +4,7 @@ import {Location, Query} from 'history';
 import {browserHistory} from 'react-router';
 
 import {t} from 'app/locale';
-import {Event} from 'app/types';
+import {Event, Organization} from 'app/types';
 import {Client} from 'app/api';
 import {getTitle} from 'app/utils/events';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
@@ -17,6 +17,8 @@ import {
   FIELD_FORMATTERS,
   FieldTypes,
   FieldFormatterRenderFunctionPartial,
+  ALL_VIEWS,
+  TRANSACTION_VIEWS,
 } from './data';
 import EventView, {Field as FieldType} from './eventView';
 import {
@@ -339,4 +341,16 @@ export function generateTitle({eventView, event}: {eventView: EventView; event?:
   titles.reverse();
 
   return titles.join(' - ');
+}
+
+export function getPrebuiltQueries(organization: Organization) {
+  let views = ALL_VIEWS;
+  if (organization.features.includes('transaction-events')) {
+    // insert transactions queries at index 2
+    const cloned = [...ALL_VIEWS];
+    cloned.splice(2, 0, ...TRANSACTION_VIEWS);
+    views = cloned;
+  }
+
+  return views;
 }

--- a/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
@@ -148,6 +148,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function() {
       // expect(wrapper.state('queryName')).toBe('');
 
       expect(mockUtils).not.toHaveBeenCalled();
+      expect(onQuerySave).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
For https://github.com/getsentry/sentry/pull/15670

One approach to making the pagination more deterministic.

Since we vary `per_page` on the first page, we use this as a `limit` param for the underlying queryset. We also use `per_page` to generate the previous/next cursors. Given cursor `X:Y:Z`, only `Y` is used as a reference point.

