### PR TITLE
fix(ui): Handle missing user in Access

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/access.tsx
+++ b/src/sentry/static/sentry/app/components/acl/access.tsx
@@ -104,7 +104,7 @@ class Access extends React.Component<Props> {
     const method = requireAll ? 'every' : 'some';
 
     const hasAccess = !access || access[method](acc => orgAccess.includes(acc));
-    const hasSuperuser = !!config.user.isSuperuser;
+    const hasSuperuser = !!(config.user && config.user.isSuperuser);
 
     const renderProps: ChildRenderProps = {
       hasAccess,

--- a/tests/js/spec/components/acl/access.spec.jsx
+++ b/tests/js/spec/components/acl/access.spec.jsx
@@ -95,6 +95,20 @@ describe('Access', function() {
       });
     });
 
+    it('handles no user', function() {
+      // Regression test for the share sheet.
+      ConfigStore.config = {
+        user: null,
+      };
+
+      mount(<Access>{childrenMock}</Access>, routerContext);
+
+      expect(childrenMock).toHaveBeenCalledWith({
+        hasAccess: true,
+        hasSuperuser: false,
+      });
+    });
+
     it('is superuser', function() {
       ConfigStore.config = {
         user: {isSuperuser: true},


### PR DESCRIPTION
The `Access` component throws if the user is not set, which is the case on the share sheet.

Fixes JAVASCRIPT-20TP