### PR TITLE
fix(discover) Use basic quantile function

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -686,15 +686,15 @@ FIELD_ALIASES = {
     "apdex": {"result_type": "number", "aggregations": [["apdex(duration, 300)", "", "apdex"]]},
     "p75": {
         "result_type": "duration",
-        "aggregations": [["quantileTiming(0.75)(duration)", "", "p75"]],
+        "aggregations": [["quantile(0.75)(duration)", "", "p75"]],
     },
     "p95": {
         "result_type": "duration",
-        "aggregations": [["quantileTiming(0.95)(duration)", "", "p95"]],
+        "aggregations": [["quantile(0.95)(duration)", "", "p95"]],
     },
     "p99": {
         "result_type": "duration",
-        "aggregations": [["quantileTiming(0.99)(duration)", "", "p99"]],
+        "aggregations": [["quantile(0.99)(duration)", "", "p99"]],
     },
 }
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1042,9 +1042,9 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["aggregations"] == [
             ["avg", "transaction.duration", "avg_transaction_duration"],
             ["apdex(duration, 300)", "", "apdex"],
-            ["quantileTiming(0.75)(duration)", "", "p75"],
-            ["quantileTiming(0.95)(duration)", "", "p95"],
-            ["quantileTiming(0.99)(duration)", "", "p99"],
+            ["quantile(0.75)(duration)", "", "p75"],
+            ["quantile(0.95)(duration)", "", "p95"],
+            ["quantile(0.99)(duration)", "", "p99"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project_id", "timestamp"], "projectid"],
         ]

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -329,7 +329,7 @@ class TransformAliasesAndQueryTransactionsTest(TestCase):
         transform_aliases_and_query(
             selected_columns=["transaction"],
             aggregations=[
-                ["quantileTiming(0.95)(duration)", "", "p95"],
+                ["quantile(0.95)(duration)", "", "p95"],
                 ["uniq", "transaction", "uniq_transaction"],
             ],
             filter_keys={"project_id": [self.project.id]},
@@ -337,7 +337,7 @@ class TransformAliasesAndQueryTransactionsTest(TestCase):
         mock_query.assert_called_with(
             selected_columns=["transaction_name"],
             aggregations=[
-                ["quantileTiming(0.95)(duration)", "", "p95"],
+                ["quantile(0.95)(duration)", "", "p95"],
                 ["uniq", "transaction_name", "uniq_transaction"],
             ],
             filter_keys={"project_id": [self.project.id]},
@@ -582,7 +582,7 @@ class DetectDatasetTest(TestCase):
         query = {"aggregations": [["argMax", ["id", "duration"], "longest"]]}
         assert detect_dataset(query) == Dataset.Events
 
-        query = {"aggregations": [["quantileTiming(0.95)", "transaction.duration", "p95_duration"]]}
+        query = {"aggregations": [["quantile(0.95)", "transaction.duration", "p95_duration"]]}
         assert detect_dataset(query) == Dataset.Transactions
 
         query = {"aggregations": [["uniq", "transaction.op", "uniq_transaction_op"]]}


### PR DESCRIPTION
The quantileTiming() function caps out at 30s which isn't great for us as celery jobs and background workers can take much longer than that.