### PR TITLE
fix(projects): Allow subject prefix to be blank

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -94,7 +94,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
     team = serializers.RegexField(r"^[a-z0-9_\-]+$", max_length=50)
     digestsMinDelay = serializers.IntegerField(min_value=60, max_value=3600)
     digestsMaxDelay = serializers.IntegerField(min_value=60, max_value=3600)
-    subjectPrefix = serializers.CharField(max_length=200)
+    subjectPrefix = serializers.CharField(max_length=200, allow_blank=True)
     subjectTemplate = serializers.CharField(max_length=200)
     securityToken = serializers.RegexField(
         r"^[-a-zA-Z0-9+/=\s]+$", max_length=255, allow_blank=True

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -102,6 +102,18 @@ class ProjectUpdateTest(APITestCase):
         )
         self.login_as(user=self.user)
 
+    def test_blank_subject_prefix(self):
+        project = Project.objects.get(id=self.project.id)
+        options = {"mail:subject_prefix": "[Sentry]"}
+        resp = self.client.put(self.path, data={"options": options})
+        assert resp.status_code == 200, resp.content
+        assert project.get_option("mail:subject_prefix") == "[Sentry]"
+
+        options["mail:subject_prefix"] = ""
+        resp = self.client.put(self.path, data={"options": options})
+        assert resp.status_code == 200, resp.content
+        assert project.get_option("mail:subject_prefix") == ""
+
     def test_team_changes_deprecated(self):
         project = self.create_project()
         team = self.create_team(members=[self.user])


### PR DESCRIPTION
- This allows the field to be emptied again
    - currently the field starts empty, but if you enter text and empty
      it again the field will error.