### PR TITLE
ref(native): Do not wrap minidump attachments in a buffer

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -4,8 +4,6 @@ import logging
 import posixpath
 import six
 
-from symbolic.utils import make_buffered_slice_reader
-
 from sentry.event_manager import validate_and_set_timestamp
 from sentry.lang.native.error import write_error, SymbolicationFailed
 from sentry.lang.native.minidump import MINIDUMP_ATTACHMENT_TYPE
@@ -240,7 +238,7 @@ def process_minidump(data):
 
     symbolicator = Symbolicator(project=project, event_id=data["event_id"])
 
-    response = symbolicator.process_minidump(make_buffered_slice_reader(minidump.data, None))
+    response = symbolicator.process_minidump(minidump.data)
 
     if _handle_response_status(data, response):
         _merge_full_response(data, response)
@@ -258,7 +256,7 @@ def process_applecrashreport(data):
 
     symbolicator = Symbolicator(project=project, event_id=data["event_id"])
 
-    response = symbolicator.process_applecrashreport(make_buffered_slice_reader(report.data, None))
+    response = symbolicator.process_applecrashreport(report.data)
 
     if _handle_response_status(data, response):
         _merge_full_response(data, response)


### PR DESCRIPTION
This is a complete shot in the dark, but at least it simplifies things. We're passing `minidump.data` directly to here:

https://github.com/getsentry/sentry/blob/9db306c35e0ba9af3d1a48e0ee9394561921e215/src/sentry/lang/native/symbolicator.py#L407

At this point, our request library will take the buffer and send it as multipart request to symbolicator.

The interesting thing is, that after loading attachment data from Redis, we run `zlib.decompress`, which iirc runs a checksum verification. This means that it's unlikely that we're downloading partial data, so I'm guessing something might be wrong with this buffer.