### PR TITLE
feat(api): Remove "time_spent" from event.as_dict()

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -343,7 +343,6 @@ class EventCommon(object):
         data["platform"] = self.platform
         data["message"] = self.real_message
         data["datetime"] = self.datetime
-        data["time_spent"] = self.time_spent
         data["tags"] = [(k.split("sentry:", 1)[-1], v) for (k, v) in self.tags]
         for k, v in sorted(six.iteritems(self.data)):
             if k in data:
@@ -570,10 +569,6 @@ class SnubaEvent(EventCommon):
         # ends with '+00:00', so just replace the TZ with UTC because we know
         # all timestamps from snuba are UTC.
         return parse_date(self.timestamp).replace(tzinfo=pytz.utc)
-
-    @property
-    def time_spent(self):
-        return None
 
     @property
     def message(self):


### PR DESCRIPTION
 time_spent has been deprecated for some time, and is not being stored
 anymore. It was removed from most APIs in 2016
 (https://github.com/getsentry/sentry/pull/2796), this removes the last
 few cases where we are using event.as_dict() instead of event
 serializers.