### PR TITLE
ref(mails): Remove mentions of reprocessing

### DIFF
--- a/src/sentry/templates/sentry/emails/activity/new_processing_issues.html
+++ b/src/sentry/templates/sentry/emails/activity/new_processing_issues.html
@@ -17,13 +17,6 @@
         Since reprocessing is enabled, these events will not show up in Sentry until the processing issues are resolved.
       {% endif %}
     </p>
-    {% if not reprocessing_active %}
-    <p>
-      <strong>Tip:</strong> If you <a href="{{ info_url }}">enable reprocessing</a>
-      you will not be receiving alert emails for such events in the future
-      until issues are resolved.
-    </p>
-    {% endif %}
     <hr>
 
     <h6>Project Affected</h6>
@@ -68,13 +61,4 @@
         </tbody>
       </table>
     </div>
-
-    {% if not reprocessing_active %}
-    <p>
-      Since reprocessing is disabled, we won't send you additional
-      notifications about issues like this. However, we recommend <a href="{{
-        info_url }}">enabling reprocessing</a> in the project settings to
-      improve your debugging experience on Sentry.
-    </p>
-    {% endif %}
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/activity/new_processing_issues.txt
+++ b/src/sentry/templates/sentry/emails/activity/new_processing_issues.txt
@@ -9,10 +9,5 @@ will not show up in Sentry until the processing issues are resolved.
   ({{ issue.extra_info }}){% endif %}
 {% endfor %}
 
-{% if not reprocessing_active %}Since reprocessing is disabled, we won't
-send you additional notifications about issues like this. However, we
-recommend enabling reprocessing in project settings to improve your
-debugging experience on Sentry.
-
-{{ info_url }}{% else %}You can fix these issues here:
-  {{ info_url }}{% endif %}
+You can fix these issues here:
+  {{ info_url }}


### PR DESCRIPTION
Since reprocessing is now in a limbo and doesn't apply to minidumps, it's best if we don't advertise it in such generic emails. We can bring the text back once we relaunch the feature.