### PR TITLE
fix(discover2): Disconnect minigraphs from the global selection header

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -26,7 +26,6 @@ type LocationQuery = {
   utc?: string | string[];
   statsPeriod?: string | string[];
   cursor?: string | string[];
-  yAxis?: string | string[];
 };
 
 const EXTERNAL_QUERY_STRING_KEYS: Readonly<Array<keyof LocationQuery>> = [

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -3,6 +3,7 @@ import isString from 'lodash/isString';
 import cloneDeep from 'lodash/cloneDeep';
 import pick from 'lodash/pick';
 import isEqual from 'lodash/isEqual';
+import omit from 'lodash/omit';
 import moment from 'moment';
 
 import {DEFAULT_PER_PAGE} from 'app/constants';
@@ -911,7 +912,7 @@ class EventView {
     // generate event query
 
     const eventQuery: EventQuery & LocationQuery = Object.assign(
-      picked,
+      omit(picked, ['start', 'end', 'utc', 'statsPeriod']),
       normalizedTimeWindowParams,
       {
         project,

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -381,6 +381,22 @@ class EventView {
     });
   }
 
+  static fromSavedQueryWithLocation(
+    saved: NewQuery | LegacySavedQuery,
+    location: Location
+  ): EventView {
+    const query = location.query;
+
+    saved = {
+      ...saved,
+      start: saved.start || decodeScalar(query.start),
+      end: saved.end || decodeScalar(query.end),
+      range: saved.range || decodeScalar(query.statsPeriod),
+    };
+
+    return EventView.fromSavedQuery(saved);
+  }
+
   static fromSavedQuery(saved: NewQuery | LegacySavedQuery): EventView {
     let fields, yAxis;
     if (isLegacySavedQuery(saved)) {
@@ -883,10 +899,10 @@ class EventView {
     // normalize datetime selection
 
     const normalizedTimeWindowParams = getParams({
-      start: this.start,
-      end: this.end,
+      start: this.start || picked.start,
+      end: this.end || picked.end,
       period: decodeScalar(query.period),
-      statsPeriod: this.statsPeriod,
+      statsPeriod: this.statsPeriod || picked.statsPeriod,
       utc: decodeScalar(query.utc),
     });
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -21,8 +21,6 @@ import {
 import {TableColumn, TableColumnSort} from './table/types';
 
 type LocationQuery = {
-  project?: string | string[];
-  environment?: string | string[];
   start?: string | string[];
   end?: string | string[];
   utc?: string | string[];
@@ -32,8 +30,6 @@ type LocationQuery = {
 };
 
 const EXTERNAL_QUERY_STRING_KEYS: Readonly<Array<keyof LocationQuery>> = [
-  'project',
-  'environment',
   'start',
   'end',
   'utc',
@@ -908,6 +904,8 @@ class EventView {
 
     const sort = this.sorts.length > 0 ? encodeSort(this.sorts[0]) : undefined;
     const fields = this.getFields();
+    const project = this.project.map(proj => String(proj));
+    const environment = this.environment as string[];
 
     // generate event query
 
@@ -915,6 +913,8 @@ class EventView {
       picked,
       normalizedTimeWindowParams,
       {
+        project,
+        environment,
         field: [...new Set(fields)],
         sort,
         per_page: DEFAULT_PER_PAGE,

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -29,11 +29,10 @@ type LocationQuery = {
   cursor?: string | string[];
 };
 
+const DATETIME_QUERY_STRING_KEYS = ['start', 'end', 'utc', 'statsPeriod'] as const;
+
 const EXTERNAL_QUERY_STRING_KEYS: Readonly<Array<keyof LocationQuery>> = [
-  'start',
-  'end',
-  'utc',
-  'statsPeriod',
+  ...DATETIME_QUERY_STRING_KEYS,
   'cursor',
 ];
 
@@ -912,7 +911,7 @@ class EventView {
     // generate event query
 
     const eventQuery: EventQuery & LocationQuery = Object.assign(
-      omit(picked, ['start', 'end', 'utc', 'statsPeriod']),
+      omit(picked, DATETIME_QUERY_STRING_KEYS),
       normalizedTimeWindowParams,
       {
         project,

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -551,6 +551,8 @@ class EventView {
       fieldnames: this.getFieldNames(),
       sort: encodeSorts(this.sorts),
       tag: this.tags,
+      environment: this.environment,
+      project: this.project,
       query: this.query,
       yAxis: this.yAxis,
     };

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -918,7 +918,7 @@ class EventView {
         field: [...new Set(fields)],
         sort,
         per_page: DEFAULT_PER_PAGE,
-        query: this.getQuery(query.query),
+        query: this.query,
       }
     );
 

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -143,7 +143,9 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
       return null;
     }
 
-    const eventView = EventView.fromSavedQuery(DEFAULT_EVENT_VIEW);
+    const {location} = this.props;
+
+    const eventView = EventView.fromSavedQueryWithLocation(DEFAULT_EVENT_VIEW, location);
 
     const to = {
       pathname: location.pathname,

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import isEqual from 'lodash/isEqual';
-import omit from 'lodash/omit';
 import {Location} from 'history';
 
 import withApi from 'app/utils/withApi';
@@ -20,27 +19,40 @@ type Props = {
   location: Location;
 };
 
-const omitProps = (props: Props) => {
-  return omit(props, ['api']);
-};
-
 class MiniGraph extends React.Component<Props> {
   shouldComponentUpdate(nextProps) {
     // We pay for the cost of the deep comparison here since it is cheaper
     // than the cost for rendering the graph, which can take ~200ms to ~300ms to
     // render.
 
-    return !isEqual(omitProps(this.props), omitProps(nextProps));
+    return !isEqual(
+      this.getPropsICareAbout(this.props),
+      this.getPropsICareAbout(nextProps)
+    );
   }
 
-  render() {
-    const {organization, api, location, eventView} = this.props;
+  getPropsICareAbout(props: Props) {
+    const {organization, location, eventView} = props;
 
     const apiPayload = eventView.getEventsAPIPayload(location);
     const query = apiPayload.query;
     const start = getUtcToLocalDateObject(apiPayload.start);
     const end = getUtcToLocalDateObject(apiPayload.end);
     const period: string | undefined = apiPayload.statsPeriod as any;
+
+    return {
+      organization,
+      apiPayload,
+      query,
+      start,
+      end,
+      period,
+    };
+  }
+
+  render() {
+    const {eventView, api} = this.props;
+    const {query, start, end, period, organization} = this.getPropsICareAbout(this.props);
 
     return (
       <EventsRequest

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -46,6 +46,8 @@ class MiniGraph extends React.Component<Props> {
         end={end}
         period={period}
         interval={getInterval({start, end, period}, true)}
+        project={selection.projects || []}
+        environment={selection.environments || []}
       >
         {({loading, timeseriesData}) => {
           if (loading) {

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -48,6 +48,7 @@ class MiniGraph extends React.Component<Props> {
         interval={getInterval({start, end, period}, true)}
         project={selection.projects || []}
         environment={selection.environments || []}
+        includePrevious={false}
       >
         {({loading, timeseriesData}) => {
           if (loading) {

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -25,10 +25,10 @@ class MiniGraph extends React.Component<Props> {
     // than the cost for rendering the graph, which can take ~200ms to ~300ms to
     // render.
 
-    return !isEqual(this.getRelevantProps(this.props), this.getRelevantProps(nextProps));
+    return !isEqual(this.getRefreshProps(this.props), this.getRefreshProps(nextProps));
   }
 
-  getRelevantProps(props: Props) {
+  getRefreshProps(props: Props) {
     // get props that are relevant to the API payload for the graph
 
     const {organization, location, eventView} = props;
@@ -51,7 +51,7 @@ class MiniGraph extends React.Component<Props> {
 
   render() {
     const {eventView, api} = this.props;
-    const {query, start, end, period, organization} = this.getRelevantProps(this.props);
+    const {query, start, end, period, organization} = this.getRefreshProps(this.props);
 
     return (
       <EventsRequest

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -25,13 +25,12 @@ class MiniGraph extends React.Component<Props> {
     // than the cost for rendering the graph, which can take ~200ms to ~300ms to
     // render.
 
-    return !isEqual(
-      this.getPropsICareAbout(this.props),
-      this.getPropsICareAbout(nextProps)
-    );
+    return !isEqual(this.getRelevantProps(this.props), this.getRelevantProps(nextProps));
   }
 
-  getPropsICareAbout(props: Props) {
+  getRelevantProps(props: Props) {
+    // get props that are relevant to the API payload for the graph
+
     const {organization, location, eventView} = props;
 
     const apiPayload = eventView.getEventsAPIPayload(location);
@@ -52,7 +51,7 @@ class MiniGraph extends React.Component<Props> {
 
   render() {
     const {eventView, api} = this.props;
-    const {query, start, end, period, organization} = this.getPropsICareAbout(this.props);
+    const {query, start, end, period, organization} = this.getRelevantProps(this.props);
 
     return (
       <EventsRequest

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -99,7 +99,7 @@ class QueryList extends React.Component<Props> {
           renderGraph={() => {
             return (
               <MiniGraph
-                query={eventView.getEventsAPIPayload(location).query}
+                location={location}
                 eventView={eventView}
                 organization={organization}
               />
@@ -155,7 +155,7 @@ class QueryList extends React.Component<Props> {
           renderGraph={() => {
             return (
               <MiniGraph
-                query={eventView.getEventsAPIPayload(location).query}
+                location={location}
                 eventView={eventView}
                 organization={organization}
               />

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -80,7 +80,7 @@ class QueryList extends React.Component<Props> {
     const views = getPrebuiltQueries(organization);
 
     const list = views.map((view, index) => {
-      const eventView = EventView.fromSavedQuery(view);
+      const eventView = EventView.fromSavedQueryWithLocation(view, location);
       const to = {
         pathname: location.pathname,
         query: {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -53,7 +53,10 @@ class Table extends React.PureComponent<TableProps, TableState> {
     const {location, eventView} = this.props;
 
     if (!eventView.isValid()) {
-      const nextEventView = EventView.fromSavedQuery(DEFAULT_EVENT_VIEW);
+      const nextEventView = EventView.fromSavedQueryWithLocation(
+        DEFAULT_EVENT_VIEW,
+        location
+      );
 
       browserHistory.replace({
         pathname: location.pathname,

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -31,8 +31,8 @@ import {
 import {TableColumn} from './table/types';
 
 export type EventQuery = {
-  field: Array<string>;
-  project?: string;
+  field: string[];
+  project?: string | string[];
   sort?: string | string[];
   query: string;
   per_page?: number;

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -497,22 +497,6 @@ describe('EventView.getEventsAPIPayload()', function() {
     expect(eventView.getEventsAPIPayload(location).query).toEqual('event.type:csp');
   });
 
-  it('does not duplicate conditions', function() {
-    const eventView = new EventView({
-      fields: generateFields(['id']),
-      sorts: [],
-      tags: [],
-      query: 'event.type:csp',
-    });
-
-    const location = {
-      query: {
-        query: 'event.type:csp',
-      },
-    };
-    expect(eventView.getEventsAPIPayload(location).query).toEqual('event.type:csp');
-  });
-
   it('only includes at most one sort key', function() {
     const eventView = new EventView({
       fields: generateFields(['count()', 'title']),

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -570,8 +570,6 @@ describe('EventView.getEventsAPIPayload()', function() {
     expect(eventView.getEventsAPIPayload(location)).toEqual({
       project: [],
       environment: [],
-      start: 'start',
-      end: 'end',
       utc: 'true',
       statsPeriod: '14d',
 
@@ -607,8 +605,6 @@ describe('EventView.getEventsAPIPayload()', function() {
     expect(eventView.getEventsAPIPayload(location)).toEqual({
       project: ['1234'],
       environment: ['staging'],
-      start: 'start',
-      end: 'end',
       utc: 'true',
       statsPeriod: '14d',
 
@@ -632,8 +628,6 @@ describe('EventView.getEventsAPIPayload()', function() {
     expect(eventView.getEventsAPIPayload(location2)).toEqual({
       project: ['1234'],
       environment: ['staging'],
-      start: 'start',
-      end: 'end',
       utc: 'true',
       statsPeriod: '14d',
 
@@ -668,7 +662,6 @@ describe('EventView.getEventsAPIPayload()', function() {
       project: ['1234'],
       environment: ['staging'],
       utc: 'true',
-      start: 'start',
       statsPeriod: '14d',
 
       field: ['title', 'count()'],
@@ -691,7 +684,6 @@ describe('EventView.getEventsAPIPayload()', function() {
       project: ['1234'],
       environment: ['staging'],
       utc: 'true',
-      end: 'end',
       statsPeriod: '14d',
 
       field: ['title', 'count()'],
@@ -759,8 +751,6 @@ describe('EventView.getTagsAPIPayload()', function() {
     expect(eventView.getTagsAPIPayload(location)).toEqual({
       project: [],
       environment: [],
-      start: 'start',
-      end: 'end',
       utc: 'true',
       statsPeriod: '14d',
 

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -381,13 +381,20 @@ describe('EventView.generateQueryStringObject()', function() {
       end: undefined,
       yAxis: undefined,
     });
-    const query = eventView.generateQueryStringObject();
-    expect(query.environment).toBeUndefined();
-    expect(query.statsPeriod).toBeUndefined();
-    expect(query.start).toBeUndefined();
-    expect(query.end).toBeUndefined();
-    expect(query.project).toBeUndefined();
-    expect(query.yAxis).toBeUndefined();
+
+    const expected = {
+      id: undefined,
+      name: undefined,
+      field: ['id', 'title'],
+      fieldnames: ['id', 'title'],
+      sort: [],
+      tag: [],
+      query: '',
+      project: [],
+      environment: [],
+    };
+
+    expect(eventView.generateQueryStringObject()).toEqual(expected);
   });
 
   it('generates query string object', function() {
@@ -474,7 +481,7 @@ describe('EventView.getEventsAPIPayload()', function() {
     expect(eventView.getEventsAPIPayload(location).query).toEqual('event.type:csp');
   });
 
-  it('appends query conditions in location', function() {
+  it('does not append query conditions in location', function() {
     const eventView = new EventView({
       fields: generateFields(['id']),
       sorts: [],
@@ -487,9 +494,7 @@ describe('EventView.getEventsAPIPayload()', function() {
         query: 'TypeError',
       },
     };
-    expect(eventView.getEventsAPIPayload(location).query).toEqual(
-      'event.type:csp TypeError'
-    );
+    expect(eventView.getEventsAPIPayload(location).query).toEqual('event.type:csp');
   });
 
   it('does not duplicate conditions', function() {
@@ -548,8 +553,6 @@ describe('EventView.getEventsAPIPayload()', function() {
 
     const location = {
       query: {
-        project: '1234',
-        environment: ['staging'],
         start: 'start',
         end: 'end',
         utc: 'true',
@@ -557,14 +560,16 @@ describe('EventView.getEventsAPIPayload()', function() {
         cursor: 'some cursor',
         yAxis: 'count(id)',
 
-        // non-relevant query strings
+        // irrelevant query strings
         bestCountry: 'canada',
+        project: '1234',
+        environment: ['staging'],
       },
     };
 
     expect(eventView.getEventsAPIPayload(location)).toEqual({
-      project: '1234',
-      environment: ['staging'],
+      project: [],
+      environment: [],
       start: 'start',
       end: 'end',
       utc: 'true',
@@ -584,12 +589,12 @@ describe('EventView.getEventsAPIPayload()', function() {
       sorts: generateSorts(['project', 'count']),
       tags: [],
       query: 'event.type:csp',
+      project: [1234],
+      environment: ['staging'],
     });
 
     const location = {
       query: {
-        project: '1234',
-        environment: ['staging'],
         start: 'start',
         end: 'end',
         utc: 'true',
@@ -600,7 +605,7 @@ describe('EventView.getEventsAPIPayload()', function() {
     };
 
     expect(eventView.getEventsAPIPayload(location)).toEqual({
-      project: '1234',
+      project: ['1234'],
       environment: ['staging'],
       start: 'start',
       end: 'end',
@@ -616,8 +621,6 @@ describe('EventView.getEventsAPIPayload()', function() {
 
     const location2 = {
       query: {
-        project: '1234',
-        environment: ['staging'],
         start: 'start',
         end: 'end',
         utc: 'true',
@@ -627,7 +630,7 @@ describe('EventView.getEventsAPIPayload()', function() {
     };
 
     expect(eventView.getEventsAPIPayload(location2)).toEqual({
-      project: '1234',
+      project: ['1234'],
       environment: ['staging'],
       start: 'start',
       end: 'end',
@@ -648,12 +651,12 @@ describe('EventView.getEventsAPIPayload()', function() {
       sorts: generateSorts(['project', 'count']),
       tags: [],
       query: 'event.type:csp',
+      project: [1234],
+      environment: ['staging'],
     });
 
     const location = {
       query: {
-        project: '1234',
-        environment: ['staging'],
         start: 'start',
         utc: 'true',
         statsPeriod: 'invalid',
@@ -662,7 +665,7 @@ describe('EventView.getEventsAPIPayload()', function() {
     };
 
     expect(eventView.getEventsAPIPayload(location)).toEqual({
-      project: '1234',
+      project: ['1234'],
       environment: ['staging'],
       utc: 'true',
       start: 'start',
@@ -677,8 +680,6 @@ describe('EventView.getEventsAPIPayload()', function() {
 
     const location2 = {
       query: {
-        project: '1234',
-        environment: ['staging'],
         end: 'end',
         utc: 'true',
         statsPeriod: 'invalid',
@@ -687,7 +688,7 @@ describe('EventView.getEventsAPIPayload()', function() {
     };
 
     expect(eventView.getEventsAPIPayload(location2)).toEqual({
-      project: '1234',
+      project: ['1234'],
       environment: ['staging'],
       utc: 'true',
       end: 'end',
@@ -709,6 +710,8 @@ describe('EventView.getEventsAPIPayload()', function() {
       query: 'event.type:csp',
       start: '2019-10-01T00:00:00',
       end: '2019-10-02T00:00:00',
+      environment: [],
+      project: [],
     });
 
     const location = {
@@ -722,6 +725,8 @@ describe('EventView.getEventsAPIPayload()', function() {
       start: '2019-10-01T00:00:00.000',
       end: '2019-10-02T00:00:00.000',
       per_page: 50,
+      project: [],
+      environment: [],
     });
   });
 });
@@ -737,23 +742,23 @@ describe('EventView.getTagsAPIPayload()', function() {
 
     const location = {
       query: {
-        project: '1234',
-        environment: ['staging'],
         start: 'start',
         end: 'end',
         utc: 'true',
         statsPeriod: '14d',
 
-        // non-relevant query strings
+        // irrelevant query strings
         bestCountry: 'canada',
         cursor: 'some cursor',
         sort: 'the world',
+        project: '1234',
+        environment: ['staging'],
       },
     };
 
     expect(eventView.getTagsAPIPayload(location)).toEqual({
-      project: '1234',
-      environment: ['staging'],
+      project: [],
+      environment: [],
       start: 'start',
       end: 'end',
       utc: 'true',
@@ -2261,8 +2266,6 @@ describe('pickRelevantLocationQueryStrings', function() {
     const actual = pickRelevantLocationQueryStrings(location);
 
     const expected = {
-      project: 'project',
-      environment: 'environment',
       start: 'start',
       end: 'end',
       utc: 'utc',

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -468,17 +468,28 @@ describe('EventView.generateQueryStringObject()', function() {
 });
 
 describe('EventView.getEventsAPIPayload()', function() {
-  it('appends any additional conditions defined for view', function() {
+  it('generates the API payload', function() {
     const eventView = new EventView({
+      id: 34,
+      name: 'amazing query',
       fields: generateFields(['id']),
-      sorts: [],
-      tags: [],
+      sorts: generateSorts(['id']),
+      tags: ['project'],
       query: 'event.type:csp',
+      project: [567],
+      environment: ['prod'],
+      yAxis: 'users',
     });
 
-    const location = {};
-
-    expect(eventView.getEventsAPIPayload(location).query).toEqual('event.type:csp');
+    expect(eventView.getEventsAPIPayload({})).toEqual({
+      field: ['id'],
+      per_page: 50,
+      sort: '-id',
+      query: 'event.type:csp',
+      project: ['567'],
+      environment: ['prod'],
+      statsPeriod: '14d',
+    });
   });
 
   it('does not append query conditions in location', function() {


### PR DESCRIPTION
**WORK IN PROGRESS**

The minigraphs on the landing page of Discover2 weren't properly reflecting the actual graphs for the saved queries. This PR addresses this.

Commits for FE cherry picked from https://github.com/getsentry/sentry/pull/15659

## TODO

- [ ] ~remove `location` param from `EventView.getEventsAPIPayload(location: Location)`~ actually keeping this for now
- [ ] ~default `14d` statsperiod for pre-built queries~ going to remove this until query cards are updated with newer designs from Dora.
- [x] update tests