### PR TITLE
fix(discover) Fix inconsistent pagination

### DIFF
--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.serializers import serialize
 from sentry.api.bases import OrganizationEndpoint
-from sentry.api.paginator import DateTimePaginator, OffsetPaginator
+from sentry.api.paginator import GenericOffsetPaginator
 from sentry.discover.models import DiscoverSavedQuery
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
@@ -47,26 +47,25 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         sort_by = request.query_params.get("sortBy")
         if sort_by in ("name", "-name"):
             order_by = sort_by
-            paginator_cls = OffsetPaginator
         elif sort_by in ("dateCreated", "-dateCreated"):
             order_by = "-date_created" if sort_by.startswith("-") else "date_created"
-            paginator_cls = DateTimePaginator
         elif sort_by in ("dateUpdated", "-dateUpdated"):
             order_by = "-date_updated" if sort_by.startswith("-") else "date_updated"
-            paginator_cls = DateTimePaginator
         else:
             order_by = "name"
-            paginator_cls = OffsetPaginator
+        queryset = queryset.order_by(order_by)
 
         # Old discover expects all queries and uses this parameter.
         if request.query_params.get("all") == "1":
             saved_queries = list(queryset.all())
             return Response(serialize(saved_queries), status=200)
+
+        def data_fn(offset, limit):
+            return list(queryset[offset : offset + limit])
+
         return self.paginate(
             request=request,
-            queryset=queryset,
-            order_by=order_by,
-            paginator_cls=paginator_cls,
+            paginator=GenericOffsetPaginator(data_fn=data_fn),
             on_results=lambda x: serialize(x, request.user),
             default_per_page=25,
         )

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -1,5 +1,5 @@
 import React, {MouseEvent} from 'react';
-import {Location} from 'history';
+import {Location, Query} from 'history';
 import styled from 'react-emotion';
 import classNames from 'classnames';
 import {browserHistory} from 'react-router';
@@ -21,7 +21,6 @@ import QueryCard from './querycard';
 import MiniGraph from './miniGraph';
 import {getPrebuiltQueries} from './utils';
 import {handleDeleteQuery, handleCreateQuery} from './savedQuery/utils';
-import {Params} from 'react-router/lib/Router';
 
 type Props = {
   api: Client;
@@ -192,7 +191,7 @@ class QueryList extends React.Component<Props> {
         <QueryGrid>{this.renderQueries()}</QueryGrid>
         <Pagination
           pageLinks={pageLinks}
-          onCursor={(cursor: string, path: string, query: Params, direction: number) => {
+          onCursor={(cursor: string, path: string, query: Query, direction: number) => {
             const offset = Number(cursor.split(':')[1]);
 
             const newQuery = {...query, cursor};

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -21,6 +21,7 @@ import QueryCard from './querycard';
 import MiniGraph from './miniGraph';
 import {getPrebuiltQueries} from './utils';
 import {handleDeleteQuery, handleCreateQuery} from './savedQuery/utils';
+import {Params} from 'react-router/lib/Router';
 
 type Props = {
   api: Client;
@@ -189,7 +190,24 @@ class QueryList extends React.Component<Props> {
     return (
       <React.Fragment>
         <QueryGrid>{this.renderQueries()}</QueryGrid>
-        <Pagination pageLinks={pageLinks} />
+        <Pagination
+          pageLinks={pageLinks}
+          onCursor={(cursor: string, path: string, query: Params, direction: number) => {
+            const offset = Number(cursor.split(':')[1]);
+
+            const newQuery = {...query, cursor};
+            const isPrevious = direction === -1;
+
+            if (offset <= 0 && isPrevious) {
+              delete newQuery.cursor;
+            }
+
+            browserHistory.push({
+              pathname: path,
+              query: newQuery,
+            });
+          }}
+        />
       </React.Fragment>
     );
   }


### PR DESCRIPTION
Augment pagination client side so that when we're going to the first page we drop the cursor from the query. This in turn lets us get the correct partial results for the first page.

Based on #15691