### PR TITLE
perf(ui): Organization projects endpoint improved

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -109,6 +109,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
         if get_all_projects:
             queryset = queryset.order_by("slug")
+            queryset = queryset.select_related("organization")
             return Response(serialize(list(queryset), request.user, ProjectSummarySerializer()))
         else:
             return self.paginate(

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -67,18 +67,18 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
         order_by = ["slug"]
 
-        if request.user.is_authenticated():
-            queryset = queryset.extra(
-                select={
-                    "is_bookmarked": """exists (
-                        select *
-                        from sentry_projectbookmark spb
-                        where spb.project_id = sentry_project.id and spb.user_id = %s
-                    )"""
-                },
-                select_params=(request.user.id,),
-            )
-            order_by.insert(0, "-is_bookmarked")
+        # if request.user.is_authenticated():
+        #     queryset = queryset.extra(
+        #         select={
+        #             "is_bookmarked": """exists (
+        #                 select *
+        #                 from sentry_projectbookmark spb
+        #                 where spb.project_id = sentry_project.id and spb.user_id = %s
+        #             )"""
+        #         },
+        #         select_params=(request.user.id,),
+        #     )
+        #     order_by.insert(0, "-is_bookmarked")
 
         query = request.GET.get("query")
         if query:
@@ -108,7 +108,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         get_all_projects = request.GET.get("all_projects") == "1"
 
         if get_all_projects:
-            queryset = queryset.order_by("slug")
+            # queryset = queryset.order_by("slug")
             queryset = queryset.select_related("organization")
             return Response(serialize(list(queryset), request.user, ProjectSummarySerializer()))
         else:

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -63,7 +63,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                     {"detail": "Current access does not point to " "organization."}, status=400
                 )
         else:
-            queryset = Project.objects.filter(organization=organization).prefetch_related("teams")
+            queryset = Project.objects.filter(organization=organization)
 
         order_by = ["slug"]
 

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -51,13 +51,11 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
             # TODO: remove this, no longer supported probably
             if hasattr(request.auth, "project"):
                 team_list = list(request.auth.project.teams.all())
-                queryset = Project.objects.filter(id=request.auth.project.id).prefetch_related(
-                    "teams"
-                )
+                queryset = Project.objects.filter(id=request.auth.project.id)
             elif request.auth.organization is not None:
                 org = request.auth.organization
                 team_list = list(Team.objects.filter(organization=org))
-                queryset = Project.objects.filter(teams__in=team_list).prefetch_related("teams")
+                queryset = Project.objects.filter(teams__in=team_list)
             else:
                 return Response(
                     {"detail": "Current access does not point to " "organization."}, status=400

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -65,18 +65,18 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
         order_by = ["slug"]
 
-        # if request.user.is_authenticated():
-        #     queryset = queryset.extra(
-        #         select={
-        #             "is_bookmarked": """exists (
-        #                 select *
-        #                 from sentry_projectbookmark spb
-        #                 where spb.project_id = sentry_project.id and spb.user_id = %s
-        #             )"""
-        #         },
-        #         select_params=(request.user.id,),
-        #     )
-        #     order_by.insert(0, "-is_bookmarked")
+        if request.user.is_authenticated():
+            queryset = queryset.extra(
+                select={
+                    "is_bookmarked": """exists (
+                        select *
+                        from sentry_projectbookmark spb
+                        where spb.project_id = sentry_project.id and spb.user_id = %s
+                    )"""
+                },
+                select_params=(request.user.id,),
+            )
+            order_by.insert(0, "-is_bookmarked")
 
         query = request.GET.get("query")
         if query:
@@ -106,8 +106,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         get_all_projects = request.GET.get("all_projects") == "1"
 
         if get_all_projects:
-            queryset = queryset.order_by("slug")
-            queryset = queryset.select_related("organization")
+            queryset = queryset.order_by("slug").select_related("organization")
             return Response(serialize(list(queryset), request.user, ProjectSummarySerializer()))
         else:
             return self.paginate(

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -108,7 +108,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         get_all_projects = request.GET.get("all_projects") == "1"
 
         if get_all_projects:
-            # queryset = queryset.order_by("slug")
+            queryset = queryset.order_by("slug")
             queryset = queryset.select_related("organization")
             return Response(serialize(list(queryset), request.user, ProjectSummarySerializer()))
         else:

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -97,33 +97,33 @@ class OrganizationProjectsTest(APITestCase):
 
         self.check_valid_response(response, [project_bar, project_foo])
 
-    def test_bookmarks_appear_first_across_pages(self):
-        self.login_as(user=self.user)
+    # def test_bookmarks_appear_first_across_pages(self):
+    #     self.login_as(user=self.user)
 
-        projects = [self.create_project(teams=[self.team], name=i, slug=i) for i in range(3)]
-        projects.sort(key=lambda project: project.slug)
+    #     projects = [self.create_project(teams=[self.team], name=i, slug=i) for i in range(3)]
+    #     projects.sort(key=lambda project: project.slug)
 
-        response = self.client.get(self.path)
-        self.check_valid_response(response, [project for project in projects])
+    #     response = self.client.get(self.path)
+    #     self.check_valid_response(response, [project for project in projects])
 
-        response = self.client.get(self.path + "?per_page=2")
-        self.check_valid_response(response, [project for project in projects[:2]])
+    #     response = self.client.get(self.path + "?per_page=2")
+    #     self.check_valid_response(response, [project for project in projects[:2]])
 
-        self.create_project_bookmark(projects[-1], user=self.user)
-        # Move the bookmarked project to the front
-        projects.insert(0, projects.pop())
-        response = self.client.get(self.path)
-        self.check_valid_response(response, [project for project in projects])
+    #     self.create_project_bookmark(projects[-1], user=self.user)
+    #     # Move the bookmarked project to the front
+    #     projects.insert(0, projects.pop())
+    #     response = self.client.get(self.path)
+    #     self.check_valid_response(response, [project for project in projects])
 
-        # Make sure that it's at the front when on the second page as well
-        response = self.client.get(self.path + "?per_page=2")
-        self.check_valid_response(response, [project for project in projects[:2]])
+    #     # Make sure that it's at the front when on the second page as well
+    #     response = self.client.get(self.path + "?per_page=2")
+    #     self.check_valid_response(response, [project for project in projects[:2]])
 
-        # Make sure that other user's bookmarks don't interfere with this user
-        other_user = self.create_user()
-        self.create_project_bookmark(projects[1], user=other_user)
-        response = self.client.get(self.path)
-        self.check_valid_response(response, [project for project in projects])
+    #     # Make sure that other user's bookmarks don't interfere with this user
+    #     other_user = self.create_user()
+    #     self.create_project_bookmark(projects[1], user=other_user)
+    #     response = self.client.get(self.path)
+    #     self.check_valid_response(response, [project for project in projects])
 
     def test_team_filter(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -97,33 +97,33 @@ class OrganizationProjectsTest(APITestCase):
 
         self.check_valid_response(response, [project_bar, project_foo])
 
-    # def test_bookmarks_appear_first_across_pages(self):
-    #     self.login_as(user=self.user)
+    def test_bookmarks_appear_first_across_pages(self):
+        self.login_as(user=self.user)
 
-    #     projects = [self.create_project(teams=[self.team], name=i, slug=i) for i in range(3)]
-    #     projects.sort(key=lambda project: project.slug)
+        projects = [self.create_project(teams=[self.team], name=i, slug=i) for i in range(3)]
+        projects.sort(key=lambda project: project.slug)
 
-    #     response = self.client.get(self.path)
-    #     self.check_valid_response(response, [project for project in projects])
+        response = self.client.get(self.path)
+        self.check_valid_response(response, [project for project in projects])
 
-    #     response = self.client.get(self.path + "?per_page=2")
-    #     self.check_valid_response(response, [project for project in projects[:2]])
+        response = self.client.get(self.path + "?per_page=2")
+        self.check_valid_response(response, [project for project in projects[:2]])
 
-    #     self.create_project_bookmark(projects[-1], user=self.user)
-    #     # Move the bookmarked project to the front
-    #     projects.insert(0, projects.pop())
-    #     response = self.client.get(self.path)
-    #     self.check_valid_response(response, [project for project in projects])
+        self.create_project_bookmark(projects[-1], user=self.user)
+        # Move the bookmarked project to the front
+        projects.insert(0, projects.pop())
+        response = self.client.get(self.path)
+        self.check_valid_response(response, [project for project in projects])
 
-    #     # Make sure that it's at the front when on the second page as well
-    #     response = self.client.get(self.path + "?per_page=2")
-    #     self.check_valid_response(response, [project for project in projects[:2]])
+        # Make sure that it's at the front when on the second page as well
+        response = self.client.get(self.path + "?per_page=2")
+        self.check_valid_response(response, [project for project in projects[:2]])
 
-    #     # Make sure that other user's bookmarks don't interfere with this user
-    #     other_user = self.create_user()
-    #     self.create_project_bookmark(projects[1], user=other_user)
-    #     response = self.client.get(self.path)
-    #     self.check_valid_response(response, [project for project in projects])
+        # Make sure that other user's bookmarks don't interfere with this user
+        other_user = self.create_user()
+        self.create_project_bookmark(projects[1], user=other_user)
+        response = self.client.get(self.path)
+        self.check_valid_response(response, [project for project in projects])
 
     def test_team_filter(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
The `organization/{orgid}/projects` endpoint was suspiciously slow in fetching all projects due to the fact that it was continually fetching the same organization instead of caching it (select_related) and also pre-fetched teams twice because the serializer already prefetches teams.