### PR TITLE
ref: Simplify binding nodes

### DIFF
--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -24,7 +24,7 @@ class EventAppleCrashReportEndpoint(ProjectEndpoint):
         if event is None:
             raise ResourceDoesNotExist
 
-        event.data.bind_node_data()
+        event.bind_node_data()
 
         if event.platform not in ("cocoa", "native"):
             return HttpResponse(

--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -7,7 +7,6 @@ from django.http import HttpResponse, StreamingHttpResponse
 from sentry import eventstore
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models import Event
 from sentry.lang.native.applecrashreport import AppleCrashReport
 from sentry.utils.safe import get_path
 
@@ -25,7 +24,7 @@ class EventAppleCrashReportEndpoint(ProjectEndpoint):
         if event is None:
             raise ResourceDoesNotExist
 
-        Event.objects.bind_nodes([event], "data")
+        event.data.bind_node_data()
 
         if event.platform not in ("cocoa", "native"):
             return HttpResponse(

--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -27,7 +27,7 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
             return Response({"detail": "Event not found"}, status=404)
 
         # populate event data
-        event.data.bind_node_data()
+        event.bind_node_data()
 
         try:
             committers = get_serialized_event_file_committers(

--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 
 from sentry import eventstore
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.models import Commit, Event, Release
+from sentry.models import Commit, Release
 from sentry.utils.committers import get_serialized_event_file_committers
 
 
@@ -27,7 +27,7 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
             return Response({"detail": "Event not found"}, status=404)
 
         # populate event data
-        Event.objects.bind_nodes([event], "data")
+        event.data.bind_node_data()
 
         try:
             committers = get_serialized_event_file_committers(

--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -8,7 +8,6 @@ from sentry import eventstore
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.grouping.api import GroupingConfigNotFound
-from sentry.models import Event
 from sentry.utils import json
 
 
@@ -25,7 +24,7 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
         if event is None:
             raise ResourceDoesNotExist
 
-        Event.objects.bind_nodes([event], "data")
+        event.data.bind_node_data()
 
         rv = {}
         config_name = request.GET.get("config") or None

--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -24,7 +24,7 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
         if event is None:
             raise ResourceDoesNotExist
 
-        event.data.bind_node_data()
+        event.bind_node_data()
 
         rv = {}
         config_name = request.GET.get("config") or None

--- a/src/sentry/api/endpoints/event_owners.py
+++ b/src/sentry/api/endpoints/event_owners.py
@@ -7,7 +7,7 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.fields.actor import Actor
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializer
-from sentry.models import Event, ProjectOwnership
+from sentry.models import ProjectOwnership
 
 
 class EventOwnersEndpoint(ProjectEndpoint):
@@ -26,7 +26,7 @@ class EventOwnersEndpoint(ProjectEndpoint):
             return Response({"detail": "Event not found"}, status=404)
 
         # populate event data
-        Event.objects.bind_nodes([event], "data")
+        event.data.bind_node_data()
 
         owners, rules = ProjectOwnership.get_owners(project.id, event.data)
 

--- a/src/sentry/api/endpoints/event_owners.py
+++ b/src/sentry/api/endpoints/event_owners.py
@@ -26,7 +26,7 @@ class EventOwnersEndpoint(ProjectEndpoint):
             return Response({"detail": "Event not found"}, status=404)
 
         # populate event data
-        event.data.bind_node_data()
+        event.bind_node_data()
 
         owners, rules = ProjectOwnership.get_owners(project.id, event.data)
 

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -18,7 +18,6 @@ from sentry.api.helpers.group_index import (
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializer
 from sentry.models import Environment, Group, GroupStatus
-from sentry.models.event import Event
 from sentry.models.savedsearch import DEFAULT_SAVED_SEARCH_QUERIES
 from sentry.signals import advanced_search
 from sentry.utils.apidocs import attach_scenarios, scenario
@@ -151,7 +150,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                 else:
                     matching_event = eventstore.get_event_by_id(project.id, event_id)
                     if matching_event is not None:
-                        Event.objects.bind_nodes([matching_event], "data")
+                        matching_event.data.bind_node_data()
             elif matching_group is None:
                 matching_group = get_by_short_id(
                     project.organization_id, request.GET.get("shortIdLookup"), query

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -150,7 +150,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                 else:
                     matching_event = eventstore.get_event_by_id(project.id, event_id)
                     if matching_event is not None:
-                        matching_event.data.bind_node_data()
+                        matching_event.bind_node_data()
             elif matching_group is None:
                 matching_group = get_by_short_id(
                     project.organization_id, request.GET.get("shortIdLookup"), query

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from django.utils import timezone
 from semaphore import meta_with_chunks
 
+from sentry import eventstore
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import Event, EventError, EventAttachment, Release, UserReport, SnubaEvent
 from sentry.search.utils import convert_user_tag_to_query
@@ -166,7 +167,7 @@ class EventSerializer(Serializer):
         return serialize(user_report, user)
 
     def get_attrs(self, item_list, user, is_public=False):
-        Event.objects.bind_nodes(item_list, "data")
+        eventstore.bind_nodes(item_list, "data")
 
         crash_files = get_crash_files(item_list)
         results = {}

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -109,13 +109,16 @@ class NodeData(collections.MutableMapping):
 
         elif self.id:
             warnings.warn("You should populate node data before accessing it.")
-            self.bind_data(nodestore.get(self.id) or {})
+            self.bind_node_data()
             return self._node_data
 
         rv = {}
         if self.field is not None and self.field.wrapper is not None:
             rv = self.field.wrapper(rv)
         return rv
+
+    def bind_node_data(self):
+        self.bind_data(nodestore.get(self.id) or {})
 
     def bind_data(self, data, ref=None):
         self.ref = data.pop("_ref", ref)

--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -109,16 +109,13 @@ class NodeData(collections.MutableMapping):
 
         elif self.id:
             warnings.warn("You should populate node data before accessing it.")
-            self.bind_node_data()
+            self.bind_data(nodestore.get(self.id) or {})
             return self._node_data
 
         rv = {}
         if self.field is not None and self.field.wrapper is not None:
             rv = self.field.wrapper(rv)
         return rv
-
-    def bind_node_data(self):
-        self.bind_data(nodestore.get(self.id) or {})
 
     def bind_data(self, data, ref=None):
         self.ref = data.pop("_ref", ref)

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -175,6 +175,9 @@ class EventStorage(Service):
         (unfetched) NodeData on those objects, fetch all the data blobs for
         those NodeDatas with a single multi-get command to nodestore, and bind
         the returned blobs to the NodeDatas
+
+        For binding a single Event object (most use cases), it's easier to use
+        event.data.bind_node_data().
         """
         object_node_list = [
             (i, getattr(i, node_name)) for i in object_list if getattr(i, node_name).id

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -177,7 +177,7 @@ class EventStorage(Service):
         the returned blobs to the NodeDatas
 
         For binding a single Event object (most use cases), it's easier to use
-        event.data.bind_node_data().
+        event.bind_node_data().
         """
         object_node_list = [
             (i, getattr(i, node_name)) for i in object_list if getattr(i, node_name).id

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -5,15 +5,7 @@ import six
 
 from sentry import features
 from sentry.integrations.exceptions import ApiError, IntegrationError
-from sentry.models import (
-    Activity,
-    Event,
-    ExternalIssue,
-    Group,
-    GroupLink,
-    GroupStatus,
-    Organization,
-)
+from sentry.models import Activity, ExternalIssue, Group, GroupLink, GroupStatus, Organization
 from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
 
@@ -67,7 +59,7 @@ class IssueBasicMixin(object):
         """
         event = group.get_latest_event()
         if event is not None:
-            Event.objects.bind_nodes([event], "data")
+            event.data.bind_node_data()
 
         return [
             {

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -59,7 +59,7 @@ class IssueBasicMixin(object):
         """
         event = group.get_latest_event()
         if event is not None:
-            event.data.bind_node_data()
+            event.bind_node_data()
 
         return [
             {

--- a/src/sentry/management/commands/backfill_eventstream.py
+++ b/src/sentry/management/commands/backfill_eventstream.py
@@ -7,6 +7,7 @@ import six
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.dateparse import parse_datetime
 
+from sentry import eventstore
 from sentry.models import Event, Project, Group
 
 
@@ -54,7 +55,7 @@ class Command(BaseCommand):
             for event in _events:
                 event.project = projects[event.project_id]
                 event.group = groups[event.group_id]
-            Event.objects.bind_nodes(_events, "data")
+            eventstore.bind_nodes(_events, "data")
 
         from sentry import eventstream
         from sentry.utils.query import RangeQuerySetWrapper

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -14,7 +14,7 @@ from hashlib import md5
 
 from semaphore.processing import StoreNormalizer
 
-from sentry import eventtypes
+from sentry import eventtypes, nodestore
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedIntegerField,
@@ -362,6 +362,12 @@ class EventCommon(object):
         data["location"] = self.location
 
         return data
+
+    def bind_node_data(self):
+        node_id = Event.generate_node_id(self.project_id, self.event_id)
+        node_data = nodestore.get(node_id) or {}
+        ref = self.data.get_ref(self)
+        self.data.bind_data(node_data, ref=ref)
 
     # ============================================
     # DEPRECATED

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -23,7 +23,7 @@ from sentry.db.models import (
     NodeField,
     sane_repr,
 )
-from sentry.db.models.manager import EventManager
+from sentry.db.models.manager import BaseManager
 from sentry.interfaces.base import get_interfaces
 from sentry.utils import json
 from sentry.utils.cache import memoize
@@ -622,7 +622,7 @@ class Event(EventCommon, Model):
         skip_nodestore_save=True,
     )
 
-    objects = EventManager()
+    objects = BaseManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/processingissue.py
+++ b/src/sentry/models/processingissue.py
@@ -60,7 +60,7 @@ class ProcessingIssueManager(BaseManager):
         a list of raw events that are now resolved and a bool that indicates
         if there are more.
         """
-        from sentry.models import RawEvent
+        from sentry import eventstore
 
         rv = list(self.find_resolved_queryset([project_id])[:limit])
         if len(rv) > limit:
@@ -70,7 +70,7 @@ class ProcessingIssueManager(BaseManager):
             has_more = False
 
         rv = list(rv)
-        RawEvent.objects.bind_nodes(rv, "data")
+        eventstore.bind_nodes(rv, "data")
         return rv, has_more
 
     def record_processing_issue(self, raw_event, scope, object, type, data=None):

--- a/src/sentry/models/rawevent.py
+++ b/src/sentry/models/rawevent.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.utils import timezone
 
 from sentry.db.models import Model, NodeField, FlexibleForeignKey, sane_repr
-from sentry.db.models.manager import EventManager
+from sentry.db.models.manager import BaseManager
 from sentry.utils.canonical import CanonicalKeyView
 
 
@@ -22,7 +22,7 @@ class RawEvent(Model):
         wrapper=CanonicalKeyView,
     )
 
-    objects = EventManager()
+    objects = BaseManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.utils.html import format_html
 from social_auth.models import UserSocialAuth
 
-from sentry.models import Activity, Event, GroupMeta
+from sentry.models import Activity, GroupMeta
 from sentry.plugins.base.v1 import Plugin
 from sentry.signals import issue_tracker_used
 from sentry.utils.auth import get_auth_providers
@@ -205,7 +205,7 @@ class IssueTrackingPlugin(Plugin):
 
         prefix = self.get_conf_key()
         event = group.get_latest_event()
-        Event.objects.bind_nodes([event], "data")
+        event.data.bind_node_data()
 
         op = request.POST.get("op", "create")
 

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -205,7 +205,7 @@ class IssueTrackingPlugin(Plugin):
 
         prefix = self.get_conf_key()
         event = group.get_latest_event()
-        event.data.bind_node_data()
+        event.bind_node_data()
 
         op = request.POST.get("op", "create")
 

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -14,7 +14,7 @@ from sentry.api.serializers.models.plugin import PluginSerializer
 
 # api compat
 from sentry.exceptions import PluginError  # NOQA
-from sentry.models import Activity, Event, GroupMeta
+from sentry.models import Activity, GroupMeta
 from sentry.plugins.base.v1 import Plugin
 from sentry.plugins.base.configuration import react_plugin_config
 from sentry.plugins.endpoints import PluginGroupEndpoint
@@ -237,7 +237,7 @@ class IssueTrackingPlugin2(Plugin):
                 },
                 status=400,
             )
-        Event.objects.bind_nodes([event], "data")
+        event.data.bind_node_data()
         try:
             fields = self.get_new_issue_fields(request, group, event, **kwargs)
         except Exception as e:
@@ -307,7 +307,7 @@ class IssueTrackingPlugin2(Plugin):
                 status=400,
             )
 
-        Event.objects.bind_nodes([event], "data")
+        event.data.bind_node_data()
 
         try:
             fields = self.get_link_existing_issue_fields(request, group, event, **kwargs)

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -237,7 +237,7 @@ class IssueTrackingPlugin2(Plugin):
                 },
                 status=400,
             )
-        event.data.bind_node_data()
+        event.bind_node_data()
         try:
             fields = self.get_new_issue_fields(request, group, event, **kwargs)
         except Exception as e:
@@ -307,7 +307,7 @@ class IssueTrackingPlugin2(Plugin):
                 status=400,
             )
 
-        event.data.bind_node_data()
+        event.bind_node_data()
 
         try:
             fields = self.get_link_existing_issue_fields(request, group, event, **kwargs)

--- a/src/sentry/tasks/email.py
+++ b/src/sentry/tasks/email.py
@@ -49,7 +49,7 @@ def process_inbound_email(mailfrom, group_id, payload):
     event = group.get_latest_event()
 
     if event:
-        event.data.bind_node_data()
+        event.bind_node_data()
         event.group = group
         event.project = group.project
 

--- a/src/sentry/tasks/email.py
+++ b/src/sentry/tasks/email.py
@@ -32,7 +32,7 @@ def _get_user_from_email(group, email):
 def process_inbound_email(mailfrom, group_id, payload):
     """
     """
-    from sentry.models import Event, Group
+    from sentry.models import Group
     from sentry.web.forms import NewNoteForm
 
     try:
@@ -49,7 +49,7 @@ def process_inbound_email(mailfrom, group_id, payload):
     event = group.get_latest_event()
 
     if event:
-        Event.objects.bind_nodes([event], "data")
+        event.data.bind_node_data()
         event.group = group
         event.project = group.project
 

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -12,7 +12,6 @@ from sentry.event_manager import generate_culprit
 from sentry.models import (
     Activity,
     Environment,
-    Event,
     EventUser,
     Group,
     GroupEnvironment,
@@ -519,7 +518,7 @@ def unmerge(
 
         return destination_id
 
-    Event.objects.bind_nodes(events, "data")
+    eventstore.bind_nodes(events, "data")
 
     source_events = []
     destination_events = []

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -166,7 +166,7 @@ def get_previous_releases(project, start_version, limit=5):
 
 def get_event_file_committers(project, event, frame_limit=25):
     # populate event data
-    event.data.bind_nodes()
+    event.data.bind_node_data()
 
     group = Group.objects.get(id=event.group_id)
 

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -166,7 +166,7 @@ def get_previous_releases(project, start_version, limit=5):
 
 def get_event_file_committers(project, event, frame_limit=25):
     # populate event data
-    event.data.bind_node_data()
+    event.bind_node_data()
 
     group = Group.objects.get(id=event.group_id)
 

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -4,7 +4,7 @@ import operator
 import six
 
 from sentry.api.serializers import serialize
-from sentry.models import Release, ReleaseCommit, Commit, CommitFileChange, Event, Group
+from sentry.models import Release, ReleaseCommit, Commit, CommitFileChange, Group
 from sentry.api.serializers.models.commit import CommitSerializer, get_users_for_commits
 from sentry.utils import metrics
 from sentry.utils.hashlib import hash_values
@@ -166,7 +166,7 @@ def get_previous_releases(project, start_version, limit=5):
 
 def get_event_file_committers(project, event, frame_limit=25):
     # populate event data
-    Event.objects.bind_nodes([event], "data")
+    event.data.bind_nodes()
 
     group = Group.objects.get(id=event.group_id)
 

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry import eventstore
-from sentry.models import Event, ProjectKey, ProjectOption, UserReport
+from sentry.models import ProjectKey, ProjectOption, UserReport
 from sentry.web.helpers import render_to_response
 from sentry.signals import user_feedback_received
 from sentry.utils import json
@@ -153,7 +153,7 @@ class ErrorPageEmbedView(View):
             event = eventstore.get_event_by_id(report.project.id, report.event_id)
 
             if event is not None:
-                Event.objects.bind_nodes([event])
+                event.data.bind_node_data()
                 report.environment = event.get_environment()
                 report.group = event.group
 

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -153,7 +153,7 @@ class ErrorPageEmbedView(View):
             event = eventstore.get_event_by_id(report.project.id, report.event_id)
 
             if event is not None:
-                event.data.bind_node_data()
+                event.bind_node_data()
                 report.environment = event.get_environment()
                 report.group = event.group
 

--- a/src/sentry/web/frontend/group_event_json.py
+++ b/src/sentry/web/frontend/group_event_json.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import, division
 from django.http import Http404, HttpResponse
 
 from sentry import eventstore
-from sentry.models import Event, Group, GroupMeta, get_group_with_redirect
+from sentry.models import Group, GroupMeta, get_group_with_redirect
+
 from sentry.utils import json
 from sentry.web.frontend.base import OrganizationView
 
@@ -27,7 +28,7 @@ class GroupEventJsonView(OrganizationView):
         if event is None:
             raise Http404
 
-        Event.objects.bind_nodes([event], "data")
+        event.data.bind_node_data()
 
         GroupMeta.objects.populate_cache([group])
 

--- a/src/sentry/web/frontend/group_event_json.py
+++ b/src/sentry/web/frontend/group_event_json.py
@@ -28,7 +28,7 @@ class GroupEventJsonView(OrganizationView):
         if event is None:
             raise Http404
 
-        event.data.bind_node_data()
+        event.bind_node_data()
 
         GroupMeta.objects.populate_cache([group])
 

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -24,7 +24,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from six import StringIO
 from werkzeug.test import Client as WerkzeugClient
 
-from sentry.models import Group, Event
+from sentry.models import Group
 from sentry.testutils import SnubaTestCase, TestCase, TransactionTestCase
 from sentry.testutils.helpers import get_auth_header
 from sentry.testutils.helpers.datetime import iso_format, before_now
@@ -177,7 +177,7 @@ class SentryRemoteTest(SnubaTestCase):
 
     def get_event(self, event_id):
         instance = eventstore.get_event_by_id(self.project.id, event_id, eventstore.full_columns)
-        Event.objects.bind_nodes([instance], "data")
+        instance.data.bind_node_data()
         return instance
 
     def test_minimal(self):
@@ -614,7 +614,7 @@ class CspReportTest(TestCase, SnubaTestCase):
         )
         assert len(events) == 1
         e = events[0]
-        Event.objects.bind_nodes([e], "data")
+        e.data.bind_node_data()
         assert output["message"] == e.data["logentry"]["formatted"]
         for key, value in six.iteritems(output["tags"]):
             assert e.get_tag(key) == value

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -177,7 +177,7 @@ class SentryRemoteTest(SnubaTestCase):
 
     def get_event(self, event_id):
         instance = eventstore.get_event_by_id(self.project.id, event_id, eventstore.full_columns)
-        instance.data.bind_node_data()
+        instance.bind_node_data()
         return instance
 
     def test_minimal(self):
@@ -614,7 +614,7 @@ class CspReportTest(TestCase, SnubaTestCase):
         )
         assert len(events) == 1
         e = events[0]
-        e.data.bind_node_data()
+        e.bind_node_data()
         assert output["message"] == e.data["logentry"]["formatted"]
         for key, value in six.iteritems(output["tags"]):
             assert e.get_tag(key) == value

--- a/tests/sentry/models/tests.py
+++ b/tests/sentry/models/tests.py
@@ -163,7 +163,7 @@ class EventNodeStoreTest(TestCase):
         assert event.data.get_ref(event) != event.data.get_ref(invalid_event)
 
         with pytest.raises(NodeIntegrityFailure):
-            event.data.bind_node_data()
+            event.bind_node_data()
 
     def test_accepts_valid_ref(self):
         event = self.create_event()

--- a/tests/sentry/models/tests.py
+++ b/tests/sentry/models/tests.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 from django.core import mail
 from django.core.urlresolvers import reverse
 
-# from django.db import connection
 from django.http import HttpRequest
 from django.utils import timezone
 from exam import fixture
@@ -147,7 +146,7 @@ class EventNodeStoreTest(TestCase):
         e4 = Event.objects.get(project_id=1, event_id="mno")
         assert e4.data.id is None
         assert e4.data.data == {}  # NodeData returns {} by default
-        Event.objects.bind_nodes([e4], "data")
+        e4.data.bind_node_data()
         assert e4.data.id is None
         assert e4.data.data == {}
 
@@ -164,13 +163,13 @@ class EventNodeStoreTest(TestCase):
         assert event.data.get_ref(event) != event.data.get_ref(invalid_event)
 
         with pytest.raises(NodeIntegrityFailure):
-            Event.objects.bind_nodes([event], "data")
+            event.data.bind_node_data()
 
     def test_accepts_valid_ref(self):
         event = self.create_event()
         event.data.bind_ref(event)
 
-        Event.objects.bind_nodes([event], "data")
+        event.data.bind_node_data()
 
         assert event.data.ref == event.project.id
 

--- a/tests/sentry/models/tests.py
+++ b/tests/sentry/models/tests.py
@@ -146,7 +146,7 @@ class EventNodeStoreTest(TestCase):
         e4 = Event.objects.get(project_id=1, event_id="mno")
         assert e4.data.id is None
         assert e4.data.data == {}  # NodeData returns {} by default
-        e4.data.bind_node_data()
+        e4.bind_node_data()
         assert e4.data.id is None
         assert e4.data.data == {}
 
@@ -157,7 +157,7 @@ class EventNodeStoreTest(TestCase):
         invalid_event = self.create_event(group=group1)
         group2 = self.create_group(project2)
         event = self.create_event(group=group2)
-        event.data.bind_ref(invalid_event)
+        event.bind_ref(invalid_event)
         event.data.save()
 
         assert event.data.get_ref(event) != event.data.get_ref(invalid_event)
@@ -167,9 +167,9 @@ class EventNodeStoreTest(TestCase):
 
     def test_accepts_valid_ref(self):
         event = self.create_event()
-        event.data.bind_ref(event)
+        event.bind_ref(event)
 
-        event.data.bind_node_data()
+        event.bind_node_data()
 
         assert event.data.ref == event.project.id
 

--- a/tests/sentry/models/tests.py
+++ b/tests/sentry/models/tests.py
@@ -157,7 +157,7 @@ class EventNodeStoreTest(TestCase):
         invalid_event = self.create_event(group=group1)
         group2 = self.create_group(project2)
         event = self.create_event(group=group2)
-        event.bind_ref(invalid_event)
+        event.data.bind_ref(invalid_event)
         event.data.save()
 
         assert event.data.get_ref(event) != event.data.get_ref(invalid_event)
@@ -167,7 +167,7 @@ class EventNodeStoreTest(TestCase):
 
     def test_accepts_valid_ref(self):
         event = self.create_event()
-        event.bind_ref(event)
+        event.data.bind_ref(event)
 
         event.bind_node_data()
 

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from mock import patch
 
 from sentry.tasks.merge import merge_groups
-from sentry.models import Event, Group, GroupEnvironment, GroupMeta, GroupRedirect, UserReport
+from sentry.models import Group, GroupEnvironment, GroupMeta, GroupRedirect, UserReport
 from sentry.similarity import _make_index_backend
 from sentry.testutils import TestCase
 from sentry.utils import redis
@@ -80,12 +80,12 @@ class MergeGroupTest(TestCase):
 
         event1 = eventstore.get_event_by_id(project.id, event1.event_id)
         assert event1.group_id == group2.id
-        Event.objects.bind_nodes([event1], "data")
+        event1.data.bind_node_data()
         assert event1.data["extra"]["foo"] == "bar"
 
         event2 = eventstore.get_event_by_id(project.id, event2.event_id)
         assert event2.group_id == group2.id
-        Event.objects.bind_nodes([event2], "data")
+        event2.data.bind_node_data()
         assert event2.data["extra"]["foo"] == "baz"
 
     def test_merge_creates_redirect(self):

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -80,12 +80,12 @@ class MergeGroupTest(TestCase):
 
         event1 = eventstore.get_event_by_id(project.id, event1.event_id)
         assert event1.group_id == group2.id
-        event1.data.bind_node_data()
+        event1.bind_node_data()
         assert event1.data["extra"]["foo"] == "bar"
 
         event2 = eventstore.get_event_by_id(project.id, event2.event_id)
         assert event2.group_id == group2.id
-        event2.data.bind_node_data()
+        event2.bind_node_data()
         assert event2.data["extra"]["foo"] == "baz"
 
     def test_merge_creates_redirect(self):

--- a/tests/snuba/models/test_event.py
+++ b/tests/snuba/models/test_event.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from datetime import datetime, timedelta
 
 from sentry.api.serializers import serialize
-from sentry.models.event import Event, SnubaEvent
+from sentry.models.event import SnubaEvent
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry import eventstore, nodestore
 from sentry.testutils.helpers.datetime import iso_format, before_now
@@ -75,7 +75,7 @@ class SnubaEventTest(TestCase, SnubaTestCase):
         """
         event = eventstore.get_event_by_id(self.proj1.id, self.event_id)
         assert event.data._node_data is None
-        Event.objects.bind_nodes([event], "data")
+        event.data.bind_node_data()
         assert event.data._node_data is not None
         assert event.data["user"]["id"] == u"user1"
 

--- a/tests/snuba/models/test_event.py
+++ b/tests/snuba/models/test_event.py
@@ -75,7 +75,7 @@ class SnubaEventTest(TestCase, SnubaTestCase):
         """
         event = eventstore.get_event_by_id(self.proj1.id, self.event_id)
         assert event.data._node_data is None
-        event.data.bind_node_data()
+        event.bind_node_data()
         assert event.data._node_data is not None
         assert event.data["user"]["id"] == u"user1"
 


### PR DESCRIPTION
When binding node data for a single event (the majority of use cases), we
now use "event.bind_node_data()" instead of
Event.objects.bind_nodes([event], "data"). In cases where we want to
bind nodes for multiple events at once to make use of nodestore's
multi_get command we will use the "eventstore.bind_nodes()" method.

The motivation for making this change now is so we can completely remove the EventManager (and the Django model manager) from our Event model.