### PR TITLE
feat(sentry): Do not capture http requests with response code 0 and 404 to Sentry

### DIFF
--- a/src/sentry/static/sentry/app/api.tsx
+++ b/src/sentry/static/sentry/app/api.tsx
@@ -303,7 +303,7 @@ export class Client {
             },
           });
 
-          if (resp.status !== 0 && resp.status !== 404) {
+          if (resp && resp.status !== 0 && resp.status !== 404) {
             Sentry.withScope(scope => {
               // `requestPromise` can pass its error object
               const preservedError = options.preservedError || errorObject;

--- a/src/sentry/static/sentry/app/api.tsx
+++ b/src/sentry/static/sentry/app/api.tsx
@@ -303,24 +303,26 @@ export class Client {
             },
           });
 
-          Sentry.withScope(scope => {
-            // `requestPromise` can pass its error object
-            const preservedError = options.preservedError || errorObject;
+          if (resp.status !== 0 && resp.status !== 404) {
+            Sentry.withScope(scope => {
+              // `requestPromise` can pass its error object
+              const preservedError = options.preservedError || errorObject;
 
-            const errorObjectToUse = createRequestError(
-              resp,
-              preservedError.stack,
-              method,
-              path
-            );
+              const errorObjectToUse = createRequestError(
+                resp,
+                preservedError.stack,
+                method,
+                path
+              );
 
-            errorObjectToUse.removeFrames(2);
+              errorObjectToUse.removeFrames(2);
 
-            // Setting this to warning because we are going to capture all failed requests
-            scope.setLevel(Sentry.Severity.Warning);
-            scope.setTag('http.statusCode', String(resp.status));
-            Sentry.captureException(errorObjectToUse);
-          });
+              // Setting this to warning because we are going to capture all failed requests
+              scope.setLevel(Sentry.Severity.Warning);
+              scope.setTag('http.statusCode', String(resp.status));
+              Sentry.captureException(errorObjectToUse);
+            });
+          }
 
           this.handleRequestError(
             {

--- a/tests/js/spec/api.spec.jsx
+++ b/tests/js/spec/api.spec.jsx
@@ -268,8 +268,8 @@ describe('api', function() {
       $.ajax.mockImplementation(async ({error}) => {
         await tick();
         error({
-          status: 404,
-          statusText: 'Not Found',
+          status: 500,
+          statusText: 'Internal server error',
           responseJSON: {detail: 'Item was not found'},
         });
 
@@ -282,8 +282,8 @@ describe('api', function() {
       await tick();
 
       const errorObjectSentryCalled = Sentry.captureException.mock.calls[0][0];
-      expect(errorObjectSentryCalled.name).toBe('NotFoundError');
-      expect(errorObjectSentryCalled.message).toBe('GET /some/url/ 404');
+      expect(errorObjectSentryCalled.name).toBe('InternalServerError');
+      expect(errorObjectSentryCalled.message).toBe('GET /some/url/ 500');
 
       // First line of stack should be this test case
       expect(errorObjectSentryCalled.stack.split('\n')[1]).toContain('api.spec.jsx');
@@ -292,7 +292,7 @@ describe('api', function() {
     it('reports correct error and stacktrace to Sentry when using promises', async function() {
       await expect(
         api.requestPromise('/some/url/')
-      ).rejects.toThrowErrorMatchingInlineSnapshot('"GET /some/url/ 404"');
+      ).rejects.toThrowErrorMatchingInlineSnapshot('"GET /some/url/ 500"');
       expect(Sentry.captureException).toHaveBeenCalled();
     });
   });

--- a/tests/js/spec/api.spec.jsx
+++ b/tests/js/spec/api.spec.jsx
@@ -129,7 +129,7 @@ describe('api', function() {
   });
 
   it('handles error callback', function() {
-    jest.spyOn(api, 'wrapCallback').mockImplementation((id, func) => func);
+    jest.spyOn(api, 'wrapCallback').mockImplementation((_id, func) => func);
     const errorCb = jest.fn();
     const args = ['test', true, 1];
     api.handleRequestError(


### PR DESCRIPTION
A lot of these are expected and not an indicator of actual problems. This especially creates a lot of noise for on-premise installs. These requests are also not very helpful when grouped so lets just not record them at all.