### PR TITLE
fix(discover) Fix pagination link generation with invalid dates

### DIFF
--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -148,17 +148,22 @@ class SnubaEventStorage(EventStorage):
 
     def __get_event_id_from_filter(self, filter=None, orderby=None):
         columns = ["event_id", "project_id"]
-        result = snuba.dataset_query(
-            selected_columns=columns,
-            conditions=filter.conditions,
-            filter_keys=filter.filter_keys,
-            start=filter.start,
-            end=filter.end,
-            limit=1,
-            referrer="eventstore.get_next_or_prev_event_id",
-            orderby=orderby,
-            dataset=snuba.detect_dataset({"conditions": filter.conditions}),
-        )
+        try:
+            result = snuba.dataset_query(
+                selected_columns=columns,
+                conditions=filter.conditions,
+                filter_keys=filter.filter_keys,
+                start=filter.start,
+                end=filter.end,
+                limit=1,
+                referrer="eventstore.get_next_or_prev_event_id",
+                orderby=orderby,
+                dataset=snuba.detect_dataset({"conditions": filter.conditions}),
+            )
+        except (snuba.QueryOutsideRetentionError, snuba.QueryOutsideGroupActivityError):
+            # This can happen when the date conditions for paging
+            # and the current event generate impossible conditions.
+            return None
 
         if "error" in result or len(result["data"]) == 0:
             return None


### PR DESCRIPTION
If an aggregate of events had its most recent event happen 14 days ago, and then the user views the event-details page. They can then change the global selection header date range to be 24h. This results in invalid date conditions being generated for the pagination link queries as the
 end and start ranges will be inverted. We should ignore this error and not 500 as the user has created an impossible query condition and there isn't a real problem.

Fixes SENTRY-D7P