### PR TITLE
build(git-hooks): Fix always calling make

### DIFF
--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -16,8 +16,6 @@ grep -E --quiet 'migrations' "$files_changed_upstream"          && migrations="a
 [[ "$py" || "$js" || "$migrations" ]] && needs_update=1
 update_command="make ${py}${js}${migrations}"
 
-echo $needs_update
-
 [[ "$needs_update" ]] && cat <<EOF
 
 [${red}${bold}!!!${reset}] ${red} It looks like some dependencies have changed that will require your intervention. Run the following to update:${reset}

--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -13,9 +13,12 @@ grep -E --quiet 'requirements.*\.txt' "$files_changed_upstream" && py="install-s
 grep -E --quiet 'yarn.lock' "$files_changed_upstream"           && js="install-yarn-pkgs "
 grep -E --quiet 'migrations' "$files_changed_upstream"          && migrations="apply-migrations "
 
+[[ "$py" || "$js" || "$migrations" ]] && needs_update=1
 update_command="make ${py}${js}${migrations}"
 
-[[ "$py" || "$js" || "$migrations" ]] && cat <<EOF
+echo $needs_update
+
+[[ "$needs_update" ]] && cat <<EOF
 
 [${red}${bold}!!!${reset}] ${red} It looks like some dependencies have changed that will require your intervention. Run the following to update:${reset}
 
@@ -23,6 +26,6 @@ update_command="make ${py}${js}${migrations}"
 
 EOF
 
-if [[ "$SENTRY_POST_MERGE_AUTO_UPDATE" ]]; then
+if [[ "$SENTRY_POST_MERGE_AUTO_UPDATE" && "$needs_update" ]]; then
   $update_command
 fi


### PR DESCRIPTION
The post-merge hook was always calling make even if dependent files were changed