### PR TITLE
fix(ui): Fix "required" validation for forms

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/input.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/input.jsx
@@ -1,8 +1,14 @@
 import styled from 'react-emotion';
+import isPropValid from '@emotion/is-prop-valid';
 
 import {inputStyles} from 'app/styles/input';
 
-const Input = styled('input')`
+/**
+ * Do not forward required to `input` to avoid default browser behavior
+ */
+const Input = styled('input', {
+  shouldForwardProp: prop => isPropValid(prop) && prop !== 'required',
+})`
   ${inputStyles};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.tsx
@@ -263,7 +263,8 @@ class FormModel {
   isValidRequiredField(id: string) {
     // Check field descriptor to see if field is required
     const isRequired = this.getDescriptor(id, 'required');
-    return !isRequired || this.getValue(id) !== '';
+    const value = this.getValue(id);
+    return !isRequired || (value !== '' && defined(value));
   }
 
   isValidField(id: string) {


### PR DESCRIPTION
Previously only checked for empty string, but should also check for undefined and null. Also do not forward `required` prop to `<input>` to avoid browser behavior for required inputs.