### PR TITLE
fix(discover) Fix missing alias resolution for discover backend

### DIFF
--- a/src/sentry/eventstore/snuba_discover/backend.py
+++ b/src/sentry/eventstore/snuba_discover/backend.py
@@ -79,7 +79,7 @@ class SnubaDiscoverEventStorage(EventStorage):
     def __get_event_id_from_filter(self, filter=None, orderby=None):
         columns = ["event_id", "project_id", "timestamp"]
         try:
-            result = snuba.raw_query(
+            result = snuba.dataset_query(
                 selected_columns=columns,
                 conditions=filter.conditions,
                 filter_keys=filter.filter_keys,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -58,6 +58,16 @@ TRANSACTIONS_SENTRY_SNUBA_MAP = {
     if col.value.transaction_name is not None
 }
 
+# This maps the public column aliases to the discover dataset column names.
+# Longer term we would like to not expose the transactions dataset directly
+# to end users and instead have all ad-hoc queries go through the discover
+# dataset.
+DISCOVER_COLUMN_MAP = {
+    col.value.alias: col.value.discover_name
+    for col in Columns
+    if col.value.discover_name is not None
+}
+
 
 @unique
 class Dataset(Enum):
@@ -68,7 +78,11 @@ class Dataset(Enum):
     OutcomesRaw = "outcomes_raw"
 
 
-DATASETS = {Dataset.Events: SENTRY_SNUBA_MAP, Dataset.Transactions: TRANSACTIONS_SENTRY_SNUBA_MAP}
+DATASETS = {
+    Dataset.Events: SENTRY_SNUBA_MAP,
+    Dataset.Transactions: TRANSACTIONS_SENTRY_SNUBA_MAP,
+    Dataset.Discover: DISCOVER_COLUMN_MAP,
+}
 
 # Store the internal field names to save work later on.
 # Add `group_id` to the events dataset list as we don't want to publically
@@ -76,6 +90,7 @@ DATASETS = {Dataset.Events: SENTRY_SNUBA_MAP, Dataset.Transactions: TRANSACTIONS
 DATASET_FIELDS = {
     Dataset.Events: list(SENTRY_SNUBA_MAP.values()) + ["group_id"],
     Dataset.Transactions: list(TRANSACTIONS_SENTRY_SNUBA_MAP.values()),
+    Dataset.Discover: list(DISCOVER_COLUMN_MAP.values()),
 }
 
 

--- a/tests/sentry/eventstore/snuba_discover/test_backend.py
+++ b/tests/sentry/eventstore/snuba_discover/test_backend.py
@@ -131,6 +131,19 @@ class SnubaDiscoverEventStorageTest(TestCase, SnubaTestCase):
         assert self.eventstore.get_prev_event_id(None, filter=filter) is None
         assert self.eventstore.get_next_event_id(None, filter=filter) is None
 
+    def test_get_next_prev_event_id_public_alias_conditions(self):
+        event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
+
+        filter = Filter(
+            project_ids=[self.project2.id],
+            conditions=[["event.type", "=", "default"], ["project.id", "=", self.project2.id]],
+        )
+        prev_event = self.eventstore.get_prev_event_id(event, filter=filter)
+        next_event = self.eventstore.get_next_event_id(event, filter=filter)
+
+        assert prev_event is None
+        assert next_event == (six.text_type(self.project2.id), "c" * 32)
+
     def test_get_latest_or_oldest_event_id(self):
         # Returns a latest/oldest event
         event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)


### PR DESCRIPTION
When getting pagination links for event details we often construct conditions based on public aliases. In order to have valid queries those public aliases need to be resolved to the internal names. This swaps the eventstore discover backend to use the existing dataset resolution logic.

Very soon I'll be adding streamlined alias resolution for just discover query paths and will be removing the automatic dataset selection, so this fix is a temporary measure.