### PR TITLE
fix(user_tags): Fix clicking affected users with special characters

### DIFF
--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -442,4 +442,4 @@ def convert_user_tag_to_query(key, value):
     if key == "user" and ":" in value:
         sub_key, value = value.split(":", 1)
         if KEYWORD_MAP.get_key(sub_key, None):
-            return "user.%s:%s" % (sub_key, value)
+            return 'user.%s:"%s"' % (sub_key, value.replace('"', '\\"'))

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -292,7 +292,7 @@ class SimpleEventSerializerTest(TestCase):
         assert result["user"]["username"] == event.username
         assert result["user"]["ip_address"] == event.ip_address
         assert result["tags"] == [
-            {"key": "user", "value": "email:test@test.com", "query": "user.email:test@test.com"}
+            {"key": "user", "value": "email:test@test.com", "query": 'user.email:"test@test.com"'}
         ]
 
     def test_no_group(self):

--- a/tests/sentry/api/serializers/test_tagvalue.py
+++ b/tests/sentry/api/serializers/test_tagvalue.py
@@ -24,7 +24,7 @@ class TagValueSerializerTest(TestCase):
         assert result["key"] == "user"
         assert result["value"] == "username:ted"
         assert result["name"] == "ted"
-        assert result["query"] == "user.username:ted"
+        assert result["query"] == 'user.username:"ted"'
 
     def test_release(self):
         user = self.create_user()
@@ -56,4 +56,4 @@ class UseTagValueSerializerTest(TestCase):
 
         result = serialize(tagvalue, user, serializer=UserTagValueSerializer(project_id=1))
         assert result["value"] == "username:ted"
-        assert result["query"] == "user.username:ted"
+        assert result["query"] == 'user.username:"ted"'

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -20,6 +20,7 @@ from sentry.search.utils import (
     parse_query,
     get_latest_release,
     get_numeric_field_value,
+    convert_user_tag_to_query,
     InvalidQuery,
 )
 
@@ -514,3 +515,17 @@ class GetLatestReleaseTest(TestCase):
             environment = self.create_environment()
             result = get_latest_release([self.project], [environment])
             assert result == new.version
+
+
+class ConvertUserTagTest(TestCase):
+    def test_simple_user_tag(self):
+        assert convert_user_tag_to_query("user", "id:123456") == 'user.id:"123456"'
+
+    def test_user_tag_with_quote(self):
+        assert convert_user_tag_to_query("user", 'id:123"456') == 'user.id:"123\\"456"'
+
+    def test_user_tag_with_space(self):
+        assert convert_user_tag_to_query("user", "id:123 456") == 'user.id:"123 456"'
+
+    def test_non_user_tag(self):
+        assert convert_user_tag_to_query("user", 'fake:123"456') is None

--- a/tests/snuba/models/test_event.py
+++ b/tests/snuba/models/test_event.py
@@ -99,5 +99,5 @@ class SnubaEventTest(TestCase, SnubaTestCase):
             {"_meta": None, "key": "foo", "value": "bar"},
             {"_meta": None, "key": "level", "value": "error"},
             {"_meta": None, "key": "release", "value": "release1"},
-            {"_meta": None, "key": "user", "query": "user.id:user1", "value": "id:user1"},
+            {"_meta": None, "key": "user", "query": 'user.id:"user1"', "value": "id:user1"},
         ]


### PR DESCRIPTION
- This is to fix an issue when clicking an affected user in an event tag
  with a space in it, currently the query is missing quotes, so we
  interpret the part after a space as another term.
    - eg. user.id:123 456
- As part of this also fixing it when the tag has a quote in it as well
    - eg. user.id:123"456
- [Jira Ticket](https://getsentry.atlassian.net/browse/ISSUE-605)