### PR TITLE
fix(django 1.10): invalid kwarg red herring

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -85,8 +85,13 @@ class EventCommon(object):
 
     @group.setter
     def group(self, group):
-        self.group_id = group.id
-        self._group_cache = group
+        # guard against None to not fail on AttributeError
+        # otherwise Django 1.10 will swallow it in db.models.base init, but
+        # consequently fail to remove from kwargs, and you'll get the red herring
+        # TypeError: 'group' is an invalid keyword argument for this function.
+        if group is not None:
+            self.group_id = group.id
+            self._group_cache = group
 
     @property
     def project(self):

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -142,7 +142,7 @@ class GroupDetailsTest(APITestCase):
         superuser = self.create_user(is_superuser=True)
         self.login_as(user=superuser, superuser=True)
 
-        group = self.create_group(title="Oh no")
+        group = self.create_group()
         url = u"/api/0/issues/{}/".format(group.id)
         response = self.client.get(url, format="json")
 

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -65,7 +65,7 @@ class SubscribeTest(TestCase):
 
     def test_actor_team(self):
         org = self.create_organization()
-        group = self.create_group(organization=org)
+        group = self.create_group()
         user = self.create_user()
         team = self.create_team(organization=org)
         self.create_member(

--- a/tests/sentry/rules/conditions/test_level_event.py
+++ b/tests/sentry/rules/conditions/test_level_event.py
@@ -38,7 +38,7 @@ class LevelConditionTest(RuleTestCase):
         self.assertPasses(rule, event)
 
     def test_without_tag(self):
-        event = self.create_event(event_id="a" * 32, tags={})
+        event = self.create_event(event_id="a" * 32)
         rule = self.get_rule(data={"match": MatchType.EQUAL, "level": "30"})
         self.assertDoesNotPass(rule, event)
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -548,9 +548,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         integration = Integration.objects.create(provider="example", name="Example")
         integration.add_organization(org, self.user)
-        group = self.create_group(
-            status=GroupStatus.UNRESOLVED, organization=org, first_seen=self.min_ago
-        )
+        group = self.create_group(status=GroupStatus.UNRESOLVED, first_seen=self.min_ago)
         self.create_event(group=group, datetime=self.min_ago)
 
         OrganizationIntegration.objects.filter(

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -423,7 +423,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         integration = Integration.objects.create(provider="example", name="Example")
         integration.add_organization(org, self.user)
-        group = self.create_group(status=GroupStatus.UNRESOLVED, organization=org)
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
 
         OrganizationIntegration.objects.filter(
             integration_id=integration.id, organization_id=group.organization.id

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -40,14 +40,14 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         self.week_ago = before_now(days=7)
 
     def test_permalink(self):
-        group = self.create_group(title="Oh no")
+        group = self.create_group()
         result = serialize(group, self.user, serializer=GroupSerializerSnuba())
         assert "http://" in result["permalink"]
         assert "{}/issues/{}".format(group.organization.slug, group.id) in result["permalink"]
 
     def test_permalink_outside_org(self):
         outside_user = self.create_user()
-        group = self.create_group(title="Oh no")
+        group = self.create_group()
         result = serialize(group, outside_user, serializer=GroupSerializerSnuba())
         assert result["permalink"] is None
 


### PR DESCRIPTION
Some of our tests result in things like `TypeError: 'title' is an invalid keyword argument for this function` under Django 1.10.

This is actually a red herring. The real issue is that we've always had AttributeErrors when setting things like `Group.title`, because it's defined as a `@property` without a setter. Django 1.9 and below have just been swallowing the AttributeError though. In Django 1.9's Model init:

```py
        if kwargs:
            for prop in list(kwargs):
                try:
                    if isinstance(getattr(self.__class__, prop), property):
                        setattr(self, prop, kwargs.pop(prop))
                except AttributeError:
                    pass
            if kwargs:
                raise TypeError("'%s' is an invalid keyword argument for this function" % list(kwargs)[0])
```

In Django 1.10, the `setattr` part still fails for us, but the removal from kwargs happens after the setattr as opposed to it just being popped then passed into setattr in 1.9:

```py
        if kwargs:
            for prop in list(kwargs):
                try:
                    # Any remaining kwargs must correspond to properties or
                    # virtual fields.
                    if (isinstance(getattr(self.__class__, prop), property) or
                            self._meta.get_field(prop)):
                        if kwargs[prop] is not DEFERRED:
                            # import pdb; pdb.set_trace()
                            setattr(self, prop, kwargs[prop])
                        del kwargs[prop]
                except (AttributeError, FieldDoesNotExist):
                    pass
            if kwargs:
                raise TypeError("'%s' is an invalid keyword argument for this function" % list(kwargs)[0])
```

So overall this is pretty good, minus the red herring part. Django 1.10 basically calls us out on this, and the result is that mostly some old tests need to be fixed.
