### PR TITLE
fix(tests): Fix Django 1.10 bug in `TestRefresher.test_happy_path`

### DIFF
--- a/src/sentry/mediators/token_exchange/refresher.py
+++ b/src/sentry/mediators/token_exchange/refresher.py
@@ -52,8 +52,7 @@ class Refresher(Mediator):
             scope_list=self.sentry_app.scope_list,
             expires_at=token_expiration(),
         )
-        self.install.api_token = token
-        self.install.save()
+        self.install.update(api_token=token)
         return token
 
     @memoize


### PR DESCRIPTION
Django 1.10 adds contraint checks to the end of test runs. Since Django uses deferrable constraints
for all fks this means we now check db constraints after each test, where we didn't before.

This causes a break in `TestRefresher.test_happy_path`. Turns out that if you use a `GrantExchanger`
it deletes the previous `ApiGrant`, which causes related foreign keys to be set to null, which is
what we want. However, if you use a `Refresher` with a cached `SentryAppInstallation`, it ends up
saving the `SentryAppInstallation`, which means it then writes the `api_grant_id` to be set back to
the previous id. This ends up causing a constraint error.

We fix this by using `.update` instead, so that only the specific field we care about is updated.