### PR TITLE
fix(api): Return "type" and "targetType" as strings from trigger action endpoints

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -9,11 +9,17 @@ from sentry.incidents.models import AlertRuleTriggerAction
 @register(AlertRuleTriggerAction)
 class AlertRuleTriggerActionSerializer(Serializer):
     def serialize(self, obj, attrs, user):
+        from sentry.incidents.endpoints.serializers import action_target_type_to_string
+
         return {
             "id": six.text_type(obj.id),
             "alertRuleTriggerId": six.text_type(obj.alert_rule_trigger_id),
-            "type": obj.type,
-            "targetType": obj.target_type,
+            "type": AlertRuleTriggerAction.get_registered_type(
+                AlertRuleTriggerAction.Type(obj.type)
+            ).slug,
+            "targetType": action_target_type_to_string[
+                AlertRuleTriggerAction.TargetType(obj.target_type)
+            ],
             "targetIdentifier": obj.target_identifier,
             "targetDisplay": obj.target_display
             if obj.target_display is not None

--- a/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import six
 
 from sentry.api.serializers import serialize
+from sentry.incidents.endpoints.serializers import action_target_type_to_string
 from sentry.incidents.logic import create_alert_rule_trigger, create_alert_rule_trigger_action
 from sentry.incidents.models import AlertRuleThresholdType, AlertRuleTriggerAction
 from sentry.testutils import TestCase
@@ -14,8 +15,16 @@ class AlertRuleTriggerActionSerializerTest(TestCase):
     def assert_action_serialized(self, action, result):
         assert result["id"] == six.text_type(action.id)
         assert result["alertRuleTriggerId"] == six.text_type(action.alert_rule_trigger_id)
-        assert result["type"] == action.type
-        assert result["targetType"] == action.target_type
+        assert (
+            result["type"]
+            == AlertRuleTriggerAction.get_registered_type(
+                AlertRuleTriggerAction.Type(action.type)
+            ).slug
+        )
+        assert (
+            result["targetType"]
+            == action_target_type_to_string[AlertRuleTriggerAction.TargetType(action.target_type)]
+        )
         assert result["targetIdentifier"] == action.target_identifier
         assert result["targetDisplay"] == action.target_identifier
         assert result["integrationId"] == action.integration_id


### PR DESCRIPTION
Missed this in previous prs.