### PR TITLE
fix(discover2): Add loading indicators for the minigraphs

### DIFF
--- a/src/sentry/static/sentry/app/components/loading/loadingContainer.tsx
+++ b/src/sentry/static/sentry/app/components/loading/loadingContainer.tsx
@@ -3,10 +3,12 @@ import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 
 import LoadingIndicator from 'app/components/loadingIndicator';
+import theme from 'app/utils/theme';
 
 const defaultProps = {
   isLoading: false,
   isReloading: false,
+  maskBackgroundColor: theme.white,
 };
 
 type DefaultProps = Readonly<typeof defaultProps>;
@@ -18,17 +20,21 @@ type Props = {
 
 type MaskProps = {
   isReloading: boolean;
+  maskBackgroundColor: string;
 };
 
 export default function LoadingContainer(props: Props) {
-  const {className, children, isReloading, isLoading} = props;
+  const {className, children, isReloading, isLoading, maskBackgroundColor} = props;
   const isLoadingOrReloading = isLoading || isReloading;
 
   return (
     <Container className={className}>
       {isLoadingOrReloading && (
         <div>
-          <LoadingMask isReloading={isReloading} />
+          <LoadingMask
+            isReloading={isReloading}
+            maskBackgroundColor={maskBackgroundColor}
+          />
           <Indicator />
         </div>
       )}
@@ -52,7 +58,7 @@ const Container = styled('div')`
 const LoadingMask = styled('div')<MaskProps>`
   position: absolute;
   z-index: 1;
-  background-color: ${p => p.theme.white};
+  background-color: ${p => p.maskBackgroundColor};
   width: 100%;
   height: 100%;
   opacity: ${p => (p.isReloading ? '0.6' : '1')};

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import isEqual from 'lodash/isEqual';
 import {Location} from 'history';
+import styled from 'react-emotion';
 
 import withApi from 'app/utils/withApi';
 import {Client} from 'app/api';
@@ -9,6 +10,7 @@ import EventsRequest from 'app/views/events/utils/eventsRequest';
 import AreaChart from 'app/components/charts/areaChart';
 import {getInterval} from 'app/components/charts/utils';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
+import LoadingIndicator from 'app/components/loadingIndicator';
 
 import EventView from './eventView';
 
@@ -68,7 +70,11 @@ class MiniGraph extends React.Component<Props> {
       >
         {({loading, timeseriesData}) => {
           if (loading) {
-            return null;
+            return (
+              <LoadingContainer>
+                <LoadingIndicator mini />
+              </LoadingContainer>
+            );
           }
 
           const data = (timeseriesData || []).map(series => {
@@ -121,5 +127,13 @@ class MiniGraph extends React.Component<Props> {
     );
   }
 }
+
+const LoadingContainer = styled('div')`
+  height: 100px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
 export default withApi(MiniGraph);

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -11,6 +11,7 @@ import AreaChart from 'app/components/charts/areaChart';
 import {getInterval} from 'app/components/charts/utils';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import LoadingIndicator from 'app/components/loadingIndicator';
+import LoadingContainer from 'app/components/loading/loadingContainer';
 
 import EventView from './eventView';
 
@@ -71,9 +72,9 @@ class MiniGraph extends React.Component<Props> {
         {({loading, timeseriesData}) => {
           if (loading) {
             return (
-              <LoadingContainer>
+              <StyledLoadingContainer>
                 <LoadingIndicator mini />
-              </LoadingContainer>
+              </StyledLoadingContainer>
             );
           }
 
@@ -128,7 +129,9 @@ class MiniGraph extends React.Component<Props> {
   }
 }
 
-const LoadingContainer = styled('div')`
+const StyledLoadingContainer = styled(props => {
+  return <LoadingContainer {...props} maskBackgroundColor="transparent" />;
+})`
   height: 100px;
 
   display: flex;


### PR DESCRIPTION
It can be hard to discern if the graphs were loaded; so I've added some loading indicators to them.

![Kapture 2019-11-21 at 20 46 00](https://user-images.githubusercontent.com/139499/69391559-3794fb80-0ca1-11ea-9b5d-79e065d5bbd3.gif)
