### PR TITLE
fix(discover2): Be able to delete columns on invalid queries

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -293,6 +293,10 @@ const queryStringFromSavedQuery = (saved: NewQuery | LegacySavedQuery): string =
   return '';
 };
 
+function validateTableMeta(tableMeta: MetaType | undefined): MetaType | undefined {
+  return tableMeta && Object.keys(tableMeta).length > 0 ? tableMeta : undefined;
+}
+
 class EventView {
   id: string | undefined;
   name: string | undefined;
@@ -695,8 +699,7 @@ class EventView {
     }
 
     // ensure tableDataMeta is non-empty
-    tableDataMeta =
-      tableDataMeta && Object.keys(tableDataMeta).length > 0 ? tableDataMeta : undefined;
+    tableDataMeta = validateTableMeta(tableDataMeta);
 
     const newEventView = this.clone();
 
@@ -771,8 +774,7 @@ class EventView {
     }
 
     // ensure tableDataMeta is non-empty
-    tableDataMeta =
-      tableDataMeta && Object.keys(tableDataMeta).length > 0 ? tableDataMeta : undefined;
+    tableDataMeta = validateTableMeta(tableDataMeta);
 
     // delete the column
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -689,7 +689,7 @@ class EventView {
       field: string;
       fieldname: string;
     },
-    tableDataMeta: MetaType
+    tableDataMeta: MetaType | undefined
   ): EventView {
     const {field, aggregation, fieldname} = updatedColumn;
 
@@ -703,6 +703,10 @@ class EventView {
     if (!updateField && !updateFieldName) {
       return this;
     }
+
+    // ensure tableDataMeta is non-empty
+    tableDataMeta =
+      tableDataMeta && Object.keys(tableDataMeta).length > 0 ? tableDataMeta : undefined;
 
     const newEventView = this.clone();
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -60,9 +60,7 @@ const isSortEqualToField = (
   field: Field,
   tableDataMeta: MetaType | undefined
 ): boolean => {
-  const sortKey = tableDataMeta
-    ? getSortKeyFromField(field, tableDataMeta)
-    : getSortKeyFromFieldWithoutMeta(field);
+  const sortKey = getSortKeyFromField(field, tableDataMeta);
   return sort.field === sortKey;
 };
 
@@ -70,9 +68,7 @@ const fieldToSort = (
   field: Field,
   tableDataMeta: MetaType | undefined
 ): Sort | undefined => {
-  const sortKey = tableDataMeta
-    ? getSortKeyFromField(field, tableDataMeta)
-    : getSortKeyFromFieldWithoutMeta(field);
+  const sortKey = getSortKeyFromField(field, tableDataMeta);
 
   if (!sortKey) {
     return void 0;
@@ -84,19 +80,17 @@ const fieldToSort = (
   };
 };
 
-function getSortKeyFromFieldWithoutMeta(field: Field): string | null {
+function getSortKeyFromField(
+  field: Field,
+  tableDataMeta: MetaType | undefined
+): string | null {
   const column = getAggregateAlias(field.field);
   if (SPECIAL_FIELDS.hasOwnProperty(column)) {
     return SPECIAL_FIELDS[column as keyof typeof SPECIAL_FIELDS].sortField;
   }
 
-  return column;
-}
-
-function getSortKeyFromField(field: Field, tableDataMeta: MetaType): string | null {
-  const column = getAggregateAlias(field.field);
-  if (SPECIAL_FIELDS.hasOwnProperty(column)) {
-    return SPECIAL_FIELDS[column as keyof typeof SPECIAL_FIELDS].sortField;
+  if (!tableDataMeta) {
+    return column;
   }
 
   if (FIELD_FORMATTERS.hasOwnProperty(tableDataMeta[column])) {
@@ -113,11 +107,7 @@ export function isFieldSortable(
   field: Field,
   tableDataMeta: MetaType | undefined
 ): boolean {
-  if (tableDataMeta) {
-    return !!getSortKeyFromField(field, tableDataMeta);
-  }
-
-  return !!getSortKeyFromFieldWithoutMeta(field);
+  return !!getSortKeyFromField(field, tableDataMeta);
 }
 
 const generateFieldAsString = (props: {aggregation: string; field: string}): string => {
@@ -341,7 +331,7 @@ class EventView {
 
     const sortKeys = fields
       .map(field => {
-        return getSortKeyFromFieldWithoutMeta(field);
+        return getSortKeyFromField(field, undefined);
       })
       .filter(
         (sortKey): sortKey is string => {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -170,13 +170,11 @@ class TableView extends React.Component<TableViewProps> {
   _deleteColumn = (columnIndex: number) => {
     const {location, eventView, tableData, organization} = this.props;
 
-    if (!tableData || !tableData.meta) {
-      return;
-    }
+    const tableMeta = (tableData && tableData.meta) || {};
 
     const prevField = explodeField(eventView.fields[columnIndex]);
 
-    const nextEventView = eventView.withDeletedColumn(columnIndex, tableData.meta);
+    const nextEventView = eventView.withDeletedColumn(columnIndex, tableMeta);
 
     // metrics
     trackAnalyticsEvent({

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -170,10 +170,9 @@ class TableView extends React.Component<TableViewProps> {
   _deleteColumn = (columnIndex: number) => {
     const {location, eventView, tableData, organization} = this.props;
 
-    const tableMeta = (tableData && tableData.meta) || {};
-
     const prevField = explodeField(eventView.fields[columnIndex]);
 
+    const tableMeta = (tableData && tableData.meta) || undefined;
     const nextEventView = eventView.withDeletedColumn(columnIndex, tableMeta);
 
     // metrics

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -108,21 +108,14 @@ class TableView extends React.Component<TableViewProps> {
   _updateColumn = (columnIndex: number, nextColumn: TableColumn<keyof TableDataRow>) => {
     const {location, eventView, tableData, organization} = this.props;
 
-    if (!tableData || !tableData.meta) {
-      return;
-    }
-
     const payload = {
       aggregation: String(nextColumn.aggregation),
       field: String(nextColumn.field),
       fieldname: nextColumn.name,
     };
 
-    const nextEventView = eventView.withUpdatedColumn(
-      columnIndex,
-      payload,
-      tableData.meta
-    );
+    const tableMeta = (tableData && tableData.meta) || undefined;
+    const nextEventView = eventView.withUpdatedColumn(columnIndex, payload, tableMeta);
 
     if (nextEventView !== eventView) {
       const changed: string[] = [];

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -1363,6 +1363,41 @@ describe('EventView.withDeletedColumn()', function() {
   });
 
   describe('deletes column, and use any remaining sortable column', function() {
+    it('using no provided table meta', function() {
+      // table meta may not be provided in the invalid query state;
+      // we will still want to be able to delete columns
+
+      const state2 = {
+        ...state,
+        fields: [
+          {field: 'title', title: 'title'},
+          {field: 'timestamp', title: 'timestamp'},
+          {field: 'count(id)', title: 'count(id)'},
+        ],
+        sorts: generateSorts(['timestamp']),
+      };
+
+      const eventView = new EventView(state2);
+
+      const expected = {
+        ...state,
+        sorts: generateSorts(['title']),
+        fields: [
+          {field: 'title', title: 'title'},
+          {field: 'count(id)', title: 'count(id)'},
+        ],
+      };
+
+      const eventView2 = eventView.withDeletedColumn(1, {});
+      expect(eventView2).toMatchObject(expected);
+
+      const eventView3 = eventView.withDeletedColumn(1);
+      expect(eventView3).toMatchObject(expected);
+
+      const eventView4 = eventView.withDeletedColumn(1, null);
+      expect(eventView4).toMatchObject(expected);
+    });
+
     it('has no remaining sortable column', function() {
       const eventView = new EventView(state);
 

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -1255,6 +1255,34 @@ describe('EventView.withUpdatedColumn()', function() {
 
       expect(eventView2).toMatchObject(nextState);
     });
+
+    it('using no provided table meta', function() {
+      // table meta may not be provided in the invalid query state;
+      // we will still want to be able to update columns
+
+      const eventView = new EventView(state);
+
+      const expected = {
+        ...state,
+        sorts: [{field: 'title', kind: 'desc'}],
+        fields: [{field: 'title', title: 'event title'}, state.fields[1]],
+      };
+
+      const newColumn = {
+        aggregation: '',
+        field: 'title',
+        fieldname: 'event title',
+      };
+
+      const eventView2 = eventView.withUpdatedColumn(0, newColumn, {});
+      expect(eventView2).toMatchObject(expected);
+
+      const eventView3 = eventView.withUpdatedColumn(0, newColumn);
+      expect(eventView3).toMatchObject(expected);
+
+      const eventView4 = eventView.withUpdatedColumn(0, newColumn, null);
+      expect(eventView4).toMatchObject(expected);
+    });
   });
 
   describe('update a column to a non-sortable column', function() {


### PR DESCRIPTION
Addresses:

- Be able to delete columns on invalid queries (i.e. the delete column button doesn't do anything when clicked)
- In invalid query state, deleting a sorted column does not update the sort query string
- In invalid query state, updating a sorted column does not update the sort query string