### PR TITLE
ref: Bump semaphore to 0.4.62

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ redis>=2.10.3,<2.10.6
 requests-oauthlib==0.3.3
 requests[security]>=2.20.0,<2.21.0
 selenium==3.141.0
-semaphore>=0.4.61,<0.5.0
+semaphore>=0.4.62,<0.5.0
 sentry-sdk>=0.13.1
 setproctitle>=1.1.7,<1.2.0
 simplejson>=3.2.0,<3.9.0


### PR DESCRIPTION
Changes relevant to sentry:

* renormalization (loading event from db) no longer crashes if the transaction is missing fields or has invalid duration