### PR TITLE
ref(relay): Set organization cache explicitly

### DIFF
--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -60,7 +60,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
 
         with Hub.current.start_span(op="relay_fetch_keys"):
             project_keys = {}
-            for key in ProjectKey.objects.get_many_from_cache(project_ids, key="project_id"):
+            for key in ProjectKey.objects.filter(project_id__in=project_ids):
                 project_keys.setdefault(key.project_id, []).append(key)
 
         metrics.timing("relay_project_configs.projects_requested", len(project_ids))
@@ -79,7 +79,10 @@ class RelayProjectConfigsEndpoint(Endpoint):
             if organization is None:
                 continue
 
+            # Try to prevent organization from being fetched again in quotas.
             project.organization = organization
+            project._organization_cache = organization
+
             org_opts = org_options.get(organization.id) or {}
 
             with Hub.current.start_span(op="get_config"):


### PR DESCRIPTION
we check for this attribute inside `quotas/base` to avoid a db query