### PR TITLE
fix(sourcemaps): Cache based on full identifier

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -202,12 +202,11 @@ def discover_sourcemap(result):
 
 
 def fetch_release_file(filename, release, dist=None):
-    cache_key = "releasefile:v1:%s:%s" % (release.id, md5_text(filename).hexdigest())
+    dist_name = dist and dist.name or None
+    cache_key = "releasefile:v1:%s:%s" % (release.id, ReleaseFile.get_ident(filename, dist_name))
 
     logger.debug("Checking cache for release artifact %r (release_id=%s)", filename, release.id)
     result = cache.get(cache_key)
-
-    dist_name = dist and dist.name or None
 
     if result is None:
         filename_choices = ReleaseFile.normalize(filename)

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -89,9 +89,9 @@ class FetchReleaseFileTest(TestCase):
             "utf-8",
         )
 
-        # test with cache hit, which should be compressed
+        # looking again should hit the cache - make sure it's come through the
+        # caching/uncaching process unscathed
         new_result = fetch_release_file("file.min.js", release)
-
         assert result == new_result
 
     def test_distribution(self):
@@ -99,55 +99,53 @@ class FetchReleaseFileTest(TestCase):
         release = Release.objects.create(organization_id=project.organization_id, version="abc")
         release.add_project(project)
 
-        other_file = File.objects.create(
+        foo_file = File.objects.create(
             name="file.min.js",
             type="release.file",
             headers={"Content-Type": "application/json; charset=utf-8"},
         )
-        file = File.objects.create(
+        foo_file.putfile(six.BytesIO("foo"))
+        foo_dist = release.add_dist("foo")
+        ReleaseFile.objects.create(
+            name="file.min.js",
+            release=release,
+            dist=foo_dist,
+            organization_id=project.organization_id,
+            file=foo_file,
+        )
+
+        bar_file = File.objects.create(
             name="file.min.js",
             type="release.file",
             headers={"Content-Type": "application/json; charset=utf-8"},
         )
-
-        binary_body = unicode_body.encode("utf-8")
-        other_file.putfile(six.BytesIO(b""))
-        file.putfile(six.BytesIO(binary_body))
-
-        dist = release.add_dist("foo")
-
+        bar_file.putfile(six.BytesIO("bar"))
+        bar_dist = release.add_dist("bar")
         ReleaseFile.objects.create(
             name="file.min.js",
             release=release,
+            dist=bar_dist,
             organization_id=project.organization_id,
-            file=other_file,
+            file=bar_file,
         )
 
-        ReleaseFile.objects.create(
-            name="file.min.js",
-            release=release,
-            dist=dist,
-            organization_id=project.organization_id,
-            file=file,
+        foo_result = fetch_release_file("file.min.js", release, foo_dist)
+
+        assert isinstance(foo_result.body, six.binary_type)
+        assert foo_result == http.UrlResult(
+            "file.min.js", {"content-type": "application/json; charset=utf-8"}, "foo", 200, "utf-8"
         )
 
-        result = fetch_release_file("file.min.js", release, dist)
+        # test that cache pays attention to dist value as well as name
+        bar_result = fetch_release_file("file.min.js", release, bar_dist)
 
-        assert isinstance(result.body, six.binary_type)
-        assert result == http.UrlResult(
-            "file.min.js",
-            {"content-type": "application/json; charset=utf-8"},
-            binary_body,
-            200,
-            "utf-8",
+        # result is cached, but that's not what we should find
+        assert bar_result != foo_result
+        assert bar_result == http.UrlResult(
+            "file.min.js", {"content-type": "application/json; charset=utf-8"}, "bar", 200, "utf-8"
         )
 
-        # test with cache hit, which should be compressed
-        new_result = fetch_release_file("file.min.js", release, dist)
-
-        assert result == new_result
-
-    def test_fallbacks(self):
+    def test_tilde(self):
         project = self.project
         release = Release.objects.create(organization_id=project.organization_id, version="abc")
         release.add_project(project)


### PR DESCRIPTION
We identify release artifacts by a combination of their name and their `dist` value, but when we cache them, we currently only key them by name. This means that the following can happen (assume that I have two files named `~/bundle.js`, both attached to `my_release`, but with two different `dist`s, `1` and `2`):

- An event comes in tagged `release: 'my_release'`, `dist: 1`, containing a frame from `.../bundle.js`. We look in our cache, find nothing, and move on to the database, where we correctly match on the name/`dist` combo and pull the first file. While we're at it, we also cache it, under a key consisting of the release id and (a hash of) the filename. So far, so good.

- An event comes in tagged `release: 'my_release'`, `dist: 2`, containing a frame from `.../bundle.js`. We look in our cache, under that same combo of release id/filename hash, and find the first file. We pull it out of the cache and use it, even though we really want the second file. Whoops.

This PR adds the `dist` value into the hash so that in the future, the second bullet point above would read identically to the first. Also changed a misleading comment after consultation w @mattrobenolt.

Once this is approved, will strategize with @JTCunning on merging/deployment timing, since it's going to involve the one-time hit of completely invalidating the cache as it exists at that moment.