### PR TITLE
feat(filters): Add Firefox extensions to browser extensions filter

### DIFF
--- a/src/sentry/message_filters.py
+++ b/src/sentry/message_filters.py
@@ -262,6 +262,8 @@ _EXTENSION_EXC_SOURCES = re.compile(
             r"static\.woopra\.com\/js\/woopra\.js",
             # Chrome extensions
             r"^chrome(?:-extension)?:\/\/",
+            # Firefox extensions
+            r"^moz-extension:\/\/",
             # Cacaoweb
             r"127\.0\.0\.1:4001\/isrunning",
             # Other

--- a/tests/sentry/filters/test_browser_extensions.py
+++ b/tests/sentry/filters/test_browser_extensions.py
@@ -61,6 +61,10 @@ class BrowserExtensionsFilterTest(TestCase):
         data = self.get_mock_data(exc_source="chrome-extension://my-extension/or/something")
         assert self.apply_filter(data)
 
+    def test_filters_firefox_extensions(self):
+        data = self.get_mock_data(exc_source="moz-extension://my-extension/or/something")
+        assert self.apply_filter(data)
+
     def test_does_not_filter_generic_data(self):
         data = self.get_mock_data()
         assert not self.apply_filter(data)


### PR DESCRIPTION
Per [this MDN page](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources), the `moz-extension://` scheme is how extensions access their resources, including their JS files.

Adding this scheme here as well as in the relay version of the filter (https://github.com/getsentry/semaphore/pull/333).