### PR TITLE
ref: Cache projectkeys more aggressively

### DIFF
--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -60,7 +60,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
 
         with Hub.current.start_span(op="relay_fetch_keys"):
             project_keys = {}
-            for key in ProjectKey.objects.filter(project_id__in=project_ids):
+            for key in ProjectKey.objects.get_many_from_cache(project_ids, key="project_id"):
                 project_keys.setdefault(key.project_id, []).append(key)
 
         metrics.timing("relay_project_configs.projects_requested", len(project_ids))

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -63,7 +63,12 @@ class ProjectKey(Model):
     rate_limit_count = BoundedPositiveIntegerField(null=True)
     rate_limit_window = BoundedPositiveIntegerField(null=True)
 
-    objects = BaseManager(cache_fields=("public_key", "secret_key"))
+    objects = BaseManager(
+        cache_fields=("public_key", "secret_key"),
+        # store projectkeys in memcached for longer than other models,
+        # specifically to make the relay_projectconfig endpoint faster.
+        cache_ttl=60 * 30,
+    )
 
     data = JSONField()
 


### PR DESCRIPTION
in https://github.com/getsentry/sentry/pull/15777 we stopped fetching projectkeys from memcached because we had the suspicion that memcached would always be empty due to low ttl. So we would pay the cost of both the memcached commands and the DB query.

Ideally we should still get rid of the DB query so let's try bumping the cache TTL for this model instead.