### PR TITLE
fix: Do not throw 500s on invalid transactions

### DIFF
--- a/src/sentry/web/api.py
+++ b/src/sentry/web/api.py
@@ -632,7 +632,14 @@ class StoreView(APIView):
         del data
 
         self.pre_normalize(event_manager, helper)
-        event_manager.normalize()
+
+        try:
+            event_manager.normalize()
+        except semaphore.ProcessingActionInvalidTransaction as e:
+            track_outcome(
+                organization_id, project_id, key.id, Outcome.INVALID, "invalid_transaction"
+            )
+            raise APIError(e)
 
         data = event_manager.get_data()
         dict_data = dict(data)


### PR DESCRIPTION
The outcome will be in sync with relay when https://github.com/getsentry/semaphore/pull/334 is deployed

Fix SENTRY-D7N
Fix SENTRY-DNT