### PR TITLE
fix(discover2): Decrease fidelity of the interval for the minigraphs

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -37,9 +37,12 @@ class MiniGraph extends React.Component<Props> {
     const {organization, location, eventView} = props;
 
     const apiPayload = eventView.getEventsAPIPayload(location);
+
     const query = apiPayload.query;
-    const start = getUtcToLocalDateObject(apiPayload.start);
-    const end = getUtcToLocalDateObject(apiPayload.end);
+    const start = apiPayload.start
+      ? getUtcToLocalDateObject(apiPayload.start)
+      : undefined;
+    const end = apiPayload.end ? getUtcToLocalDateObject(apiPayload.end) : undefined;
     const period: string | undefined = apiPayload.statsPeriod as any;
 
     return {
@@ -64,7 +67,7 @@ class MiniGraph extends React.Component<Props> {
         start={start}
         end={end}
         period={period}
-        interval={getInterval({start, end, period}, true)}
+        interval={getInterval({start, end, period}, false)}
         project={eventView.project as number[]}
         environment={eventView.environment as string[]}
         includePrevious={false}


### PR DESCRIPTION
- Decrease fidelity of the interval for the minigraphs.

- Also addresses a bug where `getUtcToLocalDateObject(undefined)`actually returns a `Date` object leading to the minigraph fidelity interval to be 1 minute; which is incorrect. We work around this by adding guards whenever `start` and `end` are truthy.