### PR TITLE
fix(discover) Fix DOMNesting error

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -33,6 +33,7 @@ type Props = {
 class QueryList extends React.Component<Props> {
   handleDeleteQuery = (eventView: EventView) => (event: React.MouseEvent<Element>) => {
     event.preventDefault();
+    event.stopPropagation();
 
     const {api, location, organization} = this.props;
 
@@ -46,6 +47,7 @@ class QueryList extends React.Component<Props> {
 
   handleDuplicateQuery = (eventView: EventView) => (event: React.MouseEvent<Element>) => {
     event.preventDefault();
+    event.stopPropagation();
 
     const {api, location, organization} = this.props;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
@@ -28,7 +28,7 @@ class QueryCard extends React.PureComponent<Props> {
     const {title, subtitle, queryDetail, renderContextMenu, renderGraph} = this.props;
 
     return (
-      <StyledQueryCard tabIndex={1} onClick={this.handleClick}>
+      <StyledQueryCard onClick={this.handleClick}>
         <QueryCardHeader>
           <StyledTitle>{title}</StyledTitle>
           <StyledQueryDetail>{queryDetail}</StyledQueryDetail>
@@ -45,21 +45,25 @@ class QueryCard extends React.PureComponent<Props> {
   }
 }
 
-const StyledQueryCard = styled('div')`
+const StyledQueryCard = styled('button')`
   background: ${p => p.theme.white};
   border: 1px solid ${p => p.theme.borderLight};
   border-radius: ${p => p.theme.borderRadius};
   display: flex;
+  align-items: stretch;
   flex-direction: column;
   justify-content: space-between;
   height: 205px;
   transition: all 0.2s ease;
   cursor: pointer;
+  text-align: left;
+  padding: 0;
 
   &:focus,
   &:hover {
     box-shadow: 0px 0px 0px 6px rgba(209, 202, 216, 0.2);
     transform: translateY(-2px);
+    outline: none;
   }
 
   &:active {
@@ -74,7 +78,6 @@ const StyledQueryCard = styled('div')`
 
 const QueryCardHeader = styled('div')`
   padding: ${space(1.5)} ${space(2)};
-  height: 80px;
   overflow: hidden;
   line-height: 1.4;
 `;

--- a/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
@@ -1,33 +1,34 @@
 import React from 'react';
 import styled from 'react-emotion';
+import {browserHistory} from 'react-router';
 
 import space from 'app/styles/space';
-import Link from 'app/components/links/link';
+import {callIfFunction} from 'app/utils/callIfFunction';
 
 type Props = {
   title?: string;
   subtitle: string;
   queryDetail?: string;
-  to?: string | object;
+  to: object;
   onEventClick?: () => void;
   renderGraph: () => React.ReactNode;
   renderContextMenu?: () => React.ReactNode;
 };
 
 class QueryCard extends React.PureComponent<Props> {
+  handleClick = (event: React.MouseEvent) => {
+    event.preventDefault();
+    const {onEventClick, to} = this.props;
+
+    callIfFunction(onEventClick);
+    browserHistory.push(to);
+  };
+
   render() {
-    const {
-      title,
-      subtitle,
-      queryDetail,
-      onEventClick,
-      to,
-      renderContextMenu,
-      renderGraph,
-    } = this.props;
+    const {title, subtitle, queryDetail, renderContextMenu, renderGraph} = this.props;
 
     return (
-      <StyledQueryCard onClick={onEventClick} to={to}>
+      <StyledQueryCard tabIndex={1} onClick={this.handleClick}>
         <QueryCardHeader>
           <StyledTitle>{title}</StyledTitle>
           <StyledQueryDetail>{queryDetail}</StyledQueryDetail>
@@ -44,7 +45,7 @@ class QueryCard extends React.PureComponent<Props> {
   }
 }
 
-const StyledQueryCard = styled(Link)`
+const StyledQueryCard = styled('div')`
   background: ${p => p.theme.white};
   border: 1px solid ${p => p.theme.borderLight};
   border-radius: ${p => p.theme.borderRadius};
@@ -53,7 +54,9 @@ const StyledQueryCard = styled(Link)`
   justify-content: space-between;
   height: 205px;
   transition: all 0.2s ease;
+  cursor: pointer;
 
+  &:focus,
   &:hover {
     box-shadow: 0px 0px 0px 6px rgba(209, 202, 216, 0.2);
     transform: translateY(-2px);


### PR DESCRIPTION
Opening the context menu would generate a DOMNesting error as the context menu uses `a` elements but the card is also using an `a` element. By switching the card to a div we don't get that error and we can retain the keyboard navigation and focus/hover styles.