### PR TITLE
fix(discover2): Make graphs on minigraphs less blobby

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -67,7 +67,7 @@ class MiniGraph extends React.Component<Props> {
         start={start}
         end={end}
         period={period}
-        interval={getInterval({start, end, period}, false)}
+        interval={getInterval({start, end, period}, true)}
         project={eventView.project as number[]}
         environment={eventView.environment as string[]}
         includePrevious={false}


### PR DESCRIPTION
The discover team doesn't like blobby minigraphs.