### PR TITLE
fix(discover) Optimize count() functions

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -694,18 +694,9 @@ FIELD_ALIASES = {
             ]
         ],
     },
-    "p75": {
-        "result_type": "duration",
-        "aggregations": [["quantile(0.75)(duration)", "", "p75"]],
-    },
-    "p95": {
-        "result_type": "duration",
-        "aggregations": [["quantile(0.95)(duration)", "", "p95"]],
-    },
-    "p99": {
-        "result_type": "duration",
-        "aggregations": [["quantile(0.99)(duration)", "", "p99"]],
-    },
+    "p75": {"result_type": "duration", "aggregations": [["quantile(0.75)(duration)", "", "p75"]]},
+    "p95": {"result_type": "duration", "aggregations": [["quantile(0.95)(duration)", "", "p95"]]},
+    "p99": {"result_type": "duration", "aggregations": [["quantile(0.99)(duration)", "", "p99"]]},
 }
 
 VALID_AGGREGATES = {
@@ -809,13 +800,18 @@ def resolve_field_list(fields, snuba_args):
             continue
 
         validate_aggregate(field, match)
-        aggregations.append(
-            [
-                VALID_AGGREGATES[match.group("function")]["snuba_name"],
-                match.group("column"),
-                get_aggregate_alias(match),
-            ]
-        )
+
+        if match.group("function") == "count":
+            # count() is a special function that ignores its column arguments.
+            aggregations.append(["count", "", get_aggregate_alias(match)])
+        else:
+            aggregations.append(
+                [
+                    VALID_AGGREGATES[match.group("function")]["snuba_name"],
+                    match.group("column"),
+                    get_aggregate_alias(match),
+                ]
+            )
 
     rollup = snuba_args.get("rollup")
     if not rollup:

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1086,12 +1086,26 @@ class ResolveFieldListTest(unittest.TestCase):
     def test_aggregate_function_expansion(self):
         fields = ["count_unique(user)", "count(id)", "min(timestamp)"]
         result = resolve_field_list(fields, {})
-        # Automatic fields should be inserted
+        # Automatic fields should be inserted, count() should have its column dropped.
         assert result["selected_columns"] == []
         assert result["aggregations"] == [
             ["uniq", "user", "count_unique_user"],
-            ["count", "id", "count_id"],
+            ["count", "", "count_id"],
             ["min", "timestamp", "min_timestamp"],
+            ["argMax", ["id", "timestamp"], "latest_event"],
+            ["argMax", ["project_id", "timestamp"], "projectid"],
+        ]
+        assert result["groupby"] == []
+
+    def test_count_function_expansion(self):
+        fields = ["count(id)", "count(user)", "count(transaction.duration)"]
+        result = resolve_field_list(fields, {})
+        # Automatic fields should be inserted, count() should have its column dropped.
+        assert result["selected_columns"] == []
+        assert result["aggregations"] == [
+            ["count", "", "count_id"],
+            ["count", "", "count_user"],
+            ["count", "", "count_transaction_duration"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project_id", "timestamp"], "projectid"],
         ]
@@ -1181,7 +1195,7 @@ class ResolveFieldListTest(unittest.TestCase):
         result = resolve_field_list(fields, snuba_args)
         assert result["orderby"] == ["-count_id"]
         assert result["aggregations"] == [
-            ["count", "id", "count_id"],
+            ["count", "", "count_id"],
             ["uniq", "user", "count_unique_user"],
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["argMax", ["project_id", "timestamp"], "projectid"],


### PR DESCRIPTION
When count() has a column it performs much slower as each value needs to be checked for null-ness. At the product layer we want count() to be a simple row count, but the current query builder requires a column. Special casing the count() function lets us get the intended results more efficiently.