### PR TITLE
ref(django 1.10): better plugin urlpatterns

### DIFF
--- a/src/sentry/plugins/base/group_api_urls.py
+++ b/src/sentry/plugins/base/group_api_urls.py
@@ -3,32 +3,28 @@ from __future__ import absolute_import
 import logging
 import re
 
-from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
-from django.conf.urls import include, url
+from django.conf.urls import include, url, RegexURLResolver, RegexURLPattern
 
 from sentry.plugins.base import plugins
 
 logger = logging.getLogger("sentry.plugins")
 
 
-def ensure_url(u):
-    if isinstance(u, (tuple, list)):
-        return url(*u)
-    elif not isinstance(u, (RegexURLResolver, RegexURLPattern)):
-        raise TypeError(
-            "url must be RegexURLResolver or RegexURLPattern, not %r: %r" % (type(u).__name__, u)
-        )
-    return u
-
-
 def load_plugin_urls(plugins):
     urlpatterns = []
     for plugin in plugins:
+        urls = plugin.get_group_urls()
+        if not urls:
+            continue
         try:
-            urls = plugin.get_group_urls()
-            if not urls:
-                continue
-            urls = [ensure_url(u) for u in urls]
+            # a plugin's get_group_urls should return an iterable of url()'s,
+            # which can either be RegexURLResolver or RegexURLPattern
+            for u in urls:
+                if not isinstance(u, (RegexURLResolver, RegexURLPattern)):
+                    raise TypeError(
+                        "url must be RegexURLResolver or RegexURLPattern, not %r: %r"
+                        % (type(u).__name__, u)
+                    )
         except Exception:
             logger.exception("routes.failed", extra={"plugin": type(plugin).__name__})
         else:

--- a/src/sentry/plugins/base/project_api_urls.py
+++ b/src/sentry/plugins/base/project_api_urls.py
@@ -3,32 +3,28 @@ from __future__ import absolute_import
 import logging
 import re
 
-from django.core.urlresolvers import RegexURLResolver, RegexURLPattern
-from django.conf.urls import include, url
+from django.conf.urls import include, url, RegexURLResolver, RegexURLPattern
 
 from sentry.plugins.base import plugins
 
 logger = logging.getLogger("sentry.plugins")
 
 
-def ensure_url(u):
-    if isinstance(u, (tuple, list)):
-        return url(*u)
-    elif not isinstance(u, (RegexURLResolver, RegexURLPattern)):
-        raise TypeError(
-            "url must be RegexURLResolver or RegexURLPattern, not %r: %r" % (type(u).__name__, u)
-        )
-    return u
-
-
 def load_plugin_urls(plugins):
     urlpatterns = []
     for plugin in plugins:
+        urls = plugin.get_project_urls()
+        if not urls:
+            continue
         try:
-            urls = plugin.get_project_urls()
-            if not urls:
-                continue
-            urls = [ensure_url(u) for u in urls]
+            # a plugin's get_project_urls should return an iterable of url()'s,
+            # which can either be RegexURLResolver or RegexURLPattern
+            for u in urls:
+                if not isinstance(u, (RegexURLResolver, RegexURLPattern)):
+                    raise TypeError(
+                        "url must be RegexURLResolver or RegexURLPattern, not %r: %r"
+                        % (type(u).__name__, u)
+                    )
         except Exception:
             logger.exception("routes.failed", extra={"plugin": type(plugin).__name__})
         else:

--- a/src/sentry_plugins/asana/plugin.py
+++ b/src/sentry_plugins/asana/plugin.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import six
 
+from django.conf.urls import url
 from rest_framework.response import Response
 
 from sentry.exceptions import PluginError, PluginIdentityRequired
@@ -25,7 +26,7 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
 
     def get_group_urls(self):
         return super(AsanaPlugin, self).get_group_urls() + [
-            (
+            url(
                 r"^autocomplete",
                 IssueGroupActionEndpoint.as_view(view_method_name="view_autocomplete", plugin=self),
             )

--- a/src/sentry_plugins/bitbucket/plugin.py
+++ b/src/sentry_plugins/bitbucket/plugin.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from django.conf.urls import url
 from rest_framework.response import Response
 
 from sentry.plugins.bases.issue2 import IssuePlugin2, IssueGroupActionEndpoint
@@ -42,7 +43,7 @@ class BitbucketPlugin(BitbucketMixin, IssuePlugin2):
 
     def get_group_urls(self):
         return super(BitbucketPlugin, self).get_group_urls() + [
-            (
+            url(
                 r"^autocomplete",
                 IssueGroupActionEndpoint.as_view(view_method_name="view_autocomplete", plugin=self),
             )

--- a/src/sentry_plugins/clubhouse/plugin.py
+++ b/src/sentry_plugins/clubhouse/plugin.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import six
 
+from django.conf.urls import url
 from rest_framework.response import Response
 
 from sentry.exceptions import PluginError
@@ -25,7 +26,7 @@ class ClubhousePlugin(CorePluginMixin, IssuePlugin2):
 
     def get_group_urls(self):
         return super(ClubhousePlugin, self).get_group_urls() + [
-            (
+            url(
                 r"^autocomplete",
                 IssueGroupActionEndpoint.as_view(view_method_name="view_autocomplete", plugin=self),
             )

--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import logging
 import six
 
+from django.conf.urls import url
 from rest_framework.response import Response
 from uuid import uuid4
 
@@ -70,7 +71,7 @@ class GitHubPlugin(GitHubMixin, IssuePlugin2):
 
     def get_group_urls(self):
         return super(GitHubPlugin, self).get_group_urls() + [
-            (
+            url(
                 r"^autocomplete",
                 IssueGroupActionEndpoint.as_view(view_method_name="view_autocomplete", plugin=self),
             )

--- a/src/sentry_plugins/phabricator/plugin.py
+++ b/src/sentry_plugins/phabricator/plugin.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
+from django.conf.urls import url
 from rest_framework.response import Response
+
 from sentry.exceptions import PluginError
 from sentry.plugins.bases.issue2 import IssuePlugin2, IssueGroupActionEndpoint
 from sentry.utils.http import absolute_uri
@@ -122,7 +124,7 @@ class PhabricatorPlugin(CorePluginMixin, IssuePlugin2):
 
     def get_group_urls(self):
         return super(PhabricatorPlugin, self).get_group_urls() + [
-            (
+            url(
                 r"^autocomplete",
                 IssueGroupActionEndpoint.as_view(view_method_name="view_autocomplete", plugin=self),
             )

--- a/src/sentry_plugins/pivotal/plugin.py
+++ b/src/sentry_plugins/pivotal/plugin.py
@@ -3,8 +3,10 @@ from __future__ import absolute_import
 import requests
 import six
 
+from django.conf.urls import url
 from django.utils.encoding import force_text
 from rest_framework.response import Response
+
 from sentry.plugins.bases.issue2 import IssuePlugin2, IssueGroupActionEndpoint, PluginError
 from sentry.http import safe_urlopen, safe_urlread
 from sentry.utils import json
@@ -23,7 +25,7 @@ class PivotalPlugin(CorePluginMixin, IssuePlugin2):
 
     def get_group_urls(self):
         return super(PivotalPlugin, self).get_group_urls() + [
-            (
+            url(
                 r"^autocomplete",
                 IssueGroupActionEndpoint.as_view(view_method_name="view_autocomplete", plugin=self),
             )

--- a/tests/sentry/plugins/base/test.py
+++ b/tests/sentry/plugins/base/test.py
@@ -32,7 +32,14 @@ def test_load_plugin_project_urls():
 
     class GoodPluginA(Plugin2):
         def get_project_urls(self):
-            return [url("", None)]
+            # XXX: Django 1.10 requires a view callable. I was too lazy to figure out
+            # how to mock one, so just using this random low-level thing.
+            # As far as I can see, none of our plugins use get_project_urls, so
+            # all this can probably even be removed, but I'm keeping it here for now
+            # for fear of breakage.
+            from django.views.generic.list import BaseListView
+
+            return [url("", BaseListView.as_view())]
 
     from sentry.plugins.base.project_api_urls import load_plugin_urls
 

--- a/tests/sentry/plugins/base/test.py
+++ b/tests/sentry/plugins/base/test.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from django.conf.urls import url
 
 from sentry.plugins.base.v2 import Plugin2
-from sentry.plugins.base.project_api_urls import load_plugin_urls
 from sentry.plugins.base.response import JSONResponse
 from sentry.testutils import TestCase
 
@@ -18,7 +17,7 @@ def test_json_response_with_status_kwarg():
     assert resp.status_code == 400
 
 
-def test_load_plugin_urls():
+def test_load_plugin_project_urls():
     class BadPluginA(Plugin2):
         def get_project_urls(self):
             return [("foo", "bar")]
@@ -35,8 +34,18 @@ def test_load_plugin_urls():
         def get_project_urls(self):
             return [url("", None)]
 
+    from sentry.plugins.base.project_api_urls import load_plugin_urls
+
     patterns = load_plugin_urls((BadPluginA(), BadPluginB(), BadPluginC(), GoodPluginA()))
 
+    assert len(patterns) == 1
+
+
+def test_load_plugin_group_urls():
+    from sentry_plugins.clubhouse.plugin import ClubhousePlugin
+    from sentry.plugins.base.group_api_urls import load_plugin_urls
+
+    patterns = load_plugin_urls((ClubhousePlugin(),))
     assert len(patterns) == 1
 
 

--- a/tests/sentry/plugins/base/test.py
+++ b/tests/sentry/plugins/base/test.py
@@ -21,7 +21,7 @@ def test_json_response_with_status_kwarg():
 def test_load_plugin_urls():
     class BadPluginA(Plugin2):
         def get_project_urls(self):
-            assert False
+            return [("foo", "bar")]
 
     class BadPluginB(Plugin2):
         def get_project_urls(self):
@@ -35,15 +35,9 @@ def test_load_plugin_urls():
         def get_project_urls(self):
             return [url("", None)]
 
-    class GoodPluginB(Plugin2):
-        def get_project_urls(self):
-            return [("foo", "bar")]
+    patterns = load_plugin_urls((BadPluginA(), BadPluginB(), BadPluginC(), GoodPluginA()))
 
-    patterns = load_plugin_urls(
-        (BadPluginA(), BadPluginB(), BadPluginC(), GoodPluginA(), GoodPluginB())
-    )
-
-    assert len(patterns) == 2
+    assert len(patterns) == 1
 
 
 class Plugin2TestCase(TestCase):

--- a/tests/sentry/plugins/base/test.py
+++ b/tests/sentry/plugins/base/test.py
@@ -50,10 +50,28 @@ def test_load_plugin_project_urls():
 
 def test_load_plugin_group_urls():
     from sentry_plugins.clubhouse.plugin import ClubhousePlugin
+    from sentry_plugins.jira.plugin import JiraPlugin
+    from sentry_plugins.github.plugin import GitHubPlugin
+    from sentry_plugins.pivotal.plugin import PivotalPlugin
+    from sentry_plugins.bitbucket.plugin import BitbucketPlugin
+    from sentry_plugins.asana.plugin import AsanaPlugin
+    from sentry_plugins.phabricator.plugin import PhabricatorPlugin
+
     from sentry.plugins.base.group_api_urls import load_plugin_urls
 
-    patterns = load_plugin_urls((ClubhousePlugin(),))
-    assert len(patterns) == 1
+    patterns = load_plugin_urls(
+        (
+            ClubhousePlugin(),
+            JiraPlugin(),
+            GitHubPlugin(),
+            PivotalPlugin(),
+            BitbucketPlugin(),
+            AsanaPlugin(),
+            PhabricatorPlugin(),
+        )
+    )
+
+    assert len(patterns) == 7
 
 
 class Plugin2TestCase(TestCase):


### PR DESCRIPTION
Previously, we had `load_plugin_urls` which would construct urls via `url(*args)` if a plugin returned a tuple/list of arbitrary args instead of `url()`s. That isn't great because Django 1.10  requires the 2nd arg to `url()` to be a view callable or the retval of an `include()`. Rather than add more complicated checks for that, I felt it was easier and better to be stricter about plugins needing to return an iterable of `url()`s in the first place.

Also, it's pretty ironic that `load_plugin_urls` in `project_api_urls` was being tested, because I don't see any plugins implementing it. It can probably be removed, but I don't want to do that right now for fear of breakage.

`group_api_urls` on the other hand, is being used and wasn't covered by tests. You can see that I've added test coverage for `group_api_urls` and changed the plugins that were using it to return an iterable of `url()`s.