### PR TITLE
fix(api) Don't 500 on invalid offset values

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -236,6 +236,8 @@ class OffsetPaginator(object):
 
         if self.max_offset is not None and offset >= self.max_offset:
             raise BadPaginationError("Pagination offset too large")
+        if offset < 0:
+            raise BadPaginationError("Pagination offset cannot be negative")
 
         results = list(queryset[offset:stop])
         if cursor.value != limit:

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -115,6 +115,18 @@ class OffsetPaginatorTest(TestCase):
         assert not result5.next
         assert result5.prev
 
+    def test_negative_offset(self):
+        self.create_user("baz@example.com")
+        queryset = User.objects.all()
+        paginator = OffsetPaginator(queryset)
+        cursor = Cursor(10, -1)
+        with self.assertRaises(BadPaginationError):
+            paginator.get_result(cursor=cursor)
+
+        cursor = Cursor(-10, 1)
+        with self.assertRaises(BadPaginationError):
+            paginator.get_result(cursor=cursor)
+
     def test_order_by_multiple(self):
         res1 = self.create_user("foo@example.com")
         self.create_user("bar@example.com")


### PR DESCRIPTION
If a user gets or creates a cursor with a negative offset we should not 500, as it is a case of invalid user input.

Fixes SENTRY-DNV