### PR TITLE
fix(app-platform): fix setState bug in request log

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -141,19 +141,23 @@ export default class RequestLog extends AsyncComponent<Props, State> {
   }
 
   handleChangeEventType = (eventType: string) => {
-    this.setState({
-      eventType,
-      currentPage: 0,
-    });
-    this.remountComponent();
+    this.setState(
+      {
+        eventType,
+        currentPage: 0,
+      },
+      this.remountComponent
+    );
   };
 
   handleChangeErrorsOnly = () => {
-    this.setState({
-      errorsOnly: !this.state.errorsOnly,
-      currentPage: 0,
-    });
-    this.remountComponent();
+    this.setState(
+      {
+        errorsOnly: !this.state.errorsOnly,
+        currentPage: 0,
+      },
+      this.remountComponent
+    );
   };
 
   handleNextPage = () => {


### PR DESCRIPTION
setState is async and so I need to put `remountComponent` in a callback instead of directly after calling setState