### PR TITLE
ref: Remove deprecated event.level

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -377,23 +377,6 @@ class EventCommon(object):
     # DEPRECATED
     # ============================================
 
-    @property
-    def level(self):
-        # we might want to move to this:
-        # return LOG_LEVELS_MAP.get(self.get_level_display()) or self.group.level
-        if self.group:
-            return self.group.level
-        else:
-            return None
-
-    def get_level_display(self):
-        # we might want to move to this:
-        # return self.get_tag('level') or self.group.get_level_display()
-        if self.group:
-            return self.group.get_level_display()
-        else:
-            return None
-
     # TODO: This is currently used in the Twilio and Flowdock plugins
     # Remove this after usage has been removed there.
     def error(self):  # TODO why is this not a property?

--- a/tests/sentry/models/test_event.py
+++ b/tests/sentry/models/test_event.py
@@ -142,8 +142,6 @@ class EventTest(TestCase):
         )
         assert event.group is None
         assert event.culprit == "app/components/events/eventEntries in map"
-        assert event.level is None
-        assert event.get_level_display() is None
 
 
 @pytest.mark.django_db

--- a/tests/sentry/rules/conditions/test_level_event.py
+++ b/tests/sentry/rules/conditions/test_level_event.py
@@ -65,8 +65,8 @@ class LevelConditionTest(RuleTestCase):
 
         wevent.group.level = logging.WARNING
 
-        assert wevent.level == logging.WARNING
-        assert eevent.level == logging.WARNING
+        assert wevent.group.level == logging.WARNING
+        assert eevent.group.level == logging.WARNING
 
         rule = self.get_rule(data={"match": MatchType.GREATER_OR_EQUAL, "level": "40"})
         self.assertDoesNotPass(rule, wevent)


### PR DESCRIPTION
event.level isn't being used directly anymore, we always fetch the value from tags now.