### PR TITLE
chore: tighten datadog pin and move it to requirements-base

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -8,6 +8,7 @@ confluent-kafka==0.11.5
 # 'cryptography>=1.3,<1.4
 croniter>=0.3.26,<0.4.0
 cssutils==1.0.2
+datadog>=0.15.0,<0.31.0
 django-crispy-forms==1.6.1
 django-picklefield>=0.3.0,<1.1.0
 django-sudo>=2.1.0,<3.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 Babel
-datadog
 docker>=3.7.0,<3.8.0
 exam>=0.5.1
 freezegun==0.3.11


### PR DESCRIPTION
[Datadog 0.31.0 added a positional arg to `get_hostname`.](https://github.com/DataDog/datadogpy/pull/428/files#diff-31d12e3e4bb1df1e71bea504c1b890cbR38) We don't currently use that. Strangely, this is only reflected in the optional Django 1.10 tests - I don't see why it wouldn't error in the regular tests.

This tightens the pin and moves it to requirements-base because it doesn't really make sense as a dev dependency. Getsentry is using 0.15.0, so use that as lower bound.