### PR TITLE
ref: Move Dataset enum to own file

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -10,6 +10,7 @@ from sentry.api.event_search import (
     get_reference_event_conditions,
 )
 from sentry.models.project import Project
+from sentry.snuba.dataset import Dataset
 from sentry.utils import snuba
 
 
@@ -96,7 +97,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         # 'legacy' endpoints cannot access transactions dataset.
         # as they often have assumptions about which columns are returned.
         dataset = snuba.detect_dataset(snuba_args)
-        if dataset != snuba.Dataset.Events:
+        if dataset != Dataset.Events:
             raise OrganizationEventsError(
                 "Invalid query. You cannot reference non-events data in this endpoint."
             )

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -20,9 +20,10 @@ from sentry.search.utils import (
     parse_datetime_value,
     InvalidQuery,
 )
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import get_columns_from_aliases
 from sentry.utils.dates import to_timestamp
-from sentry.utils.snuba import Dataset, DATASETS, get_snuba_column_name, get_json_type
+from sentry.utils.snuba import DATASETS, get_snuba_column_name, get_json_type
 
 WILDCARD_CHARS = re.compile(r"[\*]")
 

--- a/src/sentry/eventstore/snuba_discover/backend.py
+++ b/src/sentry/eventstore/snuba_discover/backend.py
@@ -12,6 +12,7 @@ from sentry.eventstore.snuba.backend import (
     get_before_event_condition,
     SnubaEventStorage,
 )
+from sentry.snuba.dataset import Dataset
 
 
 class SnubaDiscoverEventStorage(EventStorage):
@@ -88,7 +89,7 @@ class SnubaDiscoverEventStorage(EventStorage):
                 limit=1,
                 referrer="eventstore.discover_dataset.get_next_or_prev_event_id",
                 orderby=orderby,
-                dataset=snuba.Dataset.Discover,
+                dataset=Dataset.Discover,
             )
         except (snuba.QueryOutsideRetentionError, snuba.QueryOutsideGroupActivityError):
             # This can happen when the date conditions for paging

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -15,6 +15,7 @@ from sentry.api.paginator import DateTimePaginator, SequencePaginator, Paginator
 from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.models import Group, Release, GroupEnvironment
 from sentry.search.base import SearchBackend
+from sentry.snuba.dataset import Dataset
 from sentry.utils import snuba, metrics
 
 logger = logging.getLogger("sentry.search.snuba")
@@ -560,7 +561,7 @@ def snuba_search(
         referrer = "search"
 
     snuba_results = snuba.dataset_query(
-        dataset=snuba.Dataset.Events,
+        dataset=Dataset.Events,
         start=start,
         end=end,
         selected_columns=selected_columns,

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import
+
+from enum import Enum, unique
+
+
+@unique
+class Dataset(Enum):
+    Events = "events"
+    Transactions = "transactions"
+    Discover = "discover"
+    Outcomes = "outcomes"
+    OutcomesRaw = "outcomes_raw"

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 from dateutil.parser import parse as parse_datetime
-from enum import Enum, unique
 import os
 import pytz
 import re
@@ -31,6 +30,7 @@ from sentry.net.http import connection_from_url
 from sentry.utils import metrics, json
 from sentry.utils.dates import to_timestamp
 from sentry.snuba.events import Columns
+from sentry.snuba.dataset import Dataset
 
 # TODO remove this when Snuba accepts more than 500 issues
 MAX_ISSUES = 500
@@ -67,15 +67,6 @@ DISCOVER_COLUMN_MAP = {
     for col in Columns
     if col.value.discover_name is not None
 }
-
-
-@unique
-class Dataset(Enum):
-    Events = "events"
-    Transactions = "transactions"
-    Discover = "discover"
-    Outcomes = "outcomes"
-    OutcomesRaw = "outcomes_raw"
 
 
 DATASETS = {


### PR DESCRIPTION
Avoids future circular dependency issues as we will be likely needing to
import this class in our Event model (and likely other places) in future.