### PR TITLE
fix: Make sure that `create_default_projects` doesn't error for single tenant.

### DIFF
--- a/src/sentry/receivers/core.py
+++ b/src/sentry/receivers/core.py
@@ -20,6 +20,7 @@ SELECT setval('sentry_project_id_seq', (
     SELECT GREATEST(MAX(id) + 1, nextval('sentry_project_id_seq')) - 1
     FROM sentry_project))
 """
+DEFAULT_SENTRY_PROJECT_ID = 1
 
 
 def handle_db_failure(func):
@@ -45,7 +46,12 @@ def create_default_projects(app_config, verbosity=2, **kwargs):
         return
 
     create_default_project(
-        id=settings.SENTRY_PROJECT, name="Internal", slug="internal", verbosity=verbosity
+        # This guards against sentry installs that have SENTRY_PROJECT set to None, so
+        # that they don't error after every migration. Specifically for single tenant.
+        id=settings.SENTRY_PROJECT or DEFAULT_SENTRY_PROJECT_ID,
+        name="Internal",
+        slug="internal",
+        verbosity=verbosity,
     )
 
     if settings.SENTRY_FRONTEND_PROJECT:

--- a/tests/sentry/receivers/test_core.py
+++ b/tests/sentry/receivers/test_core.py
@@ -6,7 +6,7 @@ from django.apps import apps
 from django.conf import settings
 
 from sentry.models import Organization, Project, ProjectKey, Team, User
-from sentry.receivers.core import create_default_projects
+from sentry.receivers.core import create_default_projects, DEFAULT_SENTRY_PROJECT_ID
 from sentry.testutils import TestCase
 
 
@@ -54,3 +54,26 @@ class CreateDefaultProjectsTest(TestCase):
 
         # ensure that we dont hit an error here
         create_default_projects(config)
+
+    def test_no_sentry_project(self):
+        with self.settings(SENTRY_PROJECT=None):
+            User.objects.filter(is_superuser=True).delete()
+            Team.objects.filter(slug="sentry").delete()
+            Project.objects.filter(id=DEFAULT_SENTRY_PROJECT_ID).delete()
+            config = apps.get_app_config("sentry")
+
+            create_default_projects(config)
+
+            project = Project.objects.get(id=DEFAULT_SENTRY_PROJECT_ID)
+            assert project.public is False
+            assert project.name == "Internal"
+            assert project.slug == "internal"
+            team = project.teams.first()
+            assert team.slug == "sentry"
+
+            pk = ProjectKey.objects.get(project=project)
+            assert not pk.roles.api
+            assert pk.roles.store
+
+            # ensure that we dont hit an error here
+            create_default_projects(config)


### PR DESCRIPTION
Single tenant sets `SENTRY_PROJECT` to `None`. This means that after every migration they get an
integrity error, since we try to create the default project and the slug already exists in the
default org. We guard against this by just setting a default id to fall back to.