### PR TITLE
ref(django 1.10): port jsonfield's get_prep_lookup to custom Lookups

### DIFF
--- a/src/sentry/db/models/fields/jsonfield.py
+++ b/src/sentry/db/models/fields/jsonfield.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from django.core.exceptions import ValidationError
 from django.conf import settings
 from django.db import models
+from django.db.models.lookups import Exact, IExact, In, Contains, IContains
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.db.models.utils import Creator
@@ -113,25 +114,55 @@ class JSONField(models.TextField):
             return None
         return json.dumps(value, default=default, **self.encoder_kwargs)
 
-    def get_prep_lookup(self, lookup_type, value):
-        if lookup_type in ["exact", "iexact"]:
-            return self.to_python(self.get_prep_value(value))
-        if lookup_type == "in":
-            return [self.to_python(self.get_prep_value(v)) for v in value]
-        if lookup_type == "isnull":
-            return value
-        if lookup_type in ["contains", "icontains"]:
-            if isinstance(value, (list, tuple)):
-                raise TypeError(
-                    "Lookup type %r not supported with argument of %s"
-                    % (lookup_type, type(value).__name__)
-                )
-                # Need a way co combine the values with '%', but don't escape that.
-                return self.get_prep_value(value)[1:-1].replace(", ", r"%")
-            if isinstance(value, dict):
-                return self.get_prep_value(value)[1:-1]
-            return self.to_python(self.get_prep_value(value))
-        raise TypeError("Lookup type %r not supported" % lookup_type)
-
     def value_to_string(self, obj):
         return self._get_val_from_obj(obj)
+
+
+class NoPrepareMixin(object):
+    def get_prep_lookup(self):
+        return self.rhs
+
+
+class JSONFieldExactLookup(NoPrepareMixin, Exact):
+    def get_prep_lookup(self):
+        return self.lhs.output_field.to_python(self.lhs.output_field.get_prep_value(self.rhs))
+
+
+class JSONFieldIExactLookup(NoPrepareMixin, IExact):
+    def get_prep_lookup(self):
+        return self.lhs.output_field.to_python(self.lhs.output_field.get_prep_value(self.rhs))
+
+
+class JSONFieldInLookup(NoPrepareMixin, In):
+    def get_prep_lookup(self):
+        return [
+            self.lhs.output_field.to_python(self.lhs.output_field.get_prep_value(v))
+            for v in self.rhs
+        ]
+
+
+class ContainsLookupMixin(object):
+    def get_prep_lookup(self):
+        if isinstance(self.rhs, (list, tuple)):
+            raise TypeError(
+                "Lookup type %r not supported with %s argument"
+                % (self.lookup_name, type(self.rhs).__name__)
+            )
+        if isinstance(self.rhs, dict):
+            return self.lhs.output_field.get_prep_value(self.rhs)[1:-1]
+        return self.lhs.output_field.get_prep_value(self.rhs)
+
+
+class JSONFieldContainsLookup(ContainsLookupMixin, Contains):
+    pass
+
+
+class JSONFieldIContainsLookup(ContainsLookupMixin, IContains):
+    pass
+
+
+JSONField.register_lookup(JSONFieldExactLookup)
+JSONField.register_lookup(JSONFieldIExactLookup)
+JSONField.register_lookup(JSONFieldInLookup)
+JSONField.register_lookup(JSONFieldContainsLookup)
+JSONField.register_lookup(JSONFieldIContainsLookup)

--- a/src/sentry/db/models/fields/jsonfield.py
+++ b/src/sentry/db/models/fields/jsonfield.py
@@ -150,7 +150,7 @@ class ContainsLookupMixin(object):
             )
         if isinstance(self.rhs, dict):
             return self.lhs.output_field.get_prep_value(self.rhs)[1:-1]
-        return self.lhs.output_field.get_prep_value(self.rhs)
+        return self.lhs.output_field.to_python(self.lhs.output_field.get_prep_value(self.rhs))
 
 
 class JSONFieldContainsLookup(ContainsLookupMixin, Contains):


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.10/releases/1.10/#field-get-prep-lookup-and-field-get-db-prep-lookup-methods-are-removed

In Django 1.10, `pytest tests/sentry/tasks/test_enqueue_scheduled_jobs.py -k test_schedule_job` fails because `payload` in the query isnt being `to_python`'d because `get_prep_lookup` is removed in 1.10:

1.10 (notice the `."payload" = "{\\"foo\\": \\"baz\\"}"'` at the end)

```
(Pdb) ScheduledJob.objects.filter(payload={"foo": "baz"}).query.__str__()
u'SELECT "sentry_scheduledjob"."id", "sentry_scheduledjob"."name", "sentry_scheduledjob"."payload", "sentry_scheduledjob"."date_added", "sentry_scheduledjob"."date_scheduled" FROM "sentry_scheduledjob" WHERE "sentry_scheduledjob"."payload" = "{\\"foo\\": \\"baz\\"}"'
```

1.9

```
(Pdb) ScheduledJob.objects.filter(payload={"foo": "baz"}).query.__str__()
u'SELECT "sentry_scheduledjob"."id", "sentry_scheduledjob"."name", "sentry_scheduledjob"."payload", "sentry_scheduledjob"."date_added", "sentry_scheduledjob"."date_scheduled" FROM "sentry_scheduledjob" WHERE "sentry_scheduledjob"."payload" = {"foo": "baz"}'
```

This is also the failure reason for `pytest tests/sentry/db/models/fields/test_jsonfield.py -k test_query_object`.

Adapted from https://github.com/adamchainz/django-jsonfield/commit/303876d8d4cd733649c138a6b0f76a4b95626e06. The part we had customized (and needed to be ported over aside from copypasting those changes) was:

```
        if lookup_type in ["exact", "iexact"]:
            return self.to_python(self.get_prep_value(value))
        if lookup_type == "in":
            return [self.to_python(self.get_prep_value(v)) for v in value]
```

Which becomes

```
class JSONFieldExactLookup(NoPrepareMixin, Exact):
    def get_prep_lookup(self):
        return self.lhs.output_field.to_python(self.lhs.output_field.get_prep_value(self.rhs))


class JSONFieldIExactLookup(NoPrepareMixin, IExact):
    def get_prep_lookup(self):
        return self.lhs.output_field.to_python(self.lhs.output_field.get_prep_value(self.rhs))


class JSONFieldInLookup(NoPrepareMixin, In):
    def get_prep_lookup(self):
        return [
            self.lhs.output_field.to_python(self.lhs.output_field.get_prep_value(v))
            for v in self.rhs
        ]
```