### PR TITLE
fix(django 1.10): default to empty string instead of None for email body

### DIFF
--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -255,7 +255,7 @@ class MessageBuilder(object):
         context=None,
         template=None,
         html_template=None,
-        body=None,
+        body="",
         html_body=None,
         headers=None,
         reference=None,


### PR DESCRIPTION
Some getsentry tests under Django 1.10 fail like:

```
Traceback (most recent call last):
  File "/Users/joshua.li/dev/sentry/getsentry/tests/getsentry/tasks/test_repair_accounts.py", line 72, in test_partner_account_not_managed
    repair_accounts()
  File "/Users/joshua.li/.local/share/virtualenvs/getsentry2/lib/python2.7/site-packages/celery/local.py", line 167, in <lambda>
    __call__ = lambda x, *a, **kw: x._get_current_object()(*a, **kw)
  File "/Users/joshua.li/.local/share/virtualenvs/getsentry2/lib/python2.7/site-packages/celery/app/task.py", line 420, in __call__
    return self.run(*args, **kwargs)
  File "/Users/joshua.li/dev/sentry/sentry/src/sentry/tasks/base.py", line 48, in _wrapped
    result = func(*args, **kwargs)
  File "/Users/joshua.li/dev/sentry/getsentry/getsentry/tasks/repair_accounts.py", line 78, in repair_accounts
    msg.send(["billing-eng@sentry.io"])
  File "/Users/joshua.li/dev/sentry/sentry/src/sentry/utils/email.py", line 385, in send
    self.get_built_messages(to, cc=cc, bcc=bcc), fail_silently=fail_silently
  File "/Users/joshua.li/dev/sentry/sentry/src/sentry/utils/email.py", line 414, in send_messages
    sent = connection.send_messages(messages)
  File "/Users/joshua.li/.local/share/virtualenvs/getsentry2/lib/python2.7/site-packages/django/core/mail/backends/locmem.py", line 26, in send_messages
    message.message()
  File "/Users/joshua.li/.local/share/virtualenvs/getsentry2/lib/python2.7/site-packages/django/core/mail/message.py", line 305, in message
    msg = SafeMIMEText(self.body, self.content_subtype, encoding)
  File "/Users/joshua.li/.local/share/virtualenvs/getsentry2/lib/python2.7/site-packages/django/core/mail/message.py", line 220, in __init__
    has_long_lines = any(len(l) > RFC5322_EMAIL_LINE_LENGTH_LIMIT for l in _text.splitlines())
AttributeError: 'NoneType' object has no attribute 'splitlines'
```

This is because sometimes the `body=None` isn't overridden, leading Django 1.10's `core.mail.message` to AttributeError when it calls splitlines. Similar dj bug report here: https://code.djangoproject.com/ticket/29140
