### PR TITLE
fix(discoverv2): btn icon colors, changing related to linked and readding issue to detail page

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -27,6 +27,7 @@ import Pagination from './pagination';
 import LineGraph from './lineGraph';
 import TagsTable from '../tagsTable';
 import EventInterfaces from './eventInterfaces';
+import LinkedIssue from './linkedIssue';
 import DiscoverBreadcrumb from '../breadcrumb';
 import {SectionHeading} from '../styles';
 
@@ -152,6 +153,9 @@ class EventDetailsContent extends AsyncComponent<Props, State & AsyncComponent['
               projectId={this.projectId}
             />
             <TagsTable tags={event.tags} />
+            {event.groupID && (
+              <LinkedIssue groupId={event.groupID} eventId={event.eventID} />
+            )}
           </Side>
         </ContentBox>
       </div>

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/eventInterfaces.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/eventInterfaces.tsx
@@ -15,7 +15,7 @@ import NavTabs from 'app/components/navTabs';
 import {objectIsEmpty, toTitleCase} from 'app/utils';
 import {Event, Organization} from 'app/types';
 
-import RelatedItems from './relatedItems';
+import LinkedItems from './linkedItems';
 
 const OTHER_SECTIONS = {
   contexts: EventContexts,
@@ -65,9 +65,9 @@ const ActiveTab = (props: ActiveTabProps) => {
   } else if (OTHER_SECTIONS[activeTab]) {
     const Component = OTHER_SECTIONS[activeTab];
     return <Component event={event} isShare={false} hideGuide />;
-  } else if (activeTab === 'related') {
+  } else if (activeTab === 'linked') {
     return (
-      <RelatedItems event={event} projectId={projectId} organization={organization} />
+      <LinkedItems event={event} projectId={projectId} organization={organization} />
     );
   } else {
     /*eslint no-console:0*/
@@ -163,15 +163,15 @@ class EventInterfaces extends React.Component<
               </li>
             );
           })}
-          <li key="related" className={activeTab === 'related' ? 'active' : undefined}>
+          <li key="linked" className={activeTab === 'linked' ? 'active' : undefined}>
             <a
               href="#"
               onClick={evt => {
                 evt.preventDefault();
-                this.handleTabChange('related');
+                this.handleTabChange('linked');
               }}
             >
-              {t('Related')}
+              {t('Linked')}
             </a>
           </li>
         </NavTabs>

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/eventInterfaces.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/eventInterfaces.tsx
@@ -15,7 +15,7 @@ import NavTabs from 'app/components/navTabs';
 import {objectIsEmpty, toTitleCase} from 'app/utils';
 import {Event, Organization} from 'app/types';
 
-import LinkedItems from './linkedItems';
+import LinkedEvents from './linkedEvents';
 
 const OTHER_SECTIONS = {
   contexts: EventContexts,
@@ -67,7 +67,7 @@ const ActiveTab = (props: ActiveTabProps) => {
     return <Component event={event} isShare={false} hideGuide />;
   } else if (activeTab === 'linked') {
     return (
-      <LinkedItems event={event} projectId={projectId} organization={organization} />
+      <LinkedEvents event={event} projectId={projectId} organization={organization} />
     );
   } else {
     /*eslint no-console:0*/

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedEvents.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedEvents.tsx
@@ -38,7 +38,7 @@ type State = {
   linkedEvents: {data: DiscoverResult[]};
 } & AsyncComponent['state'];
 
-class LinkedItems extends AsyncComponent<Props, State> {
+class LinkedEvents extends AsyncComponent<Props, State> {
   getEndpoints(): [string, string, any][] {
     const {event, organization} = this.props;
     const endpoints: any = [];
@@ -184,6 +184,7 @@ const StyledDate = styled('div')`
     white-space: nowrap;
   }
 `;
+
 const StyledShortId = styled(ShortId)`
   justify-content: flex-start;
   color: ${p => p.theme.gray4};
@@ -193,4 +194,4 @@ const StyledShortId = styled(ShortId)`
   }
 `;
 
-export default withProjects(LinkedItems);
+export default withProjects(LinkedEvents);

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedIssue.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedIssue.tsx
@@ -91,9 +91,7 @@ const StyledLink = styled(Link)`
 `;
 
 const IssueCardBody = styled('div')`
-  border-top: 1px solid ${p => p.theme.borderLight};
-  border-bottom: 1px solid ${p => p.theme.borderLight};
-  background: ${p => p.theme.offWhite};
+  background: ${p => p.theme.offWhiteLight};
   padding-top: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedIssue.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedIssue.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import styled from 'react-emotion';
+import PropTypes from 'prop-types';
+
+import {t} from 'app/locale';
+import AsyncComponent from 'app/components/asyncComponent';
+import GroupChart from 'app/components/stream/groupChart';
+import Link from 'app/components/links/link';
+import Placeholder from 'app/components/placeholder';
+import ProjectBadge from 'app/components/idBadge/projectBadge';
+import SeenByList from 'app/components/seenByList';
+import ShortId from 'app/components/shortId';
+import Times from 'app/components/group/times';
+import space from 'app/styles/space';
+import {Group} from 'app/types';
+import {SectionHeading} from '../styles';
+
+type Props = {
+  groupId: string;
+  eventId: string;
+};
+
+type State = {
+  group: Group;
+};
+
+class LinkedIssue extends AsyncComponent<
+  Props & AsyncComponent['props'],
+  State & AsyncComponent['state']
+> {
+  static propTypes = {
+    groupId: PropTypes.string.isRequired,
+    eventId: PropTypes.string.isRequired,
+  };
+
+  getEndpoints(): Array<[string, string]> {
+    const {groupId} = this.props;
+    const groupUrl = `/issues/${groupId}/`;
+
+    return [['group', groupUrl]];
+  }
+
+  renderLoading() {
+    return <Placeholder height="120px" bottomGutter={2} />;
+  }
+
+  renderBody() {
+    const {eventId} = this.props;
+    const {group} = this.state;
+    const issueUrl = `${group.permalink}events/${eventId}/`;
+
+    return (
+      <div>
+        <SectionHeading>{t('Event Issue')}</SectionHeading>
+        <StyledIssueCard>
+          <IssueCardHeader>
+            <StyledLink to={issueUrl} data-test-id="linked-issue">
+              <StyledShortId
+                shortId={group.shortId}
+                avatar={<ProjectBadge project={group.project} avatarSize={16} hideName />}
+              />
+            </StyledLink>
+            <StyledSeenByList seenBy={group.seenBy} maxVisibleAvatars={5} />
+          </IssueCardHeader>
+          <IssueCardBody>
+            <GroupChart id={group.id} statsPeriod="30d" data={group} height={56} />
+          </IssueCardBody>
+          <IssueCardFooter>
+            <Times lastSeen={group.lastSeen} firstSeen={group.firstSeen} />
+          </IssueCardFooter>
+        </StyledIssueCard>
+      </div>
+    );
+  }
+}
+
+const StyledIssueCard = styled('div')`
+  border: 1px solid ${p => p.theme.borderLight};
+  border-radius: ${p => p.theme.borderRadius};
+`;
+
+const IssueCardHeader = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${space(1)};
+`;
+
+const StyledLink = styled(Link)`
+  justify-content: flex-start;
+`;
+
+const IssueCardBody = styled('div')`
+  border-top: 1px solid ${p => p.theme.borderLight};
+  border-bottom: 1px solid ${p => p.theme.borderLight};
+  background: ${p => p.theme.offWhite};
+  padding-top: ${space(1)};
+`;
+
+const StyledSeenByList = styled(SeenByList)`
+  margin: 0;
+`;
+
+const StyledShortId = styled(ShortId)`
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.gray4};
+`;
+
+const IssueCardFooter = styled('div')`
+  color: ${p => p.theme.gray2};
+  font-size: ${p => p.theme.fontSizeSmall};
+  padding: ${space(0.5)} ${space(1)};
+`;
+
+export default LinkedIssue;

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedItems.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedItems.tsx
@@ -35,10 +35,10 @@ type Props = {
 
 type State = {
   issue: Group;
-  relatedEvents: {data: DiscoverResult[]};
+  linkedEvents: {data: DiscoverResult[]};
 } & AsyncComponent['state'];
 
-class RelatedItems extends AsyncComponent<Props, State> {
+class LinkedItems extends AsyncComponent<Props, State> {
   getEndpoints(): [string, string, any][] {
     const {event, organization} = this.props;
     const endpoints: any = [];
@@ -50,7 +50,7 @@ class RelatedItems extends AsyncComponent<Props, State> {
     const trace = event.tags.find(tag => tag.key === 'trace');
     if (trace) {
       endpoints.push([
-        'relatedEvents',
+        'linkedEvents',
         `/organizations/${organization.slug}/eventsv2/`,
         {
           query: {
@@ -72,14 +72,14 @@ class RelatedItems extends AsyncComponent<Props, State> {
     return endpoints;
   }
 
-  renderRelatedIssue() {
+  renderLinkedIssue() {
     const {event} = this.props;
     const {issue} = this.state;
     const issueUrl = `${issue.permalink}events/${event.eventID}/`;
 
     return (
       <Section>
-        <SectionHeading>{t('Related Issue')}</SectionHeading>
+        <SectionHeading>{t('Linked Issue')}</SectionHeading>
         <StyledCard>
           <StyledLink to={issueUrl} data-test-id="linked-issue">
             <StyledShortId
@@ -96,16 +96,16 @@ class RelatedItems extends AsyncComponent<Props, State> {
     );
   }
 
-  renderRelatedEvents() {
+  renderLinkedEvents() {
     const {event, organization, projects} = this.props;
-    const {relatedEvents} = this.state;
+    const {linkedEvents} = this.state;
     return (
       <Section>
-        <SectionHeading>{t('Related Trace Events')}</SectionHeading>
-        {relatedEvents.data.length < 1 ? (
-          <StyledCard>{t('No related events found.')}</StyledCard>
+        <SectionHeading>{t('Linked Trace Events')}</SectionHeading>
+        {linkedEvents.data.length < 1 ? (
+          <StyledCard>{t('No linked events found.')}</StyledCard>
         ) : (
-          relatedEvents.data.map((item: DiscoverResult) => {
+          linkedEvents.data.map((item: DiscoverResult) => {
             const eventSlug = generateEventSlug(item);
             const eventUrl = {
               pathname: generateEventDetailsRoute({eventSlug, organization}),
@@ -133,8 +133,8 @@ class RelatedItems extends AsyncComponent<Props, State> {
   renderBody() {
     return (
       <React.Fragment>
-        {this.state.issue && this.renderRelatedIssue()}
-        {this.state.relatedEvents && this.renderRelatedEvents()}
+        {this.state.issue && this.renderLinkedIssue()}
+        {this.state.linkedEvents && this.renderLinkedEvents()}
       </React.Fragment>
     );
   }
@@ -193,4 +193,4 @@ const StyledShortId = styled(ShortId)`
   }
 `;
 
-export default withProjects(RelatedItems);
+export default withProjects(LinkedItems);

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -318,7 +318,7 @@ const ButtonSaveIcon = styled(InlineSvg)<{isNewQuery?: boolean}>`
   margin-top: -3px; /* Align SVG vertically to text */
   margin-right: ${space(0.75)};
 
-  color: ${p => (p.isNewQuery ? p.theme.yellow : '#C4C4C4')};
+  color: ${p => (p.isNewQuery ? p.theme.gray1 : p.theme.yellow)};
 `;
 const ButtonSaveDropDown = styled('li')`
   padding: ${space(1)};


### PR DESCRIPTION
**After:**

![Screen Shot 2019-11-25 at 7 40 51 PM](https://user-images.githubusercontent.com/4830259/69597674-94ebbe00-0fbb-11ea-8d45-5ccdd6bed7cc.png)
![Screen Shot 2019-11-25 at 7 41 02 PM](https://user-images.githubusercontent.com/4830259/69597680-987f4500-0fbb-11ea-8702-8783058b7308.png)

Icon color was flipped. A saved query should have a star filled out in yellow whereas an unsaved query is gray. Also, I was concerned the term "related" was too weak when talking about events in the same aggregate and issue. Changed it to "linked". 

![Screen Shot 2019-11-25 at 10 44 04 PM](https://user-images.githubusercontent.com/4830259/69605568-4d722b80-0fd5-11ea-8b44-a049ec03ccc2.png)

Also re-adding issue to the detail page. I misunderstood what this meant earlier on - but would like to keep events in the tab. 