### PR TITLE
feat(discover2): Search and filter on saved and pre-built queries

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -17,6 +17,7 @@ import {
   isAggregateField,
   getAggregateAlias,
   decodeColumnOrder,
+  decodeScalar,
 } from './utils';
 import {TableColumn, TableColumnSort} from './table/types';
 
@@ -243,21 +244,6 @@ const decodeProjects = (location: Location): number[] => {
 
   const value = location.query.project;
   return Array.isArray(value) ? value.map(i => parseInt(i, 10)) : [parseInt(value, 10)];
-};
-
-const decodeScalar = (
-  value: string[] | string | undefined | null
-): string | undefined => {
-  if (!value) {
-    return undefined;
-  }
-  const unwrapped =
-    Array.isArray(value) && value.length > 0
-      ? value[0]
-      : isString(value)
-      ? value
-      : undefined;
-  return isString(unwrapped) ? unwrapped : undefined;
 };
 
 const queryStringFromSavedQuery = (saved: NewQuery | SavedQuery): string => {

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -115,7 +115,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
 
     const queryParams = {
       cursor,
-      query: `version:2 ${searchQuery}`,
+      query: `version:2 name:"${searchQuery}"`,
       per_page: perPage,
       sortBy: '-dateUpdated',
     };

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -96,7 +96,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
         const needleSearch = searchQuery.toLowerCase();
 
         const numOfPrebuiltQueries = views.reduce((sum, view) => {
-          const eventView = EventView.fromSavedQueryWithLocation(view, location);
+          const eventView = EventView.fromNewQueryWithLocation(view, location);
 
           // if a search is performed on the list of queries, we filter
           // on the pre-built queries
@@ -240,7 +240,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
       margin-bottom: ${space(3)};
     `;
 
-    const eventView = EventView.fromSavedQueryWithLocation(DEFAULT_EVENT_VIEW, location);
+    const eventView = EventView.fromNewQueryWithLocation(DEFAULT_EVENT_VIEW, location);
 
     const to = {
       pathname: location.pathname,

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -187,7 +187,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
   }
 
   renderActions() {
-    const {organization} = this.props;
+    const {organization, location} = this.props;
 
     const StyledSearchBar = styled(SearchBar)`
       margin-right: ${space(1)};
@@ -199,6 +199,15 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
       margin-bottom: ${space(3)};
     `;
 
+    const eventView = EventView.fromSavedQueryWithLocation(DEFAULT_EVENT_VIEW, location);
+
+    const to = {
+      pathname: location.pathname,
+      query: {
+        ...eventView.generateQueryStringObject(),
+      },
+    };
+
     return (
       <StyledActions>
         <StyledSearchBar
@@ -206,7 +215,20 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
           query={this.state.searchQueryInput}
           onSearch={this.handleSearchQuery}
         />
-        <Button priority="primary">{t('Build a new query')}</Button>
+        <Button
+          to={to}
+          priority="primary"
+          onClick={() => {
+            trackAnalyticsEvent({
+              eventKey: 'discover_v2.prebuilt_query_click',
+              eventName: 'Discoverv2: Click a pre-built query',
+              organization_id: this.props.organization.id,
+              query_name: eventView.name,
+            });
+          }}
+        >
+          {t('Build a new query')}
+        </Button>
       </StyledActions>
     );
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -32,7 +32,6 @@ import QueryList from './queryList';
 import DiscoverBreadcrumb from './breadcrumb';
 import {getPrebuiltQueries, generateTitle} from './utils';
 
-const DISPLAY_SEARCH_BAR_FLAG = false;
 const BANNER_DISMISSED_KEY = 'discover-banner-dismissed';
 
 function checkIsBannerHidden(): boolean {
@@ -47,8 +46,10 @@ type Props = {
 } & AsyncComponent['props'];
 
 type State = {
+  isBannerHidden: boolean;
   savedQueries: SavedQuery[];
   savedQueriesPageLinks: string;
+  searchQueryInput: string;
 } & AsyncComponent['state'];
 
 class DiscoverLanding extends AsyncComponent<Props, State> {
@@ -58,14 +59,18 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     router: PropTypes.object.isRequired,
   };
 
-  state = {
+  state: State = {
+    // AsyncComponent state
     loading: true,
     reloading: false,
     error: false,
     errors: [],
+
+    // local component state
     isBannerHidden: checkIsBannerHidden(),
     savedQueries: [],
     savedQueriesPageLinks: '',
+    searchQueryInput: '',
   };
 
   shouldReload = true;
@@ -177,7 +182,13 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     );
   }
 
+  handleSearchQuery(searchQuery: string) {
+    console.log('do things', searchQuery);
+  }
+
   renderActions() {
+    const {organization} = this.props;
+
     const StyledSearchBar = styled(SearchBar)`
       margin-right: ${space(1)};
       flex-grow: 1;
@@ -190,8 +201,12 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
 
     return (
       <StyledActions>
-        <StyledSearchBar />
-        <Button priority="primary">{t('Build a new query')}</Button>
+        <StyledSearchBar
+          organization={organization}
+          query={this.state.searchQueryInput}
+          onSearch={this.handleSearchQuery}
+        />
+        <Button priority="primary">{t('Search Queries')}</Button>
       </StyledActions>
     );
   }
@@ -212,7 +227,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
       <PageContent>
         <StyledPageHeader>{t('Discover')}</StyledPageHeader>
         {this.renderBanner()}
-        {DISPLAY_SEARCH_BAR_FLAG && this.renderActions()}
+        {this.renderActions()}
         {loading && this.renderLoading()}
         {!loading && (
           <QueryList
@@ -227,7 +242,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     );
   }
 
-  renderResults(eventView: EventView) {
+  renderQueryBuilder(eventView: EventView) {
     const {organization, location, router} = this.props;
     const {savedQueries, reloading} = this.state;
     const ContentBox = styled(PageContent)`
@@ -309,7 +324,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
             <GlobalSelectionHeader organization={organization} />
             <NoProjectMessage organization={organization}>
               {!hasQuery && this.renderQueryList()}
-              {hasQuery && this.renderResults(eventView)}
+              {hasQuery && this.renderQueryBuilder(eventView)}
             </NoProjectMessage>
           </React.Fragment>
         </SentryDocumentTitle>

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -206,7 +206,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
           query={this.state.searchQueryInput}
           onSearch={this.handleSearchQuery}
         />
-        <Button priority="primary">{t('Search Queries')}</Button>
+        <Button priority="primary">{t('Build a new query')}</Button>
       </StyledActions>
     );
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -89,16 +89,18 @@ class QueryList extends React.Component<Props> {
     const {location, organization, savedQuerySearchQuery} = this.props;
     const views = getPrebuiltQueries(organization);
 
+    const needleSearch = savedQuerySearchQuery.toLowerCase();
+    const hasSearchQuery = savedQuerySearchQuery && savedQuerySearchQuery.length > 0;
+
     const list = views.map((view, index) => {
       const eventView = EventView.fromNewQueryWithLocation(view, location);
 
       // if a search is performed on the list of queries, we filter
       // on the pre-built queries
       if (
-        savedQuerySearchQuery &&
-        savedQuerySearchQuery.length > 0 &&
+        hasSearchQuery &&
         eventView.name &&
-        !eventView.name.toLowerCase().includes(savedQuerySearchQuery.toLowerCase())
+        !eventView.name.toLowerCase().includes(needleSearch)
       ) {
         return null;
       }

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -30,6 +30,7 @@ type Props = {
   savedQueries: SavedQuery[];
   pageLinks: string;
   onQueryChange: () => void;
+  savedQuerySearchQuery: string;
 };
 
 class QueryList extends React.Component<Props> {
@@ -85,11 +86,23 @@ class QueryList extends React.Component<Props> {
   }
 
   renderPrebuiltQueries() {
-    const {location, organization} = this.props;
+    const {location, organization, savedQuerySearchQuery} = this.props;
     const views = getPrebuiltQueries(organization);
 
     const list = views.map((view, index) => {
       const eventView = EventView.fromNewQueryWithLocation(view, location);
+
+      // if a search is performed on the list of queries, we filter
+      // on the pre-built queries
+      if (
+        savedQuerySearchQuery &&
+        savedQuerySearchQuery.length > 0 &&
+        eventView.name &&
+        !eventView.name.toLowerCase().includes(savedQuerySearchQuery.toLowerCase())
+      ) {
+        return null;
+      }
+
       const recentTimeline = t('Last ') + eventView.statsPeriod;
       const customTimeline =
         moment(eventView.start).format('MMM D, YYYY h:mm A') +

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -114,6 +114,8 @@ class QueryList extends React.Component<Props> {
         pathname: location.pathname,
         query: {
           ...location.query,
+          // remove any landing page cursor
+          cursor: undefined,
           ...eventView.generateQueryStringObject(),
         },
       };
@@ -167,6 +169,8 @@ class QueryList extends React.Component<Props> {
         pathname: location.pathname,
         query: {
           ...location.query,
+          // remove any landing page cursor
+          cursor: undefined,
           ...eventView.generateQueryStringObject(),
         },
       };

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -89,8 +89,9 @@ class QueryList extends React.Component<Props> {
     const {location, organization, savedQuerySearchQuery} = this.props;
     const views = getPrebuiltQueries(organization);
 
-    const needleSearch = savedQuerySearchQuery.toLowerCase();
-    const hasSearchQuery = savedQuerySearchQuery && savedQuerySearchQuery.length > 0;
+    const hasSearchQuery =
+      typeof savedQuerySearchQuery === 'string' && savedQuerySearchQuery.length > 0;
+    const needleSearch = hasSearchQuery ? savedQuerySearchQuery.toLowerCase() : '';
 
     const list = views.map((view, index) => {
       const eventView = EventView.fromNewQueryWithLocation(view, location);

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -1,5 +1,6 @@
 import partial from 'lodash/partial';
 import pick from 'lodash/pick';
+import isString from 'lodash/isString';
 import {Location, Query} from 'history';
 import {browserHistory} from 'react-router';
 
@@ -335,4 +336,19 @@ export function getPrebuiltQueries(organization: Organization) {
   }
 
   return views;
+}
+
+export function decodeScalar(
+  value: string[] | string | undefined | null
+): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const unwrapped =
+    Array.isArray(value) && value.length > 0
+      ? value[0]
+      : isString(value)
+      ? value
+      : undefined;
+  return isString(unwrapped) ? unwrapped : undefined;
 }


### PR DESCRIPTION
Using the API added by @markstory in https://github.com/getsentry/sentry/pull/15605

## TODO

- [x] functional search bar to filter on search queries
- [x] implement CTA for the purple button
- [ ] dedicated button for the search bar to segregate the purple button
![Screen Shot 2019-11-26 at 8 44 24 AM](https://user-images.githubusercontent.com/139499/69654302-8b596900-1042-11ea-8dc1-86345c601065.png) EDIT: @doralchan to come back to me regarding inline search input field with a button
- [ ] ~escapse double quotes~ EDIT: not needed
