### PR TITLE
fix(discover) Add geo fields for transactions dataset

### DIFF
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -57,9 +57,11 @@ class Columns(Enum):
     DEVICE_SIMULATOR = Column("device_simulator", None, "device_simulator", "device.simulator")
     DEVICE_ONLINE = Column("device_online", None, "device_online", "device.online")
     DEVICE_CHARGING = Column("device_charging", None, "device_charging", "device.charging")
-    GEO_COUNTRY_CODE = Column("geo_country_code", None, "geo_country_code", "geo.country_code")
-    GEO_REGION = Column("geo_region", None, "geo_region", "geo.region")
-    GEO_CITY = Column("geo_city", None, "geo_city", "geo.city")
+    GEO_COUNTRY_CODE = Column(
+        "geo_country_code", "contexts[geo.country_code]", "geo_country_code", "geo.country_code"
+    )
+    GEO_REGION = Column("geo_region", "contexts[geo.region]", "geo_region", "geo.region")
+    GEO_CITY = Column("geo_city", "contexts[geo.city]", "geo_city", "geo.city")
     ERROR_TYPE = Column("exception_stacks.type", None, "exception_stacks.type", "error.type")
     ERROR_VALUE = Column("exception_stacks.value", None, "exception_stacks.value", "error.value")
     ERROR_MECHANISM = Column(

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -509,13 +509,16 @@ class TransformAliasesAndQueryTransactionsTest(TestCase):
         }
         transform_aliases_and_query(
             selected_columns=["transaction", "transaction.duration"],
-            conditions=[["http_method", "=", "GET"]],
+            conditions=[["http_method", "=", "GET"], ["geo.country_code", "=", "CA"]],
             groupby=["transaction.op"],
             filter_keys={"project_id": [self.project.id]},
         )
         mock_query.assert_called_with(
             selected_columns=["transaction_name", "duration"],
-            conditions=[["tags[http_method]", "=", "GET"]],
+            conditions=[
+                ["tags[http_method]", "=", "GET"],
+                ["contexts[geo.country_code]", "=", "CA"],
+            ],
             filter_keys={"project_id": [self.project.id]},
             groupby=["transaction_op"],
             dataset=Dataset.Transactions,


### PR DESCRIPTION
Enable the geo fields to be read out of the contexts list. This lets us build conditions and select geo properties in results.