### PR TITLE
fix(app-platform): Ensure event exists before showing link in Request Log

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_requests.py
+++ b/src/sentry/api/endpoints/sentry_app_requests.py
@@ -33,7 +33,7 @@ class SentryAppRequestsEndpoint(SentryAppBaseEndpoint):
                 if project.organization_id == sentry_app.owner_id:
                     # Make sure the event actually exists
                     event = eventstore.get_event_by_id(project.id, request["error_id"])
-                    if event is not None and event.group_id:
+                    if event is not None and event.group_id is not None:
                         error_url = reverse(
                             "sentry-organization-event-detail",
                             args=[project.organization.slug, event.group_id, event.event_id],

--- a/tests/sentry/api/endpoints/test_sentry_app_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_requests.py
@@ -13,6 +13,7 @@ class SentryAppRequestsTest(APITestCase):
         self.user = self.create_user(email="user@example.com")
         self.org = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.org)
+        self.event_id = "d5111da2c28645c5889d072017e3445d"
 
         self.published_app = self.create_sentry_app(
             name="Published App", organization=self.org, published=True
@@ -198,13 +199,15 @@ class GetSentryAppRequestsTest(SentryAppRequestsTest):
     def test_linked_error_id_converts_to_url(self):
         self.login_as(user=self.user)
 
+        event = self.store_event(data={"event_id": self.event_id}, project_id=self.project.id)
+
         buffer = SentryAppWebhookRequestsBuffer(self.published_app)
         buffer.add_request(
             response_code=200,
             org_id=self.org.id,
             event="issue.assigned",
             url=self.unpublished_app.webhook_url,
-            error_id="d5111da2c28645c5889d072017e3445d",
+            error_id=self.event_id,
             project_id=self.project.id,
         )
 
@@ -214,12 +217,14 @@ class GetSentryAppRequestsTest(SentryAppRequestsTest):
         assert len(response.data) == 1
         assert response.data[0]["organization"]["slug"] == self.org.slug
         assert response.data[0]["sentryAppSlug"] == self.published_app.slug
-        assert response.data[0]["errorUrl"] == "/organizations/{}/projects/{}/events/{}/".format(
-            self.org.slug, self.project.slug, "d5111da2c28645c5889d072017e3445d"
+        assert response.data[0]["errorUrl"] == reverse(
+            "sentry-organization-event-detail", args=[self.org.slug, event.group_id, event.event_id]
         )
 
     def test_linked_error_not_returned_if_project_does_not_exist(self):
         self.login_as(user=self.user)
+
+        self.store_event(data={"event_id": self.event_id}, project_id=self.project.id)
 
         buffer = SentryAppWebhookRequestsBuffer(self.published_app)
         buffer.add_request(
@@ -227,8 +232,31 @@ class GetSentryAppRequestsTest(SentryAppRequestsTest):
             org_id=self.org.id,
             event="issue.assigned",
             url=self.unpublished_app.webhook_url,
-            error_id="d5111da2c28645c5889d072017e3445d",
+            error_id=self.event_id,
             project_id="1000",
+        )
+
+        url = reverse("sentry-api-0-sentry-app-requests", args=[self.published_app.slug])
+        response = self.client.get(url, format="json")
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["organization"]["slug"] == self.org.slug
+        assert response.data[0]["sentryAppSlug"] == self.published_app.slug
+        assert "errorUrl" not in response.data[0]
+
+    def test_linked_error_not_returned_if_event_does_not_exist(self):
+        self.login_as(user=self.user)
+
+        # event_id doesn't correspond to an existing event because we didn't call store_event
+
+        buffer = SentryAppWebhookRequestsBuffer(self.published_app)
+        buffer.add_request(
+            response_code=200,
+            org_id=self.org.id,
+            event="issue.assigned",
+            url=self.unpublished_app.webhook_url,
+            error_id=self.event_id,
+            project_id=self.project.id,
         )
 
         url = reverse("sentry-api-0-sentry-app-requests", args=[self.published_app.slug])
@@ -249,7 +277,7 @@ class GetSentryAppRequestsTest(SentryAppRequestsTest):
             org_id=self.org.id,
             event="issue.assigned",
             url=self.unpublished_app.webhook_url,
-            error_id="d5111da2c28645c5889d072017e3445d",
+            error_id=self.event_id,
             project_id=unowned_project.id,
         )
 

--- a/tests/sentry/api/endpoints/test_sentry_app_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_requests.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
 
@@ -199,7 +200,10 @@ class GetSentryAppRequestsTest(SentryAppRequestsTest):
     def test_linked_error_id_converts_to_url(self):
         self.login_as(user=self.user)
 
-        event = self.store_event(data={"event_id": self.event_id}, project_id=self.project.id)
+        event = self.store_event(
+            data={"event_id": self.event_id, "timestamp": iso_format(before_now(minutes=1))},
+            project_id=self.project.id,
+        )
 
         buffer = SentryAppWebhookRequestsBuffer(self.published_app)
         buffer.add_request(
@@ -224,7 +228,10 @@ class GetSentryAppRequestsTest(SentryAppRequestsTest):
     def test_linked_error_not_returned_if_project_does_not_exist(self):
         self.login_as(user=self.user)
 
-        self.store_event(data={"event_id": self.event_id}, project_id=self.project.id)
+        self.store_event(
+            data={"event_id": self.event_id, "timestamp": iso_format(before_now(minutes=1))},
+            project_id=self.project.id,
+        )
 
         buffer = SentryAppWebhookRequestsBuffer(self.published_app)
         buffer.add_request(


### PR DESCRIPTION
If the event ID that was sent back in the header doesn't actually exist in the eventstore, don't display the link in the Request Log (the link would be broken otherwise)