### PR TITLE
fix(app-platform): don't show installation webhooks in the request log for internal apps

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -55,8 +55,10 @@ const getEventTypes = memoize((app: SentryApp) => {
 
   const events = [
     ALL_EVENTS,
-    'installation.created',
-    'installation.deleted',
+    // Internal apps don't have installation webhooks
+    ...(app.status !== 'internal'
+      ? ['installation.created', 'installation.deleted']
+      : []),
     ...(app.events.includes('error') ? ['error.created'] : []),
     ...(app.events.includes('issue')
       ? ['issue.created', 'issue.resolved', 'issue.ignored', 'issue.assigned']


### PR DESCRIPTION
Internal apps don't send out `installation.created` or `installation.deleted` webhooks so remove them from the event type filter options in the request log.

Open questions:
- For internal apps that don’t use any other webhooks, should we still show the request log? Since there would be no installation.created/deleted webhooks, there are no webhooks at all
- Is it better to show all “possible” webhook types for an app or just the ones that actually exist? For example, If a webhook has alerts enabled but hasn’t actually received any webhooks from it yet — do we show these event types in the dropdown filter?


