### PR TITLE
fix: Fix load mocks

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -30,7 +30,6 @@ from sentry.models import (
     CommitFileChange,
     Deploy,
     EventAttachment,
-    Event,
     Environment,
     File,
     Group,
@@ -216,7 +215,7 @@ def create_sample_time_series(event, release=None):
     if event is None:
         return
 
-    Event.objects.bind_nodes([event], "data")
+    event.bind_node_data()
 
     group = event.group
 


### PR DESCRIPTION
Event.bind_nodes([event]) moved to event.bind_node_data()