### PR TITLE
fix(discover2): Pass environment and projects to the primary chart

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/events.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/events.tsx
@@ -118,6 +118,8 @@ export default class Events extends React.Component<EventsProps> {
                   yAxisOptions={yAxisOptions}
                   yAxisValue={eventView.yAxis}
                   onYAxisChange={this.handleYAxisChange}
+                  project={eventView.project as number[]}
+                  environment={eventView.environment as string[]}
                 />
               ),
               fixed: 'events chart',


### PR DESCRIPTION
@markstory is this right? 

------

Enforce environment and projects selection from the eventview rather than thru the global selection HoC.