### PR TITLE
ref(ingest_consumer): Inject project object

### DIFF
--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -79,7 +79,13 @@ class IngestConsumerWorker(AbstractBatchWorker):
         # Preprocess this event, which spawns either process_event or
         # save_event. Pass data explicitly to avoid fetching it again from the
         # cache.
-        preprocess_event(cache_key=cache_key, data=data, start_time=start_time, event_id=event_id)
+        preprocess_event(
+            cache_key=cache_key,
+            data=data,
+            start_time=start_time,
+            event_id=event_id,
+            project=project,
+        )
 
         # remember for an 1 hour that we saved this event (deduplication protection)
         cache.set(deduplication_key, "", 3600)

--- a/tests/sentry/ingest/test_ingest_consumer.py
+++ b/tests/sentry/ingest/test_ingest_consumer.py
@@ -43,7 +43,7 @@ def _get_test_message(project):
         "ty": (0, ()),
         "start_time": time.time(),
         "event_id": event_id,
-        "project_id": 1,
+        "project_id": int(project_id),
         "payload": json.dumps(normalized_event),
     }
 


### PR DESCRIPTION
Otherwise we fetch it from cache twice within the ingest consumer