### PR TITLE
fix(globalselection) Environment picker should use all projects

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -505,7 +505,7 @@ class GlobalSelectionHeader extends React.Component {
       ? [parseInt(forceProject.id, 10)]
       : this.props.selection.projects;
 
-    const [projects, nonMemberProjects] = this.getProjects();
+    const [memberProjects, nonMemberProjects] = this.getProjects();
 
     return (
       <Header className={className}>
@@ -515,7 +515,7 @@ class GlobalSelectionHeader extends React.Component {
             organization={organization}
             shouldForceProject={shouldForceProject}
             forceProject={forceProject}
-            projects={projects}
+            projects={memberProjects}
             loadingProjects={loadingProjects}
             nonMemberProjects={nonMemberProjects}
             value={this.state.projects || this.props.selection.projects}
@@ -531,7 +531,7 @@ class GlobalSelectionHeader extends React.Component {
             <HeaderItemPosition>
               <MultipleEnvironmentSelector
                 organization={organization}
-                projects={projects}
+                projects={this.props.projects}
                 loadingProjects={loadingProjects}
                 selectedProjects={selectedProjects}
                 value={this.state.environments || this.props.selection.environments}

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -256,6 +256,41 @@ describe('GlobalSelectionHeader', function() {
     );
   });
 
+  it('shows environments for non-member projects', async function() {
+    const initialData = initializeOrg({
+      organization: {features: ['global-views']},
+      projects: [
+        {id: 1, slug: 'staging-project', environments: ['staging'], isMember: false},
+        {id: 2, slug: 'prod-project', environments: ['prod']},
+      ],
+      router: {
+        location: {query: {project: [1]}},
+      },
+    });
+    jest.spyOn(ProjectsStore, 'getState').mockImplementation(() => ({
+      projects: initialData.projects,
+      loadingProjects: false,
+    }));
+
+    const wrapper = mountWithTheme(
+      <GlobalSelectionHeader
+        router={initialData.router}
+        organization={initialData.organization}
+        projects={initialData.projects}
+      />,
+      changeQuery(initialData.routerContext, {project: 1})
+    );
+    await tick();
+    wrapper.update();
+
+    // Open environment picker
+    wrapper.find('MultipleEnvironmentSelector HeaderItem').simulate('click');
+    const checkboxes = wrapper.find('MultipleEnvironmentSelector AutoCompleteItem');
+
+    expect(checkboxes).toHaveLength(1);
+    expect(checkboxes.text()).toBe('staging');
+  });
+
   it('updates URL to match GlobalSelection store when re-rendered with `forceUrlSync` prop', async function() {
     const wrapper = mountWithTheme(
       <GlobalSelectionHeader router={router} organization={organization} />,

--- a/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
@@ -112,6 +112,17 @@ describe('MultipleEnvironmentSelector', function() {
     expect(items.at(0).text()).toBe('dev');
   });
 
+  it('shows non-member project environments when selected', async function() {
+    wrapper.setProps({selectedProjects: [3]});
+    wrapper.update();
+
+    await wrapper.find('MultipleEnvironmentSelector HeaderItem').simulate('click');
+    const items = wrapper.find('MultipleEnvironmentSelector GlobalSelectionHeaderRow');
+
+    expect(items.length).toEqual(1);
+    expect(items.at(0).text()).toBe('no-env');
+  });
+
   it('shows member project environments when there are no projects selected', async function() {
     wrapper.setProps({selectedProjects: []});
     wrapper.update();


### PR DESCRIPTION
When a user is looking at a non-member project we should show that project's environments.

Fixes ISSUE-638