### PR TITLE
ref(experiments): Remove invites experiment

### DIFF
--- a/src/sentry/api/endpoints/organization_invite_request_index.py
+++ b/src/sentry/api/endpoints/organization_invite_request_index.py
@@ -4,7 +4,7 @@ from django.db import transaction
 from django.db.models import Q
 from rest_framework.response import Response
 
-from sentry import roles, experiments
+from sentry import roles
 from sentry.app import locks
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import OffsetPaginator
@@ -60,10 +60,6 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
 
         :auth: required
         """
-        variant = experiments.get(org=organization, experiment_name="ImprovedInvitesExperiment")
-        if variant not in ("all", "invite_request"):
-            return Response(status=403)
-
         serializer = OrganizationMemberSerializer(
             data=request.data,
             context={"organization": organization, "allowed_roles": roles.get_all()},

--- a/src/sentry/api/endpoints/organization_join_request.py
+++ b/src/sentry/api/endpoints/organization_join_request.py
@@ -7,7 +7,6 @@ from rest_framework.response import Response
 from django.db import IntegrityError
 from django.db.models import Q
 
-from sentry import experiments
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.validators import AllowedEmailField
 from sentry.app import ratelimiter
@@ -45,10 +44,6 @@ class OrganizationJoinRequestEndpoint(OrganizationEndpoint):
     permission_classes = []
 
     def post(self, request, organization):
-        variant = experiments.get(org=organization, experiment_name="ImprovedInvitesExperiment")
-        if variant not in ("all", "join_request"):
-            return Response(status=403)
-
         if organization.get_option("sentry:join_requests") is False:
             return Response(
                 {"detail": "Your organization does not allow join requests."}, status=403

--- a/src/sentry/static/sentry/app/components/assigneeSelector.tsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
-import {browserHistory} from 'react-router';
 
 import SentryTypes from 'app/sentryTypes';
 import {Member, User} from 'app/types';
@@ -177,17 +176,6 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
     e.stopPropagation();
   },
 
-  hasInviteRequestExperiment() {
-    const {organization} = this.context;
-
-    if (!organization || !organization.experiments) {
-      return false;
-    }
-
-    const variant = organization.experiments.ImprovedInvitesExperiment;
-    return variant === 'all' || variant === 'invite_request';
-  },
-
   renderNewMemberNodes() {
     const {size} = this.props;
     const members = putSessionUserFirst(this.memberList());
@@ -251,13 +239,8 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
 
   render() {
     const {className} = this.props;
-    const {organization} = this.context;
     const {loading, assignedTo} = this.state;
-    const canInvite = ConfigStore.get('invitesEnabled');
-    const hasOrgWrite = organization.access.includes('org:write');
     const memberList = this.memberList();
-    const hasExperiment = this.hasInviteRequestExperiment();
-    const showInviteMemberButton = (canInvite && hasOrgWrite) || hasExperiment;
 
     return (
       <div className={className}>
@@ -298,28 +281,18 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
               )
             }
             menuFooter={
-              showInviteMemberButton && (
-                <InviteMemberLink
-                  data-test-id="invite-member"
-                  disabled={loading}
-                  onClick={() =>
-                    hasExperiment
-                      ? openInviteMembersModal({source: 'assignee_selector'})
-                      : browserHistory.push(
-                          `/settings/${
-                            organization.slug
-                          }/members/new/?referrer=assignee_selector`
-                        )
-                  }
-                >
-                  <MenuItemWrapper>
-                    <IconContainer>
-                      <InviteMemberIcon />
-                    </IconContainer>
-                    <Label>{t('Invite Member')}</Label>
-                  </MenuItemWrapper>
-                </InviteMemberLink>
-              )
+              <InviteMemberLink
+                data-test-id="invite-member"
+                disabled={loading}
+                onClick={() => openInviteMembersModal({source: 'assignee_selector'})}
+              >
+                <MenuItemWrapper>
+                  <IconContainer>
+                    <InviteMemberIcon />
+                  </IconContainer>
+                  <Label>{t('Invite Member')}</Label>
+                </MenuItemWrapper>
+              </InviteMemberLink>
             }
           >
             {({getActorProps}) => {

--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.jsx
@@ -246,9 +246,7 @@ const formGroups = [
             'Are you sure you want to allow users to request to join your organization?'
           ),
         },
-        visible: ({experiments}) =>
-          !!experiments &&
-          ['all', 'join_request'].includes(experiments.ImprovedInvitesExperiment),
+        visible: ({hasSsoEnabled}) => !hasSsoEnabled,
       },
     ],
   },

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -611,7 +611,6 @@ export type RouterProps = {
 };
 
 export type ActiveExperiments = {
-  ImprovedInvitesExperiment: 'none' | 'all' | 'join_request' | 'invite_request';
   TrialUpgradeV2Experiment: 'upgrade' | 'trial' | -1;
 };
 

--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -8,7 +8,7 @@ import styled from 'react-emotion';
 
 import {ORGANIZATION_FETCH_ERROR_TYPES} from 'app/constants';
 import {fetchOrganizationDetails} from 'app/actionCreators/organization';
-import {metric, logExperiment} from 'app/utils/analytics';
+import {metric} from 'app/utils/analytics';
 import {openSudo} from 'app/actionCreators/modal';
 import {t} from 'app/locale';
 import Alert from 'app/components/alert';
@@ -186,15 +186,6 @@ const OrganizationContext = createReactClass({
     if (organization && !error) {
       HookStore.get('organization:header').forEach(cb => {
         hooks.push(cb(organization));
-      });
-
-      // Log exposure to the improved invite experiment
-      logExperiment({
-        organization,
-        key: 'ImprovedInvitesExperiment',
-        unitName: 'org_id',
-        unitId: parseInt(organization.id, 10),
-        param: 'variant',
       });
 
       // Configure scope to have organization tag

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formPanel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formPanel.tsx
@@ -20,7 +20,6 @@ type Props = {
   // TODO(ts): See if this is still in use
   access: any;
   features: any;
-  experiments: any;
 
   additionalFieldProps: {[key: string]: any};
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.tsx
@@ -62,7 +62,6 @@ class JsonForm extends React.Component<Props, State> {
 
     access: PropTypes.object,
     features: PropTypes.object,
-    experiments: PropTypes.object,
     renderFooter: PropTypes.func,
     /**
      * Renders inside of PanelBody
@@ -130,7 +129,6 @@ class JsonForm extends React.Component<Props, State> {
       access,
       disabled,
       features,
-      experiments,
       additionalFieldProps,
       renderFooter,
       renderHeader,
@@ -142,7 +140,6 @@ class JsonForm extends React.Component<Props, State> {
       access,
       disabled,
       features,
-      experiments,
       additionalFieldProps,
       renderFooter,
       renderHeader,

--- a/src/sentry/static/sentry/app/views/settings/organizationGeneralSettings/organizationSettingsForm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationGeneralSettings/organizationSettingsForm.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {updateOrganization} from 'app/actionCreators/organizations';
+import AsyncComponent from 'app/components/asyncComponent';
 import AvatarChooser from 'app/components/avatarChooser';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
@@ -11,7 +12,7 @@ import SentryTypes from 'app/sentryTypes';
 import organizationSettingsFields from 'app/data/forms/organizationGeneralSettings';
 import withOrganization from 'app/utils/withOrganization';
 
-class OrganizationSettingsForm extends React.Component {
+class OrganizationSettingsForm extends AsyncComponent {
   static propTypes = {
     location: PropTypes.object,
     organization: SentryTypes.Organization,
@@ -21,8 +22,14 @@ class OrganizationSettingsForm extends React.Component {
     onSave: PropTypes.func.isRequired,
   };
 
+  getEndpoints() {
+    const {orgId} = this.props;
+    return [['authProvider', `/organizations/${orgId}/auth-provider/`]];
+  }
+
   render() {
     const {initialData, organization, orgId, onSave, access} = this.props;
+    const {authProvider} = this.state;
     const endpoint = `/organizations/${orgId}/`;
     return (
       <Form
@@ -42,7 +49,7 @@ class OrganizationSettingsForm extends React.Component {
       >
         <PermissionAlert />
         <JsonForm
-          experiments={organization.experiments}
+          additionalFieldProps={{hasSsoEnabled: !!authProvider}}
           features={new Set(organization.features)}
           access={access}
           location={this.props.location}

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersWrapper.tsx
@@ -27,19 +27,6 @@ type State = AsyncView['state'] & {
 };
 
 class OrganizationMembersWrapper extends AsyncView<Props, State> {
-  componentDidMount() {
-    const {organization} = this.props;
-
-    // record when requests tab is viewed on members page
-    if (this.showInviteRequests && !this.onRequestsTab) {
-      trackAnalyticsEvent({
-        eventKey: 'invite_request.tab_viewed',
-        eventName: 'Invite Request Tab Viewed',
-        organization_id: organization.id,
-      });
-    }
-  }
-
   getEndpoints(): [string, string][] {
     const {orgId} = this.props.params;
 
@@ -54,29 +41,6 @@ class OrganizationMembersWrapper extends AsyncView<Props, State> {
     return routeTitleGen(t('Members'), orgId, false);
   }
 
-  get hasExperiment() {
-    const {organization} = this.props;
-
-    return (
-      !!organization &&
-      !!organization.experiments &&
-      organization.experiments.ImprovedInvitesExperiment !== undefined &&
-      organization.experiments.ImprovedInvitesExperiment !== 'none'
-    );
-  }
-
-  get hasInviteRequestExperiment() {
-    const {organization} = this.props;
-
-    if (!organization || !organization.experiments) {
-      return false;
-    }
-
-    const variant = organization.experiments.ImprovedInvitesExperiment;
-
-    return variant === 'all' || variant === 'invite_request';
-  }
-
   get onRequestsTab() {
     return location.pathname.includes('/requests/');
   }
@@ -89,20 +53,15 @@ class OrganizationMembersWrapper extends AsyncView<Props, State> {
     return organization.access.includes('member:write');
   }
 
-  get canOpeninviteModal() {
-    return this.hasWriteAccess || this.hasInviteRequestExperiment;
-  }
-
   get showInviteRequests() {
-    return this.hasWriteAccess && this.hasExperiment;
+    return this.hasWriteAccess;
   }
 
   get showNavTabs() {
     const {requestList} = this.state;
 
     // show the requests tab if there are pending team requests,
-    // or if the organization is exposed to the experiment and
-    // the user has access to approve or deny requests
+    // or if the user has access to approve or deny invite requests
     return (requestList && requestList.length > 0) || this.showInviteRequests;
   }
 
@@ -161,12 +120,6 @@ class OrganizationMembersWrapper extends AsyncView<Props, State> {
           <Button
             priority="primary"
             onClick={() => openInviteMembersModal({source: 'members_settings'})}
-            disabled={!this.canOpeninviteModal}
-            title={
-              !this.canOpeninviteModal
-                ? t('You do not have enough permission to add new members')
-                : undefined
-            }
           >
             {t('Invite Members')}
           </Button>

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationRequestsView.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationRequestsView.tsx
@@ -59,16 +59,6 @@ class OrganizationRequestsView extends AsyncView<Props, State> {
     this.handleRedirect();
   }
 
-  componentDidMount() {
-    const {organization, showInviteRequests} = this.props;
-    showInviteRequests &&
-      trackAnalyticsEvent({
-        eventKey: 'invite_request.page_viewed',
-        eventName: 'Invite Request Page Viewed',
-        organization_id: organization.id,
-      });
-  }
-
   componentDidUpdate() {
     this.handleRedirect();
   }

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamMembers.jsx
@@ -1,4 +1,3 @@
-import {browserHistory} from 'react-router';
 import debounce from 'lodash/debounce';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -199,20 +198,7 @@ class TeamMembers extends React.Component {
     this.debouncedFetchMembersRequest(e.target.value);
   };
 
-  get hasInviteRequestExperiment() {
-    const {organization} = this.props;
-
-    if (!organization || !organization.experiments) {
-      return false;
-    }
-
-    const variant = organization.experiments.ImprovedInvitesExperiment;
-    return variant === 'all' || variant === 'invite_request';
-  }
-
   renderDropdown = access => {
-    const {params} = this.props;
-
     // You can add members if you have `org:write` or you have `team:admin` AND you belong to the team
     // a parent "team details" request should determine your team membership, so this only view is rendered only
     // when you are a member
@@ -252,13 +238,7 @@ class TeamMembers extends React.Component {
       <StyledMembersLabel>
         {t('Members')}
         <StyledCreateMemberLink
-          onClick={() =>
-            this.hasInviteRequestExperiment
-              ? openInviteMembersModal({source: 'teams'})
-              : browserHistory.push(
-                  `/settings/${params.orgId}/members/new/?referrer=teams`
-                )
-          }
+          onClick={() => openInviteMembersModal({source: 'teams'})}
           data-test-id="invite-member"
         >
           {t('Invite Member')}

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -9,7 +9,6 @@ from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.cache import never_cache
 
-from sentry import experiments
 from sentry.api.invite_helper import ApiInviteHelper, remove_invite_cookie
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import WARN_SESSION_EXPIRED
@@ -81,10 +80,6 @@ class AuthLoginView(BaseView):
 
     def get_join_request_link(self, organization):
         if not organization:
-            return None
-
-        variant = experiments.get(org=organization, experiment_name="ImprovedInvitesExperiment")
-        if variant not in ("all", "join_request"):
             return None
 
         if organization.get_option("sentry:join_requests") is False:

--- a/tests/js/spec/components/assigneeSelector.spec.jsx
+++ b/tests/js/spec/components/assigneeSelector.spec.jsx
@@ -4,7 +4,6 @@ import {
   AssigneeSelectorComponent,
   putSessionUserFirst,
 } from 'app/components/assigneeSelector';
-import {browserHistory} from 'react-router';
 import {Client} from 'app/api';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import ConfigStore from 'app/stores/configStore';
@@ -267,68 +266,17 @@ describe('AssigneeSelector', function() {
   });
 
   it('shows invite member button', async function() {
-    const organization = TestStubs.Organization();
+    jest.spyOn(ConfigStore, 'get').mockImplementation(() => true);
 
     openMenu();
     MemberListStore.loadInitialData([USER_1, USER_2]);
     assigneeSelector.update();
     expect(assigneeSelector.find('LoadingIndicator').exists()).toBe(false);
-    expect(
-      assigneeSelector.find('InviteMemberLink[data-test-id="invite-member"]')
-    ).toHaveLength(0);
-
-    assigneeSelector.unmount();
-    jest.spyOn(ConfigStore, 'get').mockImplementation(() => true);
-    assigneeSelector = mountWithTheme(
-      <AssigneeSelectorComponent id={GROUP_1.id} />,
-      TestStubs.routerContext([{organization}])
-    );
-    await tick();
-    assigneeSelector.update();
-    openMenu();
-    assigneeSelector
-      .find('InviteMemberLink[data-test-id="invite-member"]')
-      .simulate('click');
-    expect(browserHistory.push).toHaveBeenCalledWith(
-      `/settings/${organization.slug}/members/new/?referrer=assignee_selector`
-    );
-    ConfigStore.get.mockRestore();
-  });
-
-  it('requires org:write to invite member', async function() {
-    MemberListStore.loadInitialData([USER_1, USER_2]);
-    jest.spyOn(ConfigStore, 'get').mockImplementation(() => true);
-
-    // Remove org:write access permission and make sure invite member button is not shown.
-    assigneeSelector.unmount();
-    assigneeSelector = mountWithTheme(
-      <AssigneeSelectorComponent id={GROUP_1.id} />,
-      TestStubs.routerContext([{organization: TestStubs.Organization({access: []})}])
-    );
-    openMenu();
-    assigneeSelector.update();
-    expect(
-      assigneeSelector.find('InviteMemberLink[data-test-id="invite-member"]')
-    ).toHaveLength(0);
-    ConfigStore.get.mockRestore();
-  });
-
-  it('can invite member with invite request experiment', async function() {
-    const organization = TestStubs.Organization({
-      experiments: {ImprovedInvitesExperiment: 'invite_request'},
-    });
-
-    assigneeSelector.unmount();
-    assigneeSelector = mountWithTheme(
-      <AssigneeSelectorComponent id={GROUP_1.id} />,
-      TestStubs.routerContext([{organization}])
-    );
-    openMenu();
-    assigneeSelector.update();
     assigneeSelector
       .find('InviteMemberLink[data-test-id="invite-member"]')
       .simulate('click');
     expect(openInviteMembersModal).toHaveBeenCalled();
+    ConfigStore.get.mockRestore();
   });
 
   it('filters user by email and selects with keyboard', async function() {

--- a/tests/js/spec/views/settings/organizationMembers/organizationMembersWrapper.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMembersWrapper.spec.jsx
@@ -64,18 +64,8 @@ describe('OrganizationMembersWrapper', function() {
     });
   });
 
-  it('does not render requests tab', function() {
-    const wrapper = mountWithTheme(
-      <OrganizationMembersWrapper organization={organization} {...defaultProps} />,
-      TestStubs.routerContext()
-    );
-
-    expect(wrapper.find('NavTabs').exists()).toBe(false);
-  });
-
   it('does not render requests tab without access', function() {
     const org = TestStubs.Organization({
-      experiments: {ImprovedInvitesExperiment: 'invite_request'},
       access: [],
       status: {
         id: 'active',
@@ -91,9 +81,8 @@ describe('OrganizationMembersWrapper', function() {
     expect(trackAnalyticsEvent).not.toHaveBeenCalled();
   });
 
-  it('renders requests tab with ImprovedInvitesExperiment invite_request', function() {
+  it('renders requests tab with access', function() {
     const org = TestStubs.Organization({
-      experiments: {ImprovedInvitesExperiment: 'invite_request'},
       access: ['member:admin', 'org:admin', 'member:write'],
       status: {
         id: 'active',
@@ -115,12 +104,6 @@ describe('OrganizationMembersWrapper', function() {
     expect(wrapper.find('ListLink[data-test-id="members-tab"]').exists()).toBe(true);
     expect(wrapper.find('ListLink[data-test-id="requests-tab"]').exists()).toBe(true);
 
-    expect(trackAnalyticsEvent).toHaveBeenCalledWith({
-      eventKey: 'invite_request.tab_viewed',
-      eventName: 'Invite Request Tab Viewed',
-      organization_id: org.id,
-    });
-
     wrapper.find('a[data-test-id="requests-tab"]').simulate('click');
     expect(trackAnalyticsEvent).toHaveBeenCalledWith({
       eventKey: 'invite_request.tab_clicked',
@@ -129,9 +112,8 @@ describe('OrganizationMembersWrapper', function() {
     });
   });
 
-  it('renders requests tab with ImprovedInvitesExperiment join_request', function() {
+  it('renders requests tab with access and no invite requests', function() {
     const org = TestStubs.Organization({
-      experiments: {ImprovedInvitesExperiment: 'join_request'},
       access: ['member:admin', 'org:admin', 'member:write'],
       status: {
         id: 'active',
@@ -206,13 +188,12 @@ describe('OrganizationMembersWrapper', function() {
     );
 
     const inviteButton = wrapper.find('StyledButton[aria-label="Invite Members"]');
-    expect(inviteButton.prop('disabled')).toBe(false);
     inviteButton.simulate('click');
 
     expect(openInviteMembersModal).toHaveBeenCalled();
   });
 
-  it('cannot invite without permissions', function() {
+  it('can invite without permissions', function() {
     const org = TestStubs.Organization({
       access: [],
       status: {
@@ -226,7 +207,9 @@ describe('OrganizationMembersWrapper', function() {
     );
 
     const inviteButton = wrapper.find('StyledButton[aria-label="Invite Members"]');
-    expect(inviteButton.prop('disabled')).toBe(true);
+    inviteButton.simulate('click');
+
+    expect(openInviteMembersModal).toHaveBeenCalled();
   });
 
   it('renders member list', function() {

--- a/tests/js/spec/views/settings/organizationMembers/organizationRequestsView.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationRequestsView.spec.jsx
@@ -95,8 +95,8 @@ describe('OrganizationRequestsView', function() {
       TestStubs.routerContext()
     );
 
-    expect(wrapper.find('PanelHeader').exists()).toBe(false);
-    expect(trackAnalyticsEvent).not.toHaveBeenCalled();
+    expect(wrapper.find('PanelHeader').exists()).toBe(true);
+    expect(wrapper.find('InviteRequestRow').exists()).toBe(false);
   });
 
   it('can approve access request and remove', async function() {
@@ -147,9 +147,16 @@ describe('OrganizationRequestsView', function() {
       body: [accessRequest],
     });
 
+    const org = TestStubs.Organization({
+      access: ['team:write'],
+      status: {
+        id: 'active',
+      },
+    });
+
     const wrapper = mountWithTheme(
-      <OrganizationMembersWrapper organization={organization} {...defaultProps}>
-        <OrganizationRequestsView organization={organization} {...defaultProps} />
+      <OrganizationMembersWrapper organization={org} {...defaultProps}>
+        <OrganizationRequestsView organization={org} {...defaultProps} />
       </OrganizationMembersWrapper>,
       TestStubs.routerContext()
     );
@@ -174,35 +181,6 @@ describe('OrganizationRequestsView', function() {
     expect(trackAnalyticsEvent).not.toHaveBeenCalled();
   });
 
-  it('does not render invite requests without experiment', function() {
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/access-requests/',
-      method: 'GET',
-      body: [accessRequest],
-    });
-
-    const org = TestStubs.Organization({
-      experiments: {ImprovedInvitesExperiment: 'none'},
-      access: ['member:admin', 'org:admin', 'member:write'],
-      status: {
-        id: 'active',
-      },
-    });
-
-    const wrapper = mountWithTheme(
-      <OrganizationMembersWrapper organization={org} {...defaultProps}>
-        <OrganizationRequestsView organization={org} {...defaultProps} />
-      </OrganizationMembersWrapper>,
-      TestStubs.routerContext()
-    );
-
-    expect(wrapper.find('NavTabs').exists()).toBe(true);
-    expect(wrapper.find('StyledBadge[text="1"]').exists()).toBe(true);
-    expect(wrapper.find('InviteRequestRow').exists()).toBe(false);
-
-    expect(trackAnalyticsEvent).not.toHaveBeenCalled();
-  });
-
   it('does not render invite requests without access', function() {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/invite-requests/',
@@ -216,7 +194,6 @@ describe('OrganizationRequestsView', function() {
     });
 
     const org = TestStubs.Organization({
-      experiments: {ImprovedInvitesExperiment: 'all'},
       access: [],
       status: {
         id: 'active',
@@ -239,7 +216,6 @@ describe('OrganizationRequestsView', function() {
 
   it('can approve invite request and update', async function() {
     const org = TestStubs.Organization({
-      experiments: {ImprovedInvitesExperiment: 'all'},
       access: ['member:admin', 'org:admin', 'member:write'],
       status: {
         id: 'active',
@@ -284,12 +260,6 @@ describe('OrganizationRequestsView', function() {
     expect(wrapper.find('InviteRequestRow').exists()).toBe(false);
 
     expect(trackAnalyticsEvent).toHaveBeenCalledWith({
-      eventKey: 'invite_request.page_viewed',
-      eventName: 'Invite Request Page Viewed',
-      organization_id: org.id,
-    });
-
-    expect(trackAnalyticsEvent).toHaveBeenCalledWith({
       eventKey: 'invite_request.approved',
       eventName: 'Invite Request Approved',
       organization_id: org.id,
@@ -300,7 +270,6 @@ describe('OrganizationRequestsView', function() {
 
   it('can deny invite request and remove', async function() {
     const org = TestStubs.Organization({
-      experiments: {ImprovedInvitesExperiment: 'all'},
       access: ['member:admin', 'org:admin', 'member:write'],
       status: {
         id: 'active',
@@ -344,12 +313,6 @@ describe('OrganizationRequestsView', function() {
     expect(wrapper.find('InviteRequestRow').exists()).toBe(false);
 
     expect(trackAnalyticsEvent).toHaveBeenCalledWith({
-      eventKey: 'invite_request.page_viewed',
-      eventName: 'Invite Request Page Viewed',
-      organization_id: org.id,
-    });
-
-    expect(trackAnalyticsEvent).toHaveBeenCalledWith({
       eventKey: 'invite_request.denied',
       eventName: 'Invite Request Denied',
       organization_id: org.id,
@@ -360,7 +323,6 @@ describe('OrganizationRequestsView', function() {
 
   it('can update invite requests', async function() {
     const org = TestStubs.Organization({
-      experiments: {ImprovedInvitesExperiment: 'all'},
       access: ['member:admin', 'org:admin', 'member:write'],
       status: {
         id: 'active',

--- a/tests/js/spec/views/settings/organizationSettingsForm.spec.jsx
+++ b/tests/js/spec/views/settings/organizationSettingsForm.spec.jsx
@@ -14,12 +14,16 @@ describe('OrganizationSettingsForm', function() {
 
   beforeEach(function() {
     MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/auth-provider/`,
+      method: 'GET',
+    });
     onSave.mockReset();
   });
 
   it('can change a form field', function(done) {
     putMock = MockApiClient.addMockResponse({
-      url: '/organizations/3/',
+      url: `/organizations/${organization.slug}/`,
       method: 'PUT',
       data: {
         name: 'New Name',
@@ -29,7 +33,7 @@ describe('OrganizationSettingsForm', function() {
     const wrapper = mountWithTheme(
       <OrganizationSettingsForm
         location={TestStubs.location()}
-        orgId={organization.id}
+        orgId={organization.slug}
         access={new Set('org:admin')}
         initialData={TestStubs.Organization()}
         onSave={onSave}
@@ -44,7 +48,7 @@ describe('OrganizationSettingsForm', function() {
     input.simulate('blur');
 
     expect(putMock).toHaveBeenCalledWith(
-      '/organizations/3/',
+      `/organizations/${organization.slug}/`,
       expect.objectContaining({
         method: 'PUT',
         data: {
@@ -87,7 +91,7 @@ describe('OrganizationSettingsForm', function() {
 
   it('can change slug', function() {
     putMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/',
+      url: `/organizations/${organization.slug}/`,
       method: 'PUT',
     });
 

--- a/tests/js/spec/views/teamMembers.spec.jsx
+++ b/tests/js/spec/views/teamMembers.spec.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {browserHistory} from 'react-router';
 
 import {Client} from 'app/api';
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -48,28 +47,6 @@ describe('TeamMembers', function() {
         params={{orgId: organization.slug, teamId: team.slug}}
         organization={organization}
       />,
-      routerContext
-    );
-
-    await tick();
-    wrapper.update();
-
-    wrapper.find('DropdownButton[data-test-id="add-member"]').simulate('click');
-    wrapper
-      .find('StyledCreateMemberLink[data-test-id="invite-member"]')
-      .simulate('click');
-
-    expect(browserHistory.push).toHaveBeenCalledWith(
-      `/settings/${organization.slug}/members/new/?referrer=teams`
-    );
-  });
-
-  it('can open invite modal on invite member with experiment', async function() {
-    const org = TestStubs.Organization({
-      experiments: {ImprovedInvitesExperiment: 'invite_request'},
-    });
-    const wrapper = mountWithTheme(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
       routerContext
     );
 

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from django.core import mail
 from django.core.urlresolvers import reverse
 from exam import fixture
-from mock import patch
 
 from sentry.testutils import APITestCase
 from sentry.models import (
@@ -77,8 +76,7 @@ class OrganizationInviteRequestCreateTest(APITestCase):
             kwargs={"organization_slug": self.org.slug},
         )
 
-    @patch("sentry.experiments.get", return_value="invite_request")
-    def test_simple(self, mocked_experiment):
+    def test_simple(self):
         self.login_as(user=self.user)
         with self.tasks():
             response = self.client.post(
@@ -101,8 +99,7 @@ class OrganizationInviteRequestCreateTest(APITestCase):
         assert len(teams) == 1
         assert teams[0].team_id == self.team.id
 
-    @patch("sentry.experiments.get", return_value="invite_request")
-    def test_higher_role(self, mocked_experiment):
+    def test_higher_role(self):
         self.login_as(user=self.user)
         response = self.client.post(
             self.url, {"email": "eric@localhost", "role": "owner", "teams": [self.team.slug]}
@@ -114,8 +111,7 @@ class OrganizationInviteRequestCreateTest(APITestCase):
         member = OrganizationMember.objects.get(organization=self.org, email=response.data["email"])
         assert member.role == "owner"
 
-    @patch("sentry.experiments.get", return_value="invite_request")
-    def test_existing_member(self, mocked_experiment):
+    def test_existing_member(self):
         self.login_as(user=self.user)
 
         user2 = self.create_user("foobar@example.com")
@@ -128,8 +124,7 @@ class OrganizationInviteRequestCreateTest(APITestCase):
         assert resp.status_code == 400
         assert "The user %s is already a member" % user2.email in resp.content
 
-    @patch("sentry.experiments.get", return_value="invite_request")
-    def test_existing_invite_request(self, mocked_experiment):
+    def test_existing_invite_request(self):
         self.login_as(user=self.user)
 
         invite_request = self.create_member(

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -25,29 +25,17 @@ class OrganizationJoinRequestTest(APITestCase):
         resp = self.get_response("invalid-slug", email=self.email)
         assert resp.status_code == 404
 
-    @patch("sentry.experiments.get", return_value="none")
-    def test_experiment(self, mock_experiment):
-        resp = self.get_response(self.org.slug, email=self.email)
-        assert resp.status_code == 403
-
-        mock_experiment.assert_called_once_with(
-            org=self.org, experiment_name="ImprovedInvitesExperiment"
-        )
-
-    @patch("sentry.experiments.get", return_value="join_request")
-    def test_email_required(self, mock_experiment):
+    def test_email_required(self):
         resp = self.get_response(self.org.slug)
         assert resp.status_code == 400
         assert resp.data["email"][0] == "This field is required."
 
-    @patch("sentry.experiments.get", return_value="join_request")
-    def test_invalid_email(self, mock_experiment):
+    def test_invalid_email(self):
         resp = self.get_response(self.org.slug, email="invalid-email")
         assert resp.status_code == 400
         assert resp.data["email"][0] == "Enter a valid email address."
 
-    @patch("sentry.experiments.get", return_value="join_request")
-    def test_organization_setting_disabled(self, mock_experiment):
+    def test_organization_setting_disabled(self):
         OrganizationOption.objects.create(
             organization_id=self.org.id, key="sentry:join_requests", value=False
         )
@@ -58,15 +46,13 @@ class OrganizationJoinRequestTest(APITestCase):
     @patch(
         "sentry.api.endpoints.organization_join_request.ratelimiter.is_limited", return_value=True
     )
-    @patch("sentry.experiments.get", return_value="join_request")
-    def test_ratelimit(self, mock_experiment, is_limited):
+    def test_ratelimit(self, is_limited):
         resp = self.get_response(self.org.slug, email=self.email)
         assert resp.status_code == 429
         assert resp.data["detail"] == "Rate limit exceeded."
 
     @patch("sentry.api.endpoints.organization_join_request.logger")
-    @patch("sentry.experiments.get", return_value="join_request")
-    def test_org_sso_enabled(self, mock_experiment, mock_log):
+    def test_org_sso_enabled(self, mock_log):
         AuthProvider.objects.create(organization=self.org, provider="google")
 
         resp = self.get_response(self.org.slug, email=self.email)
@@ -77,8 +63,7 @@ class OrganizationJoinRequestTest(APITestCase):
         assert not mock_log.info.called
 
     @patch("sentry.api.endpoints.organization_join_request.logger")
-    @patch("sentry.experiments.get", return_value="join_request")
-    def test_user_already_exists(self, mock_experiment, mock_log):
+    def test_user_already_exists(self, mock_log):
         resp = self.get_response(self.org.slug, email=self.user.email)
         assert resp.status_code == 204
 
@@ -87,8 +72,7 @@ class OrganizationJoinRequestTest(APITestCase):
         assert not mock_log.info.called
 
     @patch("sentry.api.endpoints.organization_join_request.logger")
-    @patch("sentry.experiments.get", return_value="join_request")
-    def test_pending_member_already_exists(self, mock_experiment, mock_log):
+    def test_pending_member_already_exists(self, mock_log):
         pending_email = "pending@example.com"
         original_pending = self.create_member(
             email=pending_email, organization=self.org, role="admin"
@@ -105,8 +89,7 @@ class OrganizationJoinRequestTest(APITestCase):
 
     @patch("sentry.analytics.record")
     @patch("sentry.api.endpoints.organization_join_request.logger")
-    @patch("sentry.experiments.get", return_value="join_request")
-    def test_already_requested_to_join(self, mock_experiment, mock_log, mock_record):
+    def test_already_requested_to_join(self, mock_log, mock_record):
         join_request_email = "join-request@example.com"
         original_join_request = self.create_member(
             email=join_request_email,
@@ -127,8 +110,7 @@ class OrganizationJoinRequestTest(APITestCase):
         assert not any(c[0][0] == "join_request.created" for c in mock_record.call_args_list)
 
     @patch("sentry.analytics.record")
-    @patch("sentry.experiments.get", return_value="join_request")
-    def test_request_to_join(self, mock_experiment, mock_record):
+    def test_request_to_join(self, mock_record):
         with self.tasks():
             resp = self.get_response(self.org.slug, email=self.email)
 

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 from exam import fixture
-from mock import patch
 from django.core.urlresolvers import reverse
 
 from sentry.models import (
@@ -25,8 +24,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
     def path(self):
         return reverse("sentry-auth-organization", args=[self.organization.slug])
 
-    @patch("sentry.analytics.record")
-    def test_renders_basic(self, mock_record):
+    def test_renders_basic(self):
         self.login_as(self.user)
         resp = self.client.get(self.path)
 
@@ -36,27 +34,9 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.context["login_form"]
         assert resp.context["organization"] == self.organization
         assert "provider_key" not in resp.context
-        assert resp.context["join_request_link"] is None
+        assert resp.context["join_request_link"]
 
-        assert not any(c[0][0] == "join_request.link_viewed" for c in mock_record.call_args_list)
-
-    @patch("sentry.analytics.record")
-    @patch("sentry.experiments.get", return_value="join_request")
-    def test_get_request_join_link_with_experiment(self, mock_experiment, mock_record):
-        self.login_as(self.user)
-        resp = self.client.get(self.path)
-
-        assert resp.status_code == 200
-        assert resp.context["join_request_link"] == reverse(
-            "sentry-join-request", args=[self.organization.slug]
-        )
-
-        mock_record.assert_called_with(
-            "join_request.link_viewed", organization_id=self.organization.id
-        )
-
-    @patch("sentry.experiments.get", return_value="join_request")
-    def test_cannot_get_request_join_link_with_setting_disabled(self, mock_experiment):
+    def test_cannot_get_request_join_link_with_setting_disabled(self):
         OrganizationOption.objects.create(
             organization_id=self.organization.id, key="sentry:join_requests", value=False
         )


### PR DESCRIPTION
- Removes the `ImprovedInvitesExperiment` experiment
- Hides the `Allow Join Requests` setting from organizations that have SSO enabled