### PR TITLE
fix(issues) Don't use group values in tag bars

### DIFF
--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -12,7 +12,7 @@ import SuggestedOwners from 'app/components/group/suggestedOwners';
 import GroupParticipants from 'app/components/group/participants';
 import GroupReleaseStats from 'app/components/group/releaseStats';
 import IndicatorStore from 'app/stores/indicatorStore';
-import TagDistributionMeter from 'app/components/group/tagDistributionMeter';
+import GroupTagDistributionMeter from 'app/components/group/tagDistributionMeter';
 import LoadingError from 'app/components/loadingError';
 import SubscribeButton from 'app/components/subscribeButton';
 import {t, tct} from 'app/locale';
@@ -261,11 +261,12 @@ class GroupSidebar extends React.Component {
             const tagWithTopValues = this.state.tagsWithTopValues[tag.key];
             const topValues = tagWithTopValues ? tagWithTopValues.topValues : [];
             const topValuesTotal = tagWithTopValues ? tagWithTopValues.totalValues : 0;
+
             return (
-              <TagDistributionMeter
+              <GroupTagDistributionMeter
                 key={tag.key}
                 tag={tag.key}
-                totalValues={tag.totalValues || topValuesTotal}
+                totalValues={topValuesTotal}
                 topValues={topValues}
                 name={tag.name}
                 data-test-id="group-tag"


### PR DESCRIPTION
Whilst snuba was being added the tag totals had a fallback to the group. Now that we're fully in a post-snuba era this fallback causes stale values on active issues as you paginate backwards through time.

Fixes ISSUE-631