### PR TITLE
fix(apm): Disable self-tracing by default again

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.jsx
+++ b/src/sentry/static/sentry/app/bootstrap.jsx
@@ -30,6 +30,9 @@ if (window.__initialData) {
 }
 
 // SDK INIT  --------------------------------------------------------
+const config = ConfigStore.getConfig();
+// Only enable self-tracing when isApmDataSamplingEnabled is true
+const tracesSampleRate = config && config.isApmDataSamplingEnabled ? 1 : 0;
 Sentry.init({
   ...window.__SENTRY__OPTIONS,
   integrations: [
@@ -39,6 +42,7 @@ Sentry.init({
     }),
     new Integrations.Tracing({
       tracingOrigins: ['localhost', 'sentry.io', /^\//],
+      tracesSampleRate,
     }),
   ],
 });


### PR DESCRIPTION
Self-tracing was disabled in #15555 but the logic accidentally got removed in #15775. This patch brings it back so we don't self-trace in on-premise.