### PR TITLE
ref(django 1.10): keep pre-1.10 SubfieldBase behavior with Creator

### DIFF
--- a/src/sentry/db/models/fields/array.py
+++ b/src/sentry/db/models/fields/array.py
@@ -45,7 +45,3 @@ class ArrayField(models.Field):
         if isinstance(value, six.text_type):
             value = json.loads(value)
         return map(self.of.to_python, value)
-
-
-if hasattr(models, "SubfieldBase"):
-    ArrayField = six.add_metaclass(models.SubfieldBase)(ArrayField)

--- a/src/sentry/db/models/fields/citext.py
+++ b/src/sentry/db/models/fields/citext.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import, print_function
-
-import six
+from __future__ import absolute_import
 
 from django.db import connections, models
 from django.db.models.signals import pre_migrate
@@ -24,12 +22,6 @@ class CICharField(CIText, models.CharField):
 
 class CIEmailField(CIText, models.EmailField):
     pass
-
-
-if hasattr(models, "SubfieldBase"):
-    CITextField = six.add_metaclass(models.SubfieldBase)(CITextField)
-    CICharField = six.add_metaclass(models.SubfieldBase)(CICharField)
-    CIEmailField = six.add_metaclass(models.SubfieldBase)(CIEmailField)
 
 
 def create_citext_extension(using, **kwargs):

--- a/src/sentry/db/models/fields/citext.py
+++ b/src/sentry/db/models/fields/citext.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from django.db import connections, models
 from django.db.models.signals import pre_migrate
 
+from sentry.db.models.utils import Creator
 
 __all__ = ("CITextField", "CICharField", "CIEmailField")
 
@@ -13,15 +14,21 @@ class CIText(object):
 
 
 class CITextField(CIText, models.TextField):
-    pass
+    def contribute_to_class(self, cls, name):
+        super(CITextField, self).contribute_to_class(cls, name)
+        setattr(cls, name, Creator(self))
 
 
 class CICharField(CIText, models.CharField):
-    pass
+    def contribute_to_class(self, cls, name):
+        super(CICharField, self).contribute_to_class(cls, name)
+        setattr(cls, name, Creator(self))
 
 
 class CIEmailField(CIText, models.EmailField):
-    pass
+    def contribute_to_class(self, cls, name):
+        super(CIEmailField, self).contribute_to_class(cls, name)
+        setattr(cls, name, Creator(self))
 
 
 def create_citext_extension(using, **kwargs):


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/13255.

Our `NodeField` and `UUIDField` still have `SubfieldBase`, which is removed in 1.10. However, the consequences don't seem to manifest in any Django 1.10 test failures, unlike https://github.com/getsentry/sentry/pull/15686.

Two options here - we can blindly add `Creator` to these two fields to restore the previous `SubfieldBase` behavior surrounding `to_python` invocation, or we can see if we're actually relying on the behavior. (I'm still unclear with my understanding on the whole thing.)

Also, it looks like Django 1.8 has native UUIDField - it might be worth seeing if we can switch over.
