### PR TITLE
fix(discover) Enable wildcard searches on stack fields

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -566,7 +566,12 @@ def convert_search_filter_to_snuba_query(search_filter):
             operator = "=" if search_filter.operator == "!=" else "!="
             # make message search case insensitive
             return [["positionCaseInsensitive", ["message", "'%s'" % (value,)]], operator, 0]
-
+    elif name.startswith("stack.") or name.startswith("error."):
+        # Escape and convert meta characters for LIKE expressions.
+        raw_value = search_filter.value.raw_value
+        like_value = raw_value.replace("%", "\\%").replace("_", "\\_").replace("*", "%")
+        operator = "LIKE" if search_filter.operator == "==" else "NOT LIKE"
+        return [name, operator, like_value]
     else:
         value = (
             int(to_timestamp(value)) * 1000

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -570,7 +570,7 @@ def convert_search_filter_to_snuba_query(search_filter):
         # Escape and convert meta characters for LIKE expressions.
         raw_value = search_filter.value.raw_value
         like_value = raw_value.replace("%", "\\%").replace("_", "\\_").replace("*", "%")
-        operator = "LIKE" if search_filter.operator == "==" else "NOT LIKE"
+        operator = "LIKE" if search_filter.operator == "=" else "NOT LIKE"
         return [name, operator, like_value]
     else:
         value = (

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -566,7 +566,9 @@ def convert_search_filter_to_snuba_query(search_filter):
             operator = "=" if search_filter.operator == "!=" else "!="
             # make message search case insensitive
             return [["positionCaseInsensitive", ["message", "'%s'" % (value,)]], operator, 0]
-    elif name.startswith("stack.") or name.startswith("error."):
+    elif (
+        name.startswith("stack.") or name.startswith("error.")
+    ) and search_filter.value.is_wildcard():
         # Escape and convert meta characters for LIKE expressions.
         raw_value = search_filter.value.raw_value
         like_value = raw_value.replace("%", "\\%").replace("_", "\\_").replace("*", "%")

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -967,7 +967,7 @@ class GetSnubaQueryArgsTest(TestCase):
         assert filter.conditions == [
             ["error.value", "LIKE", "Deadlock%"],
             ["stack.filename", "LIKE", "%.py"],
-            ["stack.abs_path", "LIKE", "\\%APP\\_DIR\\%/th\_ing%"],
+            ["stack.abs_path", "LIKE", "\\%APP\\_DIR\\%/th\\_ing%"],
         ]
         assert filter.filter_keys == {}
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -960,6 +960,17 @@ class GetSnubaQueryArgsTest(TestCase):
             [["match", ["release", "'(?i)^\\\\.*$'"]], "=", 1]
         ]
 
+    def test_wildcard_array_field(self):
+        filter = get_filter(
+            "error.value:Deadlock* stack.filename:*.py stack.abs_path:%APP_DIR%/th_ing*"
+        )
+        assert filter.conditions == [
+            ["error.value", "LIKE", "Deadlock%"],
+            ["stack.filename", "LIKE", "%.py"],
+            ["stack.abs_path", "LIKE", "\\%APP\\_DIR\\%/th\_ing%"],
+        ]
+        assert filter.filter_keys == {}
+
     def test_has(self):
         assert get_filter("has:release").conditions == [[["isNull", ["release"]], "!=", 1]]
 


### PR DESCRIPTION
Use the `LIKE` and `NOT LIKE` operators for doing wildcard searches on the error array fields. These operators are converted into `arrayExists` and `arrayAll` expressions in clickhouse which is much better than a `match()` expression.