### PR TITLE
fix(discover2): Properly sync minigraphs of pre-built queries with the global selection header

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -390,7 +390,7 @@ class EventView {
   }
 
   static fromSavedQuery(saved: NewQuery | SavedQuery): EventView {
-    let fields, yAxis;
+    const fields, yAxis;
     fields = saved.fields.map((field, i) => {
       const title = saved.fieldnames && saved.fieldnames[i] ? saved.fieldnames[i] : field;
       return {field, title};

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -377,7 +377,7 @@ class EventView {
     });
   }
 
-  static fromSavedQueryWithLocation(newQuery: NewQuery, location: Location): EventView {
+  static fromNewQueryWithLocation(newQuery: NewQuery, location: Location): EventView {
     const query = location.query;
 
     // apply global selection header values from location whenever possible

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -390,12 +390,11 @@ class EventView {
   }
 
   static fromSavedQuery(saved: NewQuery | SavedQuery): EventView {
-    const fields, yAxis;
-    fields = saved.fields.map((field, i) => {
+    const fields = saved.fields.map((field, i) => {
       const title = saved.fieldnames && saved.fieldnames[i] ? saved.fieldnames[i] : field;
       return {field, title};
     });
-    yAxis = saved.yAxis;
+    const yAxis = saved.yAxis;
 
     // normalize datetime selection
     const {start, end, statsPeriod} = getParams({

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -145,7 +145,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
 
     const {location} = this.props;
 
-    const eventView = EventView.fromSavedQueryWithLocation(DEFAULT_EVENT_VIEW, location);
+    const eventView = EventView.fromNewQueryWithLocation(DEFAULT_EVENT_VIEW, location);
 
     const to = {
       pathname: location.pathname,

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -52,12 +52,22 @@ class MiniGraph extends React.Component<Props> {
       start,
       end,
       period,
+      project: eventView.project,
+      environment: eventView.environment,
     };
   }
 
   render() {
-    const {eventView, api} = this.props;
-    const {query, start, end, period, organization} = this.getRefreshProps(this.props);
+    const {api} = this.props;
+    const {
+      query,
+      start,
+      end,
+      period,
+      organization,
+      project,
+      environment,
+    } = this.getRefreshProps(this.props);
 
     return (
       <EventsRequest
@@ -68,8 +78,8 @@ class MiniGraph extends React.Component<Props> {
         end={end}
         period={period}
         interval={getInterval({start, end, period}, true)}
-        project={eventView.project as number[]}
-        environment={eventView.environment as string[]}
+        project={project as number[]}
+        environment={environment as string[]}
         includePrevious={false}
       >
         {({loading, timeseriesData}) => {

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -89,7 +89,7 @@ class QueryList extends React.Component<Props> {
     const views = getPrebuiltQueries(organization);
 
     const list = views.map((view, index) => {
-      const eventView = EventView.fromSavedQueryWithLocation(view, location);
+      const eventView = EventView.fromNewQueryWithLocation(view, location);
       const recentTimeline = t('Last ') + eventView.statsPeriod;
       const customTimeline =
         moment(eventView.start).format('MMM D, YYYY h:mm A') +

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -57,7 +57,7 @@ class Table extends React.PureComponent<TableProps, TableState> {
     const {location, eventView} = this.props;
 
     if (!eventView.isValid()) {
-      const nextEventView = EventView.fromSavedQueryWithLocation(
+      const nextEventView = EventView.fromNewQueryWithLocation(
         DEFAULT_EVENT_VIEW,
         location
       );

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -174,12 +174,12 @@ describe('EventView.fromLocation()', function() {
 });
 
 describe('EventView.fromSavedQuery()', function() {
-  it('maps basic properties of legacy query', function() {
+  it('maps basic properties of saved query', function() {
     const saved = {
       id: '42',
       name: 'best query',
       fields: ['count()', 'id'],
-      conditions: [['event.type', '=', 'transaction']],
+      query: 'event.type:transaction',
       projects: [123],
       range: '14d',
       start: '2019-10-01T00:00:00',
@@ -257,15 +257,6 @@ describe('EventView.fromSavedQuery()', function() {
     };
 
     expect(eventView).toMatchObject(expected);
-  });
-
-  it('maps equality conditions', function() {
-    const saved = {
-      fields: ['count()', 'id'],
-      conditions: [['event.type', '=', 'error']],
-    };
-    const eventView = EventView.fromSavedQuery(saved);
-    expect(eventView.query).toEqual('event.type:error');
   });
 
   it('maps properties from v2 saved query', function() {


### PR DESCRIPTION
This only applies to pre-built queries; saved queries are still disconnected.

I've renamed `EventView.fromSavedQueryWithLocation()` to `EventView. fromNewQueryWithLocation()`, and refined some TS types.

## TODO

- [x] remove `isLegacySavedQuery()`