### PR TITLE
fix(discover) When deleting the last query on page go to the first page

### DIFF
--- a/src/sentry/static/sentry/app/utils/parseLinkHeader.tsx
+++ b/src/sentry/static/sentry/app/utils/parseLinkHeader.tsx
@@ -1,7 +1,7 @@
 export default function parseLinkHeader(
   header: string | null
 ): {[key: string]: {href: string; results: boolean | null; cursor: string}} {
-  if (header === null) {
+  if (header === null || header === '') {
     return {};
   }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -37,10 +37,17 @@ class QueryList extends React.Component<Props> {
     event.preventDefault();
     event.stopPropagation();
 
-    const {api, organization, onQueryChange} = this.props;
+    const {api, organization, onQueryChange, location, savedQueries} = this.props;
 
     handleDeleteQuery(api, organization, eventView).then(() => {
-      onQueryChange();
+      if (savedQueries.length === 1) {
+        browserHistory.push({
+          pathname: location.pathname,
+          query: {...location.query, cursor: undefined},
+        });
+      } else {
+        onQueryChange();
+      }
     });
   };
 

--- a/tests/js/spec/views/eventsV2/queryList.spec.jsx
+++ b/tests/js/spec/views/eventsV2/queryList.spec.jsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import {mountWithTheme} from 'sentry-test/enzyme';
+import {browserHistory} from 'react-router';
+
+import QueryList from 'app/views/eventsV2/queryList';
+
+function openContextMenu(card) {
+  card.find('DropdownMenu ContextMenuButton div').simulate('click');
+}
+
+function clickMenuItem(card, selector) {
+  card.find(`DropdownMenu MenuItem[href="#${selector}"]`).simulate('click');
+}
+
+describe('EventsV2 > QueryList', function() {
+  let location, savedQueries, organization, deleteMock, duplicateMock, queryChangeMock;
+
+  beforeEach(function() {
+    organization = TestStubs.Organization();
+    savedQueries = [
+      TestStubs.DiscoverSavedQuery(),
+      TestStubs.DiscoverSavedQuery({name: 'saved query 2', id: '2'}),
+    ];
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      method: 'GET',
+      statusCode: 200,
+      body: {data: []},
+    });
+
+    deleteMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/discover/saved/2/',
+      method: 'DELETE',
+      statusCode: 200,
+      body: {},
+    });
+
+    duplicateMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/discover/saved/',
+      method: 'POST',
+      body: {
+        id: '3',
+        name: 'Saved query copy',
+      },
+    });
+
+    location = {
+      pathname: '/organizations/org-slug/eventsV2',
+      query: {cursor: '0:1:1', statsPeriod: '14d'},
+    };
+    queryChangeMock = jest.fn();
+  });
+
+  it('renders pre-built queries and saved ones', function() {
+    const wrapper = mountWithTheme(
+      <QueryList
+        organization={organization}
+        savedQueries={savedQueries}
+        pageLinks=""
+        onQueryChange={queryChangeMock}
+        location={location}
+      />,
+      TestStubs.routerContext()
+    );
+    const content = wrapper.find('QueryCard');
+    // pre built + saved queries
+    expect(content).toHaveLength(7);
+  });
+
+  it('can duplicate and trigger change callback', async function() {
+    const wrapper = mountWithTheme(
+      <QueryList
+        organization={organization}
+        savedQueries={savedQueries}
+        pageLinks=""
+        onQueryChange={queryChangeMock}
+        location={location}
+      />,
+      TestStubs.routerContext()
+    );
+    let card = wrapper.find('QueryCard').last();
+    expect(card.find('StyledTitle').text()).toEqual(savedQueries[1].name);
+
+    openContextMenu(card);
+    wrapper.update();
+
+    // Get a fresh node
+    card = wrapper.find('QueryCard').last();
+    clickMenuItem(card, 'duplicate-query');
+
+    // wait for request
+    await wrapper.update();
+
+    expect(duplicateMock).toHaveBeenCalled();
+    expect(queryChangeMock).toHaveBeenCalled();
+  });
+
+  it('can delete and trigger change callback', async function() {
+    const wrapper = mountWithTheme(
+      <QueryList
+        organization={organization}
+        savedQueries={savedQueries}
+        pageLinks=""
+        onQueryChange={queryChangeMock}
+        location={location}
+      />,
+      TestStubs.routerContext()
+    );
+    let card = wrapper.find('QueryCard').last();
+    expect(card.find('StyledTitle').text()).toEqual(savedQueries[1].name);
+
+    openContextMenu(card);
+    wrapper.update();
+
+    card = wrapper.find('QueryCard').last();
+    clickMenuItem(card, 'delete-query');
+
+    // wait for request
+    await wrapper.update();
+
+    expect(deleteMock).toHaveBeenCalled();
+    expect(queryChangeMock).toHaveBeenCalled();
+  });
+
+  it('can redirect on last query deletion', async function() {
+    const wrapper = mountWithTheme(
+      <QueryList
+        organization={organization}
+        savedQueries={savedQueries.slice(1)}
+        pageLinks=""
+        onQueryChange={queryChangeMock}
+        location={location}
+      />,
+      TestStubs.routerContext()
+    );
+    let card = wrapper.find('QueryCard').last();
+    expect(card.find('StyledTitle').text()).toEqual(savedQueries[1].name);
+
+    // Open the context menu
+    openContextMenu(card);
+    wrapper.update();
+
+    card = wrapper.find('QueryCard').last();
+    clickMenuItem(card, 'delete-query');
+
+    // wait for request
+    await wrapper.update();
+
+    expect(deleteMock).toHaveBeenCalled();
+    expect(queryChangeMock).not.toHaveBeenCalled();
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: location.pathname,
+      query: {cursor: undefined, statsPeriod: '14d'},
+    });
+  });
+});


### PR DESCRIPTION
When we remove the last query on the terminal page, instead of showing a blank page go back to the first page. I chose to go to the first page as there could be multiple users deleting things adding more races. Also I suspect organizations will not have 100s of saved queries making the navigation change not onerous.