### PR TITLE
ref(discover) Update events-meta endpoint to use new discover api

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -3,23 +3,23 @@ from __future__ import absolute_import
 from rest_framework.response import Response
 
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
-from sentry.utils import snuba
+from sentry.snuba import discover
 
 
 class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
         try:
             params = self.get_filter_params(request, organization)
-            snuba_args = self.get_snuba_query_args(request, organization, params)
         except OrganizationEventsError as exc:
             return Response({"detail": exc.message}, status=400)
         except NoProjects:
             return Response({"count": 0})
 
-        data = snuba.transform_aliases_and_query(
-            aggregations=[["count()", "", "count"]],
-            referrer="api.organization-event-meta",
-            **snuba_args
-        )["data"][0]
+        result = discover.query(
+            selected_columns=["count()"],
+            params=params,
+            query=request.query_params.get("query"),
+            referrer="api.organization-events-meta",
+        )
 
-        return Response({"count": data["count"]})
+        return Response({"count": result["data"][0]["count"]})

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -769,7 +769,7 @@ def get_aggregate_alias(match):
     return u"{}_{}".format(match.group("function"), column).rstrip("_")
 
 
-def resolve_field_list(fields, snuba_args):
+def resolve_field_list(fields, snuba_args, auto_fields=True):
     """
     Expand a list of fields based on aliases and aggregate functions.
 
@@ -819,7 +819,7 @@ def resolve_field_list(fields, snuba_args):
             )
 
     rollup = snuba_args.get("rollup")
-    if not rollup:
+    if not rollup and auto_fields:
         # Ensure fields we require to build a functioning interface
         # are present. We don't add fields when using a rollup as the additional fields
         # would be aggregated away. When there are aggregations

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -135,7 +135,7 @@ def resolve_discover_aliases(snuba_args):
     return resolved, translated_columns
 
 
-def query(selected_columns, query, params, orderby=None, referrer=None):
+def query(selected_columns, query, params, orderby=None, referrer=None, auto_fields=False):
     """
     High-level API for doing arbitrary user queries against events.
 
@@ -150,6 +150,8 @@ def query(selected_columns, query, params, orderby=None, referrer=None):
     query (str) Filter query string to create conditions from.
     params (Dict[str, str]) Filtering parameters with start, end, project_id, environment
     orderby (str|Sequence[str]) The field to order results by.
+    referrer (str) A reference string to help locate where queries are coming from.
+    auto_fields (bool) Set to true to have project + eventid fields automatically added.
     """
     snuba_filter = get_filter(query, params)
 
@@ -162,7 +164,7 @@ def query(selected_columns, query, params, orderby=None, referrer=None):
         "filter_keys": snuba_filter.filter_keys,
         "orderby": orderby,
     }
-    snuba_args.update(resolve_field_list(selected_columns, snuba_args))
+    snuba_args.update(resolve_field_list(selected_columns, snuba_args, auto_fields=auto_fields))
 
     # Resolve the public aliases into the discover dataset names.
     snuba_args, translated_columns = resolve_discover_aliases(snuba_args)

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -158,6 +158,28 @@ class QueryTransformTest(TestCase):
         )
 
     @patch("sentry.snuba.discover.raw_query")
+    def test_selected_columns_no_auto_fields(self, mock_query):
+        mock_query.return_value = {
+            "meta": [{"name": "user_id"}, {"name": "email"}],
+            "data": [{"user_id": "1", "email": "a@example.org"}],
+        }
+        discover.query(
+            selected_columns=["count()"], query="", params={"project_id": [self.project.id]}
+        )
+        mock_query.assert_called_with(
+            selected_columns=[],
+            aggregations=[["count", None, "count"]],
+            filter_keys={"project_id": [self.project.id]},
+            dataset=Dataset.Discover,
+            end=None,
+            start=None,
+            conditions=[],
+            groupby=[],
+            orderby=None,
+            referrer=None,
+        )
+
+    @patch("sentry.snuba.discover.raw_query")
     def test_selected_columns_aliasing_in_function(self, mock_query):
         mock_query.return_value = {
             "meta": [{"name": "transaction"}, {"name": "duration"}],


### PR DESCRIPTION
Update the events-meta endpoint to use the new discover API methods. This endpoint needed the count() with no additional fields applied, so I've added a flag to opt-out of the automatic field additions that are required by the main results page.