### PR TITLE
fix(ui): Register value toggling without jumping

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters/registerValue.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frameRegisters/registerValue.tsx
@@ -59,7 +59,8 @@ const InlinePre = styled('pre')`
 `;
 
 const FixedWidth = styled('span')`
-  width: 12em;
+  width: 11em;
+  display: inline-block;
   text-align: right;
 `;
 


### PR DESCRIPTION
A subtle change in styles, so that registers don't jump around when toggling Hexadecimal/Numeric view due to changed width.

![image](https://user-images.githubusercontent.com/9060071/69862211-33b53a80-129a-11ea-8b3b-6d535e2b9236.png)
