### PR TITLE
fix(releasefiles): Use organization id for caching in workers

### DIFF
--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -99,8 +99,8 @@ class ReleaseFileCache(object):
             return releasefile.file.getfile()
 
         file_id = six.text_type(releasefile.file_id)
-        project_id = six.text_type(releasefile.project_id)
-        file_path = os.path.join(self.cache_path, project_id, file_id)
+        organization_id = six.text_type(releasefile.organization_id)
+        file_path = os.path.join(self.cache_path, organization_id, file_id)
 
         hit = True
         try:


### PR DESCRIPTION
`project_id` is no longer set on release files. In contrast to debug files, use `organization_id` for bucketing cached release files on processing workers.