### PR TITLE
Revert "fix(javascript): Cache large sourcemaps on workers"

### DIFF
--- a/src/sentry/bgtasks/clean_releasefilecache.py
+++ b/src/sentry/bgtasks/clean_releasefilecache.py
@@ -1,9 +1,0 @@
-from __future__ import absolute_import
-
-from sentry.bgtasks.api import bgtask
-from sentry.models import ReleaseFile
-
-
-@bgtask()
-def clean_releasefilecache():
-    ReleaseFile.cache.clear_old_entries()

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -679,11 +679,7 @@ CELERYBEAT_SCHEDULE = {
 }
 
 BGTASKS = {
-    "sentry.bgtasks.clean_dsymcache:clean_dsymcache": {"interval": 5 * 60, "roles": ["worker"]},
-    "sentry.bgtasks.clean_releasefilecache:clean_releasefilecache": {
-        "interval": 5 * 60,
-        "roles": ["worker"],
-    },
+    "sentry.bgtasks.clean_dsymcache:clean_dsymcache": {"interval": 5 * 60, "roles": ["worker"]}
 }
 
 # Sentry logs to two major places: stdout, and it's internal project.

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -244,7 +244,7 @@ def fetch_release_file(filename, release, dist=None):
         )
         try:
             with metrics.timer("sourcemaps.release_file_read"):
-                with ReleaseFile.cache.getfile(releasefile) as fp:
+                with releasefile.file.getfile() as fp:
                     z_body, body = compress_file(fp)
         except Exception:
             logger.error("sourcemap.compress_read_failed", exc_info=sys.exc_info())
@@ -253,8 +253,6 @@ def fetch_release_file(filename, release, dist=None):
             headers = {k.lower(): v for k, v in releasefile.file.headers.items()}
             encoding = get_encoding_from_headers(headers)
             result = http.UrlResult(filename, headers, body, 200, encoding)
-            # This will implicitly skip too large payloads. Those will be cached
-            # on the file system by `ReleaseFile.cache`, instead.
             cache.set(cache_key, (headers, z_body, 200, encoding), 3600)
 
     elif result == -1:

--- a/src/sentry/models/debugfile.py
+++ b/src/sentry/models/debugfile.py
@@ -4,6 +4,7 @@ import re
 import os
 import six
 import uuid
+import time
 import errno
 import shutil
 import hashlib
@@ -17,12 +18,15 @@ from symbolic import Archive, SymbolicError, ObjectErrorUnsupportedObject, norma
 from sentry import options
 from sentry.constants import KNOWN_DIF_FORMATS
 from sentry.db.models import FlexibleForeignKey, Model, sane_repr, BaseManager, JSONField
-from sentry.models.file import File, clear_cached_files
+from sentry.models.file import File
 from sentry.reprocessing import resolve_processing_issue, bump_reprocessing_revision
 from sentry.utils.zip import safe_extract_zip
 
 
 logger = logging.getLogger(__name__)
+
+ONE_DAY = 60 * 60 * 24
+ONE_DAY_AND_A_HALF = int(ONE_DAY * 1.5)
 
 # How long we cache a conversion failure by checksum in cache.  Currently
 # 10 minutes is assumed to be a reasonable value here.
@@ -423,7 +427,30 @@ class DIFCache(object):
         return rv
 
     def clear_old_entries(self):
-        clear_cached_files(self.cache_path)
+        try:
+            cache_folders = os.listdir(self.cache_path)
+        except OSError:
+            return
+
+        cutoff = int(time.time()) - ONE_DAY_AND_A_HALF
+
+        for cache_folder in cache_folders:
+            cache_folder = os.path.join(self.cache_path, cache_folder)
+            try:
+                items = os.listdir(cache_folder)
+            except OSError:
+                continue
+            for cached_file in items:
+                cached_file = os.path.join(cache_folder, cached_file)
+                try:
+                    mtime = os.path.getmtime(cached_file)
+                except OSError:
+                    continue
+                if mtime < cutoff:
+                    try:
+                        os.remove(cached_file)
+                    except OSError:
+                        pass
 
 
 ProjectDebugFile.difcache = DIFCache()

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -4,7 +4,6 @@ import os
 import six
 import mmap
 import tempfile
-import time
 
 from hashlib import sha1
 from uuid import uuid4
@@ -26,7 +25,6 @@ from sentry.utils import metrics
 from sentry.utils.retries import TimedRetryPolicy
 
 ONE_DAY = 60 * 60 * 24
-ONE_DAY_AND_A_HALF = int(ONE_DAY * 1.5)
 
 UPLOAD_RETRY_TIME = getattr(settings, "SENTRY_UPLOAD_RETRY_TIME", 60)  # 1min
 
@@ -610,30 +608,3 @@ class FileBlobOwner(Model):
         app_label = "sentry"
         db_table = "sentry_fileblobowner"
         unique_together = (("blob", "organization"),)
-
-
-def clear_cached_files(cache_path):
-    try:
-        cache_folders = os.listdir(cache_path)
-    except OSError:
-        return
-
-    cutoff = int(time.time()) - ONE_DAY_AND_A_HALF
-
-    for cache_folder in cache_folders:
-        cache_folder = os.path.join(cache_path, cache_folder)
-        try:
-            items = os.listdir(cache_folder)
-        except OSError:
-            continue
-        for cached_file in items:
-            cached_file = os.path.join(cache_folder, cached_file)
-            try:
-                mtime = os.path.getmtime(cached_file)
-            except OSError:
-                continue
-            if mtime < cutoff:
-                try:
-                    os.remove(cached_file)
-                except OSError:
-                    pass

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -1,16 +1,9 @@
 from __future__ import absolute_import
 
-import os
-import errno
-import six
-
 from django.db import models
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
-from sentry import options
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
-from sentry.models import clear_cached_files
-from sentry.utils import metrics
 from sentry.utils.hashlib import sha1_text
 
 
@@ -84,38 +77,3 @@ class ReleaseFile(Model):
         if query:
             urls.append("~" + urlunsplit(uri_relative_without_query))
         return urls
-
-
-class ReleaseFileCache(object):
-    @property
-    def cache_path(self):
-        return options.get("releasefile.cache-path")
-
-    def getfile(self, releasefile):
-        cutoff = options.get("releasefile.cache-limit")
-        file_size = releasefile.file.size
-        if file_size < cutoff:
-            metrics.timing("release_file.cache.get.size", file_size, tags={"cutoff": True})
-            return releasefile.file.getfile()
-
-        file_id = six.text_type(releasefile.file_id)
-        project_id = six.text_type(releasefile.project_id)
-        file_path = os.path.join(self.cache_path, project_id, file_id)
-
-        hit = True
-        try:
-            os.stat(file_path)
-        except OSError as e:
-            if e.errno != errno.ENOENT:
-                raise
-            releasefile.file.save_to(file_path)
-            hit = False
-
-        metrics.timing("release_file.cache.get.size", file_size, tags={"hit": hit, "cutoff": False})
-        return open(file_path, "rb")
-
-    def clear_old_entries(self):
-        clear_cached_files(self.cache_path)
-
-
-ReleaseFile.cache = ReleaseFileCache()

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -42,17 +42,10 @@ register(
 )
 register("redis.options", type=Dict, flags=FLAG_NOSTORE)
 
-# Processing worker caches
+# symbolizer specifics
 register(
     "dsym.cache-path", type=String, default="/tmp/sentry-dsym-cache", flags=FLAG_PRIORITIZE_DISK
 )
-register(
-    "releasefile.cache-path",
-    type=String,
-    default="/tmp/sentry-releasefile-cache",
-    flags=FLAG_PRIORITIZE_DISK,
-)
-register("releasefile.cache-limit", type=Int, default=10 * 1024 * 1024, flags=FLAG_PRIORITIZE_DISK)
 
 # Mail
 register("mail.backend", default="smtp", flags=FLAG_NOSTORE)


### PR DESCRIPTION
Reverts getsentry/sentry#15848

Please only approve and merge unless we can fix the permissions issue for `/tmp` in a timely way. Otherwise, merge getsentry/sentry#15884 instead.