### PR TITLE
fix(javascript): Cache large sourcemaps on workers

### DIFF
--- a/src/sentry/bgtasks/clean_releasefilecache.py
+++ b/src/sentry/bgtasks/clean_releasefilecache.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+
+from sentry.bgtasks.api import bgtask
+from sentry.models import ReleaseFile
+
+
+@bgtask()
+def clean_releasefilecache():
+    ReleaseFile.cache.clear_old_entries()

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -679,7 +679,11 @@ CELERYBEAT_SCHEDULE = {
 }
 
 BGTASKS = {
-    "sentry.bgtasks.clean_dsymcache:clean_dsymcache": {"interval": 5 * 60, "roles": ["worker"]}
+    "sentry.bgtasks.clean_dsymcache:clean_dsymcache": {"interval": 5 * 60, "roles": ["worker"]},
+    "sentry.bgtasks.clean_releasefilecache:clean_releasefilecache": {
+        "interval": 5 * 60,
+        "roles": ["worker"],
+    },
 }
 
 # Sentry logs to two major places: stdout, and it's internal project.

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -330,20 +330,12 @@ class File(Model):
             delete=delete,
         )
 
-    def getfile(self, mode=None, prefetch=False, as_tempfile=False):
+    def getfile(self, mode=None, prefetch=False):
         """Returns a file object.  By default the file is fetched on
         demand but if prefetch is enabled the file is fully prefetched
         into a tempfile before reading can happen.
-
-        Additionally if `as_tempfile` is passed a NamedTemporaryFile is
-        returned instead which can help in certain situations where a
-        tempfile is necessary.
         """
-        if as_tempfile:
-            prefetch = True
         impl = self._get_chunked_blob(mode, prefetch)
-        if as_tempfile:
-            return impl.detach_tempfile()
         return FileObj(impl, self.name)
 
     def save_to(self, path):

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -4,6 +4,7 @@ import os
 import errno
 import six
 
+from django.core.files.base import File as FileObj
 from django.db import models
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
@@ -112,7 +113,7 @@ class ReleaseFileCache(object):
             hit = False
 
         metrics.timing("release_file.cache.get.size", file_size, tags={"hit": hit, "cutoff": False})
-        return open(file_path, "rb")
+        return FileObj(open(file_path, "rb"))
 
     def clear_old_entries(self):
         clear_cached_files(self.cache_path)

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -1,9 +1,16 @@
 from __future__ import absolute_import
 
+import os
+import errno
+import six
+
 from django.db import models
 from six.moves.urllib.parse import urlsplit, urlunsplit
 
+from sentry import options
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
+from sentry.models import clear_cached_files
+from sentry.utils import metrics
 from sentry.utils.hashlib import sha1_text
 
 
@@ -77,3 +84,38 @@ class ReleaseFile(Model):
         if query:
             urls.append("~" + urlunsplit(uri_relative_without_query))
         return urls
+
+
+class ReleaseFileCache(object):
+    @property
+    def cache_path(self):
+        return options.get("releasefile.cache-path")
+
+    def getfile(self, releasefile):
+        cutoff = options.get("releasefile.cache-limit")
+        file_size = releasefile.file.size
+        if file_size < cutoff:
+            metrics.timing("release_file.cache.get.size", file_size, tags={"cutoff": True})
+            return releasefile.file.getfile()
+
+        file_id = six.text_type(releasefile.file_id)
+        project_id = six.text_type(releasefile.project_id)
+        file_path = os.path.join(self.cache_path, project_id, file_id)
+
+        hit = True
+        try:
+            os.stat(file_path)
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
+            releasefile.file.save_to(file_path)
+            hit = False
+
+        metrics.timing("release_file.cache.get.size", file_size, tags={"hit": hit, "cutoff": False})
+        return open(file_path, "rb")
+
+    def clear_old_entries(self):
+        clear_cached_files(self.cache_path)
+
+
+ReleaseFile.cache = ReleaseFileCache()

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -99,8 +99,8 @@ class ReleaseFileCache(object):
             return releasefile.file.getfile()
 
         file_id = six.text_type(releasefile.file_id)
-        project_id = six.text_type(releasefile.project_id)
-        file_path = os.path.join(self.cache_path, project_id, file_id)
+        organization_id = six.text_type(releasefile.organization_id)
+        file_path = os.path.join(self.cache_path, organization_id, file_id)
 
         hit = True
         try:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -42,10 +42,17 @@ register(
 )
 register("redis.options", type=Dict, flags=FLAG_NOSTORE)
 
-# symbolizer specifics
+# Processing worker caches
 register(
     "dsym.cache-path", type=String, default="/tmp/sentry-dsym-cache", flags=FLAG_PRIORITIZE_DISK
 )
+register(
+    "releasefile.cache-path",
+    type=String,
+    default="/tmp/sentry-releasefile-cache",
+    flags=FLAG_PRIORITIZE_DISK,
+)
+register("releasefile.cache-limit", type=Int, default=10 * 1024 * 1024, flags=FLAG_PRIORITIZE_DISK)
 
 # Mail
 register("mail.backend", default="smtp", flags=FLAG_NOSTORE)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -68,6 +68,7 @@ from sentry.models import (
     EventAttachment,
     UserReport,
     PlatformExternalIssue,
+    ReleaseFile,
 )
 from sentry.models.integrationfeature import Feature, IntegrationFeature
 from sentry.signals import project_created
@@ -344,6 +345,23 @@ class Factories(object):
             )
 
         return release
+
+    @staticmethod
+    def create_release_file(release, file=None, name=None, dist=None):
+        if file is None:
+            file = Factories.create_file(
+                name="log.txt",
+                size=32,
+                headers={"Content-Type": "text/plain"},
+                checksum="dc1e3f3e411979d336c3057cce64294f3420f93a",
+            )
+
+        if name is None:
+            name = file.name
+
+        return ReleaseFile.objects.create(
+            organization=release.organization, release=release, name=name, file=file, dist=dist
+        )
 
     @staticmethod
     def create_artifact_bundle(org, release, project=None):

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -48,6 +48,10 @@ class Fixtures(object):
         )
 
     @cached_property
+    def release(self):
+        return self.create_release(project=self.project, version="foo-1.0")
+
+    @cached_property
     def environment(self):
         return self.create_environment(name="development", project=self.project)
 
@@ -103,6 +107,11 @@ class Fixtures(object):
         if project is None:
             project = self.project
         return Factories.create_release(project=project, user=user, *args, **kwargs)
+
+    def create_release_file(self, release=None, file=None, name=None, dist=None):
+        if release is None:
+            release = self.release
+        return Factories.create_release_file(release, file, name, dist)
 
     def create_artifact_bundle(self, org=None, release=None, *args, **kwargs):
         if org is None:

--- a/tests/sentry/models/test_releasefile.py
+++ b/tests/sentry/models/test_releasefile.py
@@ -1,5 +1,10 @@
 from __future__ import absolute_import
 
+import errno
+import os
+import six
+
+from sentry import options
 from sentry.models import ReleaseFile
 from sentry.testutils import TestCase
 
@@ -29,3 +34,53 @@ class ReleaseFileTestCase(TestCase):
         # unclear if we actually experience this case in the real
         # world, but worth documenting the behavior
         assert n("foo.js") == ["foo.js", "~foo.js"]
+
+
+class ReleaseFileCacheTest(TestCase):
+    def test_getfile_fs_cache(self):
+        file_content = b"this is a test"
+
+        file = self.create_file(name="dummy.txt")
+        file.putfile(six.BytesIO(file_content))
+        release_file = self.create_release_file(file=file)
+
+        expected_path = os.path.join(
+            options.get("releasefile.cache-path"),
+            six.text_type(self.organization.id),
+            six.text_type(file.id),
+        )
+
+        # Set the threshold to zero to force caching on the file system
+        options.set("releasefile.cache-limit", 0)
+        with ReleaseFile.cache.getfile(release_file) as f:
+            assert f.read() == file_content
+            assert f.name == expected_path
+
+        # Check that the file was cached
+        os.stat(expected_path)
+
+    def test_getfile_streaming(self):
+        file_content = b"this is a test"
+
+        file = self.create_file(name="dummy.txt")
+        file.putfile(six.BytesIO(file_content))
+        release_file = self.create_release_file(file=file)
+
+        expected_path = os.path.join(
+            options.get("releasefile.cache-path"),
+            six.text_type(self.organization.id),
+            six.text_type(file.id),
+        )
+
+        # Set the threshold larger than the file size to force streaming
+        options.set("releasefile.cache-limit", 1024)
+        with ReleaseFile.cache.getfile(release_file) as f:
+            assert f.read() == file_content
+
+        # Check that the file was not cached
+        try:
+            os.stat(expected_path)
+        except OSError as e:
+            assert e.errno == errno.ENOENT
+        else:
+            assert False, "file should not exist"


### PR DESCRIPTION
This is another attempt at #15848 and avoids repeated downloads of very large release files in the javascript processor.