### PR TITLE
fix(discover2): Fix malformed query strings for linked trace events

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -144,6 +144,7 @@ class EventDetailsContent extends AsyncComponent<Props, State & AsyncComponent['
               organization={organization}
               event={event}
               projectId={this.projectId}
+              eventView={eventView}
             />
           </Main>
           <Side>

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/eventInterfaces.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/eventInterfaces.tsx
@@ -16,6 +16,7 @@ import {objectIsEmpty, toTitleCase} from 'app/utils';
 import {Event, Organization} from 'app/types';
 
 import LinkedEvents from './linkedEvents';
+import EventView from '../eventView';
 
 const OTHER_SECTIONS = {
   contexts: EventContexts,
@@ -37,6 +38,7 @@ type ActiveTabProps = {
   projectId: string;
   event: Event;
   activeTab: string;
+  eventView: EventView;
 };
 
 /**
@@ -44,7 +46,7 @@ type ActiveTabProps = {
  * Some but not all interface elements require a projectId.
  */
 const ActiveTab = (props: ActiveTabProps) => {
-  const {organization, projectId, event, activeTab} = props;
+  const {organization, projectId, event, activeTab, eventView} = props;
   if (!activeTab) {
     return null;
   }
@@ -67,7 +69,12 @@ const ActiveTab = (props: ActiveTabProps) => {
     return <Component event={event} isShare={false} hideGuide />;
   } else if (activeTab === 'linked') {
     return (
-      <LinkedEvents event={event} projectId={projectId} organization={organization} />
+      <LinkedEvents
+        event={event}
+        projectId={projectId}
+        organization={organization}
+        eventView={eventView}
+      />
     );
   } else {
     /*eslint no-console:0*/
@@ -95,6 +102,7 @@ type EventInterfacesProps = {
   event: Event;
   projectId: string;
   organization: Organization;
+  eventView: EventView;
 };
 type EventInterfacesState = {
   activeTab: string;
@@ -114,7 +122,7 @@ class EventInterfaces extends React.Component<
   handleTabChange = tab => this.setState({activeTab: tab});
 
   render() {
-    const {event, projectId, organization} = this.props;
+    const {event, projectId, organization, eventView} = this.props;
     const {activeTab} = this.state;
 
     return (
@@ -181,6 +189,7 @@ class EventInterfaces extends React.Component<
             activeTab={activeTab}
             projectId={projectId}
             organization={organization}
+            eventView={eventView}
           />
         </ErrorBoundary>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedEvents.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedEvents.tsx
@@ -13,6 +13,7 @@ import withProjects from 'app/utils/withProjects';
 
 import {generateEventDetailsRoute, generateEventSlug} from './utils';
 import {SectionHeading} from '../styles';
+import EventView from '../eventView';
 
 type DiscoverResult = {
   id: string;
@@ -28,6 +29,7 @@ type Props = {
   projectId: string;
   projects: Project[];
   event: Event;
+  eventView: EventView;
 } & AsyncComponent['props'];
 
 type State = {
@@ -64,7 +66,7 @@ class LinkedEvents extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
-    const {event, organization, projects} = this.props;
+    const {event, organization, projects, eventView} = this.props;
     const {linkedEvents} = this.state;
 
     const hasLinkedEvents =
@@ -80,7 +82,7 @@ class LinkedEvents extends AsyncComponent<Props, State> {
             const eventSlug = generateEventSlug(item);
             const eventUrl = {
               pathname: generateEventDetailsRoute({eventSlug, organization}),
-              query: location.search,
+              query: eventView.generateQueryStringObject(),
             };
             const project = projects.find(p => p.slug === item['project.name']);
 


### PR DESCRIPTION
Should fix URLs with funny query strings like this: https://sentry.io/organizations/sentry/eventsv2/sentry:5e83e61cc8e048e982a4a64628954154/?0=%3F&1=f&10=l&100=u&101=s&102=e&103=r&104=s&105=%26&106=f&107=i&108=e&109=l&11=e&110=d&111=n&112=a&113=m&114=e&115=s&116=%3D&117=p&118=r&119=o&12=%26&120=j&121=e&122=c&123=t&124=%26&125=f&126=i&127=e&128=l&129=d&13=f&130=n&131=a&132=m&133=e&134=s&135=%3D&136=l&137=a&138=s&139=t&14=i&140=%2B&141=s&142=e&143=e&144=n&145=%26&146=n&147=a&148=m&149=e&15=e&150=%3D&151=E&152=r&153=r&154=o&155=r&156=s&157=%26&158=q&159=u&16=l&160=e&161=r&162=y&163=%3D&164=e&165=v&166=e&167=n&168=t&169=.&17=d&170=t&171=y&172=p&173=e&174=%25&175=3&176=A&177=e&178=r&179=r&18=%3D&180=o&181=r&182=%2B&183=u&184=s&185=e&186=r&187=.&188=e&189=m&19=c&190=a&191=i&192=l&193=%25&194=3&195=A&196=a&197=l&198=e&199=a&2=i&20=o&200=l&201=%25&202=4&203=0&204=s&205=e&206=n&207=t&208=r&209=y&21=u&210=.&211=i&212=o&213=%26&214=s&215=o&216=r&217=t&218=%3D&219=-&22=n&220=l&221=a&222=s&223=t&224=_&225=s&226=e&227=e&228=n&229=%26&23=t&230=s&231=t&232=a&233=t&234=s&235=P&236=e&237=r&238=i&239=o&24=_&240=d&241=%3D&242=1&243=4&244=d&245=%26&246=t&247=a&248=g&249=%3D&25=u&250=p&251=r&252=o&253=j&254=e&255=c&256=t&257=.&258=n&259=a&26=n&260=m&261=e&262=%26&263=t&264=a&265=g&266=%3D&267=r&268=e&269=l&27=i&270=e&271=a&272=s&273=e&274=%26&275=t&276=a&277=g&278=%3D&279=e&28=q&280=n&281=v&282=i&283=r&284=o&285=n&286=m&287=e&288=n&289=t&29=u&3=e&30=e&31=%25&32=2&33=8&34=u&35=s&36=e&37=r&38=%25&39=2&4=l&40=9&41=%26&42=f&43=i&44=e&45=l&46=d&47=%3D&48=p&49=r&5=d&50=o&51=j&52=e&53=c&54=t&55=%26&56=f&57=i&58=e&59=l&6=%3D&60=d&61=%3D&62=l&63=a&64=s&65=t&66=_&67=s&68=e&69=e&7=t&70=n&71=%26&72=f&73=i&74=e&75=l&76=d&77=n&78=a&79=m&8=i&80=e&81=s&82=%3D&83=e&84=r&85=r&86=o&87=r&88=%26&89=f&9=t&90=i&91=e&92=l&93=d&94=n&95=a&96=m&97=e&98=s&99=%3D