### PR TITLE
fix(discover) Scope tag keys and values to the selected projects

### DIFF
--- a/src/sentry/static/sentry/app/views/events/index.jsx
+++ b/src/sentry/static/sentry/app/views/events/index.jsx
@@ -20,6 +20,7 @@ class EventsContainer extends React.Component {
   static propTypes = {
     organization: SentryTypes.Organization,
     router: PropTypes.object,
+    selection: SentryTypes.GlobalSelection,
   };
 
   constructor(props) {
@@ -40,7 +41,7 @@ class EventsContainer extends React.Component {
   };
 
   render() {
-    const {organization, location, children} = this.props;
+    const {organization, location, children, selection} = this.props;
 
     return (
       <Feature
@@ -61,6 +62,7 @@ class EventsContainer extends React.Component {
                 </HeaderTitle>
                 <StyledSearchBar
                   organization={organization}
+                  projectIds={selection.projects}
                   query={(location.query && location.query.query) || ''}
                   placeholder={t('Search for events, users, tags, and everything else.')}
                   onSearch={this.handleSearch}

--- a/src/sentry/static/sentry/app/views/events/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.jsx
@@ -30,6 +30,7 @@ class SearchBar extends React.PureComponent {
   static propTypes = {
     api: PropTypes.object,
     organization: SentryTypes.Organization,
+    projectIds: PropTypes.arrayOf(PropTypes.number),
   };
 
   state = {
@@ -40,10 +41,18 @@ class SearchBar extends React.PureComponent {
     this.fetchData();
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.projectIds !== prevProps.projectIds) {
+      this.fetchData();
+      // Clear memoized data when projects change.
+      this.getEventFieldValues.cache.clear();
+    }
+  }
+
   fetchData = async () => {
-    const {api, organization} = this.props;
+    const {api, organization, projectIds} = this.props;
     try {
-      const tags = await fetchOrganizationTags(api, organization.slug);
+      const tags = await fetchOrganizationTags(api, organization.slug, projectIds);
       this.setState({
         tags: this.getAllTags(tags.map(({key}) => key)),
       });
@@ -58,9 +67,9 @@ class SearchBar extends React.PureComponent {
    */
   getEventFieldValues = memoize(
     (tag, query) => {
-      const {api, organization} = this.props;
+      const {api, organization, projectIds} = this.props;
 
-      return fetchTagValues(api, organization.slug, tag.key, query).then(
+      return fetchTagValues(api, organization.slug, tag.key, query, projectIds).then(
         results =>
           flatten(results.filter(({name}) => defined(name)).map(({name}) => name)),
         () => {

--- a/src/sentry/static/sentry/app/views/eventsV2/events.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/events.tsx
@@ -104,6 +104,7 @@ export default class Events extends React.Component<EventsProps> {
         <Top>
           <StyledSearchBar
             organization={organization}
+            projectIds={eventView.project}
             query={query}
             onSearch={this.handleSearch}
           />

--- a/tests/js/spec/views/events/searchBar.spec.jsx
+++ b/tests/js/spec/views/events/searchBar.spec.jsx
@@ -31,6 +31,7 @@ describe('SearchBar', function() {
   const organization = TestStubs.Organization();
   const props = {
     organization,
+    projectIds: [1, 2],
   };
 
   beforeEach(function() {
@@ -84,7 +85,7 @@ describe('SearchBar', function() {
 
     expect(tagValuesMock).toHaveBeenCalledWith(
       '/organizations/org-slug/tags/gpu/values/',
-      expect.objectContaining({query: {}})
+      expect.objectContaining({query: {project: [1, 2]}})
     );
 
     await tick();
@@ -115,7 +116,7 @@ describe('SearchBar', function() {
 
     expect(tagValuesMock).toHaveBeenCalledWith(
       '/organizations/org-slug/tags/gpu/values/',
-      expect.objectContaining({query: {}})
+      expect.objectContaining({query: {project: [1, 2]}})
     );
 
     await tick();
@@ -190,7 +191,7 @@ describe('SearchBar', function() {
 
     expect(tagValuesMock).toHaveBeenCalledWith(
       '/organizations/org-slug/tags/gpu/values/',
-      expect.objectContaining({query: {}})
+      expect.objectContaining({query: {project: [1, 2]}})
     );
     selectFirstAutocompleteItem(wrapper);
     expect(wrapper.find('input').prop('value')).toBe('!gpu:*"Nvidia 1080ti" ');


### PR DESCRIPTION
I've updated both discover2 and the events list to forward the selected projects so that tag key and value results can be scoped accordingly.