### PR TITLE
fix(discover2): Fix breadcrumb and title

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/breadcrumb.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/breadcrumb.tsx
@@ -27,26 +27,26 @@ class DiscoverBreadcrumb extends React.Component<Props> {
     const {eventView, event, organization, location} = this.props;
     const crumbs: React.ReactNode[] = [];
 
+    const discoverTarget = {
+      pathname: `/organizations/${organization.slug}/eventsv2/`,
+      query: {
+        ...location.query,
+        ...eventView.generateBlankQueryStringObject(),
+        ...eventView.getGlobalSelection(),
+      },
+    };
+
+    crumbs.push(
+      <BreadcrumbItem to={discoverTarget} key="eventview-home">
+        {t('Discover')}
+      </BreadcrumbItem>
+    );
+
     if (eventView && eventView.isValid()) {
       const eventTarget = {
         pathname: `/organizations/${organization.slug}/eventsv2/`,
         query: eventView.generateQueryStringObject(),
       };
-
-      const discoverTarget = {
-        pathname: `/organizations/${organization.slug}/eventsv2/`,
-        query: {
-          ...location.query,
-          ...eventView.generateBlankQueryStringObject(),
-          ...eventView.getGlobalSelection(),
-        },
-      };
-
-      crumbs.push(
-        <BreadcrumbItem to={discoverTarget} key="eventview-home">
-          {t('Discover')}
-        </BreadcrumbItem>
-      );
 
       crumbs.push(
         <span key="eventview-sep">

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -260,9 +260,15 @@ class EventDetailsWrapper extends React.Component<EventDetailsWrapperProps> {
 
 const EventHeader = (props: {event: Event}) => {
   const {title} = getTitle(props.event);
+
+  const message = getMessage(props.event);
+
   return (
     <StyledEventHeader data-test-id="event-header">
-      <StyledTitle>{title}:</StyledTitle>
+      <StyledTitle>
+        {title}
+        {message && message.length > 0 ? ':' : null}
+      </StyledTitle>
       <StyledMessage>{getMessage(props.event)}</StyledMessage>
     </StyledEventHeader>
   );


### PR DESCRIPTION
Fix breadcrumb when query string is omitted. For example: https://sentry.io/organizations/sentry/eventsv2/javascript:6a15302bfae94806b20ca28dcbd72889/

<img width="1079" alt="Screen Shot 2019-12-02 at 12 44 36 PM" src="https://user-images.githubusercontent.com/139499/69982145-c73c7480-1501-11ea-8777-8dc43f55841b.png">

------

Fix title by omitting the colon whenever the message is empty. 

<img width="518" alt="Screen Shot 2019-12-02 at 12 46 11 PM" src="https://user-images.githubusercontent.com/139499/69982146-c73c7480-1501-11ea-8c2e-b3713d420478.png">
