### PR TITLE
ref(django 1.10): fix unpacking values to for during templating

### DIFF
--- a/src/sentry/data/samples/python.json
+++ b/src/sentry/data/samples/python.json
@@ -259,21 +259,5 @@
         "lineno": 112
       }
     ]
-  },
-  "sentry.interfaces.Template": {
-    "abs_path": "/srv/example/templates/debug_toolbar/base.html",
-    "pre_context": [
-      "{% endif %}\n",
-      "<script src=\"{% static 'debug_toolbar/js/toolbar.js' %}\"></script>\n",
-      "<div id=\"djDebug\" hidden=\"hidden\" dir=\"ltr\"\n"
-    ],
-    "post_context": [
-      "     {{ toolbar.config.ROOT_TAG_EXTRA_ATTRS|safe }}>\n",
-      "\t<div hidden=\"hidden\" id=\"djDebugToolbar\">\n",
-      "\t\t<ul id=\"djDebugPanelList\">\n"
-    ],
-    "filename": "debug_toolbar/base.html",
-    "lineno": 14,
-    "context_line": "     data-store-id=\"{{ toolbar.store_id }}\" data-render-panel-url=\"{% url 'djdt:render_panel' %}\"\n"
   }
 }

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -113,7 +113,7 @@
       </div>
       {% endif %}
 
-      {% for label, html in interfaces %}
+      {% for label, html, _ in interfaces %}
       <div class="interface">
           <h3 class="title">{{ label }}</h3>
           {{ html }}

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -113,7 +113,7 @@
       </div>
       {% endif %}
 
-      {% for label, html, _ in interfaces %}
+      {% for label, html in interfaces %}
       <div class="interface">
           <h3 class="title">{{ label }}</h3>
           {{ html }}

--- a/src/sentry/templatetags/sentry_plugins.py
+++ b/src/sentry/templatetags/sentry_plugins.py
@@ -27,7 +27,7 @@ def get_actions(group, request):
         ):
             action_list.append(action)
 
-    return [(a[0], a[1], request.path == a[1]) for a in action_list]
+    return [(a[0], a[1]) for a in action_list]
 
 
 @register.filter

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -250,12 +250,15 @@ def alert(request):
 
     rule = Rule(label="An example rule")
 
+    # XXX: this interface_list code needs to be the same as in
+    #      src/sentry/plugins/sentry_mail/models.py
     interface_list = []
     for interface in six.itervalues(event.interfaces):
         body = interface.to_email_html(event)
         if not body:
             continue
-        interface_list.append((interface.get_title(), mark_safe(body)))
+        text_body = interface.to_string(event)
+        interface_list.append((interface.get_title(), mark_safe(body), text_body))
 
     return MailPreview(
         html_template="sentry/emails/error.html",

--- a/tests/fixtures/emails/alert.txt
+++ b/tests/fixtures/emails/alert.txt
@@ -28,13 +28,31 @@ Tags
 Stacktrace
 -----------
 
+Stacktrace (most recent call last):
 
+  File "raven/base.py", line 303, in build_msg
+    transformer=self.transform)
+  File "raven/base.py", line 459, in capture
+    **kwargs)
+  File "raven/base.py", line 577, in captureMessage
+    return self.capture('raven.events.Message', message=message, **kwargs)
+  File "raven/scripts/runner.py", line 77, in send_test_message
+    'loadavg': get_loadavg(),
+  File "raven/scripts/runner.py", line 112, in main
+    send_test_message(client, opts.__dict__)
 
 
 Template
 -----------
 
+Stacktrace (most recent call last):
 
+ornare elit pulvinar nisl integer cum ad massa
+
+File "debug_toolbar/base.html", line 14
+
+{% endif %}
+<script src="{% static 'debug_toolbar/js/toolbar.js' %}"></script><div id="djDebug" hidden="hidden" dir="ltr" data-store-id="{{ toolbar.store_id }}" data-render-panel-url="{% url 'djdt:render_panel' %}" {{="" toolbar.config.root_tag_extra_attrs|safe="" }}=""><div hidden="hidden" id="djDebugToolbar"><ul id="djDebugPanelList">
 
 
 Request
@@ -52,9 +70,10 @@ User
 Message
 -----------
 
-
+ornare elit pulvinar nisl integer cum ad massa
 
 
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");
+</ul></div></div>

--- a/tests/fixtures/emails/alert.txt
+++ b/tests/fixtures/emails/alert.txt
@@ -42,19 +42,6 @@ Stacktrace (most recent call last):
     send_test_message(client, opts.__dict__)
 
 
-Template
------------
-
-Stacktrace (most recent call last):
-
-ornare elit pulvinar nisl integer cum ad massa
-
-File "debug_toolbar/base.html", line 14
-
-{% endif %}
-<script src="{% static 'debug_toolbar/js/toolbar.js' %}"></script><div id="djDebug" hidden="hidden" dir="ltr" data-store-id="{{ toolbar.store_id }}" data-render-panel-url="{% url 'djdt:render_panel' %}" {{="" toolbar.config.root_tag_extra_attrs|safe="" }}=""><div hidden="hidden" id="djDebugToolbar"><ul id="djDebugPanelList">
-
-
 Request
 -----------
 
@@ -76,4 +63,3 @@ ornare elit pulvinar nisl integer cum ad massa
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");
-</ul></div></div>


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.10/releases/1.10/#features-removed-in-1-10

> Using an incorrect count of unpacked values in the for template tag raises an exception rather than failing silently.

So 6461b25 was an easy fix, but the last one was a bit more involved. After some more digging around, I found that cramer forgot to do the changes I made in 
bc722ab in a93ed9c24dc4a50870e840afe65417e72b0120ff. This lets us keep the existing 3 arg unpacking in context's `interfaces` in the templates (see for example a7e7711c38c5c53a634a0c6b3a4326fe6590013a), and even fixes text rendering of the alert email.