### PR TITLE
feat(plugins): hide flowdock, campfire, youtrack, irc, and clubhouse plugins

### DIFF
--- a/src/sentry/plugins/__init__.py
+++ b/src/sentry/plugins/__init__.py
@@ -1,3 +1,16 @@
 from __future__ import absolute_import
 
-HIDDEN_PLUGINS = ("bitbucket", "gitlab", "github", "slack", "vsts", "jira", "jira_ac")
+HIDDEN_PLUGINS = (
+    "bitbucket",
+    "gitlab",
+    "github",
+    "slack",
+    "vsts",
+    "jira",
+    "jira_ac",
+    "flowdock",
+    "irc",
+    "campfire",
+    "youtrack",
+    "clubhouse",
+)


### PR DESCRIPTION
Flowdock, Campfire, YouTrack, and IRC are going to be deprecated. We have had a Clubhouse integration for some time so the plugin should also be hidden.