### PR TITLE
ref(github): Making it clearer where these errors are from

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -76,7 +76,7 @@ metadata = IntegrationMetadata(
 )
 
 API_ERRORS = {
-    404: "GitHub returned a 404 Not Found error. If this repository exists, ensure"
+    404: "If this repository exists, ensure"
     " that your installation has permission to access this repository"
     " (https://github.com/settings/installations).",
     401: ERR_UNAUTHORIZED,
@@ -126,12 +126,9 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
     def message_from_error(self, exc):
         if isinstance(exc, ApiError):
             message = API_ERRORS.get(exc.code)
-            if message:
-                return message
-            return "Error Communicating with GitHub (HTTP %s): %s" % (
-                exc.code,
-                exc.json.get("message", "unknown error") if exc.json else "unknown error",
-            )
+            if message is None:
+                message = exc.json.get("message", "unknown error") if exc.json else "unknown error"
+            return "Error Communicating with GitHub (HTTP %s): %s" % (exc.code, message)
         else:
             return ERR_INTERNAL
 

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -95,8 +95,8 @@ metadata = IntegrationMetadata(
 
 API_ERRORS = {
     404: "If this repository exists, ensure"
-    " that your installation has permission to access this repository"
-    " (https://github.com/settings/installations).",
+    + " that your installation has permission to access this repository"
+    + " (https://github.com/settings/installations).",
     401: ERR_UNAUTHORIZED,
 }
 

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -93,7 +93,12 @@ metadata = IntegrationMetadata(
 )
 
 
-API_ERRORS = {404: "GitHub Enterprise returned a 404 Not Found error.", 401: ERR_UNAUTHORIZED}
+API_ERRORS = {
+    404: "If this repository exists, ensure"
+    " that your installation has permission to access this repository"
+    " (https://github.com/settings/installations).",
+    401: ERR_UNAUTHORIZED,
+}
 
 
 class GitHubEnterpriseIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMixin):
@@ -135,12 +140,9 @@ class GitHubEnterpriseIntegration(IntegrationInstallation, GitHubIssueBasic, Rep
     def message_from_error(self, exc):
         if isinstance(exc, ApiError):
             message = API_ERRORS.get(exc.code)
-            if message:
-                return message
-            return "Error Communicating with GitHub Enterprise (HTTP %s): %s" % (
-                exc.code,
-                exc.json.get("message", "unknown error") if exc.json else "unknown error",
-            )
+            if message is None:
+                message = exc.json.get("message", "unknown error") if exc.json else "unknown error"
+            return "Error Communicating with GitHub Enterprise (HTTP %s): %s" % (exc.code, message)
         else:
             return ERR_INTERNAL
 


### PR DESCRIPTION
- Original 401 message doesn't mention that these errors are from GitHub,
  Including that detail to make it more obvious to users
- Not sure if reusing the 404 error for GitHub enterprise makes sense,
  but not sure what to put there otherwise since the function will
  already say its a 404

eg.
Before: `Unauthorized: either your access token was invalid or you do not have access`
After: `Error Communicating with GitHub (HTTP 401): Unauthorized: either your access token was invalid or you do not have access`