### PR TITLE
feat(discover) Add transaction.status to the list of fields

### DIFF
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -206,6 +206,9 @@ class Columns(Enum):
     # Transactions specific columns
     TRANSACTION_OP = Column(None, None, "transaction_op", "transaction_op", "transaction.op")
     TRANSACTION_DURATION = Column(None, None, "duration", "duration", "transaction.duration")
+    TRANSACTION_STATUS = Column(
+        None, None, "transaction_status", "transaction_status", "transaction.status"
+    )
 
 
 def get_columns_from_aliases(aliases):

--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -147,6 +147,7 @@ export const FIELDS = {
 
   'transaction.duration': 'duration',
   'transaction.op': 'string',
+  'transaction.status': 'string',
   apdex: 'number',
   impact: 'number',
   // duration aliases
@@ -164,6 +165,7 @@ export const TRACING_FIELDS = [
   'sum',
   'transaction.duration',
   'transaction.op',
+  'transaction.status',
   'apdex',
   'impact',
   'p99',


### PR DESCRIPTION
Expose transaction_status as a field on transaction events. This doesn't handle the str/int mappings but where that happens hasn't been decided yet.