### PR TITLE
ref(pagerduty): Remove internal-catchall flag

### DIFF
--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from django.conf import settings
-
 from sentry import integrations, features
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize, IntegrationProviderSerializer
@@ -11,16 +9,11 @@ from sentry.api.serializers import serialize, IntegrationProviderSerializer
 
 class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
-        has_catchall = features.has(
-            "organizations:internal-catchall", organization, actor=request.user
-        )
         has_pagerduty = features.has("organizations:pagerduty-v2", organization, actor=request.user)
 
         providers = []
         for provider in integrations.all():
             if not has_pagerduty and provider.key == "pagerduty":
-                continue
-            if not has_catchall and provider.key in settings.SENTRY_INTERNAL_INTEGRATIONS:
                 continue
 
             providers.append(provider)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1415,9 +1415,6 @@ SENTRY_DEFAULT_INTEGRATIONS = (
 )
 
 
-SENTRY_INTERNAL_INTEGRATIONS = ["pagerduty"]
-
-
 def get_sentry_sdk_config():
     return {
         "release": sentry.__build__,


### PR DESCRIPTION
Removing the `internal-catchall` so we are only using the `pagerduty-v2` feature flag to grant access for organizations. 