### PR TITLE
feat(django 1.10): disable Content-Length checking until relay is rolled out

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -276,6 +276,14 @@ MIDDLEWARE_CLASSES = (
 
 ROOT_URLCONF = "sentry.conf.urls"
 
+# TODO(joshuarli): Django 1.10 introduced this option, which restricts the size of a
+# request body. We have some middleware in sentry.middleware.proxy that sets the
+# Content Length to max uint32 in certain cases related to minidump.
+# Once relay's fully rolled out, that can be deleted.
+# Until then, the safest and easiest thing to do is to disable this check
+# to leave things the way they were with Django <1.9.
+DATA_UPLOAD_MAX_MEMORY_SIZE = None
+
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",


### PR DESCRIPTION
Django 1.10 introduced the [DATA_UPLOAD_MAX_MEMORY_SIZE](https://docs.djangoproject.com/en/1.10/ref/settings/#data-upload-max-memory-size) setting, which restricts the size of a request body. We have some middleware in sentry.middleware.proxy that sets the Content Length to max uint32 in certain cases related to minidump. Once relay's fully rolled out, that can be deleted.

Until then, the safest and easiest thing to do is to disable this check to leave things the way they were with Django <1.9.

See:

- https://github.com/getsentry/sentry/pull/6416/commits/a5eda7ac18030cfe71bde0334144e314d4f9c39e#diff-c36a4be3be43d9945e58255610e02e7dR64
- https://github.com/getsentry/sentry/pull/9238/files#diff-c36a4be3be43d9945e58255610e02e7dR166