### PR TITLE
 feat(apm): Navigate from an ancestor transaction to a descendent transaction within a trace

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import styled from 'react-emotion';
-import SentryTypes from 'app/sentryTypes';
-import SearchBar from 'app/components/searchBar';
+import PropTypes from 'prop-types';
 
 import {t} from 'app/locale';
+import SearchBar from 'app/components/searchBar';
+import SentryTypes from 'app/sentryTypes';
 import {Panel} from 'app/components/panels';
 import space from 'app/styles/space';
+import EventView from 'app/views/eventsV2/eventView';
 
 import {SentryTransactionEvent} from './types';
 import TraceView from './traceView';
 
 type PropType = {
+  orgId: string;
   event: SentryTransactionEvent;
+  eventView: EventView;
 };
 
 type State = {
@@ -21,6 +25,7 @@ type State = {
 class SpansInterface extends React.Component<PropType, State> {
   static propTypes = {
     event: SentryTypes.Event.isRequired,
+    orgId: PropTypes.string.isRequired,
   };
 
   state: State = {
@@ -34,7 +39,7 @@ class SpansInterface extends React.Component<PropType, State> {
   };
 
   render() {
-    const {event} = this.props;
+    const {event, orgId, eventView} = this.props;
 
     return (
       <div>
@@ -45,7 +50,12 @@ class SpansInterface extends React.Component<PropType, State> {
           onSearch={this.handleSpanFilter}
         />
         <Panel>
-          <TraceView event={event} searchQuery={this.state.searchQuery} />
+          <TraceView
+            event={event}
+            searchQuery={this.state.searchQuery}
+            orgId={orgId}
+            eventView={eventView}
+          />
         </Panel>
       </div>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -9,6 +9,7 @@ import space from 'app/styles/space';
 import Count from 'app/components/count';
 import Tooltip from 'app/components/tooltip';
 import InlineSvg from 'app/components/inlineSvg';
+import EventView from 'app/views/eventsV2/eventView';
 
 import {
   toPercent,
@@ -164,6 +165,7 @@ const getDurationDisplay = ({
 };
 
 type SpanBarProps = {
+  orgId: string;
   trace: Readonly<ParsedTraceType>;
   span: Readonly<SpanType>;
   spanBarColour: string;
@@ -177,6 +179,7 @@ type SpanBarProps = {
   isRoot?: boolean;
   toggleSpanTree: () => void;
   isCurrentSpanFilteredOut: boolean;
+  eventView: EventView;
 };
 
 type SpanBarState = {
@@ -218,9 +221,11 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       return null;
     }
 
-    const {span} = this.props;
+    const {span, orgId, isRoot, eventView} = this.props;
 
-    return <SpanDetail span={span} />;
+    return (
+      <SpanDetail span={span} orgId={orgId} isRoot={!!isRoot} eventView={eventView} />
+    );
   };
 
   getBounds = (): {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -139,6 +139,35 @@ class SpanDetail extends React.Component<Props, State> {
     );
   }
 
+  renderTraceButton() {
+    const {span, orgId} = this.props;
+
+    const eventView = EventView.fromSavedQuery({
+      id: undefined,
+      name: t('Transactions'),
+      fields: ['transaction', 'trace.span', 'transaction.duration', 'timestamp'],
+      fieldnames: ['transaction', 'trace.span', 'duration', 'timestamp'],
+      orderby: '-timestamp',
+      query: `event.type:transaction trace:${span.trace_id}`,
+      tags: ['release', 'project.name', 'user.email', 'user.ip', 'environment'],
+      projects: [],
+      version: 2,
+    });
+
+    const to = {
+      pathname: generateDiscoverResultsRoute(orgId),
+      query: eventView.generateQueryStringObject(),
+    };
+
+    return (
+      <div>
+        <Button size="xsmall" to={to}>
+          {t('Search by Trace')}
+        </Button>
+      </div>
+    );
+  }
+
   render() {
     const {span} = this.props;
 
@@ -161,7 +190,9 @@ class SpanDetail extends React.Component<Props, State> {
             <Row title="Span ID" extra={this.renderTraversalButton()}>
               {span.span_id}
             </Row>
-            <Row title="Trace ID">{span.trace_id}</Row>
+            <Row title="Trace ID" extra={this.renderTraceButton()}>
+              {span.trace_id}
+            </Row>
             <Row title="Parent Span ID">{span.parent_span_id || ''}</Row>
             <Row title="Description">{get(span, 'description', '')}</Row>
             <Row title="Start Date">

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -87,22 +87,37 @@ class SpanDetail extends React.Component<Props, State> {
       return null;
     }
 
-    const {eventView} = this.props;
+    if (this.state.transactionResults.length === 1) {
+      const {eventView} = this.props;
 
-    const parentTransactionLink = generateEventDetailsRoute({
-      eventSlug: generateSlug(this.state.transactionResults[0]),
-      orgSlug: this.props.orgId,
-    });
+      const parentTransactionLink = generateEventDetailsRoute({
+        eventSlug: generateSlug(this.state.transactionResults[0]),
+        orgSlug: this.props.orgId,
+      });
+
+      const to = {
+        pathname: parentTransactionLink,
+        query: eventView.generateQueryStringObject(),
+      };
+
+      return (
+        <div>
+          <Button size="xsmall" to={to}>
+            {t('View child')}
+          </Button>
+        </div>
+      );
+    }
 
     const to = {
-      pathname: parentTransactionLink,
-      query: eventView.generateQueryStringObject(),
+      pathname: '',
+      query: this.props.eventView.generateQueryStringObject(),
     };
 
     return (
       <div>
         <Button size="xsmall" to={to}>
-          {t('Open span')}
+          {t('View children')}
         </Button>
       </div>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -4,7 +4,6 @@ import get from 'lodash/get';
 import map from 'lodash/map';
 
 import {t} from 'app/locale';
-import Link from 'app/components/links/link';
 import DateTime from 'app/components/dateTime';
 import Pills from 'app/components/pills';
 import Pill from 'app/components/pill';
@@ -124,7 +123,7 @@ class SpanDetail extends React.Component<Props, State> {
   }
 
   render() {
-    const {span, orgId, eventView} = this.props;
+    const {span} = this.props;
 
     const startTimestamp: number = span.start_timestamp;
     const endTimestamp: number = span.timestamp;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -16,9 +16,9 @@ import {
   generateEventDetailsRoute,
 } from 'app/views/eventsV2/eventDetails/utils';
 import EventView from 'app/views/eventsV2/eventView';
+import {generateDiscoverResultsRoute} from 'app/views/eventsV2/results';
 
 import {SpanType} from './types';
-import {generateDiscoverResultsRoute} from 'app/views/eventsV2/results';
 
 type TransactionResult = {
   'project.name': string;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -130,11 +130,6 @@ class SpanDetail extends React.Component<Props, State> {
             <Row title="Span ID" extra={this.renderTraversalButton()}>
               {span.span_id}
             </Row>
-            <LinkedTransactionsList
-              results={this.state.transactionResults}
-              orgId={orgId}
-              eventView={eventView}
-            />
             <Row title="Trace ID">{span.trace_id}</Row>
             <Row title="Parent Span ID">{span.parent_span_id || ''}</Row>
             <Row title="Description">{get(span, 'description', '')}</Row>
@@ -211,47 +206,6 @@ const Row = ({
         </PreValue>
         {extra}
       </ValueTd>
-    </tr>
-  );
-};
-
-const LinkedTransactionsList = (props: {
-  results?: TransactionResult[];
-  orgId: string;
-  eventView: EventView;
-}) => {
-  const {results, orgId, eventView} = props;
-
-  if (!results || !Array.isArray(results) || results.length <= 0) {
-    return null;
-  }
-
-  const list = results.map(result => {
-    const parentTransactionLink = generateEventDetailsRoute({
-      eventSlug: generateSlug(result),
-      orgSlug: orgId,
-    });
-
-    const to = {
-      pathname: parentTransactionLink,
-      query: eventView.generateQueryStringObject(),
-    };
-
-    return (
-      <div key={result.id}>
-        <PreValue className="val">
-          <Link key={result.id} to={to}>
-            {`${result['trace.span']} - ${result.transaction}`}
-          </Link>
-        </PreValue>
-      </div>
-    );
-  });
-
-  return (
-    <tr>
-      <td className="key">Linked transactions</td>
-      <td className="value">{list}</td>
     </tr>
   );
 };

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -18,6 +18,7 @@ import {
 import EventView from 'app/views/eventsV2/eventView';
 
 import {SpanType} from './types';
+import {generateDiscoverResultsRoute} from 'app/views/eventsV2/results';
 
 type TransactionResult = {
   'project.name': string;
@@ -108,9 +109,25 @@ class SpanDetail extends React.Component<Props, State> {
       );
     }
 
+    const {span, orgId} = this.props;
+
+    const eventView = EventView.fromSavedQuery({
+      id: undefined,
+      name: t('Transactions'),
+      fields: ['transaction', 'trace.span', 'timestamp'],
+      fieldnames: ['transaction', 'trace.span', 'timestamp'],
+      orderby: '-timestamp',
+      query: `event.type:transaction trace:${span.trace_id} trace.parent_span:${
+        span.span_id
+      }`,
+      tags: ['release', 'project.name', 'user.email', 'user.ip', 'environment'],
+      projects: [],
+      version: 2,
+    });
+
     const to = {
-      pathname: '',
-      query: this.props.eventView.generateQueryStringObject(),
+      pathname: generateDiscoverResultsRoute(orgId),
+      query: eventView.generateQueryStringObject(),
     };
 
     return (

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 
+import EventView from 'app/views/eventsV2/eventView';
+
 import {SpanBoundsType, SpanGeneratedBoundsType} from './utils';
 import {SpanType, ParsedTraceType} from './types';
 import SpanBar from './spanBar';
 
 type PropType = {
+  orgId: string;
+  eventView: EventView;
   span: Readonly<SpanType>;
   trace: Readonly<ParsedTraceType>;
   generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
@@ -57,11 +61,15 @@ class SpanGroup extends React.Component<PropType, State> {
       treeDepth,
       spanNumber,
       isCurrentSpanFilteredOut,
+      orgId,
+      eventView,
     } = this.props;
 
     return (
       <React.Fragment>
         <SpanBar
+          eventView={eventView}
+          orgId={orgId}
           spanBarColour={spanBarColour}
           span={span}
           showSpanTree={this.state.showSpanTree}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -3,6 +3,7 @@ import styled from 'react-emotion';
 import get from 'lodash/get';
 
 import {t} from 'app/locale';
+import EventView from 'app/views/eventsV2/eventView';
 
 import {SpanType, SpanChildrenLookupType, ParsedTraceType} from './types';
 import {
@@ -26,6 +27,8 @@ type RenderedSpanTree = {
 };
 
 type PropType = {
+  orgId: string;
+  eventView: EventView;
   trace: ParsedTraceType;
   dragProps: DragManagerChildrenProps;
   filterSpans: FilterSpans | undefined;
@@ -120,6 +123,8 @@ class SpanTree extends React.Component<PropType> {
     childSpans: Readonly<SpanChildrenLookupType>;
     generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
   }): RenderedSpanTree => {
+    const {orgId, eventView} = this.props;
+
     const spanBarColour: string = pickSpanBarColour(span.op);
     const spanChildren: Array<SpanType> = get(childSpans, span.span_id, []);
 
@@ -194,6 +199,8 @@ class SpanTree extends React.Component<PropType> {
         <React.Fragment>
           {infoMessage}
           <SpanGroup
+            eventView={eventView}
+            orgId={orgId}
             spanNumber={spanNumber}
             isLast={isLast}
             continuingTreeDepths={continuingTreeDepths}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
@@ -71,8 +71,8 @@ class TraceView extends React.PureComponent<Props, State> {
 
   static getDerivedStateFromProps(props: Props, state: State): State {
     return {
-      parsedTrace: parseTrace(props.event),
       ...state,
+      parsedTrace: parseTrace(props.event),
     };
   }
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
@@ -7,6 +7,7 @@ import isNumber from 'lodash/isNumber';
 import {t} from 'app/locale';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
+import EventView from 'app/views/eventsV2/eventView';
 
 import DragManager, {DragManagerChildrenProps} from './dragManager';
 import SpanTree from './spanTree';
@@ -43,8 +44,10 @@ export type FilterSpans = {
 };
 
 type Props = {
+  orgId: string;
   event: Readonly<SentryTransactionEvent>;
   searchQuery: string | undefined;
+  eventView: EventView;
 };
 
 type State = {
@@ -204,6 +207,7 @@ class TraceView extends React.PureComponent<Props, State> {
     }
 
     const parsedTrace = this.state.parsedTrace;
+    const {orgId, eventView} = this.props;
 
     return (
       <DragManager interactiveLayerRef={this.minimapInteractiveRef}>
@@ -216,9 +220,11 @@ class TraceView extends React.PureComponent<Props, State> {
             >
               {this.renderHeader(dragProps, parsedTrace)}
               <SpanTree
+                eventView={eventView}
                 trace={parsedTrace}
                 dragProps={dragProps}
                 filterSpans={this.state.filterSpans}
+                orgId={orgId}
               />
             </CursorGuideHandler.Provider>
           );

--- a/src/sentry/static/sentry/app/views/eventsV2/breadcrumb.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/breadcrumb.tsx
@@ -10,6 +10,7 @@ import InlineSvg from 'app/components/inlineSvg';
 import space from 'app/styles/space';
 
 import EventView from './eventView';
+import {generateDiscoverResultsRoute} from './results';
 
 type Props = {
   eventView: EventView;
@@ -44,7 +45,7 @@ class DiscoverBreadcrumb extends React.Component<Props> {
 
     if (eventView && eventView.isValid()) {
       const eventTarget = {
-        pathname: `/organizations/${organization.slug}/eventsv2/results/`,
+        pathname: generateDiscoverResultsRoute(organization.slug),
         query: eventView.generateQueryStringObject(),
       };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -258,7 +258,7 @@ const eventLink = (
 ): React.ReactNode => {
   const eventSlug = generateEventSlug(data);
   const pathname = generateEventDetailsRoute({
-    organization,
+    orgSlug: organization.slug,
     eventSlug,
   });
 
@@ -362,7 +362,7 @@ export const SPECIAL_FIELDS: SpecialFields = {
     renderFunc: (data, {location, organization}) => {
       const eventSlug = generateEventSlug(data);
       const pathname = generateEventDetailsRoute({
-        organization,
+        orgSlug: organization.slug,
         eventSlug,
       });
 
@@ -384,7 +384,7 @@ export const SPECIAL_FIELDS: SpecialFields = {
     renderFunc: (data, {location, organization}) => {
       const eventSlug = generateEventSlug(data);
       const pathname = generateEventDetailsRoute({
-        organization,
+        orgSlug: organization.slug,
         eventSlug,
       });
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/eventInterfaces.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/eventInterfaces.tsx
@@ -58,6 +58,7 @@ const ActiveTab = (props: ActiveTabProps) => {
         projectId={projectId}
         orgId={organization.slug}
         event={event}
+        eventView={eventView}
         type={entry.type}
         data={entry.data}
         isShare={false}

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/lineGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/lineGraph.tsx
@@ -143,7 +143,7 @@ const handleClick = async function(
   const eventSlug = generateEventSlug(event);
 
   browserHistory.push({
-    pathname: generateEventDetailsRoute({eventSlug, organization}),
+    pathname: generateEventDetailsRoute({eventSlug, orgSlug: organization.slug}),
     query: eventView.generateQueryStringObject(),
   });
 };

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedEvents.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedEvents.tsx
@@ -81,7 +81,10 @@ class LinkedEvents extends AsyncComponent<Props, State> {
           linkedEvents.data.map((item: DiscoverResult) => {
             const eventSlug = generateEventSlug(item);
             const eventUrl = {
-              pathname: generateEventDetailsRoute({eventSlug, organization}),
+              pathname: generateEventDetailsRoute({
+                eventSlug,
+                orgSlug: organization.slug,
+              }),
               query: eventView.generateQueryStringObject(),
             };
             const project = projects.find(p => p.slug === item['project.name']);

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/pagination.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/pagination.tsx
@@ -44,7 +44,7 @@ function buildTargets(
       const eventSlug = `${event.projectSlug}:${value}`;
 
       links[key] = {
-        pathname: generateEventDetailsRoute({eventSlug, organization}),
+        pathname: generateEventDetailsRoute({eventSlug, orgSlug: organization.slug}),
         query: eventView.generateQueryStringObject(),
       };
     }

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/utils.tsx
@@ -1,15 +1,13 @@
-import {Organization} from 'app/types';
-
 import {EventData} from '../data';
 
 export function generateEventDetailsRoute({
   eventSlug,
-  organization,
+  orgSlug,
 }: {
   eventSlug: string;
-  organization: Organization;
+  orgSlug: String;
 }): string {
-  return `/organizations/${organization.slug}/eventsv2/${eventSlug}/`;
+  return `/organizations/${orgSlug}/eventsv2/${eventSlug}/`;
 }
 
 export function generateEventSlug(eventData: EventData): string {

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -28,6 +28,7 @@ import EventView from './eventView';
 import {DEFAULT_EVENT_VIEW} from './data';
 import QueryList from './queryList';
 import {getPrebuiltQueries, decodeScalar} from './utils';
+import {generateDiscoverResultsRoute} from './results';
 
 const BANNER_DISMISSED_KEY = 'discover-banner-dismissed';
 
@@ -219,7 +220,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     const eventView = EventView.fromNewQueryWithLocation(DEFAULT_EVENT_VIEW, location);
 
     const to = {
-      pathname: `/organizations/${organization.slug}/eventsV2/results/`,
+      pathname: generateDiscoverResultsRoute(organization.slug),
       query: {
         ...eventView.generateQueryStringObject(),
       },

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -22,6 +22,7 @@ import QueryCard from './querycard';
 import MiniGraph from './miniGraph';
 import {getPrebuiltQueries} from './utils';
 import {handleDeleteQuery, handleCreateQuery} from './savedQuery/utils';
+import {generateDiscoverResultsRoute} from './results';
 
 type Props = {
   api: Client;
@@ -113,7 +114,7 @@ class QueryList extends React.Component<Props> {
         moment(eventView.end).format('MMM D, YYYY h:mm A');
 
       const to = {
-        pathname: `/organizations/${organization.slug}/eventsV2/results/`,
+        pathname: generateDiscoverResultsRoute(organization.slug),
         query: {
           ...location.query,
           // remove any landing page cursor
@@ -168,7 +169,7 @@ class QueryList extends React.Component<Props> {
         ' - ' +
         moment(eventView.end).format('MMM D, YYYY h:mm A');
       const to = {
-        pathname: `/organizations/${organization.slug}/eventsV2/results/`,
+        pathname: generateDiscoverResultsRoute(organization.slug),
         query: {
           ...location.query,
           // remove any landing page cursor

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -219,4 +219,8 @@ const ContentBox = styled(PageContent)`
   }
 `;
 
+export function generateDiscoverResultsRoute(orgSlug: string): string {
+  return `/organizations/${orgSlug}/eventsv2/results/`;
+}
+
 export default withOrganization(Results);


### PR DESCRIPTION
## NOTES

- A button will either, view the actual descendent transaction span, or view list of descendent transactions in Discover 2

## TODO

- [x] needs https://github.com/getsentry/sentry-python/pull/572 to be merged, and a release to be cut
- [x] https://github.com/getsentry/sentry-javascript/pull/2341 to be merged, and cut into a release
- [x] https://github.com/getsentry/sentry/pull/15952
- [x] need to be able to search by using the `trace.parent_span` query https://github.com/getsentry/sentry/pull/15959
- [x] navigation: parent transaction to child transaction
- [x] clean up usage of requestpromise
- [ ] ~feasible solution for child to parent traversal~ EDIT: not feasible