### PR TITLE
fix(discover) Remove sum() as a function in the builder

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -38,10 +38,6 @@ export const AGGREGATIONS = {
     type: ['timestamp', 'duration'],
     isSortable: true,
   },
-  sum: {
-    type: ['duration'],
-    isSortable: true,
-  },
   avg: {
     type: ['duration'],
     isSortable: true,


### PR DESCRIPTION
This function has not been built yet in the API layer so we shouldn't offer it to end users.