### PR TITLE
ref(django 1.10): modernize template rendering

### DIFF
--- a/src/sentry/plugins/base/configuration.py
+++ b/src/sentry/plugins/base/configuration.py
@@ -105,7 +105,6 @@ def default_plugin_config(plugin, project, request):
             template=template,
             context={
                 "form": form,
-                "request": request,
                 "plugin": plugin,
                 "plugin_description": plugin.get_description() or "",
                 "plugin_test_results": test_results,

--- a/src/sentry/plugins/base/configuration.py
+++ b/src/sentry/plugins/base/configuration.py
@@ -5,9 +5,7 @@ import six
 
 from django.utils.translation import ugettext as _
 from django.utils.safestring import mark_safe
-from django.template.loader import render_to_string
 from django.core.urlresolvers import reverse
-from django.template import RequestContext
 from django.http import HttpResponseRedirect
 from django.contrib import messages
 from django.http import Http404
@@ -18,6 +16,7 @@ from sentry.api import client
 from sentry.api.serializers import serialize
 from sentry.models import ProjectOption
 from sentry.utils import json
+from sentry.web.helpers import render_to_string
 
 
 def react_plugin_config(plugin, project, request):
@@ -103,8 +102,8 @@ def default_plugin_config(plugin, project, request):
 
     return mark_safe(
         render_to_string(
-            template,
-            {
+            template=template,
+            context={
                 "form": form,
                 "request": request,
                 "plugin": plugin,
@@ -112,7 +111,7 @@ def default_plugin_config(plugin, project, request):
                 "plugin_test_results": test_results,
                 "plugin_is_configured": is_configured,
             },
-            context_instance=RequestContext(request),
+            request=request,
         )
     )
 

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -95,10 +95,6 @@ def recover(request):
     return render_to_response(tpl, context, request)
 
 
-def get_template(name, mode):
-    return u"sentry/account/{}/{}.html".format(mode, name)
-
-
 def recover_confirm(request, user_id, hash, mode="recover"):
     try:
         password_hash = LostPasswordHash.objects.get(user=user_id, hash=hash)
@@ -108,8 +104,7 @@ def recover_confirm(request, user_id, hash, mode="recover"):
         user = password_hash.user
 
     except LostPasswordHash.DoesNotExist:
-        tpl = get_template("failure", mode)
-        return render_to_response(tpl, {}, request)
+        return render_to_response(u"sentry/account/{}/{}.html".format(mode, "failure"), {}, request)
 
     if request.method == "POST":
         form = ChangePasswordRecoverForm(request.POST)
@@ -141,10 +136,9 @@ def recover_confirm(request, user_id, hash, mode="recover"):
     else:
         form = ChangePasswordRecoverForm()
 
-    tpl = get_template("confirm", mode)
-    context = {"form": form}
-
-    return render_to_response(tpl, context, request)
+    return render_to_response(
+        u"sentry/account/{}/{}.html".format(mode, "confirm"), {"form": form}, request
+    )
 
 
 # Set password variation of password recovery

--- a/src/sentry/web/frontend/auth_close.py
+++ b/src/sentry/web/frontend/auth_close.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
-from django.shortcuts import render_to_response
-
 from sentry.web.frontend.base import BaseView
+from sentry.web.helpers import render_to_response
 
 
 class AuthCloseView(BaseView):
@@ -13,4 +12,4 @@ class AuthCloseView(BaseView):
     def handle(self, request):
         logged_in = request.user.is_authenticated()
 
-        return render_to_response("sentry/auth_close.html", {"logged_in": logged_in})
+        return render_to_response("sentry/auth_close.html", context={"logged_in": logged_in})

--- a/src/sentry/web/frontend/csrf_failure.py
+++ b/src/sentry/web/frontend/csrf_failure.py
@@ -11,7 +11,7 @@ from sentry.web.helpers import render_to_response
 class CsrfFailureView(View):
     @method_decorator(csrf_exempt)
     def dispatch(self, request, reason=""):
-        context = {"no_referer": reason == REASON_NO_REFERER, "request": request}
+        context = {"no_referer": reason == REASON_NO_REFERER}
 
         return render_to_response("sentry/403-csrf-failure.html", context, request, status=403)
 

--- a/src/sentry/web/frontend/debug/debug_auth_views.py
+++ b/src/sentry/web/frontend/debug/debug_auth_views.py
@@ -11,14 +11,14 @@ class DebugAuthConfirmIdentity(View):
         auth_identity = {"id": "bar@example.com", "email": "bar@example.com"}
         return render_to_response(
             "sentry/auth-confirm-identity.html",
-            {
+            context={
                 "existing_user": User(email="foo@example.com"),
                 "identity": auth_identity,
                 "login_form": None,
-                "request": request,
                 "identity_display_name": auth_identity["email"],
                 "identity_identifier": auth_identity["id"],
             },
+            request=request,
         )
 
 
@@ -27,11 +27,11 @@ class DebugAuthConfirmLink(View):
         auth_identity = {"id": "bar@example.com", "email": "bar@example.com"}
         return render_to_response(
             "sentry/auth-confirm-link.html",
-            {
+            context={
                 "existing_user": User(email="foo@example.com"),
                 "identity": auth_identity,
-                "request": request,
                 "identity_display_name": auth_identity["email"],
                 "identity_identifier": auth_identity["id"],
             },
+            request=request,
         )

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -133,18 +133,19 @@ class MailPreview(object):
         add_unsubscribe_link(self.context)
 
     def text_body(self):
-        return render_to_string(self.text_template, self.context)
+        return render_to_string(self.text_template, context=self.context)
 
     def html_body(self):
         try:
-            return inline_css(render_to_string(self.html_template, self.context))
+            return inline_css(render_to_string(self.html_template, context=self.context))
         except Exception:
             traceback.print_exc()
             raise
 
     def render(self, request):
         return render_to_response(
-            "sentry/debug/mail/preview.html", {"preview": self, "format": request.GET.get("format")}
+            "sentry/debug/mail/preview.html",
+            context={"preview": self, "format": request.GET.get("format")},
         )
 
 
@@ -163,11 +164,13 @@ class ActivityMailPreview(object):
         return context
 
     def text_body(self):
-        return render_to_string(self.email.get_template(), self.get_context())
+        return render_to_string(self.email.get_template(), context=self.get_context())
 
     def html_body(self):
         try:
-            return inline_css(render_to_string(self.email.get_html_template(), self.get_context()))
+            return inline_css(
+                render_to_string(self.email.get_html_template(), context=self.get_context())
+            )
         except Exception:
             import traceback
 
@@ -209,7 +212,7 @@ class ActivityMailDebugView(View):
 
         return render_to_response(
             "sentry/debug/mail/preview.html",
-            {
+            context={
                 "preview": ActivityMailPreview(request, activity),
                 "format": request.GET.get("format"),
             },

--- a/src/sentry/web/frontend/error_404.py
+++ b/src/sentry/web/frontend/error_404.py
@@ -1,13 +1,10 @@
 from __future__ import absolute_import
 
 from django.views.generic import View
-from django.http import HttpResponseNotFound
 
 from sentry.web.helpers import render_to_response
 
 
 class Error404View(View):
     def dispatch(self, request):
-        return render_to_response(
-            "sentry/404.html", response_cls=HttpResponseNotFound, request=request
-        )
+        return render_to_response("sentry/404.html", status=404, request=request)

--- a/src/sentry/web/frontend/error_404.py
+++ b/src/sentry/web/frontend/error_404.py
@@ -1,13 +1,11 @@
 from __future__ import absolute_import
 
 from django.views.generic import View
-from django.template import Context, loader
+from django.template import loader
 from django.http import HttpResponseNotFound
 
 
 class Error404View(View):
     def dispatch(self, request):
-        context = {"request": request}
-
         t = loader.get_template("sentry/404.html")
-        return HttpResponseNotFound(t.render(Context(context)))
+        return HttpResponseNotFound(t.render(request=request))

--- a/src/sentry/web/frontend/error_404.py
+++ b/src/sentry/web/frontend/error_404.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
 
 from django.views.generic import View
-from django.template import loader
 from django.http import HttpResponseNotFound
+
+from sentry.web.helpers import render_to_response
 
 
 class Error404View(View):
     def dispatch(self, request):
-        t = loader.get_template("sentry/404.html")
-        return HttpResponseNotFound(t.render(request=request))
+        return render_to_response(
+            "sentry/404.html", response_cls=HttpResponseNotFound, request=request
+        )

--- a/src/sentry/web/frontend/error_500.py
+++ b/src/sentry/web/frontend/error_500.py
@@ -4,11 +4,11 @@ import logging
 
 from django.conf import settings
 from django.views.generic import View
-from django.template import loader
 from django.http import HttpResponseServerError
 
 from sentry.models import ProjectKey
 from sentry.utils import json
+from sentry.web.helpers import render_to_response
 
 
 class Error500View(View):
@@ -36,5 +36,9 @@ class Error500View(View):
         if embed_config:
             context["embed_config"] = json.dumps_htmlsafe(embed_config)
 
-        t = loader.get_template("sentry/500.html")
-        return HttpResponseServerError(t.render(context=context, request=request))
+        return render_to_response(
+            "sentry/500.html",
+            response_cls=HttpResponseServerError,
+            context=context,
+            request=request,
+        )

--- a/src/sentry/web/frontend/error_500.py
+++ b/src/sentry/web/frontend/error_500.py
@@ -4,7 +4,7 @@ import logging
 
 from django.conf import settings
 from django.views.generic import View
-from django.template import Context, loader
+from django.template import loader
 from django.http import HttpResponseServerError
 
 from sentry.models import ProjectKey
@@ -31,17 +31,10 @@ class Error500View(View):
         return result
 
     def dispatch(self, request):
-        """
-        500 error handler.
-
-        Templates: `500.html`
-        Context: None
-        """
-        context = {"request": request}
-
+        context = {}
         embed_config = self.get_embed_config(request)
         if embed_config:
             context["embed_config"] = json.dumps_htmlsafe(embed_config)
 
         t = loader.get_template("sentry/500.html")
-        return HttpResponseServerError(t.render(Context(context)))
+        return HttpResponseServerError(t.render(context=context, request=request))

--- a/src/sentry/web/frontend/error_500.py
+++ b/src/sentry/web/frontend/error_500.py
@@ -4,7 +4,6 @@ import logging
 
 from django.conf import settings
 from django.views.generic import View
-from django.http import HttpResponseServerError
 
 from sentry.models import ProjectKey
 from sentry.utils import json
@@ -36,9 +35,4 @@ class Error500View(View):
         if embed_config:
             context["embed_config"] = json.dumps_htmlsafe(embed_config)
 
-        return render_to_response(
-            "sentry/500.html",
-            response_cls=HttpResponseServerError,
-            context=context,
-            request=request,
-        )
+        return render_to_response("sentry/500.html", status=500, context=context, request=request)

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -6,7 +6,6 @@ from django import forms
 from django.db import IntegrityError, transaction
 from django.http import HttpResponse
 from django.views.generic import View
-from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
@@ -14,7 +13,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from sentry import eventstore
 from sentry.models import ProjectKey, ProjectOption, UserReport
-from sentry.web.helpers import render_to_response
+from sentry.web.helpers import render_to_response, render_to_string
 from sentry.signals import user_feedback_received
 from sentry.utils import json
 from sentry.utils.http import absolute_uri, is_valid_origin, origin_from_request
@@ -193,7 +192,7 @@ class ErrorPageEmbedView(View):
 
         template = render_to_string(
             "sentry/error-page-embed.html",
-            {
+            context={
                 "form": form,
                 "show_branding": show_branding,
                 "title": options["title"],

--- a/src/sentry/web/frontend/generic.py
+++ b/src/sentry/web/frontend/generic.py
@@ -8,9 +8,6 @@ from django.http import HttpResponseNotFound, Http404
 from django.contrib.staticfiles import finders
 from django.utils.six.moves.urllib.parse import unquote
 from django.views import static
-from django.views.generic import TemplateView as BaseTemplateView
-
-from sentry.web.helpers import render_to_response
 
 FOREVER_CACHE = "max-age=315360000"
 NEVER_CACHE = "max-age=0, no-cache, no-store, must-revalidate"
@@ -90,13 +87,3 @@ def static_media(request, **kwargs):
         response["Cache-Control"] = NEVER_CACHE
 
     return response
-
-
-class TemplateView(BaseTemplateView):
-    def render_to_response(self, context, **response_kwargs):
-        return render_to_response(
-            request=self.request,
-            template=self.get_template_names(),
-            context=context,
-            **response_kwargs
-        )

--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -1,22 +1,17 @@
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.http import HttpResponse
 from django.middleware.csrf import get_token as get_csrf_token
-from django.template import loader, Context
 
 from sentry.models import Project
 from sentry.signals import first_event_pending
+from sentry.web.helpers import render_to_response
 from sentry.web.frontend.base import BaseView, OrganizationView
 
 
 class ReactMixin(object):
-    def get_context(self, request):
-        # this hook is utilized by getsentry
-        return {"request": request, "CSRF_COOKIE_NAME": settings.CSRF_COOKIE_NAME}
-
     def handle_react(self, request):
-        context = Context(self.get_context(request))
+        context = {"CSRF_COOKIE_NAME": settings.CSRF_COOKIE_NAME}
 
         # Force a new CSRF token to be generated and set in user's
         # Cookie. Alternatively, we could use context_processor +
@@ -24,12 +19,7 @@ class ReactMixin(object):
         # page. So there's no point in rendering a random `<input>` field.
         get_csrf_token(request)
 
-        template = loader.render_to_string("sentry/bases/react.html", context)
-
-        response = HttpResponse(template)
-        response["Content-Type"] = "text/html"
-
-        return response
+        return render_to_response("sentry/bases/react.html", context=context, request=request)
 
 
 # TODO(dcramer): once we implement basic auth hooks in React we can make this

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -93,15 +93,8 @@ def render_to_string(template, context=None, request=None):
     return loader.render_to_string(template, context=context, request=request)
 
 
-def render_to_response(
-    template,
-    context=None,
-    request=None,
-    response_cls=HttpResponse,
-    status=200,
-    content_type="text/html",
-):
-    response = response_cls(render_to_string(template, context, request))
+def render_to_response(template, context=None, request=None, status=200, content_type="text/html"):
+    response = HttpResponse(render_to_string(template, context, request))
     response.status_code = status
     response["Content-Type"] = content_type
     return response

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -45,8 +45,6 @@ def get_default_context(request, existing_context=None, team=None):
         organization = None
 
     if request:
-        context.update({"request": request})
-
         if (not existing_context or "TEAM_LIST" not in existing_context) and team:
             context["TEAM_LIST"] = Team.objects.get_for_user(
                 organization=team.organization, user=request.user, with_projects=True

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -95,8 +95,15 @@ def render_to_string(template, context=None, request=None):
     return loader.render_to_string(template, context=context, request=request)
 
 
-def render_to_response(template, context=None, request=None, status=200, content_type="text/html"):
-    response = HttpResponse(render_to_string(template, context, request))
+def render_to_response(
+    template,
+    context=None,
+    request=None,
+    response_cls=HttpResponse,
+    status=200,
+    content_type="text/html",
+):
+    response = response_cls(render_to_string(template, context, request))
     response.status_code = status
     response["Content-Type"] = content_type
     return response

--- a/tests/sentry/templatetags/test_sentry_api.py
+++ b/tests/sentry/templatetags/test_sentry_api.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 
-from django.template import Context, Template
+from django.template import engines
 
 from sentry.testutils import TestCase
 
 
 class SerializeDetailedOrgTest(TestCase):
-    TEMPLATE = Template(
+    TEMPLATE = engines["django"].from_string(
         """
         {% load sentry_api %}
         {% serialize_detailed_org org %}
@@ -15,8 +15,7 @@ class SerializeDetailedOrgTest(TestCase):
 
     def test_escapes_js(self):
         org = self.create_organization(name="<script>alert(1);</script>")
-
-        result = self.TEMPLATE.render(Context({"org": org}))
+        result = self.TEMPLATE.render(context={"org": org})
 
         assert "<script>" not in result
         assert "\u003cscript\u003ealert(1);\u003c/script\u003e" in result

--- a/tests/sentry/templatetags/test_sentry_assets.py
+++ b/tests/sentry/templatetags/test_sentry_assets.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 
-from django.template import Context, Template
-from mock import Mock
+from django.template import engines
+from mock import MagicMock
 
 from sentry.testutils import TestCase
 
 
 class AssetsTest(TestCase):
-    TEMPLATE = Template(
+    TEMPLATE = engines["django"].from_string(
         """
         {% load sentry_assets %}
         {% locale_js_include %}
@@ -16,24 +16,24 @@ class AssetsTest(TestCase):
 
     def test_supported_foreign_lang(self):
         result = self.TEMPLATE.render(
-            Context({"request": Mock(LANGUAGE_CODE="fr")})  # French, in locale/catalogs.json
+            request=MagicMock(LANGUAGE_CODE="fr")  # French, in locale/catalogs.json
         )
 
         assert '<script src="/_static/{version}/sentry/dist/locale/fr.js"></script>' in result
 
     def test_unsupported_foreign_lang(self):
         result = self.TEMPLATE.render(
-            Context({"request": Mock(LANGUAGE_CODE="ro")})  # Romanian, not in locale/catalogs.json
+            request=MagicMock(LANGUAGE_CODE="ro")  # Romanian, not in locale/catalogs.json
         )
 
         assert result.strip() == ""
 
     def test_english(self):
-        result = self.TEMPLATE.render(Context({"request": Mock(LANGUAGE_CODE="en")}))
+        result = self.TEMPLATE.render(request=MagicMock(LANGUAGE_CODE="en"))
 
         assert result.strip() == ""
 
     def test_no_lang(self):
-        result = self.TEMPLATE.render(Context({"request": Mock()}))
+        result = self.TEMPLATE.render(request=MagicMock())
 
         assert result.strip() == ""

--- a/tests/sentry/templatetags/test_sentry_features.py
+++ b/tests/sentry/templatetags/test_sentry_features.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 
-from django.template import Context, Template
-from mock import Mock
+from django.template import engines
 
 from sentry.testutils import TestCase
 
 
 class FeaturesTest(TestCase):
-    TEMPLATE = Template(
+    # get a backend-dependent Template, just like get_template in >= Django 1.8
+    TEMPLATE = engines["django"].from_string(
         """
         {% load sentry_features %}
         {% feature auth:register %}
@@ -20,12 +20,10 @@ class FeaturesTest(TestCase):
 
     def test_enabled(self):
         with self.feature("auth:register"):
-            result = self.TEMPLATE.render(Context({"request": Mock()}))
-
-        assert "<span>register</span>" in result
+            result = self.TEMPLATE.render()
+            assert "<span>register</span>" in result
 
     def test_disabled(self):
         with self.feature({"auth:register": False}):
-            result = self.TEMPLATE.render(Context({"request": Mock()}))
-
-        assert "<span>nope</span>" in result
+            result = self.TEMPLATE.render()
+            assert "<span>nope</span>" in result

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -1,18 +1,19 @@
 from __future__ import absolute_import
 
 import pytest
-from django.template import Context, Template
+from django.template import engines
 
 
 def test_system_origin():
     result = (
-        Template(
+        engines["django"]
+        .from_string(
             """
         {% load sentry_helpers %}
         {% system_origin %}
     """
         )
-        .render(Context())
+        .render()
         .strip()
     )
 
@@ -54,5 +55,10 @@ def test_system_origin():
 )
 def test_absolute_uri(input, output):
     prefix = "{% load sentry_helpers %}"
-    result = Template(prefix + input).render(Context({"who": "matt", "desc": "awesome"})).strip()
+    result = (
+        engines["django"]
+        .from_string(prefix + input)
+        .render(context={"who": "matt", "desc": "awesome"})
+        .strip()
+    )
     assert result == output

--- a/tests/sentry/templatetags/test_sentry_plugins.py
+++ b/tests/sentry/templatetags/test_sentry_plugins.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
-from django.template import Context, Template
-from mock import Mock
+from mock import MagicMock
+from django.template import engines
 
 from sentry.plugins.base.v2 import Plugin2
 from sentry.testutils import PluginTestCase
@@ -24,7 +24,7 @@ class SamplePlugin(Plugin2):
 class GetActionsTest(PluginTestCase):
     plugin = SamplePlugin
 
-    TEMPLATE = Template(
+    TEMPLATE = engines["django"].from_string(
         """
         {% load sentry_plugins %}
         {% for k, v in group|get_actions:request %}
@@ -35,8 +35,7 @@ class GetActionsTest(PluginTestCase):
 
     def test_includes_v2_plugins(self):
         group = self.create_group()
-
-        result = self.TEMPLATE.render(Context({"request": Mock(), "group": group}))
+        result = self.TEMPLATE.render(context={"group": group}, request=MagicMock())
 
         assert "<span>Example Action - http://example.com?id=%s</span>" % (group.id,) in result
 
@@ -44,7 +43,7 @@ class GetActionsTest(PluginTestCase):
 class GetAnnotationsTest(PluginTestCase):
     plugin = SamplePlugin
 
-    TEMPLATE = Template(
+    TEMPLATE = engines["django"].from_string(
         """
         {% load sentry_plugins %}
         {% for a in group|get_annotations:request %}
@@ -55,8 +54,7 @@ class GetAnnotationsTest(PluginTestCase):
 
     def test_includes_v2_plugins(self):
         group = self.create_group()
-
-        result = self.TEMPLATE.render(Context({"request": Mock(), "group": group}))
+        result = self.TEMPLATE.render(context={"group": group}, request=MagicMock())
 
         assert "<span>Example Tag - http://example.com?id=%s</span>" % (group.id,) in result
         assert "<span>Example Two - None</span>" in result


### PR DESCRIPTION
Summarily, the changes are as follows:

- Consolidate usage of our own renderer functions in sentry.web.helpers for consistency, porting over Template.render and django.shortcuts calls.
  - No more `Context`, `RequestContext`.
  - This avoids usage of passing `context_instance=RequestContext`. See note at end of comment.
- Don't put `"request": request` in passed contexts, instead just pass `request=request`
  - We use the request in some templates. Giving the request to our render_to_{string,response} achieves the same effect of making the request available to templates.

Relevant documentation:

- https://docs.djangoproject.com/en/1.10/ref/templates/upgrading/
- https://docs.djangoproject.com/en/1.10/topics/templates

Prior art:

- https://github.com/getsentry/sentry/pull/15839
- https://github.com/getsentry/getsentry/pull/3381

Main concern with these changes would be test coverage, since this PR doesn't fix anything as far as our test suite is concerned. If anything I'd expect some Percy snapshot diffs to change if I did anything incorrectly.

**Note**: the following was changed in Django 1.10 _according to the documentation_, but isn't actually implemented until 1.11.

    Django template objects returned by get_template() and select_template() no longer accept a Context in their render() method.
