### PR TITLE
fix(settings) Refresh issue filter state on project change

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/index.jsx
@@ -12,15 +12,16 @@ import SentryTypes from 'app/sentryTypes';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import recreateRoute from 'app/utils/recreateRoute';
+import withProject from 'app/utils/withProject';
 
 class ProjectFilters extends React.Component {
-  static contextTypes = {
+  static propTypes = {
     project: SentryTypes.Project,
   };
 
   render() {
-    const {project} = this.context;
-    const {orgId, projectId, filterType} = this.props.params;
+    const {project, params} = this.props;
+    const {orgId, projectId, filterType} = params;
     if (!project) {
       return null;
     }
@@ -40,7 +41,7 @@ class ProjectFilters extends React.Component {
         </TextBlock>
 
         <div>
-          <ProjectFiltersChart params={this.props.params} />
+          <ProjectFiltersChart project={project} params={this.props.params} />
 
           {features.has('discard-groups') && (
             <NavTabs underlined style={{paddingTop: '30px'}}>
@@ -60,7 +61,7 @@ class ProjectFilters extends React.Component {
           )}
 
           {filterType === 'discarded-groups' ? (
-            <GroupTombstones orgId={orgId} projectId={projectId} />
+            <GroupTombstones orgId={orgId} projectId={project.slug} />
           ) : (
             <ProjectFiltersSettings
               project={project}
@@ -74,4 +75,4 @@ class ProjectFilters extends React.Component {
   }
 }
 
-export default ProjectFilters;
+export default withProject(ProjectFilters);

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
+import SentryTypes from 'app/sentryTypes';
 import moment from 'moment';
 
 import {intcomma} from 'app/utils';
@@ -14,20 +14,19 @@ import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import StackedBarChart from 'app/components/stackedBarChart';
 import formatAbbreviatedNumber from 'app/utils/formatAbbreviatedNumber';
 
-const ProjectFiltersChart = createReactClass({
-  displayName: 'ProjectFiltersChart',
-  propTypes: {
+class ProjectFiltersChart extends React.Component {
+  static propTypes = {
     api: PropTypes.object,
-  },
-  contextTypes: {
-    project: PropTypes.object,
-  },
+    project: SentryTypes.Project,
+  };
 
-  getInitialState() {
+  constructor(props) {
+    super(props);
+
     const until = Math.floor(new Date().getTime() / 1000);
     const since = until - 3600 * 24 * 30;
 
-    return {
+    this.state = {
       loading: true,
       error: false,
       statsError: false,
@@ -37,11 +36,17 @@ const ProjectFiltersChart = createReactClass({
       formattedData: [],
       blankStats: true,
     };
-  },
+  }
 
   componentDidMount() {
     this.fetchData();
-  },
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.project !== this.props.project) {
+      this.fetchData();
+    }
+  }
 
   getStatOpts() {
     return {
@@ -56,7 +61,7 @@ const ProjectFiltersChart = createReactClass({
       cors: 'CORS',
       'discarded-hash': 'Discarded Issue',
     };
-  },
+  }
 
   formatData(rawData) {
     return Object.keys(this.getStatOpts()).map(stat => {
@@ -72,12 +77,13 @@ const ProjectFiltersChart = createReactClass({
         statName: stat,
       };
     });
-  },
+  }
 
   getFilterStats() {
     const statOptions = Object.keys(this.getStatOpts());
-    const {orgId, projectId} = this.props.params;
-    const statEndpoint = `/projects/${orgId}/${projectId}/stats/`;
+    const {project} = this.props;
+    const {orgId} = this.props.params;
+    const statEndpoint = `/projects/${orgId}/${project.slug}/stats/`;
     const query = {
       since: this.state.querySince,
       until: this.state.queryUntil,
@@ -122,17 +128,17 @@ const ProjectFiltersChart = createReactClass({
           this.setState({error: true});
         }.bind(this)
       );
-  },
+  }
 
   fetchData() {
     this.getFilterStats();
-  },
+  }
 
   timeLabelAsDay(point) {
     const timeMoment = moment(point.x * 1000);
 
     return timeMoment.format('LL');
-  },
+  }
 
   renderTooltip(point) {
     const timeLabel = this.timeLabelAsDay(point);
@@ -170,7 +176,7 @@ const ProjectFiltersChart = createReactClass({
         })}
       </div>
     );
-  },
+  }
 
   render() {
     const {loading, error} = this.state;
@@ -207,8 +213,8 @@ const ProjectFiltersChart = createReactClass({
         </PanelBody>
       </Panel>
     );
-  },
-});
+  }
+}
 
 export {ProjectFiltersChart};
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.jsx
@@ -130,9 +130,9 @@ class ProjectFiltersChart extends React.Component {
       );
   }
 
-  fetchData() {
+  fetchData = () => {
     this.getFilterStats();
-  }
+  };
 
   timeLabelAsDay(point) {
     const timeMoment = moment(point.x * 1000);

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.jsx
@@ -1,4 +1,3 @@
-import {Flex} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
@@ -134,13 +133,13 @@ class LegacyBrowserFilterRow extends React.Component {
             return (
               <FilterGridItemWrapper key={key}>
                 <FilterGridItem>
-                  <Flex align="center" flex="1">
+                  <FilterItem>
                     <FilterGridIcon className={`icon-${subfilter.icon}`} />
                     <div>
                       <FilterTitle>{subfilter.title}</FilterTitle>
                       <FilterDescription>{subfilter.helpText}</FilterDescription>
                     </div>
-                  </Flex>
+                  </FilterItem>
 
                   <Switch
                     isActive={this.state.subfilters.has(key)}
@@ -171,12 +170,20 @@ class ProjectFiltersSettings extends AsyncComponent {
       hooksDisabled: HookStore.get('project:custom-inbound-filters:disabled'),
     };
   }
+
   getEndpoints() {
     const {orgId, projectId} = this.props.params;
     return [
       ['filterList', `/projects/${orgId}/${projectId}/filters/`],
       ['project', `/projects/${orgId}/${projectId}/`],
     ];
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (prevProps.project !== this.props.project) {
+      this.reloadData();
+    }
+    super.componentDidUpdate(prevProps, prevState);
   }
 
   handleLegacyChange = (onChange, onBlur, _filter, subfilters, e) => {
@@ -338,6 +345,12 @@ const FilterGridItem = styled('div')`
 const FilterGridItemWrapper = styled('div')`
   padding: 12px;
   width: 50%;
+`;
+
+const FilterItem = styled('div')`
+  display: flex;
+  flex: 1;
+  align-items: center;
 `;
 
 const FilterGridIcon = styled('div')`


### PR DESCRIPTION
When projects are changed in the breadcrumb we should reload the data.
I've also taken this opportunity to remove the legacy context API,
createReactClass() and grid-emotion usage here.

Fixes ISSUE-639