### PR TITLE
ref(signals): Consolidate sigint/sigterm usage under atexit

### DIFF
--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 
 import os
 import click
+import signal
 import sys
 import sentry
 import datetime
@@ -161,4 +162,8 @@ def call_command(name, obj=None, **kwargs):
 
 
 def main():
+    def sigHandler(signo, frame):
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, sigHandler)
     cli(prog_name=get_prog(), obj={}, max_content_width=100)

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -162,8 +162,8 @@ def call_command(name, obj=None, **kwargs):
 
 
 def main():
-    def sigHandler(signo, frame):
+    def sigterm_handler(signo, frame):
         sys.exit(0)
 
-    signal.signal(signal.SIGTERM, sigHandler)
+    signal.signal(signal.SIGTERM, sigterm_handler)
     cli(prog_name=get_prog(), obj={}, max_content_width=100)

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -356,7 +356,7 @@ def query_subscription_consumer(**options):
         initial_offset_reset=options["initial_offset_reset"],
     )
 
-    atexit.register(subscriber.shutdown())
+    atexit.register(subscriber.shutdown)
 
     subscriber.run()
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-import signal
+import atexit
 import sys
 from multiprocessing import cpu_count
 
@@ -356,10 +356,7 @@ def query_subscription_consumer(**options):
         initial_offset_reset=options["initial_offset_reset"],
     )
 
-    def handler(signum, frame):
-        subscriber.shutdown()
-
-    signal.signal(signal.SIGINT, handler)
+    atexit.register(subscriber.shutdown())
 
     subscriber.run()
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, print_function
 
-import atexit
 import sys
 from multiprocessing import cpu_count
 
@@ -355,8 +354,6 @@ def query_subscription_consumer(**options):
         commit_batch_size=options["commit_batch_size"],
         initial_offset_reset=options["initial_offset_reset"],
     )
-
-    atexit.register(subscriber.shutdown)
 
     subscriber.run()
 

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -97,10 +97,10 @@ class QuerySubscriptionConsumer(object):
                 if i % self.commit_batch_size == 0:
                     logger.debug("Committing offsets")
                     self.commit_offsets()
-        except KeyboardInterrupt:
+        except (SystemExit, KeyboardInterrupt):
             pass
-
-        self.shutdown()
+        finally:
+            self.shutdown()
 
     def commit_offsets(self):
         if self.offsets and self.consumer:

--- a/src/sentry/utils/kafka.py
+++ b/src/sentry/utils/kafka.py
@@ -67,6 +67,4 @@ def create_batching_kafka_consumer(topic_name, worker, **options):
         **options
     )
 
-    atexit.register(consumer.signal_shutdown)
-
     return consumer

--- a/src/sentry/utils/kafka.py
+++ b/src/sentry/utils/kafka.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import atexit
 import logging
-import signal
 
 from sentry.utils.batching_kafka_consumer import BatchingKafkaConsumer
 from sentry.utils import metrics
@@ -68,10 +67,6 @@ def create_batching_kafka_consumer(topic_name, worker, **options):
         **options
     )
 
-    def handler(signum, frame):
-        consumer.signal_shutdown()
-
-    signal.signal(signal.SIGINT, handler)
-    signal.signal(signal.SIGTERM, handler)
+    atexit.register(consumer.signal_shutdown)
 
     return consumer


### PR DESCRIPTION
Instead of sprinkling incomplete signal handlers over the codebase
prefer using `atexit.register` and trigger an exit upon receiving
`SIGTERM` as it normally bypasses the `atexit` callbacks.

The new code should behave identical to the old one, but more complete
as in it now handles more exit triggers instead of just `SIGINT`.

This is a follow up to #15934.