### PR TITLE
test(Django 1.10): assert for full redirect chain instead of reusing assertRedirects

### DIFF
--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -74,10 +74,11 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         with self.settings(
             TERMS_URL="https://example.com/terms", PRIVACY_URL="https://example.com/privacy"
         ):
-            resp = self.client.post(path, {"op": "newuser"}, follow=False)
-            self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
             resp = self.client.post(path, {"op": "newuser"}, follow=True)
-            self.assertRedirects(resp, "/organizations/foo/issues/")
+            assert resp.redirect_chain == [
+                (reverse("sentry-login"), 302),
+                ("/organizations/foo/issues/", 302),
+            ]
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -111,10 +112,11 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(resp, "sentry/auth-confirm-link.html")
         assert resp.status_code == 200
 
-        resp = self.client.post(path, {"op": "confirm"}, follow=False)
-        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
         resp = self.client.post(path, {"op": "confirm"}, follow=True)
-        self.assertRedirects(resp, "/organizations/foo/issues/")
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/foo/issues/", 302),
+        ]
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
         assert user == auth_identity.user
@@ -136,10 +138,11 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert self.provider.TEMPLATE in resp.content.decode("utf-8")
 
         path = reverse("sentry-auth-sso")
-        resp = self.client.post(path, {"email": "foo@example.com"}, follow=False)
-        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
         resp = self.client.post(path, {"email": "foo@example.com"}, follow=True)
-        self.assertRedirects(resp, "/organizations/foo/issues/")
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/foo/issues/", 302),
+        ]
 
     def test_flow_as_unauthenticated_existing_matched_user_no_merge(self):
         auth_provider = AuthProvider.objects.create(
@@ -160,10 +163,11 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.context["existing_user"] == user
         assert resp.context["login_form"]
 
-        resp = self.client.post(path, {"op": "newuser"}, follow=False)
-        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
         resp = self.client.post(path, {"op": "newuser"}, follow=True)
-        self.assertRedirects(resp, "/organizations/foo/issues/")
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/foo/issues/", 302),
+        ]
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
         new_user = auth_identity.user
@@ -210,11 +214,11 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(resp, "sentry/auth-confirm-link.html")
         assert resp.status_code == 200
 
-        resp = self.client.post(path, {"op": "confirm"}, follow=False)
-        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
         resp = self.client.post(path, {"op": "confirm"}, follow=True)
-        self.assertRedirects(resp, "/organizations/foo/issues/")
-
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/foo/issues/", 302),
+        ]
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
         new_user = auth_identity.user
@@ -252,11 +256,11 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(resp, "sentry/auth-confirm-link.html")
         assert resp.status_code == 200
 
-        resp = self.client.post(path, {"op": "confirm"}, follow=False)
-        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
         resp = self.client.post(path, {"op": "confirm"}, follow=True)
-        self.assertRedirects(resp, "/organizations/foo/issues/")
-
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/foo/issues/", 302),
+        ]
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
         new_user = auth_identity.user
@@ -294,10 +298,11 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(resp, "sentry/auth-confirm-link.html")
         assert resp.status_code == 200
 
-        resp = self.client.post(path, {"op": "confirm"}, follow=False)
-        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
         resp = self.client.post(path, {"op": "confirm"}, follow=True)
-        self.assertRedirects(resp, "/organizations/foo/issues/")
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/foo/issues/", 302),
+        ]
 
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
@@ -340,10 +345,11 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.assertTemplateUsed(resp, "sentry/auth-confirm-link.html")
         assert resp.status_code == 200
 
-        resp = self.client.post(path, {"op": "confirm"}, follow=False)
-        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
         resp = self.client.post(path, {"op": "confirm"}, follow=True)
-        self.assertRedirects(resp, "/organizations/foo/issues/")
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/foo/issues/", 302),
+        ]
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -386,10 +392,11 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert not resp.context["existing_user"]
         assert resp.context["login_form"]
 
-        resp = self.client.post(path, {"op": "newuser"}, follow=False)
-        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
         resp = self.client.post(path, {"op": "newuser"}, follow=True)
-        self.assertRedirects(resp, "/organizations/foo/issues/")
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/foo/issues/", 302),
+        ]
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -439,14 +446,14 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         # we're suggesting the identity changed (as if the Google ident was
         # updated to be something else)
         resp = self.client.post(
-            path, {"email": "bar@example.com", "id": "123", "email_verified": "1"}, follow=False
-        )
-        # there should be no prompt as we auto merge the identity
-        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
-        resp = self.client.post(
             path, {"email": "bar@example.com", "id": "123", "email_verified": "1"}, follow=True
         )
-        self.assertRedirects(resp, "/auth/login/foo/")
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/foo/issues/", 302),
+            ("/auth/login/foo/", 302),
+        ]
+        # there should be no prompt as we auto merge the identity
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -598,10 +605,12 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         # we're suggesting the identity changed (as if the Google ident was
         # updated to be something else)
-        resp = self.client.post(path, {"email": "adfadsf@example.com"}, follow=False)
-        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
         resp = self.client.post(path, {"email": "adfadsf@example.com"}, follow=True)
-        self.assertRedirects(resp, "/auth/login/foo/")
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/foo/issues/", 302),
+            ("/auth/login/foo/", 302),
+        ]
 
         assert not AuthIdentity.objects.filter(id=identity1.id).exists()
 
@@ -635,13 +644,12 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         path = reverse("sentry-auth-sso")
 
         resp = self.client.post(
-            path, {"email": "foo@new-domain.com", "legacy_email": "foo@example.com"}, follow=False
-        )
-        self.assertRedirects(resp, reverse("sentry-login"), target_status_code=302)
-        resp = self.client.post(
             path, {"email": "foo@new-domain.com", "legacy_email": "foo@example.com"}, follow=True
         )
-        self.assertRedirects(resp, "/organizations/foo/issues/")
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/foo/issues/", 302),
+        ]
 
         # Ensure the ident was migrated from the legacy identity
         updated_ident = AuthIdentity.objects.get(id=user_ident.id)


### PR DESCRIPTION
So it actually turns out sometimes we have more than 1 redirect. Django's `assertRedirects` isn't meant for redirect chains - it only asserts there's a redirect and then the final url in the chain. I didn't know about `redirect_chain` at the time, and using `assertRedirects` twice (one for `follow=False`, another for true) was a shitty hack at best.

Asserting for the entire `redirect_chain` is fully correct.