### PR TITLE
feat: Add migrations lockfile to help prevent migration conflicts on master

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -1,0 +1,16 @@
+Django migrations lock file. This helps us avoid migration conflicts on master.
+If you have a conflict in this file, it means that someone has committed a migration
+ahead of you.
+
+To resolve this, rebase against latest master and regenerate your migration. This file
+will then be regenerated, and you should be able to merge without conflicts.
+
+admin: 0002_logentry_remove_auto_add
+auth: 0008_alter_user_username_max_length
+contenttypes: 0002_remove_content_type_name
+jira_ac: 0001_initial
+nodestore: 0001_initial
+sentry: 0029_discover_query_upgrade
+sessions: 0001_initial
+sites: 0002_alter_domain_unique
+social_auth: 0001_initial

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1735,3 +1735,8 @@ SOUTH_MIGRATION_CONVERSIONS = (
 # of models, similar to how syncdb used to work. The former is more correct, the latter
 # is much faster.
 MIGRATIONS_TEST_MIGRATE = os.environ.get("MIGRATIONS_TEST_MIGRATE", "0") == "1"
+# Specifies the list of django apps to include in the lockfile. If Falsey then include
+# all apps with migrations
+MIGRATIONS_LOCKFILE_APP_WHITELIST = ()
+# Where to write the lockfile to.
+MIGRATIONS_LOCKFILE_PATH = os.path.join(PROJECT_ROOT, os.path.pardir, os.path.pardir)

--- a/src/sentry/management/commands/makemigrations.py
+++ b/src/sentry/management/commands/makemigrations.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import, unicode_literals
+
+import io
+import os
+
+import six
+from django.conf import settings
+from django.db.migrations.loader import MigrationLoader
+from django.core.management.commands import makemigrations
+
+template = """Django migrations lock file. This helps us avoid migration conflicts on master.
+If you have a conflict in this file, it means that someone has committed a migration
+ahead of you.
+
+To resolve this, rebase against latest master and regenerate your migration. This file
+will then be regenerated, and you should be able to merge without conflicts.
+
+%s
+"""
+
+
+class Command(makemigrations.Command):
+    """
+    Generates a lockfile so that Git will detect merge conflicts if there's a migration
+    on master that doesn't exist in a branch.
+    """
+
+    def handle(self, *app_labels, **options):
+        super(Command, self).handle(*app_labels, **options)
+        loader = MigrationLoader(None, ignore_no_migrations=True)
+
+        latest_migration_by_app = {}
+        for migration in six.itervalues(loader.disk_migrations):
+            name = migration.name
+            app_label = migration.app_label
+            if (
+                settings.MIGRATIONS_LOCKFILE_APP_WHITELIST
+                and app_label not in settings.MIGRATIONS_LOCKFILE_APP_WHITELIST
+            ):
+                continue
+            latest_migration_by_app[app_label] = max(
+                latest_migration_by_app.get(app_label, ""), name
+            )
+
+        result = "\n".join(
+            "{}: {}".format(app_label, name)
+            for app_label, name in sorted(latest_migration_by_app.items())
+        )
+
+        with io.open(
+            os.path.join(settings.MIGRATIONS_LOCKFILE_PATH, "migrations_lockfile.txt"), "w"
+        ) as f:
+            f.write(template % result)


### PR DESCRIPTION
This modifies the `makemigrations` command to generate a lockfile after it makes migrations. We
commit the lockfile each time, and so if someone has committed a migration to master, then github
will detect the conflict and prevent merging.

Modified from https://gist.github.com/r3m0t/f4e1388f8412404a990f2c776fb48b44 and based on this
defunct blog post: https://web.archive.org/web/20180520172740/https://engineering.zenefits.com/2015/11/using-old-ideas-to-solve-new-problems/