### PR TITLE
Fix for legacy browser filter changes in audit logs

### DIFF
--- a/src/sentry/api/endpoints/project_filter_details.py
+++ b/src/sentry/api/endpoints/project_filter_details.py
@@ -6,7 +6,6 @@ from sentry import message_filters
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.models.auditlogentry import AuditLogEntryEvent
-import six
 
 
 class ProjectFilterDetailsEndpoint(ProjectEndpoint):
@@ -38,16 +37,10 @@ class ProjectFilterDetailsEndpoint(ProjectEndpoint):
         audit_log_state = AuditLogEntryEvent.PROJECT_ENABLE
 
         if filter_id == "legacy-browsers":
-            if (
-                isinstance(current_state, bool)
-                or new_state == 0
-                or isinstance(new_state, six.binary_type)
-            ):
+            if isinstance(current_state, bool) or isinstance(new_state, bool):
                 returned_state = new_state
-
-                if isinstance(new_state, six.binary_type):
+                if not new_state:
                     audit_log_state = AuditLogEntryEvent.PROJECT_DISABLE
-                    returned_state = current_state
 
             elif current_state - new_state:
                 returned_state = current_state - new_state

--- a/src/sentry/message_filters.py
+++ b/src/sentry/message_filters.py
@@ -72,7 +72,7 @@ def set_filter_state(filter_id, project, state):
             project=project, key=u"filters:{}".format(filter_id), value=option_val
         )
 
-        return option_val
+        return option_val == "1" if option_val in ("0", "1") else option_val
 
     else:
         # all boolean filters


### PR DESCRIPTION
Fixes ISSUE-590

The value that was saved to audit logs can be a few different types depending on
which filter is used, with legacy browser filters having a few different states.
Change the save functionality to save better values in audit logs going forward
and change the audit log display function to handle all the possible values.

/cc @markstory @LSSangha 