### PR TITLE
fix(discover1): Fix date for GlobalSelectionHeader not being updated

### DIFF
--- a/src/sentry/static/sentry/app/views/discover/sidebar/savedQueryList.tsx
+++ b/src/sentry/static/sentry/app/views/discover/sidebar/savedQueryList.tsx
@@ -26,49 +26,42 @@ type SavedQueriesProps = {
 type SavedQueriesState = {
   isLoading: boolean;
   data: SavedQuery[];
-  topSavedQuery: SavedQuery | null;
+  savedQuery: SavedQuery | null;
 };
 
 export default class SavedQueries extends React.Component<
   SavedQueriesProps,
   SavedQueriesState
 > {
-  constructor(props: SavedQueriesProps) {
-    super(props);
-    this.state = {
-      isLoading: true,
-      data: [],
-      topSavedQuery: props.savedQuery,
-    };
+  state: SavedQueriesState = {
+    isLoading: true,
+    data: [],
+    savedQuery: null,
+  };
+
+  static getDerivedStateFromProps(
+    nextProps: SavedQueriesProps,
+    prevState: SavedQueriesState
+  ): Partial<SavedQueriesState> {
+    const nextState: Partial<SavedQueriesState> = {};
+
+    if (nextProps.savedQuery && nextProps.savedQuery !== prevState.savedQuery) {
+      nextState.data = prevState.data.map(q =>
+        q.id === nextProps.savedQuery!.id ? nextProps.savedQuery! : q
+      );
+    }
+
+    return nextState;
   }
 
   componentDidMount() {
     this.fetchAll();
   }
 
-  componentWillReceiveProps(nextProps: SavedQueriesProps) {
-    // Refetch on deletion
-    if (!nextProps.savedQuery && this.props.savedQuery !== nextProps.savedQuery) {
+  componentDidUpdate(prevProps) {
+    // Re-fetch on deletion
+    if (!this.props.savedQuery && prevProps.savedQuery) {
       this.fetchAll();
-    }
-
-    // Update query in the list with new data
-    if (nextProps.savedQuery && nextProps.savedQuery !== this.props.savedQuery) {
-      const data = this.state.data.map(savedQuery =>
-        savedQuery.id === nextProps.savedQuery!.id ? nextProps.savedQuery! : savedQuery
-      );
-      this.setState({data});
-    }
-
-    // Update saved query if any name / details have been updated
-    if (
-      nextProps.savedQuery &&
-      (!this.state.topSavedQuery ||
-        nextProps.savedQuery.id === this.state.topSavedQuery.id)
-    ) {
-      this.setState({
-        topSavedQuery: nextProps.savedQuery,
-      });
     }
   }
 
@@ -101,9 +94,11 @@ export default class SavedQueries extends React.Component<
 
     const {id, name, dateUpdated} = query;
     const {organization} = this.props;
+    const relativeLink = `/organizations/${organization.slug}/discover/saved/${id}/`;
+
     return (
       <SavedQueryListItem key={id} isActive={savedQuery && savedQuery.id === id}>
-        <SavedQueryLink to={`/organizations/${organization.slug}/discover/saved/${id}/`}>
+        <SavedQueryLink to={relativeLink}>
           {getDynamicText({value: name, fixed: 'saved query'})}
           <SavedQueryUpdated>
             {tct('Updated [date] (UTC)', {
@@ -119,25 +114,18 @@ export default class SavedQueries extends React.Component<
   }
 
   renderList() {
-    const {data, topSavedQuery} = this.state;
+    const {data} = this.state;
 
-    const savedQueryId = topSavedQuery ? topSavedQuery.id : null;
-
-    if (!data.length) {
-      return this.renderEmpty();
-    }
-
-    return data.map(query => {
-      return query.id !== savedQueryId ? this.renderListItem(query) : null;
-    });
+    return data.length
+      ? data.map(query => this.renderListItem(query))
+      : this.renderEmpty();
   }
 
   render() {
-    const {topSavedQuery, isLoading} = this.state;
+    const {isLoading} = this.state;
 
     return (
       <SavedQueryList>
-        {topSavedQuery && this.renderListItem(topSavedQuery)}
         {isLoading ? this.renderLoading() : this.renderList()}
       </SavedQueryList>
     );

--- a/src/sentry/static/sentry/app/views/discover/utils.tsx
+++ b/src/sentry/static/sentry/app/views/discover/utils.tsx
@@ -146,7 +146,7 @@ export function fetchSavedQueries(organization: any): Promise<any> {
 
   return api.requestPromise(endpoint, {
     method: 'GET',
-    query: {all: 1, query: 'version:1'},
+    query: {all: 1, query: 'version:1', sortBy: '-dateUpdated'},
   } as any); // TODO: Remove as any
 }
 

--- a/tests/js/spec/views/discover/index.spec.jsx
+++ b/tests/js/spec/views/discover/index.spec.jsx
@@ -31,6 +31,13 @@ describe('DiscoverContainer', function() {
           meta: [],
         },
       });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/projects',
+        method: 'GET',
+        body: {
+          data: organization.projects,
+        },
+      });
       wrapper = mountWithTheme(
         <DiscoverContainer
           location={{query: {}, search: ''}}


### PR DESCRIPTION
@lynnagara It's been >1 year since you looked at this but I wanted to check in to make sure I'm not missing anything. I removed the `topSavedQuery` on `discover/sidebar/savedQueryList.tsx` because the UX does not make sense to me. 

Current implementation sorts the queries by `dateUpdated` but the most recently viewed query is placed at the top (and then moved back to its original position when another query is viewed). IMO if we want to pop and place the most recently viewed query on top of the stack, then we should be tracking a `lastSeen` property. 

@dashed I can't tell if this is related to the issue that you're trying to fix in #15400. I'm not encountering any issues with the date format.

Refs ISSUE-637