### PR TITLE
feat(relay): Add endpoint to fetch project ids for public keys

### DIFF
--- a/src/sentry/api/endpoints/relay_projectids.py
+++ b/src/sentry/api/endpoints/relay_projectids.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from sentry.api.base import Endpoint
 from sentry.api.permissions import RelayPermission
 from sentry.api.authentication import RelayAuthentication
-from sentry.models import Project, ProjectKey
+from sentry.models import ProjectKey
 
 
 class RelayProjectIdsEndpoint(Endpoint):
@@ -29,10 +29,6 @@ class RelayProjectIdsEndpoint(Endpoint):
             # NB: Do not validate pk here (is_active or store). Relay should
             # also receive a mapping for disabled public keys and then perform
             # the full project config fetch.
-
-            project = Project.objects.get_from_cache(id=pk.project_id)
-            if not request.relay.has_org_access(project.organization):
-                continue
 
             project_ids[public_key] = pk.project_id
 

--- a/src/sentry/api/endpoints/relay_projectids.py
+++ b/src/sentry/api/endpoints/relay_projectids.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint
+from sentry.api.permissions import RelayPermission
+from sentry.api.authentication import RelayAuthentication
+from sentry.models import Project, ProjectKey
+
+
+class RelayProjectIdsEndpoint(Endpoint):
+    authentication_classes = (RelayAuthentication,)
+    permission_classes = (RelayPermission,)
+
+    def post(self, request):
+        relay = request.relay
+        assert relay is not None  # should be provided during Authentication
+
+        project_ids = {}
+        for public_key in request.relay_request_data.get("publicKeys") or ():
+            if not ProjectKey.looks_like_api_key(public_key):
+                continue
+
+            try:
+                pk = ProjectKey.objects.get_from_cache(public_key=public_key)
+            except ProjectKey.DoesNotExist:
+                continue
+
+            # NB: Do not validate pk here (is_active or store). Relay should
+            # also receive a mapping for disabled public keys and then perform
+            # the full project config fetch.
+
+            project = Project.objects.get_from_cache(id=pk.project_id)
+            if not request.relay.has_org_access(project.organization):
+                continue
+
+            project_ids[public_key] = pk.project_id
+
+        return Response({"projectIds": project_ids}, status=200)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -224,6 +224,7 @@ from .endpoints.prompts_activity import PromptsActivityEndpoint
 from .endpoints.relay_details import RelayDetailsEndpoint
 from .endpoints.relay_index import RelayIndexEndpoint
 from .endpoints.relay_projectconfigs import RelayProjectConfigsEndpoint
+from .endpoints.relay_projectids import RelayProjectIdsEndpoint
 from .endpoints.relay_publickeys import RelayPublicKeysEndpoint
 from .endpoints.relay_register import RelayRegisterChallengeEndpoint, RelayRegisterResponseEndpoint
 from .endpoints.release_deploys import ReleaseDeploysEndpoint
@@ -365,6 +366,11 @@ urlpatterns = [
                     r"^projectconfigs/$",
                     RelayProjectConfigsEndpoint.as_view(),
                     name="sentry-api-0-relay-projectconfigs",
+                ),
+                url(
+                    r"^projectids/$",
+                    RelayProjectIdsEndpoint.as_view(),
+                    name="sentry-api-0-relay-projectids",
                 ),
                 url(
                     r"^publickeys/$",

--- a/tests/sentry/api/endpoints/test_relay_projectids.py
+++ b/tests/sentry/api/endpoints/test_relay_projectids.py
@@ -97,4 +97,6 @@ class RelayProjectIdsEndpointTest(APITestCase):
         result, status_code = self._call_endpoint(public_key)
 
         assert status_code < 400
-        assert safe.get_path(result, "projectIds", public_key) is None
+        # NB: Unauthorized Relays also receive the project id, but cannot fetch
+        # the project ID afterwards.
+        assert safe.get_path(result, "projectIds", public_key) == self.project.id

--- a/tests/sentry/api/endpoints/test_relay_projectids.py
+++ b/tests/sentry/api/endpoints/test_relay_projectids.py
@@ -1,0 +1,100 @@
+from __future__ import absolute_import
+
+import json
+import six
+import re
+
+from uuid import uuid4
+
+from django.core.urlresolvers import reverse
+
+from sentry.utils import safe
+from sentry.models.relay import Relay
+from sentry.testutils import APITestCase
+
+from semaphore.auth import generate_key_pair
+
+
+def _get_all_keys(config):
+    for key in config:
+        yield key
+        if isinstance(config[key], dict):
+            for key in _get_all_keys(config[key]):
+                yield key
+
+
+class RelayProjectIdsEndpointTest(APITestCase):
+    _date_regex = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$")
+
+    def _setup_relay(self, internal, add_org_key):
+        self.key_pair = generate_key_pair()
+
+        self.public_key = self.key_pair[1]
+        self.private_key = self.key_pair[0]
+        self.relay_id = six.binary_type(uuid4())
+
+        self.relay = Relay.objects.create(
+            relay_id=self.relay_id,
+            public_key=six.binary_type(self.public_key),
+            is_internal=internal,
+        )
+
+        self.project = self.create_project()
+        self.project.update_option("sentry:scrub_ip_address", True)
+        self.path = reverse("sentry-api-0-relay-projectids")
+
+        self.project_key = self.create_project_key()
+
+        org = self.project.organization
+
+        if add_org_key:
+            org.update_option("sentry:trusted-relays", [self.relay.public_key])
+
+    def _call_endpoint(self, public_key):
+        raw_json, signature = self.private_key.pack({"publicKeys": [public_key]})
+
+        resp = self.client.post(
+            self.path,
+            data=raw_json,
+            content_type="application/json",
+            HTTP_X_SENTRY_RELAY_ID=self.relay_id,
+            HTTP_X_SENTRY_RELAY_SIGNATURE=signature,
+        )
+
+        return json.loads(resp.content), resp.status_code
+
+    def test_internal_relay(self):
+        self._setup_relay(internal=True, add_org_key=True)
+
+        public_key = self.project_key.public_key
+        result, status_code = self._call_endpoint(public_key)
+
+        assert status_code < 400
+        assert safe.get_path(result, "projectIds", public_key) == self.project.id
+
+    def test_external_relay(self):
+        self._setup_relay(internal=False, add_org_key=True)
+
+        public_key = self.project_key.public_key
+        result, status_code = self._call_endpoint(public_key)
+
+        assert status_code < 400
+        assert safe.get_path(result, "projectIds", public_key) == self.project.id
+
+    def test_unknown_key(self):
+        self._setup_relay(internal=True, add_org_key=True)
+
+        public_key = "feedfacefeedfacefeedfacefeedface"
+        result, status_code = self._call_endpoint(public_key)
+
+        assert status_code < 400
+        assert safe.get_path(result, "projectIds", public_key) is None
+
+    def test_unauthorized_relay(self):
+        self._setup_relay(internal=False, add_org_key=False)
+
+        public_key = self.project_key.public_key
+        result, status_code = self._call_endpoint(public_key)
+
+        assert status_code < 400
+        assert safe.get_path(result, "projectIds", public_key) is None


### PR DESCRIPTION
To support the legacy store endpoint `/api/store/`, Relay needs to maintain a reverse mapping of public keys to project ids. This endpoint allows authenticated Relays to fetch this mapping.

Relay actually only queries one key per request. Since the volume on the legacy endpoint is very low and the key mappings are cached indefinitely, the load on this endpoint will be considerably low.

Ref https://github.com/getsentry/semaphore/pull/352
