### PR TITLE
feat(plugins): adds trello plugin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ setup(
             "redmine = sentry_plugins.redmine",
             "sessionstack = sentry_plugins.sessionstack",
             "teamwork = sentry_plugins.teamwork",
+            "trello = sentry_plugins.trello",
             "twilio = sentry_plugins.twilio",
         ],
         "sentry.plugins": [
@@ -172,6 +173,7 @@ setup(
             "slack = sentry_plugins.slack.plugin:SlackPlugin",
             "splunk = sentry_plugins.splunk.plugin:SplunkPlugin",
             "teamwork = sentry_plugins.teamwork.plugin:TeamworkPlugin",
+            "trello = sentry_plugins.trello.plugin:TrelloPlugin",
             "twilio = sentry_plugins.twilio.plugin:TwilioPlugin",
             "victorops = sentry_plugins.victorops.plugin:VictorOpsPlugin",
             "vsts = sentry_plugins.vsts.plugin:VstsPlugin",

--- a/src/sentry/templates/sentry/plugins/trello/create_trello_issue.html
+++ b/src/sentry/templates/sentry/plugins/trello/create_trello_issue.html
@@ -1,0 +1,31 @@
+{% extends "sentry/plugins/bases/issue/create_issue.html" %}
+
+{% block scripts %}
+    {{ block.super }}
+    <script type="text/javascript">
+        $(function(){
+            var $boards = $('#id_trello_board');
+            var $lists = $('#id_trello_list');
+            $boards.on('change', function(evt) {
+                $lists.prop('disabled', true);
+                $.ajax({
+                    url: '?action=lists&board_id=' + evt.val,
+                    success: function(data) {
+                        var result = data.result;
+                        if (!result.length) {
+                            $lists.prop('disabled', false);
+                            return;
+                        }
+                        var options = [];
+                        for (var i=0; i<result.length; i++) {
+                            options.push(
+                                '<option value="'+result[i].id+'">'+result[i].name+'</option>'
+                            );
+                        }
+                        $lists.append(options).prop('disabled', false).val(result[0].id).trigger('change');
+                    }
+                });
+            });
+        });
+    </script>
+{% endblock %}

--- a/src/sentry/templates/sentry/plugins/trello/plugin_misconfigured.html
+++ b/src/sentry/templates/sentry/plugins/trello/plugin_misconfigured.html
@@ -1,0 +1,14 @@
+{% extends "sentry/plugins/bases/issue/create_issue.html" %}
+{% load sentry_helpers %}
+
+{% block main %}
+    <p>There is an error with the Trello configuration stored for your project.</p>
+    <ul>
+        {% if response %}
+            <li>{{ response }}</li>
+        {% else %}
+            <li>An unknown error occurred while communicating with Trello.</li>
+        {% endif %}
+    </ul>
+    <p>You may wish to double check your <a href="{% absolute_uri '/{}/{}/settings/plugins/{}/' project.organization.slug project.slug plugin.slug %}">configuration</a>.</p>
+{% endblock %}

--- a/src/sentry_plugins/trello/HOW_TO_SETUP.md
+++ b/src/sentry_plugins/trello/HOW_TO_SETUP.md
@@ -1,0 +1,10 @@
+How to configure the plugin
+===========================
+
+Get the API key from [here](https://trello.com/1/appKey/generate)
+Note: The secret is *not* the token.
+
+Get the token from
+https://trello.com/1/authorize?response_type=token&scope=read,write&expiration=never&key=API_KEY_HERE
+
+Save your settings and then select organization

--- a/src/sentry_plugins/trello/__init__.py
+++ b/src/sentry_plugins/trello/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/src/sentry_plugins/trello/client.py
+++ b/src/sentry_plugins/trello/client.py
@@ -1,0 +1,70 @@
+from __future__ import absolute_import
+
+from sentry import http
+from sentry.utils import json
+
+
+class TrelloClient(object):
+    base_url = "https://trello.com/1/"
+
+    def __init__(self, apikey, token=None, timeout=5):
+        self._apikey = apikey
+        self._token = token
+        self._timeout = timeout
+
+    def _request(self, path, method="GET", params=None, data=None):
+        path = path.lstrip("/")
+        url = self.base_url + path
+
+        if not params:
+            params = {}
+
+        params.setdefault("key", self._apikey)
+        params.setdefault("token", self._token)
+
+        session = http.build_session()
+        resp = getattr(session, method.lower())(
+            url, params=params, json=data, timeout=self._timeout
+        )
+        resp.raise_for_status()
+        return json.loads(resp.content)
+
+    def get_organization_boards(self, org_id_or_name, fields=None):
+        return self._request(
+            path="/organizations/%s/boards" % (org_id_or_name), params={"fields": fields}
+        )
+
+    def get_organization_list(self, member_id_or_username, fields=None):
+        return self._request(
+            path="/members/%s/organizations" % (member_id_or_username), params={"fields": fields}
+        )
+
+    def get_board_list(self, board_id, fields=None):
+        return self._request(path="/boards/%s/lists" % (board_id), params={"fields": fields})
+
+    def new_card(self, name, idList, desc=None):
+        return self._request(
+            path="/cards", method="POST", data={"name": name, "idList": idList, "desc": desc}
+        )
+
+    def get_boards(self, member_id_or_username="me", fields=None):
+        return self._request(
+            path="/members/%s/boards" % member_id_or_username, params={"fields": fields}
+        )
+
+    def organizations_to_options(self, member_id_or_username="me"):
+        organizations = self.get_organization_list(member_id_or_username, fields="name")
+        options = tuple()
+        for org in organizations:
+            options += ((org["id"], org["name"]),)
+        return options
+
+    def boards_to_options(self, organization=None):
+        if organization:
+            boards = self.get_organization_boards(organization, fields="name")
+        else:
+            boards = self.get_boards(fields="name")
+        options = tuple()
+        for board in boards:
+            options += ((board["id"], board["name"]),)
+        return options

--- a/src/sentry_plugins/trello/plugin.py
+++ b/src/sentry_plugins/trello/plugin.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+from __future__ import absolute_import
+
+import sentry
+import six
+
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+from requests.exceptions import RequestException
+from sentry.plugins.base import JSONResponse
+from sentry.plugins.bases.issue import IssuePlugin, NewIssueForm
+from sentry.exceptions import PluginError
+from sentry.utils.http import absolute_uri
+
+from .client import TrelloClient
+
+SETUP_URL = (
+    "https://github.com/getsentry/sentry/blob/master/src/sentry_plugins/trello/HOW_TO_SETUP.md"
+)  # NOQA
+
+ISSUES_URL = "https://github.com/getsentry/sentry/issues"
+
+EMPTY = (("", "--"),)
+
+
+class TrelloError(Exception):
+    status_code = None
+
+    def __init__(self, response_text, status_code=None):
+        if status_code is not None:
+            self.status_code = status_code
+        self.text = response_text
+        super(TrelloError, self).__init__(response_text[:128])
+
+    @classmethod
+    def from_response(cls, response):
+        return cls(response.text, response.status_code)
+
+
+class TrelloUnauthorized(TrelloError):
+    status_code = 401
+
+
+class TrelloForm(NewIssueForm):
+    title = forms.CharField(
+        label=_("Title"), max_length=200, widget=forms.TextInput(attrs={"class": "span9"})
+    )
+    description = forms.CharField(
+        label=_("Description"), widget=forms.Textarea(attrs={"class": "span9"})
+    )
+    trello_board = forms.CharField(label=_("Board"), max_length=50)
+    trello_list = forms.CharField(label=_("List"), max_length=50)
+
+    def __init__(self, data=None, initial=None):
+        super(TrelloForm, self).__init__(data=data, initial=initial)
+        self.fields["trello_board"].widget = forms.Select(choices=EMPTY + initial.get("boards", ()))
+        self.fields["trello_list"].widget = forms.Select(
+            attrs={"disabled": True}, choices=initial.get("list", ())
+        )
+
+
+class TrelloPlugin(IssuePlugin):
+    author = "Damian Zaremba"
+    author_url = "https://sentry.io"
+    title = _("Trello")
+    description = _("Create Trello cards on exceptions.")
+    slug = "trello"
+
+    resource_links = [
+        (_("How do I configure this?"), SETUP_URL),
+        (_("Bug Tracker"), ISSUES_URL),
+        (_("Source"), "https://github.com/getsentry/sentry"),
+    ]
+
+    error_messages = {
+        "invalid_auth": _("Invalid credentials. Please check your key and token and try again."),
+        "api_failure": _("An unknown error occurred while fetching data from Trello."),
+    }
+
+    conf_title = title
+    conf_key = "trello"
+
+    version = sentry.VERSION
+    new_issue_form = TrelloForm
+    create_issue_template = "sentry/plugins/trello/create_trello_issue.html"
+    plugin_misconfigured_template = "sentry/plugins/trello/plugin_misconfigured.html"
+
+    def __init__(self):
+        super(TrelloPlugin, self).__init__()
+        self.client_errors = []
+        self.additial_fields = []
+
+    def _get_group_description(self, request, group, event):
+        """
+        Return group description in markdown-compatible format.
+
+        This overrides an internal method to IssuePlugin.
+        """
+        output = [absolute_uri(group.get_absolute_url())]
+        body = self._get_group_body(request, group, event)
+        if body:
+            output.extend(["", "\n".join("    " + line for line in body.splitlines())])
+        return "\n".join(output)
+
+    def is_configured(self, request, project, **kwargs):
+        return all((self.get_option(key, project) for key in ("key", "token")))
+
+    def has_project_conf(self):
+        return True
+
+    def get_client(self, project):
+        return TrelloClient(
+            apikey=self.get_option("key", project), token=self.get_option("token", project)
+        )
+
+    def view(self, request, group, **kwargs):
+        if request.is_ajax():
+            view = self.view_ajax
+        else:
+            view = super(TrelloPlugin, self).view
+        try:
+            return view(request, group, **kwargs)
+        except TrelloError as e:
+            if request.is_ajax():
+                return JSONResponse({})
+            return self.render(
+                self.plugin_misconfigured_template,
+                {"text": e.text, "title": self.get_new_issue_title()},
+            )
+
+    def view_ajax(self, request, group, **kwargs):
+        if request.GET.get("action", "") != "lists":
+            return JSONResponse({})
+        board_id = request.GET["board_id"]
+        trello = self.get_client(group.project)
+        lists = trello.get_board_list(board_id, fields="name")
+        return JSONResponse({"result": lists})
+
+    def get_initial_form_data(self, request, group, event, **kwargs):
+        # TODO(dcramer): token is a secret and should be treated like a password
+        # i.e. not returned into responses
+        initial = super(TrelloPlugin, self).get_initial_form_data(request, group, event, **kwargs)
+        trello = self.get_client(group.project)
+        organization = self.get_option("organization", group.project)
+        options = {}
+        if organization:
+            options["organization"] = organization
+        try:
+            boards = trello.boards_to_options(**options)
+        except RequestException as e:
+            resp = e.response
+            if not resp:
+                raise TrelloError("Internal Error")
+            if resp.status_code == 401:
+                raise TrelloUnauthorized.from_response(resp)
+            raise TrelloError.from_response(resp)
+
+        initial.update({"boards": boards})
+        return initial
+
+    def get_issue_label(self, group, issue_id, **kwargs):
+        iid, iurl = issue_id.split("/", 1)
+        return _("Trello-%s") % iid
+
+    def get_issue_url(self, group, issue_id, **kwargs):
+        iid, iurl = issue_id.split("/", 1)
+        return iurl
+
+    def get_new_issue_title(self, **kwargs):
+        return _("Create Trello Card")
+
+    def create_issue(self, request, group, form_data, **kwargs):
+        trello = self.get_client(group.project)
+        try:
+            card = trello.new_card(
+                name=form_data["title"],
+                desc=form_data["description"],
+                idList=form_data["trello_list"],
+            )
+        except RequestException as e:
+            raise forms.ValidationError(_("Error adding Trello card: %s") % six.text_type(e))
+
+        return "%s/%s" % (card["id"], card["url"])
+
+    def get_config(self, project, **kwargs):
+        def get_from_initial(initial, field):
+            return initial.get(field) or self.get_option(field, project)
+
+        initial = kwargs.get("initial") or {}
+        key_value = get_from_initial(initial, "key")
+
+        key = {
+            "name": "key",
+            "label": _("Trello API Key"),
+            "type": "text",
+            "required": True,
+            "default": key_value,
+        }
+        token = {
+            "name": "token",
+            "label": _("Trello API Token"),
+            "type": "secret",
+            "required": True,
+        }
+        token_value = get_from_initial(initial, "token")
+
+        if token_value:
+            token["has_saved_value"] = True
+            token["prefix"] = token_value[:6]
+            token["required"] = False
+
+        config = [key, token]
+
+        if key_value and token_value:
+            trello = TrelloClient(key_value, token_value)
+            organizations = tuple()
+            try:
+                organizations = trello.organizations_to_options()
+                organization_value = self.get_option("organization", project)
+                if not organization_value:
+                    organizations = EMPTY + organizations
+                if get_from_initial(initial, "organization") or kwargs.get("add_additial_fields"):
+                    config.append(
+                        {
+                            "name": "organization",
+                            "label": _("Trello Organization"),
+                            "type": "select",
+                            "choices": organizations,
+                            "default": organization_value,
+                            "required": True,
+                        }
+                    )
+            except RequestException as exc:
+                if exc.response is not None and exc.response.status_code == 401:
+                    self.client_errors.append(self.error_messages["invalid_auth"])
+                else:
+                    self.client_errors.append(self.error_messages["api_failure"])
+        return config
+
+    def validate_config(self, project, config, actor):
+        super(TrelloPlugin, self).validate_config(project, config, actor)
+        errors = self.client_errors
+        if errors:
+            self.reset_options(project=project)
+            self.client_errors = []
+            raise PluginError(errors[0])
+
+        return config

--- a/tests/sentry_plugins/trello/test_plugin.py
+++ b/tests/sentry_plugins/trello/test_plugin.py
@@ -1,0 +1,295 @@
+from __future__ import absolute_import
+
+import responses
+
+from django.core.urlresolvers import reverse
+from exam import fixture
+from sentry.models import GroupMeta, AuditLogEntry, AuditLogEntryEvent, ProjectOption
+from sentry.plugins.base import register, unregister
+from sentry.testutils import TestCase
+from sentry.utils import json
+from sentry.testutils.helpers.datetime import iso_format, before_now
+
+from sentry_plugins.trello.plugin import TrelloPlugin
+
+base_template_path = "sentry/plugins/"
+
+
+def show_response_error(response):
+    if response.context and "form" in response.context:
+        return dict(response.context["form"].errors)
+    return (response.status_code, response.content[:128].strip())
+
+
+def trello_mock():
+    # TODO(dcramer): we cannot currently assert on auth, which is pretty damned
+    # important
+
+    mock = responses.RequestsMock(assert_all_requests_are_fired=False)
+    mock.add(mock.GET, "https://trello.com/1/members/me/boards", json=[{"id": "1", "name": "Foo"}])
+    mock.add(
+        mock.POST,
+        "https://trello.com/1/cards",
+        json={"id": "2", "url": "https://example.trello.com/cards/2"},
+    )
+    mock.add(
+        mock.GET, "https://trello.com/1/members/me/organizations", json=[{"id": "3", "name": "Bar"}]
+    )
+
+    return mock
+
+
+class TrelloPluginTest(TestCase):
+    plugin_cls = TrelloPlugin
+
+    def setUp(self):
+        super(TrelloPluginTest, self).setUp()
+        register(self.plugin_cls)
+
+        min_ago = iso_format(before_now(minutes=1))
+        self.project = self.create_project()
+        self.event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "Hello world",
+                "timestamp": min_ago,
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+        self.group = self.event.group
+
+    def tearDown(self):
+        unregister(self.plugin_cls)
+        super(TrelloPluginTest, self).tearDown()
+
+    @fixture
+    def plugin(self):
+        return self.plugin_cls()
+
+    @fixture
+    def action_path(self):
+        project = self.project
+        return reverse(
+            "sentry-group-plugin-action",
+            kwargs={
+                "organization_slug": project.organization.slug,
+                "project_slug": project.slug,
+                "group_id": self.group.id,
+                "slug": self.plugin.slug,
+            },
+        )
+
+    @fixture
+    def configure_path(self):
+        project = self.project
+        return reverse(
+            "sentry-api-0-project-plugin-details",
+            kwargs={
+                "organization_slug": project.organization.slug,
+                "project_slug": project.slug,
+                "plugin_id": self.plugin.slug,
+            },
+        )
+
+    def test_create_issue_renders(self):
+        project = self.project
+        plugin = self.plugin
+
+        plugin.set_option("key", "foo", project)
+        plugin.set_option("token", "bar", project)
+
+        self.login_as(self.user)
+
+        with trello_mock(), self.options({"system.url-prefix": "http://example.com"}):
+            response = self.client.get(self.action_path)
+
+        assert response.status_code == 200, vars(response)
+        self.assertTemplateUsed(
+            response, "%strello/create_trello_issue.html" % (base_template_path)
+        )
+
+    def test_create_issue_saves(self):
+        project = self.project
+        plugin = self.plugin
+
+        plugin.set_option("key", "foo", project)
+        plugin.set_option("token", "bar", project)
+
+        self.login_as(self.user)
+
+        with trello_mock() as mock:
+            response = self.client.post(
+                self.action_path,
+                {
+                    "title": "foo",
+                    "description": "A ticket description",
+                    "trello_board": "1",
+                    "trello_list": "15",
+                },
+            )
+
+            assert response.status_code == 302, show_response_error(response)
+            meta = GroupMeta.objects.get(group=self.group, key="trello:tid")
+            assert meta.value == "2/https://example.trello.com/cards/2"
+
+            trello_request = mock.calls[-1].request
+            assert trello_request.url == "https://trello.com/1/cards?token=bar&key=foo"
+            assert json.loads(trello_request.body) == {
+                "desc": "A ticket description",
+                "idList": "15",
+                "name": "foo",
+            }
+
+    def test_can_get_config(self):
+        self.login_as(user=self.user)
+        response = self.client.get(self.configure_path)
+        assert response.status_code == 200
+        assert response.data["id"] == "trello"
+        assert response.data["config"] == [
+            {
+                "readonly": False,
+                "choices": None,
+                "placeholder": None,
+                "name": u"key",
+                "help": None,
+                "defaultValue": None,
+                "required": True,
+                "type": "text",
+                "value": None,
+                "label": u"Trello API Key",
+            },
+            {
+                "help": None,
+                "prefix": "",
+                "label": u"Trello API Token",
+                "placeholder": None,
+                "name": u"token",
+                "defaultValue": None,
+                "required": True,
+                "hasSavedValue": False,
+                "value": None,
+                "choices": None,
+                "readonly": False,
+                "type": "secret",
+            },
+        ]
+
+    def test_can_get_config_with_options(self):
+        project = self.project
+        plugin = self.plugin
+
+        plugin.set_option("key", "foo", project)
+        plugin.set_option("token", "bar", project)
+
+        self.login_as(self.user)
+
+        with trello_mock():
+            response = self.client.get(self.configure_path)
+        assert response.status_code == 200
+        assert response.data["id"] == "trello"
+        assert response.data["config"] == [
+            {
+                "readonly": False,
+                "choices": None,
+                "placeholder": None,
+                "name": u"key",
+                "help": None,
+                "defaultValue": u"foo",
+                "required": True,
+                "type": "text",
+                "value": u"foo",
+                "label": u"Trello API Key",
+            },
+            {
+                "help": None,
+                "prefix": u"bar",
+                "label": u"Trello API Token",
+                "placeholder": None,
+                "name": u"token",
+                "defaultValue": None,
+                "required": False,
+                "hasSavedValue": True,
+                "value": None,
+                "choices": None,
+                "readonly": False,
+                "type": "secret",
+            },
+            {
+                "readonly": False,
+                "choices": (("", "--"), ("3", "Bar")),
+                "placeholder": None,
+                "name": u"organization",
+                "help": None,
+                "defaultValue": None,
+                "required": True,
+                "type": "select",
+                "value": None,
+                "label": u"Trello Organization",
+            },
+        ]
+
+    def test_can_enable_plugin(self):
+        self.login_as(user=self.user)
+        self.plugin.disable(self.project)
+
+        audit = AuditLogEntry.objects.filter(target_object=self.project.id)
+        assert not audit
+
+        response = self.client.post(self.configure_path)
+        audit = AuditLogEntry.objects.get(target_object=self.project.id)
+        assert audit.event == AuditLogEntryEvent.INTEGRATION_ADD
+        assert response.status_code == 201, (response.status_code, response.content)
+
+        assert ProjectOption.objects.get(key="trello:enabled", project=self.project).value is True
+        audit.delete()
+
+    def test_can_disable_plugin(self):
+        self.login_as(user=self.user)
+        self.plugin.enable(self.project)
+
+        audit = AuditLogEntry.objects.filter(target_object=self.project.id)
+        assert not audit
+
+        response = self.client.delete(self.configure_path)
+        audit = AuditLogEntry.objects.get(target_object=self.project.id)
+        assert audit.event == AuditLogEntryEvent.INTEGRATION_REMOVE
+        assert response.status_code == 204, (response.status_code, response.content)
+
+        assert ProjectOption.objects.get(key="trello:enabled", project=self.project).value is False
+        audit.delete()
+
+    @responses.activate
+    def test_create_issue_with_fetch_errors(self):
+        project = self.project
+        plugin = self.plugin
+
+        plugin.set_option("key", "foo", project)
+        plugin.set_option("token", "bar", project)
+
+        self.login_as(self.user)
+
+        response = self.client.get(self.action_path)
+
+        assert response.status_code == 200, vars(response)
+        self.assertTemplateUsed(
+            response, "%strello/plugin_misconfigured.html" % (base_template_path)
+        )
+
+    def test_configure_saves_options(self):
+        self.login_as(self.user)
+        with trello_mock():
+            response = self.client.put(
+                self.configure_path,
+                content_type="application/json",
+                data=json.dumps(
+                    {"plugin": "trello", "token": "foo", "key": "bar", "organization": None}
+                ),
+            )
+        assert response.status_code == 200, show_response_error(response)
+
+        project = self.project
+        plugin = self.plugin
+        assert plugin.get_option("token", project) == "foo"
+        assert plugin.get_option("key", project) == "bar"


### PR DESCRIPTION
I had a problem with the loading the templates in tests when they were inside the trello plugin directory (src/sentry_plugins/trello/templates/trello) even though it worked just fine when running the application. As a result, I put them in a different location (src/sentry/templates/sentry/plugins/trello). I would prefer not to do this but I already spent almost 2 hours debugging this and I didn't think it made sense to spend more time when there was an easy alternative.