### PR TITLE
fix(organization-option): Switch to threading cache - WIP

### DIFF
--- a/src/sentry/models/organizationoption.py
+++ b/src/sentry/models/organizationoption.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, print_function
 
-from celery.signals import task_postrun
-from django.core.signals import request_finished
 from django.db import models
 
 from sentry.db.models import Model, FlexibleForeignKey, sane_repr
@@ -11,19 +9,9 @@ from sentry.utils.cache import cache
 
 
 class OrganizationOptionManager(BaseManager):
-    def __init__(self, *args, **kwargs):
-        super(OrganizationOptionManager, self).__init__(*args, **kwargs)
-        self.__cache = {}
-
-    def __getstate__(self):
-        d = self.__dict__.copy()
-        # we cant serialize weakrefs
-        d.pop("_OrganizationOptionManager__cache", None)
-        return d
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
-        self.__cache = {}
+    def _get_local_cache(self):
+        with BaseManager.local_cache():
+            return super(OrganizationOptionManager, self)._get_local_cache()
 
     def _make_key(self, instance_id):
         assert instance_id
@@ -59,23 +47,21 @@ class OrganizationOptionManager(BaseManager):
         else:
             organization_id = organization
 
-        if organization_id not in self.__cache:
+        local_cache = self._get_local_cache()
+        if organization_id not in local_cache:
             cache_key = self._make_key(organization_id)
             result = cache.get(cache_key)
             if result is None:
                 result = self.reload_cache(organization_id)
             else:
-                self.__cache[organization_id] = result
-        return self.__cache.get(organization_id, {})
-
-    def clear_local_cache(self, **kwargs):
-        self.__cache = {}
+                local_cache[organization_id] = result
+        return local_cache.get(organization_id, {})
 
     def reload_cache(self, organization_id):
         cache_key = self._make_key(organization_id)
         result = dict((i.key, i.value) for i in self.filter(organization=organization_id))
         cache.set(cache_key, result)
-        self.__cache[organization_id] = result
+        self._get_local_cache()[organization_id] = result
         return result
 
     def post_save(self, instance, **kwargs):
@@ -86,8 +72,6 @@ class OrganizationOptionManager(BaseManager):
 
     def contribute_to_class(self, model, name):
         super(OrganizationOptionManager, self).contribute_to_class(model, name)
-        task_postrun.connect(self.clear_local_cache)
-        request_finished.connect(self.clear_local_cache)
 
 
 class OrganizationOption(Model):

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -243,9 +243,9 @@ def pytest_runtest_teardown(item):
 
     discard_all()
 
-    from sentry.models import OrganizationOption, ProjectOption, UserOption
+    from sentry.models import ProjectOption, UserOption
 
-    for model in (OrganizationOption, ProjectOption, UserOption):
+    for model in (ProjectOption, UserOption):
         model.objects.clear_local_cache()
 
     Hub.main.bind_client(None)


### PR DESCRIPTION
- Since we can't rely on manager object caching in Django 1.10 moving to
  using the threading.local cache [can read more here](https://github.com/getsentry/sentry/blob/master/src/sentry/db/models/manager.py#L70)
- I'm not sure if removing the signals that wipe this cache is the right
  thing to do. I'm pretty sure that since the cache is on the thread now
  postrun/request finished ends the thread already.
- This is currently WIP, just looking to see if all tests pass, and get
  feedback if this is the right thing to do. There seems to be other
  Options models that this shoudl be done to.