### PR TITLE
feat(discover2) Add public fields to discover for tracing

### DIFF
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -209,6 +209,28 @@ class Columns(Enum):
     TRANSACTION_STATUS = Column(
         None, None, "transaction_status", "transaction_status", "transaction.status"
     )
+    # Tracing context fields.
+    TRACE_ID = Column(
+        "events.contexts[trace.trace_id]",
+        "contexts[trace.trace_id]",
+        "trace_id",
+        "contexts[trace.trace_id]",
+        "trace",
+    )
+    SPAN_ID = Column(
+        "events.contexts[trace.span_id]",
+        "contexts[trace.span_id]",
+        "span_id",
+        "contexts[trace.span_id]",
+        "trace.span",
+    )
+    PARENT_SPAN_ID = Column(
+        None,
+        None,
+        "contexts[trace.parent_span_id]",
+        "contexts[trace.parent_span_id]",
+        "trace.parent_span",
+    )
 
 
 def get_columns_from_aliases(aliases):

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -213,14 +213,14 @@ class Columns(Enum):
     TRACE_ID = Column(
         "events.contexts[trace.trace_id]",
         "contexts[trace.trace_id]",
-        "trace_id",
+        "contexts[trace.trace_id]",
         "contexts[trace.trace_id]",
         "trace",
     )
     SPAN_ID = Column(
         "events.contexts[trace.span_id]",
         "contexts[trace.span_id]",
-        "span_id",
+        "contexts[trace.span_id]",
         "contexts[trace.span_id]",
         "trace.span",
     )

--- a/tests/acceptance/test_create_project.py
+++ b/tests/acceptance/test_create_project.py
@@ -23,7 +23,6 @@ class CreateProjectTest(AcceptanceTestCase):
         self.browser.snapshot(name="create project")
 
         self.browser.click('[data-test-id="create-project"]')
-        self.browser.wait_until(title="java")
         self.browser.wait_until_not(".loading")
 
         project = Project.objects.get(organization=self.org)

--- a/tests/acceptance/test_create_project.py
+++ b/tests/acceptance/test_create_project.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from sentry.testutils import AcceptanceTestCase
 from sentry.models import Project
+from mock import patch
 
 
 class CreateProjectTest(AcceptanceTestCase):
@@ -13,9 +14,11 @@ class CreateProjectTest(AcceptanceTestCase):
 
         self.path = u"/organizations/{}/projects/new/".format(self.org.slug)
 
-    def test_simple(self):
+    @patch("django.db.models.signals.ModelSignal.send")
+    def test_simple(self, mock_signal):
         self.team = self.create_team(organization=self.org, name="Mariachi Band")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
+
         self.browser.get(self.path)
         self.browser.wait_until_not(".loading")
 
@@ -24,6 +27,7 @@ class CreateProjectTest(AcceptanceTestCase):
 
         self.browser.click('[data-test-id="create-project"]')
         self.browser.wait_until_not(".loading")
+        self.browser.wait_until("#installation")
 
         project = Project.objects.get(organization=self.org)
         assert project.name == "Java"


### PR DESCRIPTION
I've not added the new fields to the query builder as I don't think they are that useful to end user result sets. I've opted to go with the `trace` prefix as that matches the tags we're currently generating and the name of the context in the raw event payloads.