### PR TITLE
fix(mobile): Scrolling is stuck on small devices

### DIFF
--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -454,6 +454,7 @@ footer {
 
   .app {
     overflow-x: hidden;
+    overflow-y: hidden;
   }
 
   .messages-container {


### PR DESCRIPTION
- On small devices this element gets it own scrollbar, which means that
  you can't scroll the page until the smaller element gets scrolled.
  Giving the feeling that the page is "stuck"
- Fixes ISSUE-624

Current Production:
![Production](https://user-images.githubusercontent.com/4205004/70281264-9b7ef000-1788-11ea-9ce2-7966e86f0aa3.gif)

With this change:
![new](https://user-images.githubusercontent.com/4205004/70281285-ae91c000-1788-11ea-8e42-694090541a20.gif)
