### PR TITLE
fix(ui): Fix loading some metric alert rules [SEN-1240]

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/details.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/details.tsx
@@ -29,6 +29,13 @@ class IncidentRulesDetails extends AsyncView<
   RouteComponentProps<RouteParams, {}> & Props,
   State
 > {
+  getDefaultState() {
+    return {
+      ...super.getDefaultState(),
+      actions: new Map(),
+    };
+  }
+
   getEndpoints() {
     const {orgId, incidentRuleId} = this.props.params;
 
@@ -58,9 +65,9 @@ class IncidentRulesDetails extends AsyncView<
       });
 
       const actionsTriggersTuples: [string, any][] = await Promise.all(resp);
-      this.setState(() => ({
+      this.setState({
         actions: new Map(actionsTriggersTuples),
-      }));
+      });
     } catch (_err) {
       addErrorMessage(t('Unable to fetch actions'));
     }


### PR DESCRIPTION
`this.state.actions` was improperly initialized.

Fixes SEN-1240
Fixes JAVASCRIPT-20Y9