### PR TITLE
test: Refactor some tests to use store_event

### DIFF
--- a/tests/sentry/tasks/test_servicehooks.py
+++ b/tests/sentry/tasks/test_servicehooks.py
@@ -2,8 +2,9 @@ from __future__ import absolute_import
 
 from mock import patch
 
-from sentry.testutils import TestCase
 from sentry.tasks.servicehooks import get_payload_v0, process_service_hook
+from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.testutils.helpers.faux import faux
 from sentry.utils import json
 
@@ -32,7 +33,10 @@ class TestServiceHooks(TestCase):
         import hmac
         from hashlib import sha256
 
-        event = self.create_event(project=self.project)
+        event = self.store_event(
+            data={"timestamp": iso_format(before_now(minutes=1))}, project_id=self.project.id
+        )
+
         process_service_hook(self.hook.id, event)
 
         body = json.dumps(get_payload_v0(event))
@@ -47,7 +51,9 @@ class TestServiceHooks(TestCase):
     def test_event_created_sends_service_hook(self, safe_urlopen):
         self.hook.update(events=["event.created", "event.alert"])
 
-        event = self.create_event(project=self.project)
+        event = self.store_event(
+            data={"timestamp": iso_format(before_now(minutes=1))}, project_id=self.project.id
+        )
 
         process_service_hook(self.hook.id, event)
 
@@ -66,7 +72,9 @@ class TestServiceHooks(TestCase):
         )
 
     def test_v0_payload(self):
-        event = self.create_event(project=self.project)
+        event = self.store_event(
+            data={"timestamp": iso_format(before_now(minutes=1))}, project_id=self.project.id
+        )
 
         process_service_hook(self.hook.id, event)
         body = get_payload_v0(event)

--- a/tests/sentry_plugins/amazon_sqs/test_plugin.py
+++ b/tests/sentry_plugins/amazon_sqs/test_plugin.py
@@ -29,16 +29,14 @@ class AmazonSQSPluginTest(PluginTestCase):
             "queue_url", "https://sqs-us-east-1.amazonaws.com/12345678/myqueue", self.project
         )
 
-        group = self.create_group(message="Hello world", culprit="foo.bar")
-        event = self.create_event(
-            group=group,
+        event = self.store_event(
             data={
                 "sentry.interfaces.Exception": {"type": "ValueError", "value": "foo bar"},
                 "sentry.interfaces.User": {"id": "1", "email": "foo@example.com"},
                 "type": "error",
                 "metadata": {"type": "ValueError", "value": "foo bar"},
             },
-            tags={"level": "warning"},
+            project_id=self.project.id,
         )
 
         with self.options({"system.url-prefix": "http://example.com"}):
@@ -75,8 +73,7 @@ class AmazonSQSPluginTest(PluginTestCase):
         self.run_test()
         assert len(logger.info.call_args_list) == 1
         assert (
-            logger.info.call_args_list[0][0][0]
-            == "sentry_plugins.amazon_sqs.access_token_invalid"
+            logger.info.call_args_list[0][0][0] == "sentry_plugins.amazon_sqs.access_token_invalid"
         )
 
     @patch("sentry_plugins.amazon_sqs.plugin.logger")


### PR DESCRIPTION
create_event is deprecated however migrating all occurences of it
will take some time.

These are the tests that will need to be refactored for
https://github.com/getsentry/sentry/pull/15593/