### PR TITLE
fix(opsgenie): event.get_tags() -> event.tags

### DIFF
--- a/src/sentry_plugins/opsgenie/plugin.py
+++ b/src/sentry_plugins/opsgenie/plugin.py
@@ -78,7 +78,7 @@ class OpsGeniePlugin(notify.NotificationPlugin):
 
         payload["tags"] = [
             "%s:%s" % (six.text_type(x).replace(",", ""), six.text_type(y).replace(",", ""))
-            for x, y in event.get_tags()
+            for x, y in event.tags
         ]
 
         return payload


### PR DESCRIPTION
event.get_tags() has been deprecated and removed