### PR TITLE
feat(django 1.10): continue to let inactive/soft-deleted users authenticate

### DIFF
--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -298,3 +298,10 @@ class EmailAuthBackend(ModelBackend):
                 except ValueError:
                     continue
         return None
+
+    # TODO(joshuarli): When we're fully on Django 1.10, we should switch to
+    # subclassing AllowAllUsersModelBackend (this isn't available in 1.9 and
+    # simply overriding user_can_authenticate here is a lot less verbose than
+    # conditionally importing).
+    def user_can_authenticate(self, user):
+        return True

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -425,7 +425,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         # setup a 'previous' identity, such as when we migrated Google from
         # the old idents to the new
-        user = self.create_user("bar@example.com", is_managed=True)
+        user = self.create_user("bar@example.com", is_managed=True, is_active=False)
         auth_identity = AuthIdentity.objects.create(
             auth_provider=auth_provider, user=user, ident="bar@example.com"
         )
@@ -580,14 +580,14 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         # setup a 'previous' identity, such as when we migrated Google from
         # the old idents to the new
-        user = self.create_user("bar@example.com", is_managed=True)
+        user = self.create_user("bar@example.com", is_managed=True, is_active=False)
         identity1 = AuthIdentity.objects.create(
             auth_provider=auth_provider, user=user, ident="bar@example.com"
         )
 
         # create another identity which is used, but not by the authenticating
         # user
-        user2 = self.create_user("adfadsf@example.com", is_managed=True)
+        user2 = self.create_user("adfadsf@example.com", is_managed=True, is_active=False)
         identity2 = AuthIdentity.objects.create(
             auth_provider=auth_provider, user=user2, ident="adfadsf@example.com"
         )

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -425,7 +425,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         # setup a 'previous' identity, such as when we migrated Google from
         # the old idents to the new
-        user = self.create_user("bar@example.com", is_active=False, is_managed=True)
+        user = self.create_user("bar@example.com", is_managed=True)
         auth_identity = AuthIdentity.objects.create(
             auth_provider=auth_provider, user=user, ident="bar@example.com"
         )
@@ -480,7 +480,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         # setup a 'previous' identity, such as when we migrated Google from
         # the old idents to the new
-        user = self.create_user("bar@example.com", is_active=False, is_managed=True)
+        user = self.create_user("bar@example.com", is_managed=True)
         AuthIdentity.objects.create(auth_provider=auth_provider, user=user, ident="bar@example.com")
 
         # they must be a member for the auto merge to happen
@@ -543,7 +543,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         # setup a 'previous' identity, such as when we migrated Google from
         # the old idents to the new
-        user = self.create_user("bar@example.com", is_active=False, is_managed=True)
+        user = self.create_user("bar@example.com", is_managed=True)
         AuthIdentity.objects.create(auth_provider=auth_provider, user=user, ident="bar@example.com")
 
         # user needs to be logged in
@@ -580,14 +580,14 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         # setup a 'previous' identity, such as when we migrated Google from
         # the old idents to the new
-        user = self.create_user("bar@example.com", is_active=False, is_managed=True)
+        user = self.create_user("bar@example.com", is_managed=True)
         identity1 = AuthIdentity.objects.create(
             auth_provider=auth_provider, user=user, ident="bar@example.com"
         )
 
         # create another identity which is used, but not by the authenticating
         # user
-        user2 = self.create_user("adfadsf@example.com", is_active=False, is_managed=True)
+        user2 = self.create_user("adfadsf@example.com", is_managed=True)
         identity2 = AuthIdentity.objects.create(
             auth_provider=auth_provider, user=user2, ident="adfadsf@example.com"
         )


### PR DESCRIPTION
From https://docs.djangoproject.com/en/1.10/releases/1.10/#django-contrib-auth:

	The new AllowAllUsersModelBackend and AllowAllUsersRemoteUserBackend ignore the value of User.is_active, while ModelBackend and RemoteUserBackend now reject inactive users.

We use `is_active` as a soft delete (see `src/sentry/templates/sentry/reactivate-account.html`), so we don't want this behavior. Under 1.10 we'd like to use `AllowAllUsersModelBackend`. Unfortunately this is only added in 1.10. But rather than add some verbose conditional imports, overriding the `user_can_authenticate` is much cleaner. In 1.10, this is literally the entire new thing:

```
class AllowAllUsersModelBackend(ModelBackend):
    def user_can_authenticate(self, user):
        return True
```

Now, just to be sure... from https://docs.djangoproject.com/en/1.10/ref/contrib/auth/#django.contrib.auth.models.User.is_active:

    You can use AllowAllUsersModelBackend or AllowAllUsersRemoteUserBackend if you want to allow inactive users to login.

	In this case, you’ll also want to customize the AuthenticationForm used by the LoginView as it rejects inactive users.

	Be aware that the permission-checking methods such as has_perm() and the authentication in the Django admin all return False for inactive users.

For `AuthenticationForm`, we roll our own in `sentry.web.forms.accounts` and it doesn't look like we reject inactive users (cause we use it as soft delete). In fact, I think we could remove the error_message `"inactive": _("This account is inactive."),` since it doesn't seem to be referenced anywhere.

For `has_perm`, we roll our own in `sentry.models.user.User`. Our `has_perm` seems fine (and it doesn't seem like we use it at all anymore):

```
    def has_perm(self, perm_name):
        warnings.warn("User.has_perm is deprecated", DeprecationWarning)
        return self.is_superuser
```

Finally, I noticed that we had `is_active=False` all over `tests/sentry/web/frontend/test_auth_organization_login.py`, which feels like a copypaste. Only the test `test_flow_as_unauthenticated_existing_inactive_user_with_merge_and_existing_identity` mentions inactive user, so for all the other tests I removed `is_active` (defaults to True). In 
6f36c96a0b0e67de8a39333af90b39d14c0b8768 I added false back since it was causing tests to fail - I tried to understand why, but then it was taking too much time and I was observing the same exact behavior on Django 1.9 master if I flipped it to true in the problematic tests.
