### PR TITLE
fix(ui): Fix "Slack" action configuration for metric alerts [SEN-1239]

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -9,6 +9,7 @@ import {removeAtArrayIndex} from 'app/utils/removeAtArrayIndex';
 import {replaceAtArrayIndex} from 'app/utils/replaceAtArrayIndex';
 import {t} from 'app/locale';
 import DeleteActionButton from 'app/views/settings/incidentRules/triggers/actionsPanel/deleteActionButton';
+import Input from 'app/views/settings/components/forms/controls/input';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import PanelSubHeader from 'app/views/settings/incidentRules/triggers/panelSubHeader';
 import SelectControl from 'app/components/forms/selectControl';
@@ -43,6 +44,16 @@ type Props = {
 };
 
 class ActionsPanel extends React.PureComponent<Props> {
+  doChangeTargetIdentifier(index: number, value: string) {
+    const {actions, onChange} = this.props;
+    const newAction = {
+      ...actions[index],
+      targetIdentifier: value,
+    };
+
+    onChange(replaceAtArrayIndex(actions, index, newAction));
+  }
+
   handleAddAction = (value: {label: string; value: Action['type']}) => {
     this.props.onAdd(value.value);
   };
@@ -63,14 +74,15 @@ class ActionsPanel extends React.PureComponent<Props> {
     onChange(replaceAtArrayIndex(actions, index, newAction));
   };
 
-  handleChangeTargetIdentifier = (index: number, value) => {
-    const {actions, onChange} = this.props;
-    const newAction = {
-      ...actions[index],
-      targetIdentifier: value.value,
-    };
+  handleChangeTargetIdentifier = (index: number, value: SelectValue<string>) => {
+    this.doChangeTargetIdentifier(index, value.value);
+  };
 
-    onChange(replaceAtArrayIndex(actions, index, newAction));
+  handleChangeSpecificTargetIdentifier = (
+    index: number,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    this.doChangeTargetIdentifier(index, e.target.value);
   };
 
   render() {
@@ -107,20 +119,24 @@ class ActionsPanel extends React.PureComponent<Props> {
                 <PanelItemGrid key={i}>
                   {ActionLabel[action.type]}
 
-                  <SelectControl
-                    disabled={loading}
-                    value={action.targetType}
-                    options={
-                      availableAction &&
-                      availableAction.allowedTargetTypes.map(allowedType => ({
-                        value: allowedType,
-                        label: TargetLabel[allowedType],
-                      }))
-                    }
-                    onChange={this.handleChangeTarget.bind(this, i)}
-                  />
+                  {availableAction && availableAction.allowedTargetTypes.length > 1 ? (
+                    <SelectControl
+                      disabled={loading}
+                      value={action.targetType}
+                      options={
+                        availableAction &&
+                        availableAction.allowedTargetTypes.map(allowedType => ({
+                          value: allowedType,
+                          label: TargetLabel[allowedType],
+                        }))
+                      }
+                      onChange={this.handleChangeTarget.bind(this, i)}
+                    />
+                  ) : (
+                    <span />
+                  )}
 
-                  {(isUser || isTeam) && (
+                  {isUser || isTeam ? (
                     <SelectMembers
                       key={isTeam ? 'team' : 'member'}
                       showTeam={isTeam}
@@ -128,6 +144,13 @@ class ActionsPanel extends React.PureComponent<Props> {
                       organization={organization}
                       value={action.targetIdentifier}
                       onChange={this.handleChangeTargetIdentifier.bind(this, i)}
+                    />
+                  ) : (
+                    <Input
+                      key={action.type}
+                      value={action.targetIdentifier}
+                      onChange={this.handleChangeSpecificTargetIdentifier.bind(this, i)}
+                      placeholder="Channel or user i.e. #critical"
                     />
                   )}
                   <DeleteActionButton index={i} onClick={this.handleDeleteAction} />

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
@@ -13,13 +13,7 @@ import ThresholdControl from 'app/views/settings/incidentRules/triggers/threshol
 import withApi from 'app/utils/withApi';
 import withConfig from 'app/utils/withConfig';
 
-import {
-  AlertRuleThreshold,
-  Trigger,
-  Action,
-  TargetType,
-  ThresholdControlValue,
-} from '../types';
+import {AlertRuleThreshold, Trigger, Action, ThresholdControlValue} from '../types';
 
 type AlertRuleThresholdKey = {
   [AlertRuleThreshold.INCIDENT]: 'alertThreshold';
@@ -206,14 +200,21 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
   };
 
   handleAddAction = (value: Action['type']) => {
-    const {onChange, trigger, triggerIndex} = this.props;
+    const {onChange, trigger, triggerIndex, availableActions} = this.props;
+    const actionConfig =
+      availableActions && availableActions.find(({type}) => type === value);
     const actions = [
       ...trigger.actions,
       {
         type: value,
-        targetType: TargetType.USER,
-        targetIdentifier: null,
-      },
+        targetType:
+          actionConfig &&
+          actionConfig.allowedTargetTypes &&
+          actionConfig.allowedTargetTypes.length > 0
+            ? actionConfig.allowedTargetTypes[0]
+            : null,
+        targetIdentifier: '',
+      } as Action,
     ];
     onChange(triggerIndex, {...trigger, actions});
   };

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -91,7 +91,7 @@ export type Action = {
   id?: string;
   type: ActionType;
 
-  targetType: TargetType;
+  targetType: TargetType | null;
 
   // How to identify the target. Can be email, slack channel, pagerduty service, user_id, team_id, etc
   targetIdentifier: string | null;

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -159,7 +159,7 @@ describe('Incident Rules Details', function() {
             expect.objectContaining({
               actions: [
                 {
-                  targetIdentifier: null,
+                  targetIdentifier: '',
                   targetType: 'user',
                   type: 'email',
                 },


### PR DESCRIPTION
This fixes the default target type to use value from "available actions" instead of always using "user". Adds UI for "specific" target type.

Currently hardcoded placeholder for input field.

Fixes SEN-1239