### PR TITLE
fix(glob): Allow newlines in glob by default to match old behavior

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -67,7 +67,7 @@ redis>=2.10.3,<2.10.6
 requests-oauthlib==0.3.3
 requests[security]>=2.20.0,<2.21.0
 selenium==3.141.0
-semaphore>=0.4.62,<0.5.0
+semaphore>=0.4.64,<0.5.0
 sentry-sdk>=0.13.5
 setproctitle>=1.1.7,<1.2.0
 simplejson>=3.2.0,<3.9.0

--- a/src/sentry/utils/glob.py
+++ b/src/sentry/utils/glob.py
@@ -3,7 +3,9 @@ from __future__ import absolute_import
 import semaphore
 
 
-def glob_match(value, pat, doublestar=False, ignorecase=False, path_normalize=False):
+def glob_match(
+    value, pat, doublestar=False, ignorecase=False, path_normalize=False, allow_newline=True
+):
     """A beefed up version of fnmatch.fnmatch"""
     return semaphore.is_glob_match(
         value,
@@ -11,4 +13,5 @@ def glob_match(value, pat, doublestar=False, ignorecase=False, path_normalize=Fa
         double_star=doublestar,
         case_insensitive=ignorecase,
         path_normalize=path_normalize,
+        allow_newline=allow_newline,
     )

--- a/tests/sentry/event_manager/interfaces/snapshots/test_breadcrumbs/test_non_string_keys.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_breadcrumbs/test_non_string_keys.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-05-27T14:36:16.428735Z'
+created: '2019-12-06T10:30:09.462695Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_breadcrumbs.py
 ---
@@ -10,5 +10,5 @@ to_json:
       extra:
         foo: bar
     level: info
-    timestamp: 1458857193.973
+    timestamp: 1458857193.973275
     type: message

--- a/tests/sentry/event_manager/interfaces/snapshots/test_breadcrumbs/test_simple.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_breadcrumbs/test_simple.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:34.819147Z'
+created: '2019-12-06T10:30:09.416213Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_breadcrumbs.py
 ---
@@ -9,5 +9,5 @@ to_json:
   - data:
       message: Whats up dawg?
     level: info
-    timestamp: 1458857193.973
+    timestamp: 1458857193.973275
     type: message

--- a/tests/sentry/event_manager/interfaces/snapshots/test_breadcrumbs/test_string_data.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_breadcrumbs/test_string_data.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2019-03-14T17:12:34.886186Z'
+created: '2019-12-06T10:30:09.470614Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_breadcrumbs.py
 ---
@@ -11,5 +11,5 @@ errors:
 to_json:
   values:
   - level: info
-    timestamp: 1458857193.973
+    timestamp: 1458857193.973275
     type: message

--- a/tests/sentry/utils/test_glob.py
+++ b/tests/sentry/utils/test_glob.py
@@ -6,15 +6,16 @@ from sentry.utils.glob import glob_match
 
 
 class GlobInput(object):
-    def __init__(self, value, pat, doublestar=False, ignorecase=False, path_normalize=False):
+    def __init__(self, value, pat, **kwargs):
         self.value = value
         self.pat = pat
-        self.doublestar = doublestar
-        self.ignorecase = ignorecase
-        self.path_normalize = path_normalize
+        self.kwargs = kwargs
 
     def __call__(self):
-        return glob_match(**self.__dict__)
+        return glob_match(self.value, self.pat, **self.kwargs)
+
+    def __repr__(self):
+        return "<GlobInput %r>" % (self.__dict__,)
 
 
 @pytest.mark.parametrize(
@@ -45,6 +46,8 @@ class GlobInput(object):
             ),
             True,
         ],
+        [GlobInput("foo:\nbar", "foo:*"), True],
+        [GlobInput("foo:\nbar", "foo:*", allow_newline=False), False],
     ],
 )
 def test_glob_match(glob_input, expect):


### PR DESCRIPTION
This resolves a regression with custom server side fingerprinting.