### PR TITLE
feat(ui): Change color and lineheight for `<RadioGroup>` description [SEN-1228]

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/radioGroup.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/radioGroup.tsx
@@ -119,9 +119,9 @@ const RadioLineText = styled('div', {shouldForwardProp})<{disabled?: boolean}>`
 `;
 
 const Description = styled('div')`
-  color: ${p => p.theme.gray1};
+  color: ${p => p.theme.gray2};
   font-size: ${p => p.theme.fontSizeRelativeSmall};
-  line-height: 1.25em;
+  line-height: 1.4em;
 `;
 
 export default RadioGroup;


### PR DESCRIPTION
This changes the color of `<RadioGroup>` description to be darker and increases line-height as well.

New:
![image](https://user-images.githubusercontent.com/79684/70339310-7aa7b080-1803-11ea-8113-9db9c86e7e1d.png)

Old:
![image](https://user-images.githubusercontent.com/79684/70339361-901cda80-1803-11ea-98ca-6288c28a55cb.png)


Fixes SEN-1228