### PR TITLE
feat(ui): Make Metric Alert chart work again [SEN-1226]

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -25,7 +25,6 @@ type Props = {
   query: IncidentRule['query'];
   timeWindow: IncidentRule['timeWindow'];
   aggregations: IncidentRule['aggregations'];
-  triggers: Trigger[];
 
   isInverted?: boolean;
   alertThreshold?: number | null;
@@ -49,7 +48,6 @@ class TriggersChart extends React.PureComponent<Props> {
       timeWindow,
       query,
       aggregations,
-      triggers,
     } = this.props;
 
     return (
@@ -99,7 +97,6 @@ class TriggersChart extends React.PureComponent<Props> {
                       resolveThreshold={resolveThreshold}
                       isInverted={isInverted}
                       data={timeseriesData}
-                      triggers={triggers}
                     />
                   </React.Fragment>
                 )}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -13,7 +13,7 @@ import LoadingMask from 'app/components/loadingMask';
 import Placeholder from 'app/components/placeholder';
 import space from 'app/styles/space';
 
-import {AlertRuleAggregations, IncidentRule, TimeWindow} from '../../types';
+import {AlertRuleAggregations, IncidentRule, TimeWindow, Trigger} from '../../types';
 import ThresholdsChart from './thresholdsChart';
 
 type Props = {
@@ -25,6 +25,7 @@ type Props = {
   query: IncidentRule['query'];
   timeWindow: IncidentRule['timeWindow'];
   aggregations: IncidentRule['aggregations'];
+  triggers: Trigger[];
 
   isInverted?: boolean;
   alertThreshold?: number | null;
@@ -48,6 +49,7 @@ class TriggersChart extends React.PureComponent<Props> {
       timeWindow,
       query,
       aggregations,
+      triggers,
     } = this.props;
 
     return (
@@ -97,6 +99,7 @@ class TriggersChart extends React.PureComponent<Props> {
                       resolveThreshold={resolveThreshold}
                       isInverted={isInverted}
                       data={timeseriesData}
+                      triggers={triggers}
                     />
                   </React.Fragment>
                 )}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -13,7 +13,7 @@ import LoadingMask from 'app/components/loadingMask';
 import Placeholder from 'app/components/placeholder';
 import space from 'app/styles/space';
 
-import {AlertRuleAggregations, IncidentRule, TimeWindow, Trigger} from '../../types';
+import {AlertRuleAggregations, IncidentRule, TimeWindow} from '../../types';
 import ThresholdsChart from './thresholdsChart';
 
 type Props = {


### PR DESCRIPTION
This makes Metric Alert chart work again after the inline Triggers refactor. Store "Rule Condition" form values in state of its parent component so that we can pass it down to `<TriggersChart>`

Fixes SEN-1226