### PR TITLE
Update broken loader link

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -136,7 +136,7 @@ class KeySettings extends React.Component<Props, State> {
                 <PanelBody>
                   <Field
                     help={tct(
-                      'Copy this script into your website to setup our JavaScript SDK without any additional configuration. [link]',
+                      'Copy this script into your website to setup your JavaScript SDK without any additional configuration. [link]',
                       {
                         link: (
                           <ExternalLink href="https://docs.sentry.io/platforms/javascript/#what-does-the-loader-provide">

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -139,7 +139,7 @@ class KeySettings extends React.Component<Props, State> {
                       'Copy this script into your website to setup our JavaScript SDK without any additional configuration. [link]',
                       {
                         link: (
-                          <ExternalLink href="https://docs.sentry.io/platforms/javascript/browser/">
+                          <ExternalLink href="https://docs.sentry.io/platforms/javascript/#what-does-the-loader-provide">
                             What does the script provide?
                           </ExternalLink>
                         ),


### PR DESCRIPTION
Currently in the product it goes here: https://docs.sentry.io/platforms/javascript/browser/ which 404s

I _think_ it's supposed to go here https://docs.sentry.io/platforms/javascript/#what-does-the-loader-provide but correct me if I'm wrong 