### PR TITLE
fix(ui): Fix creating Slack actions for Metric Alerts

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
@@ -214,6 +214,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
             ? actionConfig.allowedTargetTypes[0]
             : null,
         targetIdentifier: '',
+        integrationId: actionConfig && actionConfig.integrationId,
       } as Action,
     ];
     onChange(triggerIndex, {...trigger, actions});

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
@@ -214,7 +214,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
             ? actionConfig.allowedTargetTypes[0]
             : null,
         targetIdentifier: '',
-        integrationId: actionConfig && actionConfig.integrationId,
+        integration: actionConfig && actionConfig.integrationId,
       } as Action,
     ];
     onChange(triggerIndex, {...trigger, actions});

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
@@ -214,7 +214,9 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
             ? actionConfig.allowedTargetTypes[0]
             : null,
         targetIdentifier: '',
-        integration: actionConfig && actionConfig.integrationId,
+        ...(actionConfig && actionConfig.integrationId !== null
+          ? {integration: actionConfig.integrationId}
+          : {}),
       } as Action,
     ];
     onChange(triggerIndex, {...trigger, actions});

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -159,6 +159,7 @@ describe('Incident Rules Details', function() {
             expect.objectContaining({
               actions: [
                 {
+                  integrationId: null,
                   targetIdentifier: '',
                   targetType: 'user',
                   type: 'email',

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -159,7 +159,6 @@ describe('Incident Rules Details', function() {
             expect.objectContaining({
               actions: [
                 {
-                  integration: null,
                   targetIdentifier: '',
                   targetType: 'user',
                   type: 'email',

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -159,7 +159,7 @@ describe('Incident Rules Details', function() {
             expect.objectContaining({
               actions: [
                 {
-                  integrationId: null,
+                  integration: null,
                   targetIdentifier: '',
                   targetType: 'user',
                   type: 'email',


### PR DESCRIPTION
We need to pass `integrationId` when creating actions