### PR TITLE
fix: Treat a null integration the same as not passing an integration when creating an alert rule action

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -245,7 +245,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
         extra_kwargs = {
             "target_identifier": {"required": True},
             "target_display": {"required": False},
-            "integration": {"required": False, "allow_null": False},
+            "integration": {"required": False, "allow_null": True},
         }
 
     def validate_type(self, type):
@@ -308,7 +308,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                 ).exists():
                     raise serializers.ValidationError("User does not belong to this organization")
         elif attrs.get("type") == AlertRuleTriggerAction.Type.SLACK:
-            if "integration" not in attrs:
+            if not attrs.get("integration"):
                 raise serializers.ValidationError(
                     {"integration": "Integration must be provided for slack"}
                 )


### PR DESCRIPTION
This allows frontend to keep their code simpler/more consistent.