### PR TITLE
fix: Make passing identifiers more consistent when creating alert trigger actions

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -20,8 +20,7 @@ class AlertRuleTriggerActionSerializer(Serializer):
             "targetType": action_target_type_to_string[
                 AlertRuleTriggerAction.TargetType(obj.target_type)
             ],
-            "targetIdentifier": obj.target_identifier,
-            "targetDisplay": obj.target_display
+            "targetIdentifier": obj.target_display
             if obj.target_display is not None
             else obj.target_identifier,
             "integrationId": obj.integration_id,

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -241,7 +241,7 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
 
     class Meta:
         model = AlertRuleTriggerAction
-        fields = ["type", "target_type", "target_identifier", "target_display", "integration"]
+        fields = ["type", "target_type", "target_identifier", "integration"]
         extra_kwargs = {
             "target_identifier": {"required": True},
             "target_display": {"required": False},

--- a/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
@@ -26,7 +26,6 @@ class AlertRuleTriggerActionSerializerTest(TestCase):
             == action_target_type_to_string[AlertRuleTriggerAction.TargetType(action.target_type)]
         )
         assert result["targetIdentifier"] == action.target_identifier
-        assert result["targetDisplay"] == action.target_identifier
         assert result["integrationId"] == action.integration_id
         assert result["dateAdded"] == action.date_added
 


### PR DESCRIPTION
From the frontend perspective we should hide the concept of identifier vs display, and just treat it
all as an identifier. When we have a slack channel name, that's the display value, but acts as both
what should be shown to the user and also what we pass when creating/updating actions. For target
types that reference an object in our system (user/team/future pagerduty services) this will just be
the id, and the list of those objects can be fetched from a separate endpoint.