### PR TITLE
ref(django 1.10): cleanup get_prep_lookup stubs

### DIFF
--- a/src/sentry/db/models/fields/array.py
+++ b/src/sentry/db/models/fields/array.py
@@ -46,11 +46,6 @@ class ArrayField(models.Field):
             value = json.loads(value)
         return map(self.of.to_python, value)
 
-    def get_prep_lookup(self, lookup_type, value):
-        raise NotImplementedError(
-            u"{!r} lookup type for {!r} is not supported".format(lookup_type, self)
-        )
-
 
 if hasattr(models, "SubfieldBase"):
     ArrayField = six.add_metaclass(models.SubfieldBase)(ArrayField)

--- a/src/sentry/db/models/fields/encrypted.py
+++ b/src/sentry/db/models/fields/encrypted.py
@@ -34,11 +34,6 @@ class EncryptedCharField(CharField):
             value = decrypt(value)
         return super(EncryptedCharField, self).to_python(value)
 
-    def get_prep_lookup(self, lookup_type, value):
-        raise NotImplementedError(
-            u"{!r} lookup type for {!r} is not supported".format(lookup_type, self)
-        )
-
 
 class EncryptedJsonField(JSONField):
     def get_db_prep_value(self, value, *args, **kwargs):
@@ -49,11 +44,6 @@ class EncryptedJsonField(JSONField):
         if value is not None and isinstance(value, six.string_types):
             value = decrypt(value)
         return super(EncryptedJsonField, self).to_python(value)
-
-    def get_prep_lookup(self, lookup_type, value):
-        raise NotImplementedError(
-            u"{!r} lookup type for {!r} is not supported".format(lookup_type, self)
-        )
 
 
 class EncryptedPickledObjectField(PickledObjectField):
@@ -67,11 +57,6 @@ class EncryptedPickledObjectField(PickledObjectField):
         if value is not None and isinstance(value, six.string_types):
             value = decrypt(value)
         return super(EncryptedPickledObjectField, self).to_python(value)
-
-    def get_prep_lookup(self, lookup_type, value):
-        raise NotImplementedError(
-            u"{!r} lookup type for {!r} is not supported".format(lookup_type, self)
-        )
 
 
 class EncryptedTextField(TextField):
@@ -91,8 +76,3 @@ class EncryptedTextField(TextField):
         if value is not None and isinstance(value, six.string_types):
             value = decrypt(value)
         return super(EncryptedTextField, self).to_python(value)
-
-    def get_prep_lookup(self, lookup_type, value):
-        raise NotImplementedError(
-            u"{!r} lookup type for {!r} is not supported".format(lookup_type, self)
-        )


### PR DESCRIPTION
We don't implement these; they can just be removed.

Also, we don't have any get_db_prep_lookup except in vendored bitfield - there'll be a followup PR converting it to custom Lookups.

https://docs.djangoproject.com/en/1.10/releases/1.10/#field-get-prep-lookup-and-field-get-db-prep-lookup-methods-are-removed