### PR TITLE
fix(ui): Fix `<ReleaseSeries>` and using `moment.tz`

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -1,7 +1,7 @@
 import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import isEqual from 'lodash/isEqual';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';


### PR DESCRIPTION
I think to reliably use `moment.tz` we need to import from `moment-timezone`. I cannot repro, but it is what we do elsewhere.

Fixes JAVASCRIPT-VB2