### PR TITLE
test(js): Fix mock API warnings for `<Events>`

### DIFF
--- a/tests/js/spec/views/events/events.spec.jsx
+++ b/tests/js/spec/views/events/events.spec.jsx
@@ -49,7 +49,20 @@ describe('EventsErrors', function() {
 
   beforeAll(function() {
     MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/releases/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/recent-searches/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      method: 'POST',
       body: [],
     });
     MockApiClient.addMockResponse({


### PR DESCRIPTION
Fixes unmocked API warnings for `<Events>`