### PR TITLE
ref: Move generate_node_id to eventstore

### DIFF
--- a/src/sentry/deletions/defaults/group.py
+++ b/src/sentry/deletions/defaults/group.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function
 
 import os
 from sentry import eventstore, nodestore
-from sentry.models import Event, EventAttachment, UserReport
+from sentry.models import EventAttachment, UserReport
 
 from ..base import BaseDeletionTask, BaseRelation, ModelDeletionTask, ModelRelation
 
@@ -48,7 +48,9 @@ class EventDataDeletionTask(BaseDeletionTask):
         self.last_event = events[-1]
 
         # Remove from nodestore
-        node_ids = [Event.generate_node_id(self.project_id, event.event_id) for event in events]
+        node_ids = [
+            eventstore.generate_node_id(self.project_id, event.event_id) for event in events
+        ]
         nodestore.delete_multi(node_ids)
 
         # Remove EventAttachment and UserReport

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -15,7 +15,7 @@ from django.db.models import Func
 from django.utils import timezone
 from django.utils.encoding import force_text
 
-from sentry import buffer, eventtypes, eventstream, tsdb
+from sentry import buffer, eventtypes, eventstream, eventstore, tsdb
 from sentry.constants import (
     DEFAULT_STORE_NORMALIZER_ARGS,
     LOG_LEVELS,
@@ -388,7 +388,7 @@ class EventManager(object):
         date = date.replace(tzinfo=timezone.utc)
         time_spent = data.get("time_spent")
 
-        data["node_id"] = Event.generate_node_id(project_id, event_id)
+        data["node_id"] = eventstore.generate_node_id(project_id, event_id)
 
         return Event(
             project_id=project_id or self._project.id,

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from hashlib import md5
 
 from sentry import nodestore
 from sentry.snuba.events import Columns
@@ -65,6 +66,7 @@ class EventStorage(Service):
         "get_earliest_event_id",
         "get_latest_event_id",
         "bind_nodes",
+        "generate_node_id",
     )
 
     # The minimal list of columns we need to get from snuba to bootstrap an
@@ -192,3 +194,12 @@ class EventStorage(Service):
         for item, node in object_node_list:
             data = node_results.get(node.id) or {}
             node.bind_data(data, ref=node.get_ref(item))
+
+    def generate_node_id(self, project_id, event_id):
+        """
+        Returns a deterministic node_id for this event based on the project_id
+        and event_id which together are globally unique. The event body should
+        be saved under this key in nodestore so it can be retrieved using the
+        same generated id when we only have project_id and event_id.
+        """
+        return md5("{}:{}".format(project_id, event_id)).hexdigest()

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -9,11 +9,10 @@ from dateutil.parser import parse as parse_date
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
-from hashlib import md5
 
 from semaphore.processing import StoreNormalizer
 
-from sentry import eventtypes, nodestore
+from sentry import eventstore, eventtypes, nodestore
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedIntegerField,
@@ -57,16 +56,6 @@ class EventCommon(object):
     """
     Methods and properties common to both Event and SnubaEvent.
     """
-
-    @classmethod
-    def generate_node_id(cls, project_id, event_id):
-        """
-        Returns a deterministic node_id for this event based on the project_id
-        and event_id which together are globally unique. The event body should
-        be saved under this key in nodestore so it can be retrieved using the
-        same generated id when we only have project_id and event_id.
-        """
-        return md5("{}:{}".format(project_id, event_id)).hexdigest()
 
     # TODO (alex) We need a better way to cache these properties.  functools32
     # doesn't quite do the trick as there is a reference bug with unsaved
@@ -363,7 +352,7 @@ class EventCommon(object):
         return data
 
     def bind_node_data(self):
-        node_id = Event.generate_node_id(self.project_id, self.event_id)
+        node_id = eventstore.generate_node_id(self.project_id, self.event_id)
         node_data = nodestore.get(node_id) or {}
         ref = self.data.get_ref(self)
         self.data.bind_data(node_data, ref=ref)
@@ -404,7 +393,7 @@ class SnubaEvent(EventCommon):
         self.snuba_data = snuba_values
 
         # self.data is a (lazy) dict of everything we got from nodestore
-        node_id = SnubaEvent.generate_node_id(
+        node_id = eventstore.generate_node_id(
             self.snuba_data["project_id"], self.snuba_data["event_id"]
         )
         self.data = NodeData(node_id, data=None, wrapper=EventDict)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -20,6 +20,7 @@ from hashlib import sha1
 from loremipsum import Generator
 from uuid import uuid4
 
+from sentry import eventstore
 from sentry.event_manager import EventManager
 from sentry.constants import SentryAppStatus
 from sentry.incidents.logic import (
@@ -507,7 +508,9 @@ class Factories(object):
 
         # This is needed so that create_event saves the event in nodestore
         # under the correct key. This is usually dont in EventManager.save()
-        kwargs["data"].setdefault("node_id", Event.generate_node_id(kwargs["project"].id, event_id))
+        kwargs["data"].setdefault(
+            "node_id", eventstore.generate_node_id(kwargs["project"].id, event_id)
+        )
 
         event = Event(event_id=event_id, group=group, **kwargs)
         # emulate EventManager refs

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -4,7 +4,6 @@ import mock
 from uuid import uuid4
 
 from sentry.models import (
-    Event,
     EventAttachment,
     File,
     Group,
@@ -14,7 +13,7 @@ from sentry.models import (
     GroupRedirect,
     UserReport,
 )
-from sentry import nodestore
+from sentry import eventstore, nodestore
 from sentry.deletions.defaults.group import EventDataDeletionTask
 from sentry.tasks.deletion import delete_groups
 from sentry.testutils import SnubaTestCase, TestCase
@@ -76,9 +75,9 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         GroupMeta.objects.create(group=group, key="foo", value="bar")
         GroupRedirect.objects.create(group_id=group.id, previous_group_id=1)
 
-        self.node_id = Event.generate_node_id(self.project.id, self.event_id)
-        self.node_id2 = Event.generate_node_id(self.project.id, self.event_id2)
-        self.node_id3 = Event.generate_node_id(self.project.id, self.event_id3)
+        self.node_id = eventstore.generate_node_id(self.project.id, self.event_id)
+        self.node_id2 = eventstore.generate_node_id(self.project.id, self.event_id2)
+        self.node_id3 = eventstore.generate_node_id(self.project.id, self.event_id3)
 
     def test_simple(self):
         EventDataDeletionTask.DEFAULT_CHUNK_SIZE = 1  # test chunking logic

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 from django.utils import timezone
 from time import time
 
-from sentry import nodestore
+from sentry import eventstore, nodestore
 from sentry.app import tsdb
 from sentry.constants import MAX_VERSION_LENGTH
 from sentry.event_manager import HashDiscarded, EventManager, EventUser
@@ -20,7 +20,6 @@ from sentry.grouping.utils import hash_from_values
 from sentry.models import (
     Activity,
     Environment,
-    Event,
     ExternalIssue,
     Group,
     GroupEnvironment,
@@ -89,7 +88,7 @@ class EventManagerTest(TestCase):
         # Saves the latest event to nodestore and eventstream
         project_id = 1
         event_id = "a" * 32
-        node_id = Event.generate_node_id(project_id, event_id)
+        node_id = eventstore.generate_node_id(project_id, event_id)
 
         manager = EventManager(make_event(event_id=event_id, message="first"))
         manager.normalize()

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import pytest
 
-from sentry import nodestore
+from sentry import eventstore, nodestore
 from sentry.constants import ObjectStatus
 from sentry.exceptions import DeleteAborted
 from sentry.models import (
@@ -18,7 +18,6 @@ from sentry.models import (
     CommitAuthor,
     Environment,
     EnvironmentProject,
-    Event,
     Group,
     GroupAssignee,
     GroupHash,
@@ -182,8 +181,8 @@ class DeleteGroupTest(TestCase):
         event_id_2 = "b" * 32
         project = self.create_project()
 
-        node_id = Event.generate_node_id(project.id, event_id)
-        node_id_2 = Event.generate_node_id(project.id, event_id_2)
+        node_id = eventstore.generate_node_id(project.id, event_id)
+        node_id_2 = eventstore.generate_node_id(project.id, event_id_2)
 
         event = self.store_event(
             data={
@@ -217,7 +216,6 @@ class DeleteGroupTest(TestCase):
         with self.tasks():
             delete_groups(object_ids=[group.id])
 
-        assert not Event.objects.filter(event_id=event.event_id).exists()
         assert not GroupRedirect.objects.filter(group_id=group.id).exists()
         assert not GroupHash.objects.filter(group_id=group.id).exists()
         assert not Group.objects.filter(id=group.id).exists()

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -6,9 +6,8 @@ from django.conf import settings
 from sentry.utils.sdk import configure_sdk, bind_organization_context
 from sentry.app import raven
 
-from sentry.models import Event
 from sentry.testutils import TestCase
-from sentry import nodestore
+from sentry import eventstore, nodestore
 
 
 class SentryInternalClientTest(TestCase):
@@ -19,7 +18,7 @@ class SentryInternalClientTest(TestCase):
         with self.tasks():
             event_id = raven.captureMessage("internal client test")
 
-        event = nodestore.get(Event.generate_node_id(settings.SENTRY_PROJECT, event_id))
+        event = nodestore.get(eventstore.generate_node_id(settings.SENTRY_PROJECT, event_id))
 
         assert event["project"] == settings.SENTRY_PROJECT
         assert event["event_id"] == event_id
@@ -37,7 +36,7 @@ class SentryInternalClientTest(TestCase):
                 "check the req", extra={"request": NotJSONSerializable()}
             )
 
-        event = nodestore.get(Event.generate_node_id(settings.SENTRY_PROJECT, event_id))
+        event = nodestore.get(eventstore.generate_node_id(settings.SENTRY_PROJECT, event_id))
 
         assert event["project"] == settings.SENTRY_PROJECT
         assert event["logentry"]["formatted"] == "check the req"

--- a/tests/snuba/models/test_event.py
+++ b/tests/snuba/models/test_event.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from datetime import datetime, timedelta
 
 from sentry.api.serializers import serialize
-from sentry.models.event import SnubaEvent
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry import eventstore, nodestore
 from sentry.testutils.helpers.datetime import iso_format, before_now
@@ -81,7 +80,7 @@ class SnubaEventTest(TestCase, SnubaTestCase):
 
     def test_event_with_no_body(self):
         # remove the event from nodestore to simulate an event with no body.
-        node_id = SnubaEvent.generate_node_id(self.proj1.id, self.event_id)
+        node_id = eventstore.generate_node_id(self.proj1.id, self.event_id)
         nodestore.delete(node_id)
         assert nodestore.get(node_id) is None
 


### PR DESCRIPTION
Event (at least in it's current form) is going away and moving into
eventstore. As a result I think it will be a bit clearer to expose
this method as eventstore.generate_node_id(), rather than as a method on
the Event class.