### PR TITLE
ref(integrations): add logging for pipeline steps

### DIFF
--- a/src/sentry/models/identity.py
+++ b/src/sentry/models/identity.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import logging
+
 from django.conf import settings
 from django.db import models
 from django.db.models import Q
@@ -14,7 +16,11 @@ from sentry.db.models import (
 )
 
 
+logger = logging.getLogger(__name__)
+
 # TODO(dcramer): pull in enum library
+
+
 class IdentityStatus(object):
     UNKNOWN = 0
     VALID = 1
@@ -84,5 +90,21 @@ class Identity(Model):
         """
         lookup = Q(external_id=external_id) | Q(user=user)
         Identity.objects.filter(lookup, idp=idp).delete()
+        logger.info(
+            "deleted-identity",
+            extra={"external_id": external_id, "idp_id": idp.id, "user_id": user.id},
+        )
 
-        return Identity.objects.create(idp=idp, user=user, external_id=external_id, **defaults)
+        identity_model = Identity.objects.create(
+            idp=idp, user=user, external_id=external_id, **defaults
+        )
+        logger.info(
+            "created-identity",
+            extra={
+                "idp_id": idp.id,
+                "external_id": external_id,
+                "object_id": identity_model.id,
+                "user_id": user.id,
+            },
+        )
+        return identity_model

--- a/src/sentry/models/integration.py
+++ b/src/sentry/models/integration.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import logging
+
 from django.db import models, IntegrityError
 from django.utils import timezone
 
@@ -11,6 +13,9 @@ from sentry.db.models import (
     Model,
 )
 from sentry.signals import integration_added
+
+
+logger = logging.getLogger(__name__)
 
 
 class PagerDutyService(Model):
@@ -145,6 +150,14 @@ class Integration(Model):
             if not created and default_auth_id:
                 org_integration.update(default_auth_id=default_auth_id)
         except IntegrityError:
+            logger.info(
+                "add-organization-integrity-error",
+                extra={
+                    "organization_id": organization.id,
+                    "integration_id": self.id,
+                    "default_auth_id": default_auth_id,
+                },
+            )
             return False
         else:
             integration_added.send_robust(


### PR DESCRIPTION
There is a bug where the `default_auth_id` is pointing to an identity object that seems to be deleted. I think something is failing in the pipeline step and I am hoping more logging will confirm my suspicion.