### PR TITLE
perf: Simplify resolving columns

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -5,7 +5,7 @@ import six
 from collections import namedtuple
 from copy import deepcopy
 
-from sentry.api.event_search import TAG_KEY_RE, get_filter, resolve_field_list, InvalidSearchQuery
+from sentry.api.event_search import get_filter, resolve_field_list, InvalidSearchQuery
 from sentry.models import Project, ProjectStatus
 from sentry.utils.snuba import (
     Dataset,
@@ -35,7 +35,12 @@ def find_reference_event(reference_event):
     except Project.DoesNotExist:
         raise InvalidSearchQuery("Invalid reference event")
 
-    column_names = [resolve_column(col) for col in reference_event.fields]
+    # count() is allowable as a selected field in Discover
+    valid_functions = ["count()"]
+
+    column_names = [
+        resolve_column(col) for col in reference_event.fields if col not in valid_functions
+    ]
 
     # We don't need to run a query if there are no columns
     if not column_names:
@@ -64,25 +69,17 @@ def create_reference_event_conditions(reference_event):
     reference_event (ReferenceEvent) The reference event to build conditions from.
     """
     conditions = []
-    tags = {}
     event_data = find_reference_event(reference_event)
     if event_data is None:
         return conditions
 
-    if "tags.key" in event_data and "tags.value" in event_data:
-        tags = dict(zip(event_data["tags.key"], event_data["tags.value"]))
-
     field_names = [resolve_column(col) for col in reference_event.fields]
     for (i, field) in enumerate(reference_event.fields):
-        match = TAG_KEY_RE.match(field_names[i])
-        if match:
-            value = tags.get(match.group(1), None)
-        else:
-            value = event_data.get(field_names[i], None)
-            # If the value is a sequence use the first element as snuba
-            # doesn't support `=` or `IN` operations on fields like exception_frames.filename
-            if isinstance(value, (list, set)) and value:
-                value = value.pop()
+        value = event_data.get(field_names[i], None)
+        # If the value is a sequence use the first element as snuba
+        # doesn't support `=` or `IN` operations on fields like exception_frames.filename
+        if isinstance(value, (list, set)) and value:
+            value = value.pop()
         if value:
             conditions.append([field, "=", value])
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 
 from sentry.api.event_search import TAG_KEY_RE, get_filter, resolve_field_list, InvalidSearchQuery
 from sentry.models import Project, ProjectStatus
-from sentry.snuba.events import get_columns_from_aliases
 from sentry.utils.snuba import (
     Dataset,
     SnubaTSResult,
@@ -36,7 +35,8 @@ def find_reference_event(reference_event):
     except Project.DoesNotExist:
         raise InvalidSearchQuery("Invalid reference event")
 
-    column_names = [c.value.discover_name for c in get_columns_from_aliases(reference_event.fields)]
+    column_names = [resolve_column(col) for col in reference_event.fields]
+
     # We don't need to run a query if there are no columns
     if not column_names:
         return None

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -230,20 +230,3 @@ class Columns(Enum):
         "contexts[trace.parent_span_id]",
         "trace.parent_span",
     )
-
-
-def get_columns_from_aliases(aliases):
-    """
-    Resolve a list of aliases to the columns
-    """
-    columns = set()
-    for alias in aliases:
-        for _i, col in enumerate(Columns):
-            if col.value.alias == alias:
-                columns.add(col)
-                continue
-            # Handle as a tag if its not on the list
-            columns.add(Columns.TAGS_KEY)
-            columns.add(Columns.TAGS_VALUE)
-
-    return list(columns)


### PR DESCRIPTION
Avoids unnecessarily requesting all tags_key and tags_value columns anytime an unknown column is encountered.