### PR TITLE
feat(discover) Format transaction.status as a string

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -733,6 +733,8 @@ def get_json_meta_type(field, snuba_type):
         return alias_definition.get("result_type")
     if "duration" in field:
         return "duration"
+    if field == "transaction.status":
+        return "string"
     return get_json_type(snuba_type)
 
 

--- a/src/sentry/data/samples/transaction.json
+++ b/src/sentry/data/samples/transaction.json
@@ -70,7 +70,8 @@
          "type": "trace",
          "op": "foobar",
          "trace_id": "a7d67cf796774551a95be6543cacd459",
-         "span_id": "babaae0d4b7512d9"
+         "span_id": "babaae0d4b7512d9",
+         "status": "ok"
       },
       "browser": {
          "version": "2.22",

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -583,10 +583,12 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 self.url,
                 format="json",
                 data={
-                    "field": ["transaction", "transaction.duration"],
+                    "field": ["transaction", "transaction.duration", "transaction.status"],
                     "query": "event.type:transaction",
                 },
             )
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
         assert response.data["meta"]["transaction.duration"] == "duration"
+        assert response.data["meta"]["transaction.status"] == "string"
+        assert response.data["data"][0]["transaction.status"] == "ok"


### PR DESCRIPTION
When returning results transaction.status should be formatted as a string. For the short term I've done the translation in the endpoint, but I'd like to move that into the discover.query function once it has broader use.