### PR TITLE
fix(ui): Fix updating "Metric Alerts" aggregation

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -15,11 +15,12 @@ export function createDefaultTrigger(): Trigger {
   };
 }
 
-export const DEFAULT_METRIC = [AlertRuleAggregations.TOTAL];
+export const DEFAULT_METRIC = AlertRuleAggregations.TOTAL;
 
 export function createDefaultRule(): UnsavedIncidentRule {
   return {
-    aggregations: DEFAULT_METRIC,
+    aggregation: DEFAULT_METRIC,
+    aggregations: [DEFAULT_METRIC],
     query: '',
     timeWindow: 60,
     triggers: [createDefaultTrigger()],

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/list.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/list.tsx
@@ -85,7 +85,7 @@ class IncidentRulesList extends AsyncView<Props, State> {
                 <RuleRow key={rule.id}>
                   <RuleLink to={ruleLink}>{rule.name}</RuleLink>
 
-                  <MetricName>{getMetricDisplayName(rule.aggregations[0])}</MetricName>
+                  <MetricName>{getMetricDisplayName(rule.aggregation)}</MetricName>
 
                   <ThresholdColumn>
                     <Thresholds>

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -37,7 +37,7 @@ class RuleConditionsForm extends React.PureComponent<Props> {
         <PanelHeader>{t('Configure Rule Conditions')}</PanelHeader>
         <PanelBody>
           <SelectField
-            name="aggregations"
+            name="aggregation"
             label={t('Metric')}
             help={t('Choose which metric to trigger on')}
             choices={[
@@ -51,8 +51,6 @@ class RuleConditionsForm extends React.PureComponent<Props> {
               ],
             ]}
             required
-            setValue={value => (value && value.length ? value[0] : value)}
-            getValue={value => [value]}
           />
           <FormField
             name="query"

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -49,7 +49,7 @@ type State = {
   // Rule conditions form inputs
   // Needed for TriggersChart
   query: string;
-  aggregations: AlertRuleAggregations[];
+  aggregation: AlertRuleAggregations[];
   timeWindow: number;
 } & AsyncComponent['state'];
 
@@ -62,7 +62,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     return {
       ...super.getDefaultState(),
 
-      aggregations: rule.aggregations,
+      aggregation: rule.aggregation,
       query: rule.query || '',
       timeWindow: rule.timeWindow,
       triggerErrors: new Map(),
@@ -139,9 +139,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   }
 
   handleFieldChange = (name: string, value: unknown) => {
-    if (name === 'aggregations') {
-      this.setState({[name]: [value] as AlertRuleAggregations[]});
-    } else if (['query', 'timeWindow'].includes(name)) {
+    if (['query', 'timeWindow', 'aggregation'].includes(name)) {
       this.setState({[name]: value});
     }
   };
@@ -238,7 +236,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       params,
       onSubmitSuccess,
     } = this.props;
-    const {query, aggregations, timeWindow, triggers} = this.state;
+    const {query, aggregation, timeWindow, triggers} = this.state;
 
     return (
       <Form
@@ -248,7 +246,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
         }`}
         initialData={{
           name: rule.name || '',
-          aggregations: rule.aggregations,
+          aggregation: rule.aggregation,
           query: rule.query || '',
           timeWindow: rule.timeWindow,
         }}
@@ -264,7 +262,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
           projects={this.state.projects}
           triggers={triggers}
           query={query}
-          aggregations={aggregations}
+          aggregation={aggregation}
           timeWindow={timeWindow}
         />
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -49,7 +49,7 @@ type State = {
   // Rule conditions form inputs
   // Needed for TriggersChart
   query: string;
-  aggregation: AlertRuleAggregations[];
+  aggregation: AlertRuleAggregations;
   timeWindow: number;
 } & AsyncComponent['state'];
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -24,7 +24,7 @@ type Props = {
 
   query: IncidentRule['query'];
   timeWindow: IncidentRule['timeWindow'];
-  aggregations: IncidentRule['aggregations'];
+  aggregation: IncidentRule['aggregation'];
   triggers: Trigger[];
 };
 
@@ -41,7 +41,7 @@ class TriggersChart extends React.PureComponent<Props> {
       projects,
       timeWindow,
       query,
-      aggregations,
+      aggregation,
       triggers,
     } = this.props;
 
@@ -53,9 +53,7 @@ class TriggersChart extends React.PureComponent<Props> {
         project={projects.map(({id}) => Number(id))}
         interval={`${timeWindow}s`}
         period={getPeriodForTimeWindow(timeWindow)}
-        yAxis={
-          aggregations[0] === AlertRuleAggregations.TOTAL ? 'event_count' : 'user_count'
-        }
+        yAxis={aggregation === AlertRuleAggregations.TOTAL ? 'event_count' : 'user_count'}
         includePrevious={false}
       >
         {({loading, reloading, timeseriesData}) => {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -36,6 +36,7 @@ export type SavedTrigger = UnsavedTrigger & {
 export type Trigger = Partial<SavedTrigger> & UnsavedTrigger;
 
 export type UnsavedIncidentRule = {
+  aggregation: AlertRuleAggregations;
   aggregations: AlertRuleAggregations[];
   projects: string[];
   query: string;

--- a/tests/js/sentry-test/fixtures/incidentRule.js
+++ b/tests/js/sentry-test/fixtures/incidentRule.js
@@ -9,7 +9,7 @@ export function IncidentRule(params) {
     id: '4',
     name: 'My Incident Rule',
     timeWindow: 60,
-    aggregations: [0],
+    aggregation: 0,
     projects: ['project-slug'],
     dateModified: '2019-07-31T23:02:02.731Z',
     triggers: [IncidentTrigger()],

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -147,7 +147,7 @@ describe('Incident Rules Details', function() {
       expect.anything(),
       expect.objectContaining({
         data: expect.objectContaining({
-          aggregations: [0],
+          aggregation: 0,
           dataset: 'events',
           id: '4',
           name: 'My Incident Rule',
@@ -228,7 +228,7 @@ describe('Incident Rules Details', function() {
       expect.anything(),
       expect.objectContaining({
         data: expect.objectContaining({
-          aggregations: [0],
+          aggregation: 0,
           dataset: 'events',
           id: '4',
           name: 'My Incident Rule',

--- a/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
@@ -59,7 +59,7 @@ describe('Incident Rules Form', function() {
     it('creates a rule', async function() {
       const wrapper = createWrapper({
         rule: {
-          aggregations: [0],
+          aggregation: 0,
           query: '',
           projects: [project.slug],
           timeWindow: 60,


### PR DESCRIPTION
This fixes being able to save/update the "Metric" field for "Metric Alerts" (e.g. Events vs Users)