### PR TITLE
fix(discover) Update timeseries_query results

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -332,7 +332,7 @@ def timeseries_query(selected_columns, query, params, rollup, reference_event=No
     )
     result = zerofill(result["data"], snuba_args["start"], snuba_args["end"], rollup, "time")
 
-    return SnubaTSResult(result, snuba_filter.start, snuba_filter.end, rollup)
+    return SnubaTSResult({"data": result}, snuba_filter.start, snuba_filter.end, rollup)
 
 
 def get_id(result):

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -524,7 +524,7 @@ class TimeseriesQueryTest(SnubaTestCase, TestCase):
             },
             rollup=3600,
         )
-        assert len(result.data) == 3
+        assert len(result.data["data"]) == 3
 
     def test_aggregate_function(self):
         result = discover.timeseries_query(
@@ -537,8 +537,8 @@ class TimeseriesQueryTest(SnubaTestCase, TestCase):
             },
             rollup=3600,
         )
-        assert len(result.data) == 3
-        assert [2] == [val["count"] for val in result.data if "count" in val]
+        assert len(result.data["data"]) == 3
+        assert [2] == [val["count"] for val in result.data["data"] if "count" in val]
 
     def test_zerofilling(self):
         result = discover.timeseries_query(
@@ -551,8 +551,10 @@ class TimeseriesQueryTest(SnubaTestCase, TestCase):
             },
             rollup=3600,
         )
-        assert len(result.data) == 4, "Should have empty results"
-        assert [2, 1] == [val["count"] for val in result.data if "count" in val], result.data
+        assert len(result.data["data"]) == 4, "Should have empty results"
+        assert [2, 1] == [
+            val["count"] for val in result.data["data"] if "count" in val
+        ], result.data["data"]
 
     def test_reference_event(self):
         ref = discover.ReferenceEvent(
@@ -571,8 +573,8 @@ class TimeseriesQueryTest(SnubaTestCase, TestCase):
             reference_event=ref,
             rollup=3600,
         )
-        assert len(result.data) == 4
-        assert [1, 1] == [val["count"] for val in result.data if "count" in val]
+        assert len(result.data["data"]) == 4
+        assert [1, 1] == [val["count"] for val in result.data["data"] if "count" in val]
 
 
 class CreateReferenceEventConditionsTest(SnubaTestCase, TestCase):


### PR DESCRIPTION
The snuba serializers are coupled to having a dict with 'data' in them.