### PR TITLE
fix(ui): LightWeightNoProjectMessage changed to not be so disruptive

### DIFF
--- a/src/sentry/static/sentry/app/components/lightWeightNoProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/lightWeightNoProjectMessage.tsx
@@ -16,10 +16,13 @@ class LightWeightNoProjectMessage extends React.Component<Props> {
     if ('projects' in organization) {
       return <NoProjectMessage {...this.props} />;
     }
-    if (loadingProjects) {
-      return this.props.children;
-    }
-    return <NoProjectMessage {...this.props} projects={projects} />;
+    return (
+      <NoProjectMessage
+        {...this.props}
+        projects={projects}
+        loadingProjects={loadingProjects}
+      />
+    );
   }
 }
 

--- a/src/sentry/static/sentry/app/components/lightWeightNoProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/lightWeightNoProjectMessage.tsx
@@ -13,14 +13,11 @@ type Props = {
 class LightWeightNoProjectMessage extends React.Component<Props> {
   render() {
     const {organization, projects, loadingProjects} = this.props;
-    if ('projects' in organization) {
-      return <NoProjectMessage {...this.props} />;
-    }
     return (
       <NoProjectMessage
         {...this.props}
         projects={projects}
-        loadingProjects={loadingProjects}
+        loadingProjects={!('projects' in organization) && loadingProjects}
       />
     );
   }

--- a/src/sentry/static/sentry/app/components/noProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/noProjectMessage.tsx
@@ -16,6 +16,7 @@ import img from '../../images/dashboard/hair-on-fire.svg';
 type Props = {
   organization: LightWeightOrganization | Organization;
   projects?: Project[];
+  loadingProjects?: boolean;
 };
 
 export default class NoProjectMessage extends React.Component<Props> {
@@ -25,10 +26,11 @@ export default class NoProjectMessage extends React.Component<Props> {
     children: PropTypes.node,
     organization: SentryTypes.Organization,
     projects: PropTypes.arrayOf(SentryTypes.Project),
+    loadingProjects: PropTypes.bool,
   };
 
   render() {
-    const {children, organization, projects} = this.props;
+    const {children, organization, projects, loadingProjects} = this.props;
     const orgId = organization.slug;
     const canCreateProject = organization.access.includes('project:write');
     const canJoinTeam = organization.access.includes('team:read');
@@ -44,7 +46,7 @@ export default class NoProjectMessage extends React.Component<Props> {
       hasProjects = projects && projects.length > 0;
     }
 
-    return hasProjects ? (
+    return hasProjects || loadingProjects ? (
       children
     ) : (
       <Wrapper>

--- a/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
@@ -26,30 +26,43 @@ describe('LightWeightNoProjectMessage', function() {
   });
 
   it('does not remount when the projects store loads', async function() {
-    const child = jest.fn(() => null);
+    const mount = jest.fn();
+    const unmount = jest.fn();
+    class MockComponent extends React.Component {
+      componentWillMount() {
+        mount();
+      }
+      componentWillUnmount() {
+        unmount();
+      }
+      render() {
+        return <div>children</div>;
+      }
+    }
+
     const project1 = TestStubs.Project();
     const project2 = TestStubs.Project();
     const organization = TestStubs.Organization({slug: 'org-slug'});
     delete organization.projects;
     const wrapper = mountWithTheme(
       <LightWeightNoProjectMessage organization={organization}>
-        {child()}
+        <MockComponent />
       </LightWeightNoProjectMessage>,
       TestStubs.routerContext()
     );
 
     // verify child is called/mounted once
-    expect(child).toHaveBeenCalledTimes(1);
+    expect(mount).toHaveBeenCalledTimes(1);
     expect(wrapper.find('NoProjectMessage')).toHaveLength(1);
     expect(wrapper.find('NoProjectMessage').prop('loadingProjects')).toEqual(true);
-
     ProjectsStore.loadInitialData([project1, project2]);
     // await for trigger from projects store to resolve
     await tick();
     wrapper.update();
 
     // verify child is still only called/mounted once
-    expect(child).toHaveBeenCalledTimes(1);
+    expect(unmount).toHaveBeenCalledTimes(0);
+    expect(mount).toHaveBeenCalledTimes(1);
     expect(wrapper.find('NoProjectMessage')).toHaveLength(1);
     expect(wrapper.find('NoProjectMessage').prop('loadingProjects')).toEqual(false);
   });

--- a/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
@@ -44,7 +44,7 @@ describe('LightWeightNoProjectMessage', function() {
     expect(wrapper.find('NoProjectMessage').prop('loadingProjects')).toEqual(true);
 
     ProjectsStore.loadInitialData([project1, project2]);
-    await tick();
+    // await for trigger from projects store to resolve
     await tick();
     wrapper.update();
 

--- a/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
@@ -5,6 +5,10 @@ import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMess
 import ProjectsStore from 'app/stores/projectsStore';
 
 describe('LightWeightNoProjectMessage', function() {
+  beforeEach(function() {
+    ProjectsStore.reset();
+  });
+
   it('renders', async function() {
     const project1 = TestStubs.Project();
     const project2 = TestStubs.Project();
@@ -19,5 +23,34 @@ describe('LightWeightNoProjectMessage', function() {
     );
     expect(wrapper.prop('children')).toBe(null);
     expect(wrapper.find('NoProjectMessage').exists()).toBe(true);
+  });
+
+  it('does not remount when the projects store loads', async function() {
+    const child = jest.fn(() => null);
+    const project1 = TestStubs.Project();
+    const project2 = TestStubs.Project();
+    const organization = TestStubs.Organization({slug: 'org-slug'});
+    delete organization.projects;
+    const wrapper = mountWithTheme(
+      <LightWeightNoProjectMessage organization={organization}>
+        {child()}
+      </LightWeightNoProjectMessage>,
+      TestStubs.routerContext()
+    );
+
+    // verify child is called/mounted once
+    expect(child).toHaveBeenCalledTimes(1);
+    expect(wrapper.find('NoProjectMessage')).toHaveLength(1);
+    expect(wrapper.find('NoProjectMessage').prop('loadingProjects')).toEqual(true);
+
+    ProjectsStore.loadInitialData([project1, project2]);
+    await tick();
+    await tick();
+    wrapper.update();
+
+    // verify child is still only called/mounted once
+    expect(child).toHaveBeenCalledTimes(1);
+    expect(wrapper.find('NoProjectMessage')).toHaveLength(1);
+    expect(wrapper.find('NoProjectMessage').prop('loadingProjects')).toEqual(false);
   });
 });

--- a/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/lightWeightNoProjectMessage.spec.jsx
@@ -51,7 +51,7 @@ describe('LightWeightNoProjectMessage', function() {
       TestStubs.routerContext()
     );
 
-    // verify child is called/mounted once
+    // verify MockComponent is mounted once
     expect(mount).toHaveBeenCalledTimes(1);
     expect(wrapper.find('NoProjectMessage')).toHaveLength(1);
     expect(wrapper.find('NoProjectMessage').prop('loadingProjects')).toEqual(true);
@@ -60,7 +60,7 @@ describe('LightWeightNoProjectMessage', function() {
     await tick();
     wrapper.update();
 
-    // verify child is still only called/mounted once
+    // verify MockComponent is not unmounted and is still mounted once
     expect(unmount).toHaveBeenCalledTimes(0);
     expect(mount).toHaveBeenCalledTimes(1);
     expect(wrapper.find('NoProjectMessage')).toHaveLength(1);

--- a/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
@@ -55,4 +55,20 @@ describe('NoProjectMessage', function() {
       wrapper.find('Button[to="/organizations/org-slug/projects/new/"]')
     ).toHaveLength(1);
   });
+
+  it('handles loading projects from props', function() {
+    const lightWeightOrg = TestStubs.Organization();
+    delete lightWeightOrg.projects;
+
+    const child = <div>child</div>;
+
+    const wrapper = shallow(
+      <NoProjectMessage projects={[]} loadingProjects organization={lightWeightOrg}>
+        {child}
+      </NoProjectMessage>,
+      TestStubs.routerContext()
+    );
+    // ensure loading projects causes children to render
+    expect(wrapper.find('div')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
Previously setting the projects in the project store would trigger a DOM unmount, remount because of this lightweight component which would conditionally render its children or let the NoProjectMessage render its children. This was causing unnecessary refetching of data for the issues page which is being converted into the lightweight org context.

Now it will always render the NoProjectMessage but supply an additional prop to specify if the projects are loaded or not.