### PR TITLE
chore: Register option for rollout of new Event model

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -173,6 +173,9 @@ register("store.save-event-skips-nodestore", default=False, flags=FLAG_PRIORITIZ
 # Skip saving an event to postgres
 register("store.skip-pg-save", default=True, flags=FLAG_PRIORITIZE_DISK)
 
+# Use Django event
+register("store.use-django-event", default=False, flags=FLAG_PRIORITIZE_DISK)
+
 # Symbolicator refactors
 # - Disabling minidump stackwalking in endpoints
 register("symbolicator.minidump-refactor-projects-opt-in", type=Sequence, default=[])  # unused


### PR DESCRIPTION
Register option to be used for https://github.com/getsentry/sentry/pull/15593

After this is merged we should set it to True in prod, before deploying 15593.