### PR TITLE
fix(testing): Fix `--help` and `--version` for `py.test`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,7 +19,9 @@ def pytest_configure(config):
     warnings.filterwarnings("error", "", Warning, r"^(?!(|kombu|raven|sentry))")
 
     # if we are running any tests for plugins, we need to make sure we install them first
-    if any("tests/sentry_plugins" in s for s in config.getoption("file_or_dir")):
+    # (for `py.test --version` or `py.test --help`, there are no files to test)
+    test_targets = config.getoption("file_or_dir")
+    if test_targets and any("tests/sentry_plugins" in s for s in test_targets):
         install_sentry_plugins()
 
 


### PR DESCRIPTION
Currently, if you call `py.test --version` or `py.test --help` (with no argument representing what files should be tested), the `file_or_dir` config option gets set to `None` rather than `[]`. When we then try to iterate over it, everything breaks. Arguably `pytest` should handle this gracefully itself, but in the meantime...