### PR TITLE
ref(tests): Make sample event configurable, add event attribute tests

### DIFF
--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -272,33 +272,14 @@ class EventAttributeConditionTest(RuleTestCase):
             }
         )
 
-        rule = self.get_rule(
-            data={
-                "match": MatchType.EQUAL,
-                "attribute": "stacktrace.filename",
-                "value": "example.php",
-            }
-        )
-        self.assertPasses(rule, event)
+        # correctly matching filenames, at various locations in the stacktrace
+        for value in ["example.php", "somecode.php", "othercode.php"]:
+            rule = self.get_rule(
+                data={"match": MatchType.EQUAL, "attribute": "stacktrace.filename", "value": value}
+            )
+            self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            data={
-                "match": MatchType.EQUAL,
-                "attribute": "stacktrace.filename",
-                "value": "somecode.php",
-            }
-        )
-        self.assertPasses(rule, event)
-
-        rule = self.get_rule(
-            data={
-                "match": MatchType.EQUAL,
-                "attribute": "stacktrace.filename",
-                "value": "othercode.php",
-            }
-        )
-        self.assertPasses(rule, event)
-
+        # non-matching filename
         rule = self.get_rule(
             data={"match": MatchType.EQUAL, "attribute": "stacktrace.filename", "value": "foo.php"}
         )
@@ -325,21 +306,14 @@ class EventAttributeConditionTest(RuleTestCase):
             }
         )
 
-        rule = self.get_rule(
-            data={"match": MatchType.EQUAL, "attribute": "stacktrace.module", "value": "example"}
-        )
-        self.assertPasses(rule, event)
+        # correctly matching modules, at various locations in the stacktrace
+        for value in ["example", "somecode", "othercode"]:
+            rule = self.get_rule(
+                data={"match": MatchType.EQUAL, "attribute": "stacktrace.module", "value": value}
+            )
+            self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            data={"match": MatchType.EQUAL, "attribute": "stacktrace.module", "value": "somecode"}
-        )
-        self.assertPasses(rule, event)
-
-        rule = self.get_rule(
-            data={"match": MatchType.EQUAL, "attribute": "stacktrace.module", "value": "othercode"}
-        )
-        self.assertPasses(rule, event)
-
+        # non-matching module
         rule = self.get_rule(
             data={"match": MatchType.EQUAL, "attribute": "stacktrace.module", "value": "foo"}
         )
@@ -381,29 +355,14 @@ class EventAttributeConditionTest(RuleTestCase):
             }
         )
 
-        rule = self.get_rule(
-            data={
-                "match": MatchType.EQUAL,
-                "attribute": "stacktrace.code",
-                "value": "somecode.bar()",
-            }
-        )
-        self.assertPasses(rule, event)
+        # correctly matching code, at various locations in the stacktrace
+        for value in ["somecode.bar()", "othercode.baz()", "hi()"]:
+            rule = self.get_rule(
+                data={"match": MatchType.EQUAL, "attribute": "stacktrace.code", "value": value}
+            )
+            self.assertPasses(rule, event)
 
-        rule = self.get_rule(
-            data={
-                "match": MatchType.EQUAL,
-                "attribute": "stacktrace.code",
-                "value": "othercode.baz()",
-            }
-        )
-        self.assertPasses(rule, event)
-
-        rule = self.get_rule(
-            data={"match": MatchType.EQUAL, "attribute": "stacktrace.code", "value": "hi()"}
-        )
-        self.assertPasses(rule, event)
-
+        # non-matching code
         rule = self.get_rule(
             data={"match": MatchType.EQUAL, "attribute": "stacktrace.code", "value": "foo"}
         )


### PR DESCRIPTION
I was playing around with these tests, and added some to learn how the feature worked (namely, to convince myself that the `stacktrace.*` attributes seen in alert rules will match anywhere in the stack), and figured it couldn't hurt to include them in the test suite.

In the process, I wanted the sample event to be configurable, so I made it so that you can pass any of the top-level keys in order to overwrite the defaults.