### PR TITLE
ref(docs): Clarify docstring for `create_or_update`

### DIFF
--- a/src/sentry/db/models/query.py
+++ b/src/sentry/db/models/query.py
@@ -50,14 +50,19 @@ update.alters_data = True
 def create_or_update(model, using=None, **kwargs):
     """
     Similar to get_or_create, either updates a row or creates it.
-    only values args are used for update
-    both default and values are used for create
 
-    The result will be (rows affected, False), if the row was not created,
+    In order to determine if the row exists, this searches on all of the kwargs
+    besides `values` and `default`.
+
+    If the row exists, it is updated with the data in `values`. If it
+    doesn't, it is created with the data in `values`, `defaults`, and the remaining
+    kwargs.
+
+    The result will be (rows affected, False) if the row was not created,
     or (instance, True) if the object is new.
 
     >>> create_or_update(MyModel, key='value', values={
-    >>>     'value': F('value') + 1,
+    >>>     'col_name': F('col_name') + 1,
     >>> }, defaults={'created_at': timezone.now()})
     """
     values = kwargs.pop("values", {})


### PR DESCRIPTION
I've had to figure these details out more than once, so trying to pay it forward.