### PR TITLE
fix(outcomes): Remove asynchronous publisher wrapper

### DIFF
--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -13,7 +13,7 @@ from sentry import tsdb, options
 from sentry.utils import json, metrics
 from sentry.utils.data_filters import FILTER_STAT_KEYS_TO_VALUES
 from sentry.utils.dates import to_datetime
-from sentry.utils.pubsub import QueuedPublisherService, KafkaPublisher
+from sentry.utils.pubsub import KafkaPublisher
 
 # valid values for outcome
 
@@ -110,9 +110,7 @@ def track_outcome(org_id, project_id, key_id, outcome, reason=None, timestamp=No
     """
     global outcomes_publisher
     if outcomes_publisher is None:
-        outcomes_publisher = QueuedPublisherService(
-            KafkaPublisher(settings.KAFKA_CLUSTERS[outcomes["cluster"]])
-        )
+        outcomes_publisher = KafkaPublisher(settings.KAFKA_CLUSTERS[outcomes["cluster"]])
 
     assert isinstance(org_id, six.integer_types)
     assert isinstance(project_id, six.integer_types)


### PR DESCRIPTION
There is no benefit to wrapping the `KafkaPublisher` instance with the `QueuedPublisherService` because the Kafka client is already asynchronous. Wrapping this class prevents the producer from draining gracefully during shutdown (even after #15934) because messages may still be in the outermost queue.

This does slightly change the behavior of this function — the `QueuedPublisherService` bounds the queue at 100 items and _silently discards items_ if the queue is full: https://github.com/getsentry/sentry/blob/19016164d8d139a20cbc2c679c6113e77176cf30/src/sentry/utils/pubsub.py#L52-L55

The `KafkaProducer` has a much larger buffer by default, and will raise `BufferError` if its internal queue is full.