### PR TITLE
feat(discv2): fixing padding regrets

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -341,11 +341,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     }
 
     const chevronElement = !isRoot ? (
-      <div
-        style={{
-          textAlign: 'right',
-        }}
-      >
+      <div>
         {chevron}
       </div>
     ) : null;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -666,7 +666,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
 
     return (
       <Tooltip title={warningText}>
-        <WarningIcon src="icon-circle-info" />
+        <WarningIcon src="icon-circle-exclamation" />
       </Tooltip>
     );
   };
@@ -859,14 +859,14 @@ const SpanTreeTogglerContainer = styled('div')<TogglerTypes>`
   height: 16px;
   width: ${p => (p.hasToggler ? '40px' : '12px')};
   min-width: ${p => (p.hasToggler ? '40px' : '12px')};
-  margin-right: ${p => (p.hasToggler ? space(0.75) : space(1.5))};
+  margin-right: ${p => (p.hasToggler ? space(0.5) : space(1))};
   z-index: ${zIndex.spanTreeToggler};
   display: flex;
   justify-content: flex-end;
 `;
 
 const SpanTreeConnector = styled('div')<TogglerTypes>`
-  height: ${p => (p.isLast ? '75%' : '160%')};
+  height: ${p => (p.isLast ? '80%' : '160%')};
   width: 100%;
   border-left: 1px solid ${p => p.theme.gray1};
   position: absolute;
@@ -923,7 +923,7 @@ type SpanTreeTogglerAndDivProps = OmitHtmlDivProps<{
 
 const SpanTreeToggler = styled('div')<SpanTreeTogglerAndDivProps>`
   white-space: nowrap;
-  min-width: 32px;
+  min-width: 30px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -343,7 +343,6 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     const chevronElement = !isRoot ? (
       <div
         style={{
-          width: '5px',
           textAlign: 'right',
         }}
       >
@@ -367,9 +366,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
             this.props.toggleSpanTree();
           }}
         >
-          <span style={{textAlign: 'center'}}>
-            <Count value={numOfSpanChildren} />
-          </span>
+          <Count value={numOfSpanChildren} />
           {chevronElement}
         </SpanTreeToggler>
       </SpanTreeTogglerContainer>
@@ -970,16 +967,15 @@ const DurationPill = styled('div')<{durationDisplay: DurationDisplay}>`
 const SpanBarRectangle = styled('div')`
   position: relative;
   height: 100%;
-
   min-width: 1px;
   user-select: none;
-
   transition: border-color 0.15s ease-in-out;
   border-right: 1px solid rgba(0, 0, 0, 0);
 `;
 
 const WarningIcon = styled(InlineSvg)`
   margin-left: ${space(0.25)};
+  margin-bottom: ${space(0.25)};
 `;
 
 const Chevron = styled(InlineSvg)`

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -340,11 +340,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       );
     }
 
-    const chevronElement = !isRoot ? (
-      <div>
-        {chevron}
-      </div>
-    ) : null;
+    const chevronElement = !isRoot ? <div>{chevron}</div> : null;
 
     return (
       <SpanTreeTogglerContainer style={{left: `${left}px`}} hasToggler>
@@ -872,6 +868,17 @@ const SpanTreeConnector = styled('div')<TogglerTypes>`
     width: 100%;
     position: absolute;
     bottom: ${p => (p.isLast ? '0' : '50%')};
+  }
+
+  &:after {
+    content: '';
+    background-color: ${p => p.theme.gray1};
+    border-radius: 4px;
+    height: 3px;
+    width: 3px;
+    position: absolute;
+    right: 0;
+    top: 11px;
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -160,11 +160,9 @@ class SpanDetail extends React.Component<Props, State> {
     };
 
     return (
-      <div>
-        <Button size="xsmall" to={to}>
-          {t('Search by Trace')}
-        </Button>
-      </div>
+      <StyledButton size="xsmall" to={to}>
+        {t('Search by Trace')}
+      </StyledButton>
     );
   }
 
@@ -228,6 +226,12 @@ class SpanDetail extends React.Component<Props, State> {
   }
 }
 
+const StyledButton = styled(Button)`
+  position: absolute;
+  top: ${space(0.75)};
+  right: ${space(0.5)};
+`;
+
 const SpanDetailContainer = styled('div')`
   border-bottom: 1px solid ${p => p.theme.gray1};
   padding: ${space(2)};
@@ -235,13 +239,7 @@ const SpanDetailContainer = styled('div')`
 `;
 
 const ValueTd = styled('td')`
-  display: flex !important;
-  max-width: 100% !important;
-  align-items: center;
-`;
-
-const PreValue = styled('pre')`
-  flex: 1;
+  position: relative;
 `;
 
 const Row = ({
@@ -263,9 +261,9 @@ const Row = ({
     <tr>
       <td className="key">{title}</td>
       <ValueTd className="value">
-        <PreValue className="val">
+        <pre className="val">
           <span className="val-string">{children}</span>
-        </PreValue>
+        </pre>
         {extra}
       </ValueTd>
     </tr>


### PR DESCRIPTION
![Screen Shot 2019-12-10 at 5 31 28 PM](https://user-images.githubusercontent.com/4830259/70583766-96001c00-1b73-11ea-812d-7a8a6a025c46.png)
![Screen Shot 2019-12-11 at 9 53 24 AM](https://user-images.githubusercontent.com/4830259/70646682-487bc180-1bfc-11ea-86d3-b0290de10fe2.png)


- Moving button 
- Reducing margin between treeline and title
- Added dot