### PR TITLE
ref(apm): Use absolute start/end datetime ranges when fetching transactions

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -221,10 +221,16 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       return null;
     }
 
-    const {span, orgId, isRoot, eventView} = this.props;
+    const {span, orgId, isRoot, eventView, trace} = this.props;
 
     return (
-      <SpanDetail span={span} orgId={orgId} isRoot={!!isRoot} eventView={eventView} />
+      <SpanDetail
+        span={span}
+        orgId={orgId}
+        isRoot={!!isRoot}
+        eventView={eventView}
+        trace={trace}
+      />
     );
   };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedEvents.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedEvents.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import styled from 'react-emotion';
+import get from 'lodash/get';
+import moment from 'moment';
 
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Organization, Event, Project} from 'app/types';
 import AsyncComponent from 'app/components/asyncComponent';
 import DateTime from 'app/components/dateTime';
@@ -43,6 +46,17 @@ class LinkedEvents extends AsyncComponent<Props, State> {
 
     const trace = event.tags.find(tag => tag.key === 'trace');
     if (trace) {
+      const {start, end} = getParams({
+        start: moment
+          .unix(get(event, 'startTimestamp', 0))
+          .subtract(12, 'hours')
+          .format('YYYY-MM-DDTHH:mm:ss.SSS'),
+        end: moment
+          .unix(get(event, 'endTimestamp', 0))
+          .add(12, 'hours')
+          .format('YYYY-MM-DDTHH:mm:ss.SSS'),
+      });
+
       endpoints.push([
         'linkedEvents',
         `/organizations/${organization.slug}/eventsv2/`,
@@ -58,6 +72,8 @@ class LinkedEvents extends AsyncComponent<Props, State> {
             ],
             sort: ['-timestamp'],
             query: `trace:${trace.value}`,
+            start,
+            end,
           },
         },
       ]);


### PR DESCRIPTION
Given a transaction event's `startTimestamp` and `endTimestamp`, we can drastically improve the amount of data that ClickHouse will have to search/traverse through by explicitly indicating the absolute start/end datetime range on the `/organizations/${orgId}/eventsv2/` endpoint.

I arbitrarily used `start = startTimestamp - 12 hours` and `end = endTimestamp + 12 hours` with the assumption that the actual trace (that the transaction resides in) doesn't span by more than 24 hours.

This affects:

- searching for the direct descendant child in the span details component
- the list of transactions related by their trace id

