### PR TITLE
ref(ui): Decouple selecting groups away from issue list overview

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/resolve.jsx
+++ b/src/sentry/static/sentry/app/components/actions/resolve.jsx
@@ -23,6 +23,7 @@ export default class ResolveActions extends React.Component {
     isResolved: PropTypes.bool,
     isAutoResolved: PropTypes.bool,
     confirmLabel: PropTypes.string,
+    projectFetchError: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -97,6 +98,7 @@ export default class ResolveActions extends React.Component {
       disabled,
       confirmLabel,
       disableDropdown,
+      projectFetchError,
     } = this.props;
 
     const buttonClass = this.getButtonClass();
@@ -126,77 +128,79 @@ export default class ResolveActions extends React.Component {
           projectId={projectId}
         />
         <GuideAnchor target="resolve">
-          <div className="btn-group">
-            <ActionLink
-              {...actionLinkProps}
-              title="Resolve"
-              className={buttonClass}
-              onAction={() => onUpdate({status: 'resolved'})}
-            >
-              <span className="icon-checkmark hidden-xs" style={{marginRight: 5}} />
-              {t('Resolve')}
-            </ActionLink>
+          <Tooltip disabled={!projectFetchError} title={t('Error fetching project')}>
+            <div className="btn-group">
+              <ActionLink
+                {...actionLinkProps}
+                title="Resolve"
+                className={buttonClass}
+                onAction={() => onUpdate({status: 'resolved'})}
+              >
+                <span className="icon-checkmark hidden-xs" style={{marginRight: 5}} />
+                {t('Resolve')}
+              </ActionLink>
 
-            <DropdownLink
-              key="resolve-dropdown"
-              caret
-              className={buttonClass}
-              title=""
-              alwaysRenderMenu
-              disabled={disableDropdown || disabled}
-            >
-              <MenuItem header>{t('Resolved In')}</MenuItem>
-              <MenuItem noAnchor>
-                <Tooltip title={actionTitle} containerDisplayMode="block">
-                  <ActionLink
-                    {...actionLinkProps}
-                    onAction={() => {
-                      return (
-                        hasRelease &&
-                        onUpdate({
-                          status: 'resolved',
-                          statusDetails: {
-                            inNextRelease: true,
-                          },
-                        })
-                      );
-                    }}
-                  >
-                    {t('The next release')}
-                  </ActionLink>
-                </Tooltip>
-                <Tooltip title={actionTitle} containerDisplayMode="block">
-                  <ActionLink
-                    {...actionLinkProps}
-                    onAction={() => {
-                      return (
-                        hasRelease &&
-                        onUpdate({
-                          status: 'resolved',
-                          statusDetails: {
-                            inRelease: latestRelease ? latestRelease.version : 'latest',
-                          },
-                        })
-                      );
-                    }}
-                  >
-                    {latestRelease
-                      ? t('The current release (%s)', latestRelease.version)
-                      : t('The current release')}
-                  </ActionLink>
-                </Tooltip>
-                <Tooltip title={actionTitle} containerDisplayMode="block">
-                  <ActionLink
-                    {...actionLinkProps}
-                    onAction={() => hasRelease && this.setState({modal: true})}
-                    shouldConfirm={false}
-                  >
-                    {t('Another version\u2026')}
-                  </ActionLink>
-                </Tooltip>
-              </MenuItem>
-            </DropdownLink>
-          </div>
+              <DropdownLink
+                key="resolve-dropdown"
+                caret
+                className={buttonClass}
+                title=""
+                alwaysRenderMenu
+                disabled={disableDropdown || disabled}
+              >
+                <MenuItem header>{t('Resolved In')}</MenuItem>
+                <MenuItem noAnchor>
+                  <Tooltip title={actionTitle} containerDisplayMode="block">
+                    <ActionLink
+                      {...actionLinkProps}
+                      onAction={() => {
+                        return (
+                          hasRelease &&
+                          onUpdate({
+                            status: 'resolved',
+                            statusDetails: {
+                              inNextRelease: true,
+                            },
+                          })
+                        );
+                      }}
+                    >
+                      {t('The next release')}
+                    </ActionLink>
+                  </Tooltip>
+                  <Tooltip title={actionTitle} containerDisplayMode="block">
+                    <ActionLink
+                      {...actionLinkProps}
+                      onAction={() => {
+                        return (
+                          hasRelease &&
+                          onUpdate({
+                            status: 'resolved',
+                            statusDetails: {
+                              inRelease: latestRelease ? latestRelease.version : 'latest',
+                            },
+                          })
+                        );
+                      }}
+                    >
+                      {latestRelease
+                        ? t('The current release (%s)', latestRelease.version)
+                        : t('The current release')}
+                    </ActionLink>
+                  </Tooltip>
+                  <Tooltip title={actionTitle} containerDisplayMode="block">
+                    <ActionLink
+                      {...actionLinkProps}
+                      onAction={() => hasRelease && this.setState({modal: true})}
+                      shouldConfirm={false}
+                    >
+                      {t('Another version\u2026')}
+                    </ActionLink>
+                  </Tooltip>
+                </MenuItem>
+              </DropdownLink>
+            </div>
+          </Tooltip>
         </GuideAnchor>
       </div>
     );

--- a/src/sentry/static/sentry/app/views/issueList/actions.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.jsx
@@ -20,7 +20,6 @@ import IgnoreActions from 'app/components/actions/ignore';
 import IndicatorStore from 'app/stores/indicatorStore';
 import InlineSvg from 'app/components/inlineSvg';
 import LoadingError from 'app/components/loadingError';
-import LoadingIndicator from 'app/components/loadingIndicator';
 import MenuItem from 'app/components/menuItem';
 import Projects from 'app/utils/projects';
 import ResolveActions from 'app/components/actions/resolve';
@@ -348,14 +347,21 @@ const IssueListActions = createReactClass({
     }
   },
 
-  renderResolveActions({hasReleases, latestRelease, projectId, confirm, label}) {
+  renderResolveActions({
+    hasReleases,
+    latestRelease,
+    projectId,
+    confirm,
+    label,
+    loadingProjects,
+  }) {
     const {orgId} = this.props;
     const {anySelected} = this.state;
 
     // resolve requires a single project to be active in an org context
     // projectId is null when 0 or >1 projects are selected.
     const resolveDisabled = !anySelected;
-    const resolveDropdownDisabled = !(anySelected && projectId);
+    const resolveDropdownDisabled = !(anySelected && projectId) || loadingProjects;
     return (
       <ResolveActions
         hasRelease={hasReleases}
@@ -409,20 +415,17 @@ const IssueListActions = createReactClass({
               <Projects orgId={orgId} slugs={[selectedProjectSlug]}>
                 {({projects, initiallyLoaded, fetchError}) => {
                   const selectedProject = projects[0];
-                  return initiallyLoaded ? (
-                    fetchError ? (
-                      <LoadingError message={t('Error loading project')} />
-                    ) : (
-                      this.renderResolveActions({
-                        hasReleases: new Set(selectedProject.features).has('releases'),
-                        latestRelease: selectedProject.latestRelease,
-                        projectId: selectedProject.slug,
-                        confirm,
-                        label,
-                      })
-                    )
+                  return fetchError ? (
+                    <LoadingError message={t('Error loading project')} />
                   ) : (
-                    <LoadingIndicator mini />
+                    this.renderResolveActions({
+                      hasReleases: new Set(selectedProject.features).has('releases'),
+                      latestRelease: selectedProject.latestRelease,
+                      projectId: selectedProject.slug,
+                      confirm,
+                      label,
+                      loadingProjects: !initiallyLoaded,
+                    })
                   );
                 }}
               </Projects>

--- a/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
+++ b/tests/js/spec/components/actions/__snapshots__/resolve.spec.jsx.snap
@@ -82,74 +82,56 @@ exports[`ResolveActions with confirmation step renders 1`] = `
     <GuideAnchor
       target="resolve"
     >
-      <div
-        className="btn-group"
+      <Tooltip
+        containerDisplayMode="inline-block"
+        disabled={true}
+        position="top"
+        title="Error fetching project"
       >
-        <ActionLink
-          className="btn btn-default btn-sm"
-          confirmLabel="Resolve"
-          disabled={false}
-          message="Are you sure???"
-          onAction={[Function]}
-          shouldConfirm={true}
-          title="Resolve"
+        <div
+          className="btn-group"
         >
-          <Confirm
-            cancelText="Cancel"
-            confirmText="Resolve"
-            disableConfirmButton={false}
+          <ActionLink
+            className="btn btn-default btn-sm"
+            confirmLabel="Resolve"
+            disabled={false}
             message="Are you sure???"
-            onConfirm={[Function]}
-            priority="primary"
-            stopPropagation={false}
+            onAction={[Function]}
+            shouldConfirm={true}
+            title="Resolve"
           >
-            <a
-              aria-label="Resolve"
-              className="btn btn-default btn-sm"
-              onClick={[Function]}
-              title="Resolve"
+            <Confirm
+              cancelText="Cancel"
+              confirmText="Resolve"
+              disableConfirmButton={false}
+              message="Are you sure???"
+              onConfirm={[Function]}
+              priority="primary"
+              stopPropagation={false}
             >
-               
-              <span
-                className="icon-checkmark hidden-xs"
-                style={
-                  Object {
-                    "marginRight": 5,
+              <a
+                aria-label="Resolve"
+                className="btn btn-default btn-sm"
+                onClick={[Function]}
+                title="Resolve"
+              >
+                 
+                <span
+                  className="icon-checkmark hidden-xs"
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
                   }
-                }
-              />
-              Resolve
-            </a>
-            <Modal
-              animation={false}
-              autoFocus={true}
-              backdrop={true}
-              bsClass="modal"
-              dialogComponentClass={[Function]}
-              enforceFocus={true}
-              keyboard={true}
-              manager={
-                ModalManager {
-                  "add": [Function],
-                  "containers": Array [],
-                  "data": Array [],
-                  "handleContainerOverflow": true,
-                  "hideSiblingNodes": true,
-                  "isTopModal": [Function],
-                  "modals": Array [],
-                  "remove": [Function],
-                }
-              }
-              onHide={[Function]}
-              renderBackdrop={[Function]}
-              restoreFocus={true}
-              show={false}
-            >
+                />
+                Resolve
+              </a>
               <Modal
+                animation={false}
                 autoFocus={true}
                 backdrop={true}
-                backdropClassName="modal-backdrop"
-                containerClassName="modal-open"
+                bsClass="modal"
+                dialogComponentClass={[Function]}
                 enforceFocus={true}
                 keyboard={true}
                 manager={
@@ -164,358 +146,383 @@ exports[`ResolveActions with confirmation step renders 1`] = `
                     "remove": [Function],
                   }
                 }
-                onEntering={[Function]}
-                onExited={[Function]}
                 onHide={[Function]}
                 renderBackdrop={[Function]}
                 restoreFocus={true}
                 show={false}
-              />
-            </Modal>
-          </Confirm>
-        </ActionLink>
-        <DropdownLink
-          alwaysRenderMenu={true}
-          anchorRight={false}
-          caret={true}
-          className="btn btn-default btn-sm"
-          disabled={false}
-          key="resolve-dropdown"
-          title=""
-        >
-          <DropdownMenu
-            alwaysRenderMenu={true}
-            closeOnEscape={true}
-            keepMenuOpen={false}
-          >
-            <span
-              className="dropdown"
-            >
-              <a
-                className="dropdown-actor btn btn-default btn-sm dropdown-toggle"
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "outline": "none",
+              >
+                <Modal
+                  autoFocus={true}
+                  backdrop={true}
+                  backdropClassName="modal-backdrop"
+                  containerClassName="modal-open"
+                  enforceFocus={true}
+                  keyboard={true}
+                  manager={
+                    ModalManager {
+                      "add": [Function],
+                      "containers": Array [],
+                      "data": Array [],
+                      "handleContainerOverflow": true,
+                      "hideSiblingNodes": true,
+                      "isTopModal": [Function],
+                      "modals": Array [],
+                      "remove": [Function],
+                    }
                   }
-                }
+                  onEntering={[Function]}
+                  onExited={[Function]}
+                  onHide={[Function]}
+                  renderBackdrop={[Function]}
+                  restoreFocus={true}
+                  show={false}
+                />
+              </Modal>
+            </Confirm>
+          </ActionLink>
+          <DropdownLink
+            alwaysRenderMenu={true}
+            anchorRight={false}
+            caret={true}
+            className="btn btn-default btn-sm"
+            disabled={false}
+            key="resolve-dropdown"
+            title=""
+          >
+            <DropdownMenu
+              alwaysRenderMenu={true}
+              closeOnEscape={true}
+              keepMenuOpen={false}
+            >
+              <span
+                className="dropdown"
               >
-                <div
-                  className="dropdown-actor-title"
+                <a
+                  className="dropdown-actor btn btn-default btn-sm dropdown-toggle"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "outline": "none",
+                    }
+                  }
                 >
-                  <span />
-                  <i
-                    className="icon-arrow-down"
-                  />
-                </div>
-              </a>
-              <ul
-                className="dropdown-menu"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-              >
-                <MenuItem
-                  header={true}
-                >
-                  <li
-                    className="dropdown-header"
-                    role="presentation"
+                  <div
+                    className="dropdown-actor-title"
                   >
-                    Resolved In
-                  </li>
-                </MenuItem>
-                <MenuItem
-                  noAnchor={true}
+                    <span />
+                    <i
+                      className="icon-arrow-down"
+                    />
+                  </div>
+                </a>
+                <ul
+                  className="dropdown-menu"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
-                  <li
-                    className=""
-                    role="presentation"
+                  <MenuItem
+                    header={true}
                   >
-                    <Tooltip
-                      containerDisplayMode="block"
-                      position="top"
-                      title="Set up release tracking in order to use this feature."
+                    <li
+                      className="dropdown-header"
+                      role="presentation"
                     >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Container
-                              aria-describedby="tooltip-123456"
-                              containerDisplayMode="block"
-                              innerRef={[Function]}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
+                      Resolved In
+                    </li>
+                  </MenuItem>
+                  <MenuItem
+                    noAnchor={true}
+                  >
+                    <li
+                      className=""
+                      role="presentation"
+                    >
+                      <Tooltip
+                        containerDisplayMode="block"
+                        position="top"
+                        title="Set up release tracking in order to use this feature."
+                      >
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
                             >
-                              <span
+                              <Container
                                 aria-describedby="tooltip-123456"
-                                className="css-1v55bsv-Container eowlwvy0"
+                                containerDisplayMode="block"
+                                innerRef={[Function]}
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <ActionLink
-                                  confirmLabel="Resolve"
-                                  disabled={false}
-                                  message="Are you sure???"
-                                  onAction={[Function]}
-                                  shouldConfirm={true}
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1v55bsv-Container eowlwvy0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
                                 >
-                                  <Confirm
-                                    cancelText="Cancel"
-                                    confirmText="Resolve"
-                                    disableConfirmButton={false}
-                                    message="Are you sure???"
-                                    onConfirm={[Function]}
-                                    priority="primary"
-                                    stopPropagation={false}
-                                  >
-                                    <a
-                                      onClick={[Function]}
-                                    >
-                                       
-                                      The next release
-                                    </a>
-                                    <Modal
-                                      animation={false}
-                                      autoFocus={true}
-                                      backdrop={true}
-                                      bsClass="modal"
-                                      dialogComponentClass={[Function]}
-                                      enforceFocus={true}
-                                      keyboard={true}
-                                      manager={
-                                        ModalManager {
-                                          "add": [Function],
-                                          "containers": Array [],
-                                          "data": Array [],
-                                          "handleContainerOverflow": true,
-                                          "hideSiblingNodes": true,
-                                          "isTopModal": [Function],
-                                          "modals": Array [],
-                                          "remove": [Function],
-                                        }
-                                      }
-                                      onHide={[Function]}
-                                      renderBackdrop={[Function]}
-                                      restoreFocus={true}
-                                      show={false}
-                                    >
-                                      <Modal
-                                        autoFocus={true}
-                                        backdrop={true}
-                                        backdropClassName="modal-backdrop"
-                                        containerClassName="modal-open"
-                                        enforceFocus={true}
-                                        keyboard={true}
-                                        manager={
-                                          ModalManager {
-                                            "add": [Function],
-                                            "containers": Array [],
-                                            "data": Array [],
-                                            "handleContainerOverflow": true,
-                                            "hideSiblingNodes": true,
-                                            "isTopModal": [Function],
-                                            "modals": Array [],
-                                            "remove": [Function],
-                                          }
-                                        }
-                                        onEntering={[Function]}
-                                        onExited={[Function]}
-                                        onHide={[Function]}
-                                        renderBackdrop={[Function]}
-                                        restoreFocus={true}
-                                        show={false}
-                                      />
-                                    </Modal>
-                                  </Confirm>
-                                </ActionLink>
-                              </span>
-                            </Container>
-                          </InnerReference>
-                        </Reference>
-                      </Manager>
-                    </Tooltip>
-                    <Tooltip
-                      containerDisplayMode="block"
-                      position="top"
-                      title="Set up release tracking in order to use this feature."
-                    >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Container
-                              aria-describedby="tooltip-123456"
-                              containerDisplayMode="block"
-                              innerRef={[Function]}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                            >
-                              <span
-                                aria-describedby="tooltip-123456"
-                                className="css-1v55bsv-Container eowlwvy0"
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                onMouseEnter={[Function]}
-                                onMouseLeave={[Function]}
-                              >
-                                <ActionLink
-                                  confirmLabel="Resolve"
-                                  disabled={false}
-                                  message="Are you sure???"
-                                  onAction={[Function]}
-                                  shouldConfirm={true}
-                                >
-                                  <Confirm
-                                    cancelText="Cancel"
-                                    confirmText="Resolve"
-                                    disableConfirmButton={false}
-                                    message="Are you sure???"
-                                    onConfirm={[Function]}
-                                    priority="primary"
-                                    stopPropagation={false}
-                                  >
-                                    <a
-                                      onClick={[Function]}
-                                    >
-                                       
-                                      The current release
-                                    </a>
-                                    <Modal
-                                      animation={false}
-                                      autoFocus={true}
-                                      backdrop={true}
-                                      bsClass="modal"
-                                      dialogComponentClass={[Function]}
-                                      enforceFocus={true}
-                                      keyboard={true}
-                                      manager={
-                                        ModalManager {
-                                          "add": [Function],
-                                          "containers": Array [],
-                                          "data": Array [],
-                                          "handleContainerOverflow": true,
-                                          "hideSiblingNodes": true,
-                                          "isTopModal": [Function],
-                                          "modals": Array [],
-                                          "remove": [Function],
-                                        }
-                                      }
-                                      onHide={[Function]}
-                                      renderBackdrop={[Function]}
-                                      restoreFocus={true}
-                                      show={false}
-                                    >
-                                      <Modal
-                                        autoFocus={true}
-                                        backdrop={true}
-                                        backdropClassName="modal-backdrop"
-                                        containerClassName="modal-open"
-                                        enforceFocus={true}
-                                        keyboard={true}
-                                        manager={
-                                          ModalManager {
-                                            "add": [Function],
-                                            "containers": Array [],
-                                            "data": Array [],
-                                            "handleContainerOverflow": true,
-                                            "hideSiblingNodes": true,
-                                            "isTopModal": [Function],
-                                            "modals": Array [],
-                                            "remove": [Function],
-                                          }
-                                        }
-                                        onEntering={[Function]}
-                                        onExited={[Function]}
-                                        onHide={[Function]}
-                                        renderBackdrop={[Function]}
-                                        restoreFocus={true}
-                                        show={false}
-                                      />
-                                    </Modal>
-                                  </Confirm>
-                                </ActionLink>
-                              </span>
-                            </Container>
-                          </InnerReference>
-                        </Reference>
-                      </Manager>
-                    </Tooltip>
-                    <Tooltip
-                      containerDisplayMode="block"
-                      position="top"
-                      title="Set up release tracking in order to use this feature."
-                    >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Container
-                              aria-describedby="tooltip-123456"
-                              containerDisplayMode="block"
-                              innerRef={[Function]}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
-                            >
-                              <span
-                                aria-describedby="tooltip-123456"
-                                className="css-1v55bsv-Container eowlwvy0"
-                                onBlur={[Function]}
-                                onFocus={[Function]}
-                                onMouseEnter={[Function]}
-                                onMouseLeave={[Function]}
-                              >
-                                <ActionLink
-                                  confirmLabel="Resolve"
-                                  disabled={false}
-                                  message="Are you sure???"
-                                  onAction={[Function]}
-                                  shouldConfirm={false}
-                                >
-                                  <ActionLinkAnchor
-                                    className=""
-                                    data-test-id="action-link"
+                                  <ActionLink
+                                    confirmLabel="Resolve"
                                     disabled={false}
-                                    onClick={[Function]}
+                                    message="Are you sure???"
+                                    onAction={[Function]}
+                                    shouldConfirm={true}
                                   >
-                                    <a
-                                      className="css-19ecu88-ActionLinkAnchor ehtyk0g0"
+                                    <Confirm
+                                      cancelText="Cancel"
+                                      confirmText="Resolve"
+                                      disableConfirmButton={false}
+                                      message="Are you sure???"
+                                      onConfirm={[Function]}
+                                      priority="primary"
+                                      stopPropagation={false}
+                                    >
+                                      <a
+                                        onClick={[Function]}
+                                      >
+                                         
+                                        The next release
+                                      </a>
+                                      <Modal
+                                        animation={false}
+                                        autoFocus={true}
+                                        backdrop={true}
+                                        bsClass="modal"
+                                        dialogComponentClass={[Function]}
+                                        enforceFocus={true}
+                                        keyboard={true}
+                                        manager={
+                                          ModalManager {
+                                            "add": [Function],
+                                            "containers": Array [],
+                                            "data": Array [],
+                                            "handleContainerOverflow": true,
+                                            "hideSiblingNodes": true,
+                                            "isTopModal": [Function],
+                                            "modals": Array [],
+                                            "remove": [Function],
+                                          }
+                                        }
+                                        onHide={[Function]}
+                                        renderBackdrop={[Function]}
+                                        restoreFocus={true}
+                                        show={false}
+                                      >
+                                        <Modal
+                                          autoFocus={true}
+                                          backdrop={true}
+                                          backdropClassName="modal-backdrop"
+                                          containerClassName="modal-open"
+                                          enforceFocus={true}
+                                          keyboard={true}
+                                          manager={
+                                            ModalManager {
+                                              "add": [Function],
+                                              "containers": Array [],
+                                              "data": Array [],
+                                              "handleContainerOverflow": true,
+                                              "hideSiblingNodes": true,
+                                              "isTopModal": [Function],
+                                              "modals": Array [],
+                                              "remove": [Function],
+                                            }
+                                          }
+                                          onEntering={[Function]}
+                                          onExited={[Function]}
+                                          onHide={[Function]}
+                                          renderBackdrop={[Function]}
+                                          restoreFocus={true}
+                                          show={false}
+                                        />
+                                      </Modal>
+                                    </Confirm>
+                                  </ActionLink>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip>
+                      <Tooltip
+                        containerDisplayMode="block"
+                        position="top"
+                        title="Set up release tracking in order to use this feature."
+                      >
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
+                            >
+                              <Container
+                                aria-describedby="tooltip-123456"
+                                containerDisplayMode="block"
+                                innerRef={[Function]}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                              >
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1v55bsv-Container eowlwvy0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  <ActionLink
+                                    confirmLabel="Resolve"
+                                    disabled={false}
+                                    message="Are you sure???"
+                                    onAction={[Function]}
+                                    shouldConfirm={true}
+                                  >
+                                    <Confirm
+                                      cancelText="Cancel"
+                                      confirmText="Resolve"
+                                      disableConfirmButton={false}
+                                      message="Are you sure???"
+                                      onConfirm={[Function]}
+                                      priority="primary"
+                                      stopPropagation={false}
+                                    >
+                                      <a
+                                        onClick={[Function]}
+                                      >
+                                         
+                                        The current release
+                                      </a>
+                                      <Modal
+                                        animation={false}
+                                        autoFocus={true}
+                                        backdrop={true}
+                                        bsClass="modal"
+                                        dialogComponentClass={[Function]}
+                                        enforceFocus={true}
+                                        keyboard={true}
+                                        manager={
+                                          ModalManager {
+                                            "add": [Function],
+                                            "containers": Array [],
+                                            "data": Array [],
+                                            "handleContainerOverflow": true,
+                                            "hideSiblingNodes": true,
+                                            "isTopModal": [Function],
+                                            "modals": Array [],
+                                            "remove": [Function],
+                                          }
+                                        }
+                                        onHide={[Function]}
+                                        renderBackdrop={[Function]}
+                                        restoreFocus={true}
+                                        show={false}
+                                      >
+                                        <Modal
+                                          autoFocus={true}
+                                          backdrop={true}
+                                          backdropClassName="modal-backdrop"
+                                          containerClassName="modal-open"
+                                          enforceFocus={true}
+                                          keyboard={true}
+                                          manager={
+                                            ModalManager {
+                                              "add": [Function],
+                                              "containers": Array [],
+                                              "data": Array [],
+                                              "handleContainerOverflow": true,
+                                              "hideSiblingNodes": true,
+                                              "isTopModal": [Function],
+                                              "modals": Array [],
+                                              "remove": [Function],
+                                            }
+                                          }
+                                          onEntering={[Function]}
+                                          onExited={[Function]}
+                                          onHide={[Function]}
+                                          renderBackdrop={[Function]}
+                                          restoreFocus={true}
+                                          show={false}
+                                        />
+                                      </Modal>
+                                    </Confirm>
+                                  </ActionLink>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip>
+                      <Tooltip
+                        containerDisplayMode="block"
+                        position="top"
+                        title="Set up release tracking in order to use this feature."
+                      >
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
+                            >
+                              <Container
+                                aria-describedby="tooltip-123456"
+                                containerDisplayMode="block"
+                                innerRef={[Function]}
+                                onBlur={[Function]}
+                                onFocus={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                              >
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1v55bsv-Container eowlwvy0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
+                                >
+                                  <ActionLink
+                                    confirmLabel="Resolve"
+                                    disabled={false}
+                                    message="Are you sure???"
+                                    onAction={[Function]}
+                                    shouldConfirm={false}
+                                  >
+                                    <ActionLinkAnchor
+                                      className=""
                                       data-test-id="action-link"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      Another version…
-                                    </a>
-                                  </ActionLinkAnchor>
-                                </ActionLink>
-                              </span>
-                            </Container>
-                          </InnerReference>
-                        </Reference>
-                      </Manager>
-                    </Tooltip>
-                  </li>
-                </MenuItem>
-              </ul>
-            </span>
-          </DropdownMenu>
-        </DropdownLink>
-      </div>
+                                      <a
+                                        className="css-19ecu88-ActionLinkAnchor ehtyk0g0"
+                                        data-test-id="action-link"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                      >
+                                        Another version…
+                                      </a>
+                                    </ActionLinkAnchor>
+                                  </ActionLink>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip>
+                    </li>
+                  </MenuItem>
+                </ul>
+              </span>
+            </DropdownMenu>
+          </DropdownLink>
+        </div>
+      </Tooltip>
     </GuideAnchor>
   </div>
 </ResolveActions>
@@ -601,276 +608,283 @@ exports[`ResolveActions without confirmation renders 1`] = `
     <GuideAnchor
       target="resolve"
     >
-      <div
-        className="btn-group"
+      <Tooltip
+        containerDisplayMode="inline-block"
+        disabled={true}
+        position="top"
+        title="Error fetching project"
       >
-        <ActionLink
-          className="btn btn-default btn-sm"
-          confirmLabel="Resolve"
-          disabled={false}
-          onAction={[Function]}
-          shouldConfirm={false}
-          title="Resolve"
+        <div
+          className="btn-group"
         >
-          <ActionLinkAnchor
-            aria-label="Resolve"
+          <ActionLink
             className="btn btn-default btn-sm"
-            data-test-id="action-link-resolve"
+            confirmLabel="Resolve"
             disabled={false}
-            onClick={[Function]}
+            onAction={[Function]}
+            shouldConfirm={false}
+            title="Resolve"
           >
-            <a
+            <ActionLinkAnchor
               aria-label="Resolve"
-              className="btn btn-default btn-sm css-19ecu88-ActionLinkAnchor ehtyk0g0"
+              className="btn btn-default btn-sm"
               data-test-id="action-link-resolve"
               disabled={false}
               onClick={[Function]}
             >
-              <span
-                className="icon-checkmark hidden-xs"
-                style={
-                  Object {
-                    "marginRight": 5,
-                  }
-                }
-              />
-              Resolve
-            </a>
-          </ActionLinkAnchor>
-        </ActionLink>
-        <DropdownLink
-          alwaysRenderMenu={true}
-          anchorRight={false}
-          caret={true}
-          className="btn btn-default btn-sm"
-          disabled={false}
-          key="resolve-dropdown"
-          title=""
-        >
-          <DropdownMenu
-            alwaysRenderMenu={true}
-            closeOnEscape={true}
-            keepMenuOpen={false}
-          >
-            <span
-              className="dropdown"
-            >
               <a
-                className="dropdown-actor btn btn-default btn-sm dropdown-toggle"
+                aria-label="Resolve"
+                className="btn btn-default btn-sm css-19ecu88-ActionLinkAnchor ehtyk0g0"
+                data-test-id="action-link-resolve"
+                disabled={false}
                 onClick={[Function]}
-                onKeyDown={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "outline": "none",
+              >
+                <span
+                  className="icon-checkmark hidden-xs"
+                  style={
+                    Object {
+                      "marginRight": 5,
+                    }
                   }
-                }
-              >
-                <div
-                  className="dropdown-actor-title"
-                >
-                  <span />
-                  <i
-                    className="icon-arrow-down"
-                  />
-                </div>
+                />
+                Resolve
               </a>
-              <ul
-                className="dropdown-menu"
-                onClick={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
+            </ActionLinkAnchor>
+          </ActionLink>
+          <DropdownLink
+            alwaysRenderMenu={true}
+            anchorRight={false}
+            caret={true}
+            className="btn btn-default btn-sm"
+            disabled={false}
+            key="resolve-dropdown"
+            title=""
+          >
+            <DropdownMenu
+              alwaysRenderMenu={true}
+              closeOnEscape={true}
+              keepMenuOpen={false}
+            >
+              <span
+                className="dropdown"
               >
-                <MenuItem
-                  header={true}
+                <a
+                  className="dropdown-actor btn btn-default btn-sm dropdown-toggle"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                  style={
+                    Object {
+                      "outline": "none",
+                    }
+                  }
                 >
-                  <li
-                    className="dropdown-header"
-                    role="presentation"
+                  <div
+                    className="dropdown-actor-title"
                   >
-                    Resolved In
-                  </li>
-                </MenuItem>
-                <MenuItem
-                  noAnchor={true}
+                    <span />
+                    <i
+                      className="icon-arrow-down"
+                    />
+                  </div>
+                </a>
+                <ul
+                  className="dropdown-menu"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
                 >
-                  <li
-                    className=""
-                    role="presentation"
+                  <MenuItem
+                    header={true}
                   >
-                    <Tooltip
-                      containerDisplayMode="block"
-                      position="top"
-                      title="Set up release tracking in order to use this feature."
+                    <li
+                      className="dropdown-header"
+                      role="presentation"
                     >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Container
-                              aria-describedby="tooltip-123456"
-                              containerDisplayMode="block"
-                              innerRef={[Function]}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
+                      Resolved In
+                    </li>
+                  </MenuItem>
+                  <MenuItem
+                    noAnchor={true}
+                  >
+                    <li
+                      className=""
+                      role="presentation"
+                    >
+                      <Tooltip
+                        containerDisplayMode="block"
+                        position="top"
+                        title="Set up release tracking in order to use this feature."
+                      >
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
                             >
-                              <span
+                              <Container
                                 aria-describedby="tooltip-123456"
-                                className="css-1v55bsv-Container eowlwvy0"
+                                containerDisplayMode="block"
+                                innerRef={[Function]}
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <ActionLink
-                                  confirmLabel="Resolve"
-                                  disabled={false}
-                                  onAction={[Function]}
-                                  shouldConfirm={false}
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1v55bsv-Container eowlwvy0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
                                 >
-                                  <ActionLinkAnchor
-                                    className=""
-                                    data-test-id="action-link"
+                                  <ActionLink
+                                    confirmLabel="Resolve"
                                     disabled={false}
-                                    onClick={[Function]}
+                                    onAction={[Function]}
+                                    shouldConfirm={false}
                                   >
-                                    <a
-                                      className="css-19ecu88-ActionLinkAnchor ehtyk0g0"
+                                    <ActionLinkAnchor
+                                      className=""
                                       data-test-id="action-link"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      The next release
-                                    </a>
-                                  </ActionLinkAnchor>
-                                </ActionLink>
-                              </span>
-                            </Container>
-                          </InnerReference>
-                        </Reference>
-                      </Manager>
-                    </Tooltip>
-                    <Tooltip
-                      containerDisplayMode="block"
-                      position="top"
-                      title="Set up release tracking in order to use this feature."
-                    >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Container
-                              aria-describedby="tooltip-123456"
-                              containerDisplayMode="block"
-                              innerRef={[Function]}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
+                                      <a
+                                        className="css-19ecu88-ActionLinkAnchor ehtyk0g0"
+                                        data-test-id="action-link"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                      >
+                                        The next release
+                                      </a>
+                                    </ActionLinkAnchor>
+                                  </ActionLink>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip>
+                      <Tooltip
+                        containerDisplayMode="block"
+                        position="top"
+                        title="Set up release tracking in order to use this feature."
+                      >
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
                             >
-                              <span
+                              <Container
                                 aria-describedby="tooltip-123456"
-                                className="css-1v55bsv-Container eowlwvy0"
+                                containerDisplayMode="block"
+                                innerRef={[Function]}
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <ActionLink
-                                  confirmLabel="Resolve"
-                                  disabled={false}
-                                  onAction={[Function]}
-                                  shouldConfirm={false}
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1v55bsv-Container eowlwvy0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
                                 >
-                                  <ActionLinkAnchor
-                                    className=""
-                                    data-test-id="action-link"
+                                  <ActionLink
+                                    confirmLabel="Resolve"
                                     disabled={false}
-                                    onClick={[Function]}
+                                    onAction={[Function]}
+                                    shouldConfirm={false}
                                   >
-                                    <a
-                                      className="css-19ecu88-ActionLinkAnchor ehtyk0g0"
+                                    <ActionLinkAnchor
+                                      className=""
                                       data-test-id="action-link"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      The current release
-                                    </a>
-                                  </ActionLinkAnchor>
-                                </ActionLink>
-                              </span>
-                            </Container>
-                          </InnerReference>
-                        </Reference>
-                      </Manager>
-                    </Tooltip>
-                    <Tooltip
-                      containerDisplayMode="block"
-                      position="top"
-                      title="Set up release tracking in order to use this feature."
-                    >
-                      <Manager>
-                        <Reference>
-                          <InnerReference
-                            setReferenceNode={[Function]}
-                          >
-                            <Container
-                              aria-describedby="tooltip-123456"
-                              containerDisplayMode="block"
-                              innerRef={[Function]}
-                              onBlur={[Function]}
-                              onFocus={[Function]}
-                              onMouseEnter={[Function]}
-                              onMouseLeave={[Function]}
+                                      <a
+                                        className="css-19ecu88-ActionLinkAnchor ehtyk0g0"
+                                        data-test-id="action-link"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                      >
+                                        The current release
+                                      </a>
+                                    </ActionLinkAnchor>
+                                  </ActionLink>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip>
+                      <Tooltip
+                        containerDisplayMode="block"
+                        position="top"
+                        title="Set up release tracking in order to use this feature."
+                      >
+                        <Manager>
+                          <Reference>
+                            <InnerReference
+                              setReferenceNode={[Function]}
                             >
-                              <span
+                              <Container
                                 aria-describedby="tooltip-123456"
-                                className="css-1v55bsv-Container eowlwvy0"
+                                containerDisplayMode="block"
+                                innerRef={[Function]}
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onMouseEnter={[Function]}
                                 onMouseLeave={[Function]}
                               >
-                                <ActionLink
-                                  confirmLabel="Resolve"
-                                  disabled={false}
-                                  onAction={[Function]}
-                                  shouldConfirm={false}
+                                <span
+                                  aria-describedby="tooltip-123456"
+                                  className="css-1v55bsv-Container eowlwvy0"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onMouseEnter={[Function]}
+                                  onMouseLeave={[Function]}
                                 >
-                                  <ActionLinkAnchor
-                                    className=""
-                                    data-test-id="action-link"
+                                  <ActionLink
+                                    confirmLabel="Resolve"
                                     disabled={false}
-                                    onClick={[Function]}
+                                    onAction={[Function]}
+                                    shouldConfirm={false}
                                   >
-                                    <a
-                                      className="css-19ecu88-ActionLinkAnchor ehtyk0g0"
+                                    <ActionLinkAnchor
+                                      className=""
                                       data-test-id="action-link"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      Another version…
-                                    </a>
-                                  </ActionLinkAnchor>
-                                </ActionLink>
-                              </span>
-                            </Container>
-                          </InnerReference>
-                        </Reference>
-                      </Manager>
-                    </Tooltip>
-                  </li>
-                </MenuItem>
-              </ul>
-            </span>
-          </DropdownMenu>
-        </DropdownLink>
-      </div>
+                                      <a
+                                        className="css-19ecu88-ActionLinkAnchor ehtyk0g0"
+                                        data-test-id="action-link"
+                                        disabled={false}
+                                        onClick={[Function]}
+                                      >
+                                        Another version…
+                                      </a>
+                                    </ActionLinkAnchor>
+                                  </ActionLink>
+                                </span>
+                              </Container>
+                            </InnerReference>
+                          </Reference>
+                        </Manager>
+                      </Tooltip>
+                    </li>
+                  </MenuItem>
+                </ul>
+              </span>
+            </DropdownMenu>
+          </DropdownLink>
+        </div>
+      </Tooltip>
     </GuideAnchor>
   </div>
 </ResolveActions>


### PR DESCRIPTION
Move the responsibility of keeping track of selected groups on the issues page to the `<IssueListActions>`. The `<IssueListActions>` component uses the selected group information to conditionally show options such as resolving the issue in the next/current release or merging issues. This will also loosen the issues pages grip on organization.projects.

Loading Example:
![Kapture 2019-12-11 at 15 07 11](https://user-images.githubusercontent.com/9372512/70668276-fbade000-1c27-11ea-95f8-016583aafbf8.gif)

Project Fetch Error Example:
![image](https://user-images.githubusercontent.com/9372512/70677374-ddee7400-1c43-11ea-996f-7745f30c3cd1.png)

