### PR TITLE
fix(app) Ensure that the order of project owners is preserved

### DIFF
--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -84,7 +84,15 @@ class ProjectOwnership(Model):
             return cls.Everyone if ownership.fallthrough else [], None
 
         owners = {o for rule in rules for o in rule.owners}
-        return filter(None, resolve_actors(owners, project_id).values()), rules
+        owners_to_actors = resolve_actors(owners, project_id)
+        ordered_actors = []
+        for rule in rules:
+            for o in rule.owners:
+                if o in owners and owners_to_actors.get(o) is not None:
+                    ordered_actors.append(owners_to_actors[o])
+                    owners.remove(o)
+
+        return ordered_actors, rules
 
     @classmethod
     def get_autoassign_owner(cls, project_id, data):

--- a/tests/sentry/api/endpoints/test_event_owners.py
+++ b/tests/sentry/api/endpoints/test_event_owners.py
@@ -1,0 +1,232 @@
+from __future__ import absolute_import
+
+import six
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase
+
+from sentry.models import ProjectOwnership
+from sentry.ownership.grammar import Rule, Owner, Matcher, dump_schema
+
+
+class ProjectOwnershipEndpointTestCase(APITestCase):
+    def setUp(self):
+        self.login_as(user=self.user)
+        self.user2 = self.create_user("user2@example.com")
+        self.user3 = self.create_user("user3@example.com")
+
+        self.team = self.create_team(
+            organization=self.organization, slug="tiger-team", members=[self.user]
+        )
+        self.team2 = self.create_team(
+            organization=self.organization, slug="tiger-team2", members=[self.user2]
+        )
+        self.team3 = self.create_team(
+            organization=self.organization, slug="tiger-team3", members=[self.user3]
+        )
+
+        self.project = self.create_project(
+            organization=self.organization, teams=[self.team, self.team2, self.team3], slug="bengal"
+        )
+
+    def test_no_rules(self):
+        event1 = self.store_event(
+            data={"stacktrace": {"frames": [{"filename": "foo.py"}]}}, project_id=self.project.id
+        )
+
+        self.path = reverse(
+            "sentry-api-0-event-owners",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": self.project.slug,
+                "event_id": event1.event_id,
+            },
+        )
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert len(resp.data["owners"]) == 0
+        assert resp.data["rule"] is None
+        assert len(resp.data["rules"]) == 0
+
+    def test_no_matching_owners(self):
+        rule_a = Rule(Matcher("path", "bar.py"), [Owner("user", self.user.email)])
+
+        ProjectOwnership.objects.create(
+            project_id=self.project.id, schema=dump_schema([rule_a]), fallthrough=True
+        )
+
+        event1 = self.store_event(
+            data={"stacktrace": {"frames": [{"filename": "foo.py"}]}}, project_id=self.project.id
+        )
+
+        self.path = reverse(
+            "sentry-api-0-event-owners",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": self.project.slug,
+                "event_id": event1.event_id,
+            },
+        )
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert len(resp.data["owners"]) == 0
+        assert resp.data["rule"] is None
+        assert len(resp.data["rules"]) == 0
+
+    def test_matching_non_existing_owner(self):
+        rule_a = Rule(Matcher("path", "*"), [Owner("user", "doesnotexist@fake.com")])
+
+        ProjectOwnership.objects.create(
+            project_id=self.project.id, schema=dump_schema([rule_a]), fallthrough=True
+        )
+
+        event1 = self.store_event(
+            data={"stacktrace": {"frames": [{"filename": "foo.py"}]}}, project_id=self.project.id
+        )
+
+        self.path = reverse(
+            "sentry-api-0-event-owners",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": self.project.slug,
+                "event_id": event1.event_id,
+            },
+        )
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert len(resp.data["owners"]) == 0
+        assert resp.data["rule"] == Matcher(type="path", pattern="*")
+        assert len(resp.data["rules"]) == 1
+
+    def test_one_owner(self):
+        rule_a = Rule(Matcher("path", "*.py"), [Owner("user", self.user.email)])
+
+        ProjectOwnership.objects.create(
+            project_id=self.project.id, schema=dump_schema([rule_a]), fallthrough=True
+        )
+
+        event1 = self.store_event(
+            data={"stacktrace": {"frames": [{"filename": "foo.py"}]}}, project_id=self.project.id
+        )
+
+        self.path = reverse(
+            "sentry-api-0-event-owners",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": self.project.slug,
+                "event_id": event1.event_id,
+            },
+        )
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert len(resp.data["owners"]) == 1
+        assert resp.data["owners"][0]["id"] == six.text_type(self.user.id)
+        assert resp.data["rule"] == Matcher("path", "*.py")
+        assert len(resp.data["rules"]) == 1
+
+    def test_multiple_owners(self):
+        users = [self.user, self.user2, self.user3]
+        rules = [
+            Rule(Matcher("path", "*.py"), [Owner("user", users[0].email)]),
+            Rule(Matcher("path", "*foo*"), [Owner("user", users[1].email)]),
+            Rule(Matcher("path", "*"), [Owner("user", users[2].email)]),
+        ]
+
+        ProjectOwnership.objects.create(
+            project_id=self.project.id, schema=dump_schema(rules), fallthrough=True
+        )
+
+        event1 = self.store_event(
+            data={"stacktrace": {"frames": [{"filename": "foo.py"}]}}, project_id=self.project.id
+        )
+
+        self.path = reverse(
+            "sentry-api-0-event-owners",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": self.project.slug,
+                "event_id": event1.event_id,
+            },
+        )
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert len(resp.data["owners"]) == 3
+        assert [o["id"] for o in resp.data["owners"]] == [six.text_type(u.id) for u in users]
+        assert resp.data["rule"] == Matcher("path", "*.py")
+        assert len(resp.data["rules"]) == 3
+
+    def test_multiple_owners_order_matters(self):
+        users = [self.user, self.user2, self.user3]
+        rules = [
+            Rule(Matcher("path", "*.py"), [Owner("user", users[0].email)]),
+            Rule(Matcher("path", "*foo*"), [Owner("user", users[1].email)]),
+            Rule(Matcher("path", "*"), [Owner("user", users[2].email)]),
+        ]
+        rules.reverse()
+
+        ProjectOwnership.objects.create(
+            project_id=self.project.id, schema=dump_schema(rules), fallthrough=True
+        )
+
+        event1 = self.store_event(
+            data={"stacktrace": {"frames": [{"filename": "foo.py"}]}}, project_id=self.project.id
+        )
+
+        self.path = reverse(
+            "sentry-api-0-event-owners",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": self.project.slug,
+                "event_id": event1.event_id,
+            },
+        )
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert len(resp.data["owners"]) == 3
+        assert [o["id"] for o in resp.data["owners"]] == [
+            six.text_type(u.id) for u in reversed(users)
+        ]
+        assert resp.data["rule"] == Matcher("path", "*")
+        assert len(resp.data["rules"]) == 3
+
+    def test_owners_of_different_types_ordered_correctly(self):
+        owners = [self.user, self.team3, self.user2, self.team2, self.user3, self.team]
+        rules = [
+            Rule(Matcher("path", "*.py"), [Owner("user", owners[0].email)]),
+            Rule(Matcher("path", "*py"), [Owner("team", owners[1].slug)]),
+            Rule(Matcher("path", "*foo*"), [Owner("user", owners[2].email)]),
+            Rule(Matcher("path", "*y"), [Owner("team", owners[3].slug)]),
+            Rule(Matcher("path", "*"), [Owner("user", owners[4].email)]),
+            Rule(Matcher("path", "*o.py"), [Owner("team", owners[5].slug)]),
+        ]
+
+        ProjectOwnership.objects.create(
+            project_id=self.project.id, schema=dump_schema(rules), fallthrough=True
+        )
+
+        event1 = self.store_event(
+            data={"stacktrace": {"frames": [{"filename": "foo.py"}]}}, project_id=self.project.id
+        )
+
+        self.path = reverse(
+            "sentry-api-0-event-owners",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": self.project.slug,
+                "event_id": event1.event_id,
+            },
+        )
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert len(resp.data["owners"]) == 6
+        assert [o["id"] for o in resp.data["owners"]] == [six.text_type(o.id) for o in owners]
+        assert [o["type"] for o in resp.data["owners"]] == ["user", "team"] * 3
+        assert resp.data["rule"] == Matcher("path", "*.py")
+        assert len(resp.data["rules"]) == 6

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -56,7 +56,7 @@ class ProjectOwnershipTestCase(TestCase):
             ProjectOwnership.get_owners(
                 self.project.id, {"stacktrace": {"frames": [{"filename": "src/foo.py"}]}}
             ),
-            ([Actor(self.user.id, User), Actor(self.team.id, Team)], [rule_a, rule_b]),
+            ([Actor(self.team.id, Team), Actor(self.user.id, User)], [rule_a, rule_b]),
         )
 
         assert ProjectOwnership.get_owners(
@@ -71,6 +71,13 @@ class ProjectOwnershipTestCase(TestCase):
         assert ProjectOwnership.get_owners(
             self.project.id, {"stacktrace": {"frames": [{"filename": "xxxx"}]}}
         ) == ([], None)
+
+        self.assert_ownership_equals(
+            ProjectOwnership.get_owners(
+                self.project.id, {"stacktrace": {"frames": [{"filename": "src/foo.py"}]}}
+            ),
+            ([Actor(self.team.id, Team), Actor(self.user.id, User)], [rule_a, rule_b]),
+        )
 
 
 class ResolveActorsTestCase(TestCase):


### PR DESCRIPTION
Make sure that the order of owners when returned in the API matches the order
of the rules that matched them, while still deduping the owners.

Fixes ISSUE-608