### PR TITLE
fix(ui): Fix Threshold areas not updating after "time window" change [SEN-1244]

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -82,7 +82,7 @@ export default class ThresholdsChart extends React.PureComponent<Props, State> {
       // can return a negitive position (probably because yAxisMax is not synced with chart yet)
       this.setState({yAxisMax: Math.round(threshold * 1.1)}, this.forceUpdate);
     } else {
-      this.setState({yAxisMax: null});
+      this.setState({yAxisMax: null}, this.forceUpdate);
     }
   }, 150);
 


### PR DESCRIPTION
This fixes the issue where we chart the threshold areas for triggers and the y axis scale changes (e.g. when changing time window or query), but the areas do not update to reflect the new y axis scale.

Fixes SEN-1244