### PR TITLE
feat(backend): Add additional query params to sent_first_event endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -22,7 +22,17 @@ class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
         :pparam string organization_slug: the slug of the organization
                                           containing the projects to check
                                           for a first event from.
+        :qparam boolean is_member:        An optional boolean to choose to filter on
+                                          projects which the user is a member of.
+        :qparam array[string] project:    An optional list of project ids to filter
         :auth: required
         """
+        is_member = request.GET.get("is_member")
+        project_ids = set(map(int, request.GET.getlist("project")))
         queryset = Project.objects.filter(organization=organization, first_event__isnull=False)
+        if is_member:
+            queryset = queryset.filter(teams__organizationmember__user=request.user)
+        if project_ids:
+            queryset = queryset.filter(id__in=project_ids)
+
         return Response(serialize({"sentFirstEvent": queryset.count() > 0}, request.user))

--- a/tests/sentry/api/endpoints/test_organization_projects_sent_first_event.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_sent_first_event.py
@@ -49,3 +49,25 @@ class OrganizationProjectsSentFirstEventEndpointTest(APITestCase):
         assert response.status_code == 200
 
         assert response.data["sentFirstEvent"]
+
+    def test_no_first_event_in_member_projects(self):
+        self.create_project(teams=[self.team], first_event=datetime.now())
+        self.create_member(organization=self.org, user=self.foo)
+
+        self.login_as(user=self.foo)
+
+        response = self.client.get(u"{}?is_member=true".format(self.url))
+        assert response.status_code == 200
+
+        assert not response.data["sentFirstEvent"]
+
+    def test_first_event_from_project_ids(self):
+        project = self.create_project(teams=[self.team], first_event=datetime.now())
+        self.create_member(organization=self.org, user=self.foo)
+
+        self.login_as(user=self.foo)
+
+        response = self.client.get(u"{}?project={}".format(self.url, project.id))
+        assert response.status_code == 200
+
+        assert response.data["sentFirstEvent"]


### PR DESCRIPTION
The issues page does a couple operations on `organization.projects` (all projects) just to check for the existence of projects that have sent a first event. See https://github.com/getsentry/sentry/blob/1e1eb7222d7938ee6c962f35e250a5bcf23002e7/src/sentry/static/sentry/app/views/issueList/overview.jsx#L602-L605

In order to decouple issues from `organization.projects` I have added some additional query params to mimic the operations that the frontend does on the list of all projects. This modified endpoint will be used instead of fetching `organization.projects`.