### PR TITLE
Fix(parsing) Allow words for event.handled queries

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -232,7 +232,7 @@ class SearchVisitor(NodeVisitor):
             # so they can be used in conditions
         ]
     )
-    boolean_keys = set(["error.handled", "device.online", "stack.in_app"])
+    boolean_keys = set(["error.handled", "device.charging", "device.online", "stack.in_app"])
     date_keys = set(
         [
             "start",

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -5,7 +5,6 @@ from collections import defaultdict, Iterable
 from dateutil.parser import parse as parse_datetime
 import six
 
-from sentry.api.event_search import get_filter
 from sentry.tagstore import TagKeyStatus
 from sentry.tagstore.base import TagStorage, TOP_VALUES_DEFAULT_LIMIT
 from sentry.tagstore.exceptions import (
@@ -591,7 +590,7 @@ class SnubaTagStorage(TagStorage):
             snuba_key = "tags[%s]" % (key,)
 
         if query:
-            conditions = get_filter(query).conditions
+            conditions.append([snuba_key, "LIKE", u"%{}%".format(query)])
         else:
             conditions.append([snuba_key, "!=", ""])
 

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -5,6 +5,7 @@ from collections import defaultdict, Iterable
 from dateutil.parser import parse as parse_datetime
 import six
 
+from sentry.api.event_search import SearchVisitor
 from sentry.tagstore import TagKeyStatus
 from sentry.tagstore.base import TagStorage, TOP_VALUES_DEFAULT_LIMIT
 from sentry.tagstore.exceptions import (
@@ -589,10 +590,17 @@ class SnubaTagStorage(TagStorage):
         if snuba_key in BLACKLISTED_COLUMNS:
             snuba_key = "tags[%s]" % (key,)
 
-        if query:
-            conditions.append([snuba_key, "LIKE", u"%{}%".format(query)])
+        if key in SearchVisitor.numeric_keys:
+            if query:
+                conditions.append([snuba_key, ">=", int(query) - 50])
+                conditions.append([snuba_key, "<=", int(query) + 50])
+            else:
+                conditions.append([[snuba_key, ">=", 0], [snuba_key, "<", 0]])
         else:
-            conditions.append([snuba_key, "!=", ""])
+            if query:
+                conditions.append([snuba_key, "LIKE", u"%{}%".format(query)])
+            else:
+                conditions.append([snuba_key, "!=", ""])
 
         filters = {"project_id": projects}
         if environments:
@@ -617,7 +625,7 @@ class SnubaTagStorage(TagStorage):
         )
 
         tag_values = [
-            TagValue(key=key, value=value, **fix_tag_value_data(data))
+            TagValue(key=key, value=six.binary_type(value), **fix_tag_value_data(data))
             for value, data in six.iteritems(results)
         ]
 

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -587,10 +587,7 @@ class SnubaTagStorage(TagStorage):
 
         conditions = []
 
-        if snuba_key in BLACKLISTED_COLUMNS:
-            snuba_key = "tags[%s]" % (key,)
-
-        if key in SearchVisitor.numeric_keys:
+        if key in SearchVisitor.numeric_keys and snuba_key not in BLACKLISTED_COLUMNS:
             if query is not None and key in SearchVisitor.boolean_keys:
                 query = SearchVisitor.convert_boolean_text(query)
             if query is not None:
@@ -599,6 +596,9 @@ class SnubaTagStorage(TagStorage):
             else:
                 conditions.append([[snuba_key, ">=", 0], [snuba_key, "<", 0]])
         else:
+            if snuba_key in BLACKLISTED_COLUMNS:
+                snuba_key = "tags[%s]" % (key,)
+
             if query:
                 conditions.append([snuba_key, "LIKE", u"%{}%".format(query)])
             else:

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -591,7 +591,9 @@ class SnubaTagStorage(TagStorage):
             snuba_key = "tags[%s]" % (key,)
 
         if key in SearchVisitor.numeric_keys:
-            if query:
+            if query is not None and key in SearchVisitor.boolean_keys:
+                query = SearchVisitor.convert_boolean_text(query)
+            if query is not None:
                 conditions.append([snuba_key, ">=", int(query) - 50])
                 conditions.append([snuba_key, "<=", int(query) + 50])
             else:

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -590,7 +590,7 @@ class SnubaTagStorage(TagStorage):
         if key in SearchVisitor.numeric_keys and snuba_key not in BLACKLISTED_COLUMNS:
             if query is not None and key in SearchVisitor.boolean_keys:
                 query = SearchVisitor.convert_boolean_text(query)
-            if query is not None:
+            if query is not None and query.isdigit():
                 conditions.append([snuba_key, ">=", int(query) - 50])
                 conditions.append([snuba_key, "<=", int(query) + 50])
             else:

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -5,6 +5,7 @@ from collections import defaultdict, Iterable
 from dateutil.parser import parse as parse_datetime
 import six
 
+from sentry.api.event_search import get_filter
 from sentry.tagstore import TagKeyStatus
 from sentry.tagstore.base import TagStorage, TOP_VALUES_DEFAULT_LIMIT
 from sentry.tagstore.exceptions import (
@@ -590,7 +591,7 @@ class SnubaTagStorage(TagStorage):
             snuba_key = "tags[%s]" % (key,)
 
         if query:
-            conditions.append([snuba_key, "LIKE", u"%{}%".format(query)])
+            conditions = get_filter(query).conditions
         else:
             conditions.append([snuba_key, "!=", ""])
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -510,6 +510,30 @@ class ParseSearchQueryTest(unittest.TestCase):
             ):
                 parse_search_query(invalid_query)
 
+    def test_boolean_filter(self):
+        assert parse_search_query("error.handled:TrUe") == [
+            SearchFilter(
+                key=SearchKey(name="error.handled"), operator="=", value=SearchValue(raw_value=1)
+            )
+        ]
+        assert parse_search_query("error.handled:fAlSe") == [
+            SearchFilter(
+                key=SearchKey(name="error.handled"), operator="=", value=SearchValue(raw_value=0)
+            )
+        ]
+
+    def test_negated_boolean_filter(self):
+        assert parse_search_query("!error.handled:TrUe") == [
+            SearchFilter(
+                key=SearchKey(name="error.handled"), operator="=", value=SearchValue(raw_value=0)
+            )
+        ]
+        assert parse_search_query("!error.handled:fAlSe") == [
+            SearchFilter(
+                key=SearchKey(name="error.handled"), operator="=", value=SearchValue(raw_value=1)
+            )
+        ]
+
     def test_quotes_filtered_on_raw(self):
         # Enclose the full raw query? Strip it.
         assert parse_search_query('thinger:unknown "what is this?"') == [

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -60,6 +60,14 @@ class TagStorageTest(TestCase, SnubaTestCase):
                             "sentry:user": u"id:user{}".format(r),
                         },
                         "user": {"id": u"user{}".format(r), "email": u"user{}@sentry.io".format(r)},
+                        "exception": {
+                            "values": [
+                                {
+                                    "mechanism": {"handled": True},
+                                    "stacktrace": {"frames": [{"lineno": 29}]},
+                                }
+                            ]
+                        },
                     },
                 }
                 for r in [1, 2]
@@ -412,6 +420,68 @@ class TagStorageTest(TestCase, SnubaTestCase):
             )
             is None
         )
+
+    def test_get_tag_value_paginator_boolean(self):
+        from sentry.tagstore.types import TagValue
+
+        assert list(
+            self.ts.get_tag_value_paginator(
+                self.proj1.id, self.proj1env1.id, "error.handled"
+            ).get_result(10)
+        ) == [
+            TagValue(
+                key="error.handled",
+                value="1",
+                times_seen=2,
+                first_seen=self.now - timedelta(seconds=2),
+                last_seen=self.now - timedelta(seconds=1),
+            )
+        ]
+
+        assert list(
+            self.ts.get_tag_value_paginator(
+                self.proj1.id, self.proj1env1.id, "error.handled", query="True"
+            ).get_result(10)
+        ) == [
+            TagValue(
+                key="error.handled",
+                value="1",
+                times_seen=2,
+                first_seen=self.now - timedelta(seconds=2),
+                last_seen=self.now - timedelta(seconds=1),
+            )
+        ]
+
+    def test_get_tag_value_paginator_numeric(self):
+        from sentry.tagstore.types import TagValue
+
+        assert list(
+            self.ts.get_tag_value_paginator(
+                self.proj1.id, self.proj1env1.id, "stack.lineno"
+            ).get_result(10)
+        ) == [
+            TagValue(
+                key="stack.lineno",
+                value="29",
+                times_seen=2,
+                first_seen=self.now - timedelta(seconds=2),
+                last_seen=self.now - timedelta(seconds=1),
+            )
+        ]
+
+        assert list(
+            self.ts.get_tag_value_paginator(
+                self.proj1.id, self.proj1env1.id, "stack.lineno", query="30"
+            ).get_result(10)
+        ) == [
+            TagValue(
+                key="stack.lineno",
+                value="29",
+                times_seen=2,
+                first_seen=self.now - timedelta(seconds=2),
+                last_seen=self.now - timedelta(seconds=1),
+            )
+        ]
 
     def test_get_tag_value_paginator(self):
         from sentry.tagstore.types import TagValue


### PR DESCRIPTION
- Should fix: https://sentry.io/organizations/sentry/issues/1235234594/events/1644cc92e65b40d58269f9cadb0043b0/?project=300688
- error.handled is either 0 or 1, but IMO from a user perspective they
  would expect to be able to say true or false
    - eg. Right now its not possible to do a search for `event.handled: true` but that's more intuitive than `event.handled: 1`