### PR TITLE
ref(invite): Add invite modal to suggested assignees and suspect commits

### DIFF
--- a/src/sentry/static/sentry/app/components/commitRow.tsx
+++ b/src/sentry/static/sentry/app/components/commitRow.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import {Commit} from 'app/types';
-import {inviteRow} from 'app/components/modals/inviteMembersModal';
 import {openInviteMembersModal} from 'app/actionCreators/modal';
 import {PanelItem} from 'app/components/panels';
 import {t, tct} from 'app/locale';
@@ -51,7 +50,6 @@ export default class CommitRow extends React.Component<Props> {
                   openInviteMembersModal({
                     initialData: [
                       {
-                        ...inviteRow,
                         emails: new Set([author.email]),
                       },
                     ],

--- a/src/sentry/static/sentry/app/components/commitRow.tsx
+++ b/src/sentry/static/sentry/app/components/commitRow.tsx
@@ -120,6 +120,10 @@ const EmailWarning = styled('div')`
 const StyledLink = styled(Link)`
   color: ${p => p.theme.textColor};
   border-bottom: 1px dotted ${p => p.theme.textColor};
+
+  &:hover {
+    color: ${p => p.theme.textColor};
+  }
 `;
 
 const EmailWarningIcon = styled(InlineSvg)`

--- a/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
@@ -9,6 +9,7 @@ import Alert from 'app/components/alert';
 import Hovercard from 'app/components/hovercard';
 import InlineSvg from 'app/components/inlineSvg';
 import Link from 'app/components/links/link';
+import {openInviteMembersModal} from 'app/actionCreators/modal';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
@@ -24,10 +25,17 @@ const SuggestedOwnerHovercard = ({actor, commits, rules, ...props}) => (
         {actor.id === undefined && (
           <EmailAlert icon="icon-warning-sm" type="warning">
             {tct(
-              'The email [actorEmail]  has no associated Sentry account. Make sure to link alternative emails in [accountSettings:Account Settings].',
+              'The email [actorEmail] has no associated Sentry account. You can [inviteUser:invite this user] to your organization or link additional emails in [accountSettings:account settings].',
               {
                 actorEmail: <strong>{actor.email}</strong>,
                 accountSettings: <Link to="/settings/account/emails/" />,
+                inviteUser: (
+                  <a
+                    onClick={() =>
+                      openInviteMembersModal({source: 'suggested_assignees'})
+                    }
+                  />
+                ),
               }
             )}
           </EmailAlert>
@@ -170,7 +178,7 @@ const OwnershipValue = styled('code')`
 `;
 
 const EmailAlert = styled(p => <Alert iconSize="16px" {...p} />)`
-  margin: 10px -13px -9px;
+  margin: 10px -13px -13px;
   border-radius: 0;
   border-color: #ece0b0;
   padding: 10px;

--- a/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
@@ -26,7 +26,7 @@ const SuggestedOwnerHovercard = ({actor, commits, rules, ...props}) => (
         {actor.id === undefined && (
           <EmailAlert icon="icon-warning-sm" type="warning">
             {tct(
-              'The email [actorEmail] has no associated Sentry account. You can [inviteUser:invite this user] to your organization or link additional emails in [accountSettings:account settings].',
+              'The email [actorEmail] is not a member of your organization. [inviteUser:Invite] them or link additional emails in [accountSettings:account settings].',
               {
                 actorEmail: <strong>{actor.email}</strong>,
                 accountSettings: <Link to="/settings/account/emails/" />,

--- a/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
@@ -4,12 +4,13 @@ import moment from 'moment';
 import styled from 'react-emotion';
 
 import {t, tct} from 'app/locale';
+import {inviteRow} from 'app/components/modals/inviteMembersModal';
+import {openInviteMembersModal} from 'app/actionCreators/modal';
 import ActorAvatar from 'app/components/avatar/actorAvatar';
 import Alert from 'app/components/alert';
 import Hovercard from 'app/components/hovercard';
 import InlineSvg from 'app/components/inlineSvg';
 import Link from 'app/components/links/link';
-import {openInviteMembersModal} from 'app/actionCreators/modal';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
@@ -32,7 +33,15 @@ const SuggestedOwnerHovercard = ({actor, commits, rules, ...props}) => (
                 inviteUser: (
                   <a
                     onClick={() =>
-                      openInviteMembersModal({source: 'suggested_assignees'})
+                      openInviteMembersModal({
+                        initialData: [
+                          {
+                            ...inviteRow,
+                            emails: new Set([actor.email]),
+                          },
+                        ],
+                        source: 'suggested_assignees',
+                      })
                     }
                   />
                 ),

--- a/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.jsx
@@ -4,7 +4,6 @@ import moment from 'moment';
 import styled from 'react-emotion';
 
 import {t, tct} from 'app/locale';
-import {inviteRow} from 'app/components/modals/inviteMembersModal';
 import {openInviteMembersModal} from 'app/actionCreators/modal';
 import ActorAvatar from 'app/components/avatar/actorAvatar';
 import Alert from 'app/components/alert';
@@ -36,7 +35,6 @@ const SuggestedOwnerHovercard = ({actor, commits, rules, ...props}) => (
                       openInviteMembersModal({
                         initialData: [
                           {
-                            ...inviteRow,
                             emails: new Set([actor.email]),
                           },
                         ],

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
@@ -25,7 +25,7 @@ type Props = AsyncComponent['props'] &
     organization: Organization;
     teams: Team[];
     source?: string;
-    initialData?: InviteRow[];
+    initialData?: Partial<InviteRow>[];
   };
 
 type State = AsyncComponent['state'] & {
@@ -36,11 +36,6 @@ type State = AsyncComponent['state'] & {
 };
 
 const DEFAULT_ROLE = 'member';
-const inviteRow: InviteRow = {
-  emails: new Set(),
-  teams: new Set(),
-  role: DEFAULT_ROLE,
-};
 
 const InviteModalHook = HookOrDefault({
   hookName: 'member-invite-modal:customization',
@@ -51,8 +46,12 @@ const InviteModalHook = HookOrDefault({
 type InviteModalRenderFunc = React.ComponentProps<typeof InviteModalHook>['children'];
 
 class InviteMembersModal extends AsyncComponent<Props, State> {
-  get inviteTemplate() {
-    return inviteRow;
+  get inviteTemplate(): InviteRow {
+    return {
+      emails: new Set(),
+      teams: new Set(),
+      role: DEFAULT_ROLE,
+    };
   }
 
   /**
@@ -85,9 +84,16 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
     const state = super.getDefaultState();
     const {initialData} = this.props;
 
+    const pendingInvites = initialData
+      ? initialData.map(initial => ({
+          ...this.inviteTemplate,
+          ...initial,
+        }))
+      : [this.inviteTemplate];
+
     return {
       ...state,
-      pendingInvites: initialData ? initialData : [this.inviteTemplate],
+      pendingInvites,
       inviteStatus: {},
       complete: false,
       sendingInvites: false,
@@ -494,6 +500,6 @@ const modalClassName = css`
     margin: 50px auto;
   }
 `;
-export {inviteRow};
+
 export {modalClassName};
 export default withLatestContext(withTeams(InviteMembersModal));

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
@@ -25,6 +25,7 @@ type Props = AsyncComponent['props'] &
     organization: Organization;
     teams: Team[];
     source?: string;
+    initialData?: InviteRow[];
   };
 
 type State = AsyncComponent['state'] & {
@@ -35,6 +36,11 @@ type State = AsyncComponent['state'] & {
 };
 
 const DEFAULT_ROLE = 'member';
+const inviteRow: InviteRow = {
+  emails: new Set(),
+  teams: new Set(),
+  role: DEFAULT_ROLE,
+};
 
 const InviteModalHook = HookOrDefault({
   hookName: 'member-invite-modal:customization',
@@ -45,8 +51,8 @@ const InviteModalHook = HookOrDefault({
 type InviteModalRenderFunc = React.ComponentProps<typeof InviteModalHook>['children'];
 
 class InviteMembersModal extends AsyncComponent<Props, State> {
-  get inviteTemplate(): InviteRow {
-    return {emails: new Set(), teams: new Set(), role: DEFAULT_ROLE};
+  get inviteTemplate() {
+    return inviteRow;
   }
 
   /**
@@ -77,9 +83,11 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
 
   getDefaultState() {
     const state = super.getDefaultState();
+    const {initialData} = this.props;
+
     return {
       ...state,
-      pendingInvites: [this.inviteTemplate],
+      pendingInvites: initialData ? initialData : [this.inviteTemplate],
       inviteStatus: {},
       complete: false,
       sendingInvites: false,
@@ -486,5 +494,6 @@ const modalClassName = css`
     margin: 50px auto;
   }
 `;
+export {inviteRow};
 export {modalClassName};
 export default withLatestContext(withTeams(InviteMembersModal));

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -47,6 +47,7 @@ const InviteRowControl = ({
   <div className={className}>
     <div>
       <SelectControl
+        data-test-id="select-emails"
         disabled={disabled}
         placeholder={t('Enter one or more email')}
         value={emails}
@@ -74,6 +75,7 @@ const InviteRowControl = ({
     </div>
     <div>
       <RoleSelectControl
+        data-test-id="select-role"
         disabled={disabled}
         value={role}
         roles={roleOptions}
@@ -83,6 +85,7 @@ const InviteRowControl = ({
     </div>
     <div>
       <SelectControl
+        data-test-id="select-teams"
         disabled={disabled}
         placeholder={t('Add to teams...')}
         value={teams}

--- a/tests/js/spec/components/events/eventCause.spec.jsx
+++ b/tests/js/spec/components/events/eventCause.spec.jsx
@@ -5,16 +5,21 @@ import {Client} from 'app/api';
 import EventCause from 'app/components/events/eventCause';
 
 describe('EventCause', function() {
-  let wrapper, organization, project, event;
+  const event = TestStubs.Event();
+  const organization = TestStubs.Organization();
+  const project = TestStubs.Project();
+
+  const context = {
+    organization,
+    project,
+    group: TestStubs.Group(),
+  };
 
   afterEach(function() {
     Client.clearMockResponses();
   });
 
   beforeEach(function() {
-    event = TestStubs.Event();
-    organization = TestStubs.Organization();
-    project = TestStubs.Project();
     Client.addMockResponse({
       method: 'GET',
       url: `/projects/${organization.slug}/${project.slug}/events/${
@@ -58,38 +63,81 @@ describe('EventCause', function() {
         ],
       },
     });
+  });
 
-    wrapper = mount(
+  it('renders', async function() {
+    const wrapper = mount(
       <EventCause event={event} orgId={organization.slug} projectId={project.slug} />,
       {
-        context: {
-          organization,
-          project,
-          group: TestStubs.Group(),
-        },
+        context,
       }
     );
-  });
 
-  it('renders', function(done) {
+    await tick();
     wrapper.update();
 
-    setTimeout(() => {
-      expect(wrapper.find('CommitRow')).toHaveLength(1);
-      done();
-    });
+    expect(wrapper.find('CommitRow')).toHaveLength(1);
+    expect(wrapper.find('EmailWarningIcon').exists()).toBe(false);
+    expect(wrapper.find('Hovercard').exists()).toBe(false);
   });
 
-  it('expands', async function(done) {
+  it('expands', async function() {
+    const wrapper = mount(
+      <EventCause event={event} orgId={organization.slug} projectId={project.slug} />,
+      {
+        context,
+      }
+    );
+
+    await tick();
     wrapper.update();
+
     wrapper.find('ExpandButton').simulate('click');
     await tick();
     expect(wrapper.find('CommitRow')).toHaveLength(2);
-    //and hides
+
+    // and hides
     wrapper.find('ExpandButton').simulate('click');
     await tick();
     expect(wrapper.find('CommitRow')).toHaveLength(1);
+  });
 
-    done();
+  it('shows unassociated email warning', async function() {
+    Client.addMockResponse({
+      method: 'GET',
+      url: `/projects/${organization.slug}/${project.slug}/events/${
+        event.id
+      }/committers/`,
+      body: {
+        committers: [
+          {
+            author: {name: 'Somebody else', email: 'somebodyelse@email.com'},
+            commits: [
+              {
+                message: 'fix: Make things less broken',
+                score: 2,
+                id: 'zzzzzz3d0c9000829084ac7b1c9221fb18437c',
+                repository: TestStubs.Repository(),
+                dateCreated: '2018-03-02T16:30:26Z',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const wrapper = mount(
+      <EventCause event={event} orgId={organization.slug} projectId={project.slug} />,
+      {
+        context,
+      }
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('CommitRow')).toHaveLength(1);
+    expect(wrapper.find('EmailWarningIcon').exists()).toBe(true);
+    expect(wrapper.find('Hovercard').exists()).toBe(true);
   });
 });

--- a/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
+++ b/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
@@ -2,7 +2,7 @@ import {Modal} from 'react-bootstrap';
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
-import InviteMembersModal, {inviteRow} from 'app/components/modals/inviteMembersModal';
+import InviteMembersModal from 'app/components/modals/inviteMembersModal';
 import TeamStore from 'app/stores/teamStore';
 
 describe('InviteMembersModal', function() {
@@ -274,7 +274,7 @@ describe('InviteMembersModal', function() {
     });
 
     const initialEmail = 'test@gmail.com';
-    const initialData = [{...inviteRow, emails: new Set([initialEmail])}];
+    const initialData = [{emails: new Set([initialEmail])}];
 
     const wrapper = mountWithTheme(
       <InviteMembersModal

--- a/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
+++ b/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
@@ -2,10 +2,13 @@ import {Modal} from 'react-bootstrap';
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
-import InviteMembersModal from 'app/components/modals/inviteMembersModal';
+import InviteMembersModal, {inviteRow} from 'app/components/modals/inviteMembersModal';
+import TeamStore from 'app/stores/teamStore';
 
 describe('InviteMembersModal', function() {
-  const org = TestStubs.Organization({access: ['member:write']});
+  const team = TestStubs.Team();
+  const org = TestStubs.Organization({access: ['member:write'], teams: [team]});
+  TeamStore.loadInitialData([team]);
 
   const noWriteOrg = TestStubs.Organization({
     access: [],
@@ -262,6 +265,106 @@ describe('InviteMembersModal', function() {
     expect(
       wrapper.find('SelectControl EmailLabel InlineSvg[src="icon-warning-sm"]').exists()
     ).toBe(true);
+  });
+
+  it('can send initial email', async function() {
+    const createMemberMock = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/members/`,
+      method: 'POST',
+    });
+
+    const initialEmail = 'test@gmail.com';
+    const initialData = [{...inviteRow, emails: new Set([initialEmail])}];
+
+    const wrapper = mountWithTheme(
+      <InviteMembersModal
+        Body={Modal.Body}
+        Header={Modal.Header}
+        Footer={Modal.Footer}
+        organization={org}
+        initialData={initialData}
+      />,
+      TestStubs.routerContext()
+    );
+
+    expect(
+      wrapper
+        .find('span[className="Select-value-label"]')
+        .first()
+        .text()
+        .includes(initialEmail)
+    ).toBe(true);
+
+    wrapper.find('FooterContent Button[priority="primary"]').simulate('click');
+    await tick();
+    wrapper.update();
+
+    expect(createMemberMock).toHaveBeenCalledWith(
+      `/organizations/${org.slug}/members/`,
+      expect.objectContaining({
+        data: {email: initialEmail, role: 'member', teams: []},
+      })
+    );
+
+    expect(wrapper.find('StatusMessage').text()).toBe('Sent 1 invite');
+  });
+
+  it('can send initial email with role and team', async function() {
+    const createMemberMock = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/members/`,
+      method: 'POST',
+    });
+
+    const initialEmail = 'test@gmail.com';
+    const role = 'admin';
+    const initialData = [
+      {emails: new Set([initialEmail]), role, teams: new Set([team.slug])},
+    ];
+
+    const wrapper = mountWithTheme(
+      <InviteMembersModal
+        Body={Modal.Body}
+        Header={Modal.Header}
+        Footer={Modal.Footer}
+        organization={org}
+        initialData={initialData}
+      />,
+      TestStubs.routerContext()
+    );
+
+    expect(
+      wrapper
+        .find('SelectControl[data-test-id="select-emails"]')
+        .text()
+        .includes(initialEmail)
+    ).toBe(true);
+
+    expect(
+      wrapper
+        .find('SelectControl[data-test-id="select-role"]')
+        .text()
+        .toLowerCase()
+    ).toBe(role);
+
+    expect(
+      wrapper
+        .find('SelectControl[data-test-id="select-teams"]')
+        .text()
+        .includes(team.slug)
+    ).toBe(true);
+
+    wrapper.find('FooterContent Button[priority="primary"]').simulate('click');
+    await tick();
+    wrapper.update();
+
+    expect(createMemberMock).toHaveBeenCalledWith(
+      `/organizations/${org.slug}/members/`,
+      expect.objectContaining({
+        data: {email: initialEmail, role, teams: [team.slug]},
+      })
+    );
+
+    expect(wrapper.find('StatusMessage').text()).toBe('Sent 1 invite');
   });
 
   describe('member invite request mode', function() {

--- a/tests/js/spec/views/releases/detail/__snapshots__/releaseCommits.spec.jsx.snap
+++ b/tests/js/spec/views/releases/detail/__snapshots__/releaseCommits.spec.jsx.snap
@@ -245,18 +245,18 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                         </AvatarWrapper>
                         <CommitMessage>
                           <div
-                            className="css-bm0kt8-CommitMessage eyce8w21"
+                            className="css-bm0kt8-CommitMessage eyce8w24"
                           >
                             <Message>
                               <div
-                                className="css-q4dmcs-TextOverflow-Message eyce8w22"
+                                className="css-q4dmcs-TextOverflow-Message eyce8w25"
                               >
                                 (improve) Add Links to Spike-Protection Email (#2408)
                               </div>
                             </Message>
                             <Meta>
-                              <p
-                                className="css-10csi2f-Meta eyce8w23"
+                              <div
+                                className="css-qb05h1-TextOverflow-Meta eyce8w26"
                               >
                                 <span
                                   key="4"
@@ -284,7 +284,7 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                                     </time>
                                   </TimeSince>
                                 </span>
-                              </p>
+                              </div>
                             </Meta>
                           </div>
                         </CommitMessage>
@@ -568,18 +568,18 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                         </AvatarWrapper>
                         <CommitMessage>
                           <div
-                            className="css-bm0kt8-CommitMessage eyce8w21"
+                            className="css-bm0kt8-CommitMessage eyce8w24"
                           >
                             <Message>
                               <div
-                                className="css-q4dmcs-TextOverflow-Message eyce8w22"
+                                className="css-q4dmcs-TextOverflow-Message eyce8w25"
                               >
                                 (improve) Add Links to Spike-Protection Email (#2408)
                               </div>
                             </Message>
                             <Meta>
-                              <p
-                                className="css-10csi2f-Meta eyce8w23"
+                              <div
+                                className="css-qb05h1-TextOverflow-Meta eyce8w26"
                               >
                                 <span
                                   key="4"
@@ -607,7 +607,7 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                                     </time>
                                   </TimeSince>
                                 </span>
-                              </p>
+                              </div>
                             </Meta>
                           </div>
                         </CommitMessage>


### PR DESCRIPTION
Adds the invite modal to suspect commits and suggested assignees, when the user email is not associated with a member account. Also, prefills the email into the invite modal.

Before:
<img width="490" alt="Screen Shot 2019-12-16 at 5 06 16 PM" src="https://user-images.githubusercontent.com/16394317/70955652-71e68400-2026-11ea-8169-1e71df47a172.png">

After:
<img width="490" alt="Screen Shot 2019-12-16 at 4 57 19 PM" src="https://user-images.githubusercontent.com/16394317/70955657-7c088280-2026-11ea-9f96-2072c5118808.png">
<img width="613" alt="Screen Shot 2019-12-16 at 5 09 53 PM" src="https://user-images.githubusercontent.com/16394317/70955806-f2a58000-2026-11ea-8723-5a99f239dce3.png">




