### PR TITLE
ref(apm): Use absolute start/end datetime ranges when searching by trace id

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'react-emotion';
 import get from 'lodash/get';
 import map from 'lodash/map';
-import moment from 'moment';
 
 import {t} from 'app/locale';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
@@ -21,6 +20,7 @@ import EventView from 'app/views/eventsV2/eventView';
 import {generateDiscoverResultsRoute} from 'app/views/eventsV2/results';
 
 import {SpanType, ParsedTraceType} from './types';
+import {getTraceDateTimeRange} from './utils';
 
 type TransactionResult = {
   'project.name': string;
@@ -73,16 +73,12 @@ class SpanDetail extends React.Component<Props, State> {
 
     const url = `/organizations/${orgId}/eventsv2/`;
 
-    const {start, end} = getParams({
-      start: moment
-        .unix(trace.traceStartTimestamp)
-        .subtract(12, 'hours')
-        .format('YYYY-MM-DDTHH:mm:ss.SSS'),
-      end: moment
-        .unix(trace.traceEndTimestamp)
-        .add(12, 'hours')
-        .format('YYYY-MM-DDTHH:mm:ss.SSS'),
-    });
+    const {start, end} = getParams(
+      getTraceDateTimeRange({
+        start: trace.traceStartTimestamp,
+        end: trace.traceEndTimestamp,
+      })
+    );
 
     const query = {
       field: ['transaction', 'id', 'trace.span'],
@@ -156,7 +152,12 @@ class SpanDetail extends React.Component<Props, State> {
   }
 
   renderTraceButton() {
-    const {span, orgId} = this.props;
+    const {span, orgId, trace} = this.props;
+
+    const {start, end} = getTraceDateTimeRange({
+      start: trace.traceStartTimestamp,
+      end: trace.traceEndTimestamp,
+    });
 
     const eventView = EventView.fromSavedQuery({
       id: undefined,
@@ -168,6 +169,9 @@ class SpanDetail extends React.Component<Props, State> {
       tags: ['release', 'project.name', 'user.email', 'user.ip', 'environment'],
       projects: [],
       version: 2,
+
+      start,
+      end,
     });
 
     const to = {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -1,4 +1,6 @@
 import isString from 'lodash/isString';
+import moment from 'moment';
+
 import CHART_PALETTE from 'app/constants/chartPalette';
 import {ParsedTraceType, SpanType} from './types';
 
@@ -313,4 +315,25 @@ export function generateRootSpan(trace: ParsedTraceType): SpanType {
   };
 
   return rootSpan;
+}
+
+// start and end are assumed to be unix timestamps with fractional seconds
+export function getTraceDateTimeRange(input: {
+  start: number;
+  end: number;
+}): {start: string; end: string} {
+  const start = moment
+    .unix(input.start)
+    .subtract(12, 'hours')
+    .format('YYYY-MM-DDTHH:mm:ss.SSS');
+
+  const end = moment
+    .unix(input.end)
+    .add(12, 'hours')
+    .format('YYYY-MM-DDTHH:mm:ss.SSS');
+
+  return {
+    start,
+    end,
+  };
 }

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedEvents.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedEvents.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'react-emotion';
 import get from 'lodash/get';
-import moment from 'moment';
 
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Organization, Event, Project} from 'app/types';
@@ -13,6 +12,7 @@ import {t} from 'app/locale';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import withProjects from 'app/utils/withProjects';
+import {getTraceDateTimeRange} from 'app/components/events/interfaces/spans/utils.tsx';
 
 import {generateEventDetailsRoute, generateEventSlug} from './utils';
 import {SectionHeading} from '../styles';
@@ -46,16 +46,12 @@ class LinkedEvents extends AsyncComponent<Props, State> {
 
     const trace = event.tags.find(tag => tag.key === 'trace');
     if (trace) {
-      const {start, end} = getParams({
-        start: moment
-          .unix(get(event, 'startTimestamp', 0))
-          .subtract(12, 'hours')
-          .format('YYYY-MM-DDTHH:mm:ss.SSS'),
-        end: moment
-          .unix(get(event, 'endTimestamp', 0))
-          .add(12, 'hours')
-          .format('YYYY-MM-DDTHH:mm:ss.SSS'),
-      });
+      const {start, end} = getParams(
+        getTraceDateTimeRange({
+          start: get(event, 'startTimestamp', 0),
+          end: get(event, 'endTimestamp', 0),
+        })
+      );
 
       endpoints.push([
         'linkedEvents',


### PR DESCRIPTION
I created a `getTraceDateTimeRange` function to generate the trace datetime range as part of the payload query for fetching transactions.

In addition, I'm also applying the same datetime range for the "Search by trace". This allows searching for transaction spans by a trace id to be more snappy. 