### PR TITLE
fix(discv2): standardizing headers after new controls

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -308,14 +308,14 @@ const ContentBox = styled('div')`
   }
 
   @media (min-width: ${p => p.theme.breakpoints[2]}) {
-    grid-template-columns: auto 350px;
+    grid-template-columns: auto 325px;
   }
 `;
 
 const HeaderBox = styled(ContentBox)`
   background-color: ${p => p.theme.white};
   border-bottom: 1px solid ${p => p.theme.borderDark};
-  grid-row-gap: ${space(1)};
+  grid-row-gap: ${space(2)};
 `;
 
 const Controller = styled('div')`

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -21,7 +21,6 @@ import FileSize from 'app/components/fileSize';
 import NotFound from 'app/components/errors/notFound';
 import AsyncComponent from 'app/components/asyncComponent';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
-import {PageContent} from 'app/styles/organization';
 
 import EventView from '../eventView';
 import {hasAggregateField, EventQuery, generateTitle} from '../utils';
@@ -297,12 +296,13 @@ const EventMetadata = (props: {
   );
 };
 
-const ContentBox = styled(PageContent)`
+const ContentBox = styled('div')`
+  padding: ${space(2)} ${space(4)} ${space(3)};
   margin: 0;
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     display: grid;
-    grid-template-rows: 1fr auto;
+    grid-template-rows: 1fr 30px;
     grid-template-columns: 65% auto;
     grid-column-gap: ${space(3)};
   }
@@ -315,7 +315,7 @@ const ContentBox = styled(PageContent)`
 const HeaderBox = styled(ContentBox)`
   background-color: ${p => p.theme.white};
   border-bottom: 1px solid ${p => p.theme.borderDark};
-  grid-row-gap: ${space(2)};
+  grid-row-gap: ${space(1)};
 `;
 
 const Controller = styled('div')`

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -297,7 +297,7 @@ const EventMetadata = (props: {
 };
 
 const ContentBox = styled('div')`
-  padding: ${space(2)} ${space(4)} ${space(3)};
+  padding: ${space(2)} ${space(4)};
   margin: 0;
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {

--- a/src/sentry/static/sentry/app/views/eventsV2/eventInputName.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventInputName.tsx
@@ -4,6 +4,7 @@ import {browserHistory} from 'react-router';
 
 import {Client} from 'app/api';
 import {t} from 'app/locale';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
 import {Organization, SavedQuery} from 'app/types';
 import withApi from 'app/utils/withApi';
 
@@ -79,7 +80,7 @@ class EventInputName extends React.Component<Props> {
     const {eventView} = this.props;
 
     return (
-      <StyledHeader>
+      <StyledListHeader>
         <InlineInput
           ref={this.refInput}
           name="discover2-query-name"
@@ -87,18 +88,17 @@ class EventInputName extends React.Component<Props> {
           value={eventView.name || NAME_DEFAULT}
           onBlur={this.onBlur}
         />
-      </StyledHeader>
+      </StyledListHeader>
     );
   }
 }
 
-const StyledHeader = styled('div')`
-  display: flex;
-  align-items: center;
-  height: 24px;
+const StyledListHeader = styled('div')`
   font-size: ${p => p.theme.headerFontSize};
   color: ${p => p.theme.gray4};
   grid-column: 1/2;
+  align-self: center;
+  ${overflowEllipsis};
 `;
 
 export default withApi(EventInputName);

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -141,44 +141,42 @@ class Results extends React.Component<Props, State> {
               location={location}
               eventView={eventView}
             />
-            <div>
-              <ContentBox>
-                <Top>
-                  <StyledSearchBar
-                    organization={organization}
-                    projectIds={eventView.project}
-                    query={query}
-                    onSearch={this.handleSearch}
-                  />
-                  <StyledPanel>
-                    {getDynamicText({
-                      value: (
-                        <EventsChart
-                          router={router}
-                          query={eventView.getEventsAPIPayload(location).query}
-                          organization={organization}
-                          showLegend
-                          yAxisOptions={yAxisOptions}
-                          yAxisValue={eventView.yAxis}
-                          onYAxisChange={this.handleYAxisChange}
-                          project={eventView.project as number[]}
-                          environment={eventView.environment as string[]}
-                        />
-                      ),
-                      fixed: 'events chart',
-                    })}
-                  </StyledPanel>
-                </Top>
-                <Main eventView={eventView}>
-                  <Table
-                    organization={organization}
-                    eventView={eventView}
-                    location={location}
-                  />
-                </Main>
-                <Side eventView={eventView}>{this.renderTagsTable()}</Side>
-              </ContentBox>
-            </div>
+            <ContentBox>
+              <Top>
+                <StyledSearchBar
+                  organization={organization}
+                  projectIds={eventView.project}
+                  query={query}
+                  onSearch={this.handleSearch}
+                />
+                <StyledPanel>
+                  {getDynamicText({
+                    value: (
+                      <EventsChart
+                        router={router}
+                        query={eventView.getEventsAPIPayload(location).query}
+                        organization={organization}
+                        showLegend
+                        yAxisOptions={yAxisOptions}
+                        yAxisValue={eventView.yAxis}
+                        onYAxisChange={this.handleYAxisChange}
+                        project={eventView.project as number[]}
+                        environment={eventView.environment as string[]}
+                      />
+                    ),
+                    fixed: 'events chart',
+                  })}
+                </StyledPanel>
+              </Top>
+              <Main eventView={eventView}>
+                <Table
+                  organization={organization}
+                  eventView={eventView}
+                  location={location}
+                />
+              </Main>
+              <Side eventView={eventView}>{this.renderTagsTable()}</Side>
+            </ContentBox>
           </NoProjectMessage>
         </React.Fragment>
       </SentryDocumentTitle>

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -219,7 +219,7 @@ const ContentBox = styled(PageContent)`
   }
 
   @media (min-width: ${p => p.theme.breakpoints[2]}) {
-    grid-template-columns: auto 350px;
+    grid-template-columns: auto 325px;
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
@@ -6,7 +6,6 @@ import {Organization, SavedQuery} from 'app/types';
 import {fetchSavedQuery} from 'app/actionCreators/discoverSavedQueries';
 
 import {Client} from 'app/api';
-import {PageContent} from 'app/styles/organization';
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 
@@ -85,18 +84,16 @@ class ResultsHeader extends React.Component<Props, State> {
   }
 }
 
-const HeaderBox = styled(PageContent)`
+const HeaderBox = styled('div')`
+  padding: ${space(2)} ${space(4)} ${space(3)};
   background-color: ${p => p.theme.white};
   border-bottom: 1px solid ${p => p.theme.borderDark};
   grid-row-gap: ${space(1)};
-
-  /* app container is a flex box */
-  flex-grow: 0;
   margin: 0;
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     display: grid;
-    grid-template-rows: 1fr auto;
+    grid-template-rows: 1fr 30px;
     grid-template-columns: 65% auto;
     grid-column-gap: ${space(3)};
   }
@@ -107,8 +104,9 @@ const HeaderBox = styled(PageContent)`
 `;
 
 const Controller = styled('div')`
+  display: flex;
   justify-self: end;
-  grid-row: 1/3;
+  grid-row: 1/2;
   grid-column: 2/3;
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
@@ -88,7 +88,7 @@ const HeaderBox = styled('div')`
   padding: ${space(2)} ${space(4)};
   background-color: ${p => p.theme.white};
   border-bottom: 1px solid ${p => p.theme.borderDark};
-  grid-row-gap: ${space(1)};
+  grid-row-gap: ${space(2)};
   margin: 0;
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
@@ -99,7 +99,7 @@ const HeaderBox = styled('div')`
   }
 
   @media (min-width: ${p => p.theme.breakpoints[2]}) {
-    grid-template-columns: auto 350px;
+    grid-template-columns: auto 325px;
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
@@ -85,7 +85,7 @@ class ResultsHeader extends React.Component<Props, State> {
 }
 
 const HeaderBox = styled('div')`
-  padding: ${space(2)} ${space(4)} ${space(3)};
+  padding: ${space(2)} ${space(4)};
   background-color: ${p => p.theme.white};
   border-bottom: 1px solid ${p => p.theme.borderDark};
   grid-row-gap: ${space(1)};

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -299,9 +299,14 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
 const ButtonGroup = styled('div')`
   display: flex;
   align-items: center;
+  margin-top: ${space(1)};
 
   > * + * {
     margin-left: ${space(1)};
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    margin-top: 0;
   }
 `;
 


### PR DESCRIPTION
![Screen Shot 2019-12-11 at 6 03 35 PM](https://user-images.githubusercontent.com/4830259/70676339-bd70ea80-1c40-11ea-9a9a-3ab2b5a92932.png)

- Removed need for PageContent because it adds an unnecessary flex 