### PR TITLE
revert test(ci): only run migrations for backend tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -166,6 +166,16 @@ matrix:
       name: '[Django 1.10] Backend [Postgres] (2/2)'
       env: DJANGO_VERSION=">=1.10,<1.11" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1
 
+    # allowed to fail
+    - <<: *postgres_default
+      name: '[Django 1.10] Backend with migrations [Postgres] (1/2)'
+      env: DJANGO_VERSION=">=1.10,<1.11" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0
+
+    # allowed to fail
+    - <<: *postgres_default
+      name: '[Django 1.10] Backend with migrations [Postgres] (2/2)'
+      env: DJANGO_VERSION=">=1.10,<1.11" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1
+
     - <<: *acceptance_default
       name: '[Django 1.10] Acceptance'
       env: DJANGO_VERSION=">=1.10,<1.11" TEST_SUITE=acceptance USE_SNUBA=1 PERCY_ENABLE=0
@@ -279,6 +289,8 @@ matrix:
 
   allow_failures:
     - name: 'Storybook Deploy'
+    - name: '[Django 1.10] Backend with migrations [Postgres] (1/2)'
+    - name: '[Django 1.10] Backend with migrations [Postgres] (2/2)'
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -169,12 +169,12 @@ matrix:
     # allowed to fail
     - <<: *postgres_default
       name: '[Django 1.10] Backend with migrations [Postgres] (1/2)'
-      env: DJANGO_VERSION=">=1.10,<1.11" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0
+      env: DJANGO_VERSION=">=1.10,<1.11" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0 MIGRATIONS_TEST_MIGRATE=1
 
     # allowed to fail
     - <<: *postgres_default
       name: '[Django 1.10] Backend with migrations [Postgres] (2/2)'
-      env: DJANGO_VERSION=">=1.10,<1.11" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1
+      env: DJANGO_VERSION=">=1.10,<1.11" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1
 
     - <<: *acceptance_default
       name: '[Django 1.10] Acceptance'

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,6 +140,14 @@ matrix:
       script: flake8
 
     - <<: *postgres_default
+      name: 'Backend [Postgres] (1/2)'
+      env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0
+
+    - <<: *postgres_default
+      name: 'Backend [Postgres] (2/2)'
+      env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1
+
+    - <<: *postgres_default
       name: 'Backend with migrations [Postgres] (1/2)'
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0 MIGRATIONS_TEST_MIGRATE=1
     - <<: *postgres_default
@@ -151,12 +159,12 @@ matrix:
       env: TEST_SUITE=acceptance USE_SNUBA=1
 
     - <<: *postgres_default
-      name: '[Django 1.10] Backend with migrations [Postgres] (1/2)'
-      env: DJANGO_VERSION=">=1.10,<1.11" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0 MIGRATIONS_TEST_MIGRATE=1
+      name: '[Django 1.10] Backend [Postgres] (1/2)'
+      env: DJANGO_VERSION=">=1.10,<1.11" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0
 
     - <<: *postgres_default
-      name: '[Django 1.10] Backend with migrations [Postgres] (2/2)'
-      env: DJANGO_VERSION=">=1.10,<1.11" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1
+      name: '[Django 1.10] Backend [Postgres] (2/2)'
+      env: DJANGO_VERSION=">=1.10,<1.11" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1
 
     - <<: *acceptance_default
       name: '[Django 1.10] Acceptance'


### PR DESCRIPTION
Reverts https://github.com/getsentry/sentry/pull/16078 until Django 1.10 tests with migrations are fixed.