### PR TITLE
ref: Remove dead code from issuedetailspage

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/rawStacktraceContent.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawStacktraceContent.jsx
@@ -162,28 +162,10 @@ function getFrame(frame, frameIdx, platform) {
 }
 
 export default function render(data, platform, exception) {
-  let firstFrameOmitted, lastFrameOmitted;
   const frames = [];
-
-  if (data.framesOmitted) {
-    firstFrameOmitted = data.framesOmitted[0];
-    lastFrameOmitted = data.framesOmitted[1];
-  } else {
-    firstFrameOmitted = null;
-    lastFrameOmitted = null;
-  }
 
   data.frames.forEach((frame, frameIdx) => {
     frames.push(getFrame(frame, frameIdx, platform));
-    if (frameIdx === firstFrameOmitted) {
-      frames.push(
-        '.. frames ' +
-          firstFrameOmitted +
-          ' until ' +
-          lastFrameOmitted +
-          ' were omitted and not available ..'
-      );
-    }
   });
 
   if (platform !== 'python') {


### PR DESCRIPTION
semaphore does no longer support this attribute so this code is pointless. The only remarkable thing it does is crash if `data` is `null`.

Fix JAVASCRIPT-Y1E