### PR TITLE
fix(pagerduty): Route to PD account when adding new services

### DIFF
--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -164,6 +164,6 @@ class PagerDutyInstallationRedirect(PipelineView):
             pipeline.bind_state("config", request.GET["config"])
             return pipeline.next_step()
 
-        account_name = getattr(request, "account", None)
+        account_name = request.GET.get("account", None)
 
         return self.redirect(self.get_app_url(account_name))


### PR DESCRIPTION
The `account_name` in the following was always defaulting to `None`.

```python
account_name = getattr(request, "account", None)
```