### PR TITLE
ref: prevent lookups for Bit and BitHandler under Django 1.9, 1.10

### DIFF
--- a/src/bitfield/models.py
+++ b/src/bitfield/models.py
@@ -5,7 +5,7 @@ import six
 from django.db.models.fields import BigIntegerField, Field
 
 from bitfield.forms import BitFormField
-from bitfield.query import BitQueryLookupWrapper
+from bitfield.query import BitQueryExactLookupStub
 from bitfield.types import Bit, BitHandler
 
 # Count binary capacity. Truncate "0b" prefix from binary form.
@@ -173,4 +173,4 @@ class BitField(BigIntegerField):
         return name, path, args, kwargs
 
 
-BitField.register_lookup(BitQueryLookupWrapper)
+BitField.register_lookup(BitQueryExactLookupStub)

--- a/src/bitfield/models.py
+++ b/src/bitfield/models.py
@@ -135,21 +135,17 @@ class BitField(BigIntegerField):
         return int(value)
 
     def get_db_prep_lookup(self, lookup_type, value, connection, prepared=False):
-        if isinstance(getattr(value, "expression", None), Bit):
-            value = value.expression
         if isinstance(value, (BitHandler, Bit)):
-            return [value.mask]
+            raise NotImplementedError("get_db_prep_lookup not supported with types Bit, BitHandler")
+
         return BigIntegerField.get_db_prep_lookup(
             self, lookup_type=lookup_type, value=value, connection=connection, prepared=prepared
         )
 
     def get_prep_lookup(self, lookup_type, value):
-        if isinstance(getattr(value, "expression", None), Bit):
-            value = value.expression
         if isinstance(value, Bit):
-            if lookup_type in ("exact",):
-                return value
-            raise TypeError("Lookup type %r not supported with `Bit` type." % lookup_type)
+            raise NotImplementedError("Lookup type %r not supported with Bit type." % lookup_type)
+
         return BigIntegerField.get_prep_lookup(self, lookup_type, value)
 
     def to_python(self, value):

--- a/src/bitfield/query.py
+++ b/src/bitfield/query.py
@@ -2,22 +2,16 @@ from __future__ import absolute_import
 
 from bitfield.types import Bit, BitHandler
 
-from django.db.models.lookups import Lookup
+from django.db.models.lookups import Exact
 
 
-class BitQueryLookupWrapper(Lookup):
-    def process_lhs(self, qn, connection, lhs=None):
-        lhs_sql, params = super(BitQueryLookupWrapper, self).process_lhs(qn, connection, lhs)
-        if self.rhs:
-            lhs_sql = lhs_sql + " & %s"
-        else:
-            lhs_sql = lhs_sql + " | %s"
-        params.extend(self.process_rhs(qn, connection)[1])
-        return lhs_sql, params
-
+class BitQueryExactLookupStub(Exact):
     def get_db_prep_lookup(self, value, connection, prepared=False):
-        v = value.mask if isinstance(value, (BitHandler, Bit)) else value
-        return super(BitQueryLookupWrapper, self).get_db_prep_lookup(v, connection)
+        if isinstance(value, (BitHandler, Bit)):
+            raise NotImplementedError("get_db_prep_lookup not supported for Bit, BitHandler")
+        return super(BitQueryExactLookupStub, self).get_db_prep_lookup(value, connection)
 
     def get_prep_lookup(self):
+        if isinstance(self.rhs, (Bit,)):
+            raise NotImplementedError("get_db_prep_lookup not supported for Bit")
         return self.rhs

--- a/tests/sentry/db/models/fields/bitfield/test_bitfield.py
+++ b/tests/sentry/db/models/fields/bitfield/test_bitfield.py
@@ -233,7 +233,9 @@ class BitFieldTest(TestCase):
         self.assertTrue(instance.flags.FLAG_1)
         self.assertTrue(instance.flags.FLAG_3)
         self.assertFalse(
-            BitFieldTestModel.objects.filter(flags=BitFieldTestModel.flags.FLAG_0).exists()
+            BitFieldTestModel.objects.filter(
+                flags=F("flags").bitor(BitFieldTestModel.flags.FLAG_0)
+            ).exists()
         )
 
         BitFieldTestModel.objects.filter(pk=instance.pk).update(


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/16048.

So it turns out under Django 1.10, subclassing Lookup for BitQueryLookupWrapper results in it not actually being run! It needs to have, at the very least, a `lookup_name = "exact"`, but it's probably more correct to just subclass `Exact`. Still, the following from https://github.com/getsentry/sentry/pull/16048 still stands:

> Ideally, we can use upstream's Exact lookup without breaking our existing F-style lookups.

There's an easier way out of this though - I hypothesized we don't do lookups with Bit or BitHandler on the RHS. If you look at the lookup logic under Django 1.9, it basically just delegates to BigIntegerField except in cases of Bit/BitHandler. If we don't need to support that, then we basically don't need to customize lookup functions.

To be safe, and to verify that I'm correct, I'm changing the lookups under Django 1.9 to raise when those types are encountered. The only thing that broke was one bitfield test, which wasn't using our lookup style - I fully understand why we do bitor/and now, it's so that we do an Exact lookup with a BitField.

For Django 1.9 and 1.10 interop to work, I also did the same for the lookups under Django 1.10. Once we're fully on 1.10 then we can remove the 1.9 lookups.

Also, just to make sure getsentry doesn't break, I have a testing branch with sentry bumped here: https://github.com/getsentry/getsentry/pull/3403