### PR TITLE
ref(ui): Check first event sent via API in Issues Overview

### DIFF
--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -191,6 +191,8 @@ export const MAX_PICKABLE_DAYS = 90;
 
 export const DEFAULT_STATS_PERIOD = '14d';
 
+export const DEFAULT_QUERY = 'is:unresolved';
+
 export const DEFAULT_USE_UTC = true;
 
 export const DEFAULT_RELATIVE_PERIODS = {

--- a/src/sentry/static/sentry/app/views/issueList/noGroupsHandler.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/noGroupsHandler.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+
+import {Client} from 'app/api';
+import {DEFAULT_QUERY} from 'app/constants';
+import {LightWeightOrganization, Project} from 'app/types';
+import {t} from 'app/locale';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
+import ErrorRobot from 'app/components/errorRobot';
+import LoadingIndicator from 'app/components/loadingIndicator';
+
+type Props = {
+  api: Client;
+  organization: LightWeightOrganization;
+  query: string;
+  selectedProjectIds?: number[];
+  groupIds: number[];
+};
+
+type State = {
+  fetchingSentFirstEvent: boolean;
+  firstEventProjects?: Project[];
+  sentFirstEvent?: boolean;
+};
+
+const CongratsRobots = React.lazy(() =>
+  import(/* webpackChunkName: "CongratsRobots" */ 'app/views/issueList/congratsRobots')
+);
+
+class NoGroupsHandler extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      fetchingSentFirstEvent: true,
+    };
+  }
+
+  componentDidMount() {
+    this.fetchSentFirstEvent();
+  }
+
+  async fetchSentFirstEvent() {
+    this.setState({
+      fetchingSentFirstEvent: true,
+    });
+
+    const {organization, selectedProjectIds, api} = this.props;
+    let sentFirstEvent = false;
+    let projects = [];
+    // const selectedProjectIds = this.props.selection.projects;
+
+    // If no projects are selected, then we must check every project the user is a
+    // member of and make sure there are no first events for all of the projects
+    let firstEventQuery = {};
+    const projectsQuery = {per_page: 1, query: {}};
+    if (!selectedProjectIds || !selectedProjectIds.length) {
+      firstEventQuery = {is_member: true};
+    } else {
+      firstEventQuery = {project: selectedProjectIds};
+      projectsQuery.query = selectedProjectIds.map(id => `id:${id}`).join(' ');
+    }
+
+    [{sentFirstEvent}, projects] = await Promise.all([
+      // checks to see if selection has sent a first event
+      api.requestPromise(`/organizations/${organization.slug}/sent-first-event/`, {
+        query: firstEventQuery,
+      }),
+      // retrieves a single project to feed to the ErrorRobot from renderStreamBody
+      api.requestPromise(`/organizations/${organization.slug}/projects/`, {
+        query: projectsQuery,
+      }),
+    ]);
+
+    this.setState({
+      fetchingSentFirstEvent: false,
+      sentFirstEvent,
+      firstEventProjects: projects,
+    });
+  }
+
+  renderLoading() {
+    return <LoadingIndicator />;
+  }
+
+  renderAwaitingEvents(projects) {
+    const {organization} = this.props;
+    const project = projects.length > 0 ? projects[0] : null;
+
+    const sampleIssueId = this.props.groupIds.length > 0 ? this.props.groupIds[0] : '';
+    return (
+      <ErrorRobot
+        org={organization}
+        project={project}
+        sampleIssueId={sampleIssueId}
+        gradient
+      />
+    );
+  }
+
+  renderNoUnresolvedIssues() {
+    return (
+      <React.Suspense fallback={this.renderLoading()}>
+        <CongratsRobots data-test-id="congrats-robots" />
+      </React.Suspense>
+    );
+  }
+
+  renderEmpty() {
+    return (
+      <EmptyStateWarning>
+        <p>{t('Sorry, no issues match your filters.')}</p>
+      </EmptyStateWarning>
+    );
+  }
+
+  render() {
+    const {fetchingSentFirstEvent, sentFirstEvent, firstEventProjects} = this.state;
+    const {query} = this.props;
+    // render things accordingly
+    if (fetchingSentFirstEvent) {
+      return this.renderLoading();
+    } else if (!sentFirstEvent) {
+      return this.renderAwaitingEvents(firstEventProjects);
+    } else if (query === DEFAULT_QUERY) {
+      return this.renderNoUnresolvedIssues();
+    } else {
+      return this.renderEmpty();
+    }
+  }
+}
+
+export default NoGroupsHandler;

--- a/src/sentry/static/sentry/app/views/issueList/noGroupsHandler.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/noGroupsHandler.tsx
@@ -46,7 +46,6 @@ class NoGroupsHandler extends React.Component<Props, State> {
     const {organization, selectedProjectIds, api} = this.props;
     let sentFirstEvent = false;
     let projects = [];
-    // const selectedProjectIds = this.props.selection.projects;
 
     // If no projects are selected, then we must check every project the user is a
     // member of and make sure there are no first events for all of the projects

--- a/src/sentry/static/sentry/app/views/issueList/noGroupsHandler.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/noGroupsHandler.tsx
@@ -26,6 +26,12 @@ const CongratsRobots = React.lazy(() =>
   import(/* webpackChunkName: "CongratsRobots" */ 'app/views/issueList/congratsRobots')
 );
 
+/**
+ * Component which is rendered when no groups/issues were found. This could
+ * either be caused by having no first events, having resolved all issues, or
+ * having no issues be returned from a query. This component will conditionally
+ * render one of those states.
+ */
 class NoGroupsHandler extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -95,7 +95,6 @@ const IssueListOverview = createReactClass({
       // Will only be set if selected issues all belong
       // to one project.
       selectedProject: null,
-      fetchingSentFirstEvent: true,
     };
   },
 
@@ -108,7 +107,6 @@ const IssueListOverview = createReactClass({
 
     this.fetchTags();
     this.fetchMemberList();
-    this.fetchSentFirstEvent();
 
     // Start by getting searches first so if the user is on a saved search
     // or they have a pinned search we load the correct data the first time.
@@ -130,7 +128,6 @@ const IssueListOverview = createReactClass({
     if (!isEqual(prevProps.selection.projects, this.props.selection.projects)) {
       this.fetchMemberList();
       this.fetchTags();
-      this.fetchSentFirstEvent();
     }
 
     const prevQuery = prevProps.location.query;
@@ -279,45 +276,6 @@ const IssueListOverview = createReactClass({
   fetchTags() {
     const {organization, selection} = this.props;
     fetchOrganizationTags(this.api, organization.slug, selection.projects);
-  },
-
-  async fetchSentFirstEvent() {
-    this.setState({
-      fetchingSentFirstEvent: true,
-    });
-
-    const {organization} = this.props;
-    let sentFirstEvent = false;
-    let projects = [];
-    const selectedProjectIds = this.props.selection.projects;
-
-    // If no projects are selected, then we must check every project the user is a
-    // member of and make sure there are no first events for all of the projects
-    let firstEventQuery = {};
-    const projectsQuery = {per_page: 1};
-    if (!selectedProjectIds || !selectedProjectIds.length) {
-      firstEventQuery = {is_member: true};
-    } else {
-      firstEventQuery = {project: selectedProjectIds};
-      projectsQuery.query = selectedProjectIds.map(id => `id:${id}`).join(' ');
-    }
-
-    [{sentFirstEvent}, projects] = await Promise.all([
-      // checks to see if selection has sent a first event
-      this.api.requestPromise(`/organizations/${organization.slug}/sent-first-event/`, {
-        query: firstEventQuery,
-      }),
-      // retrieves a single project to feed to the ErrorRobot from renderStreamBody
-      this.api.requestPromise(`/organizations/${organization.slug}/projects/`, {
-        query: projectsQuery,
-      }),
-    ]);
-
-    this.setState({
-      fetchingSentFirstEvent: false,
-      sentFirstEvent,
-      firstEventProjects: projects,
-    });
   },
 
   fetchData() {

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -11,7 +11,7 @@ import pickBy from 'lodash/pickBy';
 import qs from 'query-string';
 
 import {Client} from 'app/api';
-import {DEFAULT_STATS_PERIOD} from 'app/constants';
+import {DEFAULT_QUERY, DEFAULT_STATS_PERIOD} from 'app/constants';
 import {Panel, PanelBody} from 'app/components/panels';
 import {analytics} from 'app/utils/analytics';
 import {defined} from 'app/utils';
@@ -24,10 +24,7 @@ import {extractSelectionParameters} from 'app/components/organizations/globalSel
 import {fetchOrgMembers, indexMembersByProject} from 'app/actionCreators/members';
 import {fetchOrganizationTags, fetchTagValues} from 'app/actionCreators/tags';
 import {getUtcDateString} from 'app/utils/dates';
-import {t} from 'app/locale';
 import CursorPoller from 'app/utils/cursorPoller';
-import EmptyStateWarning from 'app/components/emptyStateWarning';
-import ErrorRobot from 'app/components/errorRobot';
 import GroupStore from 'app/stores/groupStore';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -47,18 +44,14 @@ import withSavedSearches from 'app/utils/withSavedSearches';
 import IssueListActions from './actions';
 import IssueListFilters from './filters';
 import IssueListSidebar from './sidebar';
+import NoGroupsHandler from './noGroupsHandler';
 
 const MAX_ITEMS = 25;
-const DEFAULT_QUERY = 'is:unresolved';
 const DEFAULT_SORT = 'date';
 // the default period for the graph in each issue row
 const DEFAULT_GRAPH_STATS_PERIOD = '24h';
 // the allowed period choices for graph in each issue row
 const STATS_PERIODS = new Set(['14d', '24h']);
-
-const CongratsRobots = React.lazy(() =>
-  import(/* webpackChunkName: "CongratsRobots" */ 'app/views/issueList/congratsRobots')
-);
 
 const IssueListOverview = createReactClass({
   displayName: 'IssueListOverview',
@@ -588,29 +581,12 @@ const IssueListOverview = createReactClass({
     return <PanelBody>{groupNodes}</PanelBody>;
   },
 
-  renderEmpty() {
-    return (
-      <EmptyStateWarning>
-        <p>{t('Sorry, no issues match your filters.')}</p>
-      </EmptyStateWarning>
-    );
-  },
-
   renderLoading() {
     return <LoadingIndicator />;
   },
 
-  renderNoUnresolvedIssues() {
-    return (
-      <React.Suspense fallback={this.renderLoading()}>
-        <CongratsRobots data-test-id="congrats-robots" />
-      </React.Suspense>
-    );
-  },
-
   renderStreamBody() {
     let body;
-    const query = this.getQuery();
 
     if (this.state.issuesLoading) {
       body = this.renderLoading();
@@ -618,14 +594,16 @@ const IssueListOverview = createReactClass({
       body = <LoadingError message={this.state.error} onRetry={this.fetchData} />;
     } else if (this.state.groupIds.length > 0) {
       body = this.renderGroupNodes(this.state.groupIds, this.getGroupStatsPeriod());
-    } else if (this.state.fetchingSentFirstEvent) {
-      body = this.renderLoading();
-    } else if (!this.state.sentFirstEvent) {
-      body = this.renderAwaitingEvents(this.state.firstEventProjects);
-    } else if (query === DEFAULT_QUERY) {
-      body = this.renderNoUnresolvedIssues();
     } else {
-      body = this.renderEmpty();
+      body = (
+        <NoGroupsHandler
+          api={this.api}
+          organization={this.props.organization}
+          query={this.getQuery()}
+          selectedProjectIds={this.props.selection.projects}
+          groupIds={this.state.groupIds}
+        />
+      );
     }
     return body;
   },
@@ -656,21 +634,6 @@ const IssueListOverview = createReactClass({
         () => this.transitionTo({}, null)
       );
     });
-  },
-
-  renderAwaitingEvents(projects) {
-    const {organization} = this.props;
-    const project = projects.length > 0 ? projects[0] : null;
-
-    const sampleIssueId = this.state.groupIds.length > 0 ? this.state.groupIds[0] : '';
-    return (
-      <ErrorRobot
-        org={organization}
-        project={project}
-        sampleIssueId={sampleIssueId}
-        gradient
-      />
-    );
   },
 
   tagValueLoader(key, search) {

--- a/tests/js/spec/views/issueList/createIncident.spec.jsx
+++ b/tests/js/spec/views/issueList/createIncident.spec.jsx
@@ -108,6 +108,14 @@ describe('IssueList --> Create Incident', function() {
         }),
       ],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sent-first-event/',
+      body: {sentFirstEvent: true},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [project],
+    });
   });
 
   afterEach(function() {

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -1338,7 +1338,7 @@ describe('IssueList,', function() {
 
   describe('render states', function() {
     beforeEach(function() {
-      wrapper = shallow(<IssueListOverview {...props} />, {
+      wrapper = mountWithTheme(<IssueListOverview {...props} />, {
         disableLifecycleMethods: false,
       });
     });
@@ -1360,18 +1360,20 @@ describe('IssueList,', function() {
       expect(error.props().message).toEqual('Things broke');
     });
 
-    it('displays congrats robots animation with only is:unresolved query', function() {
+    it('displays congrats robots animation with only is:unresolved query', async function() {
       wrapper.setState({
         savedSearchLoading: false,
         issuesLoading: false,
         error: false,
         groupIds: [],
       });
+      await tick();
+      wrapper.update();
 
-      expect(wrapper.find('lazy[data-test-id="congrats-robots"]').exists()).toBe(true);
+      expect(wrapper.find('CongratsRobots').exists()).toBe(true);
     });
 
-    it('displays an empty resultset with is:unresolved and level:error query', function() {
+    it('displays an empty resultset with is:unresolved and level:error query', async function() {
       const errorsOnlyQuery = {
         ...props,
         location: {
@@ -1379,7 +1381,7 @@ describe('IssueList,', function() {
         },
       };
 
-      wrapper = shallow(<IssueListOverview {...errorsOnlyQuery} />, {
+      wrapper = mountWithTheme(<IssueListOverview {...errorsOnlyQuery} />, {
         disableLifecycleMethods: false,
       });
 
@@ -1391,10 +1393,13 @@ describe('IssueList,', function() {
         fetchingSentFirstEvent: false,
         sentFirstEvent: true,
       });
+      await tick();
+      wrapper.update();
+
       expect(wrapper.find('EmptyStateWarning').exists()).toBe(true);
     });
 
-    it('displays an empty resultset with has:browser query', function() {
+    it('displays an empty resultset with has:browser query', async function() {
       const hasBrowserQuery = {
         ...props,
         location: {
@@ -1402,7 +1407,7 @@ describe('IssueList,', function() {
         },
       };
 
-      wrapper = shallow(<IssueListOverview {...hasBrowserQuery} />, {
+      wrapper = mountWithTheme(<IssueListOverview {...hasBrowserQuery} />, {
         disableLifecycleMethods: false,
       });
 
@@ -1414,6 +1419,9 @@ describe('IssueList,', function() {
         fetchingSentFirstEvent: false,
         sentFirstEvent: true,
       });
+      await tick();
+      wrapper.update();
+
       expect(wrapper.find('EmptyStateWarning').exists()).toBe(true);
     });
   });
@@ -1421,6 +1429,7 @@ describe('IssueList,', function() {
   describe('Error Robot', function() {
     const createWrapper = moreProps => {
       const defaultProps = {
+        ...props,
         savedSearchLoading: false,
         useOrgSavedSearches: true,
         selection: {
@@ -1435,7 +1444,7 @@ describe('IssueList,', function() {
         }),
         ...moreProps,
       };
-      const localWrapper = shallow(<IssueListOverview {...defaultProps} />, {
+      const localWrapper = mountWithTheme(<IssueListOverview {...defaultProps} />, {
         disableLifecycleMethods: false,
       });
       localWrapper.setState({
@@ -1477,7 +1486,7 @@ describe('IssueList,', function() {
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/projects/',
-        body: [projects],
+        body: projects,
       });
       wrapper = createWrapper({
         organization: TestStubs.Organization({
@@ -1520,7 +1529,7 @@ describe('IssueList,', function() {
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/projects/',
-        body: [projects],
+        body: projects,
       });
       wrapper = createWrapper({
         organization: TestStubs.Organization({
@@ -1563,7 +1572,7 @@ describe('IssueList,', function() {
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/projects/',
-        body: [projects],
+        body: projects,
       });
 
       wrapper = createWrapper({
@@ -1612,7 +1621,7 @@ describe('IssueList,', function() {
       });
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/projects/',
-        body: [projects],
+        body: projects,
       });
 
       wrapper = createWrapper({


### PR DESCRIPTION
Previously, the issues page would use the list of all projects (`organization.projects`) to check if any selected projects had sent a first event. This meant that the issues page was blocked on the loading of all projects. Now it is changed to make use of the `sent-first-event/` API call which can take in `is_member` or `project` ids as query parameters. Also fixed up some tests that were not correctly waiting for the right async calls.