### PR TITLE
fix(ui): Re-arrange `<Form>` footer buttons

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -11,6 +11,7 @@ import FormModel, {
   FieldValue,
 } from 'app/views/settings/components/forms/model';
 import Panel from 'app/components/panels/panel';
+import space from 'app/styles/space';
 
 type Data = {};
 
@@ -219,38 +220,41 @@ export default class Form extends React.Component<Props> {
             style={footerStyle}
             saveOnBlur={saveOnBlur}
           >
-            <Observer>
-              {() => (
-                <Button
-                  data-test-id="form-submit"
-                  priority={submitPriority}
-                  disabled={
-                    this.model.isError ||
-                    this.model.isSaving ||
-                    submitDisabled ||
-                    (requireChanges ? !this.model.formChanged : false)
-                  }
-                  type="submit"
-                >
-                  {submitLabel}
-                </Button>
+            {extraButton}
+            <DefaultButtons>
+              {onCancel && (
+                <Observer>
+                  {() => (
+                    <Button
+                      type="button"
+                      disabled={this.model.isSaving}
+                      onClick={onCancel}
+                      style={{marginLeft: 5}}
+                    >
+                      {cancelLabel}
+                    </Button>
+                  )}
+                </Observer>
               )}
-            </Observer>
 
-            {onCancel && (
               <Observer>
                 {() => (
                   <Button
-                    disabled={this.model.isSaving}
-                    onClick={onCancel}
-                    style={{marginLeft: 5}}
+                    data-test-id="form-submit"
+                    priority={submitPriority}
+                    disabled={
+                      this.model.isError ||
+                      this.model.isSaving ||
+                      submitDisabled ||
+                      (requireChanges ? !this.model.formChanged : false)
+                    }
+                    type="submit"
                   >
-                    {cancelLabel}
+                    {submitLabel}
                   </Button>
                 )}
               </Observer>
-            )}
-            {extraButton}
+            </DefaultButtons>
           </StyledFooter>
         )}
       </form>
@@ -259,7 +263,8 @@ export default class Form extends React.Component<Props> {
 }
 
 const StyledFooter = styled('div')<{saveOnBlur?: boolean}>`
-  text-align: right;
+  display: flex;
+  justify-content: flex-end;
   margin-top: 25px;
   border-top: 1px solid #e9ebec;
   background: none;
@@ -284,6 +289,14 @@ const StyledFooter = styled('div')<{saveOnBlur?: boolean}>`
     padding-bottom: 16px;
   }
   `};
+`;
+
+const DefaultButtons = styled('div')`
+  display: grid;
+  grid-gap: ${space(1)};
+  grid-auto-flow: column;
+  justify-content: flex-end;
+  flex: 1;
 `;
 
 export {FieldValue};

--- a/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
@@ -339,67 +339,73 @@ exports[`FormField + model renders with Form 1`] = `
       saveOnBlur={false}
     >
       <div
-        className="css-1g4ne7-StyledFooter e1r1zmbj0"
+        className="css-bobn3u-StyledFooter e1r1zmbj0"
       >
-        <Observer>
-          <Button
-            align="center"
-            data-test-id="form-submit"
-            disabled={false}
-            priority="primary"
-            type="submit"
+        <DefaultButtons>
+          <div
+            className="css-5mbz2j-DefaultButtons e1r1zmbj1"
           >
-            <StyledButton
-              aria-disabled={false}
-              aria-label="Save Changes"
-              data-test-id="form-submit"
-              disabled={false}
-              onClick={[Function]}
-              priority="primary"
-              role="button"
-              type="submit"
-            >
-              <ForwardRef
-                aria-disabled={false}
-                aria-label="Save Changes"
-                className="css-xiynrq-StyledButton-getColors edwq9my0"
+            <Observer>
+              <Button
+                align="center"
                 data-test-id="form-submit"
                 disabled={false}
-                onClick={[Function]}
                 priority="primary"
-                role="button"
                 type="submit"
               >
-                <button
+                <StyledButton
                   aria-disabled={false}
                   aria-label="Save Changes"
-                  className="css-xiynrq-StyledButton-getColors edwq9my0"
                   data-test-id="form-submit"
+                  disabled={false}
                   onClick={[Function]}
+                  priority="primary"
                   role="button"
                   type="submit"
                 >
-                  <ButtonLabel
-                    align="center"
+                  <ForwardRef
+                    aria-disabled={false}
+                    aria-label="Save Changes"
+                    className="css-xiynrq-StyledButton-getColors edwq9my0"
+                    data-test-id="form-submit"
+                    disabled={false}
+                    onClick={[Function]}
                     priority="primary"
+                    role="button"
+                    type="submit"
                   >
-                    <Component
-                      align="center"
-                      className="css-oo1m2a-ButtonLabel edwq9my1"
-                      priority="primary"
+                    <button
+                      aria-disabled={false}
+                      aria-label="Save Changes"
+                      className="css-xiynrq-StyledButton-getColors edwq9my0"
+                      data-test-id="form-submit"
+                      onClick={[Function]}
+                      role="button"
+                      type="submit"
                     >
-                      <span
-                        className="css-oo1m2a-ButtonLabel edwq9my1"
+                      <ButtonLabel
+                        align="center"
+                        priority="primary"
                       >
-                        Save Changes
-                      </span>
-                    </Component>
-                  </ButtonLabel>
-                </button>
-              </ForwardRef>
-            </StyledButton>
-          </Button>
-        </Observer>
+                        <Component
+                          align="center"
+                          className="css-oo1m2a-ButtonLabel edwq9my1"
+                          priority="primary"
+                        >
+                          <span
+                            className="css-oo1m2a-ButtonLabel edwq9my1"
+                          >
+                            Save Changes
+                          </span>
+                        </Component>
+                      </ButtonLabel>
+                    </button>
+                  </ForwardRef>
+                </StyledButton>
+              </Button>
+            </Observer>
+          </div>
+        </DefaultButtons>
       </div>
     </StyledFooter>
   </form>

--- a/tests/js/spec/components/forms/__snapshots__/tableField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/tableField.spec.jsx.snap
@@ -500,67 +500,73 @@ exports[`TableField renders renders with form context 1`] = `
       saveOnBlur={false}
     >
       <div
-        className="css-1g4ne7-StyledFooter e1r1zmbj0"
+        className="css-bobn3u-StyledFooter e1r1zmbj0"
       >
-        <Observer>
-          <Button
-            align="center"
-            data-test-id="form-submit"
-            disabled={false}
-            priority="primary"
-            type="submit"
+        <DefaultButtons>
+          <div
+            className="css-5mbz2j-DefaultButtons e1r1zmbj1"
           >
-            <StyledButton
-              aria-disabled={false}
-              aria-label="Save Changes"
-              data-test-id="form-submit"
-              disabled={false}
-              onClick={[Function]}
-              priority="primary"
-              role="button"
-              type="submit"
-            >
-              <ForwardRef
-                aria-disabled={false}
-                aria-label="Save Changes"
-                className="css-xiynrq-StyledButton-getColors edwq9my0"
+            <Observer>
+              <Button
+                align="center"
                 data-test-id="form-submit"
                 disabled={false}
-                onClick={[Function]}
                 priority="primary"
-                role="button"
                 type="submit"
               >
-                <button
+                <StyledButton
                   aria-disabled={false}
                   aria-label="Save Changes"
-                  className="css-xiynrq-StyledButton-getColors edwq9my0"
                   data-test-id="form-submit"
+                  disabled={false}
                   onClick={[Function]}
+                  priority="primary"
                   role="button"
                   type="submit"
                 >
-                  <ButtonLabel
-                    align="center"
+                  <ForwardRef
+                    aria-disabled={false}
+                    aria-label="Save Changes"
+                    className="css-xiynrq-StyledButton-getColors edwq9my0"
+                    data-test-id="form-submit"
+                    disabled={false}
+                    onClick={[Function]}
                     priority="primary"
+                    role="button"
+                    type="submit"
                   >
-                    <Component
-                      align="center"
-                      className="css-oo1m2a-ButtonLabel edwq9my1"
-                      priority="primary"
+                    <button
+                      aria-disabled={false}
+                      aria-label="Save Changes"
+                      className="css-xiynrq-StyledButton-getColors edwq9my0"
+                      data-test-id="form-submit"
+                      onClick={[Function]}
+                      role="button"
+                      type="submit"
                     >
-                      <span
-                        className="css-oo1m2a-ButtonLabel edwq9my1"
+                      <ButtonLabel
+                        align="center"
+                        priority="primary"
                       >
-                        Save Changes
-                      </span>
-                    </Component>
-                  </ButtonLabel>
-                </button>
-              </ForwardRef>
-            </StyledButton>
-          </Button>
-        </Observer>
+                        <Component
+                          align="center"
+                          className="css-oo1m2a-ButtonLabel edwq9my1"
+                          priority="primary"
+                        >
+                          <span
+                            className="css-oo1m2a-ButtonLabel edwq9my1"
+                          >
+                            Save Changes
+                          </span>
+                        </Component>
+                      </ButtonLabel>
+                    </button>
+                  </ForwardRef>
+                </StyledButton>
+              </Button>
+            </Observer>
+          </div>
+        </DefaultButtons>
       </div>
     </StyledFooter>
   </form>


### PR DESCRIPTION
Rearranges the buttons in a `<Form>` footer. This makes the "submit" button remain in a more consistent state (always in the bottom right corner), where previously, if you added a Cancel button, it would shift the submit button to the left of the Cancel.

![image](https://user-images.githubusercontent.com/79684/70754188-6d9b2d80-1ceb-11ea-9242-5dcb6401f02d.png)
