### PR TITLE
ref(ts) Convert remaining avatar components to typescript

### DIFF
--- a/src/sentry/static/sentry/app/components/avatar/actorAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/actorAvatar.tsx
@@ -2,14 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as Sentry from '@sentry/browser';
 
+import SentryTypes from 'app/sentryTypes';
 import Avatar from 'app/components/avatar';
 import MemberListStore from 'app/stores/memberListStore';
 import TeamStore from 'app/stores/teamStore';
-import {Actor} from 'app/sentryTypes';
+import {Actor} from 'app/types';
 
-class ActorAvatar extends React.Component {
+type Props = {
+  actor: Actor;
+  size?: number;
+  default?: string;
+  title?: string;
+  gravatar?: boolean;
+};
+
+class ActorAvatar extends React.Component<Props> {
   static propTypes = {
-    actor: Actor.isRequired,
+    actor: SentryTypes.Actor.isRequired,
     size: PropTypes.number,
     default: PropTypes.string,
     title: PropTypes.string,

--- a/src/sentry/static/sentry/app/components/avatar/index.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/index.tsx
@@ -6,10 +6,17 @@ import ProjectAvatar from 'app/components/avatar/projectAvatar';
 import SentryTypes from 'app/sentryTypes';
 import TeamAvatar from 'app/components/avatar/teamAvatar';
 import UserAvatar from 'app/components/avatar/userAvatar';
+import {Project, Team, LightWeightOrganization} from 'app/types';
+
+type Props = {
+  team: Team;
+  organization: LightWeightOrganization;
+  project: Project;
+} & UserAvatar['props'];
 
 const BasicModelShape = PropTypes.shape({slug: PropTypes.string});
 
-class Avatar extends React.Component {
+class Avatar extends React.Component<Props> {
   static propTypes = {
     team: PropTypes.oneOfType([BasicModelShape, SentryTypes.Team]),
     organization: PropTypes.oneOfType([BasicModelShape, SentryTypes.Organization]),

--- a/src/sentry/static/sentry/app/components/avatar/organizationAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/organizationAvatar.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import {Organization} from 'app/types';
+import {LightWeightOrganization} from 'app/types';
 import {explodeSlug} from 'app/utils';
 import BaseAvatar from 'app/components/avatar/baseAvatar';
 import SentryTypes from 'app/sentryTypes';
 
 type Props = {
-  organization: Organization;
+  organization: LightWeightOrganization;
 } & BaseAvatar['props'];
 
 class OrganizationAvatar extends React.Component<Props> {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -15,18 +15,24 @@ export type Avatar = {
   avatarType: 'letter_avatar' | 'upload' | 'gravatar';
 };
 
+export type Actor = {
+  id: string;
+  type: 'user' | 'team';
+  name: string;
+};
+
 export type LightWeightOrganization = {
   id: string;
   slug: string;
   name: string;
   access: string[];
   features: string[];
+  avatar: Avatar;
 };
 
 export type Organization = LightWeightOrganization & {
   projects: Project[];
   teams: Team[];
-  avatar: Avatar;
 };
 
 export type OrganizationDetailed = Organization & {


### PR DESCRIPTION
I've also moved the `avatar` property to the light org as it should always be present and we need avatars to be compatible with the light org.