### PR TITLE
fix(command-palette): Fixed crash when asking for project selection

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/navigation.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/navigation.jsx
@@ -9,7 +9,7 @@ export function navigateTo(to, router) {
   // Check for placeholder params
   const needOrg = to.indexOf(':orgId') > -1;
   const needProject = to.indexOf(':projectId') > -1;
-  const comingFromPojectId = get(router, 'location.query.project');
+  const comingFromProjectId = get(router, 'location.query.project');
 
   if (needOrg || needProject) {
     openModal(
@@ -20,7 +20,7 @@ export function navigateTo(to, router) {
           nextPath={to}
           needOrg={needOrg}
           needProject={needProject}
-          comingFromPojectId={comingFromPojectId}
+          comingFromProjectId={comingFromProjectId}
           onFinish={path => {
             closeModal();
             router.push(path);

--- a/src/sentry/static/sentry/app/actionCreators/navigation.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/navigation.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import get from 'lodash/get';
 
 import {openModal} from 'app/actionCreators/modal';
 import ContextPickerModal from 'app/components/contextPickerModal';
@@ -8,6 +9,7 @@ export function navigateTo(to, router) {
   // Check for placeholder params
   const needOrg = to.indexOf(':orgId') > -1;
   const needProject = to.indexOf(':projectId') > -1;
+  const comingFromPojectId = get(router, 'location.query.project');
 
   if (needOrg || needProject) {
     openModal(
@@ -18,6 +20,7 @@ export function navigateTo(to, router) {
           nextPath={to}
           needOrg={needOrg}
           needProject={needProject}
+          comingFromPojectId={comingFromPojectId}
           onFinish={path => {
             closeModal();
             router.push(path);

--- a/src/sentry/static/sentry/app/components/contextPickerModal.jsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.jsx
@@ -65,7 +65,7 @@ class ContextPickerModal extends React.Component {
      * Id of the project (most likely from the URL)
      * on which the modal was opened
      */
-    comingFromPojectId: PropTypes.string,
+    comingFromProjectId: PropTypes.string,
   };
 
   constructor(props) {
@@ -259,7 +259,7 @@ class ContextPickerModal extends React.Component {
       organizations,
       Header,
       Body,
-      comingFromPojectId,
+      comingFromProjectId,
     } = this.props;
     const {loading} = this.state;
 
@@ -306,7 +306,7 @@ class ContextPickerModal extends React.Component {
               <StyledSelectControl
                 forwardedRef={ref => {
                   this.focusSelector(ref);
-                  this.focusProjectOption(ref, comingFromPojectId, projects);
+                  this.focusProjectOption(ref, comingFromProjectId, projects);
                 }}
                 placeholder="Select a Project"
                 name="project"

--- a/src/sentry/static/sentry/app/components/contextPickerModal.jsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.jsx
@@ -60,6 +60,12 @@ class ContextPickerModal extends React.Component {
      * Does modal need to prompt for project
      */
     needProject: PropTypes.bool,
+
+    /**
+     * Id of the project (most likely from the URL)
+     * on which the modal was opened
+     */
+    comingFromPojectId: PropTypes.string,
   };
 
   constructor(props) {
@@ -198,6 +204,21 @@ class ContextPickerModal extends React.Component {
     }
   };
 
+  focusProjectOption = (ref, projectId, projects) => {
+    if (!ref) {
+      return;
+    }
+
+    const projectToBeFocused = projects.find(({id}) => id === projectId);
+
+    if (projectToBeFocused) {
+      ref.focusOption({
+        label: projectToBeFocused.slug,
+        value: projectToBeFocused.slug,
+      });
+    }
+  };
+
   handleSelectOrganization = ({value}) => {
     // Don't do anything if org value doesn't actually change
     if (this.state.selectedOrganization === value) {
@@ -231,7 +252,15 @@ class ContextPickerModal extends React.Component {
   };
 
   render() {
-    const {latestContext, needOrg, needProject, organizations, Header, Body} = this.props;
+    const {
+      latestContext,
+      needOrg,
+      needProject,
+      organizations,
+      Header,
+      Body,
+      comingFromPojectId,
+    } = this.props;
     const {loading} = this.state;
 
     const shouldShowPicker = needOrg || needProject;
@@ -277,7 +306,7 @@ class ContextPickerModal extends React.Component {
               <StyledSelectControl
                 forwardedRef={ref => {
                   this.focusSelector(ref);
-                  // TODO: preselect the current project - ref.focusOption({label: 'myproject', value: 'myproject'});
+                  this.focusProjectOption(ref, comingFromPojectId, projects);
                 }}
                 placeholder="Select a Project"
                 name="project"

--- a/src/sentry/static/sentry/app/stores/latestContextStore.jsx
+++ b/src/sentry/static/sentry/app/stores/latestContextStore.jsx
@@ -73,7 +73,11 @@ const LatestContextStore = Reflux.createStore({
         organization: null,
         project: null,
       };
-    } else if (!this.state.organization || this.state.organization.slug !== org.slug) {
+    } else if (
+      !this.state.organization ||
+      this.state.organization.slug !== org.slug ||
+      this.state.organization.projects !== org.projects
+    ) {
       // Update only if different
       this.state = {
         ...this.state,


### PR DESCRIPTION
This PR fixes a frequent crash when using the command palette to navigate somewhere else through context switcher (choose organization/project).

It doesn't happen all the time (race condition involved), so here is a screen recording of the issue:
![chrome-capture](https://user-images.githubusercontent.com/9060071/70762940-45b9c300-1d07-11ea-9a0b-db34f3fcefe9.gif)

I also added a feature, that prefocuses the current project in the list (if it can be determined).