### PR TITLE
ref(ui) Stop using Avatar wrapper

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/item/avatar.jsx
+++ b/src/sentry/static/sentry/app/components/activity/item/avatar.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import InlineSvg from 'app/components/inlineSvg';
 import Placeholder from 'app/components/placeholder';
 import SentryTypes from 'app/sentryTypes';
@@ -21,7 +21,7 @@ class ActivityAvatar extends React.Component {
   render() {
     const {className, type, user, size} = this.props;
     if (user) {
-      return <Avatar user={user} size={size} className={className} />;
+      return <UserAvatar user={user} size={size} className={className} />;
     }
 
     if (type === 'system') {

--- a/src/sentry/static/sentry/app/components/assigneeSelector.tsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.tsx
@@ -5,14 +5,15 @@ import createReactClass from 'create-react-class';
 import styled from 'react-emotion';
 
 import SentryTypes from 'app/sentryTypes';
-import {Member, User} from 'app/types';
+import {User} from 'app/types';
 
 import {assignToUser, assignToActor, clearAssignment} from 'app/actionCreators/group';
 import {openInviteMembersModal} from 'app/actionCreators/modal';
 import {t} from 'app/locale';
 import {valueIsEqual, buildUserId, buildTeamId} from 'app/utils';
 import ActorAvatar from 'app/components/avatar/actorAvatar';
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
+import TeamAvatar from 'app/components/avatar/teamAvatar';
 import ConfigStore from 'app/stores/configStore';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 import DropdownBubble from 'app/components/dropdownBubble';
@@ -29,13 +30,13 @@ import space from 'app/styles/space';
 type Props = {
   id: string | null;
   size: number;
-  memberList?: Member[];
+  memberList?: User[];
 };
 
 type State = {
   loading: boolean;
   assignedTo: User;
-  memberList: Member[];
+  memberList: User[];
 };
 
 const AssigneeSelectorComponent = createReactClass<Props, State>({
@@ -191,7 +192,7 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
             onSelect={this.assignToUser.bind(this, member)}
           >
             <IconContainer>
-              <Avatar user={member} size={size} />
+              <UserAvatar user={member} size={size} />
             </IconContainer>
             <Label>
               <Highlight text={inputValue}>{member.name || member.email}</Highlight>
@@ -216,7 +217,7 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
             onSelect={this.assignToTeam.bind(this, team)}
           >
             <IconContainer>
-              <Avatar team={team} size={size} />
+              <TeamAvatar team={team} size={size} />
             </IconContainer>
             <Label>
               <Highlight text={inputValue}>{display}</Highlight>
@@ -314,7 +315,7 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
   },
 });
 
-export function putSessionUserFirst(members: Member[]): Member[] {
+export function putSessionUserFirst(members: User[]): User[] {
   // If session user is in the filtered list of members, put them at the top
   if (!members) {
     return [];

--- a/src/sentry/static/sentry/app/components/avatar/actorAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/actorAvatar.tsx
@@ -2,14 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as Sentry from '@sentry/browser';
 
-import Avatar from 'app/components/avatar';
+import SentryTypes from 'app/sentryTypes';
+import UserAvatar from 'app/components/avatar/userAvatar';
+import TeamAvatar from 'app/components/avatar/teamAvatar';
 import MemberListStore from 'app/stores/memberListStore';
 import TeamStore from 'app/stores/teamStore';
-import {Actor} from 'app/sentryTypes';
+import {Actor} from 'app/types';
 
-class ActorAvatar extends React.Component {
+type Props = {
+  actor: Actor;
+  size?: number;
+  default?: string;
+  title?: string;
+  gravatar?: boolean;
+  className?: string;
+};
+
+class ActorAvatar extends React.Component<Props> {
   static propTypes = {
-    actor: Actor.isRequired,
+    actor: SentryTypes.Actor.isRequired,
     size: PropTypes.number,
     default: PropTypes.string,
     title: PropTypes.string,
@@ -21,12 +32,12 @@ class ActorAvatar extends React.Component {
 
     if (actor.type === 'user') {
       const user = actor.id ? MemberListStore.getById(actor.id) : actor;
-      return <Avatar user={user} hasTooltip {...props} />;
+      return <UserAvatar user={user} hasTooltip {...props} />;
     }
 
     if (actor.type === 'team') {
       const team = TeamStore.getById(actor.id);
-      return <Avatar team={team} hasTooltip {...props} />;
+      return <TeamAvatar team={team} hasTooltip {...props} />;
     }
 
     Sentry.withScope(scope => {

--- a/src/sentry/static/sentry/app/components/avatar/avatarList.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/avatarList.tsx
@@ -4,7 +4,6 @@ import styled, {css} from 'react-emotion';
 
 import {User} from 'app/types';
 import SentryTypes from 'app/sentryTypes';
-import Avatar from 'app/components/avatar';
 import UserAvatar from 'app/components/avatar/userAvatar';
 import Tooltip from 'app/components/tooltip';
 
@@ -98,7 +97,7 @@ const Circle = css`
   }
 `;
 
-const StyledAvatar = styled(Avatar)`
+const StyledAvatar = styled(UserAvatar)`
   overflow: hidden;
   ${Circle};
 `;

--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
@@ -14,6 +14,30 @@ const DEFAULT_GRAVATAR_SIZE = 64;
 const ALLOWED_SIZES = [20, 32, 36, 48, 52, 64, 80, 96, 120];
 const DEFAULT_REMOTE_SIZE = 120;
 
+const defaultProps = {
+  // No default size to ease transition from CSS defined sizes
+  // size: 64,
+  style: {},
+  /**
+   * Enable to display tooltips.
+   */
+  hasTooltip: false,
+  /**
+   * The type of avatar being rendered.
+   */
+  type: 'letter_avatar',
+  /**
+   * Path to uploaded avatar (differs based on model type)
+   */
+  uploadPath: 'avatar',
+  /**
+   * Should avatar be round instead of a square
+   */
+  round: false,
+};
+
+type DefaultProps = Readonly<typeof defaultProps>;
+
 type Props = {
   size?: number;
   /**
@@ -24,18 +48,7 @@ type Props = {
    * Default gravatar to display
    */
   default?: string;
-  /**
-   * Enable to display tooltips.
-   */
-  hasTooltip?: boolean;
-  /**
-   * The type of avatar being rendered.
-   */
-  type?: string;
-  /**
-   * Path to uploaded avatar (differs based on model type)
-   */
-  uploadPath?: 'avatar' | 'team-avatar' | 'organization-avatar' | 'project-avatar';
+  uploadPath: 'avatar' | 'team-avatar' | 'organization-avatar' | 'project-avatar';
   uploadId?: string | null | undefined;
   gravatarId?: string;
   letterId?: string;
@@ -48,14 +61,11 @@ type Props = {
    * Additional props for the tooltip
    */
   tooltipOptions?: Tooltip['props'];
-  /**
-   * Should avatar be round instead of a square
-   */
-  round: boolean;
 
   className?: string;
-  style: React.CSSProperties;
-};
+
+  style?: React.CSSProperties;
+} & Partial<DefaultProps>;
 
 type State = {
   showBackupAvatar: boolean;
@@ -109,15 +119,7 @@ class BaseAvatar extends React.Component<Props, State> {
     round: PropTypes.bool,
   };
 
-  static defaultProps = {
-    // No default size to ease transition from CSS defined sizes
-    // size: 64,
-    style: {},
-    hasTooltip: false,
-    type: 'letter_avatar',
-    uploadPath: 'avatar',
-    round: false,
-  };
+  static defaultProps = defaultProps;
 
   constructor(props: Props) {
     super(props);
@@ -217,7 +219,7 @@ class BaseAvatar extends React.Component<Props, State> {
         <StyledBaseAvatar
           loaded={this.state.hasLoaded}
           className={classNames('avatar', className)}
-          round={round}
+          round={!!round}
           style={{
             ...sizeStyle,
             ...style,

--- a/src/sentry/static/sentry/app/components/avatar/organizationAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/organizationAvatar.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import {Organization} from 'app/types';
+import {LightWeightOrganization} from 'app/types';
 import {explodeSlug} from 'app/utils';
 import BaseAvatar from 'app/components/avatar/baseAvatar';
 import SentryTypes from 'app/sentryTypes';
 
 type Props = {
-  organization: Organization;
-} & BaseAvatar['props'];
+  organization: LightWeightOrganization;
+} & Omit<BaseAvatar['props'], 'uploadPath' | 'uploadId'>;
 
 class OrganizationAvatar extends React.Component<Props> {
   static propTypes = {

--- a/src/sentry/static/sentry/app/components/avatar/teamAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/teamAvatar.tsx
@@ -7,7 +7,7 @@ import {Team} from 'app/types';
 
 type Props = {
   team: Team | null;
-} & BaseAvatar['props'];
+} & Omit<BaseAvatar['props'], 'uploadPath' | 'uploadId'>;
 
 class TeamAvatar extends React.Component<Props> {
   static propTypes = {

--- a/src/sentry/static/sentry/app/components/avatar/userAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/userAvatar.tsx
@@ -24,10 +24,10 @@ const defaultProps = {
 type DefaultProps = typeof defaultProps;
 
 type Props = {
-  user: AvatarUser;
+  user: AvatarUser | undefined;
   renderTooltip?: RenderTooltipFunc;
 } & Partial<DefaultProps> &
-  BaseAvatar['props'];
+  Omit<BaseAvatar['props'], 'uploadPath' | 'uploadId'>;
 
 class UserAvatar extends React.Component<Props> {
   static propTypes: any = {

--- a/src/sentry/static/sentry/app/components/commitRow.tsx
+++ b/src/sentry/static/sentry/app/components/commitRow.tsx
@@ -5,7 +5,7 @@ import styled from 'react-emotion';
 import {Commit} from 'app/types';
 import {PanelItem} from 'app/components/panels';
 import {t, tct} from 'app/locale';
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import CommitLink from 'app/components/commitLink';
 import TextOverflow from 'app/components/textOverflow';
 import TimeSince from 'app/components/timeSince';
@@ -42,7 +42,7 @@ export default class CommitRow extends React.Component<Props> {
           customAvatar
         ) : (
           <AvatarWrapper>
-            <Avatar size={36} user={author} />
+            <UserAvatar size={36} user={author} />
           </AvatarWrapper>
         )}
 

--- a/src/sentry/static/sentry/app/components/events/contextSummary.jsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import DeviceName from 'app/components/deviceName';
 import {removeFilterMaskedEntries} from 'app/components/events/interfaces/utils';
 import SentryTypes from 'app/sentryTypes';
@@ -127,7 +127,12 @@ export class UserSummary extends React.Component {
     return (
       <div className="context-item user">
         {userTitle ? (
-          <Avatar user={user} size={48} className="context-item-icon" gravatar={false} />
+          <UserAvatar
+            user={user}
+            size={48}
+            className="context-item-icon"
+            gravatar={false}
+          />
         ) : (
           <span className="context-item-icon" />
         )}

--- a/src/sentry/static/sentry/app/components/events/contexts/user.jsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/user.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import each from 'lodash/each';
 
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import ErrorBoundary from 'app/components/errorBoundary';
 import ExternalLink from 'app/components/links/externalLink';
 import KeyValueList from 'app/components/events/interfaces/keyValueList';
@@ -49,7 +49,7 @@ class UserContextType extends React.Component {
     return (
       <div className="user-widget">
         <div className="pull-left">
-          <Avatar user={removeFilterMaskedEntries(user)} size={48} gravatar={false} />
+          <UserAvatar user={removeFilterMaskedEntries(user)} size={48} gravatar={false} />
         </div>
         <table className="key-value table">
           <tbody>

--- a/src/sentry/static/sentry/app/components/events/eventRow.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventRow.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router';
 import EventStore from 'app/stores/eventStore';
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import TimeSince from 'app/components/timeSince';
 
 class EventRow extends React.Component {
@@ -27,7 +27,7 @@ class EventRow extends React.Component {
     }
   }
 
-  shouldComponentUpdate(nextProps, nextState) {
+  shouldComponentUpdate(_nextProps, _nextState) {
     return false;
   }
 
@@ -61,7 +61,7 @@ class EventRow extends React.Component {
         <td className="event-user table-user-info">
           {event.user ? (
             <div>
-              <Avatar user={event.user} size={64} className="avatar" />
+              <UserAvatar user={event.user} size={64} className="avatar" />
               {event.user.email}
             </div>
           ) : (

--- a/src/sentry/static/sentry/app/components/eventsTable/eventsTableRow.jsx
+++ b/src/sentry/static/sentry/app/components/eventsTable/eventsTableRow.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import AttachmentUrl from 'app/utils/attachmentUrl';
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import DateTime from 'app/components/dateTime';
 import DeviceName from 'app/components/deviceName';
 import FileSize from 'app/components/fileSize';
@@ -71,7 +71,12 @@ class EventsTableRow extends React.Component {
           <td className="event-user table-user-info">
             {event.user ? (
               <div>
-                <Avatar user={event.user} size={24} className="avatar" gravatar={false} />
+                <UserAvatar
+                  user={event.user}
+                  size={24}
+                  className="avatar"
+                  gravatar={false}
+                />
                 {event.user.email}
               </div>
             ) : (

--- a/src/sentry/static/sentry/app/components/group/participants.jsx
+++ b/src/sentry/static/sentry/app/components/group/participants.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 
 const GroupParticipants = props => {
   const participants = props.participants;
@@ -14,10 +14,10 @@ const GroupParticipants = props => {
         </span>
       </h6>
       <ul className="faces">
-        {participants.map((user, i) => {
+        {participants.map(user => {
           return (
             <li key={user.username}>
-              <Avatar size={28} user={user} hasTooltip />
+              <UserAvatar size={28} user={user} hasTooltip />
             </li>
           );
         })}

--- a/src/sentry/static/sentry/app/components/idBadge/userBadge.jsx
+++ b/src/sentry/static/sentry/app/components/idBadge/userBadge.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import Link from 'app/components/links/link';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
@@ -98,7 +98,7 @@ const StyledName = styled(({useLink, to, ...props}) => {
   ${overflowEllipsis};
 `;
 
-const StyledAvatar = styled(props => <Avatar {...props} />)`
+const StyledAvatar = styled(props => <UserAvatar {...props} />)`
   min-width: ${space(3)};
   min-height: ${space(3)};
   margin-right: ${space(1)};

--- a/src/sentry/static/sentry/app/components/lastCommit.tsx
+++ b/src/sentry/static/sentry/app/components/lastCommit.tsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {Commit} from 'app/types';
-import Avatar from 'app/components/avatar';
+import {AvatarUser, Commit} from 'app/types';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import TimeSince from 'app/components/timeSince';
 
 import {t} from 'app/locale';
@@ -10,6 +10,19 @@ import {t} from 'app/locale';
 type Props = {
   commit: Commit;
   headerClass: string;
+};
+
+const unknownUser: AvatarUser = {
+  id: '',
+  name: '',
+  username: '??',
+  email: '',
+  avatarUrl: '',
+  avatar: {
+    avatarUuid: '',
+    avatarType: 'letter_avatar',
+  },
+  ip_address: '',
 };
 
 class LastCommit extends React.Component<Props> {
@@ -45,7 +58,7 @@ class LastCommit extends React.Component<Props> {
         <h6 className={headerClass}>Last commit</h6>
         <div className="commit">
           <div className="commit-avatar">
-            <Avatar user={commitAuthor || {username: '?'}} />
+            <UserAvatar user={commitAuthor || unknownUser} />
           </div>
           <div className="commit-message truncate">
             {this.renderMessage(commit.message)}

--- a/src/sentry/static/sentry/app/components/resolutionBox.jsx
+++ b/src/sentry/static/sentry/app/components/resolutionBox.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import CommitLink from 'app/components/commitLink';
 import TimeSince from 'app/components/timeSince';
 import Version from 'app/components/version';
@@ -25,7 +25,7 @@ export default class ResolutionBox extends React.Component {
     const {orgId, statusDetails} = this.props;
     const actor = statusDetails.actor ? (
       <strong>
-        <Avatar user={statusDetails.actor} size={20} className="avatar" />
+        <UserAvatar user={statusDetails.actor} size={20} className="avatar" />
         <span style={{marginLeft: 5}}>{statusDetails.actor.name}</span>
       </strong>
     ) : null;

--- a/src/sentry/static/sentry/app/components/selectMembers/valueComponent.tsx
+++ b/src/sentry/static/sentry/app/components/selectMembers/valueComponent.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
+import {Actor} from 'app/types';
 import ActorAvatar from 'app/components/avatar/actorAvatar';
 
 type Value = {
-  actor: {};
+  actor: Actor;
 };
 
 type Props = {

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarOrgSummary.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarOrgSummary.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'react-emotion';
 
-import Avatar from 'app/components/avatar';
+import OrganizationAvatar from 'app/components/avatar/organizationAvatar';
 import SentryTypes from 'app/sentryTypes';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 
@@ -21,7 +21,7 @@ class SidebarOrgSummary extends React.Component {
 
     return (
       <OrgSummary>
-        <Avatar css={{flexShrink: 0}} organization={organization} size={36} />
+        <OrganizationAvatar css={{flexShrink: 0}} organization={organization} size={36} />
 
         <Details>
           <SummaryOrgName>{organization.name}</SummaryOrgName>

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -15,18 +15,24 @@ export type Avatar = {
   avatarType: 'letter_avatar' | 'upload' | 'gravatar';
 };
 
+export type Actor = {
+  id: string;
+  type: 'user' | 'team';
+  name: string;
+};
+
 export type LightWeightOrganization = {
   id: string;
   slug: string;
   name: string;
   access: string[];
   features: string[];
+  avatar: Avatar;
 };
 
 export type Organization = LightWeightOrganization & {
   projects: Project[];
   teams: Team[];
-  avatar: Avatar;
 };
 
 export type OrganizationDetailed = Organization & {

--- a/src/sentry/static/sentry/app/views/organizationActivity/activityFeedItem.jsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity/activityFeedItem.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import {t, tn, tct} from 'app/locale';
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import CommitLink from 'app/components/commitLink';
 import Duration from 'app/components/duration';
 import IssueLink from 'app/components/issueLink';
@@ -309,7 +309,7 @@ class ActivityItem extends React.Component {
     }
 
     const avatar = item.user ? (
-      <Avatar user={item.user} size={36} className="activity-avatar" />
+      <UserAvatar user={item.user} size={36} className="activity-avatar" />
     ) : (
       <div className="activity-avatar avatar sentry">
         <span className="icon-sentry-logo" />

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {isUrl, percent} from 'app/utils';
 import {t} from 'app/locale';
 import withApi from 'app/utils/withApi';
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import DeviceName from 'app/components/deviceName';
 import ExternalLink from 'app/components/links/externalLink';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
@@ -126,7 +126,7 @@ class GroupTagValues extends React.Component {
             >
               {tagKey.key === 'user' ? (
                 <React.Fragment>
-                  <Avatar user={tagValue} size={20} className="avatar" />
+                  <UserAvatar user={tagValue} size={20} className="avatar" />
                   <span style={{marginLeft: 10}}>
                     {this.getUserDisplayName(tagValue)}
                   </span>

--- a/src/sentry/static/sentry/app/views/releases/detail/commitAuthorStats.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/commitAuthorStats.jsx
@@ -1,12 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Flex} from 'grid-emotion';
+import styled from 'react-emotion';
 
 import LoadingIndicator from 'app/components/loadingIndicator';
 import LoadingError from 'app/components/loadingError';
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 
 import withApi from 'app/utils/withApi';
+import space from 'app/styles/space';
 
 import {t} from 'app/locale';
 import {Panel, PanelItem, PanelBody} from 'app/components/panels';
@@ -116,16 +117,16 @@ class CommitAuthorStats extends React.Component {
               const {author, commitCount} = commitAuthor;
               return (
                 <PanelItem key={i} p={1} align="center">
-                  <Flex>
-                    <Avatar user={author} size={20} hasTooltip />
-                  </Flex>
-                  <Flex flex="1" px={1}>
+                  <AvatarWrapper>
+                    <UserAvatar user={author} size={20} hasTooltip />
+                  </AvatarWrapper>
+                  <CommitBarContainer>
                     <CommitBar
                       style={{marginLeft: 5}}
                       totalCommits={commitList.length}
                       authorCommits={commitCount}
                     />
-                  </Flex>
+                  </CommitBarContainer>
                   <div>{commitCount}</div>
                 </PanelItem>
               );
@@ -136,5 +137,15 @@ class CommitAuthorStats extends React.Component {
     );
   }
 }
+
+const AvatarWrapper = styled('div')`
+  display: flex;
+`;
+
+const CommitBarContainer = styled('div')`
+  display: flex;
+  flex-grow: 1;
+  padding: ${space(1)};
+`;
 
 export default withApi(CommitAuthorStats);

--- a/src/sentry/static/sentry/app/views/sentryAppExternalInstallation.tsx
+++ b/src/sentry/static/sentry/app/views/sentryAppExternalInstallation.tsx
@@ -9,7 +9,7 @@ import Field from 'app/views/settings/components/forms/field';
 import IndicatorStore from 'app/stores/indicatorStore';
 import NarrowLayout from 'app/components/narrowLayout';
 import SelectControl from 'app/components/forms/selectControl';
-import Avatar from 'app/components/avatar';
+import OrganizationAvatar from 'app/components/avatar/organizationAvatar';
 import SentryAppDetailsModal from 'app/components/modals/sentryAppDetailsModal';
 import {installSentryApp} from 'app/actionCreators/sentryAppInstallations';
 import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
@@ -147,7 +147,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
     return this.state.organizations.map(org => [
       org.slug,
       <div key={org.slug}>
-        <Avatar organization={org} />
+        <OrganizationAvatar organization={org} />
         <OrgNameHolder>{org.slug}</OrgNameHolder>
       </div>,
     ]);

--- a/src/sentry/static/sentry/app/views/settings/organizationAuditLog/auditLogList.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuditLog/auditLogList.jsx
@@ -1,10 +1,9 @@
-import {Box} from 'grid-emotion';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'react-emotion';
 
 import {t} from 'app/locale';
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import DateTime from 'app/components/dateTime';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import Pagination from 'app/components/pagination';
@@ -13,8 +12,9 @@ import SelectField from 'app/components/forms/selectField';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import Tooltip from 'app/components/tooltip';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
+import space from 'app/styles/space';
 
-const UserInfo = styled(Box)`
+const UserInfo = styled('div')`
   display: flex;
   line-height: 1.2;
   font-size: 13px;
@@ -33,10 +33,26 @@ const Name = styled('div')`
 `;
 const Note = styled('div')`
   font-size: 13px;
+  word-break: break-word;
 `;
 const OverflowBox = styled('div')`
   ${overflowEllipsis};
 `;
+
+const StyledPanelHeader = styled(PanelHeader)`
+  display: grid;
+  grid-template-columns: 1fr 150px 130px 150px;
+  grid-column-gap: ${space(2)};
+  padding: ${space(2)};
+`;
+
+const StyledPanelItem = styled(PanelItem)`
+  display: grid;
+  grid-template-columns: 1fr 150px 130px 150px;
+  grid-column-gap: ${space(2)};
+  padding: ${space(2)};
+`;
+
 const avatarStyle = {
   width: 36,
   height: 36,
@@ -77,18 +93,13 @@ class AuditLogList extends React.Component {
     return (
       <div>
         <SettingsPageHeader title={t('Audit Log')} action={action} />
-
         <Panel>
-          <PanelHeader disablePadding>
-            <Box flex="1" pl={2}>
-              {t('Member')}
-            </Box>
-            <Box w={150}>{t('Action')}</Box>
-            <Box w={130}>{t('IP')}</Box>
-            <Box w={150} px={1}>
-              {t('Time')}
-            </Box>
-          </PanelHeader>
+          <StyledPanelHeader disablePadding>
+            <div>{t('Member')}</div>
+            <div>{t('Action')}</div>
+            <div>{t('IP')}</div>
+            <div>{t('Time')}</div>
+          </StyledPanelHeader>
 
           <PanelBody>
             {!hasEntries && (
@@ -98,11 +109,11 @@ class AuditLogList extends React.Component {
             {hasEntries &&
               entries.map(entry => {
                 return (
-                  <PanelItem p={0} align="center" key={entry.id}>
-                    <UserInfo flex="1" p={2}>
+                  <StyledPanelItem align="center" key={entry.id}>
+                    <UserInfo>
                       <div>
                         {entry.actor.email && (
-                          <Avatar style={avatarStyle} user={entry.actor} />
+                          <UserAvatar style={avatarStyle} user={entry.actor} />
                         )}
                       </div>
                       <NameContainer>
@@ -114,24 +125,23 @@ class AuditLogList extends React.Component {
                         <Note>{entry.note}</Note>
                       </NameContainer>
                     </UserInfo>
-                    <Box w={150}>{entry.event}</Box>
-                    <Box w={130}>
+                    <div>{entry.event}</div>
+                    <div>
                       <Tooltip
                         title={entry.ipAddress}
                         disabled={entry.ipAddress && entry.ipAddress.length <= ipv4Length}
                       >
                         <OverflowBox>{entry.ipAddress}</OverflowBox>
                       </Tooltip>
-                    </Box>
-                    <Box w={150} p={1}>
+                    </div>
+                    <div>
                       <DateTime date={entry.dateCreated} />
-                    </Box>
-                  </PanelItem>
+                    </div>
+                  </StyledPanelItem>
                 );
               })}
           </PanelBody>
         </Panel>
-
         {pageLinks && <Pagination pageLinks={pageLinks} {...this.props} />}
       </div>
     );

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberRow.jsx
@@ -4,7 +4,7 @@ import styled from 'react-emotion';
 
 import {PanelItem} from 'app/components/panels';
 import {t, tct} from 'app/locale';
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import InlineSvg from 'app/components/inlineSvg';
@@ -98,7 +98,7 @@ export default class OrganizationMemberRow extends React.PureComponent {
     return (
       <StyledPanelItem data-test-id={email}>
         <MemberHeading>
-          <Avatar size={32} user={user ? user : {id: email, email}} />
+          <UserAvatar size={32} user={user ? user : {id: email, email}} />
           <MemberDescription to={detailsUrl}>
             <h5 style={{margin: '0 0 3px'}}>
               <UserName>{name}</UserName>

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamMembers.jsx
@@ -8,7 +8,7 @@ import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {joinTeam, leaveTeam} from 'app/actionCreators/teams';
 import {openInviteMembersModal} from 'app/actionCreators/modal';
 import {t} from 'app/locale';
-import Avatar from 'app/components/avatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import Button from 'app/components/button';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 import DropdownButton from 'app/components/dropdownButton';
@@ -341,7 +341,7 @@ const StyledNameOrEmail = styled('div')`
   ${overflowEllipsis};
 `;
 
-const StyledAvatar = styled(props => <Avatar {...props} />)`
+const StyledAvatar = styled(props => <UserAvatar {...props} />)`
   min-width: 1.75em;
   min-height: 1.75em;
   width: 1.5em;

--- a/src/sentry/static/sentry/app/views/settings/settingsIndex.tsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsIndex.tsx
@@ -4,7 +4,8 @@ import React from 'react';
 import styled, {css} from 'react-emotion';
 
 import {t} from 'app/locale';
-import Avatar from 'app/components/avatar';
+import OrganizationAvatar from 'app/components/avatar/organizationAvatar';
+import UserAvatar from 'app/components/avatar/userAvatar';
 import ConfigStore from 'app/stores/configStore';
 import ExternalLink from 'app/components/links/externalLink';
 import {fetchOrganizationDetails} from 'app/actionCreators/organizations';
@@ -89,7 +90,7 @@ class SettingsIndex extends React.Component<Props> {
               <HomePanelHeader>
                 <HomeLinkIcon to="/settings/account/">
                   <AvatarContainer>
-                    <Avatar user={user} size={HOME_ICON_SIZE} />
+                    <UserAvatar user={user} size={HOME_ICON_SIZE} />
                   </AvatarContainer>
                   {t('My Account')}
                 </HomeLinkIcon>
@@ -122,7 +123,10 @@ class SettingsIndex extends React.Component<Props> {
                 <HomeLinkIcon to={organizationSettingsUrl}>
                   {organization ? (
                     <AvatarContainer>
-                      <Avatar organization={organization} size={HOME_ICON_SIZE} />
+                      <OrganizationAvatar
+                        organization={organization}
+                        size={HOME_ICON_SIZE}
+                      />
                     </AvatarContainer>
                   ) : (
                     <HomeIcon color="green">

--- a/tests/js/spec/components/__snapshots__/resolutionBox.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/resolutionBox.spec.jsx.snap
@@ -166,9 +166,9 @@ exports[`ResolutionBox render() handles inNextRelease with actor 1`] = `
       <strong
         key="0"
       >
-        <Avatar
+        <UserAvatar
           className="avatar"
-          hasTooltip={false}
+          gravatar={false}
           size={20}
           user={
             Object {
@@ -288,9 +288,9 @@ exports[`ResolutionBox render() handles inRelease with actor 1`] = `
       <strong
         key="0"
       >
-        <Avatar
+        <UserAvatar
           className="avatar"
-          hasTooltip={false}
+          gravatar={false}
           size={20}
           user={
             Object {

--- a/tests/js/spec/components/assigneeSelector.spec.jsx
+++ b/tests/js/spec/components/assigneeSelector.spec.jsx
@@ -101,7 +101,6 @@ describe('AssigneeSelector', function() {
 
       assigneeSelector.update();
       expect(assigneeSelector.find('LoadingIndicator')).toHaveLength(0);
-      expect(assigneeSelector.find('Avatar')).toHaveLength(3);
       expect(assigneeSelector.find('UserAvatar')).toHaveLength(2);
       expect(assigneeSelector.find('TeamAvatar')).toHaveLength(1);
 
@@ -147,7 +146,6 @@ describe('AssigneeSelector', function() {
     expect(assigneeSelector.instance().assignableTeams()).toHaveLength(1);
 
     expect(assigneeSelector.find('LoadingIndicator')).toHaveLength(0);
-    expect(assigneeSelector.find('Avatar')).toHaveLength(3);
     expect(assigneeSelector.find('UserAvatar')).toHaveLength(2);
     expect(assigneeSelector.find('TeamAvatar')).toHaveLength(1);
   });
@@ -157,13 +155,13 @@ describe('AssigneeSelector', function() {
     MemberListStore.loadInitialData([USER_1, USER_2]);
     assigneeSelector.update();
 
-    expect(assigneeSelector.find('Avatar')).toHaveLength(3);
+    expect(assigneeSelector.find('UserAvatar')).toHaveLength(2);
     expect(assigneeSelector.find('LoadingIndicator').exists()).toBe(false);
 
     MemberListStore.loadInitialData([USER_1, USER_2, USER_3]);
     assigneeSelector.update();
 
-    expect(assigneeSelector.find('Avatar')).toHaveLength(3);
+    expect(assigneeSelector.find('UserAvatar')).toHaveLength(2);
     expect(assigneeSelector.find('LoadingIndicator').exists()).toBe(false);
   });
 
@@ -232,7 +230,7 @@ describe('AssigneeSelector', function() {
     // Assign first item in list, which is TEAM_1
     assigneeSelector.update();
     assigneeSelector
-      .find('Avatar')
+      .find('TeamAvatar')
       .first()
       .simulate('click');
     assigneeSelector.update();
@@ -289,8 +287,8 @@ describe('AssigneeSelector', function() {
       .find('StyledInput')
       .simulate('change', {target: {value: 'JohnSmith@example.com'}});
 
-    expect(assigneeSelector.find('Avatar')).toHaveLength(1);
-    expect(assigneeSelector.find('Avatar').prop('user')).toEqual(USER_2);
+    expect(assigneeSelector.find('UserAvatar')).toHaveLength(1);
+    expect(assigneeSelector.find('UserAvatar').prop('user')).toEqual(USER_2);
 
     assigneeSelector.find('StyledInput').simulate('keyDown', {key: 'Enter'});
     assigneeSelector.update();

--- a/tests/js/spec/components/avatar/__snapshots__/actorAvatar.spec.jsx.snap
+++ b/tests/js/spec/components/avatar/__snapshots__/actorAvatar.spec.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Avatar render() should show a gravatar when actor type is a team 1`] = `
-<Avatar
+exports[`ActorAvatar render() should show a gravatar when actor type is a team 1`] = `
+<TeamAvatar
   hasTooltip={true}
   team={
     Object {
@@ -18,14 +18,15 @@ exports[`Avatar render() should show a gravatar when actor type is a team 1`] = 
 />
 `;
 
-exports[`Avatar render() should show a gravatar when actor type is a user 1`] = `
-<Avatar
+exports[`ActorAvatar render() should show a gravatar when actor type is a user 1`] = `
+<UserAvatar
+  gravatar={false}
   hasTooltip={true}
   user={
     Object {
       "email": "janebloggs@example.com",
       "id": "1",
-      "name": "Jane Bloggs",
+      "name": "JanActore Bloggs",
     }
   }
 />

--- a/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
+++ b/tests/js/spec/components/avatar/__snapshots__/avatarList.spec.jsx.snap
@@ -154,6 +154,7 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
         </Manager>
       </Tooltip>
       <StyledAvatar
+        gravatar={false}
         hasTooltip={true}
         key="1-foo@example.com"
         size={28}
@@ -179,8 +180,9 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
           }
         }
       >
-        <Avatar
+        <UserAvatar
           className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+          gravatar={false}
           hasTooltip={true}
           size={28}
           tooltipOptions={
@@ -205,84 +207,66 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
             }
           }
         >
-          <UserAvatar
+          <BaseAvatar
             className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-            gravatar={false}
+            gravatarId="foo@example.com"
             hasTooltip={true}
+            letterId="foo@example.com"
+            round={true}
             size={28}
+            style={Object {}}
+            title="Foo Bar"
+            tooltip="Foo Bar (foo@example.com)"
             tooltipOptions={
               Object {
                 "position": "top",
               }
             }
-            user={
-              Object {
-                "email": "foo@example.com",
-                "flags": Object {
-                  "newsletter_consent_prompt": false,
-                },
-                "hasPasswordAuth": true,
-                "id": "1",
-                "isAuthenticated": true,
-                "name": "Foo Bar",
-                "options": Object {
-                  "timezone": "UTC",
-                },
-                "username": "foo@example.com",
-              }
-            }
+            type="letter_avatar"
+            uploadId=""
+            uploadPath="avatar"
           >
-            <BaseAvatar
-              className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-              gravatarId="foo@example.com"
-              hasTooltip={true}
-              letterId="foo@example.com"
-              round={true}
-              size={28}
-              style={Object {}}
-              title="Foo Bar"
-              tooltip="Foo Bar (foo@example.com)"
-              tooltipOptions={
-                Object {
-                  "position": "top",
-                }
-              }
-              type="letter_avatar"
-              uploadId=""
-              uploadPath="avatar"
+            <Tooltip
+              containerDisplayMode="inline-block"
+              disabled={false}
+              position="top"
+              title="Foo Bar (foo@example.com)"
             >
-              <Tooltip
-                containerDisplayMode="inline-block"
-                disabled={false}
-                position="top"
-                title="Foo Bar (foo@example.com)"
-              >
-                <Manager>
-                  <Reference>
-                    <InnerReference
-                      setReferenceNode={[Function]}
+              <Manager>
+                <Reference>
+                  <InnerReference
+                    setReferenceNode={[Function]}
+                  >
+                    <Container
+                      aria-describedby="tooltip-123456"
+                      containerDisplayMode="inline-block"
+                      innerRef={[Function]}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                     >
-                      <Container
+                      <span
                         aria-describedby="tooltip-123456"
-                        containerDisplayMode="inline-block"
-                        innerRef={[Function]}
+                        className="css-1vf31z4-Container eowlwvy0"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span
-                          aria-describedby="tooltip-123456"
-                          className="css-1vf31z4-Container eowlwvy0"
-                          onBlur={[Function]}
-                          onFocus={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
+                        <StyledBaseAvatar
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+                          loaded={true}
+                          round={true}
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-                            loaded={true}
-                            round={true}
+                          <span
+                            className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
                             style={
                               Object {
                                 "height": "28px",
@@ -290,69 +274,60 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                               }
                             }
                           >
-                            <span
-                              className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
-                              style={
-                                Object {
-                                  "height": "28px",
-                                  "width": "28px",
-                                }
-                              }
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              <LetterAvatar
+                              <Component
+                                className="css-vyy37i-LetterAvatar e12lgfev0"
                                 displayName="Foo Bar"
                                 identifier="foo@example.com"
                                 round={true}
                               >
-                                <Component
+                                <svg
                                   className="css-vyy37i-LetterAvatar e12lgfev0"
-                                  displayName="Foo Bar"
-                                  identifier="foo@example.com"
-                                  round={true}
+                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-vyy37i-LetterAvatar e12lgfev0"
-                                    viewBox="0 0 120 120"
-                                  >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
                                       }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
-                                    >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Component>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
-                      </Container>
-                    </InnerReference>
-                  </Reference>
-                </Manager>
-              </Tooltip>
-            </BaseAvatar>
-          </UserAvatar>
-        </Avatar>
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Component>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </span>
+                    </Container>
+                  </InnerReference>
+                </Reference>
+              </Manager>
+            </Tooltip>
+          </BaseAvatar>
+        </UserAvatar>
       </StyledAvatar>
       <StyledAvatar
+        gravatar={false}
         hasTooltip={true}
         key="2-foo@example.com"
         size={28}
@@ -378,8 +353,9 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
           }
         }
       >
-        <Avatar
+        <UserAvatar
           className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+          gravatar={false}
           hasTooltip={true}
           size={28}
           tooltipOptions={
@@ -404,84 +380,66 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
             }
           }
         >
-          <UserAvatar
+          <BaseAvatar
             className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-            gravatar={false}
+            gravatarId="foo@example.com"
             hasTooltip={true}
+            letterId="foo@example.com"
+            round={true}
             size={28}
+            style={Object {}}
+            title="Foo Bar"
+            tooltip="Foo Bar (foo@example.com)"
             tooltipOptions={
               Object {
                 "position": "top",
               }
             }
-            user={
-              Object {
-                "email": "foo@example.com",
-                "flags": Object {
-                  "newsletter_consent_prompt": false,
-                },
-                "hasPasswordAuth": true,
-                "id": "2",
-                "isAuthenticated": true,
-                "name": "Foo Bar",
-                "options": Object {
-                  "timezone": "UTC",
-                },
-                "username": "foo@example.com",
-              }
-            }
+            type="letter_avatar"
+            uploadId=""
+            uploadPath="avatar"
           >
-            <BaseAvatar
-              className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-              gravatarId="foo@example.com"
-              hasTooltip={true}
-              letterId="foo@example.com"
-              round={true}
-              size={28}
-              style={Object {}}
-              title="Foo Bar"
-              tooltip="Foo Bar (foo@example.com)"
-              tooltipOptions={
-                Object {
-                  "position": "top",
-                }
-              }
-              type="letter_avatar"
-              uploadId=""
-              uploadPath="avatar"
+            <Tooltip
+              containerDisplayMode="inline-block"
+              disabled={false}
+              position="top"
+              title="Foo Bar (foo@example.com)"
             >
-              <Tooltip
-                containerDisplayMode="inline-block"
-                disabled={false}
-                position="top"
-                title="Foo Bar (foo@example.com)"
-              >
-                <Manager>
-                  <Reference>
-                    <InnerReference
-                      setReferenceNode={[Function]}
+              <Manager>
+                <Reference>
+                  <InnerReference
+                    setReferenceNode={[Function]}
+                  >
+                    <Container
+                      aria-describedby="tooltip-123456"
+                      containerDisplayMode="inline-block"
+                      innerRef={[Function]}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                     >
-                      <Container
+                      <span
                         aria-describedby="tooltip-123456"
-                        containerDisplayMode="inline-block"
-                        innerRef={[Function]}
+                        className="css-1vf31z4-Container eowlwvy0"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span
-                          aria-describedby="tooltip-123456"
-                          className="css-1vf31z4-Container eowlwvy0"
-                          onBlur={[Function]}
-                          onFocus={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
+                        <StyledBaseAvatar
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+                          loaded={true}
+                          round={true}
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-                            loaded={true}
-                            round={true}
+                          <span
+                            className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
                             style={
                               Object {
                                 "height": "28px",
@@ -489,69 +447,60 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                               }
                             }
                           >
-                            <span
-                              className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
-                              style={
-                                Object {
-                                  "height": "28px",
-                                  "width": "28px",
-                                }
-                              }
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              <LetterAvatar
+                              <Component
+                                className="css-vyy37i-LetterAvatar e12lgfev0"
                                 displayName="Foo Bar"
                                 identifier="foo@example.com"
                                 round={true}
                               >
-                                <Component
+                                <svg
                                   className="css-vyy37i-LetterAvatar e12lgfev0"
-                                  displayName="Foo Bar"
-                                  identifier="foo@example.com"
-                                  round={true}
+                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-vyy37i-LetterAvatar e12lgfev0"
-                                    viewBox="0 0 120 120"
-                                  >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
                                       }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
-                                    >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Component>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
-                      </Container>
-                    </InnerReference>
-                  </Reference>
-                </Manager>
-              </Tooltip>
-            </BaseAvatar>
-          </UserAvatar>
-        </Avatar>
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Component>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </span>
+                    </Container>
+                  </InnerReference>
+                </Reference>
+              </Manager>
+            </Tooltip>
+          </BaseAvatar>
+        </UserAvatar>
       </StyledAvatar>
       <StyledAvatar
+        gravatar={false}
         hasTooltip={true}
         key="3-foo@example.com"
         size={28}
@@ -577,8 +526,9 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
           }
         }
       >
-        <Avatar
+        <UserAvatar
           className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+          gravatar={false}
           hasTooltip={true}
           size={28}
           tooltipOptions={
@@ -603,84 +553,66 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
             }
           }
         >
-          <UserAvatar
+          <BaseAvatar
             className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-            gravatar={false}
+            gravatarId="foo@example.com"
             hasTooltip={true}
+            letterId="foo@example.com"
+            round={true}
             size={28}
+            style={Object {}}
+            title="Foo Bar"
+            tooltip="Foo Bar (foo@example.com)"
             tooltipOptions={
               Object {
                 "position": "top",
               }
             }
-            user={
-              Object {
-                "email": "foo@example.com",
-                "flags": Object {
-                  "newsletter_consent_prompt": false,
-                },
-                "hasPasswordAuth": true,
-                "id": "3",
-                "isAuthenticated": true,
-                "name": "Foo Bar",
-                "options": Object {
-                  "timezone": "UTC",
-                },
-                "username": "foo@example.com",
-              }
-            }
+            type="letter_avatar"
+            uploadId=""
+            uploadPath="avatar"
           >
-            <BaseAvatar
-              className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-              gravatarId="foo@example.com"
-              hasTooltip={true}
-              letterId="foo@example.com"
-              round={true}
-              size={28}
-              style={Object {}}
-              title="Foo Bar"
-              tooltip="Foo Bar (foo@example.com)"
-              tooltipOptions={
-                Object {
-                  "position": "top",
-                }
-              }
-              type="letter_avatar"
-              uploadId=""
-              uploadPath="avatar"
+            <Tooltip
+              containerDisplayMode="inline-block"
+              disabled={false}
+              position="top"
+              title="Foo Bar (foo@example.com)"
             >
-              <Tooltip
-                containerDisplayMode="inline-block"
-                disabled={false}
-                position="top"
-                title="Foo Bar (foo@example.com)"
-              >
-                <Manager>
-                  <Reference>
-                    <InnerReference
-                      setReferenceNode={[Function]}
+              <Manager>
+                <Reference>
+                  <InnerReference
+                    setReferenceNode={[Function]}
+                  >
+                    <Container
+                      aria-describedby="tooltip-123456"
+                      containerDisplayMode="inline-block"
+                      innerRef={[Function]}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                     >
-                      <Container
+                      <span
                         aria-describedby="tooltip-123456"
-                        containerDisplayMode="inline-block"
-                        innerRef={[Function]}
+                        className="css-1vf31z4-Container eowlwvy0"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span
-                          aria-describedby="tooltip-123456"
-                          className="css-1vf31z4-Container eowlwvy0"
-                          onBlur={[Function]}
-                          onFocus={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
+                        <StyledBaseAvatar
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+                          loaded={true}
+                          round={true}
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-                            loaded={true}
-                            round={true}
+                          <span
+                            className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
                             style={
                               Object {
                                 "height": "28px",
@@ -688,69 +620,60 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                               }
                             }
                           >
-                            <span
-                              className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
-                              style={
-                                Object {
-                                  "height": "28px",
-                                  "width": "28px",
-                                }
-                              }
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              <LetterAvatar
+                              <Component
+                                className="css-vyy37i-LetterAvatar e12lgfev0"
                                 displayName="Foo Bar"
                                 identifier="foo@example.com"
                                 round={true}
                               >
-                                <Component
+                                <svg
                                   className="css-vyy37i-LetterAvatar e12lgfev0"
-                                  displayName="Foo Bar"
-                                  identifier="foo@example.com"
-                                  round={true}
+                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-vyy37i-LetterAvatar e12lgfev0"
-                                    viewBox="0 0 120 120"
-                                  >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
                                       }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
-                                    >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Component>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
-                      </Container>
-                    </InnerReference>
-                  </Reference>
-                </Manager>
-              </Tooltip>
-            </BaseAvatar>
-          </UserAvatar>
-        </Avatar>
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Component>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </span>
+                    </Container>
+                  </InnerReference>
+                </Reference>
+              </Manager>
+            </Tooltip>
+          </BaseAvatar>
+        </UserAvatar>
       </StyledAvatar>
       <StyledAvatar
+        gravatar={false}
         hasTooltip={true}
         key="4-foo@example.com"
         size={28}
@@ -776,8 +699,9 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
           }
         }
       >
-        <Avatar
+        <UserAvatar
           className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+          gravatar={false}
           hasTooltip={true}
           size={28}
           tooltipOptions={
@@ -802,84 +726,66 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
             }
           }
         >
-          <UserAvatar
+          <BaseAvatar
             className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-            gravatar={false}
+            gravatarId="foo@example.com"
             hasTooltip={true}
+            letterId="foo@example.com"
+            round={true}
             size={28}
+            style={Object {}}
+            title="Foo Bar"
+            tooltip="Foo Bar (foo@example.com)"
             tooltipOptions={
               Object {
                 "position": "top",
               }
             }
-            user={
-              Object {
-                "email": "foo@example.com",
-                "flags": Object {
-                  "newsletter_consent_prompt": false,
-                },
-                "hasPasswordAuth": true,
-                "id": "4",
-                "isAuthenticated": true,
-                "name": "Foo Bar",
-                "options": Object {
-                  "timezone": "UTC",
-                },
-                "username": "foo@example.com",
-              }
-            }
+            type="letter_avatar"
+            uploadId=""
+            uploadPath="avatar"
           >
-            <BaseAvatar
-              className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-              gravatarId="foo@example.com"
-              hasTooltip={true}
-              letterId="foo@example.com"
-              round={true}
-              size={28}
-              style={Object {}}
-              title="Foo Bar"
-              tooltip="Foo Bar (foo@example.com)"
-              tooltipOptions={
-                Object {
-                  "position": "top",
-                }
-              }
-              type="letter_avatar"
-              uploadId=""
-              uploadPath="avatar"
+            <Tooltip
+              containerDisplayMode="inline-block"
+              disabled={false}
+              position="top"
+              title="Foo Bar (foo@example.com)"
             >
-              <Tooltip
-                containerDisplayMode="inline-block"
-                disabled={false}
-                position="top"
-                title="Foo Bar (foo@example.com)"
-              >
-                <Manager>
-                  <Reference>
-                    <InnerReference
-                      setReferenceNode={[Function]}
+              <Manager>
+                <Reference>
+                  <InnerReference
+                    setReferenceNode={[Function]}
+                  >
+                    <Container
+                      aria-describedby="tooltip-123456"
+                      containerDisplayMode="inline-block"
+                      innerRef={[Function]}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                     >
-                      <Container
+                      <span
                         aria-describedby="tooltip-123456"
-                        containerDisplayMode="inline-block"
-                        innerRef={[Function]}
+                        className="css-1vf31z4-Container eowlwvy0"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span
-                          aria-describedby="tooltip-123456"
-                          className="css-1vf31z4-Container eowlwvy0"
-                          onBlur={[Function]}
-                          onFocus={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
+                        <StyledBaseAvatar
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+                          loaded={true}
+                          round={true}
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-                            loaded={true}
-                            round={true}
+                          <span
+                            className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
                             style={
                               Object {
                                 "height": "28px",
@@ -887,69 +793,60 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                               }
                             }
                           >
-                            <span
-                              className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
-                              style={
-                                Object {
-                                  "height": "28px",
-                                  "width": "28px",
-                                }
-                              }
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              <LetterAvatar
+                              <Component
+                                className="css-vyy37i-LetterAvatar e12lgfev0"
                                 displayName="Foo Bar"
                                 identifier="foo@example.com"
                                 round={true}
                               >
-                                <Component
+                                <svg
                                   className="css-vyy37i-LetterAvatar e12lgfev0"
-                                  displayName="Foo Bar"
-                                  identifier="foo@example.com"
-                                  round={true}
+                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-vyy37i-LetterAvatar e12lgfev0"
-                                    viewBox="0 0 120 120"
-                                  >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
                                       }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
-                                    >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Component>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
-                      </Container>
-                    </InnerReference>
-                  </Reference>
-                </Manager>
-              </Tooltip>
-            </BaseAvatar>
-          </UserAvatar>
-        </Avatar>
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Component>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </span>
+                    </Container>
+                  </InnerReference>
+                </Reference>
+              </Manager>
+            </Tooltip>
+          </BaseAvatar>
+        </UserAvatar>
       </StyledAvatar>
       <StyledAvatar
+        gravatar={false}
         hasTooltip={true}
         key="5-foo@example.com"
         size={28}
@@ -975,8 +872,9 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
           }
         }
       >
-        <Avatar
+        <UserAvatar
           className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+          gravatar={false}
           hasTooltip={true}
           size={28}
           tooltipOptions={
@@ -1001,84 +899,66 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
             }
           }
         >
-          <UserAvatar
+          <BaseAvatar
             className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-            gravatar={false}
+            gravatarId="foo@example.com"
             hasTooltip={true}
+            letterId="foo@example.com"
+            round={true}
             size={28}
+            style={Object {}}
+            title="Foo Bar"
+            tooltip="Foo Bar (foo@example.com)"
             tooltipOptions={
               Object {
                 "position": "top",
               }
             }
-            user={
-              Object {
-                "email": "foo@example.com",
-                "flags": Object {
-                  "newsletter_consent_prompt": false,
-                },
-                "hasPasswordAuth": true,
-                "id": "5",
-                "isAuthenticated": true,
-                "name": "Foo Bar",
-                "options": Object {
-                  "timezone": "UTC",
-                },
-                "username": "foo@example.com",
-              }
-            }
+            type="letter_avatar"
+            uploadId=""
+            uploadPath="avatar"
           >
-            <BaseAvatar
-              className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-              gravatarId="foo@example.com"
-              hasTooltip={true}
-              letterId="foo@example.com"
-              round={true}
-              size={28}
-              style={Object {}}
-              title="Foo Bar"
-              tooltip="Foo Bar (foo@example.com)"
-              tooltipOptions={
-                Object {
-                  "position": "top",
-                }
-              }
-              type="letter_avatar"
-              uploadId=""
-              uploadPath="avatar"
+            <Tooltip
+              containerDisplayMode="inline-block"
+              disabled={false}
+              position="top"
+              title="Foo Bar (foo@example.com)"
             >
-              <Tooltip
-                containerDisplayMode="inline-block"
-                disabled={false}
-                position="top"
-                title="Foo Bar (foo@example.com)"
-              >
-                <Manager>
-                  <Reference>
-                    <InnerReference
-                      setReferenceNode={[Function]}
+              <Manager>
+                <Reference>
+                  <InnerReference
+                    setReferenceNode={[Function]}
+                  >
+                    <Container
+                      aria-describedby="tooltip-123456"
+                      containerDisplayMode="inline-block"
+                      innerRef={[Function]}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                     >
-                      <Container
+                      <span
                         aria-describedby="tooltip-123456"
-                        containerDisplayMode="inline-block"
-                        innerRef={[Function]}
+                        className="css-1vf31z4-Container eowlwvy0"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span
-                          aria-describedby="tooltip-123456"
-                          className="css-1vf31z4-Container eowlwvy0"
-                          onBlur={[Function]}
-                          onFocus={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
+                        <StyledBaseAvatar
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+                          loaded={true}
+                          round={true}
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-                            loaded={true}
-                            round={true}
+                          <span
+                            className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
                             style={
                               Object {
                                 "height": "28px",
@@ -1086,67 +966,57 @@ exports[`AvatarList renders with collapsed avatar count if > 5 users 1`] = `
                               }
                             }
                           >
-                            <span
-                              className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
-                              style={
-                                Object {
-                                  "height": "28px",
-                                  "width": "28px",
-                                }
-                              }
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              <LetterAvatar
+                              <Component
+                                className="css-vyy37i-LetterAvatar e12lgfev0"
                                 displayName="Foo Bar"
                                 identifier="foo@example.com"
                                 round={true}
                               >
-                                <Component
+                                <svg
                                   className="css-vyy37i-LetterAvatar e12lgfev0"
-                                  displayName="Foo Bar"
-                                  identifier="foo@example.com"
-                                  round={true}
+                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-vyy37i-LetterAvatar e12lgfev0"
-                                    viewBox="0 0 120 120"
-                                  >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
                                       }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
-                                    >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Component>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
-                      </Container>
-                    </InnerReference>
-                  </Reference>
-                </Manager>
-              </Tooltip>
-            </BaseAvatar>
-          </UserAvatar>
-        </Avatar>
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Component>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </span>
+                    </Container>
+                  </InnerReference>
+                </Reference>
+              </Manager>
+            </Tooltip>
+          </BaseAvatar>
+        </UserAvatar>
       </StyledAvatar>
     </div>
   </AvatarListWrapper>
@@ -1201,6 +1071,7 @@ exports[`AvatarList renders with user avatars 1`] = `
       className="css-e1rf9n-AvatarListWrapper e1mtf41h0"
     >
       <StyledAvatar
+        gravatar={false}
         hasTooltip={true}
         key="1-foo@example.com"
         size={28}
@@ -1226,8 +1097,9 @@ exports[`AvatarList renders with user avatars 1`] = `
           }
         }
       >
-        <Avatar
+        <UserAvatar
           className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+          gravatar={false}
           hasTooltip={true}
           size={28}
           tooltipOptions={
@@ -1252,84 +1124,66 @@ exports[`AvatarList renders with user avatars 1`] = `
             }
           }
         >
-          <UserAvatar
+          <BaseAvatar
             className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-            gravatar={false}
+            gravatarId="foo@example.com"
             hasTooltip={true}
+            letterId="foo@example.com"
+            round={true}
             size={28}
+            style={Object {}}
+            title="Foo Bar"
+            tooltip="Foo Bar (foo@example.com)"
             tooltipOptions={
               Object {
                 "position": "top",
               }
             }
-            user={
-              Object {
-                "email": "foo@example.com",
-                "flags": Object {
-                  "newsletter_consent_prompt": false,
-                },
-                "hasPasswordAuth": true,
-                "id": "1",
-                "isAuthenticated": true,
-                "name": "Foo Bar",
-                "options": Object {
-                  "timezone": "UTC",
-                },
-                "username": "foo@example.com",
-              }
-            }
+            type="letter_avatar"
+            uploadId=""
+            uploadPath="avatar"
           >
-            <BaseAvatar
-              className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-              gravatarId="foo@example.com"
-              hasTooltip={true}
-              letterId="foo@example.com"
-              round={true}
-              size={28}
-              style={Object {}}
-              title="Foo Bar"
-              tooltip="Foo Bar (foo@example.com)"
-              tooltipOptions={
-                Object {
-                  "position": "top",
-                }
-              }
-              type="letter_avatar"
-              uploadId=""
-              uploadPath="avatar"
+            <Tooltip
+              containerDisplayMode="inline-block"
+              disabled={false}
+              position="top"
+              title="Foo Bar (foo@example.com)"
             >
-              <Tooltip
-                containerDisplayMode="inline-block"
-                disabled={false}
-                position="top"
-                title="Foo Bar (foo@example.com)"
-              >
-                <Manager>
-                  <Reference>
-                    <InnerReference
-                      setReferenceNode={[Function]}
+              <Manager>
+                <Reference>
+                  <InnerReference
+                    setReferenceNode={[Function]}
+                  >
+                    <Container
+                      aria-describedby="tooltip-123456"
+                      containerDisplayMode="inline-block"
+                      innerRef={[Function]}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                     >
-                      <Container
+                      <span
                         aria-describedby="tooltip-123456"
-                        containerDisplayMode="inline-block"
-                        innerRef={[Function]}
+                        className="css-1vf31z4-Container eowlwvy0"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span
-                          aria-describedby="tooltip-123456"
-                          className="css-1vf31z4-Container eowlwvy0"
-                          onBlur={[Function]}
-                          onFocus={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
+                        <StyledBaseAvatar
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+                          loaded={true}
+                          round={true}
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-                            loaded={true}
-                            round={true}
+                          <span
+                            className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
                             style={
                               Object {
                                 "height": "28px",
@@ -1337,69 +1191,60 @@ exports[`AvatarList renders with user avatars 1`] = `
                               }
                             }
                           >
-                            <span
-                              className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
-                              style={
-                                Object {
-                                  "height": "28px",
-                                  "width": "28px",
-                                }
-                              }
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              <LetterAvatar
+                              <Component
+                                className="css-vyy37i-LetterAvatar e12lgfev0"
                                 displayName="Foo Bar"
                                 identifier="foo@example.com"
                                 round={true}
                               >
-                                <Component
+                                <svg
                                   className="css-vyy37i-LetterAvatar e12lgfev0"
-                                  displayName="Foo Bar"
-                                  identifier="foo@example.com"
-                                  round={true}
+                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-vyy37i-LetterAvatar e12lgfev0"
-                                    viewBox="0 0 120 120"
-                                  >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
                                       }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
-                                    >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Component>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
-                      </Container>
-                    </InnerReference>
-                  </Reference>
-                </Manager>
-              </Tooltip>
-            </BaseAvatar>
-          </UserAvatar>
-        </Avatar>
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Component>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </span>
+                    </Container>
+                  </InnerReference>
+                </Reference>
+              </Manager>
+            </Tooltip>
+          </BaseAvatar>
+        </UserAvatar>
       </StyledAvatar>
       <StyledAvatar
+        gravatar={false}
         hasTooltip={true}
         key="2-foo@example.com"
         size={28}
@@ -1425,8 +1270,9 @@ exports[`AvatarList renders with user avatars 1`] = `
           }
         }
       >
-        <Avatar
+        <UserAvatar
           className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+          gravatar={false}
           hasTooltip={true}
           size={28}
           tooltipOptions={
@@ -1451,84 +1297,66 @@ exports[`AvatarList renders with user avatars 1`] = `
             }
           }
         >
-          <UserAvatar
+          <BaseAvatar
             className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-            gravatar={false}
+            gravatarId="foo@example.com"
             hasTooltip={true}
+            letterId="foo@example.com"
+            round={true}
             size={28}
+            style={Object {}}
+            title="Foo Bar"
+            tooltip="Foo Bar (foo@example.com)"
             tooltipOptions={
               Object {
                 "position": "top",
               }
             }
-            user={
-              Object {
-                "email": "foo@example.com",
-                "flags": Object {
-                  "newsletter_consent_prompt": false,
-                },
-                "hasPasswordAuth": true,
-                "id": "2",
-                "isAuthenticated": true,
-                "name": "Foo Bar",
-                "options": Object {
-                  "timezone": "UTC",
-                },
-                "username": "foo@example.com",
-              }
-            }
+            type="letter_avatar"
+            uploadId=""
+            uploadPath="avatar"
           >
-            <BaseAvatar
-              className="css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-              gravatarId="foo@example.com"
-              hasTooltip={true}
-              letterId="foo@example.com"
-              round={true}
-              size={28}
-              style={Object {}}
-              title="Foo Bar"
-              tooltip="Foo Bar (foo@example.com)"
-              tooltipOptions={
-                Object {
-                  "position": "top",
-                }
-              }
-              type="letter_avatar"
-              uploadId=""
-              uploadPath="avatar"
+            <Tooltip
+              containerDisplayMode="inline-block"
+              disabled={false}
+              position="top"
+              title="Foo Bar (foo@example.com)"
             >
-              <Tooltip
-                containerDisplayMode="inline-block"
-                disabled={false}
-                position="top"
-                title="Foo Bar (foo@example.com)"
-              >
-                <Manager>
-                  <Reference>
-                    <InnerReference
-                      setReferenceNode={[Function]}
+              <Manager>
+                <Reference>
+                  <InnerReference
+                    setReferenceNode={[Function]}
+                  >
+                    <Container
+                      aria-describedby="tooltip-123456"
+                      containerDisplayMode="inline-block"
+                      innerRef={[Function]}
+                      onBlur={[Function]}
+                      onFocus={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
                     >
-                      <Container
+                      <span
                         aria-describedby="tooltip-123456"
-                        containerDisplayMode="inline-block"
-                        innerRef={[Function]}
+                        className="css-1vf31z4-Container eowlwvy0"
                         onBlur={[Function]}
                         onFocus={[Function]}
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
                       >
-                        <span
-                          aria-describedby="tooltip-123456"
-                          className="css-1vf31z4-Container eowlwvy0"
-                          onBlur={[Function]}
-                          onFocus={[Function]}
-                          onMouseEnter={[Function]}
-                          onMouseLeave={[Function]}
+                        <StyledBaseAvatar
+                          className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
+                          loaded={true}
+                          round={true}
+                          style={
+                            Object {
+                              "height": "28px",
+                              "width": "28px",
+                            }
+                          }
                         >
-                          <StyledBaseAvatar
-                            className="avatar css-ptswrs-StyledAvatar-Circle e1mtf41h1"
-                            loaded={true}
-                            round={true}
+                          <span
+                            className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
                             style={
                               Object {
                                 "height": "28px",
@@ -1536,67 +1364,57 @@ exports[`AvatarList renders with user avatars 1`] = `
                               }
                             }
                           >
-                            <span
-                              className="avatar e1mtf41h1 css-p25dkn-StyledBaseAvatar-StyledAvatar-Circle e147uwb0"
-                              style={
-                                Object {
-                                  "height": "28px",
-                                  "width": "28px",
-                                }
-                              }
+                            <LetterAvatar
+                              displayName="Foo Bar"
+                              identifier="foo@example.com"
+                              round={true}
                             >
-                              <LetterAvatar
+                              <Component
+                                className="css-vyy37i-LetterAvatar e12lgfev0"
                                 displayName="Foo Bar"
                                 identifier="foo@example.com"
                                 round={true}
                               >
-                                <Component
+                                <svg
                                   className="css-vyy37i-LetterAvatar e12lgfev0"
-                                  displayName="Foo Bar"
-                                  identifier="foo@example.com"
-                                  round={true}
+                                  viewBox="0 0 120 120"
                                 >
-                                  <svg
-                                    className="css-vyy37i-LetterAvatar e12lgfev0"
-                                    viewBox="0 0 120 120"
-                                  >
-                                    <rect
-                                      fill="#315cac"
-                                      height="120"
-                                      rx="15"
-                                      ry="15"
-                                      width="120"
-                                      x="0"
-                                      y="0"
-                                    />
-                                    <text
-                                      fill="#FFFFFF"
-                                      fontSize="65"
-                                      style={
-                                        Object {
-                                          "dominantBaseline": "central",
-                                        }
+                                  <rect
+                                    fill="#315cac"
+                                    height="120"
+                                    rx="15"
+                                    ry="15"
+                                    width="120"
+                                    x="0"
+                                    y="0"
+                                  />
+                                  <text
+                                    fill="#FFFFFF"
+                                    fontSize="65"
+                                    style={
+                                      Object {
+                                        "dominantBaseline": "central",
                                       }
-                                      textAnchor="middle"
-                                      x="50%"
-                                      y="50%"
-                                    >
-                                      FB
-                                    </text>
-                                  </svg>
-                                </Component>
-                              </LetterAvatar>
-                            </span>
-                          </StyledBaseAvatar>
-                        </span>
-                      </Container>
-                    </InnerReference>
-                  </Reference>
-                </Manager>
-              </Tooltip>
-            </BaseAvatar>
-          </UserAvatar>
-        </Avatar>
+                                    }
+                                    textAnchor="middle"
+                                    x="50%"
+                                    y="50%"
+                                  >
+                                    FB
+                                  </text>
+                                </svg>
+                              </Component>
+                            </LetterAvatar>
+                          </span>
+                        </StyledBaseAvatar>
+                      </span>
+                    </Container>
+                  </InnerReference>
+                </Reference>
+              </Manager>
+            </Tooltip>
+          </BaseAvatar>
+        </UserAvatar>
       </StyledAvatar>
     </div>
   </AvatarListWrapper>

--- a/tests/js/spec/components/avatar/actorAvatar.spec.jsx
+++ b/tests/js/spec/components/avatar/actorAvatar.spec.jsx
@@ -4,10 +4,10 @@ import ActorAvatar from 'app/components/avatar/actorAvatar';
 import MemberListStore from 'app/stores/memberListStore';
 import TeamStore from 'app/stores/teamStore';
 
-describe('Avatar', function() {
+describe('ActorAvatar', function() {
   const USER = {
     id: '1',
-    name: 'Jane Bloggs',
+    name: 'JanActore Bloggs',
     email: 'janebloggs@example.com',
   };
   const TEAM_1 = {

--- a/tests/js/spec/components/avatar/avatarList.spec.jsx
+++ b/tests/js/spec/components/avatar/avatarList.spec.jsx
@@ -8,7 +8,7 @@ describe('AvatarList', function() {
     const users = [TestStubs.User({id: '1'}), TestStubs.User({id: '2'})];
 
     const wrapper = mount(<AvatarList users={users} />);
-    expect(wrapper.find('Avatar')).toHaveLength(2);
+    expect(wrapper.find('UserAvatar')).toHaveLength(2);
     expect(wrapper.find('CollapsedUsers')).toHaveLength(0);
     expect(wrapper).toMatchSnapshot();
   });
@@ -24,7 +24,7 @@ describe('AvatarList', function() {
     ];
 
     const wrapper = mount(<AvatarList users={users} />);
-    expect(wrapper.find('Avatar')).toHaveLength(5);
+    expect(wrapper.find('UserAvatar')).toHaveLength(5);
     expect(wrapper.find('CollapsedUsers')).toHaveLength(1);
     expect(wrapper).toMatchSnapshot();
   });

--- a/tests/js/spec/components/seenByList.spec.jsx
+++ b/tests/js/spec/components/seenByList.spec.jsx
@@ -28,7 +28,7 @@ describe('SeenByList', function() {
 
     expect(wrapper.find('EyeIcon')).toHaveLength(1);
     expect(wrapper.find('AvatarList')).toHaveLength(1);
-    expect(wrapper.find('Avatar')).toHaveLength(2);
+    expect(wrapper.find('UserAvatar')).toHaveLength(2);
   });
 
   it('filters out the current user from list of users', function() {
@@ -47,7 +47,7 @@ describe('SeenByList', function() {
 
     expect(wrapper.find('EyeIcon')).toHaveLength(1);
     expect(wrapper.find('AvatarList')).toHaveLength(1);
-    expect(wrapper.find('Avatar')).toHaveLength(1);
+    expect(wrapper.find('UserAvatar')).toHaveLength(1);
     expect(wrapper.find('LetterAvatar').prop('displayName')).toBe('john@example.com');
   });
 });

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -201,9 +201,8 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
         <div
           className="css-1d1he2f-OrgSummary e1dvf3yd0"
         >
-          <Avatar
+          <OrganizationAvatar
             className="css-6su6fj"
-            hasTooltip={false}
             organization={
               Object {
                 "access": Array [
@@ -234,61 +233,37 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
             }
             size={36}
           >
-            <OrganizationAvatar
+            <BaseAvatar
               className="css-6su6fj"
               hasTooltip={false}
-              organization={
-                Object {
-                  "access": Array [
-                    "org:read",
-                    "org:write",
-                    "org:admin",
-                    "org:integrations",
-                    "project:read",
-                    "project:write",
-                    "project:admin",
-                    "team:read",
-                    "team:write",
-                    "team:admin",
-                  ],
-                  "features": Array [],
-                  "id": "3",
-                  "name": "Organization Name",
-                  "onboardingTasks": Array [],
-                  "projects": Array [],
-                  "scrapeJavaScript": true,
-                  "slug": "org-slug",
-                  "status": Object {
-                    "id": "active",
-                    "name": "active",
-                  },
-                  "teams": Array [],
-                }
-              }
+              letterId="org-slug"
+              round={false}
               size={36}
+              style={Object {}}
+              title="org slug"
+              tooltip="org-slug"
+              type="letter_avatar"
+              uploadPath="organization-avatar"
             >
-              <BaseAvatar
-                className="css-6su6fj"
-                hasTooltip={false}
-                letterId="org-slug"
-                round={false}
-                size={36}
-                style={Object {}}
-                title="org slug"
-                tooltip="org-slug"
-                type="letter_avatar"
-                uploadPath="organization-avatar"
+              <Tooltip
+                containerDisplayMode="inline-block"
+                disabled={true}
+                position="top"
+                title="org-slug"
               >
-                <Tooltip
-                  containerDisplayMode="inline-block"
-                  disabled={true}
-                  position="top"
-                  title="org-slug"
+                <StyledBaseAvatar
+                  className="avatar css-6su6fj"
+                  loaded={true}
+                  round={false}
+                  style={
+                    Object {
+                      "height": "36px",
+                      "width": "36px",
+                    }
+                  }
                 >
-                  <StyledBaseAvatar
-                    className="avatar css-6su6fj"
-                    loaded={true}
-                    round={false}
+                  <span
+                    className="avatar css-1ezk8y8-StyledBaseAvatar e147uwb0"
                     style={
                       Object {
                         "height": "36px",
@@ -296,62 +271,52 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                       }
                     }
                   >
-                    <span
-                      className="avatar css-1ezk8y8-StyledBaseAvatar e147uwb0"
-                      style={
-                        Object {
-                          "height": "36px",
-                          "width": "36px",
-                        }
-                      }
+                    <LetterAvatar
+                      displayName="org slug"
+                      identifier="org-slug"
+                      round={false}
                     >
-                      <LetterAvatar
+                      <Component
+                        className="css-1k35his-LetterAvatar e12lgfev0"
                         displayName="org slug"
                         identifier="org-slug"
                         round={false}
                       >
-                        <Component
+                        <svg
                           className="css-1k35his-LetterAvatar e12lgfev0"
-                          displayName="org slug"
-                          identifier="org-slug"
-                          round={false}
+                          viewBox="0 0 120 120"
                         >
-                          <svg
-                            className="css-1k35his-LetterAvatar e12lgfev0"
-                            viewBox="0 0 120 120"
-                          >
-                            <rect
-                              fill="#4674ca"
-                              height="120"
-                              rx="15"
-                              ry="15"
-                              width="120"
-                              x="0"
-                              y="0"
-                            />
-                            <text
-                              fill="#FFFFFF"
-                              fontSize="65"
-                              style={
-                                Object {
-                                  "dominantBaseline": "central",
-                                }
+                          <rect
+                            fill="#4674ca"
+                            height="120"
+                            rx="15"
+                            ry="15"
+                            width="120"
+                            x="0"
+                            y="0"
+                          />
+                          <text
+                            fill="#FFFFFF"
+                            fontSize="65"
+                            style={
+                              Object {
+                                "dominantBaseline": "central",
                               }
-                              textAnchor="middle"
-                              x="50%"
-                              y="50%"
-                            >
-                              OS
-                            </text>
-                          </svg>
-                        </Component>
-                      </LetterAvatar>
-                    </span>
-                  </StyledBaseAvatar>
-                </Tooltip>
-              </BaseAvatar>
-            </OrganizationAvatar>
-          </Avatar>
+                            }
+                            textAnchor="middle"
+                            x="50%"
+                            y="50%"
+                          >
+                            OS
+                          </text>
+                        </svg>
+                      </Component>
+                    </LetterAvatar>
+                  </span>
+                </StyledBaseAvatar>
+              </Tooltip>
+            </BaseAvatar>
+          </OrganizationAvatar>
           <Details>
             <div
               className="css-r07pll-Details e1dvf3yd3"
@@ -697,9 +662,9 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                                 }
                               }
                             >
-                              <Avatar
+                              <UserAvatar
                                 className="css-1u6j7yz-StyledAvatar ev46mzr4"
-                                hasTooltip={false}
+                                gravatar={false}
                                 size={32}
                                 user={
                                   Object {
@@ -719,53 +684,39 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                                   }
                                 }
                               >
-                                <UserAvatar
+                                <BaseAvatar
                                   className="css-1u6j7yz-StyledAvatar ev46mzr4"
-                                  gravatar={false}
+                                  gravatarId="foo@example.com"
                                   hasTooltip={false}
+                                  letterId="foo@example.com"
+                                  round={true}
                                   size={32}
-                                  user={
-                                    Object {
-                                      "email": "foo@example.com",
-                                      "flags": Object {
-                                        "newsletter_consent_prompt": false,
-                                      },
-                                      "hasPasswordAuth": true,
-                                      "id": "1",
-                                      "isAuthenticated": true,
-                                      "name": "Foo Bar",
-                                      "options": Object {
-                                        "timezone": "UTC",
-                                      },
-                                      "permissions": Set {},
-                                      "username": "foo@example.com",
-                                    }
-                                  }
+                                  style={Object {}}
+                                  title="Foo Bar"
+                                  tooltip="Foo Bar (foo@example.com)"
+                                  type="letter_avatar"
+                                  uploadId=""
+                                  uploadPath="avatar"
                                 >
-                                  <BaseAvatar
-                                    className="css-1u6j7yz-StyledAvatar ev46mzr4"
-                                    gravatarId="foo@example.com"
-                                    hasTooltip={false}
-                                    letterId="foo@example.com"
-                                    round={true}
-                                    size={32}
-                                    style={Object {}}
-                                    title="Foo Bar"
-                                    tooltip="Foo Bar (foo@example.com)"
-                                    type="letter_avatar"
-                                    uploadId=""
-                                    uploadPath="avatar"
+                                  <Tooltip
+                                    containerDisplayMode="inline-block"
+                                    disabled={true}
+                                    position="top"
+                                    title="Foo Bar (foo@example.com)"
                                   >
-                                    <Tooltip
-                                      containerDisplayMode="inline-block"
-                                      disabled={true}
-                                      position="top"
-                                      title="Foo Bar (foo@example.com)"
+                                    <StyledBaseAvatar
+                                      className="avatar css-1u6j7yz-StyledAvatar ev46mzr4"
+                                      loaded={true}
+                                      round={true}
+                                      style={
+                                        Object {
+                                          "height": "32px",
+                                          "width": "32px",
+                                        }
+                                      }
                                     >
-                                      <StyledBaseAvatar
-                                        className="avatar css-1u6j7yz-StyledAvatar ev46mzr4"
-                                        loaded={true}
-                                        round={true}
+                                      <span
+                                        className="avatar ev46mzr4 css-wxw9er-StyledBaseAvatar-StyledAvatar e147uwb0"
                                         style={
                                           Object {
                                             "height": "32px",
@@ -773,62 +724,52 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                                           }
                                         }
                                       >
-                                        <span
-                                          className="avatar ev46mzr4 css-wxw9er-StyledBaseAvatar-StyledAvatar e147uwb0"
-                                          style={
-                                            Object {
-                                              "height": "32px",
-                                              "width": "32px",
-                                            }
-                                          }
+                                        <LetterAvatar
+                                          displayName="Foo Bar"
+                                          identifier="foo@example.com"
+                                          round={true}
                                         >
-                                          <LetterAvatar
+                                          <Component
+                                            className="css-vyy37i-LetterAvatar e12lgfev0"
                                             displayName="Foo Bar"
                                             identifier="foo@example.com"
                                             round={true}
                                           >
-                                            <Component
+                                            <svg
                                               className="css-vyy37i-LetterAvatar e12lgfev0"
-                                              displayName="Foo Bar"
-                                              identifier="foo@example.com"
-                                              round={true}
+                                              viewBox="0 0 120 120"
                                             >
-                                              <svg
-                                                className="css-vyy37i-LetterAvatar e12lgfev0"
-                                                viewBox="0 0 120 120"
-                                              >
-                                                <rect
-                                                  fill="#315cac"
-                                                  height="120"
-                                                  rx="15"
-                                                  ry="15"
-                                                  width="120"
-                                                  x="0"
-                                                  y="0"
-                                                />
-                                                <text
-                                                  fill="#FFFFFF"
-                                                  fontSize="65"
-                                                  style={
-                                                    Object {
-                                                      "dominantBaseline": "central",
-                                                    }
+                                              <rect
+                                                fill="#315cac"
+                                                height="120"
+                                                rx="15"
+                                                ry="15"
+                                                width="120"
+                                                x="0"
+                                                y="0"
+                                              />
+                                              <text
+                                                fill="#FFFFFF"
+                                                fontSize="65"
+                                                style={
+                                                  Object {
+                                                    "dominantBaseline": "central",
                                                   }
-                                                  textAnchor="middle"
-                                                  x="50%"
-                                                  y="50%"
-                                                >
-                                                  FB
-                                                </text>
-                                              </svg>
-                                            </Component>
-                                          </LetterAvatar>
-                                        </span>
-                                      </StyledBaseAvatar>
-                                    </Tooltip>
-                                  </BaseAvatar>
-                                </UserAvatar>
-                              </Avatar>
+                                                }
+                                                textAnchor="middle"
+                                                x="50%"
+                                                y="50%"
+                                              >
+                                                FB
+                                              </text>
+                                            </svg>
+                                          </Component>
+                                        </LetterAvatar>
+                                      </span>
+                                    </StyledBaseAvatar>
+                                  </Tooltip>
+                                </BaseAvatar>
+                              </UserAvatar>
                             </Component>
                           </StyledAvatar>
                           <StyledNameAndEmail>
@@ -3468,9 +3409,9 @@ exports[`Sidebar renders without org and router 1`] = `
                                 }
                               }
                             >
-                              <Avatar
+                              <UserAvatar
                                 className="css-1u6j7yz-StyledAvatar ev46mzr4"
-                                hasTooltip={false}
+                                gravatar={false}
                                 size={32}
                                 user={
                                   Object {
@@ -3490,53 +3431,39 @@ exports[`Sidebar renders without org and router 1`] = `
                                   }
                                 }
                               >
-                                <UserAvatar
+                                <BaseAvatar
                                   className="css-1u6j7yz-StyledAvatar ev46mzr4"
-                                  gravatar={false}
+                                  gravatarId="foo@example.com"
                                   hasTooltip={false}
+                                  letterId="foo@example.com"
+                                  round={true}
                                   size={32}
-                                  user={
-                                    Object {
-                                      "email": "foo@example.com",
-                                      "flags": Object {
-                                        "newsletter_consent_prompt": false,
-                                      },
-                                      "hasPasswordAuth": true,
-                                      "id": "1",
-                                      "isAuthenticated": true,
-                                      "name": "Foo Bar",
-                                      "options": Object {
-                                        "timezone": "UTC",
-                                      },
-                                      "permissions": Set {},
-                                      "username": "foo@example.com",
-                                    }
-                                  }
+                                  style={Object {}}
+                                  title="Foo Bar"
+                                  tooltip="Foo Bar (foo@example.com)"
+                                  type="letter_avatar"
+                                  uploadId=""
+                                  uploadPath="avatar"
                                 >
-                                  <BaseAvatar
-                                    className="css-1u6j7yz-StyledAvatar ev46mzr4"
-                                    gravatarId="foo@example.com"
-                                    hasTooltip={false}
-                                    letterId="foo@example.com"
-                                    round={true}
-                                    size={32}
-                                    style={Object {}}
-                                    title="Foo Bar"
-                                    tooltip="Foo Bar (foo@example.com)"
-                                    type="letter_avatar"
-                                    uploadId=""
-                                    uploadPath="avatar"
+                                  <Tooltip
+                                    containerDisplayMode="inline-block"
+                                    disabled={true}
+                                    position="top"
+                                    title="Foo Bar (foo@example.com)"
                                   >
-                                    <Tooltip
-                                      containerDisplayMode="inline-block"
-                                      disabled={true}
-                                      position="top"
-                                      title="Foo Bar (foo@example.com)"
+                                    <StyledBaseAvatar
+                                      className="avatar css-1u6j7yz-StyledAvatar ev46mzr4"
+                                      loaded={true}
+                                      round={true}
+                                      style={
+                                        Object {
+                                          "height": "32px",
+                                          "width": "32px",
+                                        }
+                                      }
                                     >
-                                      <StyledBaseAvatar
-                                        className="avatar css-1u6j7yz-StyledAvatar ev46mzr4"
-                                        loaded={true}
-                                        round={true}
+                                      <span
+                                        className="avatar ev46mzr4 css-wxw9er-StyledBaseAvatar-StyledAvatar e147uwb0"
                                         style={
                                           Object {
                                             "height": "32px",
@@ -3544,62 +3471,52 @@ exports[`Sidebar renders without org and router 1`] = `
                                           }
                                         }
                                       >
-                                        <span
-                                          className="avatar ev46mzr4 css-wxw9er-StyledBaseAvatar-StyledAvatar e147uwb0"
-                                          style={
-                                            Object {
-                                              "height": "32px",
-                                              "width": "32px",
-                                            }
-                                          }
+                                        <LetterAvatar
+                                          displayName="Foo Bar"
+                                          identifier="foo@example.com"
+                                          round={true}
                                         >
-                                          <LetterAvatar
+                                          <Component
+                                            className="css-vyy37i-LetterAvatar e12lgfev0"
                                             displayName="Foo Bar"
                                             identifier="foo@example.com"
                                             round={true}
                                           >
-                                            <Component
+                                            <svg
                                               className="css-vyy37i-LetterAvatar e12lgfev0"
-                                              displayName="Foo Bar"
-                                              identifier="foo@example.com"
-                                              round={true}
+                                              viewBox="0 0 120 120"
                                             >
-                                              <svg
-                                                className="css-vyy37i-LetterAvatar e12lgfev0"
-                                                viewBox="0 0 120 120"
-                                              >
-                                                <rect
-                                                  fill="#315cac"
-                                                  height="120"
-                                                  rx="15"
-                                                  ry="15"
-                                                  width="120"
-                                                  x="0"
-                                                  y="0"
-                                                />
-                                                <text
-                                                  fill="#FFFFFF"
-                                                  fontSize="65"
-                                                  style={
-                                                    Object {
-                                                      "dominantBaseline": "central",
-                                                    }
+                                              <rect
+                                                fill="#315cac"
+                                                height="120"
+                                                rx="15"
+                                                ry="15"
+                                                width="120"
+                                                x="0"
+                                                y="0"
+                                              />
+                                              <text
+                                                fill="#FFFFFF"
+                                                fontSize="65"
+                                                style={
+                                                  Object {
+                                                    "dominantBaseline": "central",
                                                   }
-                                                  textAnchor="middle"
-                                                  x="50%"
-                                                  y="50%"
-                                                >
-                                                  FB
-                                                </text>
-                                              </svg>
-                                            </Component>
-                                          </LetterAvatar>
-                                        </span>
-                                      </StyledBaseAvatar>
-                                    </Tooltip>
-                                  </BaseAvatar>
-                                </UserAvatar>
-                              </Avatar>
+                                                }
+                                                textAnchor="middle"
+                                                x="50%"
+                                                y="50%"
+                                              >
+                                                FB
+                                              </text>
+                                            </svg>
+                                          </Component>
+                                        </LetterAvatar>
+                                      </span>
+                                    </StyledBaseAvatar>
+                                  </Tooltip>
+                                </BaseAvatar>
+                              </UserAvatar>
                             </Component>
                           </StyledAvatar>
                           <StyledNameAndEmail>

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -2548,7 +2548,8 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                         }
                                         size={28}
                                       >
-                                        <Avatar
+                                        <UserAvatar
+                                          gravatar={false}
                                           hasTooltip={true}
                                           size={28}
                                           user={
@@ -2573,77 +2574,60 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                             }
                                           }
                                         >
-                                          <UserAvatar
-                                            gravatar={false}
+                                          <BaseAvatar
+                                            gravatarId="janebloggs@example.com"
                                             hasTooltip={true}
+                                            letterId="janebloggs@example.com"
+                                            round={true}
                                             size={28}
-                                            user={
-                                              Object {
-                                                "email": "janebloggs@example.com",
-                                                "flags": Object {
-                                                  "newsletter_consent_prompt": false,
-                                                },
-                                                "hasPasswordAuth": true,
-                                                "id": "1",
-                                                "isAuthenticated": true,
-                                                "name": "Jane Bloggs",
-                                                "options": Object {
-                                                  "timezone": "UTC",
-                                                },
-                                                "user": Object {
-                                                  "email": "janebloggs@example.com",
-                                                  "id": "1",
-                                                  "name": "Jane Bloggs",
-                                                },
-                                                "username": "foo@example.com",
-                                              }
-                                            }
+                                            style={Object {}}
+                                            title="Jane Bloggs"
+                                            tooltip="Jane Bloggs (janebloggs@example.com)"
+                                            type="letter_avatar"
+                                            uploadId=""
+                                            uploadPath="avatar"
                                           >
-                                            <BaseAvatar
-                                              gravatarId="janebloggs@example.com"
-                                              hasTooltip={true}
-                                              letterId="janebloggs@example.com"
-                                              round={true}
-                                              size={28}
-                                              style={Object {}}
-                                              title="Jane Bloggs"
-                                              tooltip="Jane Bloggs (janebloggs@example.com)"
-                                              type="letter_avatar"
-                                              uploadId=""
-                                              uploadPath="avatar"
+                                            <Tooltip
+                                              containerDisplayMode="inline-block"
+                                              disabled={false}
+                                              position="top"
+                                              title="Jane Bloggs (janebloggs@example.com)"
                                             >
-                                              <Tooltip
-                                                containerDisplayMode="inline-block"
-                                                disabled={false}
-                                                position="top"
-                                                title="Jane Bloggs (janebloggs@example.com)"
-                                              >
-                                                <Manager>
-                                                  <Reference>
-                                                    <InnerReference
-                                                      setReferenceNode={[Function]}
+                                              <Manager>
+                                                <Reference>
+                                                  <InnerReference
+                                                    setReferenceNode={[Function]}
+                                                  >
+                                                    <Container
+                                                      aria-describedby="tooltip-123456"
+                                                      containerDisplayMode="inline-block"
+                                                      innerRef={[Function]}
+                                                      onBlur={[Function]}
+                                                      onFocus={[Function]}
+                                                      onMouseEnter={[Function]}
+                                                      onMouseLeave={[Function]}
                                                     >
-                                                      <Container
+                                                      <span
                                                         aria-describedby="tooltip-123456"
-                                                        containerDisplayMode="inline-block"
-                                                        innerRef={[Function]}
+                                                        className="css-1vf31z4-Container eowlwvy0"
                                                         onBlur={[Function]}
                                                         onFocus={[Function]}
                                                         onMouseEnter={[Function]}
                                                         onMouseLeave={[Function]}
                                                       >
-                                                        <span
-                                                          aria-describedby="tooltip-123456"
-                                                          className="css-1vf31z4-Container eowlwvy0"
-                                                          onBlur={[Function]}
-                                                          onFocus={[Function]}
-                                                          onMouseEnter={[Function]}
-                                                          onMouseLeave={[Function]}
+                                                        <StyledBaseAvatar
+                                                          className="avatar"
+                                                          loaded={true}
+                                                          round={true}
+                                                          style={
+                                                            Object {
+                                                              "height": "28px",
+                                                              "width": "28px",
+                                                            }
+                                                          }
                                                         >
-                                                          <StyledBaseAvatar
-                                                            className="avatar"
-                                                            loaded={true}
-                                                            round={true}
+                                                          <span
+                                                            className="avatar css-3f9bmx-StyledBaseAvatar e147uwb0"
                                                             style={
                                                               Object {
                                                                 "height": "28px",
@@ -2651,67 +2635,57 @@ exports[`RuleBuilder renders with suggestions 1`] = `
                                                               }
                                                             }
                                                           >
-                                                            <span
-                                                              className="avatar css-3f9bmx-StyledBaseAvatar e147uwb0"
-                                                              style={
-                                                                Object {
-                                                                  "height": "28px",
-                                                                  "width": "28px",
-                                                                }
-                                                              }
+                                                            <LetterAvatar
+                                                              displayName="Jane Bloggs"
+                                                              identifier="janebloggs@example.com"
+                                                              round={true}
                                                             >
-                                                              <LetterAvatar
+                                                              <Component
+                                                                className="css-vyy37i-LetterAvatar e12lgfev0"
                                                                 displayName="Jane Bloggs"
                                                                 identifier="janebloggs@example.com"
                                                                 round={true}
                                                               >
-                                                                <Component
+                                                                <svg
                                                                   className="css-vyy37i-LetterAvatar e12lgfev0"
-                                                                  displayName="Jane Bloggs"
-                                                                  identifier="janebloggs@example.com"
-                                                                  round={true}
+                                                                  viewBox="0 0 120 120"
                                                                 >
-                                                                  <svg
-                                                                    className="css-vyy37i-LetterAvatar e12lgfev0"
-                                                                    viewBox="0 0 120 120"
-                                                                  >
-                                                                    <rect
-                                                                      fill="#4e3fb4"
-                                                                      height="120"
-                                                                      rx="15"
-                                                                      ry="15"
-                                                                      width="120"
-                                                                      x="0"
-                                                                      y="0"
-                                                                    />
-                                                                    <text
-                                                                      fill="#FFFFFF"
-                                                                      fontSize="65"
-                                                                      style={
-                                                                        Object {
-                                                                          "dominantBaseline": "central",
-                                                                        }
+                                                                  <rect
+                                                                    fill="#4e3fb4"
+                                                                    height="120"
+                                                                    rx="15"
+                                                                    ry="15"
+                                                                    width="120"
+                                                                    x="0"
+                                                                    y="0"
+                                                                  />
+                                                                  <text
+                                                                    fill="#FFFFFF"
+                                                                    fontSize="65"
+                                                                    style={
+                                                                      Object {
+                                                                        "dominantBaseline": "central",
                                                                       }
-                                                                      textAnchor="middle"
-                                                                      x="50%"
-                                                                      y="50%"
-                                                                    >
-                                                                      JB
-                                                                    </text>
-                                                                  </svg>
-                                                                </Component>
-                                                              </LetterAvatar>
-                                                            </span>
-                                                          </StyledBaseAvatar>
-                                                        </span>
-                                                      </Container>
-                                                    </InnerReference>
-                                                  </Reference>
-                                                </Manager>
-                                              </Tooltip>
-                                            </BaseAvatar>
-                                          </UserAvatar>
-                                        </Avatar>
+                                                                    }
+                                                                    textAnchor="middle"
+                                                                    x="50%"
+                                                                    y="50%"
+                                                                  >
+                                                                    JB
+                                                                  </text>
+                                                                </svg>
+                                                              </Component>
+                                                            </LetterAvatar>
+                                                          </span>
+                                                        </StyledBaseAvatar>
+                                                      </span>
+                                                    </Container>
+                                                  </InnerReference>
+                                                </Reference>
+                                              </Manager>
+                                            </Tooltip>
+                                          </BaseAvatar>
+                                        </UserAvatar>
                                       </ActorAvatar>
                                     </a>
                                   </ValueComponent>

--- a/tests/js/spec/views/releases/detail/__snapshots__/releaseCommits.spec.jsx.snap
+++ b/tests/js/spec/views/releases/detail/__snapshots__/releaseCommits.spec.jsx.snap
@@ -124,8 +124,8 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                           <div
                             className="css-wh8qge-AvatarWrapper eyce8w20"
                           >
-                            <Avatar
-                              hasTooltip={false}
+                            <UserAvatar
+                              gravatar={false}
                               size={36}
                               user={
                                 Object {
@@ -156,62 +156,38 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                                 }
                               }
                             >
-                              <UserAvatar
-                                gravatar={false}
+                              <BaseAvatar
+                                gravatarId="example@sentry.io"
                                 hasTooltip={false}
+                                letterId="example@sentry.io"
+                                round={true}
                                 size={36}
-                                user={
-                                  Object {
-                                    "avatar": Object {
-                                      "avatarType": "letter_avatar",
-                                      "avatarUuid": null,
-                                    },
-                                    "avatarUrl": "https://example.com/avatar.png",
-                                    "dateJoined": "2018-02-26T23:57:43.766Z",
-                                    "email": "example@sentry.io",
-                                    "emails": Array [
-                                      Object {
-                                        "email": "example@sentry.io",
-                                        "id": "231605",
-                                        "is_verified": true,
-                                      },
-                                    ],
-                                    "has2fa": false,
-                                    "hasPasswordAuth": true,
-                                    "id": "224288",
-                                    "isActive": true,
-                                    "isManaged": false,
-                                    "isSuperuser": true,
-                                    "lastActive": "2018-11-30T21:25:15.222Z",
-                                    "lastLogin": "2018-11-30T21:18:09.812Z",
-                                    "name": "Foo Bar",
-                                    "username": "example@sentry.io",
-                                  }
-                                }
+                                style={Object {}}
+                                title="Foo Bar"
+                                tooltip="Foo Bar (example@sentry.io)"
+                                type="letter_avatar"
+                                uploadId=""
+                                uploadPath="avatar"
                               >
-                                <BaseAvatar
-                                  gravatarId="example@sentry.io"
-                                  hasTooltip={false}
-                                  letterId="example@sentry.io"
-                                  round={true}
-                                  size={36}
-                                  style={Object {}}
-                                  title="Foo Bar"
-                                  tooltip="Foo Bar (example@sentry.io)"
-                                  type="letter_avatar"
-                                  uploadId=""
-                                  uploadPath="avatar"
+                                <Tooltip
+                                  containerDisplayMode="inline-block"
+                                  disabled={true}
+                                  position="top"
+                                  title="Foo Bar (example@sentry.io)"
                                 >
-                                  <Tooltip
-                                    containerDisplayMode="inline-block"
-                                    disabled={true}
-                                    position="top"
-                                    title="Foo Bar (example@sentry.io)"
+                                  <StyledBaseAvatar
+                                    className="avatar"
+                                    loaded={true}
+                                    round={true}
+                                    style={
+                                      Object {
+                                        "height": "36px",
+                                        "width": "36px",
+                                      }
+                                    }
                                   >
-                                    <StyledBaseAvatar
-                                      className="avatar"
-                                      loaded={true}
-                                      round={true}
+                                    <span
+                                      className="avatar css-3f9bmx-StyledBaseAvatar e147uwb0"
                                       style={
                                         Object {
                                           "height": "36px",
@@ -219,62 +195,52 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                                         }
                                       }
                                     >
-                                      <span
-                                        className="avatar css-3f9bmx-StyledBaseAvatar e147uwb0"
-                                        style={
-                                          Object {
-                                            "height": "36px",
-                                            "width": "36px",
-                                          }
-                                        }
+                                      <LetterAvatar
+                                        displayName="Foo Bar"
+                                        identifier="example@sentry.io"
+                                        round={true}
                                       >
-                                        <LetterAvatar
+                                        <Component
+                                          className="css-vyy37i-LetterAvatar e12lgfev0"
                                           displayName="Foo Bar"
                                           identifier="example@sentry.io"
                                           round={true}
                                         >
-                                          <Component
+                                          <svg
                                             className="css-vyy37i-LetterAvatar e12lgfev0"
-                                            displayName="Foo Bar"
-                                            identifier="example@sentry.io"
-                                            round={true}
+                                            viewBox="0 0 120 120"
                                           >
-                                            <svg
-                                              className="css-vyy37i-LetterAvatar e12lgfev0"
-                                              viewBox="0 0 120 120"
-                                            >
-                                              <rect
-                                                fill="#847a8c"
-                                                height="120"
-                                                rx="15"
-                                                ry="15"
-                                                width="120"
-                                                x="0"
-                                                y="0"
-                                              />
-                                              <text
-                                                fill="#FFFFFF"
-                                                fontSize="65"
-                                                style={
-                                                  Object {
-                                                    "dominantBaseline": "central",
-                                                  }
+                                            <rect
+                                              fill="#847a8c"
+                                              height="120"
+                                              rx="15"
+                                              ry="15"
+                                              width="120"
+                                              x="0"
+                                              y="0"
+                                            />
+                                            <text
+                                              fill="#FFFFFF"
+                                              fontSize="65"
+                                              style={
+                                                Object {
+                                                  "dominantBaseline": "central",
                                                 }
-                                                textAnchor="middle"
-                                                x="50%"
-                                                y="50%"
-                                              >
-                                                FB
-                                              </text>
-                                            </svg>
-                                          </Component>
-                                        </LetterAvatar>
-                                      </span>
-                                    </StyledBaseAvatar>
-                                  </Tooltip>
-                                </BaseAvatar>
-                              </UserAvatar>
-                            </Avatar>
+                                              }
+                                              textAnchor="middle"
+                                              x="50%"
+                                              y="50%"
+                                            >
+                                              FB
+                                            </text>
+                                          </svg>
+                                        </Component>
+                                      </LetterAvatar>
+                                    </span>
+                                  </StyledBaseAvatar>
+                                </Tooltip>
+                              </BaseAvatar>
+                            </UserAvatar>
                           </div>
                         </AvatarWrapper>
                         <CommitMessage>
@@ -481,8 +447,8 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                           <div
                             className="css-wh8qge-AvatarWrapper eyce8w20"
                           >
-                            <Avatar
-                              hasTooltip={false}
+                            <UserAvatar
+                              gravatar={false}
                               size={36}
                               user={
                                 Object {
@@ -513,62 +479,38 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                                 }
                               }
                             >
-                              <UserAvatar
-                                gravatar={false}
+                              <BaseAvatar
+                                gravatarId="example@sentry.io"
                                 hasTooltip={false}
+                                letterId="example@sentry.io"
+                                round={true}
                                 size={36}
-                                user={
-                                  Object {
-                                    "avatar": Object {
-                                      "avatarType": "letter_avatar",
-                                      "avatarUuid": null,
-                                    },
-                                    "avatarUrl": "https://example.com/avatar.png",
-                                    "dateJoined": "2018-02-26T23:57:43.766Z",
-                                    "email": "example@sentry.io",
-                                    "emails": Array [
-                                      Object {
-                                        "email": "example@sentry.io",
-                                        "id": "231605",
-                                        "is_verified": true,
-                                      },
-                                    ],
-                                    "has2fa": false,
-                                    "hasPasswordAuth": true,
-                                    "id": "224288",
-                                    "isActive": true,
-                                    "isManaged": false,
-                                    "isSuperuser": true,
-                                    "lastActive": "2018-11-30T21:25:15.222Z",
-                                    "lastLogin": "2018-11-30T21:18:09.812Z",
-                                    "name": "Foo Bar",
-                                    "username": "example@sentry.io",
-                                  }
-                                }
+                                style={Object {}}
+                                title="Foo Bar"
+                                tooltip="Foo Bar (example@sentry.io)"
+                                type="letter_avatar"
+                                uploadId=""
+                                uploadPath="avatar"
                               >
-                                <BaseAvatar
-                                  gravatarId="example@sentry.io"
-                                  hasTooltip={false}
-                                  letterId="example@sentry.io"
-                                  round={true}
-                                  size={36}
-                                  style={Object {}}
-                                  title="Foo Bar"
-                                  tooltip="Foo Bar (example@sentry.io)"
-                                  type="letter_avatar"
-                                  uploadId=""
-                                  uploadPath="avatar"
+                                <Tooltip
+                                  containerDisplayMode="inline-block"
+                                  disabled={true}
+                                  position="top"
+                                  title="Foo Bar (example@sentry.io)"
                                 >
-                                  <Tooltip
-                                    containerDisplayMode="inline-block"
-                                    disabled={true}
-                                    position="top"
-                                    title="Foo Bar (example@sentry.io)"
+                                  <StyledBaseAvatar
+                                    className="avatar"
+                                    loaded={true}
+                                    round={true}
+                                    style={
+                                      Object {
+                                        "height": "36px",
+                                        "width": "36px",
+                                      }
+                                    }
                                   >
-                                    <StyledBaseAvatar
-                                      className="avatar"
-                                      loaded={true}
-                                      round={true}
+                                    <span
+                                      className="avatar css-3f9bmx-StyledBaseAvatar e147uwb0"
                                       style={
                                         Object {
                                           "height": "36px",
@@ -576,62 +518,52 @@ Users now have access to useful links from the blogs and docs on Spike-protectio
                                         }
                                       }
                                     >
-                                      <span
-                                        className="avatar css-3f9bmx-StyledBaseAvatar e147uwb0"
-                                        style={
-                                          Object {
-                                            "height": "36px",
-                                            "width": "36px",
-                                          }
-                                        }
+                                      <LetterAvatar
+                                        displayName="Foo Bar"
+                                        identifier="example@sentry.io"
+                                        round={true}
                                       >
-                                        <LetterAvatar
+                                        <Component
+                                          className="css-vyy37i-LetterAvatar e12lgfev0"
                                           displayName="Foo Bar"
                                           identifier="example@sentry.io"
                                           round={true}
                                         >
-                                          <Component
+                                          <svg
                                             className="css-vyy37i-LetterAvatar e12lgfev0"
-                                            displayName="Foo Bar"
-                                            identifier="example@sentry.io"
-                                            round={true}
+                                            viewBox="0 0 120 120"
                                           >
-                                            <svg
-                                              className="css-vyy37i-LetterAvatar e12lgfev0"
-                                              viewBox="0 0 120 120"
-                                            >
-                                              <rect
-                                                fill="#847a8c"
-                                                height="120"
-                                                rx="15"
-                                                ry="15"
-                                                width="120"
-                                                x="0"
-                                                y="0"
-                                              />
-                                              <text
-                                                fill="#FFFFFF"
-                                                fontSize="65"
-                                                style={
-                                                  Object {
-                                                    "dominantBaseline": "central",
-                                                  }
+                                            <rect
+                                              fill="#847a8c"
+                                              height="120"
+                                              rx="15"
+                                              ry="15"
+                                              width="120"
+                                              x="0"
+                                              y="0"
+                                            />
+                                            <text
+                                              fill="#FFFFFF"
+                                              fontSize="65"
+                                              style={
+                                                Object {
+                                                  "dominantBaseline": "central",
                                                 }
-                                                textAnchor="middle"
-                                                x="50%"
-                                                y="50%"
-                                              >
-                                                FB
-                                              </text>
-                                            </svg>
-                                          </Component>
-                                        </LetterAvatar>
-                                      </span>
-                                    </StyledBaseAvatar>
-                                  </Tooltip>
-                                </BaseAvatar>
-                              </UserAvatar>
-                            </Avatar>
+                                              }
+                                              textAnchor="middle"
+                                              x="50%"
+                                              y="50%"
+                                            >
+                                              FB
+                                            </text>
+                                          </svg>
+                                        </Component>
+                                      </LetterAvatar>
+                                    </span>
+                                  </StyledBaseAvatar>
+                                </Tooltip>
+                              </BaseAvatar>
+                            </UserAvatar>
                           </div>
                         </AvatarWrapper>
                         <CommitMessage>

--- a/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
@@ -41,8 +41,8 @@ exports[`SettingsIndex renders 1`] = `
             to="/settings/account/"
           >
             <AvatarContainer>
-              <Avatar
-                hasTooltip={false}
+              <UserAvatar
+                gravatar={false}
                 size={76}
                 user={
                   Object {
@@ -106,8 +106,7 @@ exports[`SettingsIndex renders 1`] = `
             to="/settings/org-slug/"
           >
             <AvatarContainer>
-              <Avatar
-                hasTooltip={false}
+              <OrganizationAvatar
                 organization={
                   Object {
                     "access": Array [


### PR DESCRIPTION
The Avatar wrapper while convienent adds more components to the render tree and is hard to type because of how dynamic it is. Not using this component will allow us to remove it once it is no longer in use by getsentry as well.

Fix organization audit log layout. Grid-emotion is verboten so I switched to using CSS grid.