### PR TITLE
fix(discover) Fix errors on invalid search queries

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
+import six
+
 from rest_framework.response import Response
+from rest_framework.exceptions import ParseError
 
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
 from sentry.snuba import discover
@@ -15,11 +18,14 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
         except NoProjects:
             return Response({"count": 0})
 
-        result = discover.query(
-            selected_columns=["count()"],
-            params=params,
-            query=request.query_params.get("query"),
-            referrer="api.organization-events-meta",
-        )
+        try:
+            result = discover.query(
+                selected_columns=["count()"],
+                params=params,
+                query=request.query_params.get("query"),
+                referrer="api.organization-events-meta",
+            )
+        except discover.InvalidSearchQuery as err:
+            raise ParseError(detail=six.text_type(err))
 
         return Response({"count": result["data"][0]["count"]})

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -51,6 +51,18 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert response.data["count"] == 1
 
+    def test_invalid_query(self):
+        self.login_as(user=self.user)
+        project = self.create_project()
+
+        url = reverse(
+            "sentry-api-0-organization-events-meta",
+            kwargs={"organization_slug": project.organization.slug},
+        )
+        response = self.client.get(url, {"query": "is:unresolved"}, format="json")
+
+        assert response.status_code == 400, response.content
+
     def test_no_projects(self):
         org = self.create_organization(owner=self.user)
         self.login_as(user=self.user)


### PR DESCRIPTION
When we get an invalid filter query we should response with a 400 not a 500.

Fixes SENTRY-DTH