### PR TITLE
feat(discover) Switch trace and span id to use columns instead of context

### DIFF
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -212,15 +212,15 @@ class Columns(Enum):
     TRACE_ID = Column(
         "events.contexts[trace.trace_id]",
         "contexts[trace.trace_id]",
-        "contexts[trace.trace_id]",
-        "contexts[trace.trace_id]",
+        "trace_id",
+        "trace_id",
         "trace",
     )
     SPAN_ID = Column(
         "events.contexts[trace.span_id]",
         "contexts[trace.span_id]",
-        "contexts[trace.span_id]",
-        "contexts[trace.span_id]",
+        "span_id",
+        "span_id",
         "trace.span",
     )
     PARENT_SPAN_ID = Column(

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -4,6 +4,7 @@ import datetime
 import pytest
 import six
 import unittest
+import uuid
 from datetime import timedelta
 from semaphore.consts import SPAN_STATUS_CODE_TO_NAME
 
@@ -1078,6 +1079,10 @@ class GetSnubaQueryArgsTest(TestCase):
             get_filter("transaction.status:lol")
         assert "Invalid value" in six.text_type(err)
         assert "cancelled," in six.text_type(err)
+
+    def test_trace_id(self):
+        result = get_filter("trace:{}".format("a0fa8803753e40fd8124b21eeb2986b5"))
+        assert result.conditions == [["trace", "=", uuid.UUID("a0fa8803753e40fd8124b21eeb2986b5")]]
 
 
 class ResolveFieldListTest(unittest.TestCase):

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -592,3 +592,25 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert response.data["meta"]["transaction.duration"] == "duration"
         assert response.data["meta"]["transaction.status"] == "string"
         assert response.data["data"][0]["transaction.status"] == "ok"
+
+    def test_trace_columns(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        data = load_data("transaction")
+        data["timestamp"] = iso_format(before_now(minutes=1))
+        data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
+        self.store_event(data=data, project_id=project.id)
+
+        with self.feature("organizations:events-v2"):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={"field": ["trace", "trace.span"], "query": "event.type:transaction"},
+            )
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["meta"]["trace"] == "string"
+        assert response.data["meta"]["trace.span"] == "integer"
+        assert response.data["data"][0]["trace"] == data["contexts"]["trace"]["trace_id"]
+        assert response.data["data"][0]["trace.span"] == data["contexts"]["trace"]["span_id"]

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1376,7 +1376,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             elif key in IssueSearchVisitor.date_keys:
                 val = "2019-01-01"
             else:
-                val = "hello"
+                val = "abadcafe-dead-beef-fade-adabdeaffeed"
                 test_query("!%s:%s" % (key, val))
 
             test_query("%s:%s" % (key, val))


### PR DESCRIPTION


Have the trace_id and span_id use the built in columns instead of the context
array.

## TODO

- [ ] add test to `tests/snuba/api/endpoints/test_organization_events_v2.py`