### PR TITLE
build(webpack): Change "LastBuiltPlugin" to ignore watch mode

### DIFF
--- a/build-utils/last-built-plugin.js
+++ b/build-utils/last-built-plugin.js
@@ -6,10 +6,24 @@ const fs = require('fs');
 class LastBuiltPlugin {
   constructor({basePath}) {
     this.basePath = basePath;
+    this.isWatchMode = false;
   }
 
   apply(compiler) {
-    compiler.hooks.done.tapAsync('LastBuiltPlugin', (_compilation, callback) => {
+    compiler.hooks.watchRun.tapAsync('LastBuiltPlugin', (_, callback) => {
+      this.isWatchMode = true;
+      callback();
+    });
+
+    compiler.hooks.done.tapAsync('LastBuiltPlugin', (_, callback) => {
+      // If this is in watch mode, then assets will *NOT* be written to disk
+      // We only want to record when we write to disk since this plugin is for
+      // our acceptance test (which require assets to be on fs)
+      if (this.isWatchMode) {
+        callback();
+        return;
+      }
+
       fs.writeFile(
         path.join(this.basePath, '.webpack.meta'),
         JSON.stringify({


### PR DESCRIPTION
We should not write to the webpack meta file in watch mode since we will not have assets saved to the fs while in watch mode.