### PR TITLE
feat(plugins): adds the configuration for dependent issue fields for IssuePlugin2 plugins

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectField.jsx
@@ -111,6 +111,7 @@ export default class SelectField extends FormField {
       disabled,
       required,
       name,
+      isLoading,
     } = this.props;
 
     return (
@@ -127,6 +128,7 @@ export default class SelectField extends FormField {
         clearable={clearable}
         multiple={this.isMultiple()}
         name={name}
+        isLoading={isLoading}
       />
     );
   }

--- a/src/sentry/static/sentry/app/plugins/components/issueActions.jsx
+++ b/src/sentry/static/sentry/app/plugins/components/issueActions.jsx
@@ -104,7 +104,7 @@ class IssueActions extends PluginComponentBase {
       field.depends.map(fieldKey => [fieldKey, formData[fieldKey]])
     );
     const query = {
-      field: field.name,
+      option_field: field.name,
       ...dependentFormValues,
     };
     try {

--- a/src/sentry/static/sentry/app/plugins/components/issueActions.jsx
+++ b/src/sentry/static/sentry/app/plugins/components/issueActions.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import fromPairs from 'lodash/fromPairs';
 
 import {Form, FormState} from 'app/components/forms';
 import GroupActions from 'app/actions/groupActions';
@@ -45,13 +44,21 @@ class IssueActions extends PluginComponentBase {
     return this.props.organization;
   }
 
+  getFieldListKey() {
+    return this.props.actionType + 'FieldList';
+  }
+
+  getFormDataKey() {
+    return this.props.actionType + 'FormData';
+  }
+
   getFormData() {
-    const key = this.props.actionType + 'FormData';
+    const key = this.getFormDataKey();
     return this.state[key] || {};
   }
 
   getFieldList() {
-    const key = this.props.actionType + 'FieldList';
+    const key = this.getFormListKey();
     return this.state[key] || [];
   }
 
@@ -81,27 +88,24 @@ class IssueActions extends PluginComponentBase {
   }
 
   setDependentFieldState(fieldName, state) {
-    const dependentFieldState = {...this.state.dependentFieldState};
-    dependentFieldState[fieldName] = state;
+    const dependentFieldState = {...this.state.dependentFieldState, [fieldName]: state};
     this.setState({dependentFieldState});
   }
 
   loadOptionsForDependentField = async field => {
     const formData = this.getFormData();
 
-    const url =
-      '/issues/' +
-      this.getGroup().id +
-      '/plugins/' +
-      this.props.plugin.slug +
-      '/options/';
+    const groupId = this.group().id;
+    const pluginSlug = this.props.plugin.slug;
+    const url = `/issues/${groupId}/plugins/${pluginSlug}/options/`;
 
     //find the fields that this field is dependent on
-    const dependentFields =
-      fromPairs(field.depends.map(fieldKey => [fieldKey, formData[fieldKey]])) || {};
+    const dependentFormValues = Object.fromEntries(
+      field.depends.map(fieldKey => [fieldKey, formData[fieldKey]])
+    );
     const query = {
       field: field.name,
-      ...dependentFields,
+      ...dependentFormValues,
     };
     try {
       this.setDependentFieldState(field.name, FormState.LOADING);
@@ -115,7 +119,7 @@ class IssueActions extends PluginComponentBase {
   };
 
   updateOptionsOfDependentField = (field, choices) => {
-    const formListKey = this.props.actionType + 'FieldList';
+    const formListKey = this.getFormListKey();
     let fieldList = this.state[formListKey];
 
     //find the location of the field in our list and replace it
@@ -131,7 +135,7 @@ class IssueActions extends PluginComponentBase {
 
   resetOptionsOfDependentField = field => {
     this.updateOptionsOfDependentField(field, []);
-    const formDataKey = this.props.actionType + 'FormData';
+    const formDataKey = this.getFormDataKey();
     const formData = {...this.state[formDataKey]};
     formData[field.name] = '';
     this.setState({[formDataKey]: formData});
@@ -185,7 +189,7 @@ class IssueActions extends PluginComponentBase {
   onLoadSuccess(...args) {
     super.onLoadSuccess(...args);
 
-    //dependent fields need to be set to disabled upl loading
+    //dependent fields need to be set to disabled upon loading
     const fieldList = this.getFieldList();
     fieldList.forEach(field => {
       if (field.depends && field.depends.length > 0) {

--- a/src/sentry/static/sentry/app/plugins/components/issueActions.jsx
+++ b/src/sentry/static/sentry/app/plugins/components/issueActions.jsx
@@ -58,7 +58,7 @@ class IssueActions extends PluginComponentBase {
   }
 
   getFieldList() {
-    const key = this.getFormListKey();
+    const key = this.getFieldListKey();
     return this.state[key] || [];
   }
 
@@ -95,7 +95,7 @@ class IssueActions extends PluginComponentBase {
   loadOptionsForDependentField = async field => {
     const formData = this.getFormData();
 
-    const groupId = this.group().id;
+    const groupId = this.getGroup().id;
     const pluginSlug = this.props.plugin.slug;
     const url = `/issues/${groupId}/plugins/${pluginSlug}/options/`;
 
@@ -119,7 +119,7 @@ class IssueActions extends PluginComponentBase {
   };
 
   updateOptionsOfDependentField = (field, choices) => {
-    const formListKey = this.getFormListKey();
+    const formListKey = this.getFieldListKey();
     let fieldList = this.state[formListKey];
 
     //find the location of the field in our list and replace it

--- a/src/sentry/static/sentry/app/plugins/components/issueActions.jsx
+++ b/src/sentry/static/sentry/app/plugins/components/issueActions.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import fromPairs from 'lodash/fromPairs';
 
 import {Form, FormState} from 'app/components/forms';
 import GroupActions from 'app/actions/groupActions';
@@ -28,6 +29,7 @@ class IssueActions extends PluginComponentBase {
       error: null,
       createFormData: {},
       linkFormData: {},
+      dependentFieldState: {},
     });
   }
 
@@ -41,6 +43,16 @@ class IssueActions extends PluginComponentBase {
 
   getOrganization() {
     return this.props.organization;
+  }
+
+  getFormData() {
+    const key = this.props.actionType + 'FormData';
+    return this.state[key] || {};
+  }
+
+  getFieldList() {
+    const key = this.props.actionType + 'FieldList';
+    return this.state[key] || [];
   }
 
   componentDidMount() {
@@ -68,6 +80,86 @@ class IssueActions extends PluginComponentBase {
     );
   }
 
+  setDependentFieldState(fieldName, state) {
+    const dependentFieldState = {...this.state.dependentFieldState};
+    dependentFieldState[fieldName] = state;
+    this.setState({dependentFieldState});
+  }
+
+  loadOptionsForDependentField = async field => {
+    const formData = this.getFormData();
+
+    const url =
+      '/issues/' +
+      this.getGroup().id +
+      '/plugins/' +
+      this.props.plugin.slug +
+      '/options/';
+
+    //find the fields that this field is dependent on
+    const dependentFields =
+      fromPairs(field.depends.map(fieldKey => [fieldKey, formData[fieldKey]])) || {};
+    const query = {
+      field: field.name,
+      ...dependentFields,
+    };
+    try {
+      this.setDependentFieldState(field.name, FormState.LOADING);
+      const result = await this.api.requestPromise(url, {query});
+      this.updateOptionsOfDependentField(field, result[field.name]);
+      this.setDependentFieldState(field.name, FormState.READY);
+    } catch (err) {
+      this.setDependentFieldState(field.name, FormState.ERROR);
+      this.errorHandler(err);
+    }
+  };
+
+  updateOptionsOfDependentField = (field, choices) => {
+    const formListKey = this.props.actionType + 'FieldList';
+    let fieldList = this.state[formListKey];
+
+    //find the location of the field in our list and replace it
+    const indexOfField = fieldList.findIndex(({name}) => name === field.name);
+    field = {...field, choices};
+
+    //make a copy of the array to avoid mutation
+    fieldList = fieldList.slice();
+    fieldList[indexOfField] = field;
+
+    this.setState({[formListKey]: fieldList});
+  };
+
+  resetOptionsOfDependentField = field => {
+    this.updateOptionsOfDependentField(field, []);
+    const formDataKey = this.props.actionType + 'FormData';
+    const formData = {...this.state[formDataKey]};
+    formData[field.name] = '';
+    this.setState({[formDataKey]: formData});
+    this.setDependentFieldState(field.name, FormState.DISABLED);
+  };
+
+  getInputProps(field) {
+    const props = {};
+
+    //special logic for fields that have dependencies
+    if (field.depends && field.depends.length > 0) {
+      switch (this.state.dependentFieldState[field.name]) {
+        case FormState.LOADING:
+          props.isLoading = true;
+          props.readonly = true;
+          break;
+        case FormState.DISABLED:
+        case FormState.ERROR:
+          props.readonly = true;
+          break;
+        default:
+          break;
+      }
+    }
+
+    return props;
+  }
+
   setError(error, defaultMessage) {
     let errorBody;
     if (error.status === 400 && error.responseJSON) {
@@ -88,6 +180,18 @@ class IssueActions extends PluginComponentBase {
       state.error = {message: t('An unknown error occurred.')};
     }
     this.setState(state);
+  }
+
+  onLoadSuccess(...args) {
+    super.onLoadSuccess(...args);
+
+    //dependent fields need to be set to disabled upl loading
+    const fieldList = this.getFieldList();
+    fieldList.forEach(field => {
+      if (field.depends && field.depends.length > 0) {
+        this.setDependentFieldState(field.name, FormState.DISABLED);
+      }
+    });
   }
 
   fetchData() {
@@ -170,12 +274,36 @@ class IssueActions extends PluginComponentBase {
   }
 
   changeField(action, name, value) {
-    const key = action + 'FormData';
-    const formData = this.state[key];
+    const formDataKey = action + 'FormData';
+
+    //copy so we don't mutate
+    const formData = {...this.state[formDataKey]};
+    const fieldList = this.getFieldList();
+
     formData[name] = value;
-    const state = {};
-    state[key] = formData;
-    this.setState(state);
+
+    let callback = () => {};
+
+    //only works with one impacted field
+    const impactedField = fieldList.find(({depends}) => {
+      if (!depends || !depends.length) {
+        return false;
+      }
+      // must be dependent on the field we just set
+      return depends.includes(name);
+    });
+
+    if (impactedField) {
+      //if every dependent field is set, then search
+      if (!impactedField.depends.some(dependentField => !formData[dependentField])) {
+        callback = () => this.loadOptionsForDependentField(impactedField);
+      } else {
+        //otherwise reset the options
+        callback = () => this.resetOptionsOfDependentField(impactedField);
+      }
+    }
+
+    this.setState({[formDataKey]: formData}, callback);
   }
 
   renderForm() {
@@ -206,7 +334,7 @@ class IssueActions extends PluginComponentBase {
                 return (
                   <div key={field.name}>
                     {this.renderField({
-                      config: field,
+                      config: {...field, ...this.getInputProps(field)},
                       formData: this.state.createFormData,
                       onChange: this.changeField.bind(this, 'create', field.name),
                     })}
@@ -238,7 +366,7 @@ class IssueActions extends PluginComponentBase {
                 return (
                   <div key={field.name}>
                     {this.renderField({
-                      config: field,
+                      config: {...field, ...this.getInputProps(field)},
                       formData: this.state.linkFormData,
                       onChange: this.changeField.bind(this, 'link', field.name),
                     })}


### PR DESCRIPTION
I am re-writing the Trello plugin to inherit from `IssuePlugin2` class. There are two problems with how Trello works that require additional functionality for issue plugins:
1. The options for `list` (aka the column on a Trello board), are dependent on the choice for `board`.
2. There is no way to search for matching `lists` from a search query (meaning we can't use autocomplete)

I have solved the above issues by introducing the `depends` field which is configured on the backend like such:
```
            {
                "name": "list",
                "depends": ["board"],
                "label": "List",
                "type": "select",
                "has_autocomplete": False,
                "required": True,
            }
```
With the above config, we will load the options for `list` when the user selects the option for `board`.

I have also added some logic to disable and add a spinner for the input that is dependent on another. See below:

![Trello](https://user-images.githubusercontent.com/8533851/70949358-76a13d00-2012-11ea-9b4f-66d4b97a7c38.gif)


The field will be disabled until we successfully load the options for the dependent fields (in this case `board`).

Please note that I could not find any unit tests for this file so I have omitted them. If you believe it's worth creating a spec file to test, I will do so.

Tested on stage.