### PR TITLE
ref: Define accessible attributes of SnubaEvent

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -528,6 +528,10 @@ class SnubaEvent(EventCommon):
     def group_id(self):
         return self.snuba_data["group_id"]
 
+    @group_id.setter
+    def group_id(self, value):
+        self.snuba_data["group_id"] = value
+
     def save(self):
         raise NotImplementedError
 

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import logging
 import six
 import string
 import pytz

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -524,6 +524,10 @@ class SnubaEvent(EventCommon):
     def project_id(self):
         return self.snuba_data["project_id"]
 
+    @project_id.setter
+    def project_id(self, value):
+        self.snuba_data["project_id"] = value
+
     @property
     def group_id(self):
         return self.snuba_data["group_id"]

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -31,8 +31,6 @@ from sentry.utils.canonical import CanonicalKeyDict, CanonicalKeyView
 from sentry.utils.safe import get_path
 from sentry.utils.strings import truncatechars
 
-logger = logging.getLogger(__name__)
-
 
 class EventDict(CanonicalKeyDict):
     """
@@ -412,26 +410,6 @@ class SnubaEvent(EventCommon):
         )
         self.data = NodeData(node_id, data=None, wrapper=EventDict)
 
-    def __getattr__(self, name):
-        """
-        Depending on what snuba data this event was initialized with, we may
-        have the data available to return, or we may have to look in the
-        `data` dict (which would force a nodestore load). All unresolved
-        self.foo type accesses will come through here.
-        """
-        if name in ("_project_cache", "_group_cache", "_environment_cache"):
-            raise AttributeError()
-
-        allowed_attributes = ["timestamp", "event_id", "group_id", "project_id"]
-
-        if name not in allowed_attributes:
-            logger.warn("event.invalid-attribute", extra={"attribute_name": name})
-
-        if name in self.snuba_data:
-            return self.snuba_data[name]
-        else:
-            return self.data[name]
-
     # ============================================
     # Snuba-only implementations of properties that
     # would otherwise require nodestore data.
@@ -534,6 +512,22 @@ class SnubaEvent(EventCommon):
         # the hex event_id here. We should be moving to a world where we never
         # have to reference the row id anyway.
         return self.event_id
+
+    @property
+    def timestamp(self):
+        return self.snuba_data["timestamp"]
+
+    @property
+    def event_id(self):
+        return self.snuba_data["event_id"]
+
+    @property
+    def project_id(self):
+        return self.snuba_data["project_id"]
+
+    @property
+    def group_id(self):
+        return self.snuba_data["group_id"]
 
     def save(self):
         raise NotImplementedError

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -308,7 +308,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
             GroupRelease.objects.filter(group_id=source.id).values_list(
                 "environment", "first_seen", "last_seen"
             )
-        ) == set([(u"production", time_from_now(10), time_from_now(15))])
+        ) == set([(u"production", time_from_now(0), time_from_now(16))])
 
         assert set(
             [

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -308,7 +308,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
             GroupRelease.objects.filter(group_id=source.id).values_list(
                 "environment", "first_seen", "last_seen"
             )
-        ) == set([(u"production", time_from_now(0), time_from_now(16))])
+        ) == set([(u"production", time_from_now(10), time_from_now(15))])
 
         assert set(
             [


### PR DESCRIPTION
Do not allow random attribute access for SnubaEvent. Removes the
assumption that attribute name is the same as the Snuba column name
and nodestore key.