### PR TITLE
fix(ui): Fix Issue Alert Rules not setting default action

### DIFF
--- a/src/sentry/static/sentry/app/types/alerts.tsx
+++ b/src/sentry/static/sentry/app/types/alerts.tsx
@@ -44,16 +44,18 @@ export type IssueAlertRuleCondition = Omit<
   [key: string]: number | string;
 };
 
-// Issue-based alert rule
-export type IssueAlertRule = {
+export type UnsavedIssueAlertRule = {
   actionMatch: 'all' | 'any';
   actions: IssueAlertRuleAction[];
   conditions: IssueAlertRuleCondition[];
-  dateCreated: string;
   environment: null | string;
   frequency: number;
-  id: string;
   name: string;
+};
+// Issue-based alert rule
+export type IssueAlertRule = UnsavedIssueAlertRule & {
+  dateCreated: string;
+  id: string;
 };
 
 /**

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -11,6 +11,7 @@ import {
   IssueAlertRule,
   IssueAlertRuleActionTemplate,
   IssueAlertRuleConditionTemplate,
+  UnsavedIssueAlertRule,
 } from 'app/types/alerts';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {
@@ -48,6 +49,15 @@ const FREQUENCY_CHOICES = [
 
 const ACTION_MATCH_CHOICES = [['all', t('all')], ['any', t('any')], ['none', t('none')]];
 
+const defaultRule: UnsavedIssueAlertRule = {
+  actionMatch: 'all',
+  actions: [],
+  conditions: [],
+  name: '',
+  frequency: 30,
+  environment: ALL_ENVIRONMENTS_KEY,
+};
+
 // TODO(ts): I can't get this to work if I'm specific -- should be: 'condition' | 'action';
 type ConditionOrAction = string;
 
@@ -60,7 +70,7 @@ type Props = {
 } & RouteComponentProps<{orgId: string; projectId: string; ruleId: string}, {}>;
 
 type State = {
-  rule: IssueAlertRule | null;
+  rule: UnsavedIssueAlertRule | IssueAlertRule;
   loading: boolean;
   error: null | {
     [key: string]: string[];
@@ -68,9 +78,15 @@ type State = {
   environments: Environment[];
 };
 
+function isSavedAlertRule(
+  rule: UnsavedIssueAlertRule | IssueAlertRule
+): rule is IssueAlertRule {
+  return rule.hasOwnProperty('id');
+}
+
 class IssueRuleEditor extends React.Component<Props, State> {
   state: State = {
-    rule: null,
+    rule: {...defaultRule},
     loading: false,
     error: null,
     environments: [],
@@ -85,15 +101,6 @@ class IssueRuleEditor extends React.Component<Props, State> {
       api,
       params: {ruleId, projectId, orgId},
     } = this.props;
-
-    const defaultRule = {
-      actionMatch: 'all',
-      actions: [],
-      conditions: [],
-      name: '',
-      frequency: 30,
-      environment: ALL_ENVIRONMENTS_KEY,
-    };
 
     const promises = [
       api.requestPromise(`/projects/${orgId}/${projectId}/environments/`),
@@ -112,11 +119,11 @@ class IssueRuleEditor extends React.Component<Props, State> {
 
   handleSubmit = async () => {
     const {rule} = this.state;
-    const isNew = !rule || !rule.id;
+    const isNew = !isSavedAlertRule(rule);
     const {project, organization} = this.props;
 
     const endpoint = `/projects/${organization.slug}/${project.slug}/rules/${
-      rule && rule.id ? `${rule.id}/` : ''
+      isSavedAlertRule(rule) ? `${rule.id}/` : ''
     }`;
 
     if (rule && rule.environment === ALL_ENVIRONMENTS_KEY) {
@@ -160,7 +167,7 @@ class IssueRuleEditor extends React.Component<Props, State> {
     return error.hasOwnProperty(field);
   };
 
-  handleEnvironmentChange = val => {
+  handleEnvironmentChange = (val: string) => {
     // If 'All Environments' is selected the value should be null
     if (val === ALL_ENVIRONMENTS_KEY) {
       this.handleChange('environment', null);
@@ -246,7 +253,7 @@ class IssueRuleEditor extends React.Component<Props, State> {
       <React.Fragment>
         <SentryDocumentTitle title={title} objSlug={projectId} />
         <StyledForm
-          key={rule ? rule.id : undefined}
+          key={isSavedAlertRule(rule) ? rule.id : undefined}
           onCancel={this.handleCancel}
           onSubmit={this.handleSubmit}
           initialData={rule as object}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -123,7 +123,7 @@ class IssueRuleEditor extends React.Component<Props, State> {
     const {project, organization} = this.props;
 
     const endpoint = `/projects/${organization.slug}/${project.slug}/rules/${
-      isSavedAlertRule(rule) ? `${rule.id}/` : ''
+      !isNew ? `${rule.id}/` : ''
     }`;
 
     if (rule && rule.environment === ALL_ENVIRONMENTS_KEY) {

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -119,12 +119,11 @@ class IssueRuleEditor extends React.Component<Props, State> {
 
   handleSubmit = async () => {
     const {rule} = this.state;
-    const isNew = !isSavedAlertRule(rule);
+    const ruleId = isSavedAlertRule(rule) ? `${rule.id}/` : '';
+    const isNew = !ruleId;
     const {project, organization} = this.props;
 
-    const endpoint = `/projects/${organization.slug}/${project.slug}/rules/${
-      !isNew ? `${rule.id}/` : ''
-    }`;
+    const endpoint = `/projects/${organization.slug}/${project.slug}/rules/${ruleId}`;
 
     if (rule && rule.environment === ALL_ENVIRONMENTS_KEY) {
       delete rule.environment;


### PR DESCRIPTION
Initially `this.state.rule` is null which caused the form id to be `undefined` and when we fetch rule details (and it resolved to default rule), the default rule did not have an `id` property, so the form component key remained at `undefined` and did not update.

Change to set `this.state.rule` to initially be the default rule.