### PR TITLE
fix(ui): Frame to image pairing by address

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -15,7 +15,11 @@ import {Panel, PanelBody, PanelItem} from 'app/components/panels';
 import Tooltip from 'app/components/tooltip';
 import DebugMetaStore, {DebugMetaActions} from 'app/stores/debugMetaStore';
 import SearchInput from 'app/components/forms/searchInput';
-import {formatAddress, parseAddress} from 'app/components/events/interfaces/utils';
+import {
+  formatAddress,
+  parseAddress,
+  getImageRange,
+} from 'app/components/events/interfaces/utils';
 import ImageForBar from 'app/components/events/interfaces/imageForBar';
 import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
@@ -23,19 +27,6 @@ import space from 'app/styles/space';
 
 const IMAGE_ADDR_LEN = 12;
 const MIN_FILTER_LEN = 3;
-
-function getImageRange(image) {
-  // The start address is normalized to a `0x` prefixed hex string. The event
-  // schema also allows ingesting plain numbers, but this is converted during
-  // ingestion.
-  const startAddress = parseAddress(image.image_addr);
-
-  // The image size is normalized to a regular number. However, it can also be
-  // `null`, in which case we assume that it counts up to the next image.
-  const endAddress = startAddress + (image.image_size || 0);
-
-  return [startAddress, endAddress];
-}
 
 function getFileName(path) {
   const directorySeparator = /^([a-z]:\\|\\\\)/i.test(path) ? '\\' : '/';

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugmeta.jsx
@@ -71,7 +71,7 @@ function getImageStatusDetails(status) {
     case 'unused':
       return t('The image was not required for processing the stack trace.');
     case 'missing':
-      return t('No debug information could not be in any of the specified sources.');
+      return t('No debug information could be found in any of the specified sources.');
     case 'malformed':
       return t('The debug information file for this image failed to process.');
     case 'timeout':

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -167,15 +167,23 @@ export class Frame extends React.Component {
     return this.props.data.symbolicatorStatus !== SymbolicatorStatus.UNKNOWN_IMAGE;
   }
 
-  packageStatusIsError() {
+  packageStatus() {
+    // this is the status of image that belongs to this frame
     const {image} = this.props;
     if (!image) {
-      return true;
+      return 'empty';
     }
 
-    const imageStatus = combineStatus(image.debug_status, image.unwind_status);
+    const combinedStatus = combineStatus(image.debug_status, image.unwind_status);
 
-    return imageStatus !== 'found';
+    switch (combinedStatus) {
+      case 'unused':
+        return 'empty';
+      case 'found':
+        return 'success';
+      default:
+        return 'error';
+    }
   }
 
   scrollToImage = event => {
@@ -512,7 +520,7 @@ export class Frame extends React.Component {
               onClick={this.scrollToImage}
               isClickable={this.shouldShowLinkToImage()}
             >
-              <PackageStatus isError={this.packageStatusIsError()} />
+              <PackageStatus status={this.packageStatus()} />
             </PackageLink>
             <TogglableAddress
               address={data.instructionAddr}

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -164,7 +164,9 @@ export class Frame extends React.Component {
   }
 
   shouldShowLinkToImage() {
-    return this.props.data.symbolicatorStatus !== SymbolicatorStatus.UNKNOWN_IMAGE;
+    const {symbolicatorStatus} = this.props.data;
+
+    return symbolicatorStatus && symbolicatorStatus !== SymbolicatorStatus.UNKNOWN_IMAGE;
   }
 
   packageStatus() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/packageStatus.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/packageStatus.tsx
@@ -6,16 +6,33 @@ import Tooltip from 'app/components/tooltip';
 import space from 'app/styles/space';
 
 type Props = {
-  isError: boolean;
+  status: 'error' | 'success' | 'empty';
   tooltip?: string;
 };
 
 class PackageStatus extends React.Component<Props> {
-  render() {
-    const {isError, tooltip} = this.props;
+  getIconTypeAndSource(
+    status: Props['status']
+  ): {iconType: PackageStatusIconProps['type']; iconSrc: string} {
+    switch (status) {
+      case 'success':
+        return {iconType: 'success', iconSrc: 'icon-circle-check'};
+      case 'empty':
+        return {iconType: 'muted', iconSrc: 'icon-circle-empty'};
+      case 'error':
+      default:
+        return {iconType: 'error', iconSrc: 'icon-circle-exclamation'};
+    }
+  }
 
-    const iconType = isError ? 'error' : 'success';
-    const iconSrc = isError ? 'icon-circle-exclamation' : 'icon-circle-check';
+  render() {
+    const {status, tooltip} = this.props;
+
+    const {iconType, iconSrc} = this.getIconTypeAndSource(status);
+
+    if (status === 'empty') {
+      return null;
+    }
 
     return (
       <Tooltip title={tooltip} disabled={!(tooltip && tooltip.length)}>
@@ -26,7 +43,7 @@ class PackageStatus extends React.Component<Props> {
 }
 
 type PackageStatusIconProps = {
-  type: 'error' | 'success';
+  type: 'error' | 'success' | 'muted';
 };
 export const PackageStatusIcon = styled(InlineSvg)<PackageStatusIconProps>`
   color: ${p => p.theme.alert[p.type!].iconColor};

--- a/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/utils.jsx
@@ -2,6 +2,7 @@ import isEmpty from 'lodash/isEmpty';
 import isString from 'lodash/isString';
 import * as Sentry from '@sentry/browser';
 import queryString from 'query-string';
+import get from 'lodash/get';
 
 import {FILTER_MASK} from 'app/constants';
 import {defined} from 'app/utils';
@@ -147,4 +148,17 @@ export function parseAddress(address) {
   } catch (_e) {
     return 0;
   }
+}
+
+export function getImageRange(image) {
+  // The start address is normalized to a `0x` prefixed hex string. The event
+  // schema also allows ingesting plain numbers, but this is converted during
+  // ingestion.
+  const startAddress = parseAddress(get(image, 'image_addr'));
+
+  // The image size is normalized to a regular number. However, it can also be
+  // `null`, in which case we assume that it counts up to the next image.
+  const endAddress = startAddress + (get(image, 'image_size') || 0);
+
+  return [startAddress, endAddress];
 }


### PR DESCRIPTION
This PR changes the way we look up the frame's image.
Using the in range address instead of path.