### PR TITLE
ref(ts): Fix Organization-related types

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -21,39 +21,73 @@ export type Actor = {
   name: string;
 };
 
-export type LightWeightOrganization = {
-  id: string;
-  slug: string;
-  name: string;
-  access: string[];
-  features: string[];
+/**
+ * Organization summaries are sent when you request a
+ * list of all organiations
+ */
+export type OrganizationSummary = {
+  status: {
+    // TODO(ts): Are these fields == `ObjectStatus`?
+    id: string;
+    name: string;
+  };
+  require2FA: boolean;
   avatar: Avatar;
+  features: string[];
+  name: string;
+  dateCreated: string;
+  id: string;
+  isEarlyAdopter: boolean;
+  slug: string;
 };
 
+/**
+ * Detailed organization (e.g. when requesting details for a single org)
+ *
+ * Lightweight in this case means it does not contain `projects` or `teams`
+ */
+export type LightWeightOrganization = OrganizationSummary & {
+  scrubIPAddresses: boolean;
+  attachmentsRole: string;
+  sensitiveFields: string[];
+  openMembership: boolean;
+  quota: {
+    maxRateInterval: number | null;
+    projectLimit: number | null;
+    accountLimit: number | null;
+    maxRate: number | null;
+  };
+  defaultRole: string;
+  experiments: ActiveExperiments;
+  allowJoinRequests: boolean;
+  scrapeJavaScript: boolean;
+  isDefault: boolean;
+  pendingAccessRequests: number;
+  availableRoles: {id: string; name: string}[];
+  enhancedPrivacy: boolean;
+  safeFields: string[];
+  storeCrashReports: number;
+  access: string[];
+  allowSharedIssues: boolean;
+  dataScrubberDefaults: boolean;
+  dataScrubber: boolean;
+  role?: string;
+  onboardingTasks: Array<{
+    status: string;
+    dateCompleted: string;
+    task: number;
+    data: object;
+    user: string | null;
+  }>;
+  trustedRelays: string[];
+};
+
+/**
+ * Full organization details
+ */
 export type Organization = LightWeightOrganization & {
   projects: Project[];
   teams: Team[];
-};
-
-export type OrganizationDetailed = Organization & {
-  isDefault: boolean;
-  defaultRole: string;
-  availableRoles: {id: string; name: string}[];
-  openMembership: boolean;
-  require2FA: boolean;
-  allowSharedIssues: boolean;
-  enhancedPrivacy: boolean;
-  dataScrubber: boolean;
-  dataScrubberDefaults: boolean;
-  sensitiveFields: string[];
-  safeFields: string[];
-  storeCrashReports: boolean;
-  attachmentsRole: string;
-  scrubIPAddresses: boolean;
-  scrapeJavaScript: boolean;
-  trustedRelays: string[];
-  role?: string;
-  experiments: ActiveExperiments;
 };
 
 export type Project = {

--- a/src/sentry/static/sentry/app/utils/attachmentUrl.tsx
+++ b/src/sentry/static/sentry/app/utils/attachmentUrl.tsx
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import {OrganizationDetailed, EventAttachment} from 'app/types';
+import {Organization, EventAttachment} from 'app/types';
 import ConfigStore from 'app/stores/configStore';
 import withOrganization from 'app/utils/withOrganization';
 import SentryTypes from 'app/sentryTypes';
 
 type Props = {
-  organization: OrganizationDetailed;
+  organization: Organization;
   projectId: string;
   eventId: string;
   attachment: EventAttachment;

--- a/src/sentry/static/sentry/app/utils/withLatestContext.tsx
+++ b/src/sentry/static/sentry/app/utils/withLatestContext.tsx
@@ -8,10 +8,10 @@ import LatestContextStore from 'app/stores/latestContextStore';
 import SentryTypes from 'app/sentryTypes';
 import getDisplayName from 'app/utils/getDisplayName';
 import withOrganizations from 'app/utils/withOrganizations';
-import {Project, Organization} from 'app/types';
+import {Project, Organization, OrganizationSummary} from 'app/types';
 
 type InjectedLatestContextProps = {
-  organizations?: Organization[];
+  organizations?: OrganizationSummary[];
   organization?: Organization;
   project?: Project;
   lastRoute?: string;
@@ -19,7 +19,7 @@ type InjectedLatestContextProps = {
 
 type WithPluginProps = {
   organization?: Organization;
-  organizations: Organization[];
+  organizations: OrganizationSummary[];
 };
 
 type State = {
@@ -69,7 +69,7 @@ const withLatestContext = <P extends InjectedLatestContextProps>(
         // project from `latestContext`
         return (
           <WrappedComponent
-            organizations={organizations as Organization[]}
+            organizations={organizations as OrganizationSummary[]}
             project={project as Project}
             lastRoute={lastRoute as string}
             {...this.props as P}

--- a/src/sentry/static/sentry/app/utils/withOrganizations.tsx
+++ b/src/sentry/static/sentry/app/utils/withOrganizations.tsx
@@ -4,15 +4,15 @@ import createReactClass from 'create-react-class';
 
 import getDisplayName from 'app/utils/getDisplayName';
 import OrganizationsStore from 'app/stores/organizationsStore';
-import {Organization} from 'app/types';
+import {OrganizationSummary} from 'app/types';
 
 type InjectedOrganizationsProps = {
   organizationsLoading?: boolean;
-  organizations: Organization[];
+  organizations: OrganizationSummary[];
 };
 
 type State = {
-  organizations: Organization[];
+  organizations: OrganizationSummary[];
 };
 
 const withOrganizations = <P extends InjectedOrganizationsProps>(
@@ -29,7 +29,7 @@ const withOrganizations = <P extends InjectedOrganizationsProps>(
       return (
         <WrappedComponent
           organizationsLoading={!OrganizationsStore.loaded as boolean}
-          organizations={this.state.organizations as Organization[]}
+          organizations={this.state.organizations as OrganizationSummary[]}
           {...this.props as P}
         />
       );

--- a/src/sentry/static/sentry/app/views/sentryAppExternalInstallation.tsx
+++ b/src/sentry/static/sentry/app/views/sentryAppExternalInstallation.tsx
@@ -16,7 +16,7 @@ import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
 import {recordInteraction} from 'app/utils/recordSentryAppInteraction';
 import {
   LightWeightOrganization,
-  OrganizationDetailed,
+  Organization,
   SentryApp,
   SentryAppInstallation,
 } from 'app/types';
@@ -25,7 +25,7 @@ type Props = AsyncView['props'];
 
 type State = AsyncView['state'] & {
   selectedOrgSlug: string | null;
-  organization: OrganizationDetailed | null;
+  organization: Organization | null;
   organizations: LightWeightOrganization[];
   reloading: boolean;
   sentryApp: SentryApp;
@@ -118,7 +118,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
 
     try {
       const [organization, installations]: [
-        OrganizationDetailed,
+        Organization,
         SentryAppInstallation[]
       ] = await Promise.all([
         this.api.requestPromise(`/organizations/${orgSlug}/`),

--- a/src/sentry/static/sentry/app/views/settings/organizationGeneralSettings/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationGeneralSettings/index.tsx
@@ -3,7 +3,7 @@ import {browserHistory} from 'react-router';
 import React from 'react';
 
 import {Client} from 'app/api';
-import {OrganizationDetailed} from 'app/types';
+import {Organization} from 'app/types';
 import {Panel, PanelHeader} from 'app/components/panels';
 import {addLoadingMessage} from 'app/actionCreators/indicator';
 import {
@@ -24,7 +24,7 @@ import OrganizationSettingsForm from './organizationSettingsForm';
 
 type Props = {
   api: Client;
-  organization: OrganizationDetailed;
+  organization: Organization;
 } & RouteComponentProps<{orgId: string}, {}>;
 
 class OrganizationGeneralSettings extends React.Component<Props> {
@@ -42,7 +42,7 @@ class OrganizationGeneralSettings extends React.Component<Props> {
     });
   };
 
-  handleSave = (prevData: OrganizationDetailed, data: OrganizationDetailed) => {
+  handleSave = (prevData: Organization, data: Organization) => {
     if (data.slug && data.slug !== prevData.slug) {
       changeOrganizationSlug(prevData, data);
       browserHistory.replace(`/settings/${data.slug}/`);

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'react-emotion';
 
 import {openInviteMembersModal} from 'app/actionCreators/modal';
-import {OrganizationDetailed, Member} from 'app/types';
+import {Organization, Member} from 'app/types';
 import {Panel} from 'app/components/panels';
 import {t} from 'app/locale';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
@@ -19,7 +19,7 @@ import withOrganization from 'app/utils/withOrganization';
 
 type Props = AsyncView['props'] & {
   children?: any;
-  organization: OrganizationDetailed;
+  organization: Organization;
 };
 
 type State = AsyncView['state'] & {


### PR DESCRIPTION
Fixes our Organization-related types... we generally only use the detailed version. The summary version is seldom used (most people only belong to one organization as well).

Outline of the changes are below:

* `OrganizationDetailed` --> `Organization`
* `Organization` --> `OrganizationSummary`
* `LightweightOrganization` = `Organization` (without projects and teams)