### PR TITLE
Modifying dateCreated to be dateAdded

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -46,7 +46,7 @@ class AlertRuleSerializer(Serializer):
             "triggers": attrs.get("triggers", []),
             "includeAllProjects": obj.include_all_projects,
             "dateModified": obj.date_modified,
-            "dateAdded": obj.date_added,
+            "dateCreated": obj.date_added,
         }
 
 

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -18,7 +18,7 @@ class AlertRuleTriggerSerializer(Serializer):
             "thresholdType": obj.threshold_type,
             "alertThreshold": obj.alert_threshold,
             "resolveThreshold": obj.resolve_threshold,
-            "dateAdded": obj.date_added,
+            "dateCreated": obj.date_added,
         }
 
 

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -24,5 +24,5 @@ class AlertRuleTriggerActionSerializer(Serializer):
             if obj.target_display is not None
             else obj.target_identifier,
             "integrationId": obj.integration_id,
-            "dateAdded": obj.date_added,
+            "dateCreated": obj.date_added,
         }

--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -51,7 +51,7 @@ class IncidentSerializer(Serializer):
             "aggregation": obj.aggregation,
             "dateStarted": obj.date_started,
             "dateDetected": obj.date_detected,
-            "dateAdded": obj.date_added,
+            "dateCreated": obj.date_added,
             "dateClosed": obj.date_closed,
             "eventStats": serializer.serialize(attrs["event_stats"]),
             "totalEvents": attrs["total_events"],

--- a/src/sentry/api/serializers/models/organization_dashboard.py
+++ b/src/sentry/api/serializers/models/organization_dashboard.py
@@ -29,7 +29,7 @@ class WidgetSerializer(Serializer):
             "title": obj.title,
             "displayType": WidgetDisplayTypes.get_type_name(obj.display_type),
             "displayOptions": obj.display_options,
-            "dateAdded": obj.date_added,
+            "dateCreated": obj.date_added,
             "dashboardId": six.text_type(obj.dashboard_id),
             "dataSources": attrs["dataSources"],
         }
@@ -68,7 +68,7 @@ class DashboardWithWidgetsSerializer(Serializer):
             "id": six.text_type(obj.id),
             "title": obj.title,
             "organization": six.text_type(obj.organization.id),
-            "dateAdded": obj.date_added,
+            "dateCreated": obj.date_added,
             "createdBy": six.text_type(obj.created_by.id),
             "widgets": attrs["widgets"],
         }

--- a/src/sentry/static/sentry/app/sentryTypes.jsx
+++ b/src/sentry/static/sentry/app/sentryTypes.jsx
@@ -470,7 +470,7 @@ export const Incident = PropTypes.shape({
   dateClosed: PropTypes.string,
   dateStarted: PropTypes.string.isRequired,
   dateDetected: PropTypes.string.isRequired,
-  dateAdded: PropTypes.string.isRequired,
+  dateCreated: PropTypes.string.isRequired,
 });
 
 export const IncidentSuspectData = PropTypes.shape({

--- a/src/sentry/static/sentry/app/views/incidents/types.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/types.tsx
@@ -7,7 +7,7 @@ export type Incident = {
   dateClosed: string;
   dateStarted: string;
   dateDetected: string;
-  dateAdded: string;
+  dateCreated: string;
   eventStats: {
     data: Data;
   };

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -30,7 +30,7 @@ export type ThresholdControlValue = {
 
 export type SavedTrigger = UnsavedTrigger & {
   id: string;
-  dateAdded: string;
+  dateCreated: string;
 };
 
 export type Trigger = Partial<SavedTrigger> & UnsavedTrigger;
@@ -45,7 +45,7 @@ export type UnsavedIncidentRule = {
 };
 
 export type SavedIncidentRule = UnsavedIncidentRule & {
-  dateAdded: string;
+  dateCreated: string;
   dateModified: string;
   id: string;
   status: number;

--- a/tests/js/sentry-test/fixtures/debugSymbols.js
+++ b/tests/js/sentry-test/fixtures/debugSymbols.js
@@ -2,7 +2,7 @@ export function DebugSymbols(params) {
   return {
     debugSymbols: [
       {
-        dateAdded: '2018-01-31T07:16:26.072Z',
+        dateCreated: '2018-01-31T07:16:26.072Z',
         dsym: {
           headers: {'Content-Type': 'text/x-proguard+plain'},
           sha1: 'e6d3c5185dac63eddfdc1a5edfffa32d46103b44',

--- a/tests/js/sentry-test/fixtures/incident.js
+++ b/tests/js/sentry-test/fixtures/incident.js
@@ -6,7 +6,7 @@ export function Incident(params) {
     dateClosed: '2019-04-19T19:44:05.963Z',
     dateStarted: '2019-04-05T19:44:05.963Z',
     dateDetected: '2019-04-05T19:44:05.963Z',
-    dateAdded: '2019-04-05T19:44:05.963Z',
+    dateCreated: '2019-04-05T19:44:05.963Z',
     title: 'Too many Chrome errors',
     status: 0,
     projects: [],

--- a/tests/js/sentry-test/fixtures/incidentRule.js
+++ b/tests/js/sentry-test/fixtures/incidentRule.js
@@ -3,7 +3,7 @@ import {IncidentTrigger} from './incidentTrigger';
 export function IncidentRule(params) {
   return {
     status: 0,
-    dateAdded: '2019-07-31T23:02:02.731Z',
+    dateCreated: '2019-07-31T23:02:02.731Z',
     dataset: 'events',
     query: '',
     id: '4',

--- a/tests/js/sentry-test/fixtures/incidentTrigger.js
+++ b/tests/js/sentry-test/fixtures/incidentTrigger.js
@@ -2,7 +2,7 @@ export function IncidentTrigger(params) {
   return {
     alertRuleId: '4',
     alertThreshold: 70,
-    dateAdded: '2019-09-24T18:07:47.714Z',
+    dateCreated: '2019-09-24T18:07:47.714Z',
     id: '1',
     label: 'Trigger',
     resolveThreshold: 36,

--- a/tests/sentry/api/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/api/endpoints/test_organization_incident_details.py
@@ -65,7 +65,7 @@ class OrganizationIncidentDetailsTest(BaseIncidentDetailsTest, APITestCase):
         assert resp.data["query"] == expected["query"]
         assert resp.data["projects"] == expected["projects"]
         assert resp.data["dateDetected"] == expected["dateDetected"]
-        assert resp.data["dateAdded"] == expected["dateAdded"]
+        assert resp.data["dateCreated"] == expected["dateCreated"]
         assert resp.data["projects"] == expected["projects"]
         assert resp.data["eventStats"] == expected["eventStats"]
         assert resp.data["seenBy"] == seen_by

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -28,7 +28,7 @@ class BaseAlertRuleSerializerTest(object):
         assert result["thresholdPeriod"] == alert_rule.threshold_period
         assert result["includeAllProjects"] == alert_rule.include_all_projects
         assert result["dateModified"] == alert_rule.date_modified
-        assert result["dateAdded"] == alert_rule.date_added
+        assert result["dateCreated"] == alert_rule.date_added
 
 
 class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):

--- a/tests/sentry/api/serializers/test_alert_rule_trigger.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger.py
@@ -19,7 +19,7 @@ class BaseAlertRuleTriggerSerializerTest(object):
         assert result["thresholdType"] == trigger.threshold_type
         assert result["alertThreshold"] == trigger.alert_threshold
         assert result["resolveThreshold"] == trigger.resolve_threshold
-        assert result["dateAdded"] == trigger.date_added
+        assert result["dateCreated"] == trigger.date_added
 
 
 class AlertRuleTriggerSerializerTest(BaseAlertRuleTriggerSerializerTest, TestCase):

--- a/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
@@ -27,7 +27,7 @@ class AlertRuleTriggerActionSerializerTest(TestCase):
         )
         assert result["targetIdentifier"] == action.target_identifier
         assert result["integrationId"] == action.integration_id
-        assert result["dateAdded"] == action.date_added
+        assert result["dateCreated"] == action.date_added
 
     def test_simple(self):
         alert_rule = self.create_alert_rule()

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -33,7 +33,7 @@ class IncidentSerializerTest(TestCase):
         assert result["aggregation"] == incident.aggregation
         assert result["dateStarted"] == incident.date_started
         assert result["dateDetected"] == incident.date_detected
-        assert result["dateAdded"] == incident.date_added
+        assert result["dateCreated"] == incident.date_added
         assert result["dateClosed"] == incident.date_closed
         assert len(result["eventStats"]["data"]) == 52
         assert [data[1] for data in result["eventStats"]["data"]] == [[]] * 52


### PR DESCRIPTION
Some of our new serializers were using dateAdded, where most of our existing ones were using dateCreated.

This was noticed when merging rules into one API - issue rules were using dateCreated and AlertRules were using dateAdded.

I've made changes so that dateAdded is no longer being used, and dateCreated is used across the board.