### PR TITLE
feat(ui): Only allow two Triggers for Metric Alerts

### DIFF
--- a/src/sentry/static/sentry/app/components/circleIndicator.tsx
+++ b/src/sentry/static/sentry/app/components/circleIndicator.tsx
@@ -1,12 +1,17 @@
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 
+const defaultProps = {
+  enabled: true,
+  size: 14,
+};
+
+type DefaultProps = Readonly<typeof defaultProps>;
+
 type Props = {
-  enabled?: boolean;
-  size: number;
   color?: string;
   theme?: any;
-};
+} & Partial<DefaultProps>;
 
 const getBackgroundColor = (p: Props) => {
   if (p.color) {
@@ -35,9 +40,6 @@ CircleIndicator.propTypes = {
   color: PropTypes.string,
 };
 
-CircleIndicator.defaultProps = {
-  enabled: true,
-  size: 14,
-};
+CircleIndicator.defaultProps = defaultProps;
 
 export default CircleIndicator;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -7,7 +7,7 @@ import {
 
 export function createDefaultTrigger(): Trigger {
   return {
-    label: '',
+    label: 'critical',
     alertThreshold: 0,
     resolveThreshold: '',
     thresholdType: AlertRuleThresholdType.ABOVE,

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -194,7 +194,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
    */
   handleAddTrigger = () => {
     this.setState(({triggers}) => ({
-      triggers: [...triggers, createDefaultTrigger()],
+      triggers: [...triggers, {...createDefaultTrigger(), label: 'warning'}],
     }));
   };
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
@@ -118,33 +118,19 @@ class TriggerForm extends React.PureComponent<Props> {
     }
   };
 
-  handleChangeLabel = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const {onChange, trigger} = this.props;
-
-    onChange({...trigger, label: e.target.value});
-  };
-
   render() {
-    const {error, trigger} = this.props;
+    const {error, trigger, isCritical} = this.props;
+    const triggerLabel = isCritical
+      ? t('Critical Trigger Threshold')
+      : t('Warning Trigger Threshold');
+    const resolutionLabel = isCritical
+      ? t('Critical Resolution Threshold')
+      : t('Warning Resolution Threshold');
 
     return (
       <React.Fragment>
         <Field
-          label={t('Label')}
-          help={t('This will prefix alerts created by this trigger')}
-          required
-          error={error && error.label}
-        >
-          <Input
-            name="label"
-            placeholder={t('SEV-0')}
-            value={trigger.label}
-            required
-            onChange={this.handleChangeLabel}
-          />
-        </Field>
-        <Field
-          label={t('Trigger Threshold')}
+          label={triggerLabel}
           help={t('The threshold that will trigger the associated action(s)')}
           required
           error={error && error.alertThreshold}
@@ -158,7 +144,7 @@ class TriggerForm extends React.PureComponent<Props> {
         </Field>
 
         <Field
-          label={t('Resolution Threshold')}
+          label={resolutionLabel}
           help={t('The threshold that will resolve an alert')}
           error={error && error.resolutionThreshold}
         >

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
@@ -8,7 +8,6 @@ import {fetchOrgMembers} from 'app/actionCreators/members';
 import {t} from 'app/locale';
 import ActionsPanel from 'app/views/settings/incidentRules/triggers/actionsPanel';
 import Field from 'app/views/settings/components/forms/field';
-import Input from 'app/views/settings/components/forms/controls/input';
 import ThresholdControl from 'app/views/settings/incidentRules/triggers/thresholdControl';
 import withApi from 'app/utils/withApi';
 import withConfig from 'app/utils/withConfig';

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
@@ -32,6 +32,7 @@ type Props = {
   projects: Project[];
   trigger: Trigger;
   triggerIndex: number;
+  isCritical: boolean;
 
   onChange: (trigger: Trigger) => void;
 };
@@ -220,6 +221,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
       config,
       currentProject,
       error,
+      isCritical,
       organization,
       trigger,
       triggerIndex,
@@ -236,6 +238,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
           organization={organization}
           projects={projects}
           triggerIndex={triggerIndex}
+          isCritical={isCritical}
           onChange={this.handleChangeTrigger}
         />
         <ActionsPanel

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/index.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import styled from 'react-emotion';
 
-import {Trigger} from 'app/views/settings/incidentRules/types';
+import {MetricAction} from 'app/types/alerts';
 import {Organization, Project} from 'app/types';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import {Trigger} from 'app/views/settings/incidentRules/types';
 import {removeAtArrayIndex} from 'app/utils/removeAtArrayIndex';
 import {replaceAtArrayIndex} from 'app/utils/replaceAtArrayIndex';
 import {t} from 'app/locale';
 import Button from 'app/components/button';
+import CircleIndicator from 'app/components/circleIndicator';
 import TriggerForm from 'app/views/settings/incidentRules/triggers/form';
+import space from 'app/styles/space';
 import withProjects from 'app/utils/withProjects';
-import {MetricAction} from 'app/types/alerts';
 
 type DeleteButtonProps = {
   triggerIndex: number;
@@ -78,17 +80,29 @@ class Triggers extends React.Component<Props> {
       onAdd,
     } = this.props;
 
+    // Note we only support 2 triggers on UI - API can support many
     return (
       <React.Fragment>
         {triggers.map((trigger, index) => {
+          const isCritical = index === 0;
+          const title = isCritical ? t('Critical Trigger') : t('Warning Trigger');
           return (
             <Panel key={index}>
-              <PanelHeader hasButtons>
-                {t('Define Trigger')}
-                <DeleteButton triggerIndex={index} onDelete={this.handleDeleteTrigger} />
+              <PanelHeader hasButtons={!isCritical}>
+                <Title>
+                  {isCritical ? <CriticalIndicator /> : <WarningIndicator />}
+                  {title}
+                </Title>
+                {!isCritical && (
+                  <DeleteButton
+                    triggerIndex={index}
+                    onDelete={this.handleDeleteTrigger}
+                  />
+                )}
               </PanelHeader>
               <PanelBody>
                 <TriggerForm
+                  isCritical={isCritical}
                   error={errors && errors.get(index)}
                   availableActions={availableActions}
                   organization={organization}
@@ -103,16 +117,18 @@ class Triggers extends React.Component<Props> {
           );
         })}
 
-        <BorderlessPanel>
-          <FullWidthButton
-            type="button"
-            size="small"
-            icon="icon-circle-add"
-            onClick={onAdd}
-          >
-            {t('Add another Trigger')}
-          </FullWidthButton>
-        </BorderlessPanel>
+        {triggers.length < 2 && (
+          <BorderlessPanel>
+            <FullWidthButton
+              type="button"
+              size="small"
+              icon="icon-circle-add"
+              onClick={onAdd}
+            >
+              {t('Add Warning Trigger')}
+            </FullWidthButton>
+          </BorderlessPanel>
+        )}
       </React.Fragment>
     );
   }
@@ -124,6 +140,21 @@ const BorderlessPanel = styled(Panel)`
 
 const FullWidthButton = styled(Button)`
   width: 100%;
+`;
+
+const Title = styled('div')`
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: ${space(1)};
+  align-items: center;
+`;
+
+const CriticalIndicator = styled(CircleIndicator)`
+  background: ${p => p.theme.redLight};
+`;
+
+const WarningIndicator = styled(CircleIndicator)`
+  background: ${p => p.theme.yellowDark};
 `;
 
 export default withProjects(Triggers);

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -99,12 +99,6 @@ describe('Incident Rules Details', function() {
     // has existing trigger
     expect(
       wrapper
-        .find('input[name="label"]')
-        .first()
-        .prop('value')
-    ).toEqual('Trigger');
-    expect(
-      wrapper
         .find('input[name="alertThresholdInput"]')
         .first()
         .prop('value')
@@ -119,12 +113,8 @@ describe('Incident Rules Details', function() {
     expect(req).toHaveBeenCalled();
 
     // Create a new Trigger
-    wrapper.find('button[aria-label="Add another Trigger"]').simulate('click');
+    wrapper.find('button[aria-label="Add Warning Trigger"]').simulate('click');
 
-    wrapper
-      .find('input[name="label"]')
-      .at(1)
-      .simulate('change', {target: {value: 'New Trigger'}});
     wrapper
       .find('input[name="alertThresholdInput"]')
       .at(1)
@@ -167,17 +157,15 @@ describe('Incident Rules Details', function() {
               alertRuleId: '4',
               alertThreshold: 70,
               id: '1',
-              label: 'Trigger',
               resolveThreshold: 36,
               thresholdType: 0,
             }),
-            {
+            expect.objectContaining({
               actions: [],
               alertThreshold: 13,
-              label: 'New Trigger',
               resolveThreshold: 12,
               thresholdType: 0,
-            },
+            }),
           ],
         }),
         method: 'PUT',
@@ -198,12 +186,6 @@ describe('Incident Rules Details', function() {
     // Has correct values
     expect(
       wrapper
-        .find('input[name="label"]')
-        .at(1)
-        .prop('value')
-    ).toBe('New Trigger');
-    expect(
-      wrapper
         .find('input[name="alertThresholdInput"]')
         .at(1)
         .prop('value')
@@ -214,6 +196,8 @@ describe('Incident Rules Details', function() {
         .at(1)
         .prop('value')
     ).toBe(12);
+
+    editRule.mockReset();
 
     // Delete Trigger
     wrapper
@@ -237,32 +221,24 @@ describe('Incident Rules Details', function() {
           status: 0,
           timeWindow: 60,
           triggers: [
-            {
-              actions: [],
-              alertThreshold: 13,
-              label: 'New Trigger',
-              resolveThreshold: 12,
+            expect.objectContaining({
+              actions: [
+                {
+                  targetIdentifier: '',
+                  targetType: 'user',
+                  type: 'email',
+                },
+              ],
+              alertRuleId: '4',
+              alertThreshold: 70,
+              id: '1',
+              resolveThreshold: 36,
               thresholdType: 0,
-            },
+            }),
           ],
         }),
         method: 'PUT',
       })
     );
-
-    expect(
-      wrapper
-        .find('input[name="label"]')
-        .first()
-        .prop('value')
-    ).toBe('New Trigger');
-
-    // The last trigger is now the first trigger
-    expect(
-      wrapper
-        .find('input[name="label"]')
-        .last()
-        .prop('value')
-    ).toBe('New Trigger');
   });
 });


### PR DESCRIPTION
This changes the Metric Alert rule builder to only only 2 triggers: "Critical" and "Warning". This means we can remove the `label` field. 