### PR TITLE
fix(plugins): use gid for Asana

### DIFF
--- a/src/social_auth/backends/asana.py
+++ b/src/social_auth/backends/asana.py
@@ -25,6 +25,7 @@ class AsanaBackend(OAuthBackend):
         ("gid", "id"),
         ("refresh_token", "refresh_token"),
     ]
+    ID_KEY = "gid"
 
     def get_user_details(self, response):
         """Return user details from Asana account"""


### PR DESCRIPTION
Asana is moving from `id` to `gid`. I fixed this a few months ago (https://github.com/getsentry/sentry/pull/15129) but it seems that I didn't do it in every place and they removed `id` from authentication step in mid-November. More information: https://forum.asana.com/t/asana-is-moving-to-string-ids-updated-with-revised-timeline/29340

Fixes SENTRY-DEZ