### PR TITLE
fix(security) Strip extra characters off username

### DIFF
--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -26,7 +26,7 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
         # Rate limit logins
         is_limited = ratelimiter.is_limited(
             u"auth:login:username:{}".format(
-                md5_text(request.data.get("username").lower()).hexdigest()
+                md5_text(login_form.clean_username(request.data.get("username"))).hexdigest()
             ),
             limit=10,
             window=60,  # 10 per minute should be enough for anyone

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -81,8 +81,10 @@ class AuthenticationForm(forms.Form):
         if not self.fields["username"].label:
             self.fields["username"].label = capfirst(self.username_field.verbose_name)
 
-    def clean_username(self):
-        value = (self.cleaned_data.get("username") or "").strip()
+    def clean_username(self, value=None):
+        if not value:
+            value = self.cleaned_data.get("username") or ""
+        value = value.strip(" \n\t\r\0")
         if not value:
             return
         return value.lower()

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -155,7 +155,7 @@ class AuthLoginView(BaseView):
 
             if login_attempt and ratelimiter.is_limited(
                 u"auth:login:username:{}".format(
-                    md5_text(request.POST["username"].lower()).hexdigest()
+                    md5_text(login_form.clean_username(request.POST["username"])).hexdigest()
                 ),
                 limit=10,
                 window=60,  # 10 per minute should be enough for anyone


### PR DESCRIPTION
Strip any whitespace/null characters off the submitted username to avoid someone
appending them to the username to brute force a password.