### PR TITLE
chore(discover2): Only fetch projects whenever the PROJECT_KEY tag is requested

### DIFF
--- a/src/sentry/api/endpoints/organization_events_distribution.py
+++ b/src/sentry/api/endpoints/organization_events_distribution.py
@@ -56,9 +56,9 @@ class OrganizationEventsDistributionEndpoint(OrganizationEventsEndpointBase):
             referrer="api.organization-events-distribution",
         )["data"]
 
-        projects = {p.id: p.slug for p in self.get_projects(request, organization)}
-
         if key == PROJECT_KEY:
+            projects = {p.id: p.slug for p in self.get_projects(request, organization)}
+
             resp = {
                 "key": PROJECT_KEY,
                 "topValues": [


### PR DESCRIPTION
projects was being fetched on every tag.

Cherry picked from https://github.com/getsentry/sentry/pull/16125