### PR TITLE
ref: Remove Event handler from message builder

### DIFF
--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -24,7 +24,7 @@ from django.utils.encoding import force_bytes, force_str, force_text
 
 from sentry import options
 from sentry.logging import LoggingFormat
-from sentry.models import Activity, Event, Group, GroupEmailThread, Project, User, UserOption
+from sentry.models import Activity, Group, GroupEmailThread, Project, User, UserOption
 from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 from sentry.utils.strings import is_valid_dot_atom
@@ -240,7 +240,6 @@ default_list_type_handlers = {
     Activity: attrgetter("project.slug", "project.organization.slug"),
     Project: attrgetter("slug", "organization.slug"),
     Group: attrgetter("project.slug", "organization.slug"),
-    Event: attrgetter("project.slug", "organization.slug"),
 }
 
 make_listid_from_instance = ListResolver(

--- a/tests/sentry/utils/email/tests.py
+++ b/tests/sentry/utils/email/tests.py
@@ -33,7 +33,6 @@ class ListResolverTestCase(TestCase):
 
     def test_generates_list_ids(self):
         expected = u"{0.project.slug}.{0.organization.slug}.namespace".format(self.event)
-        assert self.resolver(self.event) == expected
         assert self.resolver(self.event.group) == expected
         assert self.resolver(self.event.project) == expected
 
@@ -284,7 +283,7 @@ class MessageBuilderTest(TestCase):
             event=self.event, namespace=options.get("mail.list-namespace")
         )
 
-        references = (self.event, self.event.group, self.event.project, self.activity)
+        references = (self.event.group, self.event.project, self.activity)
 
         for reference in references:
             (message,) = build_message(reference=reference).get_built_messages(["foo@example.com"])


### PR DESCRIPTION
We never pass an Event instance as reference to message builder. We need
to remove this line since Event is deprecated.