### PR TITLE
feat(django-1.10) - Enable model unpickle compats

### DIFF
--- a/src/sentry/monkey.py
+++ b/src/sentry/monkey.py
@@ -123,5 +123,10 @@ def patch_model_unpickle():
     django.db.models.base.simple_class_factory = simple_class_factory_compat
 
 
-for patch in (patch_parse_cookie, patch_httprequest_repr, patch_django_views_debug):
+for patch in (
+    patch_parse_cookie,
+    patch_httprequest_repr,
+    patch_django_views_debug,
+    patch_model_unpickle,
+):
     patch()

--- a/src/sentry/monkey.py
+++ b/src/sentry/monkey.py
@@ -113,8 +113,6 @@ def simple_class_factory_compat(model, attrs):
 def patch_model_unpickle():
     # https://code.djangoproject.com/ticket/27187
     # Django 1.10 breaks pickle compat with 1.9 models.
-    import django.db.models.base
-
     django.db.models.base.model_unpickle = model_unpickle_compat
 
     # Django 1.10 needs this to unpickle 1.9 models, but we can't branch while

--- a/src/sentry/monkey.py
+++ b/src/sentry/monkey.py
@@ -84,47 +84,5 @@ def patch_django_views_debug():
     debug.get_safe_settings = lambda: {}
 
 
-# For distribution builds, can't be inside `model_unpickle_compat` since we're patching the functions
-try:
-    import django.db.models.base
-
-    model_unpickle = django.db.models.base.model_unpickle
-except ImportError:
-    pass
-
-
-def model_unpickle_compat(model_id, attrs=None, factory=None):
-    from django import VERSION
-
-    if VERSION[:2] == (1, 9):
-        attrs = [] if attrs is None else attrs
-        factory = django.db.models.base.simple_class_factory if factory is None else factory
-        return model_unpickle(model_id, attrs, factory)
-    elif VERSION[:2] == (1, 10):
-        return model_unpickle(model_id)
-    else:
-        raise NotImplementedError
-
-
-def simple_class_factory_compat(model, attrs):
-    return model
-
-
-def patch_model_unpickle():
-    # https://code.djangoproject.com/ticket/27187
-    # Django 1.10 breaks pickle compat with 1.9 models.
-    django.db.models.base.model_unpickle = model_unpickle_compat
-
-    # Django 1.10 needs this to unpickle 1.9 models, but we can't branch while
-    # monkeypatching else our monkeypatched funcs won't be pickleable.
-    # So just vendor simple_class_factory from 1.9.
-    django.db.models.base.simple_class_factory = simple_class_factory_compat
-
-
-for patch in (
-    patch_parse_cookie,
-    patch_httprequest_repr,
-    patch_django_views_debug,
-    patch_model_unpickle,
-):
+for patch in (patch_parse_cookie, patch_httprequest_repr, patch_django_views_debug):
     patch()

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -299,6 +299,8 @@ def initialize_app(config, skip_service_validation=False):
     if getattr(settings, "SENTRY_DEBUGGER", None) is None:
         settings.SENTRY_DEBUGGER = settings.DEBUG
 
+    monkeypatch_model_unpickle()
+
     import django
 
     django.setup()
@@ -388,6 +390,39 @@ def validate_options(settings):
     from sentry.options import default_manager
 
     default_manager.validate(settings.SENTRY_OPTIONS, warn=True)
+
+
+def __model_unpickle_compat(model_id, attrs=None, factory=None):
+    from django import VERSION
+    import django.db.models.base
+
+    model_unpickle = django.db.models.base.model_unpickle
+
+    if VERSION[:2] == (1, 9):
+        attrs = [] if attrs is None else attrs
+        factory = django.db.models.base.simple_class_factory if factory is None else factory
+        return model_unpickle(model_id, attrs, factory)
+    elif VERSION[:2] == (1, 10):
+        return model_unpickle(model_id)
+    else:
+        raise NotImplementedError
+
+
+def __simple_class_factory_compat(model, attrs):
+    return model
+
+
+def monkeypatch_model_unpickle():
+    import django.db.models.base
+
+    # https://code.djangoproject.com/ticket/27187
+    # Django 1.10 breaks pickle compat with 1.9 models.
+    django.db.models.base.model_unpickle = __model_unpickle_compat
+
+    # Django 1.10 needs this to unpickle 1.9 models, but we can't branch while
+    # monkeypatching else our monkeypatched funcs won't be pickleable.
+    # So just vendor simple_class_factory from 1.9.
+    django.db.models.base.simple_class_factory = __simple_class_factory_compat
 
 
 def monkeypatch_django_migrations():

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -392,11 +392,13 @@ def validate_options(settings):
     default_manager.validate(settings.SENTRY_OPTIONS, warn=True)
 
 
+import django.db.models.base
+
+model_unpickle = django.db.models.base.model_unpickle
+
+
 def __model_unpickle_compat(model_id, attrs=None, factory=None):
     from django import VERSION
-    import django.db.models.base
-
-    model_unpickle = django.db.models.base.model_unpickle
 
     if VERSION[:2] == (1, 9):
         attrs = [] if attrs is None else attrs
@@ -413,8 +415,6 @@ def __simple_class_factory_compat(model, attrs):
 
 
 def monkeypatch_model_unpickle():
-    import django.db.models.base
-
     # https://code.djangoproject.com/ticket/27187
     # Django 1.10 breaks pickle compat with 1.9 models.
     django.db.models.base.model_unpickle = __model_unpickle_compat

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -143,12 +143,15 @@ def pytest_configure(config):
         bootstrap_options,
         configure_structlog,
         initialize_receivers,
+        monkeypatch_model_unpickle,
         monkeypatch_django_migrations,
         setup_services,
     )
 
     bootstrap_options(settings)
     configure_structlog()
+
+    monkeypatch_model_unpickle()
 
     import django
 


### PR DESCRIPTION
- Continuation of #16143, now with these functions deployed we can
  enable the patch.