### PR TITLE
test: Rename create_event() to create_event_deprecated()

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -803,7 +803,7 @@ class SnubaTestCase(BaseTestCase):
         world all test events would go through the full regular pipeline.
         """
         # XXX: Use `store_event` instead of this!
-        event = Factories.create_event(*args, **kwargs)
+        event = Factories.create_event_deprecated(*args, **kwargs)
 
         data = event.data.data
         tags = dict(data.get("tags", []))

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -619,7 +619,7 @@ class Factories(object):
                 }
             }"""
 
-        event = Factories.create_event(
+        event = Factories.create_event_deprecated(
             group=group,
             event_id=event_id,
             platform="javascript",

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -470,7 +470,7 @@ class Factories(object):
         return useremail
 
     @staticmethod
-    def create_event(group=None, project=None, event_id=None, normalize=True, **kwargs):
+    def create_event_deprecated(group=None, project=None, event_id=None, normalize=True, **kwargs):
         # XXX: Do not use this method for new tests! Prefer `store_event`.
         if event_id is None:
             event_id = uuid4().hex

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -140,13 +140,13 @@ class Fixtures(object):
     def create_useremail(self, *args, **kwargs):
         return Factories.create_useremail(*args, **kwargs)
 
-    def create_event(self, event_id=None, group=None, *args, **kwargs):
+    def create_event_deprecated(self, event_id=None, group=None, *args, **kwargs):
         if group is None:
             group = self.group
-        return Factories.create_event(event_id=event_id, group=group, *args, **kwargs)
+        return Factories.create_event_deprecated(event_id=event_id, group=group, *args, **kwargs)
 
     def create_issueless_event(self, event_id=None, *args, **kwargs):
-        return Factories.create_event(event_id=event_id, group=None, *args, **kwargs)
+        return Factories.create_event_deprecated(event_id=event_id, group=None, *args, **kwargs)
 
     def store_event(self, *args, **kwargs):
         return Factories.store_event(*args, **kwargs)

--- a/tests/sentry/api/endpoints/test_group_user_reports.py
+++ b/tests/sentry/api/endpoints/test_group_user_reports.py
@@ -36,7 +36,7 @@ class GroupUserReport(APITestCase, SnubaTestCase):
 
     def create_events_for_environment(self, group, environment, num_events):
         return [
-            self.create_event(group=group, tags={"environment": environment.name})
+            self.create_event_deprecated(group=group, tags={"environment": environment.name})
             for __i in range(num_events)
         ]
 

--- a/tests/sentry/deletions/test_project.py
+++ b/tests/sentry/deletions/test_project.py
@@ -26,7 +26,7 @@ class DeleteProjectTest(TestCase):
     def test_simple(self):
         project = self.create_project(name="test")
         group = self.create_group(project=project)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
         GroupAssignee.objects.create(group=group, project=project, user=self.user)
         GroupMeta.objects.create(group=group, key="foo", value="bar")
         release = Release.objects.create(version="a" * 32, organization_id=project.organization_id)

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -64,7 +64,7 @@ class GroupRecordsTestCase(TestCase):
         return self.project.rule_set.all()[0]
 
     def test_success(self):
-        events = [self.create_event(group=self.group) for _ in range(3)]
+        events = [self.create_event_deprecated(group=self.group) for _ in range(3)]
         records = [
             Record(event.event_id, Notification(event, [self.rule]), event.datetime)
             for event in events

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -164,7 +164,7 @@ class BuildIncidentAttachmentTest(TestCase):
             "fallback": u"[{}] {}".format(self.project.slug, group.title),
             "footer_icon": u"http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
         }
-        event = self.create_event()
+        event = self.create_event_deprecated()
         ts = event.datetime
         assert build_group_attachment(group, event) == {
             "color": "error",

--- a/tests/sentry/models/test_event.py
+++ b/tests/sentry/models/test_event.py
@@ -11,7 +11,7 @@ from sentry.testutils.factories import Factories
 
 class EventTest(TestCase):
     def test_pickling_compat(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             data={"tags": [("logger", "foobar"), ("site", "foo"), ("server_name", "bar")]}
         )
 
@@ -40,16 +40,16 @@ class EventTest(TestCase):
         assert event2.data == event.data
 
     def test_event_as_dict(self):
-        event = self.create_event(data={"logentry": {"formatted": "Hello World!"}})
+        event = self.create_event_deprecated(data={"logentry": {"formatted": "Hello World!"}})
 
         d = event.as_dict()
         assert d["logentry"] == {"formatted": "Hello World!"}
 
     def test_email_subject(self):
-        event1 = self.create_event(
+        event1 = self.create_event_deprecated(
             event_id="a" * 32, group=self.group, tags={"level": "info"}, message="Foo bar"
         )
-        event2 = self.create_event(
+        event2 = self.create_event_deprecated(
             event_id="b" * 32, group=self.group, tags={"level": "ERROR"}, message="Foo bar"
         )
         self.group.level = 30
@@ -77,7 +77,7 @@ class EventTest(TestCase):
         assert event1.get_email_subject() == "BAR-1 - production@0 $ baz ${tag:invalid} $invalid"
 
     def test_as_dict_hides_client_ip(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             data={"sdk": {"name": "foo", "version": "1.0", "client_ip": "127.0.0.1"}}
         )
         result = event.as_dict()
@@ -93,7 +93,7 @@ class EventTest(TestCase):
             event.get_environment() == environment
 
     def test_ip_address(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             data={
                 "user": {"ip_address": "127.0.0.1"},
                 "request": {"url": "http://some.com", "env": {"REMOTE_ADDR": "::1"}},
@@ -101,7 +101,7 @@ class EventTest(TestCase):
         )
         assert event.ip_address == "127.0.0.1"
 
-        event = self.create_event(
+        event = self.create_event_deprecated(
             data={
                 "user": {"ip_address": None},
                 "request": {"url": "http://some.com", "env": {"REMOTE_ADDR": "::1"}},
@@ -109,7 +109,7 @@ class EventTest(TestCase):
         )
         assert event.ip_address == "::1"
 
-        event = self.create_event(
+        event = self.create_event_deprecated(
             data={
                 "user": None,
                 "request": {"url": "http://some.com", "env": {"REMOTE_ADDR": "::1"}},
@@ -117,17 +117,17 @@ class EventTest(TestCase):
         )
         assert event.ip_address == "::1"
 
-        event = self.create_event(
+        event = self.create_event_deprecated(
             data={"request": {"url": "http://some.com", "env": {"REMOTE_ADDR": "::1"}}}
         )
         assert event.ip_address == "::1"
 
-        event = self.create_event(
+        event = self.create_event_deprecated(
             data={"request": {"url": "http://some.com", "env": {"REMOTE_ADDR": None}}}
         )
         assert event.ip_address is None
 
-        event = self.create_event()
+        event = self.create_event_deprecated()
         assert event.ip_address is None
 
     def test_issueless_event(self):

--- a/tests/sentry/models/tests.py
+++ b/tests/sentry/models/tests.py
@@ -139,11 +139,11 @@ class EventNodeStoreTest(TestCase):
             event.bind_node_data()
 
     def test_accepts_valid_ref(self):
-        event = self.create_event()
+        event = self.create_event_deprecated()
         event.data.bind_ref(event)
         event.bind_node_data()
         assert event.data.ref == event.project.id
 
     def test_basic_ref_binding(self):
-        event = self.create_event()
+        event = self.create_event_deprecated()
         assert event.data.get_ref(event) == event.project.id

--- a/tests/sentry/plugins/bases/notify/tests.py
+++ b/tests/sentry/plugins/bases/notify/tests.py
@@ -42,7 +42,7 @@ class NotifyPlugin(TestCase):
             def hook(*a, **kw):
                 raise err
 
-            event = self.create_event()
+            event = self.create_event_deprecated()
             notification = Notification(event)
 
             n.notify_users = hook

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -55,7 +55,9 @@ class MailPluginTest(TestCase):
 
     def test_simple_notification(self):
         group = self.create_group(message="Hello world")
-        event = self.create_event(group=group, message="Hello world", tags={"level": "error"})
+        event = self.create_event_deprecated(
+            group=group, message="Hello world", tags={"level": "error"}
+        )
 
         rule = Rule.objects.create(project=self.project, label="my rule")
 
@@ -224,7 +226,9 @@ class MailPluginTest(TestCase):
 
     def test_notify_users_with_utf8_subject(self):
         group = self.create_group(message="Hello world")
-        event = self.create_event(group=group, message=u"רונית מגן", tags={"level": "error"})
+        event = self.create_event_deprecated(
+            group=group, message=u"רונית מגן", tags={"level": "error"}
+        )
 
         notification = Notification(event=event)
 
@@ -252,7 +256,7 @@ class MailPluginTest(TestCase):
         digest = build_digest(
             project,
             (
-                event_to_record(self.create_event(group=self.create_group()), (rule,)),
+                event_to_record(self.create_event_deprecated(group=self.create_group()), (rule,)),
                 event_to_record(self.event, (rule,)),
             ),
         )
@@ -290,7 +294,7 @@ class MailPluginTest(TestCase):
         digest = build_digest(
             project,
             (
-                event_to_record(self.create_event(group=self.create_group()), (rule,)),
+                event_to_record(self.create_event_deprecated(group=self.create_group()), (rule,)),
                 event_to_record(self.event, (rule,)),
             ),
         )
@@ -387,7 +391,7 @@ class MailPluginTest(TestCase):
     def test_notify_with_suspect_commits(self):
         release = self.create_release(project=self.project, user=self.user)
         group = self.create_group(project=self.project, first_release=release)
-        event = self.create_event(group=group, tags={"sentry:release": release.version})
+        event = self.create_event_deprecated(group=group, tags={"sentry:release": release.version})
 
         notification = Notification(event=event)
 

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -24,7 +24,9 @@ class WebHooksPluginTest(TestCase):
     def test_simple_notification(self):
         responses.add(responses.POST, "http://example.com")
         group = self.create_group(message="Hello world")
-        event = self.create_event(group=group, message="Hello world", tags={"level": "warning"})
+        event = self.create_event_deprecated(
+            group=group, message="Hello world", tags={"level": "warning"}
+        )
         rule = Rule.objects.create(project=self.project, label="my rule")
         notification = Notification(event=event, rule=rule)
         self.project.update_option("webhooks:urls", "http://example.com")

--- a/tests/sentry/receivers/test_featureadoption.py
+++ b/tests/sentry/receivers/test_featureadoption.py
@@ -53,7 +53,7 @@ class FeatureAdoptionTest(TestCase):
         assert feature_complete.complete
 
     def test_first_event(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             project=self.project, platform="javascript", message="javascript error message"
         )
         first_event_received.send(project=self.project, event=event, sender=type(self.project))
@@ -67,7 +67,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="javascript", message="javascript error message"
         )
-        event = self.create_event(group=group, data={"platform": "javascript"})
+        event = self.create_event_deprecated(group=group, data={"platform": "javascript"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         js = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="javascript")
@@ -77,7 +77,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="python", message="python error message"
         )
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         python = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="python")
@@ -87,7 +87,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="node", message="node error message"
         )
-        event = self.create_event(group=group, data={"platform": "node"})
+        event = self.create_event_deprecated(group=group, data={"platform": "node"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         node = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="node")
@@ -97,7 +97,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="ruby", message="ruby error message"
         )
-        event = self.create_event(group=group, data={"platform": "ruby"})
+        event = self.create_event_deprecated(group=group, data={"platform": "ruby"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         ruby = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="ruby")
@@ -107,7 +107,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="java", message="java error message"
         )
-        event = self.create_event(group=group, data={"platform": "java"})
+        event = self.create_event_deprecated(group=group, data={"platform": "java"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         java = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="java")
@@ -117,7 +117,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="cocoa", message="cocoa error message"
         )
-        event = self.create_event(group=group, data={"platform": "cocoa"})
+        event = self.create_event_deprecated(group=group, data={"platform": "cocoa"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         cocoa = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="cocoa")
@@ -127,7 +127,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="objc", message="objc error message"
         )
-        event = self.create_event(group=group, data={"platform": "objc"})
+        event = self.create_event_deprecated(group=group, data={"platform": "objc"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         objc = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="objc")
@@ -135,7 +135,7 @@ class FeatureAdoptionTest(TestCase):
 
     def test_php(self):
         group = self.create_group(project=self.project, platform="php", message="php error message")
-        event = self.create_event(group=group, data={"platform": "php"})
+        event = self.create_event_deprecated(group=group, data={"platform": "php"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         php = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="php")
@@ -143,7 +143,7 @@ class FeatureAdoptionTest(TestCase):
 
     def test_go(self):
         group = self.create_group(project=self.project, platform="go", message="go error message")
-        event = self.create_event(group=group, data={"platform": "go"})
+        event = self.create_event_deprecated(group=group, data={"platform": "go"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         go = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="go")
@@ -153,7 +153,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="csharp", message="csharp error message"
         )
-        event = self.create_event(group=group, data={"platform": "csharp"})
+        event = self.create_event_deprecated(group=group, data={"platform": "csharp"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         csharp = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="csharp")
@@ -163,7 +163,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="perl", message="perl error message"
         )
-        event = self.create_event(group=group, data={"platform": "perl"})
+        event = self.create_event_deprecated(group=group, data={"platform": "perl"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         perl = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="perl")
@@ -173,7 +173,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="elixir", message="elixir error message"
         )
-        event = self.create_event(group=group, data={"platform": "elixir"})
+        event = self.create_event_deprecated(group=group, data={"platform": "elixir"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         elixir = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="elixir")
@@ -183,7 +183,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="cfml", message="cfml error message"
         )
-        event = self.create_event(group=group, data={"platform": "cfml"})
+        event = self.create_event_deprecated(group=group, data={"platform": "cfml"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         cfml = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="cfml")
@@ -193,7 +193,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="groovy", message="groovy error message"
         )
-        event = self.create_event(group=group, data={"platform": "groovy"})
+        event = self.create_event_deprecated(group=group, data={"platform": "groovy"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         groovy = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="groovy")
@@ -201,7 +201,7 @@ class FeatureAdoptionTest(TestCase):
 
     def test_csp(self):
         group = self.create_group(project=self.project, platform="csp", message="csp error message")
-        event = self.create_event(group=group, data={"platform": "csp"})
+        event = self.create_event_deprecated(group=group, data={"platform": "csp"})
         event_processed.send(project=self.project, event=event, sender=type(self.project))
 
         csp = FeatureAdoption.objects.get_by_slug(organization=self.organization, slug="csp")
@@ -347,7 +347,7 @@ class FeatureAdoptionTest(TestCase):
                     ]
                 }
             }"""
-        userless_event = self.create_event(
+        userless_event = self.create_event_deprecated(
             event_id="a", platform="javascript", data=json.loads(userless_payload)
         )
         event_processed.send(project=self.project, event=userless_event, sender=type(self.project))
@@ -442,7 +442,7 @@ class FeatureAdoptionTest(TestCase):
                     ]
                 }
             }"""
-        envless_event = self.create_event(
+        envless_event = self.create_event_deprecated(
             event_id="a", platform="javascript", data=json.loads(envless_payload)
         )
         event_processed.send(project=self.project, event=envless_event, sender=type(self.project))
@@ -485,7 +485,7 @@ class FeatureAdoptionTest(TestCase):
         group = self.create_group(
             project=self.project, platform="javascript", message="javascript error message"
         )
-        simple_event = self.create_event(group=group, platform="javascript")
+        simple_event = self.create_event_deprecated(group=group, platform="javascript")
         first_event_received.send(
             project=self.project, event=simple_event, sender=type(self.project)
         )

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -130,7 +130,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         now = timezone.now()
         project = self.create_project(first_event=now)
         project_created.send(project=project, user=self.user, sender=type(project))
-        event = self.create_event(
+        event = self.create_event_deprecated(
             project=project, platform="javascript", message="javascript error message"
         )
         first_event_received.send(project=project, event=event, sender=type(project))
@@ -153,7 +153,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         )
         assert second_task is not None
 
-        second_event = self.create_event(
+        second_event = self.create_event_deprecated(
             project=second_project, platform="python", message="python error message"
         )
         first_event_received.send(
@@ -250,7 +250,7 @@ class OrganizationOnboardingTaskTest(TestCase):
         user = self.create_user(email="test@example.org")
         project = self.create_project(first_event=now)
         second_project = self.create_project(first_event=now)
-        second_event = self.create_event(
+        second_event = self.create_event_deprecated(
             project=second_project, platform="python", message="python error message"
         )
         event = self.create_full_event(project=project)

--- a/tests/sentry/rules/conditions/test_level_event.py
+++ b/tests/sentry/rules/conditions/test_level_event.py
@@ -14,7 +14,7 @@ class LevelConditionTest(RuleTestCase):
         assert rule.render_label() == u"An event's level is equal to warning"
 
     def test_equals(self):
-        event = self.create_event(event_id="a" * 32, tags={"level": "info"})
+        event = self.create_event_deprecated(event_id="a" * 32, tags={"level": "info"})
         rule = self.get_rule(data={"match": MatchType.EQUAL, "level": "20"})
         self.assertPasses(rule, event)
 
@@ -22,7 +22,7 @@ class LevelConditionTest(RuleTestCase):
         self.assertDoesNotPass(rule, event)
 
     def test_greater_than(self):
-        event = self.create_event(event_id="a" * 32, tags={"level": "info"})
+        event = self.create_event_deprecated(event_id="a" * 32, tags={"level": "info"})
         rule = self.get_rule(data={"match": MatchType.GREATER_OR_EQUAL, "level": "40"})
         self.assertDoesNotPass(rule, event)
 
@@ -30,7 +30,7 @@ class LevelConditionTest(RuleTestCase):
         self.assertPasses(rule, event)
 
     def test_less_than(self):
-        event = self.create_event(event_id="a" * 32, tags={"level": "info"})
+        event = self.create_event_deprecated(event_id="a" * 32, tags={"level": "info"})
         rule = self.get_rule(data={"match": MatchType.LESS_OR_EQUAL, "level": "10"})
         self.assertDoesNotPass(rule, event)
 
@@ -38,12 +38,12 @@ class LevelConditionTest(RuleTestCase):
         self.assertPasses(rule, event)
 
     def test_without_tag(self):
-        event = self.create_event(event_id="a" * 32)
+        event = self.create_event_deprecated(event_id="a" * 32)
         rule = self.get_rule(data={"match": MatchType.EQUAL, "level": "30"})
         self.assertDoesNotPass(rule, event)
 
     def test_errors_with_invalid_level(self):
-        event = self.create_event(event_id="a" * 32, tags={"level": "foobar"})
+        event = self.create_event_deprecated(event_id="a" * 32, tags={"level": "foobar"})
         rule = self.get_rule(data={"match": MatchType.EQUAL, "level": "30"})
         self.assertDoesNotPass(rule, event)
 
@@ -57,8 +57,8 @@ class LevelConditionTest(RuleTestCase):
     # Specifically here to make sure the check is properly checking the event's level
     def test_differing_levels(self):
 
-        eevent = self.create_event(tags={"level": "error"})
-        wevent = self.create_event(tags={"level": "warning"})
+        eevent = self.create_event_deprecated(tags={"level": "error"})
+        wevent = self.create_event_deprecated(tags={"level": "warning"})
 
         assert wevent.event_id != eevent.event_id
         assert wevent.group.id == eevent.group.id

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -14,7 +14,7 @@ from sentry.rules.processor import EventCompatibilityProxy, RuleProcessor
 class RuleProcessorTest(TestCase):
     # this test relies on a few other tests passing
     def test_integrated(self):
-        event = self.create_event()
+        event = self.create_event_deprecated()
 
         action_data = {"id": "sentry.rules.actions.notify_event.NotifyEventAction"}
         condition_data = {"id": "sentry.rules.conditions.every_event.EveryEventCondition"}
@@ -55,7 +55,7 @@ class RuleProcessorTest(TestCase):
 
 class EventCompatibilityProxyTest(TestCase):
     def test_simple(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             message="biz baz",
             data={"logentry": {"message": "foo %s", "formatted": "foo bar", "params": ["bar"]}},
         )

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -43,7 +43,7 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.rules.processor.RuleProcessor")
     def test_rule_processor(self, mock_processor):
         group = self.create_group(project=self.project)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
 
         mock_callback = Mock()
         mock_futures = [Mock()]
@@ -63,7 +63,7 @@ class PostProcessGroupTest(TestCase):
     def test_group_refresh(self, mock_processor):
         group1 = self.create_group(project=self.project)
         group2 = self.create_group(project=self.project)
-        event = self.create_event(group=group1)
+        event = self.create_event_deprecated(group=group1)
 
         assert event.group_id == group1.id
         assert event.group == group1
@@ -86,7 +86,7 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.rules.processor.RuleProcessor")
     def test_invalidates_snooze(self, mock_processor):
         group = self.create_group(project=self.project, status=GroupStatus.IGNORED)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
         snooze = GroupSnooze.objects.create(group=group, until=timezone.now() - timedelta(hours=1))
 
         # Check for has_reappeared=False if is_new=True
@@ -111,7 +111,7 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.rules.processor.RuleProcessor")
     def test_maintains_valid_snooze(self, mock_processor):
         group = self.create_group(project=self.project)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
         snooze = GroupSnooze.objects.create(group=group, until=timezone.now() + timedelta(hours=1))
 
         post_process_group(
@@ -222,7 +222,7 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.tasks.servicehooks.process_service_hook")
     def test_service_hook_fires_on_new_event(self, mock_process_service_hook):
         group = self.create_group(project=self.project)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
 
         hook = self.create_service_hook(
             project=self.project,
@@ -242,7 +242,7 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.rules.processor.RuleProcessor")
     def test_service_hook_fires_on_alert(self, mock_processor, mock_process_service_hook):
         group = self.create_group(project=self.project)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
 
         mock_callback = Mock()
         mock_futures = [Mock()]
@@ -269,7 +269,7 @@ class PostProcessGroupTest(TestCase):
         self, mock_processor, mock_process_service_hook
     ):
         group = self.create_group(project=self.project)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
 
         mock_processor.return_value.apply.return_value = []
 
@@ -290,7 +290,7 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.tasks.servicehooks.process_service_hook")
     def test_service_hook_does_not_fire_without_event(self, mock_process_service_hook):
         group = self.create_group(project=self.project)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
 
         self.create_service_hook(
             project=self.project, organization=self.project.organization, actor=self.user, events=[]
@@ -306,7 +306,7 @@ class PostProcessGroupTest(TestCase):
     @patch("sentry.tasks.sentry_apps.process_resource_change_bound.delay")
     def test_processes_resource_change_task_on_new_group(self, delay):
         group = self.create_group(project=self.project)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
 
         post_process_group(
             event=event, is_new=True, is_regression=False, is_new_group_environment=False

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -141,10 +141,10 @@ class MergeGroupTest(TestCase):
     def test_merge_with_group_meta(self):
         project1 = self.create_project()
         group1 = self.create_group(project1)
-        event1 = self.create_event("a" * 32, group=group1, data={"foo": "bar"})
+        event1 = self.create_event_deprecated("a" * 32, group=group1, data={"foo": "bar"})
         project2 = self.create_project()
         group2 = self.create_group(project2)
-        event2 = self.create_event("b" * 32, group=group2, data={"foo": "baz"})
+        event2 = self.create_event_deprecated("b" * 32, group=group2, data={"foo": "baz"})
 
         GroupMeta.objects.create(group=event1.group, key="github:tid", value="134")
 
@@ -175,7 +175,7 @@ class MergeGroupTest(TestCase):
     def test_user_report_merge(self):
         project1 = self.create_project()
         group1 = self.create_group(project1)
-        event1 = self.create_event("a" * 32, group=group1, data={"foo": "bar"})
+        event1 = self.create_event_deprecated("a" * 32, group=group1, data={"foo": "bar"})
         project2 = self.create_project()
         group2 = self.create_group(project2)
         ur = UserReport.objects.create(project=project1, group=group1, event_id=event1.event_id)

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -81,7 +81,7 @@ class TestSendAlertEvent(TestCase):
     @patch("sentry.tasks.sentry_apps.safe_urlopen")
     def test_no_sentry_app(self, safe_urlopen):
         group = self.create_group(project=self.project)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
 
         send_alert_event(event, self.rule, 9999)
 
@@ -90,7 +90,7 @@ class TestSendAlertEvent(TestCase):
     @patch("sentry.tasks.sentry_apps.safe_urlopen")
     def test_no_sentry_app_in_future(self, safe_urlopen):
         group = self.create_group(project=self.project)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
         rule_future = RuleFuture(rule=self.rule, kwargs={})
 
         with self.tasks():
@@ -102,7 +102,7 @@ class TestSendAlertEvent(TestCase):
     def test_no_installation(self, safe_urlopen):
         sentry_app = self.create_sentry_app(organization=self.organization)
         group = self.create_group(project=self.project)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
         rule_future = RuleFuture(rule=self.rule, kwargs={"sentry_app": sentry_app})
 
         with self.tasks():
@@ -113,7 +113,7 @@ class TestSendAlertEvent(TestCase):
     @patch("sentry.tasks.sentry_apps.safe_urlopen", return_value=MockResponseInstance)
     def test_send_alert_event(self, safe_urlopen):
         group = self.create_group(project=self.project)
-        event = self.create_event(group=group)
+        event = self.create_event_deprecated(group=group)
         rule_future = RuleFuture(rule=self.rule, kwargs={"sentry_app": self.sentry_app})
 
         with self.tasks():
@@ -180,7 +180,7 @@ class TestProcessResourceChange(TestCase):
 
     def test_group_created_sends_webhook(self, safe_urlopen):
         issue = self.create_group(project=self.project)
-        event = self.create_event(group=issue)
+        event = self.create_event_deprecated(group=issue)
 
         with self.tasks():
             post_process_group(

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -222,7 +222,7 @@ class GetEventFileCommitters(CommitTestCase):
         )
 
     def test_java_sdk_path_mangling(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             group=self.group,
             message="Kaboom!",
             platform="java",
@@ -276,7 +276,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert result[0]["commits"][0]["id"] == "a" * 40
 
     def test_matching(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             group=self.group,
             message="Kaboom!",
             platform="python",
@@ -321,7 +321,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert result[0]["commits"][0]["id"] == "a" * 40
 
     def test_matching_case_insensitive(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             group=self.group,
             message="Kaboom!",
             platform="cpp",
@@ -358,7 +358,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert result[0]["commits"][0]["id"] == "a" * 40
 
     def test_not_matching(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             group=self.group,
             message="Kaboom!",
             platform="python",
@@ -400,7 +400,7 @@ class GetEventFileCommitters(CommitTestCase):
         assert len(result) == 0
 
     def test_no_commits(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             group=self.group,
             message="Kaboom!",
             platform="python",

--- a/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
+++ b/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
@@ -13,7 +13,7 @@ body_plain = "foo bar"
 class TestMailgunInboundWebhookView(TestCase):
     def setUp(self):
         super(TestMailgunInboundWebhookView, self).setUp()
-        self.event = self.create_event(event_id="a" * 32)
+        self.event = self.create_event_deprecated(event_id="a" * 32)
         self.mailto = group_id_to_email(self.group.pk)
 
     @mock.patch("sentry.web.frontend.mailgun_inbound_webhook.process_inbound_email")

--- a/tests/sentry_plugins/pagerduty/test_plugin.py
+++ b/tests/sentry_plugins/pagerduty/test_plugin.py
@@ -54,7 +54,9 @@ class PagerDutyPluginTest(PluginTestCase):
         self.plugin.set_option("service_key", "abcdef", self.project)
 
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        event = self.create_event(group=group, message="Hello world", tags={"level": "warning"})
+        event = self.create_event_deprecated(
+            group=group, message="Hello world", tags={"level": "warning"}
+        )
 
         rule = Rule.objects.create(project=self.project, label="my rule")
 

--- a/tests/sentry_plugins/pushover/test_plugin.py
+++ b/tests/sentry_plugins/pushover/test_plugin.py
@@ -40,7 +40,9 @@ class PushoverPluginTest(PluginTestCase):
         self.plugin.set_option("apikey", "ghijkl", self.project)
 
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        event = self.create_event(group=group, message="Hello world", tags={"level": "warning"})
+        event = self.create_event_deprecated(
+            group=group, message="Hello world", tags={"level": "warning"}
+        )
 
         rule = Rule.objects.create(project=self.project, label="my rule")
 
@@ -77,7 +79,9 @@ class PushoverPluginTest(PluginTestCase):
         self.plugin.set_option("retry", 30, self.project)
 
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        event = self.create_event(group=group, message="Hello world", tags={"level": "warning"})
+        event = self.create_event_deprecated(
+            group=group, message="Hello world", tags={"level": "warning"}
+        )
 
         rule = Rule.objects.create(project=self.project, label="my rule")
 

--- a/tests/sentry_plugins/segment/test_plugin.py
+++ b/tests/sentry_plugins/segment/test_plugin.py
@@ -27,7 +27,7 @@ class SegmentPluginTest(PluginTestCase):
         self.plugin.set_option("write_key", "secret-api-key", self.project)
 
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        event = self.create_event(
+        event = self.create_event_deprecated(
             group=group,
             data={
                 "sentry.interfaces.Exception": {"type": "ValueError", "value": "foo bar"},

--- a/tests/sentry_plugins/slack/test_plugin.py
+++ b/tests/sentry_plugins/slack/test_plugin.py
@@ -29,7 +29,9 @@ class SlackPluginTest(PluginTestCase):
         self.plugin.set_option("webhook", "http://example.com/slack", self.project)
 
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        event = self.create_event(group=group, message="Hello world", tags={"level": "warning"})
+        event = self.create_event_deprecated(
+            group=group, message="Hello world", tags={"level": "warning"}
+        )
 
         rule = Rule.objects.create(project=self.project, label="my rule")
 
@@ -64,7 +66,9 @@ class SlackPluginTest(PluginTestCase):
         self.plugin.set_option("exclude_culprit", True, self.project)
 
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        event = self.create_event(group=group, message="Hello world", tags={"level": "warning"})
+        event = self.create_event_deprecated(
+            group=group, message="Hello world", tags={"level": "warning"}
+        )
 
         rule = Rule.objects.create(project=self.project, label="my rule")
 
@@ -96,7 +100,9 @@ class SlackPluginTest(PluginTestCase):
         self.plugin.set_option("exclude_project", True, self.project)
 
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        event = self.create_event(group=group, message="Hello world", tags={"level": "warning"})
+        event = self.create_event_deprecated(
+            group=group, message="Hello world", tags={"level": "warning"}
+        )
 
         rule = Rule.objects.create(project=self.project, label="my rule")
 

--- a/tests/sentry_plugins/splunk/test_plugin.py
+++ b/tests/sentry_plugins/splunk/test_plugin.py
@@ -29,7 +29,7 @@ class SplunkPluginTest(PluginTestCase):
         self.plugin.set_option("instance", "https://splunk.example.com:8088", self.project)
 
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        event = self.create_event(
+        event = self.create_event_deprecated(
             group=group,
             data={
                 "sentry.interfaces.Exception": {"type": "ValueError", "value": "foo bar"},
@@ -54,7 +54,7 @@ class SplunkPluginTest(PluginTestCase):
         assert headers["Authorization"] == "Splunk 12345678-1234-1234-1234-1234567890AB"
 
     def test_http_payload(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             group=self.group,
             data={
                 "sentry.interfaces.Http": {
@@ -71,7 +71,7 @@ class SplunkPluginTest(PluginTestCase):
         assert result["request_referer"] == "http://example.com/foo"
 
     def test_error_payload(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             group=self.group,
             data={
                 "sentry.interfaces.Exception": {
@@ -87,7 +87,7 @@ class SplunkPluginTest(PluginTestCase):
         assert result["exception_value"] == "foo bar"
 
     def test_csp_payload(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             group=self.group,
             data={
                 "csp": {
@@ -108,7 +108,7 @@ class SplunkPluginTest(PluginTestCase):
         assert result["csp_effective_directive"] == "style-src"
 
     def test_user_payload(self):
-        event = self.create_event(
+        event = self.create_event_deprecated(
             group=self.group,
             data={
                 "sentry.interfaces.User": {

--- a/tests/sentry_plugins/victorops/test_plugin.py
+++ b/tests/sentry_plugins/victorops/test_plugin.py
@@ -55,7 +55,9 @@ class VictorOpsPluginTest(PluginTestCase):
         self.plugin.set_option("routing_key", "everyone", self.project)
 
         group = self.create_group(message="Hello world", culprit="foo.bar")
-        event = self.create_event(group=group, message="Hello world", tags={"level": "warning"})
+        event = self.create_event_deprecated(
+            group=group, message="Hello world", tags={"level": "warning"}
+        )
 
         rule = Rule.objects.create(project=self.project, label="my rule")
 
@@ -80,7 +82,9 @@ class VictorOpsPluginTest(PluginTestCase):
 
     def test_build_description_unicode(self):
         group = self.create_group(message=u"Message", culprit=u"foo.bar")
-        event = self.create_event(group=group, message=u"Messages", tags={u"level": u"error"})
+        event = self.create_event_deprecated(
+            group=group, message=u"Messages", tags={u"level": u"error"}
+        )
         event.interfaces = {
             u"Message": UnicodeTestInterface(u"abcd\xde\xb4", u"\xdc\xea\x80\x80abcd\xde\xb4")
         }

--- a/tests/snuba/api/endpoints/test_discover_query.py
+++ b/tests/snuba/api/endpoints/test_discover_query.py
@@ -24,7 +24,7 @@ class DiscoverQueryTest(APITestCase, SnubaTestCase):
 
         self.group = self.create_group(project=self.project, short_id=20)
 
-        self.event = self.create_event(
+        self.event = self.create_event_deprecated(
             group=self.group,
             platform="python",
             datetime=one_second_ago,
@@ -131,7 +131,7 @@ class DiscoverQueryTest(APITestCase, SnubaTestCase):
     def test_conditional_fields(self):
         with self.feature("organizations:discover"):
             one_second_ago = self.now - timedelta(seconds=1)
-            self.create_event(
+            self.create_event_deprecated(
                 group=self.group,
                 platform="javascript",
                 datetime=one_second_ago,
@@ -139,7 +139,7 @@ class DiscoverQueryTest(APITestCase, SnubaTestCase):
                 data={},
             )
 
-            self.create_event(
+            self.create_event_deprecated(
                 group=self.group,
                 platform="javascript",
                 datetime=one_second_ago,

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -19,8 +19,12 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         group = self.create_group()
-        event_1 = self.create_event(event_id="a" * 32, datetime=self.min_ago, group=group)
-        event_2 = self.create_event(event_id="b" * 32, datetime=self.min_ago, group=group)
+        event_1 = self.create_event_deprecated(
+            event_id="a" * 32, datetime=self.min_ago, group=group
+        )
+        event_2 = self.create_event_deprecated(
+            event_id="b" * 32, datetime=self.min_ago, group=group
+        )
 
         url = u"/api/0/issues/{}/events/".format(group.id)
         response = self.client.get(url, format="json")
@@ -35,10 +39,10 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         group = self.create_group()
-        event_1 = self.create_event(
+        event_1 = self.create_event_deprecated(
             event_id="a" * 32, datetime=self.min_ago, group=group, tags={"foo": "baz", "bar": "buz"}
         )
-        event_2 = self.create_event(
+        event_2 = self.create_event_deprecated(
             event_id="b" * 32,
             datetime=self.min_ago - timedelta(minutes=1),
             group=group,
@@ -96,8 +100,10 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         group = self.create_group()
-        event_1 = self.create_event(event_id="a" * 32, datetime=self.min_ago, group=group)
-        self.create_event(event_id="b" * 32, datetime=self.min_ago, group=group)
+        event_1 = self.create_event_deprecated(
+            event_id="a" * 32, datetime=self.min_ago, group=group
+        )
+        self.create_event_deprecated(event_id="b" * 32, datetime=self.min_ago, group=group)
 
         url = u"/api/0/issues/{}/events/?query={}".format(group.id, event_1.event_id)
         response = self.client.get(url, format="json")
@@ -110,11 +116,11 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         group = self.create_group()
-        event_1 = self.create_event(
+        event_1 = self.create_event_deprecated(
             event_id="a" * 32, datetime=self.min_ago, group=group, message="foo bar hello world"
         )
 
-        event_2 = self.create_event(
+        event_2 = self.create_event_deprecated(
             event_id="b" * 32, datetime=self.min_ago, group=group, message="this bar hello world "
         )
 
@@ -189,10 +195,12 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         project = self.create_project()
         group = self.create_group(project=project)
-        self.create_event(
+        self.create_event_deprecated(
             event_id="a" * 32, group=group, datetime=timezone.now() - timedelta(days=2)
         )
-        event_2 = self.create_event(event_id="b" * 32, datetime=self.min_ago, group=group)
+        event_2 = self.create_event_deprecated(
+            event_id="b" * 32, datetime=self.min_ago, group=group
+        )
 
         with self.options({"system.event-retention-days": 1}):
             response = self.client.get(u"/api/0/issues/{}/events/".format(group.id))
@@ -207,7 +215,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         group = self.create_group()
-        self.create_event(
+        self.create_event_deprecated(
             event_id="a" * 32,
             datetime=self.min_ago,
             group=group,
@@ -229,14 +237,14 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         first_seen = timezone.now() - timedelta(days=5)
 
         group = self.create_group(first_seen=first_seen)
-        event_1 = self.create_event(
+        event_1 = self.create_event_deprecated(
             event_id="a" * 32,
             datetime=first_seen,
             group=group,
             message="foo",
             tags={"logger": "python"},
         )
-        event_2 = self.create_event(
+        event_2 = self.create_event_deprecated(
             event_id="b" * 32,
             datetime=timezone.now() - timedelta(days=1),
             group=group,

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -26,8 +26,12 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         project2 = self.create_project()
         group = self.create_group(project=project)
         group2 = self.create_group(project=project2)
-        event_1 = self.create_event(event_id="a" * 32, group=group, datetime=self.min_ago)
-        event_2 = self.create_event(event_id="b" * 32, group=group2, datetime=self.min_ago)
+        event_1 = self.create_event_deprecated(
+            event_id="a" * 32, group=group, datetime=self.min_ago
+        )
+        event_2 = self.create_event_deprecated(
+            event_id="b" * 32, group=group2, datetime=self.min_ago
+        )
 
         url = reverse(
             "sentry-api-0-organization-events",
@@ -47,8 +51,12 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         project2 = self.create_project()
         group = self.create_group(project=project)
         group2 = self.create_group(project=project2)
-        event_1 = self.create_event(event_id="a" * 32, group=group, datetime=self.min_ago)
-        event_2 = self.create_event(event_id="b" * 32, group=group2, datetime=self.min_ago)
+        event_1 = self.create_event_deprecated(
+            event_id="a" * 32, group=group, datetime=self.min_ago
+        )
+        event_2 = self.create_event_deprecated(
+            event_id="b" * 32, group=group2, datetime=self.min_ago
+        )
 
         url = reverse(
             "sentry-api-0-organization-events",
@@ -65,10 +73,10 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
 
         project = self.create_project()
         group = self.create_group(project=project)
-        self.create_event(
+        self.create_event_deprecated(
             event_id="x" * 32, group=group, message="how to make fast", datetime=self.min_ago
         )
-        event_2 = self.create_event(
+        event_2 = self.create_event_deprecated(
             event_id="y" * 32, group=group, message="Delet the Data", datetime=self.min_ago
         )
 
@@ -88,10 +96,10 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
 
         project = self.create_project()
         group = self.create_group(project=project)
-        event_1 = self.create_event(
+        event_1 = self.create_event_deprecated(
             event_id="x" * 32, group=group, message="how to make fast", datetime=self.min_ago
         )
-        event_2 = self.create_event(
+        event_2 = self.create_event_deprecated(
             event_id="y" * 32,
             group=group,
             message="Delet the Data",
@@ -121,7 +129,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
 
         project = self.create_project()
         group = self.create_group(project=project)
-        self.create_event(
+        self.create_event_deprecated(
             event_id="x" * 32, group=group, message="how to make fast", datetime=self.min_ago
         )
 
@@ -166,9 +174,13 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         group = self.create_group(project=project)
         group2 = self.create_group(project=project2)
         group3 = self.create_group(project=project3)
-        event_1 = self.create_event(event_id="a" * 32, group=group, datetime=self.min_ago)
-        event_2 = self.create_event(event_id="b" * 32, group=group2, datetime=self.min_ago)
-        self.create_event(event_id="c" * 32, group=group3, datetime=self.min_ago)
+        event_1 = self.create_event_deprecated(
+            event_id="a" * 32, group=group, datetime=self.min_ago
+        )
+        event_2 = self.create_event_deprecated(
+            event_id="b" * 32, group=group2, datetime=self.min_ago
+        )
+        self.create_event_deprecated(event_id="c" * 32, group=group3, datetime=self.min_ago)
 
         base_url = reverse(
             "sentry-api-0-organization-events",
@@ -208,8 +220,10 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         project2 = self.create_project()
         group = self.create_group(project=project)
         group2 = self.create_group(project=project2)
-        event_1 = self.create_event(event_id="a" * 32, group=group, datetime=self.min_ago)
-        self.create_event(event_id="b" * 32, group=group2, datetime=self.day_ago)
+        event_1 = self.create_event_deprecated(
+            event_id="a" * 32, group=group, datetime=self.min_ago
+        )
+        self.create_event_deprecated(event_id="b" * 32, group=group2, datetime=self.day_ago)
 
         url = reverse(
             "sentry-api-0-organization-events",
@@ -229,8 +243,10 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         project2 = self.create_project()
         group = self.create_group(project=project)
         group2 = self.create_group(project=project2)
-        event_1 = self.create_event(event_id="a" * 32, group=group, datetime=self.min_ago)
-        self.create_event(event_id="b" * 32, group=group2, datetime=self.day_ago)
+        event_1 = self.create_event_deprecated(
+            event_id="a" * 32, group=group, datetime=self.min_ago
+        )
+        self.create_event_deprecated(event_id="b" * 32, group=group2, datetime=self.day_ago)
 
         now = timezone.now()
 
@@ -361,10 +377,10 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         project = self.create_project(organization=org, teams=[team])
         group = self.create_group(project=project)
 
-        event_1 = self.create_event(
+        event_1 = self.create_event_deprecated(
             event_id="a" * 32, group=group, datetime=self.min_ago, tags={"fruit": "apple"}
         )
-        event_2 = self.create_event(
+        event_2 = self.create_event_deprecated(
             event_id="b" * 32, group=group, datetime=self.min_ago, tags={"fruit": "orange"}
         )
 
@@ -392,17 +408,17 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         project = self.create_project(organization=org, teams=[team])
         group = self.create_group(project=project)
 
-        event_1 = self.create_event(
+        event_1 = self.create_event_deprecated(
             event_id="a" * 32, group=group, datetime=self.min_ago, tags={"sentry:release": "3.1.2"}
         )
-        event_2 = self.create_event(
+        event_2 = self.create_event_deprecated(
             event_id="b" * 32, group=group, datetime=self.min_ago, tags={"sentry:release": "4.1.2"}
         )
-        event_3 = self.create_event(
+        event_3 = self.create_event_deprecated(
             event_id="c" * 32, group=group, datetime=self.min_ago, user={"email": "foo@example.com"}
         )
 
-        event_4 = self.create_event(
+        event_4 = self.create_event_deprecated(
             event_id="d" * 32,
             group=group,
             datetime=self.min_ago,
@@ -450,10 +466,10 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         project = self.create_project(organization=org, teams=[team])
         group = self.create_group(project=project)
 
-        event_1 = self.create_event(
+        event_1 = self.create_event_deprecated(
             event_id="a" * 32, group=group, datetime=self.min_ago, user={"email": "foo@example.com"}
         )
-        event_2 = self.create_event(
+        event_2 = self.create_event_deprecated(
             event_id="b" * 32,
             group=group,
             datetime=self.min_ago,
@@ -506,7 +522,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
 
         project = self.create_project(organization=org, teams=[team])
         group = self.create_group(project=project)
-        self.create_event(
+        self.create_event_deprecated(
             event_id="a" * 32, group=group, message="best event", datetime=self.min_ago
         )
 

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -18,8 +18,8 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
         project2 = self.create_project()
         group = self.create_group(project=project)
         group2 = self.create_group(project=project2)
-        self.create_event(event_id="a" * 32, group=group, datetime=self.min_ago)
-        self.create_event(event_id="m" * 32, group=group2, datetime=self.min_ago)
+        self.create_event_deprecated(event_id="a" * 32, group=group, datetime=self.min_ago)
+        self.create_event_deprecated(event_id="m" * 32, group=group2, datetime=self.min_ago)
 
         url = reverse(
             "sentry-api-0-organization-events-meta",
@@ -35,10 +35,10 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
 
         project = self.create_project()
         group = self.create_group(project=project)
-        self.create_event(
+        self.create_event_deprecated(
             event_id="x" * 32, group=group, message="how to make fast", datetime=self.min_ago
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="m" * 32, group=group, message="Delet the Data", datetime=self.min_ago
         )
 

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -36,19 +36,19 @@ class OrganizationTagKeyValuesTest(APITestCase, SnubaTestCase):
         return self.create_group(project=self.project)
 
     def test_simple(self):
-        self.create_event(
+        self.create_event_deprecated(
             event_id="a" * 32, group=self.group, datetime=self.day_ago, tags={"fruit": "apple"}
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="b" * 32, group=self.group, datetime=self.min_ago, tags={"fruit": "orange"}
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="c" * 32,
             group=self.group,
             datetime=self.min_ago,
             tags={"some_tag": "some_value"},
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="d" * 32, group=self.group, datetime=self.min_ago, tags={"fruit": "orange"}
         )
 
@@ -66,25 +66,25 @@ class OrganizationTagKeyValuesTest(APITestCase, SnubaTestCase):
         assert response.data == {"detail": 'Invalid tag key format for "fr uit"'}
 
     def test_snuba_column(self):
-        self.create_event(
+        self.create_event_deprecated(
             event_id="a" * 32,
             group=self.group,
             datetime=self.day_ago,
             user={"email": "foo@example.com"},
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="b" * 32,
             group=self.group,
             datetime=self.min_ago,
             user={"email": "bar@example.com"},
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="c" * 32,
             group=self.group,
             datetime=before_now(seconds=10),
             user={"email": "baz@example.com"},
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="d" * 32,
             group=self.group,
             datetime=before_now(seconds=10),
@@ -96,25 +96,25 @@ class OrganizationTagKeyValuesTest(APITestCase, SnubaTestCase):
         )
 
     def test_release(self):
-        self.create_event(
+        self.create_event_deprecated(
             event_id="a" * 32,
             group=self.group,
             datetime=self.day_ago,
             tags={"sentry:release": "3.1.2"},
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="b" * 32,
             group=self.group,
             datetime=self.min_ago,
             tags={"sentry:release": "4.1.2"},
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="c" * 32,
             group=self.group,
             datetime=self.day_ago,
             tags={"sentry:release": "3.1.2"},
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="d" * 32,
             group=self.group,
             datetime=before_now(seconds=10),
@@ -123,16 +123,16 @@ class OrganizationTagKeyValuesTest(APITestCase, SnubaTestCase):
         self.run_test("release", expected=[("5.1.2", 1), ("4.1.2", 1), ("3.1.2", 2)])
 
     def test_user_tag(self):
-        self.create_event(
+        self.create_event_deprecated(
             event_id="a" * 32, group=self.group, datetime=self.day_ago, tags={"sentry:user": "1"}
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="b" * 32, group=self.group, datetime=self.min_ago, tags={"sentry:user": "2"}
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="c" * 32, group=self.group, datetime=self.day_ago, tags={"sentry:user": "1"}
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="d" * 32,
             group=self.group,
             datetime=before_now(seconds=10),
@@ -145,15 +145,15 @@ class OrganizationTagKeyValuesTest(APITestCase, SnubaTestCase):
         other_project = self.create_project(organization=other_org)
         other_group = self.create_group(project=other_project)
 
-        self.create_event(event_id="a" * 32, group=self.group, datetime=self.day_ago)
-        self.create_event(event_id="b" * 32, group=self.group, datetime=self.min_ago)
-        self.create_event(event_id="c" * 32, group=other_group, datetime=self.day_ago)
+        self.create_event_deprecated(event_id="a" * 32, group=self.group, datetime=self.day_ago)
+        self.create_event_deprecated(event_id="b" * 32, group=self.group, datetime=self.min_ago)
+        self.create_event_deprecated(event_id="c" * 32, group=other_group, datetime=self.day_ago)
         self.run_test("project.id", expected=[])
 
     def test_array_column(self):
-        self.create_event(event_id="a" * 32, group=self.group, datetime=self.day_ago)
-        self.create_event(event_id="b" * 32, group=self.group, datetime=self.min_ago)
-        self.create_event(event_id="c" * 32, group=self.group, datetime=self.day_ago)
+        self.create_event_deprecated(event_id="a" * 32, group=self.group, datetime=self.day_ago)
+        self.create_event_deprecated(event_id="b" * 32, group=self.group, datetime=self.min_ago)
+        self.create_event_deprecated(event_id="c" * 32, group=self.group, datetime=self.day_ago)
         self.run_test("error.type", expected=[])
 
     def test_no_projects(self):

--- a/tests/snuba/api/endpoints/test_organization_tags.py
+++ b/tests/snuba/api/endpoints/test_organization_tags.py
@@ -22,16 +22,16 @@ class OrganizationTagsTest(APITestCase, SnubaTestCase):
         project = self.create_project(organization=org, teams=[team])
         group = self.create_group(project=project)
 
-        self.create_event(
+        self.create_event_deprecated(
             event_id="a" * 32, group=group, datetime=self.min_ago, tags={"fruit": "apple"}
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="b" * 32, group=group, datetime=self.min_ago, tags={"fruit": "orange"}
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="c" * 32, group=group, datetime=self.min_ago, tags={"some_tag": "some_value"}
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="d" * 32, group=group, datetime=self.min_ago, tags={"fruit": "orange"}
         )
 

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -17,8 +17,12 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
 
         project = self.create_project()
         group = self.create_group(project=project)
-        event_1 = self.create_event(event_id="a" * 32, group=group, datetime=self.min_ago)
-        event_2 = self.create_event(event_id="b" * 32, group=group, datetime=self.min_ago)
+        event_1 = self.create_event_deprecated(
+            event_id="a" * 32, group=group, datetime=self.min_ago
+        )
+        event_2 = self.create_event_deprecated(
+            event_id="b" * 32, group=group, datetime=self.min_ago
+        )
 
         url = reverse(
             "sentry-api-0-project-events",
@@ -37,10 +41,10 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
 
         project = self.create_project()
         group = self.create_group(project=project)
-        self.create_event(
+        self.create_event_deprecated(
             event_id="x" * 32, group=group, message="how to make fast", datetime=self.min_ago
         )
-        event_2 = self.create_event(
+        event_2 = self.create_event_deprecated(
             event_id="y" * 32, group=group, message="Delet the Data", datetime=self.min_ago
         )
 
@@ -61,8 +65,10 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
         project = self.create_project()
         group = self.create_group(project=project)
         two_days_ago = timezone.now() - timedelta(days=2)
-        self.create_event(event_id="c" * 32, group=group, datetime=two_days_ago)
-        event_2 = self.create_event(event_id="d" * 32, group=group, datetime=self.min_ago)
+        self.create_event_deprecated(event_id="c" * 32, group=group, datetime=two_days_ago)
+        event_2 = self.create_event_deprecated(
+            event_id="d" * 32, group=group, datetime=self.min_ago
+        )
 
         with self.options({"system.event-retention-days": 1}):
             url = reverse(

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -289,7 +289,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         project = self.project
         release = Release.objects.create(organization=project.organization, version="12345")
         release.add_project(project)
-        self.create_event(
+        self.create_event_deprecated(
             group=self.group, datetime=self.min_ago, tags={"sentry:release": release.version}
         )
 

--- a/tests/snuba/api/endpoints/test_project_tags.py
+++ b/tests/snuba/api/endpoints/test_project_tags.py
@@ -21,10 +21,10 @@ class ProjectTagsTest(APITestCase, SnubaTestCase):
 
         project = self.create_project(organization=org, teams=[team])
         group = self.create_group(project=project)
-        self.create_event(
+        self.create_event_deprecated(
             event_id="a" * 32, group=group, datetime=self.min_ago, tags={"foo": "oof", "bar": "rab"}
         )
-        self.create_event(
+        self.create_event_deprecated(
             event_id="b" * 32, group=group, datetime=self.min_ago, tags={"bar": "rab2"}
         )
 


### PR DESCRIPTION
It hasn't been clear to everyone that this method is deprecated, let's
name it accordingly.