### PR TITLE
ref: revise setup.py, remove stray license headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,4 @@
 #!/usr/bin/env python
-"""
-Sentry
-======
-
-Sentry is a realtime event logging and aggregation platform. It specializes
-in monitoring errors and extracting all the information needed to do a proper
-post-mortem without any of the hassle of the standard user feedback loop.
-
-Sentry is a Server
-------------------
-
-The Sentry package, at its core, is just a simple server and web UI. It will
-handle authentication clients (such as `the Python one
-<https://github.com/getsentry/sentry-python>`_)
-and all of the logic behind storage and aggregation.
-
-That said, Sentry is not limited to Python. The primary implementation is in
-Python, but it contains a full API for sending events from any language, in
-any application.
-
-:copyright: (c) 2011-2019 by the Sentry Team, see AUTHORS for more details.
-:license: BSL-1.1, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import sys

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ Python, but it contains a full API for sending events from any language, in
 any application.
 
 :copyright: (c) 2011-2019 by the Sentry Team, see AUTHORS for more details.
-:license: BSL, see LICENSE for more details.
+:license: BSL-1.1, see LICENSE for more details.
 """
 from __future__ import absolute_import
 

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup(
     packages=find_packages("src"),
     zip_safe=False,
     install_requires=install_requires,
-    extras_require={"dev": dev_requires, "postgres": []},
+    extras_require={"dev": dev_requires},
     cmdclass=cmdclass,
     license="BSL-1.1",
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -51,16 +51,6 @@ from sentry.utils.distutils import (
 # The version of sentry
 VERSION = "10.0.0.dev0"
 
-# Hack to prevent stupid "TypeError: 'NoneType' object is not callable" error
-# in multiprocessing/util.py _exit_function when running `python
-# setup.py test` (see
-# http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html)
-for m in ("multiprocessing", "billiard"):
-    try:
-        __import__(m)
-    except ImportError:
-        pass
-
 IS_LIGHT_BUILD = os.environ.get("SENTRY_LIGHT_BUILD") == "1"
 
 # we use pip requirements files to improve Docker layer caching

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,13 @@ any application.
 """
 from __future__ import absolute_import
 
-# if sys.version_info[:2] != (2, 7):
-#     print 'Error: Sentry requires Python 2.7'
-#     sys.exit(1)
+import sys
+
+if sys.version_info[:2] != (2, 7):
+    sys.exit("Error: Sentry requires Python 2.7.")
 
 import os
 import os.path
-import sys
 
 from distutils.command.build import build as BuildCommand
 from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ from setuptools.command.develop import develop as DevelopCommand
 
 ROOT = os.path.realpath(os.path.join(os.path.dirname(sys.modules["__main__"].__file__)))
 
-# Add Sentry to path so we can import distutils
+# add sentry to path so we can import distutils
+# XXX: consequentially, this means sentry must be pip installed with --no-use-pep517
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from sentry.utils.distutils import (
@@ -48,12 +49,8 @@ from sentry.utils.distutils import (
     BuildJsSdkRegistryCommand,
 )
 
-# The version of sentry
 VERSION = "10.0.0.dev0"
-
 IS_LIGHT_BUILD = os.environ.get("SENTRY_LIGHT_BUILD") == "1"
-
-# we use pip requirements files to improve Docker layer caching
 
 
 def get_requirements(env):

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ That said, Sentry is not limited to Python. The primary implementation is in
 Python, but it contains a full API for sending events from any language, in
 any application.
 
-:copyright: (c) 2011-2014 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
+:copyright: (c) 2011-2019 by the Sentry Team, see AUTHORS for more details.
+:license: BSL, see LICENSE for more details.
 """
 from __future__ import absolute_import
 

--- a/src/sentry/conf/urls.py
+++ b/src/sentry/conf/urls.py
@@ -1,12 +1,3 @@
-"""
-sentry.conf.urls
-~~~~~~~~~~~~~~~~
-
-These are additional urls used by the Sentry-provided web server
-
-:copyright: (c) 2012 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 from django.conf import settings

--- a/src/sentry/management/commands/serve_normalize.py
+++ b/src/sentry/management/commands/serve_normalize.py
@@ -1,9 +1,3 @@
-"""
-sentry.management.commands.serve_normalize
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-:copyright: (c) 2018 by the Sentry Team, see AUTHORS for more details.
-:license: BSD, see LICENSE for more details.
-"""
 from __future__ import absolute_import, print_function
 
 import SocketServer

--- a/src/sentry_plugins/freight/plugin.py
+++ b/src/sentry_plugins/freight/plugin.py
@@ -1,10 +1,3 @@
-"""
-freight.plugin
-~~~~~~~~~~~~~~~~~~~~~
-
-:copyright: (c) 2015 by Sentry Team, see AUTHORS for more details.
-:license: Apache 2.0, see LICENSE for more details.
-"""
 from __future__ import absolute_import
 
 import json


### PR DESCRIPTION
Just a few small things, see commit messages.

Also removed some stray license headers missed by https://github.com/getsentry/sentry/pull/14095.