### PR TITLE
fix(search) - tag value performance

### DIFF
--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -4,6 +4,7 @@ from sentry import tagstore
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.utils import get_date_range_from_params
 from sentry.api.serializers import serialize
 from sentry.models import Environment
 
@@ -38,12 +39,16 @@ class ProjectTagKeyValuesEndpoint(ProjectEndpoint, EnvironmentMixin):
         except tagstore.TagKeyNotFound:
             raise ResourceDoesNotExist
 
+        start, end = get_date_range_from_params(request.GET)
+
         paginator = tagstore.get_tag_value_paginator(
             project.id,
             environment_id,
             tagkey.key,
             query=request.GET.get("query"),
             order_by="-last_seen",
+            start=start,
+            end=end,
         )
 
         return self.paginate(

--- a/src/sentry/api/endpoints/project_tagkey_values.py
+++ b/src/sentry/api/endpoints/project_tagkey_values.py
@@ -45,10 +45,10 @@ class ProjectTagKeyValuesEndpoint(ProjectEndpoint, EnvironmentMixin):
             project.id,
             environment_id,
             tagkey.key,
-            query=request.GET.get("query"),
-            order_by="-last_seen",
             start=start,
             end=end,
+            query=request.GET.get("query"),
+            order_by="-last_seen",
         )
 
         return self.paginate(

--- a/src/sentry/static/sentry/app/actionCreators/tags.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/tags.jsx
@@ -87,7 +87,7 @@ export function fetchOrganizationTags(api, orgId, projectIds = null) {
  * Fetch tag values for an organization.
  * The `projectIds` argument can be used to subset projects.
  */
-export function fetchTagValues(api, orgId, tagKey, search = null, projectIds = null) {
+export function fetchTagValues(api, orgId, tagKey, search = null, projectIds = null, endpointParams = null) {
   const url = `/organizations/${orgId}/tags/${tagKey}/values/`;
 
   const query = {};
@@ -96,6 +96,17 @@ export function fetchTagValues(api, orgId, tagKey, search = null, projectIds = n
   }
   if (projectIds) {
     query.project = projectIds;
+  }
+  if (endpointParams) {
+    if (endpointParams.start) {
+      query.start = endpointParams.start;
+    }
+    if (endpointParams.end) {
+      query.end = endpointParams.end;
+    }
+    if (endpointParams.statsPeriod) {
+      query.statsPeriod = endpointParams.statsPeriod;
+    }
   }
 
   return api.requestPromise(url, {

--- a/src/sentry/static/sentry/app/actionCreators/tags.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/tags.jsx
@@ -87,7 +87,14 @@ export function fetchOrganizationTags(api, orgId, projectIds = null) {
  * Fetch tag values for an organization.
  * The `projectIds` argument can be used to subset projects.
  */
-export function fetchTagValues(api, orgId, tagKey, search = null, projectIds = null, endpointParams = null) {
+export function fetchTagValues(
+  api,
+  orgId,
+  tagKey,
+  search = null,
+  projectIds = null,
+  endpointParams = null
+) {
   const url = `/organizations/${orgId}/tags/${tagKey}/values/`;
 
   const query = {};

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -36,6 +36,7 @@ import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams'
 
 import SearchDropdown from './searchDropdown';
 
@@ -484,12 +485,11 @@ class SmartSearchBar extends React.Component {
 
       try {
         const {location} = this.context.router;
-        const endpointParams = {};
-
-        if (location && location.query){
-          endpointParams.statsPeriod = location.query.statsPeriod ? location.query.statsPeriod : "14d";
-          endpointParams.start = location.query.start ? getUtcDateString(location.query.start) : null;
-          endpointParams.end = location.query.end ? getUtcDateString(location.query.end) : null;
+        const {start, end, statsPeriod} = getParams(location.query);
+        const endpointParams = {
+          statsPeriod: statsPeriod,
+          start: start,
+          end: end
         }
 
         const values = await this.props.onGetTagValues(tag, query, endpointParams);
@@ -504,6 +504,7 @@ class SmartSearchBar extends React.Component {
           };
         });
       } catch (err) {
+        console.log(err);
         this.setState({loading: false});
         Sentry.captureException(err);
 

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -504,7 +504,6 @@ class SmartSearchBar extends React.Component {
           };
         });
       } catch (err) {
-        console.log(err);
         this.setState({loading: false});
         Sentry.captureException(err);
 

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -15,6 +15,7 @@ import {
 } from 'app/constants';
 import {analytics} from 'app/utils/analytics';
 import {callIfFunction} from 'app/utils/callIfFunction';
+import {getUtcDateString} from 'app/utils/dates';
 import {defined} from 'app/utils';
 import {
   fetchRecentSearches,
@@ -482,7 +483,16 @@ class SmartSearchBar extends React.Component {
       });
 
       try {
-        const values = await this.props.onGetTagValues(tag, query);
+        const {location} = this.context.router;
+        const endpointParams = {};
+
+        if (location && location.query){
+          endpointParams.statsPeriod = location.query.statsPeriod ? location.query.statsPeriod : "14d";
+          endpointParams.start = location.query.start ? getUtcDateString(location.query.start) : null;
+          endpointParams.end = location.query.end ? getUtcDateString(location.query.end) : null;
+        }
+
+        const values = await this.props.onGetTagValues(tag, query, endpointParams);
         this.setState({loading: false});
         return values.map(value => {
           // Wrap in quotes if there is a space

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -15,7 +15,6 @@ import {
 } from 'app/constants';
 import {analytics} from 'app/utils/analytics';
 import {callIfFunction} from 'app/utils/callIfFunction';
-import {getUtcDateString} from 'app/utils/dates';
 import {defined} from 'app/utils';
 import {
   fetchRecentSearches,
@@ -36,7 +35,7 @@ import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
-import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams'
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 
 import SearchDropdown from './searchDropdown';
 
@@ -485,12 +484,7 @@ class SmartSearchBar extends React.Component {
 
       try {
         const {location} = this.context.router;
-        const {start, end, statsPeriod} = getParams(location.query);
-        const endpointParams = {
-          statsPeriod: statsPeriod,
-          start: start,
-          end: end
-        }
+        const endpointParams = getParams(location.query);
 
         const values = await this.props.onGetTagValues(tag, query, endpointParams);
         this.setState({loading: false});

--- a/src/sentry/static/sentry/app/views/events/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.jsx
@@ -66,10 +66,10 @@ class SearchBar extends React.PureComponent {
    * with data when ready
    */
   getEventFieldValues = memoize(
-    (tag, query) => {
+    (tag, query, endpointParams) => {
       const {api, organization, projectIds} = this.props;
 
-      return fetchTagValues(api, organization.slug, tag.key, query, projectIds).then(
+      return fetchTagValues(api, organization.slug, tag.key, query, projectIds, endpointParams).then(
         results =>
           flatten(results.filter(({name}) => defined(name)).map(({name}) => name)),
         () => {

--- a/src/sentry/static/sentry/app/views/events/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.jsx
@@ -69,7 +69,14 @@ class SearchBar extends React.PureComponent {
     (tag, query, endpointParams) => {
       const {api, organization, projectIds} = this.props;
 
-      return fetchTagValues(api, organization.slug, tag.key, query, projectIds, endpointParams).then(
+      return fetchTagValues(
+        api,
+        organization.slug,
+        tag.key,
+        query,
+        projectIds,
+        endpointParams
+      ).then(
         results =>
           flatten(results.filter(({name}) => defined(name)).map(({name}) => name)),
         () => {

--- a/src/sentry/static/sentry/app/views/issueList/overview.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.jsx
@@ -597,8 +597,9 @@ const IssueListOverview = createReactClass({
   tagValueLoader(key, search) {
     const {orgId} = this.props.params;
     const projectIds = this.getGlobalSearchProjects().map(p => p.id);
+    const endpointParams = this.getEndpointParams();
 
-    return fetchTagValues(this.api, orgId, key, search, projectIds);
+    return fetchTagValues(this.api, orgId, key, search, projectIds, endpointParams);
   },
 
   render() {

--- a/src/sentry/static/sentry/app/views/issueList/searchBar.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/searchBar.jsx
@@ -88,9 +88,9 @@ class IssueListSearchBar extends React.Component {
    * with data when ready
    */
   getTagValues = (tag, query) => {
-    const {tagValueLoader} = this.props;
+    const {tagValueLoader, projectIds} = this.props;
 
-    return tagValueLoader(tag.key, query).then(
+    return tagValueLoader(tag.key, query, projectIds).then(
       values => values.map(({value}) => value),
       () => {
         throw new Error('Unable to fetch project tags');

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -564,12 +564,21 @@ class SnubaTagStorage(TagStorage):
         return defaultdict(int, {k: v for k, v in result.items() if v})
 
     def get_tag_value_paginator(
-        self, project_id, environment_id, key, query=None, order_by="-last_seen"
+        self,
+        project_id,
+        environment_id,
+        key,
+        start=None,
+        end=None,
+        query=None,
+        order_by="-last_seen",
     ):
         return self.get_tag_value_paginator_for_projects(
             get_project_list(project_id),
             [environment_id] if environment_id else None,
             key,
+            start=start,
+            end=end,
             query=query,
             order_by=order_by,
         )

--- a/tests/js/spec/views/events/searchBar.spec.jsx
+++ b/tests/js/spec/views/events/searchBar.spec.jsx
@@ -85,7 +85,7 @@ describe('SearchBar', function() {
 
     expect(tagValuesMock).toHaveBeenCalledWith(
       '/organizations/org-slug/tags/gpu/values/',
-      expect.objectContaining({query: {project: [1, 2]}})
+      expect.objectContaining({query: {project: [1, 2], statsPeriod: '14d'}})
     );
 
     await tick();
@@ -116,7 +116,7 @@ describe('SearchBar', function() {
 
     expect(tagValuesMock).toHaveBeenCalledWith(
       '/organizations/org-slug/tags/gpu/values/',
-      expect.objectContaining({query: {project: [1, 2]}})
+      expect.objectContaining({query: {project: [1, 2], statsPeriod: '14d'}})
     );
 
     await tick();
@@ -191,7 +191,7 @@ describe('SearchBar', function() {
 
     expect(tagValuesMock).toHaveBeenCalledWith(
       '/organizations/org-slug/tags/gpu/values/',
-      expect.objectContaining({query: {project: [1, 2]}})
+      expect.objectContaining({query: {project: [1, 2], statsPeriod: '14d'}})
     );
     selectFirstAutocompleteItem(wrapper);
     expect(wrapper.find('input').prop('value')).toBe('!gpu:*"Nvidia 1080ti" ');

--- a/tests/sentry/api/endpoints/test_project_tagkey_values.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_values.py
@@ -60,3 +60,70 @@ class ProjectTagKeyValuesTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200
         assert len(response.data) == 0
+
+    def test_statperiod_query(self):
+        project = self.create_project()
+        self.store_event(
+            data={"tags": {"foo": "bar"}, "timestamp": iso_format(before_now(days=15))},
+            project_id=project.id,
+        )
+
+        self.login_as(user=self.user)
+
+        url = reverse(
+            "sentry-api-0-project-tagkey-values",
+            kwargs={
+                "organization_slug": project.organization.slug,
+                "project_slug": project.slug,
+                "key": "foo",
+            },
+        )
+        response = self.client.get(url + "?query=bar&statsPeriod=14d")
+
+        assert response.status_code == 200
+        assert len(response.data) == 0
+
+        response = self.client.get(url + "?query=bar&statsPeriod=30d")
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["value"] == "bar"
+
+    def test_start_end_query(self):
+        project = self.create_project()
+        self.store_event(
+            data={"tags": {"foo": "bar"}, "timestamp": iso_format(before_now(days=15))},
+            project_id=project.id,
+        )
+
+        self.login_as(user=self.user)
+
+        url = reverse(
+            "sentry-api-0-project-tagkey-values",
+            kwargs={
+                "organization_slug": project.organization.slug,
+                "project_slug": project.slug,
+                "key": "foo",
+            },
+        )
+
+        response = self.client.get(
+            url
+            + "?query=bar&start={}&end={}".format(
+                iso_format(before_now(days=14)), iso_format(before_now(seconds=1))
+            )
+        )
+
+        assert response.status_code == 200
+        assert len(response.data) == 0
+
+        response = self.client.get(
+            url
+            + "?query=bar&start={}&end={}".format(
+                iso_format(before_now(days=16)), iso_format(before_now(days=14))
+            )
+        )
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["value"] == "bar"

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -451,6 +451,42 @@ class TagStorageTest(TestCase, SnubaTestCase):
             )
         ]
 
+    def test_get_tag_value_paginator_with_dates(self):
+        from sentry.tagstore.types import TagValue
+
+        day_ago = self.now - timedelta(days=1)
+        two_days_ago = self.now - timedelta(days=2)
+        assert list(
+            self.ts.get_tag_value_paginator(
+                self.proj1.id, self.proj1env1.id, "sentry:user", start=day_ago, end=self.now
+            ).get_result(10)
+        ) == [
+            TagValue(
+                key="sentry:user",
+                value="id:user1",
+                times_seen=2,
+                first_seen=self.now - timedelta(seconds=2),
+                last_seen=self.now - timedelta(seconds=1),
+            ),
+            TagValue(
+                key="sentry:user",
+                value="id:user2",
+                times_seen=1,
+                first_seen=self.now - timedelta(seconds=2),
+                last_seen=self.now - timedelta(seconds=2),
+            ),
+        ]
+
+        day_ago = self.now - timedelta(days=1)
+        assert (
+            list(
+                self.ts.get_tag_value_paginator(
+                    self.proj1.id, self.proj1env1.id, "sentry:user", start=two_days_ago, end=day_ago
+                ).get_result(10)
+            )
+            == []
+        )
+
     def test_get_group_tag_value_iter(self):
         from sentry.tagstore.types import GroupTagValue
 


### PR DESCRIPTION
- Currently when a user enters a tag into a search, as they type the tags value we try to auto complete the tag value for them. As they type the API call currently doesn't include a timeframe, which results in us querying 90 days by default.
- This adds a timeframe to these queries which should help improve the performance of our queries.