### PR TITLE
ref(apm): Update names of queries generated by "Search by trace" and "View Children"

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -128,7 +128,7 @@ class SpanDetail extends React.Component<Props, State> {
 
     const eventView = EventView.fromSavedQuery({
       id: undefined,
-      name: t('Transactions'),
+      name: `Child transactions of span ${span.span_id}`,
       fields: [
         'transaction',
         'project',
@@ -170,7 +170,7 @@ class SpanDetail extends React.Component<Props, State> {
 
     const eventView = EventView.fromSavedQuery({
       id: undefined,
-      name: t('Transactions'),
+      name: `Transactions for trace ${span.trace_id}`,
       fields: [
         'transaction',
         'project',

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -128,7 +128,7 @@ class SpanDetail extends React.Component<Props, State> {
 
     const eventView = EventView.fromSavedQuery({
       id: undefined,
-      name: `Child transactions of span ${span.span_id}`,
+      name: `Children from Span ID ${span.span_id}`,
       fields: [
         'transaction',
         'project',
@@ -170,7 +170,7 @@ class SpanDetail extends React.Component<Props, State> {
 
     const eventView = EventView.fromSavedQuery({
       id: undefined,
-      name: `Transactions for trace ${span.trace_id}`,
+      name: `Transactions with Trace ID ${span.trace_id}`,
       fields: [
         'transaction',
         'project',


### PR DESCRIPTION
When clicking on "View Children" button in the trace view, we establish the query name to be "Child transactions of span \<span id\>":

<img width="1079" alt="Screen Shot 2019-12-18 at 8 32 30 PM" src="https://user-images.githubusercontent.com/139499/71137509-68038300-21d6-11ea-82fe-eb3c627ab425.png">

When clicking on "Search by trace" button in the trace view, we establish the query name to be "Transactions for trace \<trace id\>":

<img width="1071" alt="Screen Shot 2019-12-18 at 8 27 11 PM" src="https://user-images.githubusercontent.com/139499/71137510-689c1980-21d6-11ea-8393-194713d7a25d.png">
