### PR TITLE
fix: sentry now installs via pep517-enabled pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
     # PIP_VERSION causes issues because: https://github.com/pypa/pip/issues/4528
     # Note: this has to be synced with the pip version in the Makefile.
     - PYTHON_PIP_VERSION=19.2.3
-    - PIP_USE_PEP517=off
     - PIP_DISABLE_PIP_VERSION_CHECK=on
     - PIP_QUIET=1
     - SENTRY_LIGHT_BUILD=1

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 PIP := LDFLAGS="$(LDFLAGS)" python -m pip
 # Note: this has to be synced with the pip version in .travis.yml.
 PIP_VERSION := 19.2.3
-PIP_OPTS := --no-use-pep517 --disable-pip-version-check
+PIP_OPTS := --disable-pip-version-check
 WEBPACK := NODE_ENV=production ./bin/yarn webpack
 YARN := ./bin/yarn
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -101,7 +101,6 @@ COPY --from=sdist /usr/local/bin/gosu /usr/local/bin/tini /usr/local/bin/
 # Sane defaults for pip
 ENV PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PIP_USE_PEP517=off \
     # Sentry config params
     SENTRY_CONF=/etc/sentry \
     SENTRY_FILESTORE_DIR=/var/lib/sentry/files \

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ from setuptools import setup, find_packages
 from setuptools.command.sdist import sdist as SDistCommand
 from setuptools.command.develop import develop as DevelopCommand
 
-ROOT = os.path.realpath(os.path.join(os.path.dirname(sys.modules["__main__"].__file__)))
+ROOT = os.path.dirname(os.path.abspath(__file__))
 
 # Add Sentry to path so we can import distutils
 sys.path.insert(0, os.path.join(ROOT, "src"))


### PR DESCRIPTION
This fixes our setup.py so that we don't need to pip install with `--no-use-pep517` anymore. Everything still works with `--no-use-pep517` though, so this can be immediately merged. I will follow up with PRs to restore pep517-enabled pip everywhere, when I have the time.

Here's a hopefully correct recap of what went down before I started working on this; some of the stuff I said in https://github.com/getsentry/getsentry/pull/3074 and https://github.com/getsentry/getsentry/pull/3098 isn't accurate, in retrospect.

1. We introduce a `pyproject.toml` to configure black.
2. For pip 19+, the presence of this file triggers a pep517 build backend. We didn't specify a `build-system` config section, in which case the `build-backend` key under this section defaults to the pep517-compliant `setuptools.build_meta` from `setuptools>=40.2.0`. (reference: https://github.com/pypa/pip/pull/5743/files#diff-63ae2beb4199cfa5d3953329544eb9fdR130)
3. However, this breaks pip installs, and me failing to completely understand the issue or finding a fix for the root cause in a reasonable amount of time results in discovering and slapping `--no-use-pep517` everywhere. Disabling PEP 517 means we get the legacy behavior of directly executing setup.py, which works.
4. Everything is fine, but `--no-use-pep517` trips some people up, and also I get bored and think the whole situation isn't ideal, so I try again.

Okay, so. A sneaky little portion of PEP 517 says:

> If the pyproject.toml file is absent, or the build-backend key is missing, the source tree is not using this specification, and tools should revert to the legacy behaviour of running setup.py (either directly, or by implicitly invoking the setuptools.build_meta:__legacy__ backend).

I really thought this was it, because it was added in https://github.com/pypa/setuptools/issues/1642 following extensive discussion from https://github.com/pypa/pip/issues/6163. It's supposed to emulate directly executing setup.py. So I removed `--no-use-pep517` and explicitly defined

```
[build-system]
requires = ["setuptools>=40.2.0", "wheel"]
build-backend = "setuptools.build_meta:__legacy__"
```

Which got this legacy backend to run, but I ran into the same exact issue. So that implies that the emulation breaks with our `setup.py`... or does it?

Perhaps it's got to do with not actually directly executing setup.py? What are the consequences of that? Oh, look at how we calculate a part of the path to sentry to inject into sys.path so we can import `sentry.utils.distutils`:

	ROOT = os.path.realpath(os.path.join(os.path.dirname(sys.modules["__main__"].__file__)))

**The crux of it is `sys.modules["__main__"]`. When pip goes on its pep517 code path (triggered by pyproject.toml or `--use-pep517`), it actually subprocesses out to `_vendor/pep517/_in_process.py`,** which results in that being set to `<module '__main__' from '/Users/joshua.li/.local/share/virtualenvs/sentry2/lib/python2.7/site-packages/pip/_vendor/pep517/_in_process.py'>`. And then the old `ImportError: No module named sentry.utils.distutils` naturally follows.

Changing it to `os.path.dirname(os.path.abspath(__file__))` is more correct and fixes pip installs, whether or not pep517 is disabled, and regardless of `setuptools.build_meta` or `setuptools.build_meta:__legacy__` build backends. 🎉 🎉 🎉 