### PR TITLE
feat(ui): Use combined rules endpoint for new Alert Rules

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertRulesNew.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/projectAlertRulesNew.tsx
@@ -25,17 +25,15 @@ type Props = {organization: Organization} & RouteComponentProps<
   AsyncView['props'];
 
 type State = {
-  issueRules: IssueAlertRule[];
-  metricRules: SavedIncidentRule[];
+  rules: Array<
+    ({type: 'alert_rule'} & IssueAlertRule) | ({type: 'rule'} & SavedIncidentRule)
+  >;
 } & AsyncView['state'];
 
 class ProjectAlertRules extends AsyncView<Props, State> {
   getEndpoints(): [string, string][] {
     const {orgId, projectId} = this.props.params;
-    return [
-      ['issueRules', `/projects/${orgId}/${projectId}/rules/`],
-      ['metricRules', `/projects/${orgId}/${projectId}/alert-rules/`],
-    ];
+    return [['rules', `/projects/${orgId}/${projectId}/combined-rules/`]];
   }
 
   getTitle() {
@@ -58,39 +56,20 @@ class ProjectAlertRules extends AsyncView<Props, State> {
 
     return (
       <React.Fragment>
-        {this.state.issueRules.map(rule => {
-          return (
-            <RuleRow
-              type="issue"
-              api={this.api}
-              key={rule.id}
-              data={rule}
-              orgId={orgId}
-              projectId={projectId}
-              params={this.props.params}
-              location={this.props.location}
-              routes={this.props.routes}
-              canEdit={canEditRule}
-            />
-          );
-        })}
-
-        {this.state.metricRules.map(rule => {
-          return (
-            <RuleRow
-              type="metric"
-              api={this.api}
-              key={`metric-${rule.id}`}
-              data={rule}
-              orgId={orgId}
-              projectId={projectId}
-              params={this.props.params}
-              location={this.props.location}
-              routes={this.props.routes}
-              canEdit={canEditRule}
-            />
-          );
-        })}
+        {this.state.rules.map(rule => (
+          <RuleRow
+            type={rule.type === 'alert_rule' ? 'issue' : 'metric'}
+            api={this.api}
+            key={`${rule.type}-${rule.id}`}
+            data={rule}
+            orgId={orgId}
+            projectId={projectId}
+            params={this.props.params}
+            location={this.props.location}
+            routes={this.props.routes}
+            canEdit={canEditRule}
+          />
+        ))}
       </React.Fragment>
     );
   }
@@ -100,7 +79,7 @@ class ProjectAlertRules extends AsyncView<Props, State> {
   }
 
   renderBody() {
-    const {loading, issueRules} = this.state;
+    const {loading, rules} = this.state;
 
     return (
       <React.Fragment>
@@ -119,7 +98,7 @@ class ProjectAlertRules extends AsyncView<Props, State> {
           <PanelBody>
             {loading
               ? super.renderLoading()
-              : !!issueRules.length
+              : !!rules.length
               ? this.renderResults()
               : this.renderEmpty()}
           </PanelBody>


### PR DESCRIPTION
This uses the combined endpoint for rules instead of 2 separate endpoints