### PR TITLE
feat(search) - Prevent future searches on tagvalues with no results

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -220,6 +220,7 @@ class SmartSearchBar extends React.Component {
 
     this.state = {
       query: props.query !== null ? addSpace(props.query) : props.defaultQuery,
+      noValueQuery: undefined,
 
       searchTerm: '',
       searchItems: [],
@@ -486,17 +487,30 @@ class SmartSearchBar extends React.Component {
         const {location} = this.context.router;
         const endpointParams = getParams(location.query);
 
-        const values = await this.props.onGetTagValues(tag, query, endpointParams);
-        this.setState({loading: false});
-        return values.map(value => {
-          // Wrap in quotes if there is a space
-          const escapedValue =
-            value.indexOf(' ') > -1 ? `"${value.replace('"', '\\"')}"` : value;
-          return {
-            value: escapedValue,
-            desc: escapedValue,
-          };
-        });
+        if (
+          this.state.noValueQuery === undefined ||
+          !query.startsWith(this.state.noValueQuery)
+        ) {
+          const values = await this.props.onGetTagValues(tag, query, endpointParams);
+          this.setState({loading: false});
+          if (values.length === 0 && query.length > 0) {
+            this.setState({noValueQuery: query});
+          } else {
+            this.setState({noValueQuery: undefined});
+          }
+          return values.map(value => {
+            // Wrap in quotes if there is a space
+            const escapedValue =
+              value.indexOf(' ') > -1 ? `"${value.replace('"', '\\"')}"` : value;
+            return {
+              value: escapedValue,
+              desc: escapedValue,
+            };
+          });
+        } else {
+          this.setState({loading: false});
+          return [];
+        }
       } catch (err) {
         this.setState({loading: false});
         Sentry.captureException(err);

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -493,11 +493,9 @@ class SmartSearchBar extends React.Component {
         ) {
           const values = await this.props.onGetTagValues(tag, query, endpointParams);
           this.setState({loading: false});
-          if (values.length === 0 && query.length > 0) {
-            this.setState({noValueQuery: query});
-          } else {
-            this.setState({noValueQuery: undefined});
-          }
+          const noValueQuery =
+            values.length === 0 && query.length > 0 ? query : undefined;
+          this.setState({noValueQuery});
           return values.map(value => {
             // Wrap in quotes if there is a space
             const escapedValue =

--- a/tests/js/spec/views/events/searchBar.spec.jsx
+++ b/tests/js/spec/views/events/searchBar.spec.jsx
@@ -57,7 +57,11 @@ describe('SearchBar', function() {
     });
     tagKeysMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/tags/',
-      body: [{count: 3, key: 'gpu'}, {count: 3, key: 'mytag'}],
+      body: [
+        {count: 3, key: 'gpu'},
+        {count: 3, key: 'mytag'},
+        {count: 0, key: 'browser'},
+      ],
     });
   });
 
@@ -195,5 +199,55 @@ describe('SearchBar', function() {
     );
     selectFirstAutocompleteItem(wrapper);
     expect(wrapper.find('input').prop('value')).toBe('!gpu:*"Nvidia 1080ti" ');
+  });
+
+  it('stops searching after no values are returned', async function() {
+    const emptyTagValuesMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/browser/values/',
+      body: [],
+    });
+
+    const wrapper = mountWithTheme(<SearchBar {...props} />, options);
+    await tick();
+
+    setQuery(wrapper, 'browser:Nothing');
+    await tick();
+    wrapper.update();
+
+    expect(emptyTagValuesMock).toHaveBeenCalledTimes(1);
+
+    setQuery(wrapper, 'browser:NothingE');
+    await tick();
+    wrapper.update();
+
+    expect(emptyTagValuesMock).toHaveBeenCalledTimes(1);
+
+    setQuery(wrapper, 'browser:NothingEls');
+    await tick();
+    wrapper.update();
+
+    expect(emptyTagValuesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues searching after no values if query changes', async function() {
+    const emptyTagValuesMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/browser/values/',
+      body: [],
+    });
+
+    const wrapper = mountWithTheme(<SearchBar {...props} />, options);
+    await tick();
+
+    setQuery(wrapper, 'browser:Nothing');
+    await tick();
+    wrapper.update();
+
+    expect(emptyTagValuesMock).toHaveBeenCalledTimes(1);
+
+    setQuery(wrapper, 'browser:Something');
+    await tick();
+    wrapper.update();
+
+    expect(emptyTagValuesMock).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
- Once a tag value has been typed that has no results, stop trying to
  search the backend for more similar values.
- eg. current `browser.name:Noth` -> 4 searches for `N`, `No`, `Not`, `Noth` (depending on how fast you type), with the result list of `[]` every time. With this, only `N` will start a search, every subsequent letter will not result in a query now:
![Prevent Future Search](https://user-images.githubusercontent.com/4205004/71218896-461b0680-2291-11ea-811c-40364a98a427.gif)