### PR TITLE
fix(discover2): Do not overfetch tags

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -68,10 +68,10 @@ class Tags extends React.Component<Props, State> {
 
   shouldRefetchData = (prevProps: Props): boolean => {
     const thisAPIPayload = pickTagParams(
-      this.props.eventView.getTagsAPIPayload(this.props.location)
+      this.props.eventView.getEventsAPIPayload(this.props.location)
     );
     const otherAPIPayload = pickTagParams(
-      prevProps.eventView.getTagsAPIPayload(prevProps.location)
+      prevProps.eventView.getEventsAPIPayload(prevProps.location)
     );
 
     return !isEqual(thisAPIPayload, otherAPIPayload);
@@ -83,7 +83,7 @@ class Tags extends React.Component<Props, State> {
     const tagsFetchID = Symbol('tagsFetchID');
     this.setState({tags: {}, totalValues: null, isLoading: true, tagsFetchID});
 
-    const queryPayload = pickTagParams(eventView.getTagsAPIPayload(location));
+    const queryPayload = pickTagParams(eventView.getEventsAPIPayload(location));
 
     eventView.tags.forEach(async tag => {
       try {

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -122,6 +122,20 @@ export type Tag = {
   topValues: Array<TagTopValue>;
 };
 
+type PickTagParamsType = {
+  query: string;
+  field?: string[] | undefined;
+  project?: string | string[] | undefined;
+  sort?: string | string[] | undefined;
+  per_page?: number | undefined;
+};
+
+export function pickTagParams(query: PickTagParamsType): PickTagParamsType {
+  const urlParams = pick(query, Object.values(URL_PARAM));
+
+  return {...urlParams, query: query.query};
+}
+
 /**
  * Fetches tag distributions for a single tag key
  *
@@ -135,11 +149,11 @@ export function fetchTagDistribution(
   api: Client,
   orgSlug: string,
   key: string,
-  query: EventQuery
+  query: PickTagParamsType
 ): Promise<Tag> {
-  const urlParams = pick(query, Object.values(URL_PARAM));
+  const urlParams = pickTagParams(query);
 
-  const queryOption = {...urlParams, key, query: query.query};
+  const queryOption = {...urlParams, key};
 
   return api.requestPromise(`/organizations/${orgSlug}/events-distribution/`, {
     query: queryOption,
@@ -157,11 +171,11 @@ export function fetchTagDistribution(
 export function fetchTotalCount(
   api: Client,
   orgSlug: String,
-  query: EventQuery
+  query: PickTagParamsType
 ): Promise<number> {
-  const urlParams = pick(query, Object.values(URL_PARAM));
+  const urlParams = pickTagParams(query);
 
-  const queryOption = {...urlParams, query: query.query};
+  const queryOption = {...urlParams};
 
   type Response = {
     count: number;


### PR DESCRIPTION
## TODO

- [ ] ~delete `Event.getTagsAPIPayload()`~ EDIT: to be deferred in a follow up PR
- [ ] refactor `pickTagParams()` to include `start`, `end`, and `statsPeriod`. Investigate how this was being injected.