### PR TITLE
feat(discover2): Allow columns in GridEditable to be resized

### DIFF
--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -15,6 +15,7 @@ class DiscoverSavedQuerySerializer(Serializer):
             "environment",
             "query",
             "fields",
+            "widths",
             "conditions",
             "aggregations",
             "range",

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -161,6 +161,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
     fieldnames = ListField(child=serializers.CharField(), required=False, allow_null=True)
     query = serializers.CharField(required=False, allow_null=True)
     tags = ListField(child=serializers.CharField(), required=False, allow_null=True)
+    widths = ListField(child=serializers.CharField(), required=False, allow_null=True)
     yAxis = serializers.CharField(required=False, allow_null=True)
 
     disallowed_fields = {
@@ -200,6 +201,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
             "orderby",
             "limit",
             "tags",
+            "widths",
             "yAxis",
         ]
 

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -32,11 +32,13 @@ import {
   GridResizer,
 } from './styles';
 import {
+  COL_WIDTH_UNDEFINED,
   COL_WIDTH_MIN,
   COL_WIDTH_DEFAULT,
+  COL_WIDTH_BOOLEAN,
+  COL_WIDTH_DATETIME,
   COL_WIDTH_NUMBER,
   COL_WIDTH_STRING,
-  COL_WIDTH_STRING_LONG,
   ColResizeMetadata,
 } from './utils';
 
@@ -506,11 +508,13 @@ class GridEditable<
 
 export default GridEditable;
 export {
+  COL_WIDTH_UNDEFINED,
   COL_WIDTH_MIN,
   COL_WIDTH_DEFAULT,
+  COL_WIDTH_BOOLEAN,
+  COL_WIDTH_DATETIME,
   COL_WIDTH_NUMBER,
   COL_WIDTH_STRING,
-  COL_WIDTH_STRING_LONG,
   GridColumn,
   GridColumnHeader,
   GridColumnOrder,

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -164,12 +164,12 @@ class GridEditable<
     mouseup: [],
   };
 
-  clearWindowLifecycleEvents = () => {
+  clearWindowLifecycleEvents() {
     Object.keys(this.resizeWindowLifecycleEvents).forEach(e => {
       this.resizeWindowLifecycleEvents[e].forEach(c => window.removeEventListener(e, c));
       this.resizeWindowLifecycleEvents[e] = [];
     });
-  };
+  }
 
   onResizeMouseDown = (e: React.MouseEvent, i: number = -1) => {
     e.preventDefault();
@@ -306,7 +306,7 @@ class GridEditable<
           ? columnWidth
           : !c.width || isNaN(c.width) // Case 2: Draw a column with no width
           ? COL_WIDTH_DEFAULT
-          : Number(c.width); // Case 3: Draw a column with width
+          : c.width; // Case 3: Draw a column with width
 
       width = Math.max(COL_WIDTH_MIN, width);
       sumWidth += width;

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -297,10 +297,26 @@ class GridEditable<
       return;
     }
 
+    let sumWidth = 0;
     const columnWidths = columnOrder.map((c, i) => {
-      const width = i !== columnIndex ? c.width : columnWidth;
-      return `${Math.max(COL_WIDTH_MIN, Number(width) || COL_WIDTH_DEFAULT)}px`;
+      let width =
+        i === columnIndex // Case 1: Resize, then draw a specific column
+          ? columnWidth
+          : !c.width || isNaN(c.width) // Case 2: Draw a column with no width
+          ? COL_WIDTH_DEFAULT
+          : Number(c.width); // Case 3: Draw a column with width
+
+      width = Math.max(COL_WIDTH_MIN, width);
+      sumWidth += width;
+
+      return `${width}px`;
     });
+
+    // If columns are smaller than grid, let the last column fill the remaining
+    // blank space on the right of the grid
+    if (sumWidth < grid.offsetWidth) {
+      columnWidths[columnWidths.length - 1] = '1fr';
+    }
 
     grid.style.gridTemplateColumns = columnWidths.join(' ');
   }

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -280,7 +280,7 @@ export const GridBodyCell = styled('td')`
   min-width: 0;
   /* Locking in the height makes calculation for resizer to be easier.
      min-height is used to allow a cell to expand and this is used to display
-     feedback duringempty/error state */
+     feedback during empty/error state */
   min-height: ${GRID_BODY_ROW_HEIGHT}px;
   padding: ${space(1)} ${space(2)};
 

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -278,8 +278,10 @@ export const GridBodyCell = styled('td')`
   /* By default, a grid item cannot be smaller than the size of its content.
      We override this by setting min-width to be 0. */
   min-width: 0;
-  /* Locking in the height makes a lot of things easier */
-  height: ${GRID_BODY_ROW_HEIGHT}px;
+  /* Locking in the height makes calculation for resizer to be easier.
+     min-height is used to allow a cell to expand and this is used to display
+     feedback duringempty/error state */
+  min-height: ${GRID_BODY_ROW_HEIGHT}px;
   padding: ${space(1)} ${space(2)};
 
   background-color: ${p => p.theme.white};
@@ -344,6 +346,6 @@ export const GridResizer = styled('div')<{dataRows: number; isLast?: boolean}>`
    */
   &:active::after,
   &:focus::after {
-    background-color: ${p => p.theme.gray2};
+    background-color: ${p => p.theme.purple};
   }
 `;

--- a/src/sentry/static/sentry/app/components/gridEditable/types.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/types.tsx
@@ -9,6 +9,7 @@ export type ObjectKey = React.ReactText;
 
 export type GridColumn<K = ObjectKey> = {
   key: K;
+  width?: number;
 };
 
 export type GridColumnHeader<K = ObjectKey> = GridColumn<K> & {

--- a/src/sentry/static/sentry/app/components/gridEditable/utils.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/utils.tsx
@@ -1,0 +1,14 @@
+export const COL_WIDTH_MIN = 100;
+
+// Default width if it wasn't specified
+export const COL_WIDTH_DEFAULT = 300;
+export const COL_WIDTH_NUMBER = COL_WIDTH_MIN;
+export const COL_WIDTH_STRING = 250;
+export const COL_WIDTH_STRING_LONG = 400;
+
+// Store state at the start of "resize" action
+export type ColResizeMetadata = {
+  columnIndex: number; // Column being resized
+  columnWidth: number; // Column width at start of resizing
+  cursorX: number; // X-coordinate of cursor on window
+};

--- a/src/sentry/static/sentry/app/components/gridEditable/utils.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/utils.tsx
@@ -1,10 +1,15 @@
+export const COL_WIDTH_UNDEFINED = -1;
 export const COL_WIDTH_MIN = 100;
 
 // Default width if it wasn't specified
 export const COL_WIDTH_DEFAULT = 300;
+
+// Starting defaults if column values are known
+export const COL_WIDTH_BOOLEAN = COL_WIDTH_MIN;
+export const COL_WIDTH_DATETIME = 200;
 export const COL_WIDTH_NUMBER = COL_WIDTH_MIN;
-export const COL_WIDTH_STRING = 250;
-export const COL_WIDTH_STRING_LONG = 400;
+export const COL_WIDTH_STRING = COL_WIDTH_DEFAULT;
+export const COL_WIDTH_STRING_SHORT = 200;
 
 // Store state at the start of "resize" action
 export type ColResizeMetadata = {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -670,6 +670,7 @@ export type NewQuery = {
   projects: Readonly<number[]>;
   fields: Readonly<string[]>;
   fieldnames: Readonly<string[]>;
+  widths?: Readonly<string[]>;
   query: string;
   orderby?: string;
   range?: string;

--- a/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventQueryParams.tsx
@@ -92,7 +92,6 @@ export const FIELDS = {
   last_seen: 'never',
   latest_event: 'never',
 
-  // user
   user: 'string',
   'user.id': 'string',
   'user.email': 'string',

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -203,6 +203,12 @@ const Top = styled('div')`
 
 const Main = styled('div')<{eventView: EventView}>`
   grid-column: ${p => (p.eventView.tags.length <= 0 ? '1/3' : '1/2')};
+
+  /* Defining the width prevent child elements from expanding the grid
+     past the width of the screen */
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
 `;
 
 const Side = styled('div')<{eventView: EventView}>`

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -221,7 +221,8 @@ const ContentBox = styled(PageContent)`
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     display: grid;
-    grid-template-rows: 1fr auto;
+    grid-template-rows: 270px auto; /* HACK(leedongwei): Hard-coded height for
+                                       search bar and graph */
     grid-template-columns: 65% auto;
     grid-column-gap: ${space(3)};
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/sortLink.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/sortLink.tsx
@@ -10,14 +10,14 @@ import Link from 'app/components/links/link';
 import EventView, {Field, Sort, isFieldSortable} from './eventView';
 import {MetaType} from './utils';
 
-type Alignments = 'left' | 'right' | undefined;
+export type Alignments = 'left' | 'right' | undefined;
 
 type Props = {
   align: Alignments;
   field: Field;
   location: Location;
   eventView: EventView;
-  tableDataMeta: MetaType;
+  tableDataMeta?: MetaType; // Will not be defined if data is not loaded
 };
 
 class SortLink extends React.Component<Props> {
@@ -26,17 +26,23 @@ class SortLink extends React.Component<Props> {
     field: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
     eventView: PropTypes.object.isRequired,
-    tableDataMeta: PropTypes.object.isRequired,
+    tableDataMeta: PropTypes.object,
   };
 
   isCurrentColumnSorted(): Sort | undefined {
     const {eventView, field, tableDataMeta} = this.props;
+    if (!tableDataMeta) {
+      return undefined;
+    }
 
     return eventView.isFieldSorted(field, tableDataMeta);
   }
 
   getTarget() {
     const {location, field, eventView, tableDataMeta} = this.props;
+    if (!tableDataMeta) {
+      return undefined;
+    }
 
     const nextEventView = eventView.sortOnField(field, tableDataMeta);
     const queryStringObject = nextEventView.generateQueryStringObject();

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -20,7 +20,7 @@ import {
   MetaType,
 } from '../utils';
 import EventView, {pickRelevantLocationQueryStrings, Field} from '../eventView';
-import SortLink from '../sortLink';
+import SortLink, {Alignments} from '../sortLink';
 import renderTableModalEditColumnFactory from './tableModalEditColumn';
 import {TableColumn, TableData, TableDataRow} from './types';
 import {ColumnValueType} from '../eventQueryParams';
@@ -223,20 +223,18 @@ class TableView extends React.Component<TableViewProps> {
 
   _renderGridHeaderCell = (column: TableColumn<keyof TableDataRow>): React.ReactNode => {
     const {eventView, location, tableData} = this.props;
-
-    if (!tableData || !tableData.meta) {
-      return column.name;
-    }
-
     const field = column.eventViewField;
 
     // establish alignment based on the type
     const alignedTypes: ColumnValueType[] = ['number', 'duration', 'integer'];
-    let align: 'right' | 'left' = alignedTypes.includes(column.type) ? 'right' : 'left';
+    let align: Alignments = alignedTypes.includes(column.type) ? 'right' : 'left';
 
     if (column.type === 'never' || column.type === '*') {
       // fallback to align the column based on the table metadata
-      const maybeType = tableData.meta[getAggregateAlias(field.field)];
+      const maybeType =
+        tableData && tableData.meta
+          ? tableData.meta[getAggregateAlias(field.field)]
+          : undefined;
 
       if (maybeType === 'integer' || maybeType === 'number') {
         align = 'right';
@@ -249,7 +247,9 @@ class TableView extends React.Component<TableViewProps> {
         field={field}
         location={location}
         eventView={eventView}
-        tableDataMeta={tableData.meta}
+        /* TODO(leedongwei): Verbosity is due to error in Prettier, fix after
+           upgrade to v1.19.1 */
+        tableDataMeta={tableData && tableData.meta ? tableData.meta : undefined}
       />
     );
   };

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -3,7 +3,7 @@ import {Location} from 'history';
 
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import GridEditable, {COL_WIDTH_DEFAULT} from 'app/components/gridEditable';
+import GridEditable, {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
 import {
   tokenizeSearch,
   stringifyQueryObject,
@@ -13,8 +13,8 @@ import {assert} from 'app/types/utils';
 import Link from 'app/components/links/link';
 
 import {
-  getFieldRenderer,
   getAggregateAlias,
+  getFieldRenderer,
   pushEventViewToLocation,
   explodeField,
   MetaType,
@@ -65,15 +65,14 @@ class TableView extends React.Component<TableViewProps> {
     const {location, eventView, organization} = this.props;
 
     let nextEventView: EventView;
+    const payload = {
+      aggregation: String(nextColumn.aggregation),
+      field: String(nextColumn.field),
+      fieldname: nextColumn.name,
+      width: COL_WIDTH_UNDEFINED,
+    };
 
     if (typeof insertAt === 'number') {
-      const payload = {
-        aggregation: String(nextColumn.aggregation),
-        field: String(nextColumn.field),
-        fieldname: nextColumn.name,
-        width: COL_WIDTH_DEFAULT,
-      };
-
       // create and insert a column at a specific index
       nextEventView = eventView.withNewColumnAt(payload, insertAt);
 
@@ -86,12 +85,6 @@ class TableView extends React.Component<TableViewProps> {
         ...payload,
       });
     } else {
-      const payload = {
-        aggregation: String(nextColumn.aggregation),
-        field: String(nextColumn.field),
-        fieldname: nextColumn.name,
-      };
-
       // create and insert a column at the right end of the table
       nextEventView = eventView.withNewColumn(payload);
 
@@ -121,7 +114,7 @@ class TableView extends React.Component<TableViewProps> {
       aggregation: String(nextColumn.aggregation),
       field: String(nextColumn.field),
       fieldname: String(nextColumn.name),
-      width: Number(nextColumn.width) || 0,
+      width: nextColumn.width ? Number(nextColumn.width) : COL_WIDTH_UNDEFINED,
     };
 
     const tableMeta = (tableData && tableData.meta) || undefined;

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -10,7 +10,14 @@ import {Client} from 'app/api';
 import {getTitle} from 'app/utils/events';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {generateQueryWithTag} from 'app/utils';
-import {COL_WIDTH_DEFAULT} from 'app/components/gridEditable/utils';
+import {
+  COL_WIDTH_UNDEFINED,
+  COL_WIDTH_DEFAULT,
+  COL_WIDTH_BOOLEAN,
+  COL_WIDTH_DATETIME,
+  COL_WIDTH_NUMBER,
+  COL_WIDTH_STRING,
+} from 'app/components/gridEditable';
 
 import {
   AGGREGATE_ALIASES,
@@ -189,6 +196,26 @@ export type MetaType = {
   [key: string]: FieldTypes;
 };
 
+export function getDefaultWidth(key: Aggregation | Field): number {
+  if (AGGREGATIONS[key]) {
+    return COL_WIDTH_NUMBER;
+  }
+
+  switch (FIELDS[key]) {
+    case 'string':
+      return COL_WIDTH_STRING;
+    case 'boolean':
+      return COL_WIDTH_BOOLEAN;
+    case 'number':
+      return COL_WIDTH_NUMBER;
+    case 'duration':
+    case 'never': // never is usually a timestamp
+      return COL_WIDTH_DATETIME;
+    default:
+      return COL_WIDTH_DEFAULT;
+  }
+}
+
 /**
  * Get the field renderer for the named field and metadata
  *
@@ -280,7 +307,10 @@ export function decodeColumnOrder(
     column.key = col.aggregationField;
     column.name = col.name;
     column.type = (FIELDS[column.field] || 'never') as ColumnValueType;
-    column.width = col.width || COL_WIDTH_DEFAULT;
+    column.width =
+      col.width && col.width !== COL_WIDTH_UNDEFINED
+        ? col.width
+        : getDefaultWidth(aggregationField[0]);
 
     column.isSortable = AGGREGATIONS[column.aggregation]
       ? AGGREGATIONS[column.aggregation].isSortable

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -30,13 +30,7 @@ import {
   TRANSACTION_VIEWS,
 } from './data';
 import EventView, {Field as FieldType} from './eventView';
-import {
-  Aggregation,
-  Field,
-  AGGREGATIONS,
-  FIELDS,
-  ColumnValueType,
-} from './eventQueryParams';
+import {Aggregation, Field, AGGREGATIONS, FIELDS} from './eventQueryParams';
 import {TableColumn} from './table/types';
 
 export type EventQuery = {
@@ -306,7 +300,7 @@ export function decodeColumnOrder(
 
     column.key = col.aggregationField;
     column.name = col.name;
-    column.type = (FIELDS[column.field] || 'never') as ColumnValueType;
+    column.type = column.aggregation ? 'number' : FIELDS[column.field];
     column.width =
       col.width && col.width !== COL_WIDTH_UNDEFINED
         ? col.width

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -3,6 +3,7 @@ import EventView, {
   pickRelevantLocationQueryStrings,
 } from 'app/views/eventsV2/eventView';
 import {AUTOLINK_FIELDS} from 'app/views/eventsV2/data';
+import {COL_WIDTH_DEFAULT} from 'app/components/gridEditable/utils';
 
 const generateFields = fields => {
   return fields.map(field => {
@@ -51,6 +52,7 @@ describe('EventView.fromLocation()', function() {
         name: 'best query',
         field: ['count()', 'id'],
         fieldnames: ['events', 'projects'],
+        widths: ['123', '456'],
         sort: ['title', '-count'],
         tag: ['foo', 'bar'],
         query: 'event.type:transaction',
@@ -68,7 +70,10 @@ describe('EventView.fromLocation()', function() {
     expect(eventView).toMatchObject({
       id: '42',
       name: 'best query',
-      fields: [{field: 'count()', title: 'events'}, {field: 'id', title: 'projects'}],
+      fields: [
+        {field: 'count()', title: 'events', width: 123},
+        {field: 'id', title: 'projects', width: 456},
+      ],
       sorts: generateSorts(['count']),
       tags: ['foo', 'bar'],
       query: 'event.type:transaction',
@@ -88,6 +93,7 @@ describe('EventView.fromLocation()', function() {
         name: 'best query',
         field: ['count()', 'id'],
         fieldnames: ['events', 'projects'],
+        widths: ['123', '456'],
         sort: ['title', '-count'],
         tag: ['foo', 'bar'],
         query: 'event.type:transaction',
@@ -104,7 +110,10 @@ describe('EventView.fromLocation()', function() {
     expect(eventView).toMatchObject({
       id: '42',
       name: 'best query',
-      fields: [{field: 'count()', title: 'events'}, {field: 'id', title: 'projects'}],
+      fields: [
+        {field: 'count()', title: 'events', width: 123},
+        {field: 'id', title: 'projects', width: 456},
+      ],
       sorts: generateSorts(['count']),
       tags: ['foo', 'bar'],
       query: 'event.type:transaction',
@@ -123,6 +132,7 @@ describe('EventView.fromLocation()', function() {
         name: 'best query',
         field: ['count()', 'id'],
         fieldnames: ['events', 'projects'],
+        widths: ['123', '456'],
         sort: ['title', '-count'],
         tag: ['foo', 'bar'],
         query: 'event.type:transaction',
@@ -138,7 +148,10 @@ describe('EventView.fromLocation()', function() {
     expect(eventView).toMatchObject({
       id: '42',
       name: 'best query',
-      fields: [{field: 'count()', title: 'events'}, {field: 'id', title: 'projects'}],
+      fields: [
+        {field: 'count()', title: 'events', width: 123},
+        {field: 'id', title: 'projects', width: 456},
+      ],
       sorts: generateSorts(['count']),
       tags: ['foo', 'bar'],
       query: 'event.type:transaction',
@@ -192,7 +205,10 @@ describe('EventView.fromSavedQuery()', function() {
     expect(eventView).toMatchObject({
       id: saved.id,
       name: saved.name,
-      fields: [{field: 'count()', title: 'count()'}, {field: 'id', title: 'id'}],
+      fields: [
+        {field: 'count()', title: 'count()', width: COL_WIDTH_DEFAULT},
+        {field: 'id', title: 'id', width: COL_WIDTH_DEFAULT},
+      ],
       sorts: [{field: 'id', kind: 'desc'}],
       tags: [],
       query: 'event.type:transaction',
@@ -212,7 +228,10 @@ describe('EventView.fromSavedQuery()', function() {
     expect(eventView2).toMatchObject({
       id: saved.id,
       name: saved.name,
-      fields: [{field: 'count()', title: 'count()'}, {field: 'id', title: 'id'}],
+      fields: [
+        {field: 'count()', title: 'count()', width: COL_WIDTH_DEFAULT},
+        {field: 'id', title: 'id', width: COL_WIDTH_DEFAULT},
+      ],
       sorts: [{field: 'id', kind: 'desc'}],
       tags: [],
       query: 'event.type:transaction',
@@ -270,8 +289,8 @@ describe('EventView.fromSavedQuery()', function() {
     };
     const eventView = EventView.fromSavedQuery(saved);
     expect(eventView.fields).toEqual([
-      {field: 'count()', title: 'volume'},
-      {field: 'title', title: 'caption'},
+      {field: 'count()', title: 'volume', width: COL_WIDTH_DEFAULT},
+      {field: 'title', title: 'caption', width: COL_WIDTH_DEFAULT},
     ]);
     expect(eventView.name).toEqual(saved.name);
     expect(eventView.statsPeriod).toEqual('14d');
@@ -574,6 +593,7 @@ describe('EventView.generateQueryStringObject()', function() {
       name: undefined,
       field: ['id', 'title'],
       fieldnames: ['id', 'title'],
+      widths: [300, 300],
       sort: [],
       tag: [],
       query: '',
@@ -589,8 +609,8 @@ describe('EventView.generateQueryStringObject()', function() {
       id: '1234',
       name: 'best query',
       fields: [
-        {field: 'count()', title: 'events'},
-        {field: 'project.id', title: 'project'},
+        {field: 'count()', title: 'events', width: 123},
+        {field: 'project.id', title: 'project', width: 456},
       ],
       sorts: generateSorts(['count']),
       tags: ['foo', 'bar'],
@@ -610,6 +630,7 @@ describe('EventView.generateQueryStringObject()', function() {
       name: 'best query',
       field: ['count()', 'project.id'],
       fieldnames: ['events', 'project'],
+      widths: [123, 456],
       sort: ['-count'],
       tag: ['foo', 'bar'],
       query: 'event.type:error',
@@ -948,8 +969,8 @@ describe('EventView.toNewQuery()', function() {
     id: '1234',
     name: 'best query',
     fields: [
-      {field: 'count()', title: 'events'},
-      {field: 'project.id', title: 'project'},
+      {field: 'count()', title: 'events', width: 123},
+      {field: 'project.id', title: 'project', width: 456},
     ],
     sorts: generateSorts(['count']),
     tags: ['foo', 'bar'],
@@ -972,6 +993,7 @@ describe('EventView.toNewQuery()', function() {
       name: 'best query',
       fieldnames: ['events', 'project'],
       fields: ['count()', 'project.id'],
+      widths: ['123', '456'],
       orderby: '-count',
       query: 'event.type:error',
       projects: [42],
@@ -1002,6 +1024,7 @@ describe('EventView.toNewQuery()', function() {
       name: 'best query',
       fieldnames: ['events', 'project'],
       fields: ['count()', 'project.id'],
+      widths: ['123', '456'],
       orderby: '-count',
       projects: [42],
       start: '2019-10-01T00:00:00',
@@ -1031,6 +1054,7 @@ describe('EventView.toNewQuery()', function() {
       name: 'best query',
       fieldnames: ['events', 'project'],
       fields: ['count()', 'project.id'],
+      widths: ['123', '456'],
       orderby: '-count',
       projects: [42],
       start: '2019-10-01T00:00:00',

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -3,7 +3,7 @@ import EventView, {
   pickRelevantLocationQueryStrings,
 } from 'app/views/eventsV2/eventView';
 import {AUTOLINK_FIELDS} from 'app/views/eventsV2/data';
-import {COL_WIDTH_DEFAULT} from 'app/components/gridEditable/utils';
+import {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable/utils';
 
 const generateFields = fields => {
   return fields.map(field => {
@@ -206,8 +206,8 @@ describe('EventView.fromSavedQuery()', function() {
       id: saved.id,
       name: saved.name,
       fields: [
-        {field: 'count()', title: 'count()', width: COL_WIDTH_DEFAULT},
-        {field: 'id', title: 'id', width: COL_WIDTH_DEFAULT},
+        {field: 'count()', title: 'count()', width: COL_WIDTH_UNDEFINED},
+        {field: 'id', title: 'id', width: COL_WIDTH_UNDEFINED},
       ],
       sorts: [{field: 'id', kind: 'desc'}],
       tags: [],
@@ -229,8 +229,8 @@ describe('EventView.fromSavedQuery()', function() {
       id: saved.id,
       name: saved.name,
       fields: [
-        {field: 'count()', title: 'count()', width: COL_WIDTH_DEFAULT},
-        {field: 'id', title: 'id', width: COL_WIDTH_DEFAULT},
+        {field: 'count()', title: 'count()', width: COL_WIDTH_UNDEFINED},
+        {field: 'id', title: 'id', width: COL_WIDTH_UNDEFINED},
       ],
       sorts: [{field: 'id', kind: 'desc'}],
       tags: [],
@@ -249,6 +249,7 @@ describe('EventView.fromSavedQuery()', function() {
       name: 'foo bar',
       fields: ['release', 'count(id)'],
       fieldnames: ['Release tags', 'counts'],
+      widths: [111, 222],
       dateCreated: '2019-10-30T06:13:17.632078Z',
       environment: ['dev', 'production'],
       version: 2,
@@ -265,8 +266,8 @@ describe('EventView.fromSavedQuery()', function() {
       id: '5',
       name: 'foo bar',
       fields: [
-        {field: 'release', title: 'Release tags'},
-        {field: 'count(id)', title: 'counts'},
+        {field: 'release', title: 'Release tags', width: 111},
+        {field: 'count(id)', title: 'counts', width: 222},
       ],
       sorts: generateSorts(['count_id']),
       query: '',
@@ -289,8 +290,8 @@ describe('EventView.fromSavedQuery()', function() {
     };
     const eventView = EventView.fromSavedQuery(saved);
     expect(eventView.fields).toEqual([
-      {field: 'count()', title: 'volume', width: COL_WIDTH_DEFAULT},
-      {field: 'title', title: 'caption', width: COL_WIDTH_DEFAULT},
+      {field: 'count()', title: 'volume', width: COL_WIDTH_UNDEFINED},
+      {field: 'title', title: 'caption', width: COL_WIDTH_UNDEFINED},
     ]);
     expect(eventView.name).toEqual(saved.name);
     expect(eventView.statsPeriod).toEqual('14d');
@@ -593,7 +594,7 @@ describe('EventView.generateQueryStringObject()', function() {
       name: undefined,
       field: ['id', 'title'],
       fieldnames: ['id', 'title'],
-      widths: [300, 300],
+      widths: [COL_WIDTH_UNDEFINED, COL_WIDTH_UNDEFINED],
       sort: [],
       tag: [],
       query: '',

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -238,21 +238,16 @@ describe('getFieldRenderer', function() {
 
 describe('decodeColumnOrder', function() {
   it('can decode 0 elements', function() {
-    const results = decodeColumnOrder({
-      fieldnames: [],
-      field: [],
-    });
+    const results = decodeColumnOrder([]);
 
     expect(Array.isArray(results)).toBeTruthy();
     expect(results).toHaveLength(0);
   });
 
   it('can decode fields', function() {
-    const results = decodeColumnOrder({
-      field: ['title'],
-      fieldnames: ['Event title'],
-      fields: [{field: 'title', title: 'Event title'}],
-    });
+    const results = decodeColumnOrder([
+      {field: 'title', title: 'Event title', width: 123},
+    ]);
 
     expect(Array.isArray(results)).toBeTruthy();
 
@@ -261,7 +256,12 @@ describe('decodeColumnOrder', function() {
       name: 'Event title',
       aggregation: '',
       field: 'title',
-      eventViewField: {field: 'title', title: 'Event title'},
+      width: 123,
+      eventViewField: {
+        field: 'title',
+        title: 'Event title',
+        width: 123,
+      },
       isDragging: false,
       isPrimary: true,
       isSortable: false,
@@ -270,11 +270,9 @@ describe('decodeColumnOrder', function() {
   });
 
   it('can decode aggregate functions with no arguments', function() {
-    const results = decodeColumnOrder({
-      field: ['count()'],
-      fieldnames: ['projects'],
-      fields: [{field: 'count()', title: 'projects'}],
-    });
+    const results = decodeColumnOrder([
+      {field: 'count()', title: 'projects', width: 123},
+    ]);
 
     expect(Array.isArray(results)).toBeTruthy();
 
@@ -283,7 +281,12 @@ describe('decodeColumnOrder', function() {
       name: 'projects',
       aggregation: 'count',
       field: '',
-      eventViewField: {field: 'count()', title: 'projects'},
+      width: 123,
+      eventViewField: {
+        field: 'count()',
+        title: 'projects',
+        width: 123,
+      },
       isDragging: false,
       isPrimary: false,
       isSortable: true,
@@ -292,11 +295,9 @@ describe('decodeColumnOrder', function() {
   });
 
   it('can decode elements with aggregate functions with arguments', function() {
-    const results = decodeColumnOrder({
-      field: ['avg(transaction.duration)'],
-      fieldnames: ['average'],
-      fields: [{field: 'avg(transaction.duration)', title: 'average'}],
-    });
+    const results = decodeColumnOrder([
+      {field: 'avg(transaction.duration)', title: 'average'},
+    ]);
 
     expect(Array.isArray(results)).toBeTruthy();
 
@@ -305,6 +306,7 @@ describe('decodeColumnOrder', function() {
       name: 'average',
       aggregation: 'avg',
       field: 'transaction.duration',
+      width: 300,
       eventViewField: {field: 'avg(transaction.duration)', title: 'average'},
       isDragging: false,
       isPrimary: false,
@@ -338,7 +340,7 @@ describe('pushEventViewToLocation', function() {
     },
   };
 
-  it('correct query string objecet pushed to history', function() {
+  it('correct query string object pushed to history', function() {
     const eventView = new EventView(state);
 
     pushEventViewToLocation({
@@ -352,6 +354,7 @@ describe('pushEventViewToLocation', function() {
         name: 'best query',
         field: ['count()', 'project.id'],
         fieldnames: ['events', 'project'],
+        widths: [300, 300],
         sort: ['-count'],
         tag: ['foo', 'bar'],
         query: 'event.type:error',
@@ -381,6 +384,7 @@ describe('pushEventViewToLocation', function() {
         name: 'best query',
         field: ['count()', 'project.id'],
         fieldnames: ['events', 'project'],
+        widths: [300, 300],
         sort: ['-count'],
         tag: ['foo', 'bar'],
         query: 'event.type:error',

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -11,6 +11,7 @@ import {
   decodeColumnOrder,
   pushEventViewToLocation,
 } from 'app/views/eventsV2/utils';
+import {COL_WIDTH_UNDEFINED, COL_WIDTH_NUMBER} from 'app/components/gridEditable';
 
 describe('eventTagSearchUrl()', function() {
   let location;
@@ -306,7 +307,7 @@ describe('decodeColumnOrder', function() {
       name: 'average',
       aggregation: 'avg',
       field: 'transaction.duration',
-      width: 300,
+      width: COL_WIDTH_NUMBER,
       eventViewField: {field: 'avg(transaction.duration)', title: 'average'},
       isDragging: false,
       isPrimary: false,
@@ -354,7 +355,7 @@ describe('pushEventViewToLocation', function() {
         name: 'best query',
         field: ['count()', 'project.id'],
         fieldnames: ['events', 'project'],
-        widths: [300, 300],
+        widths: [COL_WIDTH_UNDEFINED, COL_WIDTH_UNDEFINED],
         sort: ['-count'],
         tag: ['foo', 'bar'],
         query: 'event.type:error',
@@ -384,7 +385,7 @@ describe('pushEventViewToLocation', function() {
         name: 'best query',
         field: ['count()', 'project.id'],
         fieldnames: ['events', 'project'],
-        widths: [300, 300],
+        widths: [COL_WIDTH_UNDEFINED, COL_WIDTH_UNDEFINED],
         sort: ['-count'],
         tag: ['foo', 'bar'],
         query: 'event.type:error',

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -291,7 +291,7 @@ describe('decodeColumnOrder', function() {
       isDragging: false,
       isPrimary: false,
       isSortable: true,
-      type: 'never',
+      type: 'number',
     });
   });
 
@@ -312,7 +312,7 @@ describe('decodeColumnOrder', function() {
       isDragging: false,
       isPrimary: false,
       isSortable: true,
-      type: 'duration',
+      type: 'number',
     });
   });
 });


### PR DESCRIPTION
Known issues:
- ~`Panel` width expands along with `GridEditable`~
- ~Column width state is not stored with `SavedQuery`~
- Grid status (error/loading) may be hidden when there are extremely wide columns
- Grid does not re-render when browser window is resized
- Percy snapshots are janky