### PR TITLE
fix(ui): Fix `indexMembersByProject` when project name is `constructor`

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/members.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/members.jsx
@@ -29,7 +29,7 @@ export function fetchOrgMembers(api, orgId, projectIds = null) {
 export function indexMembersByProject(members) {
   return members.reduce((acc, member) => {
     for (const project of member.projects) {
-      if (acc[project] === undefined) {
+      if (!acc.hasOwnProperty(project)) {
         acc[project] = [];
       }
       acc[project].push(member.user);


### PR DESCRIPTION
Use `Object.hasOwnProperty` instead of a direct key lookup.