### PR TITLE
feat(auth): adds github auth library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
     entry_points={
         "console_scripts": ["sentry = sentry.runner:main"],
         "sentry.apps": [
+            # TODO: This can be removed once the getsentry tests no longer check for this app
             "auth_github = sentry.auth.providers.github",
             "jira_ac = sentry_plugins.jira_ac",
             "jira = sentry_plugins.jira",

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
     entry_points={
         "console_scripts": ["sentry = sentry.runner:main"],
         "sentry.apps": [
+            "auth_github = sentry.auth.providers.github",
             "jira_ac = sentry_plugins.jira_ac",
             "jira = sentry_plugins.jira",
             "freight = sentry_plugins.freight",

--- a/src/sentry/auth/providers/github/__init__.py
+++ b/src/sentry/auth/providers/github/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import absolute_import
+
+
+default_app_config = "sentry.auth.providers.github.apps.Config"

--- a/src/sentry/auth/providers/github/apps.py
+++ b/src/sentry/auth/providers/github/apps.py
@@ -1,0 +1,14 @@
+from __future__ import absolute_import
+
+from django.apps import AppConfig
+
+
+class Config(AppConfig):
+    name = "sentry.auth.providers.github"
+
+    def ready(self):
+        from sentry.auth import register
+
+        from .provider import GitHubOAuth2Provider
+
+        register("github", GitHubOAuth2Provider)

--- a/src/sentry/auth/providers/github/client.py
+++ b/src/sentry/auth/providers/github/client.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+
+import six
+from requests.exceptions import RequestException
+from sentry import http
+from sentry.utils import json
+
+from .constants import API_DOMAIN
+
+
+class GitHubApiError(Exception):
+    def __init__(self, message="", status=0):
+        super(GitHubApiError, self).__init__(message)
+        self.status = status
+
+
+class GitHubClient(object):
+    def __init__(self, client_id, client_secret):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.http = http.build_session()
+
+    def _request(self, path, access_token):
+        params = {"client_id": self.client_id, "client_secret": self.client_secret}
+
+        headers = {"Authorization": "token {0}".format(access_token)}
+
+        try:
+            req = self.http.get(
+                "https://{0}/{1}".format(API_DOMAIN, path.lstrip("/")),
+                params=params,
+                headers=headers,
+            )
+        except RequestException as e:
+            raise GitHubApiError(six.text_type(e), status=getattr(e, "status_code", 0))
+        if req.status_code < 200 or req.status_code >= 300:
+            raise GitHubApiError(req.content, status=req.status_code)
+        return json.loads(req.content)
+
+    def get_org_list(self, access_token):
+        return self._request("/user/orgs", access_token)
+
+    def get_user(self, access_token):
+        return self._request("/user", access_token)
+
+    def get_user_emails(self, access_token):
+        return self._request("/user/emails", access_token)
+
+    def is_org_member(self, access_token, org_id):
+        org_list = self.get_org_list(access_token)
+        org_id = six.text_type(org_id)
+        for o in org_list:
+            if six.text_type((o["id"])) == org_id:
+                return True
+        return False

--- a/src/sentry/auth/providers/github/constants.py
+++ b/src/sentry/auth/providers/github/constants.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import, print_function
+
+from django.conf import settings
+
+CLIENT_ID = getattr(settings, "GITHUB_APP_ID", None)
+
+CLIENT_SECRET = getattr(settings, "GITHUB_API_SECRET", None)
+
+REQUIRE_VERIFIED_EMAIL = getattr(settings, "GITHUB_REQUIRE_VERIFIED_EMAIL", False)
+
+ERR_NO_ORG_ACCESS = "You do not have access to the required GitHub organization."
+
+ERR_NO_PRIMARY_EMAIL = (
+    "We were unable to find a primary email address associated with your GitHub acount."
+)
+
+ERR_NO_SINGLE_PRIMARY_EMAIL = (
+    "We were unable to find a single primary email address associated with your GitHub acount."
+)
+
+ERR_NO_VERIFIED_PRIMARY_EMAIL = (
+    "We were unable to find a verified, primary email address associated with your GitHub acount."
+)
+
+ERR_NO_SINGLE_VERIFIED_PRIMARY_EMAIL = "We were unable to find a single verified, primary email address associated with your GitHub acount."
+
+# we request repo as we share scopes with the other GitHub integration
+SCOPE = "user:email,read:org,repo"
+
+# deprecated please use GITHUB_API_DOMAIN and GITHUB_BASE_DOMAIN
+DOMAIN = getattr(settings, "GITHUB_DOMAIN", "api.github.com")
+
+BASE_DOMAIN = getattr(settings, "GITHUB_BASE_DOMAIN", "github.com")
+API_DOMAIN = getattr(settings, "GITHUB_API_DOMAIN", DOMAIN)
+
+ACCESS_TOKEN_URL = "https://{0}/login/oauth/access_token".format(BASE_DOMAIN)
+AUTHORIZE_URL = "https://{0}/login/oauth/authorize".format(BASE_DOMAIN)

--- a/src/sentry/auth/providers/github/provider.py
+++ b/src/sentry/auth/providers/github/provider.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import, print_function
+
+from sentry.auth.exceptions import IdentityNotValid
+from sentry.auth.providers.oauth2 import OAuth2Callback, OAuth2Provider, OAuth2Login
+
+from .client import GitHubApiError, GitHubClient
+from .constants import AUTHORIZE_URL, ACCESS_TOKEN_URL, CLIENT_ID, CLIENT_SECRET, SCOPE
+from .views import ConfirmEmail, FetchUser, SelectOrganization, GitHubConfigureView
+
+
+class GitHubOAuth2Provider(OAuth2Provider):
+    access_token_url = ACCESS_TOKEN_URL
+    authorize_url = AUTHORIZE_URL
+    name = "GitHub"
+    client_id = CLIENT_ID
+    client_secret = CLIENT_SECRET
+
+    def __init__(self, org=None, **config):
+        super(GitHubOAuth2Provider, self).__init__(**config)
+        self.org = org
+
+    def get_configure_view(self):
+        return GitHubConfigureView.as_view()
+
+    def get_auth_pipeline(self):
+        return [
+            OAuth2Login(authorize_url=self.authorize_url, client_id=self.client_id, scope=SCOPE),
+            OAuth2Callback(
+                access_token_url=self.access_token_url,
+                client_id=self.client_id,
+                client_secret=self.client_secret,
+            ),
+            FetchUser(client_id=self.client_id, client_secret=self.client_secret, org=self.org),
+            ConfirmEmail(),
+        ]
+
+    def get_setup_pipeline(self):
+        pipeline = self.get_auth_pipeline()
+        pipeline.append(
+            SelectOrganization(client_id=self.client_id, client_secret=self.client_secret)
+        )
+        return pipeline
+
+    def get_refresh_token_url(self):
+        return ACCESS_TOKEN_URL
+
+    def build_config(self, state):
+        return {"org": {"id": state["org"]["id"], "name": state["org"]["login"]}}
+
+    def build_identity(self, state):
+        data = state["data"]
+        user_data = state["user"]
+        return {
+            "id": user_data["id"],
+            "email": user_data["email"],
+            "name": user_data["name"],
+            "data": self.get_oauth_data(data),
+        }
+
+    def refresh_identity(self, auth_identity):
+        client = GitHubClient(self.client_id, self.client_secret)
+        access_token = auth_identity.data["access_token"]
+
+        try:
+            if not client.is_org_member(access_token, self.org["id"]):
+                raise IdentityNotValid
+        except GitHubApiError as e:
+            raise IdentityNotValid(e)

--- a/src/sentry/auth/providers/github/templates/sentry_auth_github/configure.html
+++ b/src/sentry/auth/providers/github/templates/sentry_auth_github/configure.html
@@ -1,0 +1,3 @@
+<h3>Organization</h3>
+
+<p>Users will be allowed to authenticate if they are a member of the <strong>{{ provider.org.name }}</strong> organization.</p>

--- a/src/sentry/auth/providers/github/templates/sentry_auth_github/enter-email.html
+++ b/src/sentry/auth/providers/github/templates/sentry_auth_github/enter-email.html
@@ -1,0 +1,15 @@
+{% extends "sentry/bases/auth.html" %}
+
+{% block auth_main %}
+  <div class="box">
+    <div class="box-content with-padding">
+      <h3>Confirm Email Address</h3>
+
+      <div class="help-block">It looks like your GitHub account is setup to keep your email address private. To continue signing in to Sentry we'll need you to first confirm your email address.</div>
+
+      {% with submit_label="Continue" %}
+        {% include "sentry/partial/_form.html" %}
+      {% endwith %}
+    </div>
+  </div>
+{% endblock %}

--- a/src/sentry/auth/providers/github/templates/sentry_auth_github/select-organization.html
+++ b/src/sentry/auth/providers/github/templates/sentry_auth_github/select-organization.html
@@ -1,0 +1,14 @@
+{% extends "sentry/bases/auth.html" %}
+
+{% block auth_main %}
+  <h3>Select Organization</h3>
+
+  <p>
+    Select the GitHub organization to link with Sentry. This will restrict
+    access to only organization members.
+  </p>
+
+  {% with submit_label="Continue" %}
+    {% include "sentry/partial/_form.html" %}
+  {% endwith %}
+{% endblock %}

--- a/src/sentry/auth/providers/github/views.py
+++ b/src/sentry/auth/providers/github/views.py
@@ -1,0 +1,139 @@
+from __future__ import absolute_import
+
+import six
+from django import forms
+from sentry.auth.view import AuthView, ConfigureView
+from sentry.models import AuthIdentity
+
+from .client import GitHubClient
+from .constants import ERR_NO_ORG_ACCESS
+from .constants import REQUIRE_VERIFIED_EMAIL
+from .constants import (
+    ERR_NO_SINGLE_VERIFIED_PRIMARY_EMAIL,
+    ERR_NO_SINGLE_PRIMARY_EMAIL,
+    ERR_NO_VERIFIED_PRIMARY_EMAIL,
+    ERR_NO_PRIMARY_EMAIL,
+)
+
+
+def _get_name_from_email(email):
+    """
+    Given an email return a capitalized name. Ex. john.smith@example.com would return John Smith.
+    """
+    name = email.rsplit("@", 1)[0]
+    name = " ".join([n_part.capitalize() for n_part in name.split(".")])
+    return name
+
+
+class FetchUser(AuthView):
+    def __init__(self, client_id, client_secret, org=None, *args, **kwargs):
+        self.org = org
+        self.client = GitHubClient(client_id, client_secret)
+        super(FetchUser, self).__init__(*args, **kwargs)
+
+    def handle(self, request, helper):
+        access_token = helper.fetch_state("data")["access_token"]
+
+        if self.org is not None:
+            if not self.client.is_org_member(access_token, self.org["id"]):
+                return helper.error(ERR_NO_ORG_ACCESS)
+
+        user = self.client.get_user(access_token)
+
+        if not user.get("email"):
+            emails = self.client.get_user_emails(access_token)
+            email = [
+                e["email"]
+                for e in emails
+                if ((not REQUIRE_VERIFIED_EMAIL) | e["verified"]) and e["primary"]
+            ]
+            if len(email) == 0:
+                if REQUIRE_VERIFIED_EMAIL:
+                    msg = ERR_NO_VERIFIED_PRIMARY_EMAIL
+                else:
+                    msg = ERR_NO_PRIMARY_EMAIL
+                return helper.error(msg)
+            elif len(email) > 1:
+                if REQUIRE_VERIFIED_EMAIL:
+                    msg = ERR_NO_SINGLE_VERIFIED_PRIMARY_EMAIL
+                else:
+                    msg = ERR_NO_SINGLE_PRIMARY_EMAIL
+                return helper.error(msg)
+            else:
+                user["email"] = email[0]
+
+        # A user hasn't set their name in their Github profile so it isn't
+        # populated in the response
+        if not user.get("name"):
+            user["name"] = _get_name_from_email(user["email"])
+
+        helper.bind_state("user", user)
+
+        return helper.next_step()
+
+
+class ConfirmEmailForm(forms.Form):
+    email = forms.EmailField(label="Email")
+
+
+class ConfirmEmail(AuthView):
+    def handle(self, request, helper):
+        user = helper.fetch_state("user")
+
+        # TODO(dcramer): this isnt ideal, but our current flow doesnt really
+        # support this behavior;
+        try:
+            auth_identity = AuthIdentity.objects.select_related("user").get(
+                auth_provider=helper.auth_provider, ident=user["id"]
+            )
+        except AuthIdentity.DoesNotExist:
+            pass
+        else:
+            user["email"] = auth_identity.user.email
+
+        if user.get("email"):
+            return helper.next_step()
+
+        form = ConfirmEmailForm(request.POST or None)
+        if form.is_valid():
+            user["email"] = form.cleaned_data["email"]
+            helper.bind_state("user", user)
+            return helper.next_step()
+
+        return self.respond("sentry_auth_github/enter-email.html", {"form": form})
+
+
+class SelectOrganizationForm(forms.Form):
+    org = forms.ChoiceField(label="Organization")
+
+    def __init__(self, org_list, *args, **kwargs):
+        super(SelectOrganizationForm, self).__init__(*args, **kwargs)
+
+        self.fields["org"].choices = [(o["id"], o["login"]) for o in org_list]
+        self.fields["org"].widget.choices = self.fields["org"].choices
+
+
+class SelectOrganization(AuthView):
+    def __init__(self, client_id, client_secret, *args, **kwargs):
+        self.client = GitHubClient(client_id, client_secret)
+        super(SelectOrganization, self).__init__(*args, **kwargs)
+
+    def handle(self, request, helper):
+        access_token = helper.fetch_state("data")["access_token"]
+        org_list = self.client.get_org_list(access_token)
+
+        form = SelectOrganizationForm(org_list, request.POST or None)
+        if form.is_valid():
+            org_id = form.cleaned_data["org"]
+            org = [o for o in org_list if org_id == six.text_type(o["id"])][0]
+            helper.bind_state("org", org)
+            return helper.next_step()
+
+        return self.respond(
+            "sentry_auth_github/select-organization.html", {"form": form, "org_list": org_list}
+        )
+
+
+class GitHubConfigureView(ConfigureView):
+    def dispatch(self, request, organization, auth_provider):
+        return self.render("sentry_auth_github/configure.html")

--- a/tests/sentry/auth/providers/github/test_views.py
+++ b/tests/sentry/auth/providers/github/test_views.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+import pytest
+
+from sentry.auth.providers.github.views import _get_name_from_email
+
+expected_data = [
+    ("john.smith@example.com", "John Smith"),
+    ("john@example.com", "John"),
+    ("XYZ-234=3523@example.com", "Xyz-234=3523"),
+    ("XYZ.1111@example.com", "Xyz 1111"),
+    ("JOHN@example.com", "John"),
+]
+
+
+@pytest.mark.parametrize("email,expected_name", expected_data)
+def test_get_name_from_email(email, expected_name):
+    assert _get_name_from_email(email) == expected_name


### PR DESCRIPTION
This PR is part of the effort in moving dependencies into sentry from stand-alone repos. Evan and I decided to make the path of this to be: `sentry/auth/providers` to match the other auth providers. The only real change I made was stripping out the check for Django < 1.8.

Must be merged with: https://github.com/getsentry/getsentry/pull/3431