### PR TITLE
fix(integrations): use p-debounce for external issue linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "moment-timezone": "0.5.25",
     "node-libs-browser": "0.5.3",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
+    "p-debounce": "^2.1.0",
     "papaparse": "^4.6.0",
     "parseurl": "^1.3.2",
     "platformicons": "2.0.3",

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.jsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
-import debounce from 'lodash/debounce';
+import pDebounce from 'p-debounce';
 
 import {addSuccessMessage} from 'app/actionCreators/indicator';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -45,7 +45,7 @@ class ExternalIssueForm extends AsyncComponent {
     this.props.onSubmitSuccess(data);
   };
 
-  onRequestSuccess({stateKey, data, jqXHR}) {
+  onRequestSuccess({stateKey, data}) {
     if (stateKey === 'integrationDetails' && !this.state.dynamicFieldValues) {
       this.setState({
         dynamicFieldValues: this.getDynamicFields(data),
@@ -107,7 +107,7 @@ class ExternalIssueForm extends AsyncComponent {
     return this.debouncedOptionLoad(field, input);
   };
 
-  debouncedOptionLoad = debounce(
+  debouncedOptionLoad = pDebounce(
     async (field, input) => {
       const query = queryString.stringify({
         ...this.state.dynamicFieldValues,

--- a/tests/js/spec/components/group/__snapshots__/externalIssueForm.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueForm.spec.jsx.snap
@@ -1,0 +1,3041 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ExternalIssueForm create renders 1`] = `
+<ExternalIssueForm
+  action="create"
+  group={
+    Object {
+      "activity": Array [],
+      "annotations": Array [],
+      "assignedTo": null,
+      "count": "327482",
+      "culprit": "fetchData(app/components/group/suggestedOwners)",
+      "firstRelease": null,
+      "firstSeen": "2019-04-05T19:44:05.963Z",
+      "hasSeen": false,
+      "id": "1",
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "lastRelease": null,
+      "lastSeen": "2019-04-11T01:08:59Z",
+      "level": "warning",
+      "logger": null,
+      "metadata": Object {
+        "function": "fetchData",
+        "type": "RequestError",
+      },
+      "numComments": 0,
+      "participants": Array [],
+      "permalink": "https://foo.io/organizations/foo/issues/1234/",
+      "platform": "javascript",
+      "pluginActions": Array [],
+      "pluginContexts": Array [],
+      "pluginIssues": Array [],
+      "project": Object {
+        "id": "2",
+        "platform": "javascript",
+        "slug": "project-slug",
+      },
+      "seenBy": Array [],
+      "shareId": null,
+      "shortId": "JAVASCRIPT-6QS",
+      "stats": Object {
+        "24h": Array [
+          Array [
+            1517281200,
+            2,
+          ],
+          Array [
+            1517310000,
+            1,
+          ],
+        ],
+        "30d": Array [
+          Array [
+            1514764800,
+            1,
+          ],
+          Array [
+            1515024000,
+            122,
+          ],
+        ],
+      },
+      "status": "unresolved",
+      "statusDetails": Object {},
+      "subscriptionDetails": null,
+      "tags": Array [],
+      "title": "RequestError: GET /issues/ 404",
+      "type": "error",
+      "userCount": 35097,
+      "userReportCount": 0,
+    }
+  }
+  integration={
+    Object {
+      "configData": Object {},
+      "configOrganization": Array [],
+      "domainName": "github.com/test-integration",
+      "externalIssues": Array [],
+      "icon": "http://example.com/integration_icon.png",
+      "id": "1",
+      "name": "Test Integration",
+      "projects": Array [],
+      "provider": Object {
+        "canAdd": true,
+        "features": Array [],
+        "key": "github",
+        "name": "GitHub",
+      },
+    }
+  }
+  onSubmitSuccess={[MockFunction]}
+>
+  <Form
+    allowUndo={false}
+    apiEndpoint="/groups/1/integrations/1/"
+    apiMethod="POST"
+    cancelLabel="Cancel"
+    className="form-stacked"
+    footerClass="modal-footer"
+    initialData={Object {}}
+    onFieldChange={[Function]}
+    onSubmitSuccess={[Function]}
+    requireChanges={false}
+    saveOnBlur={false}
+    submitDisabled={false}
+    submitLabel="Create Issue"
+    submitPriority="primary"
+  >
+    <form
+      className="form-stacked"
+      onSubmit={[Function]}
+    >
+      <div />
+      <StyledFooter
+        className="modal-footer"
+        saveOnBlur={false}
+      >
+        <div
+          className="modal-footer css-bobn3u-StyledFooter e1r1zmbj0"
+        >
+          <DefaultButtons>
+            <div
+              className="css-5mbz2j-DefaultButtons e1r1zmbj1"
+            >
+              <Observer>
+                <Button
+                  align="center"
+                  data-test-id="form-submit"
+                  disabled={false}
+                  priority="primary"
+                  type="submit"
+                >
+                  <StyledButton
+                    aria-disabled={false}
+                    aria-label="Create Issue"
+                    data-test-id="form-submit"
+                    disabled={false}
+                    onClick={[Function]}
+                    priority="primary"
+                    role="button"
+                    type="submit"
+                  >
+                    <ForwardRef
+                      aria-disabled={false}
+                      aria-label="Create Issue"
+                      className="css-xiynrq-StyledButton-getColors edwq9my0"
+                      data-test-id="form-submit"
+                      disabled={false}
+                      onClick={[Function]}
+                      priority="primary"
+                      role="button"
+                      type="submit"
+                    >
+                      <button
+                        aria-disabled={false}
+                        aria-label="Create Issue"
+                        className="css-xiynrq-StyledButton-getColors edwq9my0"
+                        data-test-id="form-submit"
+                        onClick={[Function]}
+                        role="button"
+                        type="submit"
+                      >
+                        <ButtonLabel
+                          align="center"
+                          priority="primary"
+                        >
+                          <Component
+                            align="center"
+                            className="css-oo1m2a-ButtonLabel edwq9my1"
+                            priority="primary"
+                          >
+                            <span
+                              className="css-oo1m2a-ButtonLabel edwq9my1"
+                            >
+                              Create Issue
+                            </span>
+                          </Component>
+                        </ButtonLabel>
+                      </button>
+                    </ForwardRef>
+                  </StyledButton>
+                </Button>
+              </Observer>
+            </div>
+          </DefaultButtons>
+        </div>
+      </StyledFooter>
+    </form>
+  </Form>
+</ExternalIssueForm>
+`;
+
+exports[`ExternalIssueForm link renders 1`] = `
+<ExternalIssueForm
+  action="link"
+  group={
+    Object {
+      "activity": Array [],
+      "annotations": Array [],
+      "assignedTo": null,
+      "count": "327482",
+      "culprit": "fetchData(app/components/group/suggestedOwners)",
+      "firstRelease": null,
+      "firstSeen": "2019-04-05T19:44:05.963Z",
+      "hasSeen": false,
+      "id": "1",
+      "isBookmarked": false,
+      "isPublic": false,
+      "isSubscribed": false,
+      "lastRelease": null,
+      "lastSeen": "2019-04-11T01:08:59Z",
+      "level": "warning",
+      "logger": null,
+      "metadata": Object {
+        "function": "fetchData",
+        "type": "RequestError",
+      },
+      "numComments": 0,
+      "participants": Array [],
+      "permalink": "https://foo.io/organizations/foo/issues/1234/",
+      "platform": "javascript",
+      "pluginActions": Array [],
+      "pluginContexts": Array [],
+      "pluginIssues": Array [],
+      "project": Object {
+        "id": "2",
+        "platform": "javascript",
+        "slug": "project-slug",
+      },
+      "seenBy": Array [],
+      "shareId": null,
+      "shortId": "JAVASCRIPT-6QS",
+      "stats": Object {
+        "24h": Array [
+          Array [
+            1517281200,
+            2,
+          ],
+          Array [
+            1517310000,
+            1,
+          ],
+        ],
+        "30d": Array [
+          Array [
+            1514764800,
+            1,
+          ],
+          Array [
+            1515024000,
+            122,
+          ],
+        ],
+      },
+      "status": "unresolved",
+      "statusDetails": Object {},
+      "subscriptionDetails": null,
+      "tags": Array [],
+      "title": "RequestError: GET /issues/ 404",
+      "type": "error",
+      "userCount": 35097,
+      "userReportCount": 0,
+    }
+  }
+  integration={
+    Object {
+      "configData": Object {},
+      "configOrganization": Array [],
+      "domainName": "github.com/test-integration",
+      "externalIssues": Array [],
+      "icon": "http://example.com/integration_icon.png",
+      "id": "1",
+      "name": "Test Integration",
+      "projects": Array [],
+      "provider": Object {
+        "canAdd": true,
+        "features": Array [],
+        "key": "github",
+        "name": "GitHub",
+      },
+    }
+  }
+  onSubmitSuccess={[MockFunction]}
+>
+  <Form
+    allowUndo={false}
+    apiEndpoint="/groups/1/integrations/1/"
+    apiMethod="PUT"
+    cancelLabel="Cancel"
+    className="form-stacked"
+    footerClass="modal-footer"
+    initialData={
+      Object {
+        "comment": "Default Value",
+        "externalIssue": "",
+        "repo": "scefali/test",
+      }
+    }
+    onFieldChange={[Function]}
+    onSubmitSuccess={[Function]}
+    requireChanges={false}
+    saveOnBlur={false}
+    submitDisabled={false}
+    submitLabel="Link Issue"
+    submitPriority="primary"
+  >
+    <form
+      className="form-stacked"
+      onSubmit={[Function]}
+    >
+      <div>
+        <FieldFromConfig
+          async={true}
+          autoload={true}
+          cache={false}
+          disabled={false}
+          field={
+            Object {
+              "choices": Array [
+                Array [
+                  "scefali/test",
+                  "test",
+                ],
+                Array [
+                  "scefali/ZeldaBazaar",
+                  "ZeldaBazaar",
+                ],
+              ],
+              "default": "scefali/test",
+              "label": "GitHub Repository",
+              "name": "repo",
+              "required": true,
+              "type": "select",
+              "updatesForm": true,
+              "url": "/search",
+            }
+          }
+          flexibleControlStateSize={true}
+          inline={false}
+          key="repo-scefali/test"
+          loadOptions={[Function]}
+          onBlurResetsInput={false}
+          onCloseResetsInput={false}
+          onSelectResetsInput={false}
+          stacked={true}
+        >
+          <SelectField
+            allowClear={false}
+            allowEmpty={false}
+            async={true}
+            autoload={true}
+            cache={false}
+            choices={
+              Array [
+                Array [
+                  "scefali/test",
+                  "test",
+                ],
+                Array [
+                  "scefali/ZeldaBazaar",
+                  "ZeldaBazaar",
+                ],
+              ]
+            }
+            default="scefali/test"
+            disabled={false}
+            escapeMarkup={true}
+            field={[Function]}
+            flexibleControlStateSize={true}
+            formatMessageValue={[Function]}
+            inline={false}
+            label="GitHub Repository"
+            loadOptions={[Function]}
+            multiple={false}
+            name="repo"
+            onBlurResetsInput={false}
+            onCloseResetsInput={false}
+            onSelectResetsInput={false}
+            placeholder="--"
+            required={true}
+            small={false}
+            stacked={true}
+            type="select"
+            updatesForm={true}
+            url="/search"
+          >
+            <InputField
+              alignRight={false}
+              allowEmpty={false}
+              async={true}
+              autoload={true}
+              cache={false}
+              choices={
+                Array [
+                  Array [
+                    "scefali/test",
+                    "test",
+                  ],
+                  Array [
+                    "scefali/ZeldaBazaar",
+                    "ZeldaBazaar",
+                  ],
+                ]
+              }
+              default="scefali/test"
+              disabled={false}
+              escapeMarkup={true}
+              field={[Function]}
+              flexibleControlStateSize={true}
+              formatMessageValue={[Function]}
+              inline={false}
+              label="GitHub Repository"
+              loadOptions={[Function]}
+              name="repo"
+              onBlurResetsInput={false}
+              onCloseResetsInput={false}
+              onSelectResetsInput={false}
+              placeholder="--"
+              required={true}
+              small={false}
+              stacked={true}
+              type="select"
+              updatesForm={true}
+              url="/search"
+            >
+              <FormField
+                alignRight={false}
+                allowEmpty={false}
+                async={true}
+                autoload={true}
+                cache={false}
+                choices={
+                  Array [
+                    Array [
+                      "scefali/test",
+                      "test",
+                    ],
+                    Array [
+                      "scefali/ZeldaBazaar",
+                      "ZeldaBazaar",
+                    ],
+                  ]
+                }
+                default="scefali/test"
+                disabled={false}
+                escapeMarkup={true}
+                field={[Function]}
+                flexibleControlStateSize={true}
+                formatMessageValue={[Function]}
+                hideErrorMessage={false}
+                inline={false}
+                label="GitHub Repository"
+                loadOptions={[Function]}
+                name="repo"
+                onBlurResetsInput={false}
+                onCloseResetsInput={false}
+                onSelectResetsInput={false}
+                placeholder="--"
+                required={true}
+                small={false}
+                stacked={true}
+                type="select"
+                updatesForm={true}
+                url="/search"
+              >
+                <Field
+                  alignRight={false}
+                  allowEmpty={false}
+                  async={true}
+                  autoload={true}
+                  cache={false}
+                  choices={
+                    Array [
+                      Array [
+                        "scefali/test",
+                        "test",
+                      ],
+                      Array [
+                        "scefali/ZeldaBazaar",
+                        "ZeldaBazaar",
+                      ],
+                    ]
+                  }
+                  default="scefali/test"
+                  disabled={false}
+                  escapeMarkup={true}
+                  field={[Function]}
+                  flexibleControlStateSize={true}
+                  formatMessageValue={[Function]}
+                  id="repo"
+                  inline={false}
+                  label="GitHub Repository"
+                  loadOptions={[Function]}
+                  name="repo"
+                  onBlurResetsInput={false}
+                  onCloseResetsInput={false}
+                  onSelectResetsInput={false}
+                  placeholder="--"
+                  required={true}
+                  small={false}
+                  stacked={true}
+                  type="select"
+                  updatesForm={true}
+                  url="/search"
+                  visible={true}
+                >
+                  <FieldWrapper
+                    hasControlState={false}
+                    inline={false}
+                    stacked={true}
+                  >
+                    <Component
+                      className="css-1743ds7-FieldWrapper-getPadding-inlineStyle etqqcs20"
+                    >
+                      <Flex
+                        className="css-1743ds7-FieldWrapper-getPadding-inlineStyle etqqcs20"
+                      >
+                        <Base
+                          className="etqqcs20 css-1i61chh-FieldWrapper-getPadding-inlineStyle"
+                        >
+                          <div
+                            className="etqqcs20 css-1i61chh-FieldWrapper-getPadding-inlineStyle"
+                            is={null}
+                          >
+                            <FieldDescription
+                              htmlFor="repo"
+                              inline={false}
+                            >
+                              <Component
+                                className="css-jq43rd-FieldDescription-inlineStyle e12jefmo0"
+                                htmlFor="repo"
+                                inline={false}
+                              >
+                                <label
+                                  className="css-jq43rd-FieldDescription-inlineStyle e12jefmo0"
+                                  htmlFor="repo"
+                                >
+                                  <FieldLabel
+                                    disabled={false}
+                                  >
+                                    <div
+                                      className="css-qzvhly-FieldLabel ejkuyjq0"
+                                    >
+                                      GitHub Repository
+                                       
+                                      <FieldRequiredBadge>
+                                        <div
+                                          className="css-x360nj-FieldRequiredBadge e1uclnuk0"
+                                        />
+                                      </FieldRequiredBadge>
+                                    </div>
+                                  </FieldLabel>
+                                </label>
+                              </Component>
+                            </FieldDescription>
+                            <FieldControl
+                              alignRight={false}
+                              controlState={
+                                <FormFieldControlState
+                                  model={
+                                    FormModel {
+                                      "api": Client {
+                                        "_chain": [Function],
+                                        "_wrapRequest": [Function],
+                                        "bulkUpdate": [Function],
+                                        "handleRequestError": [Function],
+                                        "hasProjectBeenRenamed": [Function],
+                                      },
+                                      "errors": Object {},
+                                      "fieldDescriptor": Map {
+                                        "repo" => Object {
+                                          "alignRight": false,
+                                          "allowEmpty": false,
+                                          "async": true,
+                                          "autoload": true,
+                                          "cache": false,
+                                          "children": [Function],
+                                          "choices": Array [
+                                            Array [
+                                              "scefali/test",
+                                              "test",
+                                            ],
+                                            Array [
+                                              "scefali/ZeldaBazaar",
+                                              "ZeldaBazaar",
+                                            ],
+                                          ],
+                                          "className": undefined,
+                                          "default": "scefali/test",
+                                          "disabled": false,
+                                          "escapeMarkup": true,
+                                          "field": [Function],
+                                          "flexibleControlStateSize": true,
+                                          "formatMessageValue": [Function],
+                                          "hideErrorMessage": false,
+                                          "inline": false,
+                                          "label": "GitHub Repository",
+                                          "loadOptions": [Function],
+                                          "name": "repo",
+                                          "onBlurResetsInput": false,
+                                          "onCloseResetsInput": false,
+                                          "onSelectResetsInput": false,
+                                          "placeholder": "--",
+                                          "required": true,
+                                          "small": false,
+                                          "stacked": true,
+                                          "type": "select",
+                                          "updatesForm": true,
+                                          "url": "/search",
+                                        },
+                                        "externalIssue" => Object {
+                                          "alignRight": false,
+                                          "allowEmpty": false,
+                                          "async": true,
+                                          "autoload": true,
+                                          "cache": false,
+                                          "children": [Function],
+                                          "choices": Array [],
+                                          "className": undefined,
+                                          "default": "",
+                                          "disabled": false,
+                                          "escapeMarkup": true,
+                                          "field": [Function],
+                                          "flexibleControlStateSize": true,
+                                          "formatMessageValue": [Function],
+                                          "hideErrorMessage": false,
+                                          "inline": false,
+                                          "label": "Issue",
+                                          "loadOptions": [Function],
+                                          "name": "externalIssue",
+                                          "onBlurResetsInput": false,
+                                          "onCloseResetsInput": false,
+                                          "onSelectResetsInput": false,
+                                          "placeholder": "--",
+                                          "required": true,
+                                          "small": false,
+                                          "stacked": true,
+                                          "type": "select",
+                                          "url": "/search",
+                                        },
+                                        "comment" => Object {
+                                          "children": [Function],
+                                          "className": undefined,
+                                          "default": "Default Value",
+                                          "disabled": false,
+                                          "field": [Function],
+                                          "flexibleControlStateSize": true,
+                                          "help": "Leave blank if you don't want to add a comment to the GitHub issue.",
+                                          "hideErrorMessage": false,
+                                          "inline": false,
+                                          "label": "Comment",
+                                          "name": "comment",
+                                          "required": false,
+                                          "stacked": true,
+                                          "type": "textarea",
+                                        },
+                                      },
+                                      "fieldState": Object {},
+                                      "fields": Object {
+                                        "comment": "Default Value",
+                                        "externalIssue": "",
+                                        "repo": "scefali/test",
+                                      },
+                                      "formErrors": undefined,
+                                      "formState": undefined,
+                                      "initialData": Object {
+                                        "comment": "Default Value",
+                                        "externalIssue": "",
+                                        "repo": "scefali/test",
+                                      },
+                                      "options": Object {
+                                        "allowUndo": false,
+                                        "apiEndpoint": "/groups/1/integrations/1/",
+                                        "apiMethod": "PUT",
+                                        "onFieldChange": [Function],
+                                        "onSubmitError": undefined,
+                                        "onSubmitSuccess": [Function],
+                                        "resetOnError": undefined,
+                                        "saveOnBlur": false,
+                                      },
+                                      "snapshots": Array [
+                                        Map {
+                                          "repo" => "scefali/test",
+                                          "externalIssue" => "",
+                                          "comment" => "Default Value",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  name="repo"
+                                />
+                              }
+                              disabled={false}
+                              errorState={
+                                <Observer>
+                                  [Function]
+                                </Observer>
+                              }
+                              flexibleControlStateSize={true}
+                              inline={false}
+                            >
+                              <FieldControlErrorWrapper
+                                inline={false}
+                              >
+                                <Component
+                                  className="css-1ge7tqf-FieldControlErrorWrapper e78b1iv0"
+                                  inline={false}
+                                >
+                                  <Box
+                                    className="css-1ge7tqf-FieldControlErrorWrapper e78b1iv0"
+                                  >
+                                    <Base
+                                      className="e78b1iv0 css-nnn2ut-FieldControlErrorWrapper"
+                                    >
+                                      <div
+                                        className="e78b1iv0 css-nnn2ut-FieldControlErrorWrapper"
+                                        is={null}
+                                      >
+                                        <FieldControlWrapper>
+                                          <Component
+                                            className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                          >
+                                            <Flex
+                                              className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                            >
+                                              <Base
+                                                className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                              >
+                                                <div
+                                                  className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                                  is={null}
+                                                >
+                                                  <FieldControlStyled
+                                                    alignRight={false}
+                                                  >
+                                                    <Component
+                                                      alignRight={false}
+                                                      className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                    >
+                                                      <Box
+                                                        className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                      >
+                                                        <Base
+                                                          className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                        >
+                                                          <div
+                                                            className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                            is={null}
+                                                          >
+                                                            <Observer>
+                                                              <SelectControl
+                                                                alignRight={false}
+                                                                allowEmpty={false}
+                                                                async={true}
+                                                                autoload={true}
+                                                                cache={false}
+                                                                choices={
+                                                                  Array [
+                                                                    Array [
+                                                                      "scefali/test",
+                                                                      "test",
+                                                                    ],
+                                                                    Array [
+                                                                      "scefali/ZeldaBazaar",
+                                                                      "ZeldaBazaar",
+                                                                    ],
+                                                                  ]
+                                                                }
+                                                                clearable={false}
+                                                                default="scefali/test"
+                                                                disabled={false}
+                                                                error={false}
+                                                                escapeMarkup={true}
+                                                                field={[Function]}
+                                                                formatMessageValue={[Function]}
+                                                                height={36}
+                                                                id="repo"
+                                                                initialData={
+                                                                  Object {
+                                                                    "comment": "Default Value",
+                                                                    "externalIssue": "",
+                                                                    "repo": "scefali/test",
+                                                                  }
+                                                                }
+                                                                inline={false}
+                                                                innerRef={[Function]}
+                                                                label="GitHub Repository"
+                                                                loadOptions={[Function]}
+                                                                multiple={false}
+                                                                name="repo"
+                                                                onBlurResetsInput={false}
+                                                                onChange={[Function]}
+                                                                onCloseResetsInput={false}
+                                                                onKeyDown={[Function]}
+                                                                onSelectResetsInput={false}
+                                                                options={
+                                                                  Array [
+                                                                    Object {
+                                                                      "label": "test",
+                                                                      "value": "scefali/test",
+                                                                    },
+                                                                    Object {
+                                                                      "label": "ZeldaBazaar",
+                                                                      "value": "scefali/ZeldaBazaar",
+                                                                    },
+                                                                  ]
+                                                                }
+                                                                placeholder="--"
+                                                                small={false}
+                                                                stacked={true}
+                                                                type="select"
+                                                                updatesForm={true}
+                                                                url="/search"
+                                                                value="scefali/test"
+                                                              >
+                                                                <StyledSelect
+                                                                  alignRight={false}
+                                                                  allowEmpty={false}
+                                                                  arrowRenderer={[Function]}
+                                                                  async={true}
+                                                                  autoload={true}
+                                                                  backspaceRemoves={false}
+                                                                  cache={false}
+                                                                  clearable={false}
+                                                                  default="scefali/test"
+                                                                  deleteRemoves={false}
+                                                                  disabled={false}
+                                                                  error={false}
+                                                                  escapeMarkup={true}
+                                                                  field={[Function]}
+                                                                  formatMessageValue={[Function]}
+                                                                  height={36}
+                                                                  id="repo"
+                                                                  initialData={
+                                                                    Object {
+                                                                      "comment": "Default Value",
+                                                                      "externalIssue": "",
+                                                                      "repo": "scefali/test",
+                                                                    }
+                                                                  }
+                                                                  inline={false}
+                                                                  innerRef={[Function]}
+                                                                  label="GitHub Repository"
+                                                                  loadOptions={[Function]}
+                                                                  multiple={false}
+                                                                  name="repo"
+                                                                  onBlurResetsInput={false}
+                                                                  onChange={[Function]}
+                                                                  onCloseResetsInput={false}
+                                                                  onKeyDown={[Function]}
+                                                                  onSelectResetsInput={false}
+                                                                  options={
+                                                                    Array [
+                                                                      Object {
+                                                                        "label": "test",
+                                                                        "value": "scefali/test",
+                                                                      },
+                                                                      Object {
+                                                                        "label": "ZeldaBazaar",
+                                                                        "value": "scefali/ZeldaBazaar",
+                                                                      },
+                                                                    ]
+                                                                  }
+                                                                  placeholder="--"
+                                                                  small={false}
+                                                                  stacked={true}
+                                                                  type="select"
+                                                                  updatesForm={true}
+                                                                  url="/search"
+                                                                  value="scefali/test"
+                                                                >
+                                                                  <ForwardRef(SelectPicker)
+                                                                    alignRight={false}
+                                                                    allowEmpty={false}
+                                                                    arrowRenderer={[Function]}
+                                                                    async={true}
+                                                                    autoload={true}
+                                                                    backspaceRemoves={false}
+                                                                    cache={false}
+                                                                    className="css-5srpa7-StyledSelect eho28m20"
+                                                                    clearable={false}
+                                                                    default="scefali/test"
+                                                                    deleteRemoves={false}
+                                                                    disabled={false}
+                                                                    error={false}
+                                                                    escapeMarkup={true}
+                                                                    field={[Function]}
+                                                                    formatMessageValue={[Function]}
+                                                                    height={36}
+                                                                    id="repo"
+                                                                    initialData={
+                                                                      Object {
+                                                                        "comment": "Default Value",
+                                                                        "externalIssue": "",
+                                                                        "repo": "scefali/test",
+                                                                      }
+                                                                    }
+                                                                    inline={false}
+                                                                    label="GitHub Repository"
+                                                                    loadOptions={[Function]}
+                                                                    multiple={false}
+                                                                    name="repo"
+                                                                    onBlurResetsInput={false}
+                                                                    onChange={[Function]}
+                                                                    onCloseResetsInput={false}
+                                                                    onKeyDown={[Function]}
+                                                                    onSelectResetsInput={false}
+                                                                    options={
+                                                                      Array [
+                                                                        Object {
+                                                                          "label": "test",
+                                                                          "value": "scefali/test",
+                                                                        },
+                                                                        Object {
+                                                                          "label": "ZeldaBazaar",
+                                                                          "value": "scefali/ZeldaBazaar",
+                                                                        },
+                                                                      ]
+                                                                    }
+                                                                    placeholder="--"
+                                                                    small={false}
+                                                                    stacked={true}
+                                                                    type="select"
+                                                                    updatesForm={true}
+                                                                    url="/search"
+                                                                    value="scefali/test"
+                                                                  >
+                                                                    <SelectPicker
+                                                                      alignRight={false}
+                                                                      allowEmpty={false}
+                                                                      arrowRenderer={[Function]}
+                                                                      async={true}
+                                                                      autoload={true}
+                                                                      backspaceRemoves={false}
+                                                                      cache={false}
+                                                                      className="css-5srpa7-StyledSelect eho28m20"
+                                                                      clearable={false}
+                                                                      default="scefali/test"
+                                                                      deleteRemoves={false}
+                                                                      disabled={false}
+                                                                      error={false}
+                                                                      escapeMarkup={true}
+                                                                      field={[Function]}
+                                                                      formatMessageValue={[Function]}
+                                                                      forwardedRef={[Function]}
+                                                                      height={36}
+                                                                      id="repo"
+                                                                      initialData={
+                                                                        Object {
+                                                                          "comment": "Default Value",
+                                                                          "externalIssue": "",
+                                                                          "repo": "scefali/test",
+                                                                        }
+                                                                      }
+                                                                      inline={false}
+                                                                      label="GitHub Repository"
+                                                                      loadOptions={[Function]}
+                                                                      multiple={false}
+                                                                      name="repo"
+                                                                      onBlurResetsInput={false}
+                                                                      onChange={[Function]}
+                                                                      onCloseResetsInput={false}
+                                                                      onKeyDown={[Function]}
+                                                                      onSelectResetsInput={false}
+                                                                      options={
+                                                                        Array [
+                                                                          Object {
+                                                                            "label": "test",
+                                                                            "value": "scefali/test",
+                                                                          },
+                                                                          Object {
+                                                                            "label": "ZeldaBazaar",
+                                                                            "value": "scefali/ZeldaBazaar",
+                                                                          },
+                                                                        ]
+                                                                      }
+                                                                      placeholder="--"
+                                                                      small={false}
+                                                                      stacked={true}
+                                                                      type="select"
+                                                                      updatesForm={true}
+                                                                      url="/search"
+                                                                      value="scefali/test"
+                                                                    >
+                                                                      <Async
+                                                                        alignRight={false}
+                                                                        allowEmpty={false}
+                                                                        arrowRenderer={[Function]}
+                                                                        autoload={true}
+                                                                        backspaceRemoves={false}
+                                                                        cache={false}
+                                                                        className="css-5srpa7-StyledSelect eho28m20"
+                                                                        clearable={false}
+                                                                        default="scefali/test"
+                                                                        deleteRemoves={false}
+                                                                        disabled={false}
+                                                                        error={false}
+                                                                        escapeMarkup={true}
+                                                                        field={[Function]}
+                                                                        formatMessageValue={[Function]}
+                                                                        height={36}
+                                                                        id="repo"
+                                                                        ignoreAccents={true}
+                                                                        ignoreCase={true}
+                                                                        initialData={
+                                                                          Object {
+                                                                            "comment": "Default Value",
+                                                                            "externalIssue": "",
+                                                                            "repo": "scefali/test",
+                                                                          }
+                                                                        }
+                                                                        inline={false}
+                                                                        label="GitHub Repository"
+                                                                        loadOptions={[Function]}
+                                                                        loadingPlaceholder="Loading..."
+                                                                        multiple={false}
+                                                                        name="repo"
+                                                                        onBlurResetsInput={false}
+                                                                        onChange={[Function]}
+                                                                        onCloseResetsInput={false}
+                                                                        onKeyDown={[Function]}
+                                                                        onSelectResetsInput={false}
+                                                                        options={
+                                                                          Array [
+                                                                            Object {
+                                                                              "label": "test",
+                                                                              "value": "scefali/test",
+                                                                            },
+                                                                            Object {
+                                                                              "label": "ZeldaBazaar",
+                                                                              "value": "scefali/ZeldaBazaar",
+                                                                            },
+                                                                          ]
+                                                                        }
+                                                                        placeholder="--"
+                                                                        searchPromptText="Type to search"
+                                                                        small={false}
+                                                                        stacked={true}
+                                                                        type="select"
+                                                                        updatesForm={true}
+                                                                        url="/search"
+                                                                        value="scefali/test"
+                                                                      >
+                                                                        <Select
+                                                                          alignRight={false}
+                                                                          allowEmpty={false}
+                                                                          arrowRenderer={[Function]}
+                                                                          autoload={true}
+                                                                          autosize={true}
+                                                                          backspaceRemoves={false}
+                                                                          backspaceToRemoveMessage="Press backspace to remove {label}"
+                                                                          cache={false}
+                                                                          className="css-5srpa7-StyledSelect eho28m20"
+                                                                          clearAllText="Clear all"
+                                                                          clearRenderer={[Function]}
+                                                                          clearValueText="Clear value"
+                                                                          clearable={false}
+                                                                          closeOnSelect={true}
+                                                                          default="scefali/test"
+                                                                          deleteRemoves={false}
+                                                                          delimiter=","
+                                                                          disabled={false}
+                                                                          error={false}
+                                                                          escapeClearsValue={true}
+                                                                          escapeMarkup={true}
+                                                                          field={[Function]}
+                                                                          filterOptions={[Function]}
+                                                                          formatMessageValue={[Function]}
+                                                                          height={36}
+                                                                          id="repo"
+                                                                          ignoreAccents={true}
+                                                                          ignoreCase={true}
+                                                                          initialData={
+                                                                            Object {
+                                                                              "comment": "Default Value",
+                                                                              "externalIssue": "",
+                                                                              "repo": "scefali/test",
+                                                                            }
+                                                                          }
+                                                                          inline={false}
+                                                                          inputProps={Object {}}
+                                                                          isLoading={true}
+                                                                          joinValues={false}
+                                                                          label="GitHub Repository"
+                                                                          labelKey="label"
+                                                                          loadOptions={[Function]}
+                                                                          loadingPlaceholder="Loading..."
+                                                                          matchPos="any"
+                                                                          matchProp="any"
+                                                                          menuBuffer={0}
+                                                                          menuRenderer={[Function]}
+                                                                          multi={false}
+                                                                          multiple={false}
+                                                                          name="repo"
+                                                                          noResultsText="Loading..."
+                                                                          onBlurResetsInput={false}
+                                                                          onChange={[Function]}
+                                                                          onCloseResetsInput={false}
+                                                                          onInputChange={[Function]}
+                                                                          onKeyDown={[Function]}
+                                                                          onSelectResetsInput={false}
+                                                                          openOnClick={true}
+                                                                          optionComponent={[Function]}
+                                                                          options={Array []}
+                                                                          pageSize={5}
+                                                                          placeholder="Loading..."
+                                                                          removeSelected={true}
+                                                                          required={false}
+                                                                          rtl={false}
+                                                                          scrollMenuIntoView={true}
+                                                                          searchPromptText="Type to search"
+                                                                          searchable={true}
+                                                                          simpleValue={false}
+                                                                          small={false}
+                                                                          stacked={true}
+                                                                          tabSelectsValue={true}
+                                                                          trimFilter={true}
+                                                                          type="select"
+                                                                          updatesForm={true}
+                                                                          url="/search"
+                                                                          value="scefali/test"
+                                                                          valueComponent={[Function]}
+                                                                          valueKey="value"
+                                                                        >
+                                                                          <div
+                                                                            className="Select css-5srpa7-StyledSelect eho28m20 is-loading is-searchable Select--single"
+                                                                          >
+                                                                            <div
+                                                                              className="Select-control"
+                                                                              onKeyDown={[Function]}
+                                                                              onMouseDown={[Function]}
+                                                                              onTouchEnd={[Function]}
+                                                                              onTouchMove={[Function]}
+                                                                              onTouchStart={[Function]}
+                                                                            >
+                                                                              <div
+                                                                                className="Select-multi-value-wrapper"
+                                                                                id="react-select-2--value"
+                                                                              >
+                                                                                <div
+                                                                                  className="Select-placeholder"
+                                                                                >
+                                                                                  Loading...
+                                                                                </div>
+                                                                                <AutosizeInput
+                                                                                  aria-activedescendant="react-select-2--value"
+                                                                                  aria-expanded="false"
+                                                                                  aria-haspopup="false"
+                                                                                  aria-owns=""
+                                                                                  className="Select-input"
+                                                                                  id="repo"
+                                                                                  injectStyles={true}
+                                                                                  minWidth="5"
+                                                                                  onBlur={[Function]}
+                                                                                  onChange={[Function]}
+                                                                                  onFocus={[Function]}
+                                                                                  required={false}
+                                                                                  role="combobox"
+                                                                                  value=""
+                                                                                >
+                                                                                  <div
+                                                                                    className="Select-input"
+                                                                                    style={
+                                                                                      Object {
+                                                                                        "display": "inline-block",
+                                                                                      }
+                                                                                    }
+                                                                                  >
+                                                                                    <input
+                                                                                      aria-activedescendant="react-select-2--value"
+                                                                                      aria-expanded="false"
+                                                                                      aria-haspopup="false"
+                                                                                      aria-owns=""
+                                                                                      id="repo"
+                                                                                      onBlur={[Function]}
+                                                                                      onChange={[Function]}
+                                                                                      onFocus={[Function]}
+                                                                                      required={false}
+                                                                                      role="combobox"
+                                                                                      style={
+                                                                                        Object {
+                                                                                          "boxSizing": "content-box",
+                                                                                          "width": "5px",
+                                                                                        }
+                                                                                      }
+                                                                                      value=""
+                                                                                    />
+                                                                                    <div
+                                                                                      style={
+                                                                                        Object {
+                                                                                          "height": 0,
+                                                                                          "left": 0,
+                                                                                          "overflow": "scroll",
+                                                                                          "position": "absolute",
+                                                                                          "top": 0,
+                                                                                          "visibility": "hidden",
+                                                                                          "whiteSpace": "pre",
+                                                                                        }
+                                                                                      }
+                                                                                    />
+                                                                                  </div>
+                                                                                </AutosizeInput>
+                                                                              </div>
+                                                                              <span
+                                                                                aria-hidden="true"
+                                                                                className="Select-loading-zone"
+                                                                              >
+                                                                                <span
+                                                                                  className="Select-loading"
+                                                                                />
+                                                                              </span>
+                                                                              <span
+                                                                                className="Select-arrow-zone"
+                                                                                onMouseDown={[Function]}
+                                                                              >
+                                                                                <span
+                                                                                  className="icon-arrow-down"
+                                                                                />
+                                                                              </span>
+                                                                            </div>
+                                                                          </div>
+                                                                        </Select>
+                                                                      </Async>
+                                                                    </SelectPicker>
+                                                                  </ForwardRef(SelectPicker)>
+                                                                </StyledSelect>
+                                                              </SelectControl>
+                                                            </Observer>
+                                                          </div>
+                                                        </Base>
+                                                      </Box>
+                                                    </Component>
+                                                  </FieldControlStyled>
+                                                  <FieldControlState
+                                                    flexibleControlStateSize={true}
+                                                  >
+                                                    <Component
+                                                      className="css-1x60lk6-FieldControlState e1rziqw00"
+                                                      flexibleControlStateSize={true}
+                                                    >
+                                                      <Flex
+                                                        className="css-1x60lk6-FieldControlState e1rziqw00"
+                                                      >
+                                                        <Base
+                                                          className="e1rziqw00 css-dgyrfj-FieldControlState"
+                                                        >
+                                                          <div
+                                                            className="e1rziqw00 css-dgyrfj-FieldControlState"
+                                                            is={null}
+                                                          >
+                                                            <FormFieldControlState
+                                                              model={
+                                                                FormModel {
+                                                                  "api": Client {
+                                                                    "_chain": [Function],
+                                                                    "_wrapRequest": [Function],
+                                                                    "bulkUpdate": [Function],
+                                                                    "handleRequestError": [Function],
+                                                                    "hasProjectBeenRenamed": [Function],
+                                                                  },
+                                                                  "errors": Object {},
+                                                                  "fieldDescriptor": Map {
+                                                                    "repo" => Object {
+                                                                      "alignRight": false,
+                                                                      "allowEmpty": false,
+                                                                      "async": true,
+                                                                      "autoload": true,
+                                                                      "cache": false,
+                                                                      "children": [Function],
+                                                                      "choices": Array [
+                                                                        Array [
+                                                                          "scefali/test",
+                                                                          "test",
+                                                                        ],
+                                                                        Array [
+                                                                          "scefali/ZeldaBazaar",
+                                                                          "ZeldaBazaar",
+                                                                        ],
+                                                                      ],
+                                                                      "className": undefined,
+                                                                      "default": "scefali/test",
+                                                                      "disabled": false,
+                                                                      "escapeMarkup": true,
+                                                                      "field": [Function],
+                                                                      "flexibleControlStateSize": true,
+                                                                      "formatMessageValue": [Function],
+                                                                      "hideErrorMessage": false,
+                                                                      "inline": false,
+                                                                      "label": "GitHub Repository",
+                                                                      "loadOptions": [Function],
+                                                                      "name": "repo",
+                                                                      "onBlurResetsInput": false,
+                                                                      "onCloseResetsInput": false,
+                                                                      "onSelectResetsInput": false,
+                                                                      "placeholder": "--",
+                                                                      "required": true,
+                                                                      "small": false,
+                                                                      "stacked": true,
+                                                                      "type": "select",
+                                                                      "updatesForm": true,
+                                                                      "url": "/search",
+                                                                    },
+                                                                    "externalIssue" => Object {
+                                                                      "alignRight": false,
+                                                                      "allowEmpty": false,
+                                                                      "async": true,
+                                                                      "autoload": true,
+                                                                      "cache": false,
+                                                                      "children": [Function],
+                                                                      "choices": Array [],
+                                                                      "className": undefined,
+                                                                      "default": "",
+                                                                      "disabled": false,
+                                                                      "escapeMarkup": true,
+                                                                      "field": [Function],
+                                                                      "flexibleControlStateSize": true,
+                                                                      "formatMessageValue": [Function],
+                                                                      "hideErrorMessage": false,
+                                                                      "inline": false,
+                                                                      "label": "Issue",
+                                                                      "loadOptions": [Function],
+                                                                      "name": "externalIssue",
+                                                                      "onBlurResetsInput": false,
+                                                                      "onCloseResetsInput": false,
+                                                                      "onSelectResetsInput": false,
+                                                                      "placeholder": "--",
+                                                                      "required": true,
+                                                                      "small": false,
+                                                                      "stacked": true,
+                                                                      "type": "select",
+                                                                      "url": "/search",
+                                                                    },
+                                                                    "comment" => Object {
+                                                                      "children": [Function],
+                                                                      "className": undefined,
+                                                                      "default": "Default Value",
+                                                                      "disabled": false,
+                                                                      "field": [Function],
+                                                                      "flexibleControlStateSize": true,
+                                                                      "help": "Leave blank if you don't want to add a comment to the GitHub issue.",
+                                                                      "hideErrorMessage": false,
+                                                                      "inline": false,
+                                                                      "label": "Comment",
+                                                                      "name": "comment",
+                                                                      "required": false,
+                                                                      "stacked": true,
+                                                                      "type": "textarea",
+                                                                    },
+                                                                  },
+                                                                  "fieldState": Object {},
+                                                                  "fields": Object {
+                                                                    "comment": "Default Value",
+                                                                    "externalIssue": "",
+                                                                    "repo": "scefali/test",
+                                                                  },
+                                                                  "formErrors": undefined,
+                                                                  "formState": undefined,
+                                                                  "initialData": Object {
+                                                                    "comment": "Default Value",
+                                                                    "externalIssue": "",
+                                                                    "repo": "scefali/test",
+                                                                  },
+                                                                  "options": Object {
+                                                                    "allowUndo": false,
+                                                                    "apiEndpoint": "/groups/1/integrations/1/",
+                                                                    "apiMethod": "PUT",
+                                                                    "onFieldChange": [Function],
+                                                                    "onSubmitError": undefined,
+                                                                    "onSubmitSuccess": [Function],
+                                                                    "resetOnError": undefined,
+                                                                    "saveOnBlur": false,
+                                                                  },
+                                                                  "snapshots": Array [
+                                                                    Map {
+                                                                      "repo" => "scefali/test",
+                                                                      "externalIssue" => "",
+                                                                      "comment" => "Default Value",
+                                                                    },
+                                                                  ],
+                                                                }
+                                                              }
+                                                              name="repo"
+                                                            >
+                                                              <Observer>
+                                                                <ControlState
+                                                                  error={false}
+                                                                  isSaved={null}
+                                                                  isSaving={null}
+                                                                />
+                                                              </Observer>
+                                                            </FormFieldControlState>
+                                                          </div>
+                                                        </Base>
+                                                      </Flex>
+                                                    </Component>
+                                                  </FieldControlState>
+                                                </div>
+                                              </Base>
+                                            </Flex>
+                                          </Component>
+                                        </FieldControlWrapper>
+                                        <Observer />
+                                      </div>
+                                    </Base>
+                                  </Box>
+                                </Component>
+                              </FieldControlErrorWrapper>
+                            </FieldControl>
+                          </div>
+                        </Base>
+                      </Flex>
+                    </Component>
+                  </FieldWrapper>
+                </Field>
+              </FormField>
+            </InputField>
+          </SelectField>
+        </FieldFromConfig>
+        <FieldFromConfig
+          async={true}
+          autoload={true}
+          cache={false}
+          disabled={false}
+          field={
+            Object {
+              "choices": Array [],
+              "default": "",
+              "label": "Issue",
+              "name": "externalIssue",
+              "required": true,
+              "type": "select",
+              "url": "/search",
+            }
+          }
+          flexibleControlStateSize={true}
+          inline={false}
+          key="externalIssue-"
+          loadOptions={[Function]}
+          onBlurResetsInput={false}
+          onCloseResetsInput={false}
+          onSelectResetsInput={false}
+          stacked={true}
+        >
+          <SelectField
+            allowClear={false}
+            allowEmpty={false}
+            async={true}
+            autoload={true}
+            cache={false}
+            choices={Array []}
+            default=""
+            disabled={false}
+            escapeMarkup={true}
+            field={[Function]}
+            flexibleControlStateSize={true}
+            formatMessageValue={[Function]}
+            inline={false}
+            label="Issue"
+            loadOptions={[Function]}
+            multiple={false}
+            name="externalIssue"
+            onBlurResetsInput={false}
+            onCloseResetsInput={false}
+            onSelectResetsInput={false}
+            placeholder="--"
+            required={true}
+            small={false}
+            stacked={true}
+            type="select"
+            url="/search"
+          >
+            <InputField
+              alignRight={false}
+              allowEmpty={false}
+              async={true}
+              autoload={true}
+              cache={false}
+              choices={Array []}
+              default=""
+              disabled={false}
+              escapeMarkup={true}
+              field={[Function]}
+              flexibleControlStateSize={true}
+              formatMessageValue={[Function]}
+              inline={false}
+              label="Issue"
+              loadOptions={[Function]}
+              name="externalIssue"
+              onBlurResetsInput={false}
+              onCloseResetsInput={false}
+              onSelectResetsInput={false}
+              placeholder="--"
+              required={true}
+              small={false}
+              stacked={true}
+              type="select"
+              url="/search"
+            >
+              <FormField
+                alignRight={false}
+                allowEmpty={false}
+                async={true}
+                autoload={true}
+                cache={false}
+                choices={Array []}
+                default=""
+                disabled={false}
+                escapeMarkup={true}
+                field={[Function]}
+                flexibleControlStateSize={true}
+                formatMessageValue={[Function]}
+                hideErrorMessage={false}
+                inline={false}
+                label="Issue"
+                loadOptions={[Function]}
+                name="externalIssue"
+                onBlurResetsInput={false}
+                onCloseResetsInput={false}
+                onSelectResetsInput={false}
+                placeholder="--"
+                required={true}
+                small={false}
+                stacked={true}
+                type="select"
+                url="/search"
+              >
+                <Field
+                  alignRight={false}
+                  allowEmpty={false}
+                  async={true}
+                  autoload={true}
+                  cache={false}
+                  choices={Array []}
+                  default=""
+                  disabled={false}
+                  escapeMarkup={true}
+                  field={[Function]}
+                  flexibleControlStateSize={true}
+                  formatMessageValue={[Function]}
+                  id="externalIssue"
+                  inline={false}
+                  label="Issue"
+                  loadOptions={[Function]}
+                  name="externalIssue"
+                  onBlurResetsInput={false}
+                  onCloseResetsInput={false}
+                  onSelectResetsInput={false}
+                  placeholder="--"
+                  required={true}
+                  small={false}
+                  stacked={true}
+                  type="select"
+                  url="/search"
+                  visible={true}
+                >
+                  <FieldWrapper
+                    hasControlState={false}
+                    inline={false}
+                    stacked={true}
+                  >
+                    <Component
+                      className="css-1743ds7-FieldWrapper-getPadding-inlineStyle etqqcs20"
+                    >
+                      <Flex
+                        className="css-1743ds7-FieldWrapper-getPadding-inlineStyle etqqcs20"
+                      >
+                        <Base
+                          className="etqqcs20 css-1i61chh-FieldWrapper-getPadding-inlineStyle"
+                        >
+                          <div
+                            className="etqqcs20 css-1i61chh-FieldWrapper-getPadding-inlineStyle"
+                            is={null}
+                          >
+                            <FieldDescription
+                              htmlFor="externalIssue"
+                              inline={false}
+                            >
+                              <Component
+                                className="css-jq43rd-FieldDescription-inlineStyle e12jefmo0"
+                                htmlFor="externalIssue"
+                                inline={false}
+                              >
+                                <label
+                                  className="css-jq43rd-FieldDescription-inlineStyle e12jefmo0"
+                                  htmlFor="externalIssue"
+                                >
+                                  <FieldLabel
+                                    disabled={false}
+                                  >
+                                    <div
+                                      className="css-qzvhly-FieldLabel ejkuyjq0"
+                                    >
+                                      Issue
+                                       
+                                      <FieldRequiredBadge>
+                                        <div
+                                          className="css-x360nj-FieldRequiredBadge e1uclnuk0"
+                                        />
+                                      </FieldRequiredBadge>
+                                    </div>
+                                  </FieldLabel>
+                                </label>
+                              </Component>
+                            </FieldDescription>
+                            <FieldControl
+                              alignRight={false}
+                              controlState={
+                                <FormFieldControlState
+                                  model={
+                                    FormModel {
+                                      "api": Client {
+                                        "_chain": [Function],
+                                        "_wrapRequest": [Function],
+                                        "bulkUpdate": [Function],
+                                        "handleRequestError": [Function],
+                                        "hasProjectBeenRenamed": [Function],
+                                      },
+                                      "errors": Object {},
+                                      "fieldDescriptor": Map {
+                                        "repo" => Object {
+                                          "alignRight": false,
+                                          "allowEmpty": false,
+                                          "async": true,
+                                          "autoload": true,
+                                          "cache": false,
+                                          "children": [Function],
+                                          "choices": Array [
+                                            Array [
+                                              "scefali/test",
+                                              "test",
+                                            ],
+                                            Array [
+                                              "scefali/ZeldaBazaar",
+                                              "ZeldaBazaar",
+                                            ],
+                                          ],
+                                          "className": undefined,
+                                          "default": "scefali/test",
+                                          "disabled": false,
+                                          "escapeMarkup": true,
+                                          "field": [Function],
+                                          "flexibleControlStateSize": true,
+                                          "formatMessageValue": [Function],
+                                          "hideErrorMessage": false,
+                                          "inline": false,
+                                          "label": "GitHub Repository",
+                                          "loadOptions": [Function],
+                                          "name": "repo",
+                                          "onBlurResetsInput": false,
+                                          "onCloseResetsInput": false,
+                                          "onSelectResetsInput": false,
+                                          "placeholder": "--",
+                                          "required": true,
+                                          "small": false,
+                                          "stacked": true,
+                                          "type": "select",
+                                          "updatesForm": true,
+                                          "url": "/search",
+                                        },
+                                        "externalIssue" => Object {
+                                          "alignRight": false,
+                                          "allowEmpty": false,
+                                          "async": true,
+                                          "autoload": true,
+                                          "cache": false,
+                                          "children": [Function],
+                                          "choices": Array [],
+                                          "className": undefined,
+                                          "default": "",
+                                          "disabled": false,
+                                          "escapeMarkup": true,
+                                          "field": [Function],
+                                          "flexibleControlStateSize": true,
+                                          "formatMessageValue": [Function],
+                                          "hideErrorMessage": false,
+                                          "inline": false,
+                                          "label": "Issue",
+                                          "loadOptions": [Function],
+                                          "name": "externalIssue",
+                                          "onBlurResetsInput": false,
+                                          "onCloseResetsInput": false,
+                                          "onSelectResetsInput": false,
+                                          "placeholder": "--",
+                                          "required": true,
+                                          "small": false,
+                                          "stacked": true,
+                                          "type": "select",
+                                          "url": "/search",
+                                        },
+                                        "comment" => Object {
+                                          "children": [Function],
+                                          "className": undefined,
+                                          "default": "Default Value",
+                                          "disabled": false,
+                                          "field": [Function],
+                                          "flexibleControlStateSize": true,
+                                          "help": "Leave blank if you don't want to add a comment to the GitHub issue.",
+                                          "hideErrorMessage": false,
+                                          "inline": false,
+                                          "label": "Comment",
+                                          "name": "comment",
+                                          "required": false,
+                                          "stacked": true,
+                                          "type": "textarea",
+                                        },
+                                      },
+                                      "fieldState": Object {},
+                                      "fields": Object {
+                                        "comment": "Default Value",
+                                        "externalIssue": "",
+                                        "repo": "scefali/test",
+                                      },
+                                      "formErrors": undefined,
+                                      "formState": undefined,
+                                      "initialData": Object {
+                                        "comment": "Default Value",
+                                        "externalIssue": "",
+                                        "repo": "scefali/test",
+                                      },
+                                      "options": Object {
+                                        "allowUndo": false,
+                                        "apiEndpoint": "/groups/1/integrations/1/",
+                                        "apiMethod": "PUT",
+                                        "onFieldChange": [Function],
+                                        "onSubmitError": undefined,
+                                        "onSubmitSuccess": [Function],
+                                        "resetOnError": undefined,
+                                        "saveOnBlur": false,
+                                      },
+                                      "snapshots": Array [
+                                        Map {
+                                          "repo" => "scefali/test",
+                                          "externalIssue" => "",
+                                          "comment" => "Default Value",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  name="externalIssue"
+                                />
+                              }
+                              disabled={false}
+                              errorState={
+                                <Observer>
+                                  [Function]
+                                </Observer>
+                              }
+                              flexibleControlStateSize={true}
+                              inline={false}
+                            >
+                              <FieldControlErrorWrapper
+                                inline={false}
+                              >
+                                <Component
+                                  className="css-1ge7tqf-FieldControlErrorWrapper e78b1iv0"
+                                  inline={false}
+                                >
+                                  <Box
+                                    className="css-1ge7tqf-FieldControlErrorWrapper e78b1iv0"
+                                  >
+                                    <Base
+                                      className="e78b1iv0 css-nnn2ut-FieldControlErrorWrapper"
+                                    >
+                                      <div
+                                        className="e78b1iv0 css-nnn2ut-FieldControlErrorWrapper"
+                                        is={null}
+                                      >
+                                        <FieldControlWrapper>
+                                          <Component
+                                            className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                          >
+                                            <Flex
+                                              className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                            >
+                                              <Base
+                                                className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                              >
+                                                <div
+                                                  className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                                  is={null}
+                                                >
+                                                  <FieldControlStyled
+                                                    alignRight={false}
+                                                  >
+                                                    <Component
+                                                      alignRight={false}
+                                                      className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                    >
+                                                      <Box
+                                                        className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                      >
+                                                        <Base
+                                                          className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                        >
+                                                          <div
+                                                            className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                            is={null}
+                                                          >
+                                                            <Observer>
+                                                              <SelectControl
+                                                                alignRight={false}
+                                                                allowEmpty={false}
+                                                                async={true}
+                                                                autoload={true}
+                                                                cache={false}
+                                                                choices={Array []}
+                                                                clearable={false}
+                                                                default=""
+                                                                disabled={false}
+                                                                error={false}
+                                                                escapeMarkup={true}
+                                                                field={[Function]}
+                                                                formatMessageValue={[Function]}
+                                                                height={36}
+                                                                id="externalIssue"
+                                                                initialData={
+                                                                  Object {
+                                                                    "comment": "Default Value",
+                                                                    "externalIssue": "",
+                                                                    "repo": "scefali/test",
+                                                                  }
+                                                                }
+                                                                inline={false}
+                                                                innerRef={[Function]}
+                                                                label="Issue"
+                                                                loadOptions={[Function]}
+                                                                multiple={false}
+                                                                name="externalIssue"
+                                                                onBlurResetsInput={false}
+                                                                onChange={[Function]}
+                                                                onCloseResetsInput={false}
+                                                                onKeyDown={[Function]}
+                                                                onSelectResetsInput={false}
+                                                                options={Array []}
+                                                                placeholder="--"
+                                                                small={false}
+                                                                stacked={true}
+                                                                type="select"
+                                                                url="/search"
+                                                                value=""
+                                                              >
+                                                                <StyledSelect
+                                                                  alignRight={false}
+                                                                  allowEmpty={false}
+                                                                  arrowRenderer={[Function]}
+                                                                  async={true}
+                                                                  autoload={true}
+                                                                  backspaceRemoves={false}
+                                                                  cache={false}
+                                                                  clearable={false}
+                                                                  default=""
+                                                                  deleteRemoves={false}
+                                                                  disabled={false}
+                                                                  error={false}
+                                                                  escapeMarkup={true}
+                                                                  field={[Function]}
+                                                                  formatMessageValue={[Function]}
+                                                                  height={36}
+                                                                  id="externalIssue"
+                                                                  initialData={
+                                                                    Object {
+                                                                      "comment": "Default Value",
+                                                                      "externalIssue": "",
+                                                                      "repo": "scefali/test",
+                                                                    }
+                                                                  }
+                                                                  inline={false}
+                                                                  innerRef={[Function]}
+                                                                  label="Issue"
+                                                                  loadOptions={[Function]}
+                                                                  multiple={false}
+                                                                  name="externalIssue"
+                                                                  onBlurResetsInput={false}
+                                                                  onChange={[Function]}
+                                                                  onCloseResetsInput={false}
+                                                                  onKeyDown={[Function]}
+                                                                  onSelectResetsInput={false}
+                                                                  options={Array []}
+                                                                  placeholder="--"
+                                                                  small={false}
+                                                                  stacked={true}
+                                                                  type="select"
+                                                                  url="/search"
+                                                                  value=""
+                                                                >
+                                                                  <ForwardRef(SelectPicker)
+                                                                    alignRight={false}
+                                                                    allowEmpty={false}
+                                                                    arrowRenderer={[Function]}
+                                                                    async={true}
+                                                                    autoload={true}
+                                                                    backspaceRemoves={false}
+                                                                    cache={false}
+                                                                    className="css-5srpa7-StyledSelect eho28m20"
+                                                                    clearable={false}
+                                                                    default=""
+                                                                    deleteRemoves={false}
+                                                                    disabled={false}
+                                                                    error={false}
+                                                                    escapeMarkup={true}
+                                                                    field={[Function]}
+                                                                    formatMessageValue={[Function]}
+                                                                    height={36}
+                                                                    id="externalIssue"
+                                                                    initialData={
+                                                                      Object {
+                                                                        "comment": "Default Value",
+                                                                        "externalIssue": "",
+                                                                        "repo": "scefali/test",
+                                                                      }
+                                                                    }
+                                                                    inline={false}
+                                                                    label="Issue"
+                                                                    loadOptions={[Function]}
+                                                                    multiple={false}
+                                                                    name="externalIssue"
+                                                                    onBlurResetsInput={false}
+                                                                    onChange={[Function]}
+                                                                    onCloseResetsInput={false}
+                                                                    onKeyDown={[Function]}
+                                                                    onSelectResetsInput={false}
+                                                                    options={Array []}
+                                                                    placeholder="--"
+                                                                    small={false}
+                                                                    stacked={true}
+                                                                    type="select"
+                                                                    url="/search"
+                                                                    value=""
+                                                                  >
+                                                                    <SelectPicker
+                                                                      alignRight={false}
+                                                                      allowEmpty={false}
+                                                                      arrowRenderer={[Function]}
+                                                                      async={true}
+                                                                      autoload={true}
+                                                                      backspaceRemoves={false}
+                                                                      cache={false}
+                                                                      className="css-5srpa7-StyledSelect eho28m20"
+                                                                      clearable={false}
+                                                                      default=""
+                                                                      deleteRemoves={false}
+                                                                      disabled={false}
+                                                                      error={false}
+                                                                      escapeMarkup={true}
+                                                                      field={[Function]}
+                                                                      formatMessageValue={[Function]}
+                                                                      forwardedRef={[Function]}
+                                                                      height={36}
+                                                                      id="externalIssue"
+                                                                      initialData={
+                                                                        Object {
+                                                                          "comment": "Default Value",
+                                                                          "externalIssue": "",
+                                                                          "repo": "scefali/test",
+                                                                        }
+                                                                      }
+                                                                      inline={false}
+                                                                      label="Issue"
+                                                                      loadOptions={[Function]}
+                                                                      multiple={false}
+                                                                      name="externalIssue"
+                                                                      onBlurResetsInput={false}
+                                                                      onChange={[Function]}
+                                                                      onCloseResetsInput={false}
+                                                                      onKeyDown={[Function]}
+                                                                      onSelectResetsInput={false}
+                                                                      options={Array []}
+                                                                      placeholder="--"
+                                                                      small={false}
+                                                                      stacked={true}
+                                                                      type="select"
+                                                                      url="/search"
+                                                                      value=""
+                                                                    >
+                                                                      <Async
+                                                                        alignRight={false}
+                                                                        allowEmpty={false}
+                                                                        arrowRenderer={[Function]}
+                                                                        autoload={true}
+                                                                        backspaceRemoves={false}
+                                                                        cache={false}
+                                                                        className="css-5srpa7-StyledSelect eho28m20"
+                                                                        clearable={false}
+                                                                        default=""
+                                                                        deleteRemoves={false}
+                                                                        disabled={false}
+                                                                        error={false}
+                                                                        escapeMarkup={true}
+                                                                        field={[Function]}
+                                                                        formatMessageValue={[Function]}
+                                                                        height={36}
+                                                                        id="externalIssue"
+                                                                        ignoreAccents={true}
+                                                                        ignoreCase={true}
+                                                                        initialData={
+                                                                          Object {
+                                                                            "comment": "Default Value",
+                                                                            "externalIssue": "",
+                                                                            "repo": "scefali/test",
+                                                                          }
+                                                                        }
+                                                                        inline={false}
+                                                                        label="Issue"
+                                                                        loadOptions={[Function]}
+                                                                        loadingPlaceholder="Loading..."
+                                                                        multiple={false}
+                                                                        name="externalIssue"
+                                                                        onBlurResetsInput={false}
+                                                                        onChange={[Function]}
+                                                                        onCloseResetsInput={false}
+                                                                        onKeyDown={[Function]}
+                                                                        onSelectResetsInput={false}
+                                                                        options={Array []}
+                                                                        placeholder="--"
+                                                                        searchPromptText="Type to search"
+                                                                        small={false}
+                                                                        stacked={true}
+                                                                        type="select"
+                                                                        url="/search"
+                                                                        value=""
+                                                                      >
+                                                                        <Select
+                                                                          alignRight={false}
+                                                                          allowEmpty={false}
+                                                                          arrowRenderer={[Function]}
+                                                                          autoload={true}
+                                                                          autosize={true}
+                                                                          backspaceRemoves={false}
+                                                                          backspaceToRemoveMessage="Press backspace to remove {label}"
+                                                                          cache={false}
+                                                                          className="css-5srpa7-StyledSelect eho28m20"
+                                                                          clearAllText="Clear all"
+                                                                          clearRenderer={[Function]}
+                                                                          clearValueText="Clear value"
+                                                                          clearable={false}
+                                                                          closeOnSelect={true}
+                                                                          default=""
+                                                                          deleteRemoves={false}
+                                                                          delimiter=","
+                                                                          disabled={false}
+                                                                          error={false}
+                                                                          escapeClearsValue={true}
+                                                                          escapeMarkup={true}
+                                                                          field={[Function]}
+                                                                          filterOptions={[Function]}
+                                                                          formatMessageValue={[Function]}
+                                                                          height={36}
+                                                                          id="externalIssue"
+                                                                          ignoreAccents={true}
+                                                                          ignoreCase={true}
+                                                                          initialData={
+                                                                            Object {
+                                                                              "comment": "Default Value",
+                                                                              "externalIssue": "",
+                                                                              "repo": "scefali/test",
+                                                                            }
+                                                                          }
+                                                                          inline={false}
+                                                                          inputProps={Object {}}
+                                                                          isLoading={true}
+                                                                          joinValues={false}
+                                                                          label="Issue"
+                                                                          labelKey="label"
+                                                                          loadOptions={[Function]}
+                                                                          loadingPlaceholder="Loading..."
+                                                                          matchPos="any"
+                                                                          matchProp="any"
+                                                                          menuBuffer={0}
+                                                                          menuRenderer={[Function]}
+                                                                          multi={false}
+                                                                          multiple={false}
+                                                                          name="externalIssue"
+                                                                          noResultsText="Loading..."
+                                                                          onBlurResetsInput={false}
+                                                                          onChange={[Function]}
+                                                                          onCloseResetsInput={false}
+                                                                          onInputChange={[Function]}
+                                                                          onKeyDown={[Function]}
+                                                                          onSelectResetsInput={false}
+                                                                          openOnClick={true}
+                                                                          optionComponent={[Function]}
+                                                                          options={Array []}
+                                                                          pageSize={5}
+                                                                          placeholder="Loading..."
+                                                                          removeSelected={true}
+                                                                          required={false}
+                                                                          rtl={false}
+                                                                          scrollMenuIntoView={true}
+                                                                          searchPromptText="Type to search"
+                                                                          searchable={true}
+                                                                          simpleValue={false}
+                                                                          small={false}
+                                                                          stacked={true}
+                                                                          tabSelectsValue={true}
+                                                                          trimFilter={true}
+                                                                          type="select"
+                                                                          url="/search"
+                                                                          value=""
+                                                                          valueComponent={[Function]}
+                                                                          valueKey="value"
+                                                                        >
+                                                                          <div
+                                                                            className="Select css-5srpa7-StyledSelect eho28m20 is-loading is-searchable Select--single"
+                                                                          >
+                                                                            <div
+                                                                              className="Select-control"
+                                                                              onKeyDown={[Function]}
+                                                                              onMouseDown={[Function]}
+                                                                              onTouchEnd={[Function]}
+                                                                              onTouchMove={[Function]}
+                                                                              onTouchStart={[Function]}
+                                                                            >
+                                                                              <div
+                                                                                className="Select-multi-value-wrapper"
+                                                                                id="react-select-3--value"
+                                                                              >
+                                                                                <div
+                                                                                  className="Select-placeholder"
+                                                                                >
+                                                                                  Loading...
+                                                                                </div>
+                                                                                <AutosizeInput
+                                                                                  aria-activedescendant="react-select-3--value"
+                                                                                  aria-expanded="false"
+                                                                                  aria-haspopup="false"
+                                                                                  aria-owns=""
+                                                                                  className="Select-input"
+                                                                                  id="externalIssue"
+                                                                                  injectStyles={true}
+                                                                                  minWidth="5"
+                                                                                  onBlur={[Function]}
+                                                                                  onChange={[Function]}
+                                                                                  onFocus={[Function]}
+                                                                                  required={false}
+                                                                                  role="combobox"
+                                                                                  value=""
+                                                                                >
+                                                                                  <div
+                                                                                    className="Select-input"
+                                                                                    style={
+                                                                                      Object {
+                                                                                        "display": "inline-block",
+                                                                                      }
+                                                                                    }
+                                                                                  >
+                                                                                    <input
+                                                                                      aria-activedescendant="react-select-3--value"
+                                                                                      aria-expanded="false"
+                                                                                      aria-haspopup="false"
+                                                                                      aria-owns=""
+                                                                                      id="externalIssue"
+                                                                                      onBlur={[Function]}
+                                                                                      onChange={[Function]}
+                                                                                      onFocus={[Function]}
+                                                                                      required={false}
+                                                                                      role="combobox"
+                                                                                      style={
+                                                                                        Object {
+                                                                                          "boxSizing": "content-box",
+                                                                                          "width": "5px",
+                                                                                        }
+                                                                                      }
+                                                                                      value=""
+                                                                                    />
+                                                                                    <div
+                                                                                      style={
+                                                                                        Object {
+                                                                                          "height": 0,
+                                                                                          "left": 0,
+                                                                                          "overflow": "scroll",
+                                                                                          "position": "absolute",
+                                                                                          "top": 0,
+                                                                                          "visibility": "hidden",
+                                                                                          "whiteSpace": "pre",
+                                                                                        }
+                                                                                      }
+                                                                                    />
+                                                                                  </div>
+                                                                                </AutosizeInput>
+                                                                              </div>
+                                                                              <span
+                                                                                aria-hidden="true"
+                                                                                className="Select-loading-zone"
+                                                                              >
+                                                                                <span
+                                                                                  className="Select-loading"
+                                                                                />
+                                                                              </span>
+                                                                              <span
+                                                                                className="Select-arrow-zone"
+                                                                                onMouseDown={[Function]}
+                                                                              >
+                                                                                <span
+                                                                                  className="icon-arrow-down"
+                                                                                />
+                                                                              </span>
+                                                                            </div>
+                                                                          </div>
+                                                                        </Select>
+                                                                      </Async>
+                                                                    </SelectPicker>
+                                                                  </ForwardRef(SelectPicker)>
+                                                                </StyledSelect>
+                                                              </SelectControl>
+                                                            </Observer>
+                                                          </div>
+                                                        </Base>
+                                                      </Box>
+                                                    </Component>
+                                                  </FieldControlStyled>
+                                                  <FieldControlState
+                                                    flexibleControlStateSize={true}
+                                                  >
+                                                    <Component
+                                                      className="css-1x60lk6-FieldControlState e1rziqw00"
+                                                      flexibleControlStateSize={true}
+                                                    >
+                                                      <Flex
+                                                        className="css-1x60lk6-FieldControlState e1rziqw00"
+                                                      >
+                                                        <Base
+                                                          className="e1rziqw00 css-dgyrfj-FieldControlState"
+                                                        >
+                                                          <div
+                                                            className="e1rziqw00 css-dgyrfj-FieldControlState"
+                                                            is={null}
+                                                          >
+                                                            <FormFieldControlState
+                                                              model={
+                                                                FormModel {
+                                                                  "api": Client {
+                                                                    "_chain": [Function],
+                                                                    "_wrapRequest": [Function],
+                                                                    "bulkUpdate": [Function],
+                                                                    "handleRequestError": [Function],
+                                                                    "hasProjectBeenRenamed": [Function],
+                                                                  },
+                                                                  "errors": Object {},
+                                                                  "fieldDescriptor": Map {
+                                                                    "repo" => Object {
+                                                                      "alignRight": false,
+                                                                      "allowEmpty": false,
+                                                                      "async": true,
+                                                                      "autoload": true,
+                                                                      "cache": false,
+                                                                      "children": [Function],
+                                                                      "choices": Array [
+                                                                        Array [
+                                                                          "scefali/test",
+                                                                          "test",
+                                                                        ],
+                                                                        Array [
+                                                                          "scefali/ZeldaBazaar",
+                                                                          "ZeldaBazaar",
+                                                                        ],
+                                                                      ],
+                                                                      "className": undefined,
+                                                                      "default": "scefali/test",
+                                                                      "disabled": false,
+                                                                      "escapeMarkup": true,
+                                                                      "field": [Function],
+                                                                      "flexibleControlStateSize": true,
+                                                                      "formatMessageValue": [Function],
+                                                                      "hideErrorMessage": false,
+                                                                      "inline": false,
+                                                                      "label": "GitHub Repository",
+                                                                      "loadOptions": [Function],
+                                                                      "name": "repo",
+                                                                      "onBlurResetsInput": false,
+                                                                      "onCloseResetsInput": false,
+                                                                      "onSelectResetsInput": false,
+                                                                      "placeholder": "--",
+                                                                      "required": true,
+                                                                      "small": false,
+                                                                      "stacked": true,
+                                                                      "type": "select",
+                                                                      "updatesForm": true,
+                                                                      "url": "/search",
+                                                                    },
+                                                                    "externalIssue" => Object {
+                                                                      "alignRight": false,
+                                                                      "allowEmpty": false,
+                                                                      "async": true,
+                                                                      "autoload": true,
+                                                                      "cache": false,
+                                                                      "children": [Function],
+                                                                      "choices": Array [],
+                                                                      "className": undefined,
+                                                                      "default": "",
+                                                                      "disabled": false,
+                                                                      "escapeMarkup": true,
+                                                                      "field": [Function],
+                                                                      "flexibleControlStateSize": true,
+                                                                      "formatMessageValue": [Function],
+                                                                      "hideErrorMessage": false,
+                                                                      "inline": false,
+                                                                      "label": "Issue",
+                                                                      "loadOptions": [Function],
+                                                                      "name": "externalIssue",
+                                                                      "onBlurResetsInput": false,
+                                                                      "onCloseResetsInput": false,
+                                                                      "onSelectResetsInput": false,
+                                                                      "placeholder": "--",
+                                                                      "required": true,
+                                                                      "small": false,
+                                                                      "stacked": true,
+                                                                      "type": "select",
+                                                                      "url": "/search",
+                                                                    },
+                                                                    "comment" => Object {
+                                                                      "children": [Function],
+                                                                      "className": undefined,
+                                                                      "default": "Default Value",
+                                                                      "disabled": false,
+                                                                      "field": [Function],
+                                                                      "flexibleControlStateSize": true,
+                                                                      "help": "Leave blank if you don't want to add a comment to the GitHub issue.",
+                                                                      "hideErrorMessage": false,
+                                                                      "inline": false,
+                                                                      "label": "Comment",
+                                                                      "name": "comment",
+                                                                      "required": false,
+                                                                      "stacked": true,
+                                                                      "type": "textarea",
+                                                                    },
+                                                                  },
+                                                                  "fieldState": Object {},
+                                                                  "fields": Object {
+                                                                    "comment": "Default Value",
+                                                                    "externalIssue": "",
+                                                                    "repo": "scefali/test",
+                                                                  },
+                                                                  "formErrors": undefined,
+                                                                  "formState": undefined,
+                                                                  "initialData": Object {
+                                                                    "comment": "Default Value",
+                                                                    "externalIssue": "",
+                                                                    "repo": "scefali/test",
+                                                                  },
+                                                                  "options": Object {
+                                                                    "allowUndo": false,
+                                                                    "apiEndpoint": "/groups/1/integrations/1/",
+                                                                    "apiMethod": "PUT",
+                                                                    "onFieldChange": [Function],
+                                                                    "onSubmitError": undefined,
+                                                                    "onSubmitSuccess": [Function],
+                                                                    "resetOnError": undefined,
+                                                                    "saveOnBlur": false,
+                                                                  },
+                                                                  "snapshots": Array [
+                                                                    Map {
+                                                                      "repo" => "scefali/test",
+                                                                      "externalIssue" => "",
+                                                                      "comment" => "Default Value",
+                                                                    },
+                                                                  ],
+                                                                }
+                                                              }
+                                                              name="externalIssue"
+                                                            >
+                                                              <Observer>
+                                                                <ControlState
+                                                                  error={false}
+                                                                  isSaved={null}
+                                                                  isSaving={null}
+                                                                />
+                                                              </Observer>
+                                                            </FormFieldControlState>
+                                                          </div>
+                                                        </Base>
+                                                      </Flex>
+                                                    </Component>
+                                                  </FieldControlState>
+                                                </div>
+                                              </Base>
+                                            </Flex>
+                                          </Component>
+                                        </FieldControlWrapper>
+                                        <Observer />
+                                      </div>
+                                    </Base>
+                                  </Box>
+                                </Component>
+                              </FieldControlErrorWrapper>
+                            </FieldControl>
+                          </div>
+                        </Base>
+                      </Flex>
+                    </Component>
+                  </FieldWrapper>
+                </Field>
+              </FormField>
+            </InputField>
+          </SelectField>
+        </FieldFromConfig>
+        <FieldFromConfig
+          disabled={false}
+          field={
+            Object {
+              "default": "Default Value",
+              "help": "Leave blank if you don't want to add a comment to the GitHub issue.",
+              "label": "Comment",
+              "name": "comment",
+              "required": false,
+              "type": "textarea",
+            }
+          }
+          flexibleControlStateSize={true}
+          inline={false}
+          key="comment-Default Value"
+          stacked={true}
+        >
+          <TextareaField
+            default="Default Value"
+            disabled={false}
+            flexibleControlStateSize={true}
+            help="Leave blank if you don't want to add a comment to the GitHub issue."
+            inline={false}
+            label="Comment"
+            name="comment"
+            required={false}
+            stacked={true}
+            type="textarea"
+          >
+            <InputField
+              default="Default Value"
+              disabled={false}
+              field={[Function]}
+              flexibleControlStateSize={true}
+              help="Leave blank if you don't want to add a comment to the GitHub issue."
+              inline={false}
+              label="Comment"
+              name="comment"
+              required={false}
+              stacked={true}
+              type="textarea"
+            >
+              <FormField
+                default="Default Value"
+                disabled={false}
+                field={[Function]}
+                flexibleControlStateSize={true}
+                help="Leave blank if you don't want to add a comment to the GitHub issue."
+                hideErrorMessage={false}
+                inline={false}
+                label="Comment"
+                name="comment"
+                required={false}
+                stacked={true}
+                type="textarea"
+              >
+                <Field
+                  alignRight={false}
+                  default="Default Value"
+                  disabled={false}
+                  field={[Function]}
+                  flexibleControlStateSize={true}
+                  help="Leave blank if you don't want to add a comment to the GitHub issue."
+                  id="comment"
+                  inline={false}
+                  label="Comment"
+                  name="comment"
+                  required={false}
+                  stacked={true}
+                  type="textarea"
+                  visible={true}
+                >
+                  <FieldWrapper
+                    hasControlState={false}
+                    inline={false}
+                    stacked={true}
+                  >
+                    <Component
+                      className="css-1743ds7-FieldWrapper-getPadding-inlineStyle etqqcs20"
+                    >
+                      <Flex
+                        className="css-1743ds7-FieldWrapper-getPadding-inlineStyle etqqcs20"
+                      >
+                        <Base
+                          className="etqqcs20 css-1i61chh-FieldWrapper-getPadding-inlineStyle"
+                        >
+                          <div
+                            className="etqqcs20 css-1i61chh-FieldWrapper-getPadding-inlineStyle"
+                            is={null}
+                          >
+                            <FieldDescription
+                              htmlFor="comment"
+                              inline={false}
+                            >
+                              <Component
+                                className="css-jq43rd-FieldDescription-inlineStyle e12jefmo0"
+                                htmlFor="comment"
+                                inline={false}
+                              >
+                                <label
+                                  className="css-jq43rd-FieldDescription-inlineStyle e12jefmo0"
+                                  htmlFor="comment"
+                                >
+                                  <FieldLabel
+                                    disabled={false}
+                                  >
+                                    <div
+                                      className="css-qzvhly-FieldLabel ejkuyjq0"
+                                    >
+                                      Comment
+                                       
+                                    </div>
+                                  </FieldLabel>
+                                  <FieldHelp
+                                    inline={false}
+                                    stacked={true}
+                                  >
+                                    <div
+                                      className="css-18eefdy-FieldHelp e19g0xdp0"
+                                    >
+                                      Leave blank if you don't want to add a comment to the GitHub issue.
+                                    </div>
+                                  </FieldHelp>
+                                </label>
+                              </Component>
+                            </FieldDescription>
+                            <FieldControl
+                              alignRight={false}
+                              controlState={
+                                <FormFieldControlState
+                                  model={
+                                    FormModel {
+                                      "api": Client {
+                                        "_chain": [Function],
+                                        "_wrapRequest": [Function],
+                                        "bulkUpdate": [Function],
+                                        "handleRequestError": [Function],
+                                        "hasProjectBeenRenamed": [Function],
+                                      },
+                                      "errors": Object {},
+                                      "fieldDescriptor": Map {
+                                        "repo" => Object {
+                                          "alignRight": false,
+                                          "allowEmpty": false,
+                                          "async": true,
+                                          "autoload": true,
+                                          "cache": false,
+                                          "children": [Function],
+                                          "choices": Array [
+                                            Array [
+                                              "scefali/test",
+                                              "test",
+                                            ],
+                                            Array [
+                                              "scefali/ZeldaBazaar",
+                                              "ZeldaBazaar",
+                                            ],
+                                          ],
+                                          "className": undefined,
+                                          "default": "scefali/test",
+                                          "disabled": false,
+                                          "escapeMarkup": true,
+                                          "field": [Function],
+                                          "flexibleControlStateSize": true,
+                                          "formatMessageValue": [Function],
+                                          "hideErrorMessage": false,
+                                          "inline": false,
+                                          "label": "GitHub Repository",
+                                          "loadOptions": [Function],
+                                          "name": "repo",
+                                          "onBlurResetsInput": false,
+                                          "onCloseResetsInput": false,
+                                          "onSelectResetsInput": false,
+                                          "placeholder": "--",
+                                          "required": true,
+                                          "small": false,
+                                          "stacked": true,
+                                          "type": "select",
+                                          "updatesForm": true,
+                                          "url": "/search",
+                                        },
+                                        "externalIssue" => Object {
+                                          "alignRight": false,
+                                          "allowEmpty": false,
+                                          "async": true,
+                                          "autoload": true,
+                                          "cache": false,
+                                          "children": [Function],
+                                          "choices": Array [],
+                                          "className": undefined,
+                                          "default": "",
+                                          "disabled": false,
+                                          "escapeMarkup": true,
+                                          "field": [Function],
+                                          "flexibleControlStateSize": true,
+                                          "formatMessageValue": [Function],
+                                          "hideErrorMessage": false,
+                                          "inline": false,
+                                          "label": "Issue",
+                                          "loadOptions": [Function],
+                                          "name": "externalIssue",
+                                          "onBlurResetsInput": false,
+                                          "onCloseResetsInput": false,
+                                          "onSelectResetsInput": false,
+                                          "placeholder": "--",
+                                          "required": true,
+                                          "small": false,
+                                          "stacked": true,
+                                          "type": "select",
+                                          "url": "/search",
+                                        },
+                                        "comment" => Object {
+                                          "children": [Function],
+                                          "className": undefined,
+                                          "default": "Default Value",
+                                          "disabled": false,
+                                          "field": [Function],
+                                          "flexibleControlStateSize": true,
+                                          "help": "Leave blank if you don't want to add a comment to the GitHub issue.",
+                                          "hideErrorMessage": false,
+                                          "inline": false,
+                                          "label": "Comment",
+                                          "name": "comment",
+                                          "required": false,
+                                          "stacked": true,
+                                          "type": "textarea",
+                                        },
+                                      },
+                                      "fieldState": Object {},
+                                      "fields": Object {
+                                        "comment": "Default Value",
+                                        "externalIssue": "",
+                                        "repo": "scefali/test",
+                                      },
+                                      "formErrors": undefined,
+                                      "formState": undefined,
+                                      "initialData": Object {
+                                        "comment": "Default Value",
+                                        "externalIssue": "",
+                                        "repo": "scefali/test",
+                                      },
+                                      "options": Object {
+                                        "allowUndo": false,
+                                        "apiEndpoint": "/groups/1/integrations/1/",
+                                        "apiMethod": "PUT",
+                                        "onFieldChange": [Function],
+                                        "onSubmitError": undefined,
+                                        "onSubmitSuccess": [Function],
+                                        "resetOnError": undefined,
+                                        "saveOnBlur": false,
+                                      },
+                                      "snapshots": Array [
+                                        Map {
+                                          "repo" => "scefali/test",
+                                          "externalIssue" => "",
+                                          "comment" => "Default Value",
+                                        },
+                                      ],
+                                    }
+                                  }
+                                  name="comment"
+                                />
+                              }
+                              disabled={false}
+                              errorState={
+                                <Observer>
+                                  [Function]
+                                </Observer>
+                              }
+                              flexibleControlStateSize={true}
+                              inline={false}
+                            >
+                              <FieldControlErrorWrapper
+                                inline={false}
+                              >
+                                <Component
+                                  className="css-1ge7tqf-FieldControlErrorWrapper e78b1iv0"
+                                  inline={false}
+                                >
+                                  <Box
+                                    className="css-1ge7tqf-FieldControlErrorWrapper e78b1iv0"
+                                  >
+                                    <Base
+                                      className="e78b1iv0 css-nnn2ut-FieldControlErrorWrapper"
+                                    >
+                                      <div
+                                        className="e78b1iv0 css-nnn2ut-FieldControlErrorWrapper"
+                                        is={null}
+                                      >
+                                        <FieldControlWrapper>
+                                          <Component
+                                            className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                          >
+                                            <Flex
+                                              className="css-1ke1xob-FieldControlWrapper e78b1iv2"
+                                            >
+                                              <Base
+                                                className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                              >
+                                                <div
+                                                  className="e78b1iv2 css-w4o1g8-FieldControlWrapper"
+                                                  is={null}
+                                                >
+                                                  <FieldControlStyled
+                                                    alignRight={false}
+                                                  >
+                                                    <Component
+                                                      alignRight={false}
+                                                      className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                    >
+                                                      <Box
+                                                        className="css-1pkvhmy-FieldControlStyled e78b1iv1"
+                                                      >
+                                                        <Base
+                                                          className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                        >
+                                                          <div
+                                                            className="e78b1iv1 css-wkkbba-FieldControlStyled"
+                                                            is={null}
+                                                          >
+                                                            <Observer>
+                                                              <TextArea
+                                                                default="Default Value"
+                                                                disabled={false}
+                                                                error={false}
+                                                                field={[Function]}
+                                                                help="Leave blank if you don't want to add a comment to the GitHub issue."
+                                                                id="comment"
+                                                                initialData={
+                                                                  Object {
+                                                                    "comment": "Default Value",
+                                                                    "externalIssue": "",
+                                                                    "repo": "scefali/test",
+                                                                  }
+                                                                }
+                                                                inline={false}
+                                                                innerRef={[Function]}
+                                                                label="Comment"
+                                                                name="comment"
+                                                                onBlur={[Function]}
+                                                                onChange={[Function]}
+                                                                required={false}
+                                                                stacked={true}
+                                                                type="textarea"
+                                                                value="Default Value"
+                                                              >
+                                                                <ForwardRef
+                                                                  className="css-11229su-TextArea-inputStyles e1oph3pe0"
+                                                                  default="Default Value"
+                                                                  disabled={false}
+                                                                  id="comment"
+                                                                  label="Comment"
+                                                                  name="comment"
+                                                                  onBlur={[Function]}
+                                                                  onChange={[Function]}
+                                                                  required={false}
+                                                                  type="textarea"
+                                                                  value="Default Value"
+                                                                >
+                                                                  <textarea
+                                                                    className="css-11229su-TextArea-inputStyles e1oph3pe0"
+                                                                    default="Default Value"
+                                                                    disabled={false}
+                                                                    id="comment"
+                                                                    label="Comment"
+                                                                    name="comment"
+                                                                    onBlur={[Function]}
+                                                                    onChange={[Function]}
+                                                                    required={false}
+                                                                    type="textarea"
+                                                                    value="Default Value"
+                                                                  />
+                                                                </ForwardRef>
+                                                              </TextArea>
+                                                            </Observer>
+                                                          </div>
+                                                        </Base>
+                                                      </Box>
+                                                    </Component>
+                                                  </FieldControlStyled>
+                                                  <FieldControlState
+                                                    flexibleControlStateSize={true}
+                                                  >
+                                                    <Component
+                                                      className="css-1x60lk6-FieldControlState e1rziqw00"
+                                                      flexibleControlStateSize={true}
+                                                    >
+                                                      <Flex
+                                                        className="css-1x60lk6-FieldControlState e1rziqw00"
+                                                      >
+                                                        <Base
+                                                          className="e1rziqw00 css-dgyrfj-FieldControlState"
+                                                        >
+                                                          <div
+                                                            className="e1rziqw00 css-dgyrfj-FieldControlState"
+                                                            is={null}
+                                                          >
+                                                            <FormFieldControlState
+                                                              model={
+                                                                FormModel {
+                                                                  "api": Client {
+                                                                    "_chain": [Function],
+                                                                    "_wrapRequest": [Function],
+                                                                    "bulkUpdate": [Function],
+                                                                    "handleRequestError": [Function],
+                                                                    "hasProjectBeenRenamed": [Function],
+                                                                  },
+                                                                  "errors": Object {},
+                                                                  "fieldDescriptor": Map {
+                                                                    "repo" => Object {
+                                                                      "alignRight": false,
+                                                                      "allowEmpty": false,
+                                                                      "async": true,
+                                                                      "autoload": true,
+                                                                      "cache": false,
+                                                                      "children": [Function],
+                                                                      "choices": Array [
+                                                                        Array [
+                                                                          "scefali/test",
+                                                                          "test",
+                                                                        ],
+                                                                        Array [
+                                                                          "scefali/ZeldaBazaar",
+                                                                          "ZeldaBazaar",
+                                                                        ],
+                                                                      ],
+                                                                      "className": undefined,
+                                                                      "default": "scefali/test",
+                                                                      "disabled": false,
+                                                                      "escapeMarkup": true,
+                                                                      "field": [Function],
+                                                                      "flexibleControlStateSize": true,
+                                                                      "formatMessageValue": [Function],
+                                                                      "hideErrorMessage": false,
+                                                                      "inline": false,
+                                                                      "label": "GitHub Repository",
+                                                                      "loadOptions": [Function],
+                                                                      "name": "repo",
+                                                                      "onBlurResetsInput": false,
+                                                                      "onCloseResetsInput": false,
+                                                                      "onSelectResetsInput": false,
+                                                                      "placeholder": "--",
+                                                                      "required": true,
+                                                                      "small": false,
+                                                                      "stacked": true,
+                                                                      "type": "select",
+                                                                      "updatesForm": true,
+                                                                      "url": "/search",
+                                                                    },
+                                                                    "externalIssue" => Object {
+                                                                      "alignRight": false,
+                                                                      "allowEmpty": false,
+                                                                      "async": true,
+                                                                      "autoload": true,
+                                                                      "cache": false,
+                                                                      "children": [Function],
+                                                                      "choices": Array [],
+                                                                      "className": undefined,
+                                                                      "default": "",
+                                                                      "disabled": false,
+                                                                      "escapeMarkup": true,
+                                                                      "field": [Function],
+                                                                      "flexibleControlStateSize": true,
+                                                                      "formatMessageValue": [Function],
+                                                                      "hideErrorMessage": false,
+                                                                      "inline": false,
+                                                                      "label": "Issue",
+                                                                      "loadOptions": [Function],
+                                                                      "name": "externalIssue",
+                                                                      "onBlurResetsInput": false,
+                                                                      "onCloseResetsInput": false,
+                                                                      "onSelectResetsInput": false,
+                                                                      "placeholder": "--",
+                                                                      "required": true,
+                                                                      "small": false,
+                                                                      "stacked": true,
+                                                                      "type": "select",
+                                                                      "url": "/search",
+                                                                    },
+                                                                    "comment" => Object {
+                                                                      "children": [Function],
+                                                                      "className": undefined,
+                                                                      "default": "Default Value",
+                                                                      "disabled": false,
+                                                                      "field": [Function],
+                                                                      "flexibleControlStateSize": true,
+                                                                      "help": "Leave blank if you don't want to add a comment to the GitHub issue.",
+                                                                      "hideErrorMessage": false,
+                                                                      "inline": false,
+                                                                      "label": "Comment",
+                                                                      "name": "comment",
+                                                                      "required": false,
+                                                                      "stacked": true,
+                                                                      "type": "textarea",
+                                                                    },
+                                                                  },
+                                                                  "fieldState": Object {},
+                                                                  "fields": Object {
+                                                                    "comment": "Default Value",
+                                                                    "externalIssue": "",
+                                                                    "repo": "scefali/test",
+                                                                  },
+                                                                  "formErrors": undefined,
+                                                                  "formState": undefined,
+                                                                  "initialData": Object {
+                                                                    "comment": "Default Value",
+                                                                    "externalIssue": "",
+                                                                    "repo": "scefali/test",
+                                                                  },
+                                                                  "options": Object {
+                                                                    "allowUndo": false,
+                                                                    "apiEndpoint": "/groups/1/integrations/1/",
+                                                                    "apiMethod": "PUT",
+                                                                    "onFieldChange": [Function],
+                                                                    "onSubmitError": undefined,
+                                                                    "onSubmitSuccess": [Function],
+                                                                    "resetOnError": undefined,
+                                                                    "saveOnBlur": false,
+                                                                  },
+                                                                  "snapshots": Array [
+                                                                    Map {
+                                                                      "repo" => "scefali/test",
+                                                                      "externalIssue" => "",
+                                                                      "comment" => "Default Value",
+                                                                    },
+                                                                  ],
+                                                                }
+                                                              }
+                                                              name="comment"
+                                                            >
+                                                              <Observer>
+                                                                <ControlState
+                                                                  error={false}
+                                                                  isSaved={null}
+                                                                  isSaving={null}
+                                                                />
+                                                              </Observer>
+                                                            </FormFieldControlState>
+                                                          </div>
+                                                        </Base>
+                                                      </Flex>
+                                                    </Component>
+                                                  </FieldControlState>
+                                                </div>
+                                              </Base>
+                                            </Flex>
+                                          </Component>
+                                        </FieldControlWrapper>
+                                        <Observer />
+                                      </div>
+                                    </Base>
+                                  </Box>
+                                </Component>
+                              </FieldControlErrorWrapper>
+                            </FieldControl>
+                          </div>
+                        </Base>
+                      </Flex>
+                    </Component>
+                  </FieldWrapper>
+                </Field>
+              </FormField>
+            </InputField>
+          </TextareaField>
+        </FieldFromConfig>
+      </div>
+      <StyledFooter
+        className="modal-footer"
+        saveOnBlur={false}
+      >
+        <div
+          className="modal-footer css-bobn3u-StyledFooter e1r1zmbj0"
+        >
+          <DefaultButtons>
+            <div
+              className="css-5mbz2j-DefaultButtons e1r1zmbj1"
+            >
+              <Observer>
+                <Button
+                  align="center"
+                  data-test-id="form-submit"
+                  disabled={false}
+                  priority="primary"
+                  type="submit"
+                >
+                  <StyledButton
+                    aria-disabled={false}
+                    aria-label="Link Issue"
+                    data-test-id="form-submit"
+                    disabled={false}
+                    onClick={[Function]}
+                    priority="primary"
+                    role="button"
+                    type="submit"
+                  >
+                    <ForwardRef
+                      aria-disabled={false}
+                      aria-label="Link Issue"
+                      className="css-xiynrq-StyledButton-getColors edwq9my0"
+                      data-test-id="form-submit"
+                      disabled={false}
+                      onClick={[Function]}
+                      priority="primary"
+                      role="button"
+                      type="submit"
+                    >
+                      <button
+                        aria-disabled={false}
+                        aria-label="Link Issue"
+                        className="css-xiynrq-StyledButton-getColors edwq9my0"
+                        data-test-id="form-submit"
+                        onClick={[Function]}
+                        role="button"
+                        type="submit"
+                      >
+                        <ButtonLabel
+                          align="center"
+                          priority="primary"
+                        >
+                          <Component
+                            align="center"
+                            className="css-oo1m2a-ButtonLabel edwq9my1"
+                            priority="primary"
+                          >
+                            <span
+                              className="css-oo1m2a-ButtonLabel edwq9my1"
+                            >
+                              Link Issue
+                            </span>
+                          </Component>
+                        </ButtonLabel>
+                      </button>
+                    </ForwardRef>
+                  </StyledButton>
+                </Button>
+              </Observer>
+            </div>
+          </DefaultButtons>
+        </div>
+      </StyledFooter>
+    </form>
+  </Form>
+</ExternalIssueForm>
+`;

--- a/tests/js/spec/components/group/externalIssueForm.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueForm.spec.jsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import ExternalIssueForm from 'app/components/group/externalIssueForm';
+
+describe('ExternalIssueForm', () => {
+  let group, integration, handleSubmitSuccess, wrapper, formConfig;
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    group = TestStubs.Group();
+    integration = TestStubs.GitHubIntegration({externalIssues: []});
+    handleSubmitSuccess = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const generateWrapper = (action = 'create') =>
+    mountWithTheme(
+      <ExternalIssueForm
+        group={group}
+        integration={integration}
+        onSubmitSuccess={handleSubmitSuccess}
+        action={action}
+      />,
+      TestStubs.routerContext()
+    );
+
+  describe('create', () => {
+    // TODO: expand tests
+    beforeEach(() => {
+      formConfig = {
+        createIssueConfig: [],
+      };
+      MockApiClient.addMockResponse({
+        url: `/groups/${group.id}/integrations/${integration.id}/?action=create`,
+        body: formConfig,
+      });
+    });
+    it('renders', () => {
+      wrapper = generateWrapper();
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+  describe('link', () => {
+    let externalIssueField, getFormConfigRequest;
+    beforeEach(() => {
+      externalIssueField = {
+        name: 'externalIssue',
+        default: '',
+        required: true,
+        choices: [],
+        url: '/search',
+        label: 'Issue',
+        type: 'select',
+      };
+      formConfig = {
+        status: 'active',
+        name: 'scefali',
+        domainName: 'github.com/scefali',
+        linkIssueConfig: [
+          {
+            url: '/search',
+            required: true,
+            name: 'repo',
+            default: 'scefali/test',
+            updatesForm: true,
+            choices: [['scefali/test', 'test'], ['scefali/ZeldaBazaar', 'ZeldaBazaar']],
+            type: 'select',
+            label: 'GitHub Repository',
+          },
+          externalIssueField,
+          {
+            help: "Leave blank if you don't want to add a comment to the GitHub issue.",
+            default: 'Default Value',
+            required: false,
+            label: 'Comment',
+            type: 'textarea',
+            name: 'comment',
+          },
+        ],
+        accountType: 'User',
+        provider: {
+          canAdd: true,
+          aspects: {
+            disable_dialog: {
+              body:
+                'Before deleting this integration, you must uninstall this integration from GitHub. After uninstalling, your integration will be disabled at which point you can choose to delete this integration.',
+              actionText: 'Visit GitHub',
+            },
+            removal_dialog: {
+              body:
+                'Deleting this integration will delete all associated repositories and commit data. This action cannot be undone. Are you sure you want to delete your integration?',
+              actionText: 'Delete',
+            },
+          },
+          features: ['commits', 'issue-basic'],
+          canDisable: true,
+          key: 'github',
+          name: 'GitHub',
+        },
+        id: '5',
+      };
+      getFormConfigRequest = MockApiClient.addMockResponse({
+        url: `/groups/${group.id}/integrations/${integration.id}/?action=link`,
+        body: formConfig,
+      });
+    });
+    it('renders', () => {
+      wrapper = generateWrapper('link');
+      expect(wrapper).toMatchSnapshot();
+    });
+    it('load options', async () => {
+      wrapper = generateWrapper('link');
+      await tick();
+      wrapper.update();
+      expect(getFormConfigRequest).toHaveBeenCalled();
+    });
+    describe('options loaded', () => {
+      let mockSuccessResponse, timeDelay;
+      beforeEach(async () => {
+        timeDelay = 50;
+        mockSuccessResponse = [];
+
+        const mockFetchPromise = () =>
+          new Promise(resolve => {
+            setTimeout(() => {
+              resolve({
+                json: () => Promise.resolve(mockSuccessResponse),
+                ok: true,
+              });
+            }, timeDelay);
+          });
+
+        window.fetch = jest.fn().mockImplementation(mockFetchPromise); // 4
+
+        MockApiClient.addMockResponse({
+          url: `/groups/${group.id}/integrations/${integration.id}/?action=link`,
+          body: formConfig,
+        });
+        wrapper = generateWrapper('link');
+        await tick();
+        wrapper.update();
+
+        jest.useFakeTimers();
+      });
+
+      it('long delay in typing', () => {
+        wrapper.instance().getOptions(externalIssueField, 'd');
+        jest.advanceTimersByTime(300);
+        expect(window.fetch).toHaveBeenCalledTimes(1);
+        wrapper.instance().getOptions(externalIssueField, 'do');
+        jest.advanceTimersByTime(300);
+        expect(window.fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it('fast typing is debounced', () => {
+        wrapper.instance().getOptions(externalIssueField, 'd');
+        jest.advanceTimersByTime(10);
+        expect(window.fetch).toHaveBeenCalledTimes(0);
+        wrapper.instance().getOptions(externalIssueField, 'do');
+        jest.advanceTimersByTime(10);
+        expect(window.fetch).toHaveBeenCalledTimes(0);
+        jest.advanceTimersByTime(300);
+        expect(window.fetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('debounced calls should wait until async calls to finish', async () => {
+        //add delay longer than debounce period
+        timeDelay = 1000;
+        const outputs = [undefined, undefined];
+        wrapper
+          .instance()
+          .getOptions(externalIssueField, 'd')
+          .then(out => {
+            outputs[0] = out;
+          });
+        jest.advanceTimersByTime(10);
+        wrapper
+          .instance()
+          .getOptions(externalIssueField, 'do')
+          .then(out => {
+            outputs[1] = out;
+          });
+        expect(window.fetch).toHaveBeenCalledTimes(0);
+        jest.advanceTimersByTime(300);
+        expect(window.fetch).toHaveBeenCalledTimes(1);
+
+        expect(outputs).toEqual([undefined, undefined]);
+        mockSuccessResponse = [1, 2];
+
+        jest.advanceTimersByTime(1200);
+        jest.useRealTimers();
+        await tick();
+        expect(window.fetch).toHaveBeenCalledTimes(1);
+        expect(outputs[0].options).toEqual(mockSuccessResponse);
+        expect(outputs[1].options).toEqual(mockSuccessResponse);
+      });
+    });
+  });
+});

--- a/tests/js/spec/components/group/externalIssueForm.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueForm.spec.jsx
@@ -146,6 +146,11 @@ describe('ExternalIssueForm', () => {
         jest.useFakeTimers();
       });
 
+      afterEach(() => {
+        window.fetch.mockClear();
+        delete window.fetch;
+      });
+
       it('long delay in typing', () => {
         wrapper.instance().getOptions(externalIssueField, 'd');
         jest.advanceTimersByTime(300);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9483,6 +9483,11 @@ osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+p-debounce@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-debounce/-/p-debounce-2.1.0.tgz#e79f70c6e325cbb9bddbcbec0b81025084671ad3"
+  integrity sha512-M9bMt62TTnozdZhqFgs+V7XD2MnuKCaz+7fZdlu2/T7xruI3uIE5CicQ0vx1hV7HIUYF0jF+4/R1AgfOkl74Qw==
+
 p-defer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"


### PR DESCRIPTION
Lodash's debounce doesn't work well with async functions as it will return a stale value even if it triggers the debounced function again. This is because `debounce` returns a function which just returns a value instead of a promise. This is causing a bug (https://getsentry.atlassian.net/browse/ISSUE-646).

The cleanest solution I found is to switch to a different library for debouncing (p-debounce). This debouncer returns a function that returns a promise. The debounced function calls get queued up until the user stops typing, makes the async request with the latest search term, and then returns that result. All function calls of `getOptions` wait on the single request to be finished then all return the same value.

 The other possible solution is to pass callbacks (see my other attempt: https://github.com/getsentry/sentry/pull/16215).