### PR TITLE
ref(event): Simplify culprit

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -219,9 +219,6 @@ class EventCommon(object):
 
     @property
     def culprit(self):
-        # For a while events did not save the culprit
-        if self.group_id:
-            return self.data.get("culprit") or self.group.culprit
         return self.data.get("culprit")
 
     @property

--- a/tests/sentry_plugins/pagerduty/test_plugin.py
+++ b/tests/sentry_plugins/pagerduty/test_plugin.py
@@ -53,8 +53,16 @@ class PagerDutyPluginTest(PluginTestCase):
         )
         self.plugin.set_option("service_key", "abcdef", self.project)
 
-        group = self.create_group(message="Hello world", culprit="foo.bar")
-        event = self.create_event(group=group, message="Hello world", tags={"level": "warning"})
+        event = self.store_event(
+            data={
+                "message": "Hello world",
+                "level": "warning",
+                "platform": "python",
+                "culprit": "foo.bar",
+            },
+            project_id=self.project.id,
+        )
+        group = event.group
 
         rule = Rule.objects.create(project=self.project, label="my rule")
 


### PR DESCRIPTION
All events have a culprit saved now, we no longer need to check the
group