### PR TITLE
ref: Give direct hit query a unique referrer

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -28,7 +28,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
                 request,
                 query,
                 self.get_filter_params(request, organization),
-                "api.organization-events",
+                "api.organization-events-direct-hit",
             )
         except (OrganizationEventsError, NoProjects):
             pass


### PR DESCRIPTION
It can be useful to split out this direct hit query from the main org events query when analysing performance.