### PR TITLE
fix: Make event.message consistent

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -496,7 +496,9 @@ class SnubaEvent(EventCommon):
     def message(self):
         if "message" in self.snuba_data:
             return self.snuba_data["message"]
-        return self.data.get("message")
+        from sentry.event_manager import EventManager
+        event_manager = EventManager(self.data.data)
+        return event_manager.get_search_message()
 
     @property
     def platform(self):


### PR DESCRIPTION
SnubaEvent.data.get("message") is not the same as
SnubaEvent.snuba_data.get("message"). Since the generated event.message
is stored in Snuba but only the raw form is stored in nodestore, we
reconstruct the search message if the message column was not fetched
from Snuba. This ensures that event.message always returns a consistent
result regardless of whether the underlying data was fetched from Snuba
or Nodestore.