### PR TITLE
fix(apm): Rename "Trace View" tab to "Transaction"

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/eventInterfaces.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/eventInterfaces.tsx
@@ -26,7 +26,7 @@ const OTHER_SECTIONS = {
 
 function getTabTitle(type: string): string {
   if (type === 'spans') {
-    return 'Trace View';
+    return 'Transaction';
   }
 
   return type;


### PR DESCRIPTION
<img width="1065" alt="Screen Shot 2020-01-02 at 12 57 08 PM" src="https://user-images.githubusercontent.com/139499/71683066-77023d80-2d5f-11ea-8775-fa13b39e6eba.png">


-------


"Trace view" would refer to a view that displays a trace end-to-end; which, at the moment, the transaction detail view does not do. So, we rename it to "Transaction".