### PR TITLE
test(percy): Fix percy snapshot for "Onboarding - learn more"

### DIFF
--- a/tests/acceptance/test_onboarding.py
+++ b/tests/acceptance/test_onboarding.py
@@ -48,4 +48,5 @@ class OrganizationOnboardingTest(AcceptanceTestCase):
         self.browser.snapshot(name="onboarding - invite members")
 
         self.browser.click('[data-test-id="onboarding-getting-started-learn-more"]')
+        self.browser.wait_until('input[name="email"]')
         self.browser.snapshot(name="onboarding - learn more")

--- a/tests/acceptance/test_onboarding.py
+++ b/tests/acceptance/test_onboarding.py
@@ -48,5 +48,6 @@ class OrganizationOnboardingTest(AcceptanceTestCase):
         self.browser.snapshot(name="onboarding - invite members")
 
         self.browser.click('[data-test-id="onboarding-getting-started-learn-more"]')
-        self.browser.wait_until('input[name="email"]')
+        self.browser.wait_until('[name="email"]')
+
         self.browser.snapshot(name="onboarding - learn more")

--- a/tests/acceptance/test_onboarding.py
+++ b/tests/acceptance/test_onboarding.py
@@ -45,9 +45,9 @@ class OrganizationOnboardingTest(AcceptanceTestCase):
         assert project.platform == "node"
 
         self.browser.click('[data-test-id="onboarding-getting-started-invite-members"]')
+        self.browser.wait_until('[name="email"]')
         self.browser.snapshot(name="onboarding - invite members")
 
         self.browser.click('[data-test-id="onboarding-getting-started-learn-more"]')
-        self.browser.wait_until('[name="email"]')
-
+        self.browser.wait_until_not('[name="email"]')
         self.browser.snapshot(name="onboarding - learn more")


### PR DESCRIPTION
Add a wait until condition for the new form to appear before snapshotting, otherwise it could snapshot before the tab change fully completes.

See https://percy.io/getsentry/sentry/builds/3616281\?utm_campaign\=getsentry\&utm_content\=sentry\&utm_source\=github_status_private