### PR TITLE
feat(teams): Update open membership team permissions

### DIFF
--- a/src/sentry/api/endpoints/organization_member_team_details.py
+++ b/src/sentry/api/endpoints/organization_member_team_details.py
@@ -56,6 +56,7 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
         * If they are modifying their own membership
         * If the user's role is higher than the targeted user's role (e.g. "admin" can't modify "owner")
         * If the user is an "admin" and they are modifying a team they are a member of
+        * If the "open membership" setting is enabled and the targeted user is being added to a team
         """
 
         if is_active_superuser(request):
@@ -74,6 +75,9 @@ class OrganizationMemberTeamDetailsEndpoint(OrganizationEndpoint):
         if roles.get(acting_member.role).is_global and roles.can_manage(
             acting_member.role, member.role
         ):
+            return True
+
+        if request.method == "POST" and organization.flags.allow_joinleave:
             return True
 
         return False

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamDetails.jsx
@@ -137,11 +137,11 @@ const TeamDetails = createReactClass({
     } else if (!team || !team.hasAccess) {
       return (
         <Alert type="warning">
-          <h4>{t('You do not have access to this team')}</h4>
-
-          {team && (
+          {team ? (
             <RequestAccessWrapper>
-              {tct('You may try to request access to [team]', {team: `#${team.slug}`})}
+              {tct('You do not have access to the [teamSlug] team.', {
+                teamSlug: <strong>{`#${team.slug}`}</strong>,
+              })}
               <Button
                 disabled={this.state.requesting || team.isPending}
                 size="small"
@@ -150,6 +150,8 @@ const TeamDetails = createReactClass({
                 {team.isPending ? t('Request Pending') : t('Request Access')}
               </Button>
             </RequestAccessWrapper>
+          ) : (
+            <div>{t('You do not have access to this team.')}</div>
           )}
         </Alert>
       );

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamMembers.jsx
@@ -199,10 +199,13 @@ class TeamMembers extends React.Component {
   };
 
   renderDropdown = access => {
-    // You can add members if you have `org:write` or you have `team:admin` AND you belong to the team
-    // a parent "team details" request should determine your team membership, so this only view is rendered only
-    // when you are a member
-    const canAddMembers = access.has('org:write') || access.has('team:admin');
+    const {organization} = this.props;
+
+    // members can add other members to a team if the `Open Membership` setting is enabled
+    // otherwise, `org:write` or `team:admin` permissions are required
+    const hasOpenMembership = organization && organization.openMembership;
+    const hasWriteAccess = access.has('org:write') || access.has('team:admin');
+    const canAddMembers = hasOpenMembership || hasWriteAccess;
 
     if (!canAddMembers) {
       return (
@@ -211,6 +214,7 @@ class TeamMembers extends React.Component {
           title={t('You do not have enough permission to add new members')}
           isOpen={false}
           size="xsmall"
+          data-test-id="add-member"
         >
           {t('Add Member')}
         </DropdownButton>

--- a/tests/js/spec/views/teamMembers.spec.jsx
+++ b/tests/js/spec/views/teamMembers.spec.jsx
@@ -41,12 +41,10 @@ describe('TeamMembers', function() {
     wrapper.update();
   });
 
-  it('can invite member from team dropdown', async function() {
+  it('can invite member from team dropdown with access', async function() {
+    const org = TestStubs.Organization({access: ['team:admin'], openMembership: false});
     const wrapper = mountWithTheme(
-      <TeamMembers
-        params={{orgId: organization.slug, teamId: team.slug}}
-        organization={organization}
-      />,
+      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
       routerContext
     );
 
@@ -59,6 +57,57 @@ describe('TeamMembers', function() {
       .simulate('click');
 
     expect(openInviteMembersModal).toHaveBeenCalled();
+  });
+
+  it('can invite member from team dropdown with access and `Open Membership` enabled', async function() {
+    const org = TestStubs.Organization({access: ['team:admin'], openMembership: true});
+    const wrapper = mountWithTheme(
+      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    wrapper.find('DropdownButton[data-test-id="add-member"]').simulate('click');
+    wrapper
+      .find('StyledCreateMemberLink[data-test-id="invite-member"]')
+      .simulate('click');
+
+    expect(openInviteMembersModal).toHaveBeenCalled();
+  });
+
+  it('can invite member from team dropdown without access and `Open Membership` enabled', async function() {
+    const org = TestStubs.Organization({access: [], openMembership: true});
+    const wrapper = mountWithTheme(
+      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    wrapper.find('DropdownButton[data-test-id="add-member"]').simulate('click');
+    wrapper
+      .find('StyledCreateMemberLink[data-test-id="invite-member"]')
+      .simulate('click');
+
+    expect(openInviteMembersModal).toHaveBeenCalled();
+  });
+
+  it('cannot invite member from team dropdown without access and `Open Membership` disabled', async function() {
+    const org = TestStubs.Organization({access: [], openMembership: false});
+    const wrapper = mountWithTheme(
+      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(
+      wrapper.find('DropdownButton[data-test-id="add-member"]').prop('disabled')
+    ).toBe(true);
   });
 
   it('can remove member from team', async function() {

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -1,518 +1,373 @@
 from __future__ import absolute_import
 
-from django.core.urlresolvers import reverse
-
 from sentry.models import Organization, OrganizationAccessRequest, OrganizationMemberTeam
 from sentry.testutils import APITestCase
 
 
 class CreateOrganizationMemberTeamTest(APITestCase):
+    endpoint = "sentry-api-0-organization-member-team-details"
+    method = "post"
+
     def test_can_join_as_owner_without_open_membership(self):
         organization = self.create_organization(name="foo", owner=self.user, flags=0)
         team = self.create_team(name="foo", organization=organization)
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(organization=organization, user=user, role="owner", teams=[])
-
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
+        owner = self.create_member(
+            organization=organization, user=self.create_user(), role="owner", teams=[]
         )
 
-        self.login_as(user)
-
-        resp = self.client.post(path)
-
+        self.login_as(owner.user)
+        resp = self.get_response(organization.slug, owner.id, team.slug)
         assert resp.status_code == 201
 
     def test_cannot_join_as_member_without_open_membership(self):
         organization = self.create_organization(name="foo", owner=self.user, flags=0)
         team = self.create_team(name="foo", organization=organization)
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[]
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(user)
-
-        resp = self.client.post(path)
-
+        self.login_as(member.user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
         assert resp.status_code == 202
 
         assert not OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
+            team=team, organizationmember=member
         ).exists()
-        assert OrganizationAccessRequest.objects.filter(team=team, member=member_om).exists()
+        assert OrganizationAccessRequest.objects.filter(team=team, member=member).exists()
 
     def test_can_join_as_member_with_open_membership(self):
         organization = self.create_organization(
             name="foo", owner=self.user, flags=Organization.flags.allow_joinleave
         )
         team = self.create_team(name="foo", organization=organization)
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[]
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
+        self.login_as(member.user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
+        assert resp.status_code == 201
+
+        assert OrganizationMemberTeam.objects.filter(team=team, organizationmember=member).exists()
+
+    def test_member_can_add_member_with_open_membership(self):
+        organization = self.create_organization(
+            name="foo", owner=self.user, flags=Organization.flags.allow_joinleave
+        )
+        team = self.create_team(name="foo", organization=organization)
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member"
+        )
+        target_member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[]
         )
 
-        self.login_as(user)
-
-        resp = self.client.post(path)
-
+        self.login_as(member.user)
+        resp = self.get_response(organization.slug, target_member.id, team.slug)
         assert resp.status_code == 201
 
         assert OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
+            team=team, organizationmember=target_member
         ).exists()
 
     def test_owner_can_add_member(self):
-        owner = self.create_user()
-        organization = self.create_organization(name="foo", owner=owner)
-        organization.flags.allow_joinleave = False
-        organization.save()
+        user = self.create_user()
+        organization = self.create_organization(name="foo", owner=user, flags=0)
         team = self.create_team(name="foo", organization=organization)
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[]
-        )
-
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(owner)
-
-        resp = self.client.post(path)
-
-        assert resp.status_code == 201
-
-        assert OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
-        ).exists()
-
-    def test_owner_can_add_manager(self):
-        owner = self.create_user()
-        organization = self.create_organization(name="foo", owner=owner)
-        organization.flags.allow_joinleave = False
-        organization.save()
-        team = self.create_team(name="foo", organization=organization)
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="manager", teams=[]
-        )
-
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(owner)
-
-        resp = self.client.post(path)
-
-        assert resp.status_code == 201
-
-        assert OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
-        ).exists()
-
-    def test_owner_can_add_other_owner(self):
-        owner = self.create_user()
-        organization = self.create_organization(name="foo", owner=owner)
-        organization.flags.allow_joinleave = False
-        organization.save()
-        team = self.create_team(name="foo", organization=organization)
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(organization=organization, user=user, role="owner", teams=[])
-
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(owner)
-
-        resp = self.client.post(path)
-
-        assert resp.status_code == 201
-
-        assert OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
-        ).exists()
-
-    def test_manager_can_add_member(self):
-        manager = self.create_user()
-        organization = self.create_organization(name="foo")
-        team = self.create_team(name="foo", organization=organization)
-        self.create_member(organization=organization, user=manager, role="manager", teams=[team])
-        organization.flags.allow_joinleave = False
-        organization.save()
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[]
-        )
-
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(manager)
-
-        resp = self.client.post(path)
-
-        assert resp.status_code == 201
-
-        assert OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
-        ).exists()
-
-    def test_manager_cannot_add_owner(self):
-        manager = self.create_user()
-        organization = self.create_organization(name="foo")
-        organization.flags.allow_joinleave = False
-        organization.save()
-        team = self.create_team(name="foo", organization=organization)
-        self.create_member(organization=organization, user=manager, role="manager", teams=[team])
-        owner = self.create_user()
-        user = self.create_user("dummy@example.com")
-        owner_om = self.create_member(organization=organization, user=user, role="owner", teams=[])
-
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, owner_om.id, team.slug],
-        )
-
-        self.login_as(manager)
-
-        resp = self.client.delete(path)
-
-        assert resp.status_code == 400
-
-        assert not OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember__user=owner
-        ).exists()
-
-    def test_admin_not_in_team_cannot_add_member(self):
-        owner = self.create_user()
-        admin = self.create_user()
-        organization = self.create_organization(name="foo", owner=owner)
-        organization.flags.allow_joinleave = False
-        organization.save()
-        team = self.create_team(name="foo", organization=organization)
-        self.create_member(organization=organization, user=admin, role="admin", teams=[])
-
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[]
-        )
-
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(admin)
-
-        resp = self.client.post(path)
-
-        assert resp.status_code == 400
-
-        assert not OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
-        ).exists()
-
-    def test_admin_in_team_can_add_member(self):
-        owner = self.create_user()
-        admin = self.create_user()
-        organization = self.create_organization(name="foo", owner=owner)
-        organization.flags.allow_joinleave = False
-        organization.save()
-        team = self.create_team(name="foo", organization=organization)
-        self.create_member(organization=organization, user=admin, role="admin", teams=[team])
-
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[]
-        )
-
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(admin)
-
-        resp = self.client.post(path)
-
-        assert resp.status_code == 201
-
-        assert OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
-        ).exists()
-
-
-class DeleteOrganizationMemberTeamTest(APITestCase):
-    def test_can_leave_as_member(self):
-        organization = self.create_organization(name="foo", owner=self.user)
-        team = self.create_team(name="foo", organization=organization)
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[team]
-        )
-
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[]
         )
 
         self.login_as(user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
+        assert resp.status_code == 201
 
-        resp = self.client.delete(path)
+        assert OrganizationMemberTeam.objects.filter(team=team, organizationmember=member).exists()
 
+    def test_owner_can_add_manager(self):
+        user = self.create_user()
+        organization = self.create_organization(name="foo", owner=user, flags=0)
+        team = self.create_team(name="foo", organization=organization)
+        manager = self.create_member(
+            organization=organization, user=self.create_user(), role="manager", teams=[]
+        )
+
+        self.login_as(user)
+        resp = self.get_response(organization.slug, manager.id, team.slug)
+        assert resp.status_code == 201
+
+        assert OrganizationMemberTeam.objects.filter(team=team, organizationmember=manager).exists()
+
+    def test_owner_can_add_other_owner(self):
+        user = self.create_user()
+        organization = self.create_organization(name="foo", owner=user, flags=0)
+        team = self.create_team(name="foo", organization=organization)
+        owner = self.create_member(
+            organization=organization, user=self.create_user(), role="owner", teams=[]
+        )
+
+        self.login_as(user)
+        resp = self.get_response(organization.slug, owner.id, team.slug)
+        assert resp.status_code == 201
+
+        assert OrganizationMemberTeam.objects.filter(team=team, organizationmember=owner).exists()
+
+    def test_manager_can_add_member(self):
+        organization = self.create_organization(name="foo", flags=0)
+        team = self.create_team(name="foo", organization=organization)
+        manager = self.create_member(
+            organization=organization, user=self.create_user(), role="manager", teams=[team]
+        )
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[]
+        )
+
+        self.login_as(manager.user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
+        assert resp.status_code == 201
+
+        assert OrganizationMemberTeam.objects.filter(team=team, organizationmember=member).exists()
+
+    def test_manager_cannot_add_owner(self):
+        organization = self.create_organization(name="foo", flags=0)
+        team = self.create_team(name="foo", organization=organization)
+        manager = self.create_member(
+            organization=organization, user=self.create_user(), role="manager", teams=[team]
+        )
+        owner = self.create_member(
+            organization=organization, user=self.create_user(), role="owner", teams=[]
+        )
+
+        self.login_as(manager.user)
+        resp = self.get_response(organization.slug, owner.id, team.slug)
+        assert resp.status_code == 400
+
+        assert not OrganizationMemberTeam.objects.filter(
+            team=team, organizationmember=owner
+        ).exists()
+
+    def test_admin_not_in_team_cannot_add_member(self):
+        organization = self.create_organization(name="foo", owner=self.user, flags=0)
+        team = self.create_team(name="foo", organization=organization)
+        admin = self.create_member(
+            organization=organization, user=self.create_user(), role="admin", teams=[]
+        )
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[]
+        )
+
+        self.login_as(admin.user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
+        assert resp.status_code == 400
+
+        assert not OrganizationMemberTeam.objects.filter(
+            team=team, organizationmember=member
+        ).exists()
+
+    def test_admin_in_team_can_add_member(self):
+        organization = self.create_organization(name="foo", owner=self.user, flags=0)
+        team = self.create_team(name="foo", organization=organization)
+        admin = self.create_member(
+            organization=organization, user=self.create_user(), role="admin", teams=[team]
+        )
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[]
+        )
+
+        self.login_as(admin.user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
+        assert resp.status_code == 201
+
+        assert OrganizationMemberTeam.objects.filter(team=team, organizationmember=member).exists()
+
+
+class DeleteOrganizationMemberTeamTest(APITestCase):
+    endpoint = "sentry-api-0-organization-member-team-details"
+    method = "delete"
+
+    def test_can_leave_as_member(self):
+        organization = self.create_organization(name="foo", owner=self.user)
+        team = self.create_team(name="foo", organization=organization)
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[team]
+        )
+
+        self.login_as(member.user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
         assert resp.status_code == 200
 
         assert not OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
+            team=team, organizationmember=member
         ).exists()
 
     def test_can_leave_as_non_member(self):
         organization = self.create_organization(name="foo", owner=self.user)
         team = self.create_team(name="foo", organization=organization)
-        user = self.create_user("dummy@example.com", is_superuser=False)
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[]
+        member = self.create_member(
+            organization=organization,
+            user=self.create_user(is_superuser=False),
+            role="member",
+            teams=[],
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(user)
-
-        resp = self.client.delete(path)
-
+        self.login_as(member.user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
         assert resp.status_code == 200
 
         assert not OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
+            team=team, organizationmember=member
         ).exists()
 
     def test_can_leave_as_superuser_without_membership(self):
         organization = self.create_organization(name="foo", owner=self.user)
         team = self.create_team(name="foo", organization=organization)
-        user = self.create_user("dummy@example.com", is_superuser=True)
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[]
+        member = self.create_member(
+            organization=organization,
+            user=self.create_user(is_superuser=True),
+            role="member",
+            teams=[],
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(user)
-
-        resp = self.client.delete(path)
-
+        self.login_as(member.user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
         assert resp.status_code == 200
 
         assert not OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
+            team=team, organizationmember=member
         ).exists()
 
     def test_owner_can_remove_member(self):
-        owner = self.create_user()
-        organization = self.create_organization(name="foo", owner=owner)
-        organization.flags.allow_joinleave = False
-        organization.save()
+        user = self.create_user()
+        organization = self.create_organization(name="foo", owner=user, flags=0)
         team = self.create_team(name="foo", organization=organization)
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[team]
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[team]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(owner)
-
-        resp = self.client.delete(path)
-
+        self.login_as(user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
         assert resp.status_code == 200
 
         assert not OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
+            team=team, organizationmember=member
         ).exists()
 
     def test_owner_can_remove_manager(self):
-        owner = self.create_user()
-        organization = self.create_organization(name="foo", owner=owner)
-        organization.flags.allow_joinleave = False
-        organization.save()
+        user = self.create_user()
+        organization = self.create_organization(name="foo", owner=user, flags=0)
         team = self.create_team(name="foo", organization=organization)
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="manager", teams=[team]
+        manager = self.create_member(
+            organization=organization, user=self.create_user(), role="manager", teams=[team]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(owner)
-
-        resp = self.client.delete(path)
-
+        self.login_as(user)
+        resp = self.get_response(organization.slug, manager.id, team.slug)
         assert resp.status_code == 200
 
         assert not OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
+            team=team, organizationmember=manager
         ).exists()
 
     def test_owner_can_remove_other_owner(self):
-        owner = self.create_user()
-        organization = self.create_organization(name="foo", owner=owner)
-        organization.flags.allow_joinleave = False
-        organization.save()
+        user = self.create_user()
+        organization = self.create_organization(name="foo", owner=user, flags=0)
         team = self.create_team(name="foo", organization=organization)
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="owner", teams=[team]
+        owner = self.create_member(
+            organization=organization, user=self.create_user(), role="owner", teams=[team]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(owner)
-
-        resp = self.client.delete(path)
-
+        self.login_as(user)
+        resp = self.get_response(organization.slug, owner.id, team.slug)
         assert resp.status_code == 200
 
         assert not OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
+            team=team, organizationmember=owner
         ).exists()
 
     def test_manager_can_remove_member(self):
-        manager = self.create_user()
-        organization = self.create_organization(name="foo")
+        organization = self.create_organization(name="foo", flags=0)
         team = self.create_team(name="foo", organization=organization)
-        self.create_member(organization=organization, user=manager, role="manager", teams=[team])
-        organization.flags.allow_joinleave = False
-        organization.save()
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[team]
+        manager = self.create_member(
+            organization=organization, user=self.create_user(), role="manager", teams=[team]
+        )
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[team]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(manager)
-
-        resp = self.client.delete(path)
-
+        self.login_as(manager.user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
         assert resp.status_code == 200
 
         assert not OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
+            team=team, organizationmember=member
         ).exists()
 
     def test_manager_cannot_remove_owner(self):
-        manager = self.create_user()
-        organization = self.create_organization(name="foo")
-        organization.flags.allow_joinleave = False
-        organization.save()
+        organization = self.create_organization(name="foo", flags=0)
         team = self.create_team(name="foo", organization=organization)
-        self.create_member(organization=organization, user=manager, role="manager", teams=[team])
-        owner = self.create_user()
-        owner_om = self.create_member(
-            organization=organization, user=owner, role="owner", teams=[team]
+        manager = self.create_member(
+            organization=organization, user=self.create_user(), role="manager", teams=[team]
+        )
+        owner = self.create_member(
+            organization=organization, user=self.create_user(), role="owner", teams=[team]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, owner_om.id, team.slug],
-        )
-
-        self.login_as(manager)
-
-        resp = self.client.delete(path)
-
+        self.login_as(manager.user)
+        resp = self.get_response(organization.slug, owner.id, team.slug)
         assert resp.status_code == 400
 
-        assert OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=owner_om
-        ).exists()
+        assert OrganizationMemberTeam.objects.filter(team=team, organizationmember=owner).exists()
 
     def test_admin_in_team_can_remove_member(self):
-        admin = self.create_user()
-        organization = self.create_organization(name="foo")
+        organization = self.create_organization(name="foo", flags=0)
         team = self.create_team(name="foo", organization=organization)
-        self.create_member(organization=organization, user=admin, role="admin", teams=[team])
-        organization.flags.allow_joinleave = False
-        organization.save()
-        user = self.create_user("dummy@example.com")
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[team]
+        admin = self.create_member(
+            organization=organization, user=self.create_user(), role="admin", teams=[team]
+        )
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[team]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
-        )
-
-        self.login_as(admin)
-
-        resp = self.client.delete(path)
-
+        self.login_as(admin.user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
         assert resp.status_code == 200
 
         assert not OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
+            team=team, organizationmember=member
         ).exists()
 
     def test_admin_not_in_team_cannot_remove_member(self):
-        admin = self.create_user()
-        organization = self.create_organization(name="foo")
-        organization.flags.allow_joinleave = False
-        organization.save()
+        organization = self.create_organization(name="foo", flags=0)
         team = self.create_team(name="foo", organization=organization)
-        self.create_member(organization=organization, user=admin, role="admin", teams=[])
-        user = self.create_user()
-        member_om = self.create_member(
-            organization=organization, user=user, role="member", teams=[team]
+        admin = self.create_member(
+            organization=organization, user=self.create_user(), role="admin", teams=[]
+        )
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[team]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-team-details",
-            args=[organization.slug, member_om.id, team.slug],
+        self.login_as(admin.user)
+        resp = self.get_response(organization.slug, member.id, team.slug)
+        assert resp.status_code == 400
+
+        assert OrganizationMemberTeam.objects.filter(team=team, organizationmember=member).exists()
+
+    def test_member_cannot_remove_member(self):
+        organization = self.create_organization(
+            name="foo", flags=Organization.flags.allow_joinleave
+        )
+        team = self.create_team(name="foo", organization=organization)
+        member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[team]
+        )
+        target_member = self.create_member(
+            organization=organization, user=self.create_user(), role="member", teams=[team]
         )
 
-        self.login_as(admin)
-
-        resp = self.client.delete(path)
-
+        self.login_as(member.user)
+        resp = self.get_response(organization.slug, target_member.id, team.slug)
         assert resp.status_code == 400
 
         assert OrganizationMemberTeam.objects.filter(
-            team=team, organizationmember=member_om
+            team=team, organizationmember=target_member
         ).exists()


### PR DESCRIPTION
Permissions change to allow member roles to add other members to teams, if the `Open Membership` organization settings is enabled. Permissions stay the same if `Open Membership` is disabled.