### PR TITLE
feat(search) - Caching tag_keys

### DIFF
--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -21,5 +21,6 @@ class OrganizationTagsEndpoint(OrganizationEventsEndpointBase):
             filter_params.get("environment"),
             filter_params["start"],
             filter_params["end"],
+            use_cache=request.GET.get("cache", "0") == "1",
         )
         return Response(serialize(results, request.user))

--- a/src/sentry/api/endpoints/organization_tags.py
+++ b/src/sentry/api/endpoints/organization_tags.py
@@ -21,6 +21,6 @@ class OrganizationTagsEndpoint(OrganizationEventsEndpointBase):
             filter_params.get("environment"),
             filter_params["start"],
             filter_params["end"],
-            use_cache=request.GET.get("cache", "0") == "1",
+            use_cache=request.GET.get("use_cache", "0") == "1",
         )
         return Response(serialize(results, request.user))

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -24,8 +24,9 @@ def get_datetime_from_stats_period(stats_period, now=None):
     return now - stats_period
 
 
-def default_start_end_dates():
-    now = timezone.now()
+def default_start_end_dates(now=None):
+    if now is None:
+        now = timezone.now()
     return now - MAX_STATS_PERIOD, now
 
 
@@ -51,7 +52,7 @@ def get_date_range_from_params(params, optional=False):
     """
     now = timezone.now()
 
-    start, end = default_start_end_dates()
+    start, end = default_start_end_dates(now)
 
     stats_period = params.get("statsPeriod")
     stats_period_start = params.get("statsPeriodStart")

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -24,6 +24,11 @@ def get_datetime_from_stats_period(stats_period, now=None):
     return now - stats_period
 
 
+def default_start_end_dates():
+    now = timezone.now()
+    return now - MAX_STATS_PERIOD, now
+
+
 def get_date_range_from_params(params, optional=False):
     """
     Gets a date range from standard date range params we pass to the api.
@@ -46,8 +51,7 @@ def get_date_range_from_params(params, optional=False):
     """
     now = timezone.now()
 
-    end = now
-    start = now - MAX_STATS_PERIOD
+    start, end = default_start_end_dates()
 
     stats_period = params.get("statsPeriod")
     stats_period_start = params.get("statsPeriodStart")

--- a/src/sentry/static/sentry/app/actionCreators/tags.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/tags.jsx
@@ -68,7 +68,7 @@ export function fetchOrganizationTags(api, orgId, projectIds = null) {
   TagActions.loadTags();
 
   const url = `/organizations/${orgId}/tags/`;
-  const query = projectIds ? {project: projectIds} : null;
+  const query = projectIds ? {project: projectIds, cache: 1} : null;
 
   const promise = api
     .requestPromise(url, {

--- a/src/sentry/static/sentry/app/actionCreators/tags.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/tags.jsx
@@ -68,7 +68,7 @@ export function fetchOrganizationTags(api, orgId, projectIds = null) {
   TagActions.loadTags();
 
   const url = `/organizations/${orgId}/tags/`;
-  const query = projectIds ? {project: projectIds, cache: 1} : null;
+  const query = projectIds ? {project: projectIds, use_cache: 1} : null;
 
   const promise = api
     .requestPromise(url, {

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import functools
+import random
 import six
 from collections import defaultdict, Iterable
 from dateutil.parser import parse as parse_datetime
@@ -194,7 +195,7 @@ class SnubaTagStorage(TagStorage):
         conditions = []
 
         should_cache = (
-            not options.get("snuba.tagstore.disable-cache-tagkeys")
+            random.random() <= options.get("snuba.tagstore.cache-tagkeys-rate")
             and use_cache
             and group_id is None
         )

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import functools
-import datetime
 import six
 from collections import defaultdict, Iterable
 from dateutil.parser import parse as parse_datetime
@@ -197,12 +196,10 @@ class SnubaTagStorage(TagStorage):
         cache_key = u"tagstore.__get_tag_keys:{}".format(md5_text(*filtering_strings).hexdigest())
         # Round times by 5 minutes since we cache for 5 minutes
         if start:
-            start = datetime.datetime(
-                start.year, start.month, start.day, start.hour, start.minute // 5 * 5
-            )
+            start = start.replace(minute=start.minute // 5 * 5, second=0, microsecond=0)
             cache_key += ":" + start.isoformat()
         if end:
-            end = datetime.datetime(end.year, end.month, end.day, end.hour, end.minute // 5 * 5)
+            end = end.replace(minute=end.minute // 5 * 5, second=0, microsecond=0)
             cache_key += ":" + end.isoformat()
 
         result = cache.get(cache_key, None)

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import json
 import pytz
 
+from mock import patch
 from datetime import datetime, timedelta
 from django.conf import settings
 from django.utils import timezone
@@ -17,6 +18,9 @@ now = datetime.utcnow().replace(tzinfo=pytz.utc)
 class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
         super(IssueDetailsTest, self).setUp()
+        patcher = patch("django.utils.timezone.now", return_value=now)
+        patcher.start()
+        self.addCleanup(patcher.stop)
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_project_tags_settings.py
+++ b/tests/acceptance/test_project_tags_settings.py
@@ -1,10 +1,13 @@
 from __future__ import absolute_import
 
+from datetime import datetime
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
+from mock import patch
 import pytz
 
 event_time = before_now(days=3).replace(tzinfo=pytz.utc)
+current_time = datetime.utcnow().replace(tzinfo=pytz.utc)
 
 
 class ProjectTagsSettingsTest(AcceptanceTestCase, SnubaTestCase):
@@ -19,7 +22,8 @@ class ProjectTagsSettingsTest(AcceptanceTestCase, SnubaTestCase):
         self.login_as(self.user)
         self.path = u"/settings/{}/projects/{}/tags/".format(self.org.slug, self.project.slug)
 
-    def test_tags_list(self):
+    @patch("django.utils.timezone.now", return_value=current_time)
+    def test_tags_list(self, mock_timezone):
         self.store_event(
             data={
                 "event_id": "a" * 32,

--- a/tests/snuba/api/endpoints/test_organization_tags.py
+++ b/tests/snuba/api/endpoints/test_organization_tags.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import mock
+
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
@@ -63,3 +65,72 @@ class OrganizationTagsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert response.data == []
+
+    @mock.patch("sentry.options.get", return_value=1.0)
+    @mock.patch("sentry.utils.snuba.query", return_value={})
+    def test_tag_caching(self, mock_snuba_query, mock_options):
+        user = self.create_user()
+        org = self.create_organization()
+        team = self.create_team(organization=org)
+        self.create_member(organization=org, user=user, teams=[team])
+        self.create_project(organization=org, teams=[team])
+        self.login_as(user=user)
+
+        url = reverse("sentry-api-0-organization-tags", kwargs={"organization_slug": org.slug})
+        response = self.client.get(url, {"use_cache": "1", "statsPeriod": "14d"}, format="json")
+        assert response.status_code == 200, response.content
+        assert mock_snuba_query.call_count == 1
+
+        response = self.client.get(url, {"use_cache": "1", "statsPeriod": "14d"}, format="json")
+        assert response.status_code == 200, response.content
+        # Cause we're caching, we shouldn't call snuba again
+        assert mock_snuba_query.call_count == 1
+
+    @mock.patch("sentry.options.get", return_value=1.0)
+    @mock.patch("sentry.utils.snuba.query", return_value={})
+    def test_different_statsperiod_caching(self, mock_snuba_query, mock_options):
+        user = self.create_user()
+        org = self.create_organization()
+        team = self.create_team(organization=org)
+        self.create_member(organization=org, user=user, teams=[team])
+        self.create_project(organization=org, teams=[team])
+        self.login_as(user=user)
+
+        url = reverse("sentry-api-0-organization-tags", kwargs={"organization_slug": org.slug})
+        response = self.client.get(url, {"use_cache": "1", "statsPeriod": "14d"}, format="json")
+        assert response.status_code == 200, response.content
+        # Empty cache, we should query snuba
+        assert mock_snuba_query.call_count == 1
+
+        response = self.client.get(url, {"use_cache": "1", "statsPeriod": "30d"}, format="json")
+        assert response.status_code == 200, response.content
+        # With a different statsPeriod, we shouldn't use cache and still query snuba
+        assert mock_snuba_query.call_count == 2
+
+    @mock.patch("sentry.options.get", return_value=1.0)
+    @mock.patch("sentry.utils.snuba.query", return_value={})
+    def test_different_times_caching(self, mock_snuba_query, mock_options):
+        user = self.create_user()
+        org = self.create_organization()
+        team = self.create_team(organization=org)
+        self.create_member(organization=org, user=user, teams=[team])
+        self.create_project(organization=org, teams=[team])
+        self.login_as(user=user)
+
+        start = iso_format(before_now(minutes=10))
+        end = iso_format(before_now(minutes=5))
+        url = reverse("sentry-api-0-organization-tags", kwargs={"organization_slug": org.slug})
+        response = self.client.get(
+            url, {"use_cache": "1", "start": start, "end": end}, format="json"
+        )
+        assert response.status_code == 200, response.content
+        assert mock_snuba_query.call_count == 1
+
+        # 5 minutes later, cache_key should be different
+        start = iso_format(before_now(minutes=5))
+        end = iso_format(before_now(minutes=0))
+        response = self.client.get(
+            url, {"use_cache": "1", "start": start, "end": end}, format="json"
+        )
+        assert response.status_code == 200, response.content
+        assert mock_snuba_query.call_count == 2

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -17,7 +17,7 @@ from sentry.tagstore.exceptions import (
     TagKeyNotFound,
     TagValueNotFound,
 )
-from sentry.tagstore.snuba.backend import SnubaTagStorage, cache_suffix_timeformat
+from sentry.tagstore.snuba.backend import SnubaTagStorage, cache_suffix_time
 from sentry.testutils import SnubaTestCase, TestCase
 
 
@@ -602,9 +602,9 @@ class TagStorageTest(TestCase, SnubaTestCase):
             == {}
         )
 
-    def test_cache_suffix_timeformat(self):
-        starting_key = cache_suffix_timeformat(self.now, 0)
-        finishing_key = cache_suffix_timeformat(self.now + timedelta(seconds=300), 0)
+    def test_cache_suffix_time(self):
+        starting_key = cache_suffix_time(self.now, 0)
+        finishing_key = cache_suffix_time(self.now + timedelta(seconds=300), 0)
 
         assert starting_key != finishing_key
 
@@ -619,8 +619,8 @@ class TagStorageTest(TestCase, SnubaTestCase):
         changed_on_hour = 0
         # Check multiple keyhashes so that this test doesn't depend on implementation
         for key_hash in range(10):
-            before_key = cache_suffix_timeformat(before, key_hash, duration=10)
-            on_key = cache_suffix_timeformat(on_hour, key_hash, duration=10)
+            before_key = cache_suffix_time(before, key_hash, duration=10)
+            on_key = cache_suffix_time(on_hour, key_hash, duration=10)
             if before_key != on_key:
                 changed_on_hour += 1
 
@@ -636,20 +636,20 @@ class TagStorageTest(TestCase, SnubaTestCase):
         next_day = datetime(2019, 9, 6, 0, 0, 0)
         changed_on_hour = 0
         for key_hash in range(10):
-            before_key = cache_suffix_timeformat(before, key_hash, duration=10)
-            next_key = cache_suffix_timeformat(next_day, key_hash, duration=10)
+            before_key = cache_suffix_time(before, key_hash, duration=10)
+            next_key = cache_suffix_time(next_day, key_hash, duration=10)
             if before_key != next_key:
                 changed_on_hour += 1
 
         assert changed_on_hour == 1
 
-    def test_cache_suffix_timeformat_matches_duration(self):
+    def test_cache_suffix_time_matches_duration(self):
         """ The number of seconds between keys changing should match duration """
-        previous_key = cache_suffix_timeformat(self.now, 0, duration=10)
+        previous_key = cache_suffix_time(self.now, 0, duration=10)
         changes = []
         for i in range(21):
             current_time = self.now + timedelta(seconds=i)
-            current_key = cache_suffix_timeformat(current_time, 0, duration=10)
+            current_key = cache_suffix_time(current_time, 0, duration=10)
             if current_key != previous_key:
                 changes.append(current_time)
                 previous_key = current_key
@@ -657,20 +657,20 @@ class TagStorageTest(TestCase, SnubaTestCase):
         assert len(changes) == 2
         assert (changes[1] - changes[0]).total_seconds() == 10
 
-    def test_cache_suffix_timeformat_jitter(self):
+    def test_cache_suffix_time_jitter(self):
         """ Different key hashes should change keys at different times
 
             While starting_key and other_key might begin as the same values they should change at different times
         """
-        starting_key = cache_suffix_timeformat(self.now, 0, duration=10)
+        starting_key = cache_suffix_time(self.now, 0, duration=10)
         for i in range(11):
-            current_key = cache_suffix_timeformat(self.now + timedelta(seconds=i), 0, duration=10)
+            current_key = cache_suffix_time(self.now + timedelta(seconds=i), 0, duration=10)
             if current_key != starting_key:
                 break
 
-        other_key = cache_suffix_timeformat(self.now, 5, duration=10)
+        other_key = cache_suffix_time(self.now, 5, duration=10)
         for j in range(11):
-            current_key = cache_suffix_timeformat(self.now + timedelta(seconds=j), 5, duration=10)
+            current_key = cache_suffix_time(self.now + timedelta(seconds=j), 5, duration=10)
             if current_key != other_key:
                 break
 


### PR DESCRIPTION
- This query is being called often, but the results don't change often
  so caching for 5 minutes should probably be ok
- Since we're caching to 5 minutes, also figured that rounding start/end
  times to 5 minutes so that the cache_key will stay the same for 5
  minutes shouldn't be a problem
~- This PR has become pre work to determine if this method of cache key creation is sufficient, along with making sure that memcache can handle this amount of data.~