### PR TITLE
fixes error on view when plugin is not configured

### DIFF
--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -183,6 +183,8 @@ class IssueTrackingPlugin(Plugin):
             else:
                 required_auth_settings = None
 
+            project = group.project
+
             return self.render(
                 self.not_configured_template,
                 {
@@ -190,6 +192,9 @@ class IssueTrackingPlugin(Plugin):
                     "project": group.project,
                     "has_auth_configured": has_auth_configured,
                     "required_auth_settings": required_auth_settings,
+                    "plugin_link": "/settings/{}/projects/{}/plugins/{}".format(
+                        project.organization.slug, project.slug, self.slug
+                    ),
                 },
             )
 

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -192,7 +192,7 @@ class IssueTrackingPlugin(Plugin):
                     "project": group.project,
                     "has_auth_configured": has_auth_configured,
                     "required_auth_settings": required_auth_settings,
-                    "plugin_link": "/settings/{}/projects/{}/plugins/{}".format(
+                    "plugin_link": u"/settings/{}/projects/{}/plugins/{}".format(
                         project.organization.slug, project.slug, self.slug
                     ),
                 },

--- a/src/sentry/plugins/bases/issue.py
+++ b/src/sentry/plugins/bases/issue.py
@@ -192,7 +192,7 @@ class IssueTrackingPlugin(Plugin):
                     "project": group.project,
                     "has_auth_configured": has_auth_configured,
                     "required_auth_settings": required_auth_settings,
-                    "plugin_link": u"/settings/{}/projects/{}/plugins/{}".format(
+                    "plugin_link": u"/settings/{}/projects/{}/plugins/{}/".format(
                         project.organization.slug, project.slug, self.slug
                     ),
                 },

--- a/src/sentry/templates/sentry/plugins/bases/issue/not_configured.html
+++ b/src/sentry/templates/sentry/plugins/bases/issue/not_configured.html
@@ -19,8 +19,7 @@
                 {% endfor %}
             </ul>
         {% else %}
-            {% absolute_uri '/settings/{}/projects/{}/plugins/' project.organization.slug project.slug p.slug as link %}
-            <p>{% blocktrans %}You still need to <a href="{{ link }}">configure this plugin</a>
+            <p>{% blocktrans %}You still need to <a href="{{ plugin_link }}">configure this plugin</a>
                 before you can use it.{% endblocktrans %}
             </p>
         {% endif %}


### PR DESCRIPTION
Fixes SENTRY-E15

Sentry error: https://sentry.io/organizations/sentry/issues/1415843232/?referrer=jira_integration


Only happens when you try to create an issue with a plugin that isn't properly enabled. The existing templating code is invalid. Here's the error:

```
Invalid block tag on line 22: 'absolute_uri', expected 'endif'. Did you forget to register or load this tag?
```

I am not very knowledgeable with Django templating so my solution builds the URL in Python.