### PR TITLE
perf: Do not retry Snuba Query on ReadTimeout

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -195,9 +195,35 @@ def options_override(overrides):
             OVERRIDE_OPTIONS.pop(k)
 
 
+class RetrySkipTimeout(urllib3.Retry):
+    """
+    urllib3 Retry class does not allow us to retry on read errors but to exclude
+    read timeout. Retrying after a timeout adds useless load to Snuba.
+    """
+
+    def increment(
+        self, method=None, url=None, response=None, error=None, _pool=None, _stacktrace=None
+    ):
+        """
+        Just rely on the parent class unless we have a read timeout. In that case
+        immediately give up
+        """
+        if error and isinstance(error, urllib3.exceptions.ReadTimeoutError):
+            raise six.reraise(type(error), error, _stacktrace)
+
+        return super(RetrySkipTimeout, self).increment(
+            method=method,
+            url=url,
+            response=response,
+            error=error,
+            _pool=_pool,
+            _stacktrace=_stacktrace,
+        )
+
+
 _snuba_pool = connection_from_url(
     settings.SENTRY_SNUBA,
-    retries=urllib3.Retry(
+    retries=RetrySkipTimeout(
         total=5,
         # Expand our retries to POST since all of
         # our requests are POST and they don't mutate, so they

--- a/tests/sentry/utils/test_urllib3_timeout.py
+++ b/tests/sentry/utils/test_urllib3_timeout.py
@@ -23,11 +23,11 @@ def test_retries():
     Tests that, even if I set up 5 retries, there is only one request
     made since it times out.
     """
-    conneciton_mock = mock.Mock()
-    conneciton_mock.request.side_effect = ReadTimeoutError(None, "test.com", "Timeout")
+    connection_mock = mock.Mock()
+    connection_mock.request.side_effect = ReadTimeoutError(None, "test.com", "Timeout")
 
     snuba_pool = FakeConnectionPool(
-        connection=conneciton_mock,
+        connection=connection_mock,
         host="www.test.com",
         port=80,
         retries=RetrySkipTimeout(total=5, method_whitelist={"GET", "POST"}),
@@ -38,4 +38,4 @@ def test_retries():
     with pytest.raises(HTTPError):
         snuba_pool.urlopen("POST", "/query", body="{}")
 
-    assert conneciton_mock.request.call_count == 1
+    assert connection_mock.request.call_count == 1

--- a/tests/sentry/utils/test_urllib3_timeout.py
+++ b/tests/sentry/utils/test_urllib3_timeout.py
@@ -20,7 +20,8 @@ class FakeConnectionPool(HTTPConnectionPool):
 
 def test_retries():
     """
-    5 Attempts for protocol errors
+    Tests that, even if I set up 5 retries, there is only one request
+    made since it times out.
     """
     conneciton_mock = mock.Mock()
     conneciton_mock.request.side_effect = ReadTimeoutError(None, "test.com", "Timeout")


### PR DESCRIPTION
urllib3 consider any timeout after the connection is successfully established as a read error, thus the same retry policy we set up for read error applies.
The consequence is that, when a Snuba query times out we retry. This creates additional useless load on Snuba for no reason. When snuba times out it may mean that clickhouse is overloaded or that we are reducing the number of threads to run a query. Retrying makes the situation worse. Also the client has given up by the second attempt.

Since there is no way to separate read timeout from read errors by config, this PR subclasses the Retry class from urllib3 to change the policy and adds a test to ensure this change remains relevant in case urllib3 changes.

Tested by introducing a delay in Snuba and observed that sentry gives up immediately after the first timeout while other read errors still cause retries