### PR TITLE
fix(ts): Fix missing `iconColor` property for alert themes

### DIFF
--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -87,6 +87,7 @@ const alert = {
   muted: {
     backgroundLight: colors.offWhite,
     background: colors.gray1,
+    iconColor: colors.gray1,
     border: colors.gray6,
   },
   info: {

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -87,7 +87,7 @@ const alert = {
   muted: {
     backgroundLight: colors.offWhite,
     background: colors.gray1,
-    iconColor: colors.gray1,
+    iconColor: 'inherit',
     border: colors.gray6,
   },
   info: {


### PR DESCRIPTION
This will error w/ emotion 10, so give `muted` alert type an `iconColor`
property.