### PR TITLE
fix(ui): Fix props for global selection header items

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
@@ -1,7 +1,7 @@
+import {Link} from 'react-router';
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
-import {Link} from 'react-router';
 
 import InlineSvg from 'app/components/inlineSvg';
 import Tooltip from 'app/components/tooltip';
@@ -46,7 +46,6 @@ class HeaderItem extends React.Component<Props> {
 
   render() {
     const {
-      className,
       children,
       isOpen,
       hasSelected,
@@ -59,26 +58,19 @@ class HeaderItem extends React.Component<Props> {
       loading,
       ...props
     } = this.props;
+
+    const textColorProps = {
+      locked,
+      isOpen,
+      hasSelected,
+    };
+
     return (
-      <StyledHeaderItem
-        className={className}
-        isOpen={isOpen}
-        hasSelected={hasSelected}
-        locked={locked}
-        loading={loading}
-        {...props}
-      >
-        <IconContainer hasSelected={hasSelected} locked={locked}>
-          {icon}
-        </IconContainer>
+      <StyledHeaderItem loading={loading} {...props} {...textColorProps}>
+        <IconContainer {...textColorProps}>{icon}</IconContainer>
         <Content>{children}</Content>
         {hasSelected && !locked && allowClear && (
-          <StyledClose
-            src="icon-close"
-            locked={locked}
-            hasSelected={hasSelected}
-            onClick={this.handleClear}
-          />
+          <StyledClose {...textColorProps} src="icon-close" onClick={this.handleClear} />
         )}
         {settingsLink && (
           <SettingsIconLink to={settingsLink}>
@@ -100,11 +92,18 @@ class HeaderItem extends React.Component<Props> {
   }
 }
 
+// Infer props here because of styled/theme
 const getColor = p => {
   if (p.locked) {
     return p.theme.gray2;
   }
   return p.isOpen || p.hasSelected ? p.theme.gray4 : p.theme.gray2;
+};
+
+type ColorProps = {
+  locked: boolean;
+  isOpen: boolean;
+  hasSelected: boolean;
 };
 
 const StyledHeaderItem = styled('div')`
@@ -123,12 +122,12 @@ const Content = styled('div')`
   ${overflowEllipsis};
 `;
 
-const IconContainer = styled('span')`
+const IconContainer = styled('span')<ColorProps>`
   color: ${getColor};
   margin-right: ${space(1.5)};
 `;
 
-const StyledClose = styled(InlineSvg)`
+const StyledClose = styled(InlineSvg)<ColorProps>`
   color: ${getColor};
   height: ${space(1.5)};
   width: ${space(1.5)};
@@ -138,9 +137,7 @@ const StyledClose = styled(InlineSvg)`
   margin: -${space(1)} 0px -${space(1)} -${space(1)};
 `;
 
-const StyledChevron = styled('div')<{
-  isOpen: boolean;
-}>`
+const StyledChevron = styled('div')<Pick<ColorProps, 'isOpen'>>`
   transform: rotate(${p => (p.isOpen ? '180deg' : '0deg')});
   transition: 0.1s all;
   width: ${space(2)};


### PR DESCRIPTION
Some props were not properly passed/used to child components of HeaderItem. Also fixes up typings to be compatible with emotion@10. This should make the icon have the same color as its text when the menu is open.