### PR TITLE
ref(search): Removing a class that was supporting backwards compatibility

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -311,11 +311,3 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
                 }
             )
         return queryset_conditions
-
-
-class SnubaSearchBackend(EventsDatasetSnubaSearchBackend):
-    """ IMPORTANT!!! Retaining backwards compatible for getsentry while we rename this class.
-    We will deploy with `SnubaSearchBackend` pointing to `EventsDatasetSnubaSearchBackend`, and then deploy getsentry to use `EventsDatasetSnubaSearchBackend`
-    and then delete this class."""
-
-    pass


### PR DESCRIPTION
Class is no longer needed. All references are changed.