### PR TITLE
chore(issue page): Clarify ignore modal text

### DIFF
--- a/src/sentry/static/sentry/app/components/customIgnoreDurationModal.jsx
+++ b/src/sentry/static/sentry/app/components/customIgnoreDurationModal.jsx
@@ -15,7 +15,7 @@ export default class CustomIgnoreDurationModal extends React.Component {
   };
 
   static defaultProps = {
-    label: t('Ignore this issue until it occurs after ..'),
+    label: t('Ignore this issue until ..'),
   };
 
   constructor(...args) {


### PR DESCRIPTION
"until it occurs after X" is unnecessarily complicated language