### PR TITLE
fix(audit-logs) - Adding ACL to the audit logs endpoint

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -64,6 +64,10 @@ class OrganizationPermission(SentryPermission):
         return any(request.access.has_scope(s) for s in allowed_scopes)
 
 
+class OrganizationAuditPermission(OrganizationPermission):
+    scope_map = {"GET": ["org:write"]}
+
+
 class OrganizationEventPermission(OrganizationPermission):
     scope_map = {
         "GET": ["event:read", "event:write", "event:admin"],

--- a/src/sentry/api/endpoints/organization_auditlogs.py
+++ b/src/sentry/api/endpoints/organization_auditlogs.py
@@ -3,12 +3,15 @@ from __future__ import absolute_import
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
+from sentry.api.bases.organization import OrganizationAuditPermission
 from sentry.models import AuditLogEntry
 
 EVENT_REVERSE_MAP = {v: k for k, v in AuditLogEntry._meta.get_field("event").choices}
 
 
 class OrganizationAuditLogsEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationAuditPermission,)
+
     def get(self, request, organization):
         queryset = AuditLogEntry.objects.filter(organization=organization).select_related("actor")
 


### PR DESCRIPTION
- using `org:write` which matches what the frontend uses to determine if
  we show that section in our settings.
- With this change when a user without the proper role tries to access `/audit-logs` they'll get a 403 and `{"detail":"You do not have permission to perform this action."}`
- https://app.asana.com/0/1154164241699513/1154164241699560