### PR TITLE
test(acceptance): Fix flakey onboarding test

### DIFF
--- a/tests/acceptance/test_onboarding.py
+++ b/tests/acceptance/test_onboarding.py
@@ -33,6 +33,7 @@ class OrganizationOnboardingTest(AcceptanceTestCase):
 
         # Select and create node JS project
         self.browser.click('[data-test-id="platform-node"]')
+        self.browser.wait_until_not('[data-test-id="platform-select-next"][aria-disabled="true"]')
         self.browser.click('[data-test-id="platform-select-next"]')
 
         # Project getting started


### PR DESCRIPTION
This test was only flakey in `django@1.10` - not sure what changed that would cause this (perhaps a perf regression in 1.10?), but this seems to fix the flake. I would love to understand what's going on, but it's not reproducible locally, so I'm not going to investigate further.