### PR TITLE
test(discover2): Fix Percy snapshots and UX issues on Querybuilder

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -145,6 +145,10 @@ class GridEditable<
     isEditing: false,
   };
 
+  componentDidMount() {
+    window.addEventListener('resize', this.redrawGridColumn);
+  }
+
   componentDidUpdate() {
     // Redraw columns whenever new props are recieved
     this.setGridTemplateColumns(this.props.columnOrder);
@@ -152,6 +156,7 @@ class GridEditable<
 
   componentWillUnmount() {
     this.clearWindowLifecycleEvents();
+    window.removeEventListener('resize', this.redrawGridColumn);
   }
 
   private refGrid = React.createRef<HTMLTableElement>();
@@ -283,6 +288,13 @@ class GridEditable<
       metadata.columnIndex,
       metadata.columnWidth + e.clientX - metadata.cursorX
     );
+  };
+
+  /**
+   * Recalculate the dimensions of Grid and Columns and redraws them
+   */
+  redrawGridColumn = () => {
+    this.setGridTemplateColumns(this.props.columnOrder);
   };
 
   /**

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -5,7 +5,7 @@ import {openModal} from 'app/actionCreators/modal';
 
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import InlineSvg from 'app/components/inlineSvg';
-import LoadingContainer from 'app/components/loading/loadingContainer';
+import LoadingIndicator from 'app/components/loadingIndicator';
 
 import {
   GridColumn,
@@ -26,9 +26,8 @@ import {
   GridHead,
   GridBody,
   GridBodyCell,
-  GridBodyCellSpan,
-  GridBodyCellLoading,
-  GridBodyErrorAlert,
+  GridBodyCellStatus,
+  GridStatusErrorAlert,
   GridResizer,
 } from './styles';
 import {
@@ -441,11 +440,11 @@ class GridEditable<
 
     return (
       <GridRow>
-        <GridBodyCellSpan>
-          <GridBodyErrorAlert type="error" icon="icon-circle-exclamation">
+        <GridBodyCellStatus>
+          <GridStatusErrorAlert type="error" icon="icon-circle-exclamation">
             {error}
-          </GridBodyErrorAlert>
-        </GridBodyCellSpan>
+          </GridStatusErrorAlert>
+        </GridBodyCellStatus>
       </GridRow>
     );
   };
@@ -453,11 +452,9 @@ class GridEditable<
   renderLoading = () => {
     return (
       <GridRow>
-        <GridBodyCellSpan>
-          <GridBodyCellLoading>
-            <LoadingContainer isLoading />
-          </GridBodyCellLoading>
-        </GridBodyCellSpan>
+        <GridBodyCellStatus>
+          <LoadingIndicator />
+        </GridBodyCellStatus>
       </GridRow>
     );
   };
@@ -465,11 +462,11 @@ class GridEditable<
   renderEmptyData = () => {
     return (
       <GridRow>
-        <GridBodyCellSpan>
+        <GridBodyCellStatus>
           <EmptyStateWarning>
             <p>{t('No results found')}</p>
           </EmptyStateWarning>
-        </GridBodyCellSpan>
+        </GridBodyCellStatus>
       </GridRow>
     );
   };

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -8,10 +8,19 @@ import space from 'app/styles/space';
 
 export const GRID_HEAD_ROW_HEIGHT = 45;
 export const GRID_BODY_ROW_HEIGHT = 40;
+export const GRID_STATUS_MESSAGE_HEIGHT = GRID_BODY_ROW_HEIGHT * 4;
 
-// Local z-index stacking context
-// https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
-export const Z_INDEX_RESIZER = 1;
+/**
+ * Local z-index stacking context
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
+ */
+// Parent context is Panel
+const Z_INDEX_PANEL = 1;
+const Z_INDEX_GRID_STATUS = -1;
+const Z_INDEX_GRID = 5;
+
+// Parent context is GridHeadCell
+const Z_INDEX_GRID_RESIZER = 1;
 
 type GridEditableProps = {
   numColumn?: number;
@@ -53,6 +62,7 @@ export const HeaderButton = styled('div')`
 
 const PanelWithProtectedBorder = styled(Panel)`
   overflow: hidden;
+  z-index: ${Z_INDEX_PANEL};
 `;
 export const Body: React.FC = props => (
   <PanelWithProtectedBorder>
@@ -74,7 +84,7 @@ export const Body: React.FC = props => (
  * The entire layout is determined by the usage of <th> and <td>.
  */
 export const Grid = styled('table')`
-  position: relative;
+  position: inherit;
   display: grid;
 
   /* Overwritten by GridEditable.setGridTemplateColumns */
@@ -84,8 +94,8 @@ export const Grid = styled('table')`
   border-collapse: collapse;
   margin: 0;
 
-  /* background-color: ${p => p.theme.offWhite}; */
   overflow-x: scroll;
+  z-index: ${Z_INDEX_GRID};
 `;
 export const GridRow = styled('tr')`
   display: contents;
@@ -274,7 +284,6 @@ export const GridBody = styled('tbody')`
   }
 `;
 export const GridBodyCell = styled('td')`
-  position: relative;
   /* By default, a grid item cannot be smaller than the size of its content.
      We override this by setting min-width to be 0. */
   min-width: 0;
@@ -293,15 +302,34 @@ export const GridBodyCell = styled('td')`
     border-right: none;
   }
 `;
-export const GridBodyCellSpan = styled(GridBodyCell)`
-  grid-column: 1 / -1;
-`;
-export const GridBodyCellLoading = styled('div')`
-  min-height: 220px;
-`;
 
-export const GridBodyErrorAlert = styled(Alert)`
-  margin: 0;
+const GridStatusWrapper = styled(GridBodyCell)`
+  grid-column: 1 / -1;
+  width: 100%;
+  height: ${GRID_STATUS_MESSAGE_HEIGHT}px;
+  background-color: transparent;
+`;
+const GridStatusFloat = styled('div')`
+  position: absolute;
+  top: 45px;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: ${GRID_STATUS_MESSAGE_HEIGHT}px;
+
+  z-index: ${Z_INDEX_GRID_STATUS};
+  background: ${p => p.theme.white};
+`;
+export const GridBodyCellStatus: React.FC = props => (
+  <GridStatusWrapper>
+    <GridStatusFloat>{props.children}</GridStatusFloat>
+  </GridStatusWrapper>
+);
+export const GridStatusErrorAlert = styled(Alert)`
+  width: 100%;
+  margin: ${space(2)};
 `;
 
 /**
@@ -323,7 +351,7 @@ export const GridResizer = styled('div')<{dataRows: number; isLast?: boolean}>`
   padding-right: ${p => (p.isLast ? '0px' : '4px')};
 
   cursor: col-resize;
-  z-index: ${Z_INDEX_RESIZER};
+  z-index: ${Z_INDEX_GRID_RESIZER};
 
   /**
    * This element allows us to have a fat GridResizer that is easy to hover and

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -141,7 +141,7 @@ class Results extends React.Component<Props, State> {
               location={location}
               eventView={eventView}
             />
-            <ContentBox>
+            <StyledPageContent>
               <Top>
                 <StyledSearchBar
                   organization={organization}
@@ -176,7 +176,7 @@ class Results extends React.Component<Props, State> {
                 />
               </Main>
               <Side eventView={eventView}>{this.renderTagsTable()}</Side>
-            </ContentBox>
+            </StyledPageContent>
           </NoProjectMessage>
         </React.Fragment>
       </SentryDocumentTitle>
@@ -184,11 +184,28 @@ class Results extends React.Component<Props, State> {
   }
 }
 
+const StyledPageContent = styled(PageContent)`
+  margin: 0;
+
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    display: grid;
+    /* HACK(leedongwei): Hardcoded height for search bar and graph */
+    grid-template-rows: 270px auto;
+    grid-template-columns: 66% auto;
+    grid-column-gap: ${space(3)};
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+    grid-template-columns: auto 325px;
+  }
+`;
+
 const StyledSearchBar = styled(SearchBar)`
   margin-bottom: ${space(2)};
 `;
-
 const StyledPanel = styled(Panel)`
+  /* HACK(leedongwei): Hardcoded height for graph */
+  height: 200px;
   margin-bottom: ${space(1.5)};
 
   .echarts-for-react div:first-child {
@@ -200,36 +217,14 @@ const Top = styled('div')`
   grid-column: 1/3;
   flex-grow: 0;
 `;
-
 const Main = styled('div')<{eventView: EventView}>`
   grid-column: ${p => (p.eventView.tags.length <= 0 ? '1/3' : '1/2')};
-
-  /* Defining the width prevent child elements from expanding the grid
-     past the width of the screen */
-  width: 100%;
   max-width: 100%;
   overflow: hidden;
 `;
-
 const Side = styled('div')<{eventView: EventView}>`
   display: ${p => (p.eventView.tags.length <= 0 ? 'none' : 'initial')};
   grid-column: 2/3;
-`;
-
-const ContentBox = styled(PageContent)`
-  margin: 0;
-
-  @media (min-width: ${p => p.theme.breakpoints[1]}) {
-    display: grid;
-    grid-template-rows: 270px auto; /* HACK(leedongwei): Hard-coded height for
-                                       search bar and graph */
-    grid-template-columns: 65% auto;
-    grid-column-gap: ${space(3)};
-  }
-
-  @media (min-width: ${p => p.theme.breakpoints[2]}) {
-    grid-template-columns: auto 325px;
-  }
 `;
 
 export function generateDiscoverResultsRoute(orgSlug: string): string {


### PR DESCRIPTION
- Fix on Percy snapshots
  - Set a fixed height for graph that allows CSS grids to flow properly
- Improve QueryBuilder for error/loading state messages
  - Defined a fixed height of 4 rows for error/loading states
  - Center and prevent state messages from scrolling, while allowing the GridHeader columns to scroll.
- Resize QueryBuilder when browser is resized

<br>
<br>
<br>

![image](https://user-images.githubusercontent.com/1748388/72028071-22b2fe00-3236-11ea-9c89-7a7b4409f8fd.png)
![image](https://user-images.githubusercontent.com/1748388/72028076-247cc180-3236-11ea-96b6-171b79712d03.png)
![image](https://user-images.githubusercontent.com/1748388/72028081-28104880-3236-11ea-9cf3-8251bf5b72b4.png)
