### PR TITLE
Restore compatibility for old aliases with discover2

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -21,9 +21,19 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
             return self.get_v1_results(request, organization)
 
         try:
+            column = request.GET.get("yAxis", "count()")
+            # Backwards compatibility for incidents which uses the old
+            # column aliases as it straddles both versions of events/discover.
+            # We will need these aliases until discover2 flags are enabled for all
+            # users.
+            if column == "user_count":
+                column = "count_unique(user)"
+            elif column == "event_count":
+                column = "count()"
+
             params = self.get_filter_params(request, organization)
             result = discover.timeseries_query(
-                selected_columns=[request.GET.get("yAxis", "count()")],
+                selected_columns=[column],
                 query=request.GET.get("query"),
                 params=params,
                 rollup=self.get_rollup(request),

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -133,6 +133,35 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             [{"count": 1}],
         ]
 
+    def test_discover2_backwards_compatibility(self):
+        with self.feature("organizations:events-v2"):
+            response = self.client.get(
+                self.url,
+                data={
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
+                    "interval": "1h",
+                    "yAxis": "user_count",
+                },
+                format="json",
+            )
+            assert response.status_code == 200, response.content
+            assert len(response.data["data"]) > 0
+
+        with self.feature("organizations:events-v2"):
+            response = self.client.get(
+                self.url,
+                data={
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=1, minutes=59)),
+                    "interval": "1h",
+                    "yAxis": "event_count",
+                },
+                format="json",
+            )
+            assert response.status_code == 200, response.content
+            assert len(response.data["data"]) > 0
+
     def test_with_event_count_flag(self):
         response = self.client.get(
             self.url,


### PR DESCRIPTION
Support the older `event_count` and `user_count` aliases from the discover2 implementation as they are used by incidents.