### PR TITLE
fix(tasks) Add event data to user report asynchronously

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -523,6 +523,7 @@ CELERYD_HIJACK_ROOT_LOGGER = False
 CELERY_IMPORTS = (
     "sentry.discover.tasks",
     "sentry.incidents.tasks",
+    "sentry.tasks.assemble",
     "sentry.tasks.auth",
     "sentry.tasks.auto_resolve_issues",
     "sentry.tasks.beacon",
@@ -534,6 +535,8 @@ CELERY_IMPORTS = (
     "sentry.tasks.deletion",
     "sentry.tasks.digests",
     "sentry.tasks.email",
+    "sentry.tasks.files",
+    "sentry.tasks.integrations",
     "sentry.tasks.members",
     "sentry.tasks.merge",
     "sentry.tasks.options",
@@ -543,14 +546,12 @@ CELERY_IMPORTS = (
     "sentry.tasks.reports",
     "sentry.tasks.reprocessing",
     "sentry.tasks.scheduler",
+    "sentry.tasks.sentry_apps",
+    "sentry.tasks.servicehooks",
     "sentry.tasks.signals",
     "sentry.tasks.store",
     "sentry.tasks.unmerge",
-    "sentry.tasks.servicehooks",
-    "sentry.tasks.assemble",
-    "sentry.tasks.integrations",
-    "sentry.tasks.files",
-    "sentry.tasks.sentry_apps",
+    "sentry.tasks.update_user_reports",
 )
 CELERY_QUEUES = [
     Queue("activity.notify", routing_key="activity.notify"),
@@ -661,6 +662,11 @@ CELERYBEAT_SCHEDULE = {
         "task": "sentry.tasks.collect_project_platforms",
         "schedule": timedelta(days=1),
         "options": {"expires": 3600 * 24},
+    },
+    "update-user-reports": {
+        "task": "sentry.tasks.update_user_reports",
+        "schedule": timedelta(minutes=15),
+        "options": {"expires": 300},
     },
     "schedule-auto-resolution": {
         "task": "sentry.tasks.schedule_auto_resolution",

--- a/src/sentry/tasks/update_user_reports.py
+++ b/src/sentry/tasks/update_user_reports.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry import eventstore
+from sentry.models import UserReport
+from sentry.tasks.base import instrumented_task
+
+
+@instrumented_task(name="sentry.tasks.update_user_reports", queue="update")
+def update_user_reports(**kwargs):
+    now = timezone.now()
+    user_reports = UserReport.objects.filter(
+        group__isnull=True, environment__isnull=True, date_added__gte=now - timedelta(days=1)
+    )
+
+    for report in user_reports:
+        event = eventstore.get_event_by_id(report.project_id, report.event_id)
+        if event:
+            report.update(group_id=event.group_id, environment=event.get_environment())

--- a/tests/sentry/tasks/test_update_user_reports.py
+++ b/tests/sentry/tasks/test_update_user_reports.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.models import UserReport
+from sentry.tasks.update_user_reports import update_user_reports
+from sentry.testutils import TestCase
+
+
+class UpdateUserReportTest(TestCase):
+    def test_simple(self):
+        now = timezone.now()
+        project = self.create_project()
+        event1 = self.store_event(data={}, project_id=project.id)
+        report1 = UserReport.objects.create(project=project, event_id=event1.event_id)
+        event2 = self.store_event(data={}, project_id=project.id)
+        report2 = UserReport.objects.create(
+            project=project, event_id=event2.event_id, date_added=now - timedelta(days=2)
+        )
+
+        with self.tasks():
+            update_user_reports()
+
+        report1 = UserReport.objects.get(project=project, event_id=event1.id)
+        report2 = UserReport.objects.get(project=project, event_id=event2.id)
+        assert report1.group_id == event1.group_id
+        assert report1.environment == event1.get_environment()
+        assert report2.group is None
+        assert report2.environment is None


### PR DESCRIPTION
If an event hasn't been propagated when the user report is created, then queue a
task to sync the event data once it's stored fully.