### PR TITLE
feat(filters): Add safari extensions to browser extension filter

### DIFF
--- a/src/sentry/message_filters.py
+++ b/src/sentry/message_filters.py
@@ -264,6 +264,8 @@ _EXTENSION_EXC_SOURCES = re.compile(
             r"^chrome(?:-extension)?:\/\/",
             # Firefox extensions
             r"^moz-extension:\/\/",
+            # Safari extensions
+            r"^safari-extension:\/\/",
             # Cacaoweb
             r"127\.0\.0\.1:4001\/isrunning",
             # Other

--- a/tests/sentry/filters/test_browser_extensions.py
+++ b/tests/sentry/filters/test_browser_extensions.py
@@ -65,6 +65,10 @@ class BrowserExtensionsFilterTest(TestCase):
         data = self.get_mock_data(exc_source="moz-extension://my-extension/or/something")
         assert self.apply_filter(data)
 
+    def test_filters_safari_extensions(self):
+        data = self.get_mock_data(exc_source="safari-extension://my-extension/or/something")
+        assert self.apply_filter(data)
+
     def test_does_not_filter_generic_data(self):
         data = self.get_mock_data()
         assert not self.apply_filter(data)


### PR DESCRIPTION
By popular request. Also adding it on the semaphore side of things, in https://github.com/getsentry/semaphore/pull/374.