### PR TITLE
chore(ts): converts externalIssueForm

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -21,7 +21,7 @@ type Props = AsyncComponent['props'] & {
 
 type State = AsyncComponent['state'] & {
   showModal: boolean;
-  action: string | null;
+  action: 'create' | 'link' | null;
   selectedIntegration: GroupIntegration;
   issue: IntegrationExternalIssue | null;
 };

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -31,7 +31,7 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
     integration: PropTypes.object.isRequired,
   };
 
-  constructor(props, context) {
+  constructor(props: Props, context) {
     super(props, context);
 
     this.state = {
@@ -53,7 +53,7 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
       : null;
   }
 
-  deleteIssue(issueId) {
+  deleteIssue(issueId: string) {
     const {group, integration} = this.props;
     const endpoint = `/groups/${group.id}/integrations/${
       integration.id
@@ -89,7 +89,7 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
     });
   };
 
-  handleClick = action => {
+  handleClick = (action: 'create' | 'link') => {
     this.setState({action});
   };
 

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -96,12 +96,11 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
     const {action} = this.props;
     const config: IssueConfigField[] = integrationDetails[`${action}IssueConfig`];
 
-    return config
-      .filter((field: IssueConfigField) => field.updatesForm)
-      .reduce(
-        (a: object, field: IssueConfigField) => ({...a, [field.name]: field.default}),
-        {}
-      );
+    return Object.fromEntries(
+      config
+        .filter((field: IssueConfigField) => field.updatesForm)
+        .map((field: IssueConfigField) => [field.name, field.default])
+    );
   }
 
   onFieldChange = (label: string, value: FieldValue) => {
@@ -139,7 +138,11 @@ class ExternalIssueForm extends AsyncComponent<Props, State> {
   };
 
   debouncedOptionLoad = debounce(
-    async (field: IssueConfigField, input: string, cb: (err, result?) => void) => {
+    async (
+      field: IssueConfigField,
+      input: string,
+      cb: (err: Error | null, result?) => void
+    ) => {
       const query = queryString.stringify({
         ...this.state.dynamicFieldValues,
         field: field.name,

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -705,7 +705,7 @@ export type SelectValue<T> = {
 
 /**
  * The issue config form fields we get are basically the form fields we use in the UI but with some extra information.
- * we can also assume that certain optional fields are required.
+ * Some fields marked optional in the form field are guarnteed to exist so we can mark them as required here
  */
 
 export type IssueConfigField = Field & {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -705,7 +705,7 @@ export type SelectValue<T> = {
 
 /**
  * The issue config form fields we get are basically the form fields we use in the UI but with some extra information.
- * Some fields marked optional in the form field are guarnteed to exist so we can mark them as required here
+ * Some fields marked optional in the form field are guaranteed to exist so we can mark them as required here
  */
 
 export type IssueConfigField = Field & {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -702,3 +702,26 @@ export type SelectValue<T> = {
   label: string;
   value: T;
 };
+
+/**
+ * The issue config form fields we get are basically the form fields we use in the UI but with some extra information.
+ * we can also assume that certain optional fields are required.
+ */
+
+export type IssueConfigField = Field & {
+  name: string;
+  default?: string;
+  choices?: [number | string, number | string][];
+  url?: string;
+  multiple?: boolean;
+};
+
+export type IntegrationIssueConfig = {
+  status: ObjectStatus;
+  name: string;
+  domainName: string;
+  linkIssueConfig?: IssueConfigField[];
+  createIssueConfig?: IssueConfigField[];
+  provider: IntegrationProvider;
+  icon: string[];
+};

--- a/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
@@ -24,6 +24,9 @@ type Props = {
   field: Field;
   highlighted?: boolean;
   disabled?: boolean;
+  flexibleControlStateSize?: boolean;
+  stacked?: boolean;
+  inline?: boolean;
 
   access?: Scope[];
 };

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -34,6 +34,7 @@ type BaseField = {
   disabled?: boolean | ((props: any) => boolean);
   disabledReason?: string;
   defaultValue?: FieldValue;
+  updatesForm?: boolean;
 
   /**
    * Function to format the value displayed in the undo toast. May also be


### PR DESCRIPTION
Also had to make new TS types for the form configs we use in the DB. The `IssueConfigField` is based off the type for `Field` of our forms but has extra fields that get used for logic at the form level (as opposed to the field level).