### PR TITLE
ref: Deprecate get_legacy_message

### DIFF
--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -118,16 +118,6 @@ class EventCommon(object):
     def get_interface(self, name):
         return self.interfaces.get(name)
 
-    def get_legacy_message(self):
-        # TODO: This is only used in the pagerduty plugin. We should use event.title
-        # there and remove this function once users have been notified, since PD
-        # alert routing may be based off the message field.
-        return (
-            get_path(self.data, "logentry", "formatted")
-            or get_path(self.data, "logentry", "message")
-            or self.message
-        )
-
     def get_event_type(self):
         """
         Return the type of this event.

--- a/src/sentry_plugins/pagerduty/plugin.py
+++ b/src/sentry_plugins/pagerduty/plugin.py
@@ -49,7 +49,10 @@ class PagerDutyPlugin(CorePluginMixin, NotifyPlugin):
         if not self.is_configured(group.project):
             return
 
-        description = event.get_legacy_message()[:1024]
+        # TODO: This should eventually be event.title in line with other plugins.
+        # However, we should notify users first, since PD alert routing may be
+        # based off the message field.
+        description = (event.real_message or event.message)[:1024]
 
         tags = dict(event.tags)
         details = {

--- a/tests/sentry_plugins/pagerduty/test_plugin.py
+++ b/tests/sentry_plugins/pagerduty/test_plugin.py
@@ -100,7 +100,7 @@ class PagerDutyPluginTest(PluginTestCase):
                 "datetime": event.datetime.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             },
             "service_key": "abcdef",
-            "description": event.get_legacy_message(),
+            "description": event.real_message,
         }
 
     def test_no_secrets(self):


### PR DESCRIPTION
Move the implementation into the Pagerduty plugin since this is the only
place it is used.