### PR TITLE
fix(auth): Correct path used for SSO errors

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -448,6 +448,11 @@ urlpatterns += [
                     react_page_view,
                     name="sentry-organization-member-settings",
                 ),
+                url(
+                    r"^(?P<organization_slug>[\w_-]+)/auth/$",
+                    react_page_view,
+                    name="sentry-organization-auth-settings",
+                ),
                 url(r"^", react_page_view),
             ]
         ),
@@ -508,11 +513,6 @@ urlpatterns += [
                     r"^(?P<organization_slug>[\w_-]+)/api-keys/(?P<key_id>[\w_-]+)/$",
                     react_page_view,
                     name="sentry-organization-api-key-settings",
-                ),
-                url(
-                    r"^(?P<organization_slug>[\w_-]+)/auth/$",
-                    react_page_view,
-                    name="sentry-organization-auth-settings",
                 ),
                 url(
                     r"^(?P<organization_slug>[\w_-]+)/auth/configure/$",


### PR DESCRIPTION
The route for sentry-organization-auth-settings was still located in the old settings path, this route is used for a redirect in the auth.helper module when there is a problem configuring SSO.

This just corrects the redirect so it goes back to settings instead of 404ing.