### PR TITLE
fix(translation): Don't translate Assembly

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
@@ -27,7 +27,7 @@ const Assembly: React.FC<Props> = ({
     <AssemblyWrapper>
       <Icon src="icon-return-key" />
       <AssemblyInfo>
-        <Caption>{t('Assembly')}:</Caption>
+        <Caption>{'Assembly'}:</Caption>
         {name || '-'}
       </AssemblyInfo>
       <AssemblyInfo>
@@ -39,7 +39,7 @@ const Assembly: React.FC<Props> = ({
         {culture || '-'}
       </AssemblyInfo>
       <AssemblyInfo>
-        <Caption>{t('PublicKeyToken')}:</Caption>
+        <Caption>{'PublicKeyToken'}:</Caption>
         {publicKeyToken || '-'}
       </AssemblyInfo>
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
@@ -27,7 +27,7 @@ const Assembly: React.FC<Props> = ({
     <AssemblyWrapper>
       <Icon src="icon-return-key" />
       <AssemblyInfo>
-        <Caption>{'Assembly'}:</Caption>
+        <Caption>Assembly:</Caption>
         {name || '-'}
       </AssemblyInfo>
       <AssemblyInfo>

--- a/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
@@ -39,7 +39,7 @@ const Assembly: React.FC<Props> = ({
         {culture || '-'}
       </AssemblyInfo>
       <AssemblyInfo>
-        <Caption>{'PublicKeyToken'}:</Caption>
+        <Caption>PublicKeyToken:</Caption>
         {publicKeyToken || '-'}
       </AssemblyInfo>
 


### PR DESCRIPTION
Assembly and PublicKeyToken are not to be translated.
Microsoft doesn't translate these either and if translated it makes no sense at all.