### PR TITLE
feat: Adding an option for caching tag keys

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -150,7 +150,7 @@ register("snuba.search.hits-sample-size", default=100)
 register("snuba.track-outcomes-sample-rate", default=0.0)
 
 # The percentage of tagkeys that we want to cache. Set to 1.0 in order to cache everything, <=0.0 to stop caching
-register("snuba.tagstore.cache-tagkeys-rate", default=0.01, flags=FLAG_PRIORITIZE_DISK)
+register("snuba.tagstore.cache-tagkeys-rate", default=0.0, flags=FLAG_PRIORITIZE_DISK)
 
 # Kafka Publisher
 register("kafka-publisher.raw-event-sample-rate", default=0.0)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -149,6 +149,9 @@ register("snuba.search.max-total-chunk-time-seconds", default=30.0)
 register("snuba.search.hits-sample-size", default=100)
 register("snuba.track-outcomes-sample-rate", default=0.0)
 
+# The percentage of tagkeys that we want to cache. Set to 1.0 in order to cache everything, <=0.0 to stop caching
+register("snuba.tagstore.cache-tagkeys-rate", default=0.01, flags=FLAG_PRIORITIZE_DISK)
+
 # Kafka Publisher
 register("kafka-publisher.raw-event-sample-rate", default=0.0)
 register("kafka-publisher.max-event-size", default=100000)


### PR DESCRIPTION
- Register option that will be the random rate at which we'll cache tag
  keys for #16249
- Option can also be used as a kill switch if things don't go well
  caching