### PR TITLE
fix: Suppress unexpected Type Error in capturing RouteError

### DIFF
--- a/src/sentry/static/sentry/app/views/routeError.jsx
+++ b/src/sentry/static/sentry/app/views/routeError.jsx
@@ -54,7 +54,6 @@ class RouteError extends React.Component {
         error.message = `${error.message}: ${route}`;
       } catch (e) {
         Sentry.withScope(scope => {
-          scope.setFingerprint(['route-error', 'error-message-mutation-error']);
           enrichScopeContext(scope);
           Sentry.captureException(e);
         });

--- a/src/sentry/static/sentry/app/views/routeError.jsx
+++ b/src/sentry/static/sentry/app/views/routeError.jsx
@@ -36,7 +36,19 @@ class RouteError extends React.Component {
 
     const route = getRouteStringFromRoutes(routes);
     if (route) {
-      error.message = `${error.message}: ${route}`;
+      /**
+       * Unexpectedly, error.message would sometimes not have a setter property, causing another exception to be thrown,
+       * and losing the original error in the process. Wrapping the mutation in a try-catch in an attempt to preserve
+       * the original error for logging.
+       * See https://github.com/getsentry/sentry/issues/16314 for more details.
+       */
+      try {
+        error.message = `${error.message}: ${route}`;
+      } catch (e) {
+        if (!(e instanceof TypeError)) {
+          throw e;
+        }
+      }
     }
     // TODO(dcramer): show something in addition to embed (that contains it?)
     // throw this in a timeout so if it errors we dont fall over


### PR DESCRIPTION
Wraps unreproducible Type Error (missing setter) in Error.message property in a try-catch. Type
Error is unreproducible, and when thrown causes intital error to be ignored and the newer and less
informative Type Error to be captured by Sentry instead. Currently, a minority of users are
affected and certain browser and/or browser extension incompatibility is suspected.

Suppression should help in the discovery of the actual errors causing the RouteError and perhaps
uncover the root cause of the Type Error.

Fixes GH-16314
Fixes Sentry-JAVASCRIPT-129Q