### PR TITLE
ref: Steer users towards internal integrations

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
@@ -7,12 +7,14 @@ import {
   addSuccessMessage,
 } from 'app/actionCreators/indicator';
 import {t, tct} from 'app/locale';
+import AlertLink from 'app/components/alertLink';
 import ApiTokenRow from 'app/views/settings/account/apiTokenRow';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
+import withOrganization from 'app/utils/withOrganization';
 
 class ApiTokens extends AsyncView {
   getTitle() {
@@ -58,6 +60,7 @@ class ApiTokens extends AsyncView {
   };
 
   renderBody() {
+    const {organization} = this.props;
     const {tokenList} = this.state;
 
     const isEmpty = tokenList.length === 0;
@@ -76,6 +79,15 @@ class ApiTokens extends AsyncView {
     return (
       <div>
         <SettingsPageHeader title="Auth Tokens" action={action} />
+        <AlertLink
+          to={`/settings/${(organization && organization.slug) ||
+            ''}/developer-settings/`}
+          icon="icon-circle-info"
+        >
+          {t(
+            'Auth Tokens are tied to the logged in user. If the user leaves the organization, things will break! Avoid this with Internal Integrations!'
+          )}
+        </AlertLink>
         <TextBlock>
           {t(
             "Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
@@ -122,4 +134,5 @@ class ApiTokens extends AsyncView {
   }
 }
 
-export default ApiTokens;
+export {ApiTokens};
+export default withOrganization(ApiTokens);

--- a/src/sentry/static/sentry/app/views/settings/settingsIndex.tsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsIndex.tsx
@@ -26,7 +26,6 @@ const LINKS = {
   DOCUMENTATION_CLI: 'https://docs.sentry.io/learn/cli/',
   DOCUMENTATION_API: 'https://docs.sentry.io/hosted/api/',
   API: '/settings/account/api/',
-  API_APPLICATIONS: '/settings/account/api/applications/',
   MANAGE: '/manage/',
   FORUM: 'https://forum.sentry.io/',
   GITHUB_ISSUES: 'https://github.com/getsentry/sentry/issues',
@@ -243,7 +242,9 @@ class SettingsIndex extends React.Component<Props> {
                     <HomeLink to={LINKS.API}>{t('Auth Tokens')}</HomeLink>
                   </li>
                   <li>
-                    <HomeLink to={LINKS.API_APPLICATIONS}>{t('Applications')}</HomeLink>
+                    <HomeLink to={`${organizationSettingsUrl}developer-settings/`}>
+                      {t('Integrations')}
+                    </HomeLink>
                   </li>
                   <li>
                     <ExternalHomeLink href={LINKS.DOCUMENTATION_API}>

--- a/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
@@ -1,176 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApiTokens renders empty result 1`] = `
-<SideEffect(DocumentTitle)
-  title="API Tokens - Sentry"
->
-  <div>
-    <StyledSettingsPageHeading
-      action={
-        <Button
-          align="center"
-          data-test-id="create-token"
-          disabled={false}
-          priority="primary"
-          size="small"
-          to="/settings/account/api/auth-tokens/new-token/"
-        >
-          Create New Token
-        </Button>
-      }
-      noTitleStyles={false}
-      title="Auth Tokens"
-    />
-    <TextBlock>
-      Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API.
-    </TextBlock>
-    <TextBlock>
-      <span
-        key="5"
-      >
-        <span
-          key="0"
-        >
-          For more information on how to use the web API, see our 
-        </span>
-        <a
-          href="https://docs.sentry.io/hosted/api/"
-          key="2"
-        >
-          <span
-            key="1"
-          >
-            documentation
-          </span>
-        </a>
-        <span
-          key="3"
-        >
-          .
-        </span>
-      </span>
-    </TextBlock>
-    <TextBlock>
-      <small>
-        psst. Looking for the 
-        <strong>
-          DSN
-        </strong>
-         for an SDK? You'll find that under
-         
-        <strong>
-          [Project] » Settings » Client Keys
-        </strong>
-        .
-      </small>
-    </TextBlock>
-    <Panel>
-      <PanelHeader>
-        Auth Token
-      </PanelHeader>
-      <PanelBody
-        direction="column"
-        disablePadding={true}
-        flex={false}
-      >
-        <EmptyMessage>
-          You haven't created any authentication tokens yet.
-        </EmptyMessage>
-      </PanelBody>
-    </Panel>
-  </div>
-</SideEffect(DocumentTitle)>
+<ApiTokens
+  organization={
+    Object {
+      "access": Array [
+        "org:read",
+        "org:write",
+        "org:admin",
+        "org:integrations",
+        "project:read",
+        "project:write",
+        "project:admin",
+        "team:read",
+        "team:write",
+        "team:admin",
+      ],
+      "features": Array [],
+      "id": "3",
+      "name": "Organization Name",
+      "onboardingTasks": Array [],
+      "projects": Array [],
+      "scrapeJavaScript": true,
+      "slug": "org-slug",
+      "status": Object {
+        "id": "active",
+        "name": "active",
+      },
+      "teams": Array [],
+    }
+  }
+/>
 `;
 
 exports[`ApiTokens renders with result 1`] = `
-<SideEffect(DocumentTitle)
-  title="API Tokens - Sentry"
->
-  <div>
-    <StyledSettingsPageHeading
-      action={
-        <Button
-          align="center"
-          data-test-id="create-token"
-          disabled={false}
-          priority="primary"
-          size="small"
-          to="/settings/account/api/auth-tokens/new-token/"
-        >
-          Create New Token
-        </Button>
-      }
-      noTitleStyles={false}
-      title="Auth Tokens"
-    />
-    <TextBlock>
-      Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API.
-    </TextBlock>
-    <TextBlock>
-      <span
-        key="5"
-      >
-        <span
-          key="0"
-        >
-          For more information on how to use the web API, see our 
-        </span>
-        <a
-          href="https://docs.sentry.io/hosted/api/"
-          key="2"
-        >
-          <span
-            key="1"
-          >
-            documentation
-          </span>
-        </a>
-        <span
-          key="3"
-        >
-          .
-        </span>
-      </span>
-    </TextBlock>
-    <TextBlock>
-      <small>
-        psst. Looking for the 
-        <strong>
-          DSN
-        </strong>
-         for an SDK? You'll find that under
-         
-        <strong>
-          [Project] » Settings » Client Keys
-        </strong>
-        .
-      </small>
-    </TextBlock>
-    <Panel>
-      <PanelHeader>
-        Auth Token
-      </PanelHeader>
-      <PanelBody
-        direction="column"
-        disablePadding={true}
-        flex={false}
-      >
-        <ApiTokenRow
-          key="apitoken123"
-          onRemove={[Function]}
-          token={
-            Object {
-              "dateCreated": 2018-01-12T02:01:41.000Z,
-              "scopes": Array [
-                "scope1",
-                "scope2",
-              ],
-              "token": "apitoken123",
-            }
-          }
-        />
-      </PanelBody>
-    </Panel>
-  </div>
-</SideEffect(DocumentTitle)>
+<ApiTokens
+  organization={
+    Object {
+      "access": Array [
+        "org:read",
+        "org:write",
+        "org:admin",
+        "org:integrations",
+        "project:read",
+        "project:write",
+        "project:admin",
+        "team:read",
+        "team:write",
+        "team:admin",
+      ],
+      "features": Array [],
+      "id": "3",
+      "name": "Organization Name",
+      "onboardingTasks": Array [],
+      "projects": Array [],
+      "scrapeJavaScript": true,
+      "slug": "org-slug",
+      "status": Object {
+        "id": "active",
+        "name": "active",
+      },
+      "teams": Array [],
+    }
+  }
+/>
 `;

--- a/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
@@ -318,9 +318,9 @@ exports[`SettingsIndex renders 1`] = `
             </li>
             <li>
               <HomeLink
-                to="/settings/account/api/applications/"
+                to="/settings/org-slug/developer-settings/"
               >
-                Applications
+                Integrations
               </HomeLink>
             </li>
             <li>


### PR DESCRIPTION
- Change the text on the `/settings/` to direct users towards `Integrations` instead of `API Applications`
<img width="303" alt="image" src="https://user-images.githubusercontent.com/35509934/72004816-0fd20680-3201-11ea-8092-f8436825c37c.png">

---

- Insert a warning atop the APITokens (Auth Tokens) page to direct users towards internal integrations
<img width="635" alt="image" src="https://user-images.githubusercontent.com/35509934/72004782-fb8e0980-3200-11ea-9a22-4413db3491aa.png">

---

***(Addresses [API-559](https://getsentry.atlassian.net/browse/API-559))***