### PR TITLE
ref: Steer users towards integrations 

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
@@ -16,7 +16,7 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import withOrganization from 'app/utils/withOrganization';
 
-class ApiTokens extends AsyncView {
+export class ApiTokens extends AsyncView {
   getTitle() {
     return t('API Tokens');
   }
@@ -130,5 +130,4 @@ class ApiTokens extends AsyncView {
   }
 }
 
-export {ApiTokens};
 export default withOrganization(ApiTokens);

--- a/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
@@ -79,10 +79,7 @@ class ApiTokens extends AsyncView {
     return (
       <div>
         <SettingsPageHeader title="Auth Tokens" action={action} />
-        <AlertLink
-          to={`/settings/${(organization && organization.slug) ||
-            ''}/developer-settings/new-internal`}
-        >
+        <AlertLink to={`/settings/${organization.slug}/developer-settings/new-internal`}>
           {t(
             "Auth Tokens are tied to the logged in user, meaning they'll stop working if the user leaves the organization! We suggest using internal integrations to create/manage tokens tied to the organization instead."
           )}

--- a/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
@@ -79,12 +79,9 @@ class ApiTokens extends AsyncView {
     return (
       <div>
         <SettingsPageHeader title="Auth Tokens" action={action} />
-        <AlertLink
-          to={`/settings/${organization.slug}/developer-settings/`}
-          icon="icon-circle-info"
-        >
+        <AlertLink to={`/settings/${organization.slug}/developer-settings/new-internal`}>
           {t(
-            'Auth Tokens are tied to the logged in user. If the user leaves the organization, the token will no longer work! We suggest using internal integrations to manage tokens which are not tied to a user.'
+            "Auth Tokens are tied to the logged in user, meaning they'll stop working if the user leaves the organization! We suggest using internal integrations to create/manage tokens tied to the organization instead."
           )}
         </AlertLink>
         <TextBlock>

--- a/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
@@ -80,8 +80,7 @@ class ApiTokens extends AsyncView {
       <div>
         <SettingsPageHeader title="Auth Tokens" action={action} />
         <AlertLink
-          to={`/settings/${(organization && organization.slug) ||
-            ''}/developer-settings/`}
+          to={`/settings/${organization.slug}/developer-settings/`}
           icon="icon-circle-info"
         >
           {t(

--- a/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
@@ -7,12 +7,14 @@ import {
   addSuccessMessage,
 } from 'app/actionCreators/indicator';
 import {t, tct} from 'app/locale';
+import AlertLink from 'app/components/alertLink';
 import ApiTokenRow from 'app/views/settings/account/apiTokenRow';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
+import withOrganization from 'app/utils/withOrganization';
 
 class ApiTokens extends AsyncView {
   getTitle() {
@@ -58,6 +60,7 @@ class ApiTokens extends AsyncView {
   };
 
   renderBody() {
+    const {organization} = this.props;
     const {tokenList} = this.state;
 
     const isEmpty = tokenList.length === 0;
@@ -76,6 +79,15 @@ class ApiTokens extends AsyncView {
     return (
       <div>
         <SettingsPageHeader title="Auth Tokens" action={action} />
+        <AlertLink
+          to={`/settings/${(organization && organization.slug) ||
+            ''}/developer-settings/`}
+          icon="icon-circle-info"
+        >
+          {t(
+            'Auth Tokens are tied to the logged in user. If the user leaves the organization, things will break! Avoid this with Internal Integrations!'
+          )}
+        </AlertLink>
         <TextBlock>
           {t(
             "Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
@@ -122,4 +134,5 @@ class ApiTokens extends AsyncView {
   }
 }
 
-export default ApiTokens;
+export {ApiTokens};
+export default withOrganization(ApiTokens);

--- a/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
@@ -79,7 +79,10 @@ export class ApiTokens extends AsyncView {
     return (
       <div>
         <SettingsPageHeader title="Auth Tokens" action={action} />
-        <AlertLink to={`/settings/${organization.slug}/developer-settings/new-internal`}>
+        <AlertLink
+          to={`/settings/${(organization && organization.slug) ||
+            ''}/developer-settings/new-internal`}
+        >
           {t(
             "Auth Tokens are tied to the logged in user, meaning they'll stop working if the user leaves the organization! We suggest using internal integrations to create/manage tokens tied to the organization instead."
           )}

--- a/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
@@ -79,7 +79,10 @@ class ApiTokens extends AsyncView {
     return (
       <div>
         <SettingsPageHeader title="Auth Tokens" action={action} />
-        <AlertLink to={`/settings/${organization.slug}/developer-settings/new-internal`}>
+        <AlertLink
+          to={`/settings/${(organization && organization.slug) ||
+            ''}/developer-settings/new-internal`}
+        >
           {t(
             "Auth Tokens are tied to the logged in user, meaning they'll stop working if the user leaves the organization! We suggest using internal integrations to create/manage tokens tied to the organization instead."
           )}

--- a/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiTokens.jsx
@@ -85,7 +85,7 @@ class ApiTokens extends AsyncView {
           icon="icon-circle-info"
         >
           {t(
-            'Auth Tokens are tied to the logged in user. If the user leaves the organization, things will break! Avoid this with Internal Integrations!'
+            'Auth Tokens are tied to the logged in user. If the user leaves the organization, the token will no longer work! We suggest using internal integrations to manage tokens which are not tied to a user.'
           )}
         </AlertLink>
         <TextBlock>

--- a/src/sentry/static/sentry/app/views/settings/settingsIndex.tsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsIndex.tsx
@@ -244,7 +244,7 @@ class SettingsIndex extends React.Component<Props> {
                   </li>
                   <li>
                     <HomeLink to={`${organizationSettingsUrl}developer-settings/`}>
-                      {t('Integrations')}
+                      {t('Your Integrations')}
                     </HomeLink>
                   </li>
                   <li>

--- a/src/sentry/static/sentry/app/views/settings/settingsIndex.tsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsIndex.tsx
@@ -27,7 +27,6 @@ const LINKS = {
   DOCUMENTATION_CLI: 'https://docs.sentry.io/learn/cli/',
   DOCUMENTATION_API: 'https://docs.sentry.io/hosted/api/',
   API: '/settings/account/api/',
-  API_APPLICATIONS: '/settings/account/api/applications/',
   MANAGE: '/manage/',
   FORUM: 'https://forum.sentry.io/',
   GITHUB_ISSUES: 'https://github.com/getsentry/sentry/issues',
@@ -244,7 +243,9 @@ class SettingsIndex extends React.Component<Props> {
                     <HomeLink to={LINKS.API}>{t('Auth Tokens')}</HomeLink>
                   </li>
                   <li>
-                    <HomeLink to={LINKS.API_APPLICATIONS}>{t('Applications')}</HomeLink>
+                    <HomeLink to={`${organizationSettingsUrl}developer-settings/`}>
+                      {t('Integrations')}
+                    </HomeLink>
                   </li>
                   <li>
                     <ExternalHomeLink href={LINKS.DOCUMENTATION_API}>

--- a/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
@@ -1,67 +1,176 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApiTokens renders empty result 1`] = `
-<ApiTokens
-  organization={
-    Object {
-      "access": Array [
-        "org:read",
-        "org:write",
-        "org:admin",
-        "org:integrations",
-        "project:read",
-        "project:write",
-        "project:admin",
-        "team:read",
-        "team:write",
-        "team:admin",
-      ],
-      "features": Array [],
-      "id": "3",
-      "name": "Organization Name",
-      "onboardingTasks": Array [],
-      "projects": Array [],
-      "scrapeJavaScript": true,
-      "slug": "org-slug",
-      "status": Object {
-        "id": "active",
-        "name": "active",
-      },
-      "teams": Array [],
-    }
-  }
-/>
+<SideEffect(DocumentTitle)
+  title="API Tokens - Sentry"
+>
+  <div>
+    <StyledSettingsPageHeading
+      action={
+        <Button
+          align="center"
+          data-test-id="create-token"
+          disabled={false}
+          priority="primary"
+          size="small"
+          to="/settings/account/api/auth-tokens/new-token/"
+        >
+          Create New Token
+        </Button>
+      }
+      noTitleStyles={false}
+      title="Auth Tokens"
+    />
+    <TextBlock>
+      Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API.
+    </TextBlock>
+    <TextBlock>
+      <span
+        key="5"
+      >
+        <span
+          key="0"
+        >
+          For more information on how to use the web API, see our 
+        </span>
+        <a
+          href="https://docs.sentry.io/hosted/api/"
+          key="2"
+        >
+          <span
+            key="1"
+          >
+            documentation
+          </span>
+        </a>
+        <span
+          key="3"
+        >
+          .
+        </span>
+      </span>
+    </TextBlock>
+    <TextBlock>
+      <small>
+        psst. Looking for the 
+        <strong>
+          DSN
+        </strong>
+         for an SDK? You'll find that under
+         
+        <strong>
+          [Project] » Settings » Client Keys
+        </strong>
+        .
+      </small>
+    </TextBlock>
+    <Panel>
+      <PanelHeader>
+        Auth Token
+      </PanelHeader>
+      <PanelBody
+        direction="column"
+        disablePadding={true}
+        flex={false}
+      >
+        <EmptyMessage>
+          You haven't created any authentication tokens yet.
+        </EmptyMessage>
+      </PanelBody>
+    </Panel>
+  </div>
+</SideEffect(DocumentTitle)>
 `;
 
 exports[`ApiTokens renders with result 1`] = `
-<ApiTokens
-  organization={
-    Object {
-      "access": Array [
-        "org:read",
-        "org:write",
-        "org:admin",
-        "org:integrations",
-        "project:read",
-        "project:write",
-        "project:admin",
-        "team:read",
-        "team:write",
-        "team:admin",
-      ],
-      "features": Array [],
-      "id": "3",
-      "name": "Organization Name",
-      "onboardingTasks": Array [],
-      "projects": Array [],
-      "scrapeJavaScript": true,
-      "slug": "org-slug",
-      "status": Object {
-        "id": "active",
-        "name": "active",
-      },
-      "teams": Array [],
-    }
-  }
-/>
+<SideEffect(DocumentTitle)
+  title="API Tokens - Sentry"
+>
+  <div>
+    <StyledSettingsPageHeading
+      action={
+        <Button
+          align="center"
+          data-test-id="create-token"
+          disabled={false}
+          priority="primary"
+          size="small"
+          to="/settings/account/api/auth-tokens/new-token/"
+        >
+          Create New Token
+        </Button>
+      }
+      noTitleStyles={false}
+      title="Auth Tokens"
+    />
+    <TextBlock>
+      Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API.
+    </TextBlock>
+    <TextBlock>
+      <span
+        key="5"
+      >
+        <span
+          key="0"
+        >
+          For more information on how to use the web API, see our 
+        </span>
+        <a
+          href="https://docs.sentry.io/hosted/api/"
+          key="2"
+        >
+          <span
+            key="1"
+          >
+            documentation
+          </span>
+        </a>
+        <span
+          key="3"
+        >
+          .
+        </span>
+      </span>
+    </TextBlock>
+    <TextBlock>
+      <small>
+        psst. Looking for the 
+        <strong>
+          DSN
+        </strong>
+         for an SDK? You'll find that under
+         
+        <strong>
+          [Project] » Settings » Client Keys
+        </strong>
+        .
+      </small>
+    </TextBlock>
+    <Panel>
+      <PanelHeader>
+        Auth Token
+      </PanelHeader>
+      <PanelBody
+        direction="column"
+        disablePadding={true}
+        flex={false}
+      >
+        <ApiTokenRow
+          key="apitoken123"
+          onRemove={[Function]}
+          token={
+            Object {
+              "dateCreated": 2018-01-12T02:01:41.000Z,
+              "scopes": Array [
+                "scope1",
+                "scope2",
+              ],
+              "token": "apitoken123",
+            }
+          }
+        />
+      </PanelBody>
+    </Panel>
+  </div>
+</SideEffect(DocumentTitle)>
 `;

--- a/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
@@ -1,176 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApiTokens renders empty result 1`] = `
-<SideEffect(DocumentTitle)
-  title="API Tokens - Sentry"
->
-  <div>
-    <StyledSettingsPageHeading
-      action={
-        <Button
-          align="center"
-          data-test-id="create-token"
-          disabled={false}
-          priority="primary"
-          size="small"
-          to="/settings/account/api/auth-tokens/new-token/"
-        >
-          Create New Token
-        </Button>
-      }
-      noTitleStyles={false}
-      title="Auth Tokens"
-    />
-    <TextBlock>
-      Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API.
-    </TextBlock>
-    <TextBlock>
-      <span
-        key="5"
-      >
-        <span
-          key="0"
-        >
-          For more information on how to use the web API, see our 
-        </span>
-        <a
-          href="https://docs.sentry.io/hosted/api/"
-          key="2"
-        >
-          <span
-            key="1"
-          >
-            documentation
-          </span>
-        </a>
-        <span
-          key="3"
-        >
-          .
-        </span>
-      </span>
-    </TextBlock>
-    <TextBlock>
-      <small>
-        psst. Looking for the 
-        <strong>
-          DSN
-        </strong>
-         for an SDK? You'll find that under
-         
-        <strong>
-          [Project] » Settings » Client Keys
-        </strong>
-        .
-      </small>
-    </TextBlock>
-    <Panel>
-      <PanelHeader>
-        Auth Token
-      </PanelHeader>
-      <PanelBody
-        direction="column"
-        disablePadding={true}
-        flex={false}
-      >
-        <EmptyMessage>
-          You haven't created any authentication tokens yet.
-        </EmptyMessage>
-      </PanelBody>
-    </Panel>
-  </div>
-</SideEffect(DocumentTitle)>
+<ApiTokens
+  organization={
+    Object {
+      "access": Array [
+        "org:read",
+        "org:write",
+        "org:admin",
+        "org:integrations",
+        "project:read",
+        "project:write",
+        "project:admin",
+        "team:read",
+        "team:write",
+        "team:admin",
+      ],
+      "features": Array [],
+      "id": "3",
+      "name": "Organization Name",
+      "onboardingTasks": Array [],
+      "projects": Array [],
+      "scrapeJavaScript": true,
+      "slug": "org-slug",
+      "status": Object {
+        "id": "active",
+        "name": "active",
+      },
+      "teams": Array [],
+    }
+  }
+/>
 `;
 
 exports[`ApiTokens renders with result 1`] = `
-<SideEffect(DocumentTitle)
-  title="API Tokens - Sentry"
->
-  <div>
-    <StyledSettingsPageHeading
-      action={
-        <Button
-          align="center"
-          data-test-id="create-token"
-          disabled={false}
-          priority="primary"
-          size="small"
-          to="/settings/account/api/auth-tokens/new-token/"
-        >
-          Create New Token
-        </Button>
-      }
-      noTitleStyles={false}
-      title="Auth Tokens"
-    />
-    <TextBlock>
-      Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API.
-    </TextBlock>
-    <TextBlock>
-      <span
-        key="5"
-      >
-        <span
-          key="0"
-        >
-          For more information on how to use the web API, see our 
-        </span>
-        <a
-          href="https://docs.sentry.io/hosted/api/"
-          key="2"
-        >
-          <span
-            key="1"
-          >
-            documentation
-          </span>
-        </a>
-        <span
-          key="3"
-        >
-          .
-        </span>
-      </span>
-    </TextBlock>
-    <TextBlock>
-      <small>
-        psst. Looking for the 
-        <strong>
-          DSN
-        </strong>
-         for an SDK? You'll find that under
-         
-        <strong>
-          [Project] » Settings » Client Keys
-        </strong>
-        .
-      </small>
-    </TextBlock>
-    <Panel>
-      <PanelHeader>
-        Auth Token
-      </PanelHeader>
-      <PanelBody
-        direction="column"
-        disablePadding={true}
-        flex={false}
-      >
-        <ApiTokenRow
-          key="apitoken123"
-          onRemove={[Function]}
-          token={
-            Object {
-              "dateCreated": 2018-01-12T02:01:41.000Z,
-              "scopes": Array [
-                "scope1",
-                "scope2",
-              ],
-              "token": "apitoken123",
-            }
-          }
-        />
-      </PanelBody>
-    </Panel>
-  </div>
-</SideEffect(DocumentTitle)>
+<ApiTokens
+  organization={
+    Object {
+      "access": Array [
+        "org:read",
+        "org:write",
+        "org:admin",
+        "org:integrations",
+        "project:read",
+        "project:write",
+        "project:admin",
+        "team:read",
+        "team:write",
+        "team:admin",
+      ],
+      "features": Array [],
+      "id": "3",
+      "name": "Organization Name",
+      "onboardingTasks": Array [],
+      "projects": Array [],
+      "scrapeJavaScript": true,
+      "slug": "org-slug",
+      "status": Object {
+        "id": "active",
+        "name": "active",
+      },
+      "teams": Array [],
+    }
+  }
+/>
 `;

--- a/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/apiTokens.spec.jsx.snap
@@ -1,67 +1,190 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApiTokens renders empty result 1`] = `
-<ApiTokens
-  organization={
-    Object {
-      "access": Array [
-        "org:read",
-        "org:write",
-        "org:admin",
-        "org:integrations",
-        "project:read",
-        "project:write",
-        "project:admin",
-        "team:read",
-        "team:write",
-        "team:admin",
-      ],
-      "features": Array [],
-      "id": "3",
-      "name": "Organization Name",
-      "onboardingTasks": Array [],
-      "projects": Array [],
-      "scrapeJavaScript": true,
-      "slug": "org-slug",
-      "status": Object {
-        "id": "active",
-        "name": "active",
-      },
-      "teams": Array [],
-    }
-  }
-/>
+<SideEffect(DocumentTitle)
+  title="API Tokens - Sentry"
+>
+  <div>
+    <StyledSettingsPageHeading
+      action={
+        <Button
+          align="center"
+          data-test-id="create-token"
+          disabled={false}
+          priority="primary"
+          size="small"
+          to="/settings/account/api/auth-tokens/new-token/"
+        >
+          Create New Token
+        </Button>
+      }
+      noTitleStyles={false}
+      title="Auth Tokens"
+    />
+    <AlertLink
+      priority="warning"
+      size="normal"
+      to="/settings/org-slug/developer-settings/new-internal"
+    >
+      Auth Tokens are tied to the logged in user, meaning they'll stop working if the user leaves the organization! We suggest using internal integrations to create/manage tokens tied to the organization instead.
+    </AlertLink>
+    <TextBlock>
+      Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API.
+    </TextBlock>
+    <TextBlock>
+      <span
+        key="5"
+      >
+        <span
+          key="0"
+        >
+          For more information on how to use the web API, see our 
+        </span>
+        <a
+          href="https://docs.sentry.io/hosted/api/"
+          key="2"
+        >
+          <span
+            key="1"
+          >
+            documentation
+          </span>
+        </a>
+        <span
+          key="3"
+        >
+          .
+        </span>
+      </span>
+    </TextBlock>
+    <TextBlock>
+      <small>
+        psst. Looking for the 
+        <strong>
+          DSN
+        </strong>
+         for an SDK? You'll find that under
+         
+        <strong>
+          [Project] » Settings » Client Keys
+        </strong>
+        .
+      </small>
+    </TextBlock>
+    <Panel>
+      <PanelHeader>
+        Auth Token
+      </PanelHeader>
+      <PanelBody
+        direction="column"
+        disablePadding={true}
+        flex={false}
+      >
+        <EmptyMessage>
+          You haven't created any authentication tokens yet.
+        </EmptyMessage>
+      </PanelBody>
+    </Panel>
+  </div>
+</SideEffect(DocumentTitle)>
 `;
 
 exports[`ApiTokens renders with result 1`] = `
-<ApiTokens
-  organization={
-    Object {
-      "access": Array [
-        "org:read",
-        "org:write",
-        "org:admin",
-        "org:integrations",
-        "project:read",
-        "project:write",
-        "project:admin",
-        "team:read",
-        "team:write",
-        "team:admin",
-      ],
-      "features": Array [],
-      "id": "3",
-      "name": "Organization Name",
-      "onboardingTasks": Array [],
-      "projects": Array [],
-      "scrapeJavaScript": true,
-      "slug": "org-slug",
-      "status": Object {
-        "id": "active",
-        "name": "active",
-      },
-      "teams": Array [],
-    }
-  }
-/>
+<SideEffect(DocumentTitle)
+  title="API Tokens - Sentry"
+>
+  <div>
+    <StyledSettingsPageHeading
+      action={
+        <Button
+          align="center"
+          data-test-id="create-token"
+          disabled={false}
+          priority="primary"
+          size="small"
+          to="/settings/account/api/auth-tokens/new-token/"
+        >
+          Create New Token
+        </Button>
+      }
+      noTitleStyles={false}
+      title="Auth Tokens"
+    />
+    <AlertLink
+      priority="warning"
+      size="normal"
+      to="/settings/org-slug/developer-settings/new-internal"
+    >
+      Auth Tokens are tied to the logged in user, meaning they'll stop working if the user leaves the organization! We suggest using internal integrations to create/manage tokens tied to the organization instead.
+    </AlertLink>
+    <TextBlock>
+      Authentication tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API.
+    </TextBlock>
+    <TextBlock>
+      <span
+        key="5"
+      >
+        <span
+          key="0"
+        >
+          For more information on how to use the web API, see our 
+        </span>
+        <a
+          href="https://docs.sentry.io/hosted/api/"
+          key="2"
+        >
+          <span
+            key="1"
+          >
+            documentation
+          </span>
+        </a>
+        <span
+          key="3"
+        >
+          .
+        </span>
+      </span>
+    </TextBlock>
+    <TextBlock>
+      <small>
+        psst. Looking for the 
+        <strong>
+          DSN
+        </strong>
+         for an SDK? You'll find that under
+         
+        <strong>
+          [Project] » Settings » Client Keys
+        </strong>
+        .
+      </small>
+    </TextBlock>
+    <Panel>
+      <PanelHeader>
+        Auth Token
+      </PanelHeader>
+      <PanelBody
+        direction="column"
+        disablePadding={true}
+        flex={false}
+      >
+        <ApiTokenRow
+          key="apitoken123"
+          onRemove={[Function]}
+          token={
+            Object {
+              "dateCreated": 2018-01-12T02:01:41.000Z,
+              "scopes": Array [
+                "scope1",
+                "scope2",
+              ],
+              "token": "apitoken123",
+            }
+          }
+        />
+      </PanelBody>
+    </Panel>
+  </div>
+</SideEffect(DocumentTitle)>
 `;

--- a/tests/js/spec/views/apiTokens.spec.jsx
+++ b/tests/js/spec/views/apiTokens.spec.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import {shallow, mountWithTheme} from 'sentry-test/enzyme';
 
 import {Client} from 'app/api';
-import ApiTokens from 'app/views/settings/account/apiTokens';
+import {ApiTokens} from 'app/views/settings/account/apiTokens';
+
+const organization = TestStubs.Organization();
 
 describe('ApiTokens', function() {
   const routerContext = TestStubs.routerContext();
@@ -16,7 +18,7 @@ describe('ApiTokens', function() {
       url: '/api-tokens/',
     });
 
-    const wrapper = shallow(<ApiTokens />, routerContext);
+    const wrapper = shallow(<ApiTokens organization={organization} />, routerContext);
 
     // Should be loading
     expect(wrapper).toMatchSnapshot();
@@ -28,7 +30,7 @@ describe('ApiTokens', function() {
       body: [TestStubs.ApiToken()],
     });
 
-    const wrapper = shallow(<ApiTokens />, routerContext);
+    const wrapper = shallow(<ApiTokens organization={organization} />, routerContext);
 
     // Should be loading
     expect(wrapper).toMatchSnapshot();
@@ -47,7 +49,10 @@ describe('ApiTokens', function() {
 
     expect(mock).not.toHaveBeenCalled();
 
-    const wrapper = mountWithTheme(<ApiTokens />, routerContext);
+    const wrapper = mountWithTheme(
+      <ApiTokens organization={organization} />,
+      routerContext
+    );
 
     wrapper.find('button[aria-label="Remove"]').simulate('click');
 

--- a/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
@@ -318,9 +318,9 @@ exports[`SettingsIndex renders 1`] = `
             </li>
             <li>
               <HomeLink
-                to="/settings/account/api/applications/"
+                to="/settings/org-slug/developer-settings/"
               >
-                Applications
+                Your Integrations
               </HomeLink>
             </li>
             <li>

--- a/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
@@ -320,7 +320,7 @@ exports[`SettingsIndex renders 1`] = `
               <HomeLink
                 to="/settings/org-slug/developer-settings/"
               >
-                Integrations
+                Your Integrations
               </HomeLink>
             </li>
             <li>

--- a/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
@@ -318,9 +318,9 @@ exports[`SettingsIndex renders 1`] = `
             </li>
             <li>
               <HomeLink
-                to="/settings/org-slug/developer-settings/"
+                to="/settings/account/api/applications/"
               >
-                Your Integrations
+                Applications
               </HomeLink>
             </li>
             <li>

--- a/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/settingsIndex.spec.jsx.snap
@@ -318,9 +318,9 @@ exports[`SettingsIndex renders 1`] = `
             </li>
             <li>
               <HomeLink
-                to="/settings/account/api/applications/"
+                to="/settings/org-slug/developer-settings/"
               >
-                Applications
+                Integrations
               </HomeLink>
             </li>
             <li>


### PR DESCRIPTION
- Change the text on the `/settings/` to direct users towards `Integrations` instead of `API Applications`
<img width="303" alt="image" src="https://user-images.githubusercontent.com/35509934/72004816-0fd20680-3201-11ea-8092-f8436825c37c.png">

---

- Insert a warning atop the APITokens (Auth Tokens) page to direct users towards internal integrations
<img width="635" alt="image" src="https://user-images.githubusercontent.com/35509934/72004782-fb8e0980-3200-11ea-9a22-4413db3491aa.png">

---

***(Addresses [API-559](https://getsentry.atlassian.net/browse/API-559))***