### PR TITLE
ref: Improve Webhook URL description

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.tsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.tsx
@@ -56,7 +56,7 @@ const getPublicFormFields = (): Field[] => [
     disabled: ({webhookDisabled}) => webhookDisabled,
     disabledReason: 'Cannot enable alert rule action without a webhook url',
     help: tct(
-      'If enabled, this integration will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions [learn_more:Here].',
+      'If enabled, this integration will be an action under alert rules in Sentry. The notification destination is the Webhook URL specified above. More on actions [learn_more:here].',
       {
         learn_more: <a href="https://docs.sentry.io/product/notifications/#actions" />,
       }

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.tsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.tsx
@@ -28,7 +28,7 @@ const getPublicFormFields = (): Field[] => [
     label: 'Webhook URL',
     placeholder: 'e.g. https://example.com/sentry/webhook/',
     help:
-      'The URL Sentry will send requests to for events such as installation changes and any Resource Subscriptions the Integration subscribes to.',
+      'Any time an event in Sentry triggers a request to your integration, it will get sent to this URL.',
   },
   {
     name: 'redirectUrl',

--- a/src/sentry/static/sentry/app/data/forms/sentryApplication.tsx
+++ b/src/sentry/static/sentry/app/data/forms/sentryApplication.tsx
@@ -27,8 +27,14 @@ const getPublicFormFields = (): Field[] => [
     required: true,
     label: 'Webhook URL',
     placeholder: 'e.g. https://example.com/sentry/webhook/',
-    help:
-      'Any time an event in Sentry triggers a request to your integration, it will get sent to this URL.',
+    help: tct(
+      'All webhook requests for your integration will be sent to this URL. Visit the [webhook_docs:documentation] to see the different types and payloads.',
+      {
+        webhook_docs: (
+          <a href="https://docs.sentry.io/workflow/integrations/integration-platform/webhooks/" />
+        ),
+      }
+    ),
   },
   {
     name: 'redirectUrl',


### PR DESCRIPTION
- Communicate the use of a Webhook URL more accurately on both integration pages (internal/public)
<img width="913" alt="image" src="https://user-images.githubusercontent.com/35509934/72008527-e61cdd80-3208-11ea-9a33-e51af1b27f54.png">

---

***(Addresses [API-244](https://getsentry.atlassian.net/browse/API-244))***