### PR TITLE
fix(projects) - Prevent non org users from getting 302

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -123,6 +123,8 @@ class ProjectEndpoint(Endpoint):
                 redirect = redirect.get(
                     organization__slug=organization_slug, redirect_slug=project_slug
                 )
+                # Without object permissions don't reveal the rename
+                self.check_object_permissions(request, redirect.project)
 
                 # get full path so that we keep query strings
                 requested_url = request.get_full_path()

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -89,6 +89,24 @@ class ProjectDetailsTest(APITestCase):
         # (this is with self.assertRedirects(response, ...))
         assert response["Location"] == redirect_path
 
+    def test_non_org_rename_403(self):
+        org = self.create_organization()
+        team = self.create_team(organization=org, name="foo", slug="foo")
+        user = self.create_user(is_superuser=False)
+        self.create_member(user=user, organization=org, role="member", teams=[team])
+
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        ProjectRedirect.record(other_project, "old_slug")
+
+        url = reverse(
+            "sentry-api-0-project-details",
+            kwargs={"organization_slug": other_org.slug, "project_slug": "old_slug"},
+        )
+        self.login_as(user=user)
+        response = self.client.get(url)
+        assert response.status_code == 403
+
 
 class ProjectUpdateTest(APITestCase):
     def setUp(self):


### PR DESCRIPTION
- Currently when a user accesses a project url that they don't belong
  to, if that project was renamed we currently 302 them to the new
  project url. The new url will 403, but this 302 reveals the new
  project name.
Asana Task: https://app.asana.com/0/1154164241699513/1154164241699566