### PR TITLE
fix(ui) Fix gravatar fallbacks

### DIFF
--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
@@ -178,6 +178,7 @@ class BaseAvatar extends React.Component<Props, State> {
           gravatarId={gravatarId}
           round={round}
           remoteSize={DEFAULT_REMOTE_SIZE}
+          {...eventProps}
         />
       );
     }

--- a/src/sentry/static/sentry/app/components/avatar/gravatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/gravatar.tsx
@@ -16,6 +16,8 @@ type Props = {
    * Should avatar be round instead of a square
    */
   round?: boolean;
+  onLoad?: () => void;
+  onError?: () => void;
 };
 
 type State = {
@@ -81,9 +83,16 @@ class Gravatar extends React.Component<Props, State> {
       return null;
     }
 
-    const {round} = this.props;
+    const {round, onError, onLoad} = this.props;
 
-    return <Image round={round} src={this.buildGravatarUrl()} />;
+    return (
+      <Image
+        round={round}
+        src={this.buildGravatarUrl()}
+        onLoad={onLoad}
+        onError={onError}
+      />
+    );
   }
 }
 


### PR DESCRIPTION
When updating Gravatar to typescript, I removed some property spreads as they triggered typescript warnings and the propTypes didn't cover any props that needed spreading. The onLoad and onError props were load bearing as they are used to handle gravatar fallbacks.