### PR TITLE
fix: Use django's is_safe_url function

### DIFF
--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib.auth import login as _login
 from django.contrib.auth.backends import ModelBackend
 from django.core.urlresolvers import reverse, resolve
-from sudo.utils import is_safe_url
+from django.utils.http import is_safe_url
 from time import time
 
 from sentry.models import User, Authenticator

--- a/src/sentry/web/frontend/auth_logout.py
+++ b/src/sentry/web/frontend/auth_logout.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.contrib.auth import logout, REDIRECT_FIELD_NAME
 from django.contrib.auth.models import AnonymousUser
-from sudo.utils import is_safe_url
+from django.utils.http import is_safe_url
 
 from sentry.web.frontend.base import BaseView
 from sentry.utils import auth

--- a/src/sentry/web/frontend/group_plugin_action.py
+++ b/src/sentry/web/frontend/group_plugin_action.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division
 
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
-from sudo.utils import is_safe_url
+from django.utils.http import is_safe_url
 
 from sentry.models import Group, GroupMeta
 from sentry.plugins.base import plugins

--- a/src/social_auth/views.py
+++ b/src/social_auth/views.py
@@ -9,13 +9,13 @@ from __future__ import absolute_import
 
 import six
 
-from sudo.utils import is_safe_url
 from django.conf import settings
 from django.http import HttpResponseRedirect, HttpResponse
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.views.decorators.csrf import csrf_exempt
+from django.utils.http import is_safe_url
 
 from social_auth.exceptions import AuthException
 from social_auth.utils import setting, backend_setting, clean_partial_pipeline

--- a/tests/sentry/web/frontend/test_auth_logout.py
+++ b/tests/sentry/web/frontend/test_auth_logout.py
@@ -41,7 +41,14 @@ class AuthLogoutTest(TestCase):
 
     def test_doesnt_redirect_to_external_next_url(self):
         next = "http://example.com"
-        self.client.post(self.path + "?next=" + quote(next))
+        resp = self.client.post(self.path + "?next=" + quote(next))
+        self.assertRedirects(resp, "/auth/login/")
 
-        resp = self.client.post(self.path)
+        resp = self.client.post(self.path + "?next=" + quote("http:1234556"))
+        self.assertRedirects(resp, "/auth/login/")
+
+        resp = self.client.post(self.path + "?next=" + quote("///example.com"))
+        self.assertRedirects(resp, "/auth/login/")
+
+        resp = self.client.post(self.path + "?next=" + quote("http:///example.com"))
         self.assertRedirects(resp, "/auth/login/")


### PR DESCRIPTION
The implementation of this function from django 1.9.13 covers more invalid URLs
than the one from django-sudo does. We should not redirect to `http:123347` style URLs.

I manually checked that [all of these negative scenarios](https://github.com/mattrobenolt/django-sudo/blob/a1ae0cca67589fcd884122a6b335af66be949eb9/tests/utils.py#L123-L128) do not result in a bad redirect on the logout flow as well.