### PR TITLE
fix(discover) - Show errors if we encounter them loading discover

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -243,31 +243,36 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
   }
 
   render() {
+    let body;
     const {location, organization} = this.props;
-    const {loading, savedQueries, savedQueriesPageLinks} = this.state;
+    const {loading, savedQueries, savedQueriesPageLinks, error} = this.state;
+    if (loading) {
+      body = this.renderLoading();
+    } else if (error) {
+      body = this.renderError();
+    } else {
+      body = (
+        <PageContent>
+          <StyledPageHeader>{t('Discover')}</StyledPageHeader>
+          {this.renderBanner()}
+          {this.renderActions()}
+          <QueryList
+            pageLinks={savedQueriesPageLinks}
+            savedQueries={savedQueries}
+            savedQuerySearchQuery={this.getSavedQuerySearchQuery()}
+            location={location}
+            organization={organization}
+            onQueryChange={this.handleQueryChange}
+          />
+        </PageContent>
+      );
+    }
 
     return (
       <SentryDocumentTitle title={t('Discover')} objSlug={organization.slug}>
         <React.Fragment>
           <GlobalSelectionHeader organization={organization} />
-          <NoProjectMessage organization={organization}>
-            <PageContent>
-              <StyledPageHeader>{t('Discover')}</StyledPageHeader>
-              {this.renderBanner()}
-              {this.renderActions()}
-              {loading && this.renderLoading()}
-              {!loading && (
-                <QueryList
-                  pageLinks={savedQueriesPageLinks}
-                  savedQueries={savedQueries}
-                  savedQuerySearchQuery={this.getSavedQuerySearchQuery()}
-                  location={location}
-                  organization={organization}
-                  onQueryChange={this.handleQueryChange}
-                />
-              )}
-            </PageContent>
-          </NoProjectMessage>
+          <NoProjectMessage organization={organization}>{body}</NoProjectMessage>
         </React.Fragment>
       </SentryDocumentTitle>
     );


### PR DESCRIPTION
- Shows a permission error if a user without access to events like a
  billing account tries to access discover
- Preview (Do... we want the banner still if its permission denied?):
![image](https://user-images.githubusercontent.com/4205004/72025478-454d1300-3246-11ea-866d-e0414c5852c4.png)
