### PR TITLE
chore: remove hiredis

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -29,8 +29,6 @@ google-cloud-bigtable==0.32.2
 google-cloud-pubsub==0.35.4
 # optional
 google-cloud-storage==1.13.3
-# broken on python3
-hiredis>=0.1.0,<0.2.0
 ipaddress>=1.0.16,<1.1.0
 jsonschema==2.6.0
 kombu==3.0.35


### PR DESCRIPTION
It doesn't seem to be used anymore. Also, nothing depends on it:

```
$ pipdeptree -r -p hiredis
hiredis==0.1.6
  - sentry==10.1.0.dev0 [requires: hiredis>=0.1.0,<0.2.0]
```