### PR TITLE
test: fix remaining Django 1.11 tests and make required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,17 +149,14 @@ matrix:
       name: 'Acceptance'
       env: TEST_SUITE=acceptance USE_SNUBA=1
 
-    # allowed to fail
     - <<: *postgres_default
       name: '[Django 1.11] Backend with migrations [Postgres] (1/2)'
       env: DJANGO_VERSION=">=1.11,<1.12" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0 MIGRATIONS_TEST_MIGRATE=1
 
-    # allowed to fail
     - <<: *postgres_default
       name: '[Django 1.11] Backend with migrations [Postgres] (2/2)'
       env: DJANGO_VERSION=">=1.11,<1.12" TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1
 
-    # allowed to fail
     - <<: *acceptance_default
       name: '[Django 1.11] Acceptance'
       env: DJANGO_VERSION=">=1.11,<1.12" TEST_SUITE=acceptance USE_SNUBA=1 PERCY_ENABLE=0
@@ -229,7 +226,6 @@ matrix:
       before_script:
         - psql -c 'create database sentry;' -U postgres
 
-    # allowed to fail
     - python: 2.7
       name: '[Django 1.11] Snuba Integration with migrations'
       env: DJANGO_VERSION=">=1.11,<1.12" TEST_SUITE=snuba USE_SNUBA=1 SENTRY_ZOOKEEPER_HOSTS=localhost:2181 SENTRY_KAFKA_HOSTS=localhost:9092 MIGRATIONS_TEST_MIGRATE=1
@@ -273,10 +269,6 @@ matrix:
 
   allow_failures:
     - name: 'Storybook Deploy'
-    - name: '[Django 1.11] Backend with migrations [Postgres] (1/2)'
-    - name: '[Django 1.11] Backend with migrations [Postgres] (2/2)'
-    - name: '[Django 1.11] Acceptance'
-    - name: '[Django 1.11] Snuba Integration with migrations'
 
 notifications:
   webhooks:

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -491,6 +491,7 @@ class SentryRemoteTest(SnubaTestCase):
 
 
 class SentryWsgiRemoteTest(TransactionTestCase):
+    @override_settings(ALLOWED_HOSTS=["localhost"])
     def test_traceparent_header_wsgi(self):
         # Assert that posting something to store will not create another
         # (transaction) event under any circumstances.

--- a/tests/sentry/utils/test_linksign.py
+++ b/tests/sentry/utils/test_linksign.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+from django.test import override_settings
 from django.test.client import RequestFactory
 
 from sentry.testutils import TestCase
@@ -9,6 +10,7 @@ from sentry.utils import linksign
 
 
 class LinkSignTestCase(TestCase):
+    @override_settings(ALLOWED_HOSTS=["something-else", "testserver"])
     def test_link_signing(self):
         rf = RequestFactory()
 


### PR DESCRIPTION
From https://docs.djangoproject.com/en/1.11/releases/1.11/#backwards-incompatible-changes-in-1-11:

- ALLOWED_HOSTS validation is no longer disabled when running tests. If your application includes tests with custom host names, you must include those host names in ALLOWED_HOSTS.