### PR TITLE
fix(tagstore) Don't explode on null values

### DIFF
--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -107,7 +107,7 @@ class TagStorage(Service):
     def get_tag_value_label(self, key, value):
         label = value
 
-        if key == "sentry:user":
+        if key == "sentry:user" and value:
             if value.startswith("id:"):
                 label = value[len("id:") :]
             elif value.startswith("email:"):

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -272,6 +272,14 @@ class TagStorageTest(TestCase, SnubaTestCase):
                 value="notreal",
             )
 
+    def test_get_tag_value_label(self):
+        assert self.ts.get_tag_value_label("foo", "notreal") == "notreal"
+        assert self.ts.get_tag_value_label("sentry:user", None) is None
+        assert self.ts.get_tag_value_label("sentry:user", "id:stuff") == "stuff"
+        assert self.ts.get_tag_value_label("sentry:user", "email:stuff") == "stuff"
+        assert self.ts.get_tag_value_label("sentry:user", "username:stuff") == "stuff"
+        assert self.ts.get_tag_value_label("sentry:user", "ip:stuff") == "stuff"
+
     def test_get_groups_user_counts(self):
         assert self.ts.get_groups_user_counts(
             project_ids=[self.proj1.id],


### PR DESCRIPTION
The `sentry:user` tag can come back null when it is read from the promoted columns. Handling nulls allows get_tag_value_label() to be used more broadly.