### PR TITLE
feat(analytics): adds analytics functionality to sidebar clicks

### DIFF
--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -168,7 +168,10 @@ type FeatureDisabledHook = (opts: {
  */
 type AnalyticsInitUser = (user: User) => void;
 
-export type AnalyticsTrackEventOptions = {
+/**
+ * Trigger analytics tracking in the hook store.
+ */
+type AnalyticsTrackEvent = (opts: {
   /**
    * The key used to identify the event.
    */
@@ -181,12 +184,7 @@ export type AnalyticsTrackEventOptions = {
    * Arbitrary data to track
    */
   [key: string]: any;
-};
-
-/**
- * Trigger analytics tracking in the hook store.
- */
-type AnalyticsTrackEvent = (opts: AnalyticsTrackEventOptions) => void;
+}) => void;
 
 /**
  * Trigger adhoc analytics tracking in the hook store.

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -168,10 +168,7 @@ type FeatureDisabledHook = (opts: {
  */
 type AnalyticsInitUser = (user: User) => void;
 
-/**
- * Trigger analytics tracking in the hook store.
- */
-type AnalyticsTrackEvent = (opts: {
+export type AnalyticsTrackEventOptions = {
   /**
    * The key used to identify the event.
    */
@@ -184,7 +181,12 @@ type AnalyticsTrackEvent = (opts: {
    * Arbitrary data to track
    */
   [key: string]: any;
-}) => void;
+};
+
+/**
+ * Trigger analytics tracking in the hook store.
+ */
+type AnalyticsTrackEvent = (opts: AnalyticsTrackEventOptions) => void;
 
 /**
  * Trigger adhoc analytics tracking in the hook store.

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.tsx
@@ -12,6 +12,7 @@ type Props = {
   badge?: string | number | null;
   index?: boolean;
   id?: string;
+  onClick?: (e: React.MouseEvent) => void;
 };
 
 const SettingsNavItem = ({badge, label, index, id, ...props}: Props) => {

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import styled from 'react-emotion';
+import omitBy from 'lodash/omitBy';
+import isUndefined from 'lodash/isUndefined';
 
 import SettingsNavItem from 'app/views/settings/components/settingsNavItem';
 import replaceRouterParams from 'app/utils/replaceRouterParams';
 import {NavigationGroupProps} from 'app/views/settings/types';
+import {AnalyticsTrackEventOptions} from 'app/types/hooks';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 
 const SettingsNavigationGroup = (props: NavigationGroupProps) => {
   const {organization, project, name, items} = props;
@@ -11,7 +15,7 @@ const SettingsNavigationGroup = (props: NavigationGroupProps) => {
   return (
     <NavSection data-test-id={name}>
       <SettingsHeading>{name}</SettingsHeading>
-      {items.map(({path, title, index, show, badge, id}) => {
+      {items.map(({path, title, index, show, badge, id, analyticsParams}) => {
         if (typeof show === 'function' && !show(props)) {
           return null;
         }
@@ -24,6 +28,22 @@ const SettingsNavigationGroup = (props: NavigationGroupProps) => {
           ...(project ? {projectId: project.slug} : {}),
         });
 
+        const handleClick = () => {
+          //only call the analytics event if the URL is changing
+          if (analyticsParams && to !== window.location.pathname) {
+            //remvove any undefines to stop warnings
+            analyticsParams = omitBy(
+              {
+                organization_id: organization && organization.id,
+                project_id: project && project.id,
+                ...analyticsParams,
+              },
+              isUndefined
+            ) as AnalyticsTrackEventOptions;
+            trackAnalyticsEvent(analyticsParams);
+          }
+        };
+
         return (
           <SettingsNavItem
             key={title}
@@ -32,6 +52,7 @@ const SettingsNavigationGroup = (props: NavigationGroupProps) => {
             index={index}
             badge={badgeResult}
             id={id}
+            onClick={handleClick}
           />
         );
       })}

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import styled from 'react-emotion';
-import omitBy from 'lodash/omitBy';
-import isUndefined from 'lodash/isUndefined';
 
 import SettingsNavItem from 'app/views/settings/components/settingsNavItem';
 import replaceRouterParams from 'app/utils/replaceRouterParams';
 import {NavigationGroupProps} from 'app/views/settings/types';
-import {AnalyticsTrackEventOptions} from 'app/types/hooks';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 
 const SettingsNavigationGroup = (props: NavigationGroupProps) => {
@@ -15,7 +12,7 @@ const SettingsNavigationGroup = (props: NavigationGroupProps) => {
   return (
     <NavSection data-test-id={name}>
       <SettingsHeading>{name}</SettingsHeading>
-      {items.map(({path, title, index, show, badge, id, analyticsParams}) => {
+      {items.map(({path, title, index, show, badge, id, recordAnalytics}) => {
         if (typeof show === 'function' && !show(props)) {
           return null;
         }
@@ -30,17 +27,15 @@ const SettingsNavigationGroup = (props: NavigationGroupProps) => {
 
         const handleClick = () => {
           //only call the analytics event if the URL is changing
-          if (analyticsParams && to !== window.location.pathname) {
-            //remvove any undefines to stop warnings
-            analyticsParams = omitBy(
-              {
-                organization_id: organization && organization.id,
-                project_id: project && project.id,
-                ...analyticsParams,
-              },
-              isUndefined
-            ) as AnalyticsTrackEventOptions;
-            trackAnalyticsEvent(analyticsParams);
+          if (recordAnalytics && to !== window.location.pathname) {
+            trackAnalyticsEvent({
+              organization_id: organization && organization.id,
+              project_id: project && project.id,
+              eventName: 'Sidebar Item Clicked',
+              eventKey: 'sidebar.item_clicked',
+              sidebar_item_id: id,
+              dest: path,
+            });
           }
         };
 

--- a/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
@@ -74,10 +74,7 @@ const organizationNavigation: NavigationSection[] = [
           'Manage organization-level integrations, including: Slack, Github, Bitbucket, Jira, and Azure DevOps'
         ),
         id: 'integrations',
-        analyticsParams: {
-          eventKey: 'sidebar.integrations_clicked',
-          eventName: 'Sidebar Integrations Clicked',
-        },
+        recordAnalytics: true,
       },
       {
         path: `${pathPrefix}/developer-settings/`,

--- a/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
@@ -74,6 +74,10 @@ const organizationNavigation: NavigationSection[] = [
           'Manage organization-level integrations, including: Slack, Github, Bitbucket, Jira, and Azure DevOps'
         ),
         id: 'integrations',
+        analyticsParams: {
+          eventKey: 'sidebar.integrations_clicked',
+          eventName: 'Sidebar Integrations Clicked',
+        },
       },
       {
         path: `${pathPrefix}/developer-settings/`,

--- a/src/sentry/static/sentry/app/views/settings/types.ts
+++ b/src/sentry/static/sentry/app/views/settings/types.ts
@@ -1,5 +1,4 @@
 import {Organization, Project, Scope} from 'app/types';
-import {AnalyticsTrackEventOptions} from 'app/types/hooks';
 
 export type NavigationProps = {
   id?: string;
@@ -44,9 +43,8 @@ export type NavigationItem = {
   badge?: (opts: NavigationGroupProps) => string | number | null;
 
   /**
-   * Parameters to pass to the trackAnalyticsEvent when the navigation item is clicked
    */
-  analyticsParams?: AnalyticsTrackEventOptions;
+  recordAnalytics?: boolean;
 };
 
 export type NavigationSection = {

--- a/src/sentry/static/sentry/app/views/settings/types.ts
+++ b/src/sentry/static/sentry/app/views/settings/types.ts
@@ -1,4 +1,5 @@
 import {Organization, Project, Scope} from 'app/types';
+import {AnalyticsTrackEventOptions} from 'app/types/hooks';
 
 export type NavigationProps = {
   id?: string;
@@ -41,6 +42,11 @@ export type NavigationItem = {
    * Returns the text of the badge to render next to the navigation.
    */
   badge?: (opts: NavigationGroupProps) => string | number | null;
+
+  /**
+   * Parameters to pass to the trackAnalyticsEvent when the navigation item is clicked
+   */
+  analyticsParams?: AnalyticsTrackEventOptions;
 };
 
 export type NavigationSection = {

--- a/src/sentry/static/sentry/app/views/settings/types.ts
+++ b/src/sentry/static/sentry/app/views/settings/types.ts
@@ -41,7 +41,6 @@ export type NavigationItem = {
    * Returns the text of the badge to render next to the navigation.
    */
   badge?: (opts: NavigationGroupProps) => string | number | null;
-
   /**
    * Should clicking on the sidebar generate an analytics event
    */

--- a/src/sentry/static/sentry/app/views/settings/types.ts
+++ b/src/sentry/static/sentry/app/views/settings/types.ts
@@ -43,6 +43,7 @@ export type NavigationItem = {
   badge?: (opts: NavigationGroupProps) => string | number | null;
 
   /**
+   * Should clicking on the sidebar generate an analytics event
    */
   recordAnalytics?: boolean;
 };


### PR DESCRIPTION
This PR adds analytic capabilities for clicks on navigation items though an optional boolean field `recordAnalytics`.  When the item is clicked and that field is set to true, it calls `trackAnalyticsEvent` with the following parameters:

- organization_id
- project_id
- eventName: `Sidebar Item Clicked`
- eventName: `sidebar.item_clicked`
- sidebar_item_id: The id of the item as defined in the config of that sidebar (ex: `integrations`)
- dest: the path the sidebar item brings you to

I have added a single use case for clicking on integrations on the sidebar, but I am planning on adding more.

Reload PR: https://github.com/getsentry/reload/pull/133