### PR TITLE
chore(django 1.11): bump django-crispy-forms to 1.7.2

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -9,7 +9,7 @@ confluent-kafka==0.11.5
 croniter>=0.3.26,<0.4.0
 cssutils==1.0.2
 datadog>=0.15.0,<0.31.0
-django-crispy-forms==1.6.1
+django-crispy-forms==1.7.2
 django-picklefield>=0.3.0,<1.1.0
 django-sudo>=3.0.0,<4.0.0
 Django>=1.10,<1.11


### PR DESCRIPTION
Reading their commit logs, they've added tests for Django 1.11 and Python 3.6 since 1.6.1. It's also mostly fixes, and I don't see any deprecations, so this should be an easy bump.