### PR TITLE
fix(saml): Wrap individual idp config tabs with forms

### DIFF
--- a/src/sentry/auth/providers/saml2/generic/templates/sentry_auth_saml2/select-idp.html
+++ b/src/sentry/auth/providers/saml2/generic/templates/sentry_auth_saml2/select-idp.html
@@ -23,19 +23,17 @@
   </li>
 </ul>
 
-<form action="" method="post" class="form-stacked">
-  {% csrf_token %}
+<div class="tab-content">
+  <div class="tab-pane {% if op == "url" %}active{% endif %}" id="metadata-url">
+    <p>Provide a Metadata URL to retrieve the IdP details.</p>
+    <form action="" method="post" class="form-stacked">
+      {% csrf_token %}
 
-  {% if plugin %}
-      <input type="hidden" name="plugin" value="{{ plugin.slug }}" />
-  {% endif %}
+      {% if plugin %}
+          <input type="hidden" name="plugin" value="{{ plugin.slug }}" />
+      {% endif %}
 
-  <input type="hidden" name="provider" value="saml2" />
-
-  <div class="tab-content">
-    <div class="tab-pane {% if op == "url" %}active{% endif %}" id="metadata-url">
-      <p>Provide a Metadata URL to retrieve the IdP details.</p>
-
+      <input type="hidden" name="provider" value="saml2" />
       {{ forms.url|as_crispy_errors }}
 
       {% for field in forms.url %}
@@ -48,11 +46,19 @@
           class="btn btn-primary"
           name="action_save" value="url">{% trans "Get metadata" %}</button>
       </fieldset>
-    </div>
+    </form>
+  </div>
 
-    <div class="tab-pane {% if op == "xml" %}active{% endif %}" id="xml">
-      <p>Provide the raw Metadata XML IdP details.</p>
+  <div class="tab-pane {% if op == "xml" %}active{% endif %}" id="xml">
+    <p>Provide the raw Metadata XML IdP details.</p>
+    <form action="" method="post" class="form-stacked">
+      {% csrf_token %}
 
+      {% if plugin %}
+          <input type="hidden" name="plugin" value="{{ plugin.slug }}" />
+      {% endif %}
+
+      <input type="hidden" name="provider" value="saml2" />
       {{ forms.xml|as_crispy_errors }}
 
       {% for field in forms.xml %}
@@ -65,13 +71,21 @@
           class="btn btn-primary"
           name="action_save" value="xml">{% trans "Parse Metadata" %}</button>
       </fieldset>
-    </div>
+    </form>
+  </div>
 
-    <div class="tab-pane {% if op == "idp" %}active{% endif %}" id="idp-data">
-      <p>
-        Provide your individual Identity Provider metadata fields.
-      </p>
+  <div class="tab-pane {% if op == "idp" %}active{% endif %}" id="idp-data">
+    <p>
+      Provide your individual Identity Provider metadata fields.
+    </p>
+    <form action="" method="post" class="form-stacked">
+      {% csrf_token %}
 
+      {% if plugin %}
+          <input type="hidden" name="plugin" value="{{ plugin.slug }}" />
+      {% endif %}
+
+      <input type="hidden" name="provider" value="saml2" />
       {{ forms.idp|as_crispy_errors }}
 
       {% for field in forms.idp %}
@@ -84,7 +98,7 @@
           class="btn btn-primary"
           name="action_save" value="idp">{% trans "Save Metadata" %}</button>
       </fieldset>
-    </div>
+    </form>
   </div>
-</form>
+</div>
 {% endblock %}


### PR DESCRIPTION
Without this you'll see errors now in chrome:

```
An invalid form control ... is not focusable
```

This is because all form tabs were wrapped in the same form, even when they were not needed.

This changed in django 1.10

https://docs.djangoproject.com/en/3.0/releases/1.10/#forms

> Required form fields now have the required HTML attribute. Set the new Form.use_required_attribute attribute to False to disable it. The required attribute isn’t included on forms of formsets because the browser validation may not be correct when adding and deleting formsets.
