### PR TITLE
ref(discover2): For metrics, stop tracking tags for saved queries

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/utils.tsx
@@ -230,11 +230,10 @@ export function getAnalyticsCreateEventKeyName(
  * the desired fields to populate into reload analytics
  */
 export function extractAnalyticsQueryFields(payload: NewQuery): Partial<NewQuery> {
-  const {projects, fields, query, tags} = payload;
+  const {projects, fields, query} = payload;
   return {
     projects,
     fields,
     query,
-    tags,
   };
 }


### PR DESCRIPTION
Related to https://github.com/getsentry/reload/pull/131