### PR TITLE
ref(ui): Remove grid-emotion from file

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.tsx
@@ -160,6 +160,7 @@ const ProviderDetails = styled(Flex)`
 const StatusContainer = styled(Flex)`
   align-items: center;
 `;
+
 type StatusProps = {
   enabled: boolean;
   theme?: any; //TS complains if we don't make this optional
@@ -189,11 +190,6 @@ const Status = styled(
     font-weight: normal;
   }
   margin-right: ${space(0.75)};
-`;
-
-const StatusWrapper = styled('div')`
-  display: flex;
-  align-items: center;
 `;
 
 const NewInstallation = styled('div')`

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.tsx
@@ -121,9 +121,9 @@ export default class ProviderRow extends React.Component<Props> {
               <StyledLink onClick={this.openModal}>Learn More</StyledLink>
             </ProviderDetails>
           </ProviderBox>
-          <Box>
+          <div>
             <Button size="small" onClick={this.openModal} {...this.buttonProps} />
-          </Box>
+          </div>
         </PanelItemFlex>
         {this.renderIntegrations()}
       </PanelItem>
@@ -134,16 +134,14 @@ export default class ProviderRow extends React.Component<Props> {
 const Flex = styled('div')`
   display: flex;
 `;
-const Box = styled('div')``;
 
 const PanelItemFlex = styled(Flex)`
-  align-items: 'center';
+  align-items: center;
   padding: ${space(2)};
 `;
 
-const ProviderBox = styled(Box)`
-  padding-right: ${space(2)};
-  padding-left: ${space(2)};
+const ProviderBox = styled('div')`
+  padding: 0 ${space(2)};
   flex: 1;
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.tsx
@@ -1,4 +1,3 @@
-import {Box, Flex} from 'reflexbox';
 import {withTheme} from 'emotion-theming';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -112,25 +111,41 @@ export default class ProviderRow extends React.Component<Props> {
 
   render() {
     return (
-      <PanelItem p={0} flexDirection="column" data-test-id={this.props.provider.key}>
-        <Flex alignItems="center" p={2}>
+      <PanelItem p={0} direction="column" data-test-id={this.props.provider.key}>
+        <PanelItemFlex>
           <PluginIcon size={36} pluginId={this.props.provider.key} />
-          <Box px={2} flex={1}>
+          <ProviderBox>
             <ProviderName>{this.props.provider.name}</ProviderName>
             <ProviderDetails>
               <Status enabled={this.isEnabled} />
               <StyledLink onClick={this.openModal}>Learn More</StyledLink>
             </ProviderDetails>
-          </Box>
+          </ProviderBox>
           <Box>
             <Button size="small" onClick={this.openModal} {...this.buttonProps} />
           </Box>
-        </Flex>
+        </PanelItemFlex>
         {this.renderIntegrations()}
       </PanelItem>
     );
   }
 }
+
+const Flex = styled('div')`
+  display: flex;
+`;
+const Box = styled('div')``;
+
+const PanelItemFlex = styled(Flex)`
+  align-items: 'center';
+  padding: ${space(2)};
+`;
+
+const ProviderBox = styled(Box)`
+  padding-right: ${space(2)};
+  padding-left: ${space(2)};
+  flex: 1;
+`;
 
 const ProviderName = styled('div')`
   font-weight: bold;
@@ -142,6 +157,9 @@ const ProviderDetails = styled(Flex)`
   font-size: 0.8em;
 `;
 
+const StatusContainer = styled(Flex)`
+  align-items: center;
+`;
 type StatusProps = {
   enabled: boolean;
   theme?: any; //TS complains if we don't make this optional
@@ -151,14 +169,14 @@ const Status = styled(
   withTheme((props: StatusProps) => {
     const {enabled, theme, ...p} = props;
     return (
-      <StatusWrapper>
+      <StatusContainer>
         <CircleIndicator
           enabled={enabled}
           size={6}
           color={enabled ? theme.success : theme.gray2}
         />
         <div {...p}>{enabled ? t('Installed') : t('Not Installed')}</div>
-      </StatusWrapper>
+      </StatusContainer>
     );
   })
 )`

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.tsx
@@ -134,14 +134,16 @@ export default class ProviderRow extends React.Component<Props> {
 const Flex = styled('div')`
   display: flex;
 `;
+const Box = styled('div')``;
 
 const PanelItemFlex = styled(Flex)`
-  align-items: center;
+  align-items: 'center';
   padding: ${space(2)};
 `;
 
-const ProviderBox = styled('div')`
-  padding: 0 ${space(2)};
+const ProviderBox = styled(Box)`
+  padding-right: ${space(2)};
+  padding-left: ${space(2)};
   flex: 1;
 `;
 
@@ -158,7 +160,6 @@ const ProviderDetails = styled(Flex)`
 const StatusContainer = styled(Flex)`
   align-items: center;
 `;
-
 type StatusProps = {
   enabled: boolean;
   theme?: any; //TS complains if we don't make this optional

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/providerRow.tsx
@@ -158,6 +158,7 @@ const ProviderDetails = styled(Flex)`
 const StatusContainer = styled(Flex)`
   align-items: center;
 `;
+
 type StatusProps = {
   enabled: boolean;
   theme?: any; //TS complains if we don't make this optional


### PR DESCRIPTION
Followed the [Frontend-Handbook](https://github.com/getsentry/frontend-handbook/blob/master/migration-guides/grid-emotion.md) to refactor away from grid-emotion.