### PR TITLE
feat(ui): Remove chart from Incident activity item

### DIFF
--- a/src/sentry/static/sentry/app/views/incidents/details/activity/activity.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/details/activity/activity.tsx
@@ -149,7 +149,6 @@ class Activity extends React.Component<Props> {
                         <ErrorBoundary mini key={`note-${activity.id}`}>
                           <StatusItem
                             showTime
-                            incident={incident}
                             authorName={authorName}
                             activity={activity}
                           />

--- a/src/sentry/static/sentry/app/views/incidents/details/activity/statusItem.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/details/activity/statusItem.tsx
@@ -4,14 +4,13 @@ import styled from 'react-emotion';
 import {IncidentActivityType, IncidentStatus} from 'app/views/incidents/utils';
 import {t} from 'app/locale';
 import ActivityItem from 'app/components/activity/item';
-import Chart from 'app/views/incidents/details/chart';
 import getDynamicText from 'app/utils/getDynamicText';
-import {ActivityType, Incident} from '../../types';
+
+import {ActivityType} from '../../types';
 
 type Props = {
   activity: ActivityType;
   authorName: string;
-  incident?: Incident;
   showTime: boolean;
 };
 
@@ -25,7 +24,7 @@ type Props = {
  */
 class StatusItem extends React.Component<Props> {
   render() {
-    const {activity, authorName, incident, showTime} = this.props;
+    const {activity, authorName, showTime} = this.props;
 
     const isCreated = activity.type === IncidentActivityType.CREATED;
     const isDetected = activity.type === IncidentActivityType.DETECTED;
@@ -44,6 +43,9 @@ class StatusItem extends React.Component<Props> {
 
     return (
       <ActivityItem
+        bubbleProps={{
+          borderColor: 'transparent',
+        }}
         showTime={showTime}
         author={{
           type: activity.user ? 'user' : 'system',
@@ -58,20 +60,7 @@ class StatusItem extends React.Component<Props> {
           </div>
         }
         date={getDynamicText({value: activity.dateCreated, fixed: new Date(0)})}
-      >
-        {activity.eventStats &&
-          getDynamicText({
-            value: (
-              <Chart
-                data={activity.eventStats.data}
-                detected={
-                  ((isCreated || isDetected) && incident && incident.dateStarted) || ''
-                }
-              />
-            ),
-            fixed: 'Chart Placeholder for Percy',
-          })}
-      </ActivityItem>
+      />
     );
   }
 }


### PR DESCRIPTION
Previously we displayed a chart when an incident is created. Remove the chart and make the activity item borderless.