### PR TITLE
fix(user-feedback): Escape content of certain User Feedback widget options

### DIFF
--- a/src/sentry/templates/sentry/error-page-embed.js
+++ b/src/sentry/templates/sentry/error-page-embed.js
@@ -17,8 +17,21 @@
   var template = /*{{ template }}*/'';
   var endpoint = /*{{ endpoint }}*/'';
 
-  var GENERIC_ERROR = '<p class="message-error">' + strings.generic_error + '</p>';
-  var FORM_ERROR = '<p class="message-error">' + strings.form_error + '</p>';
+  var setChild = function(target, child) {
+    target.innerHTML = '';
+    target.appendChild(child);
+  };
+
+  var buildMessage = function(className, message) {
+    var p = document.createElement('p');
+    p.className = className;
+    p.appendChild(document.createTextNode(message));
+    return p;
+  };
+
+  var GENERIC_ERROR = buildMessage('message-error', strings.generic_error);
+  var FORM_ERROR = buildMessage('message-error', strings.form_error);
+  var FORM_SUCCESS = buildMessage('message-success', strings.sent_message);
 
   // XMLHttpRequest.DONE does not exist in all browsers
   var XHR_DONE = 4;
@@ -117,7 +130,7 @@
         } else if (xhr.status == 400) {
           self.onFormError(JSON.parse(xhr.responseText));
         } else {
-          self._errorWrapper.innerHTML = GENERIC_ERROR;
+          setChild(self._errorWrapper, GENERIC_ERROR);
         }
         self._submitInProgress = false;
       }
@@ -129,7 +142,7 @@
 
   SentryErrorEmbed.prototype.onSuccess = function() {
     this._errorWrapper.innerHTML = '';
-    this._formContent.innerHTML = '<p class="message-success">' + strings.sent_message + '</p>';
+    setChild(this._formContent, FORM_SUCCESS);
     this._submitBtn.parentNode.removeChild(this._submitBtn);
   };
 
@@ -145,7 +158,7 @@
         node.className = node.className.replace(/form-errors/, '');
       }
     }
-    this._errorWrapper.innerHTML = FORM_ERROR;
+    setChild(this._errorWrapper, FORM_ERROR);
   };
 
   SentryErrorEmbed.prototype.attach = function(parent) {

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -7,7 +7,6 @@ from django.db import IntegrityError, transaction
 from django.http import HttpResponse
 from django.views.generic import View
 from django.utils import timezone
-from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
@@ -213,9 +212,9 @@ class ErrorPageEmbedView(View):
             "template": mark_safe("*/" + json.dumps(template) + ";/*"),
             "strings": json.dumps_htmlsafe(
                 {
-                    "generic_error": escape(six.text_type(options["errorGeneric"])),
-                    "form_error": escape(six.text_type(options["errorFormEntry"])),
-                    "sent_message": escape(six.text_type(options["successMessage"])),
+                    "generic_error": six.text_type(options["errorGeneric"]),
+                    "form_error": six.text_type(options["errorFormEntry"]),
+                    "sent_message": six.text_type(options["successMessage"]),
                 }
             ),
         }

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -7,6 +7,7 @@ from django.db import IntegrityError, transaction
 from django.http import HttpResponse
 from django.views.generic import View
 from django.utils import timezone
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
@@ -212,9 +213,9 @@ class ErrorPageEmbedView(View):
             "template": mark_safe("*/" + json.dumps(template) + ";/*"),
             "strings": json.dumps_htmlsafe(
                 {
-                    "generic_error": six.text_type(options["errorGeneric"]),
-                    "form_error": six.text_type(options["errorFormEntry"]),
-                    "sent_message": six.text_type(options["successMessage"]),
+                    "generic_error": escape(six.text_type(options["errorGeneric"])),
+                    "form_error": escape(six.text_type(options["errorFormEntry"])),
+                    "sent_message": escape(six.text_type(options["successMessage"])),
                 }
             ),
         }

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 from django.test import override_settings
-from django.utils.html import escape
-from django.utils.safestring import mark_safe, SafeData
 from six.moves.urllib.parse import quote, urlencode
 from uuid import uuid4
 import logging
@@ -11,7 +9,6 @@ import logging
 from sentry.models import Environment, UserReport
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
-from sentry.utils import json
 
 
 @override_settings(ROOT_URLCONF="sentry.conf.urls")
@@ -96,13 +93,10 @@ class ErrorPageEmbedTest(TestCase):
     def test_xss(self):
         user_feedback_options = {}
 
-        # options that are known to be injected into JS
-        unsafe_option_keys = ["errorFormEntry", "successMessage", "errorGeneric"]
-        for key in unsafe_option_keys:
-            user_feedback_options[key] = "<img src=x onerror=alert({0})>XSS_{0}".format(key)
-
-        # options that are known to be used within a Django template but are automatically escaped
-        safe_option_keys = [
+        option_keys = [
+            "errorFormEntry",
+            "successMessage",
+            "errorGeneric",
             "title",
             "subtitle",
             "subtitle2",
@@ -112,10 +106,8 @@ class ErrorPageEmbedTest(TestCase):
             "labelSubmit",
             "labelClose",
         ]
-        for key in safe_option_keys:
-            user_feedback_options[key] = mark_safe(
-                "<img src=x onerror=alert({0})>XSS_{0}".format(key)
-            )
+        for key in option_keys:
+            user_feedback_options[key] = "<img src=x onerror=alert({0})>XSS_{0}".format(key)
 
         user_feedback_options_qs = urlencode(user_feedback_options)
         path_with_qs = "%s?eventId=%s&dsn=%s&%s" % (
@@ -133,11 +125,6 @@ class ErrorPageEmbedTest(TestCase):
         self.assertTemplateUsed(resp, "sentry/error-page-embed.html")
 
         for xss_payload in user_feedback_options.values():
-            is_safe = isinstance(xss_payload, SafeData)
-            if is_safe:
-                assert escape(xss_payload) in resp.content, resp.content
-            else:
-                assert json.dumps_htmlsafe(escape(xss_payload)) in resp.content, resp.content
             assert xss_payload not in resp.content
 
     def test_submission(self):


### PR DESCRIPTION
Sentry's User Feedback widget allows developers to customize some of the widget's messages by specifying parameters. However, it was discovered that certain options can be rendered as is in HTML. This implies that if a developer does not know that fact, and generates the content of these options with user input, it can lead to a XSS vector on the developer's web app.

The customization options of the User Feedback widget is documented in https://docs.sentry.io/enriching-error-data/user-feedback/

The affected options were: `errorFormEntry`, `successMessage`, and `errorGeneric`

~We resolve this by encoding ampersands, quotes and angle brackets for use in HTML using the `django.utils.html.escape` function: https://docs.djangoproject.com/en/1.10/ref/utils/#django.utils.html.escape~

EDIT: We resolve this using the method outlined in https://github.com/getsentry/sentry/pull/16384#discussion_r365354379