### PR TITLE
feat(tracing) Add spans for snuba queries

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -11,6 +11,7 @@ import re
 import six
 import time
 import urllib3
+import sentry_sdk
 
 from concurrent.futures import ThreadPoolExecutor
 from django.conf import settings
@@ -724,13 +725,16 @@ def bulk_raw_query(snuba_param_list, referrer=None):
         query_params, forward, reverse = params
         try:
             with timer("snuba_query"):
-                return (
-                    _snuba_pool.urlopen(
-                        "POST", "/query", body=json.dumps(query_params), headers=headers
-                    ),
-                    forward,
-                    reverse,
-                )
+                body = json.dumps(query_params)
+                with sentry_sdk.start_span(
+                    op="snuba", description=u"query {}".format(body)
+                ) as span:
+                    span.set_tag("referrer", headers.get("referer", "<unknown>"))
+                    return (
+                        _snuba_pool.urlopen("POST", "/query", body=body, headers=headers),
+                        forward,
+                        reverse,
+                    )
         except urllib3.exceptions.HTTPError as err:
             raise SnubaError(err)
 


### PR DESCRIPTION
Add spans to collect more information about snuba queries. Having the referrer and the start of the query body should make tracking down slow queries in snuba easier as we have more context.

![Screen Shot 2020-01-10 at 11 57 33 AM](https://user-images.githubusercontent.com/24086/72171202-7a6d7880-33a0-11ea-987b-ec4a6aeeaaa2.png)
