### PR TITLE
ref(discover) Remove the raw field

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -265,7 +265,6 @@ class SpanDetail extends React.Component<Props, State> {
                 </Row>
               );
             })}
-            <Row title="Raw">{JSON.stringify(span, null, 4)}</Row>
           </tbody>
         </table>
       </SpanDetailContainer>


### PR DESCRIPTION
Outputting the raw data when we also output all the formatted keys wastes space and adds visual noise.