### PR TITLE
test(emotion): Get rid of `first-child` warnings in tests

### DIFF
--- a/tests/js/sentry-test/enzyme.js
+++ b/tests/js/sentry-test/enzyme.js
@@ -1,12 +1,17 @@
 import {mount, shallow, render} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {CacheProvider} from '@emotion/core';
 import {ThemeProvider} from 'emotion-theming';
+import {cache} from 'emotion'; // eslint-disable-line emotion/no-vanilla
+
 import React from 'react';
 
 import theme from 'app/utils/theme';
 
 const mountWithTheme = (tree, opts) => {
   const WrappingThemeProvider = props => (
-    <ThemeProvider theme={theme}>{props.children}</ThemeProvider>
+    <CacheProvider value={cache}>
+      <ThemeProvider theme={theme}>{props.children}</ThemeProvider>
+    </CacheProvider>
   );
 
   return mount(tree, {wrappingComponent: WrappingThemeProvider, ...opts});

--- a/tests/js/spec/components/avatar.spec.jsx
+++ b/tests/js/spec/components/avatar.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import Avatar from 'app/components/avatar';
 
 jest.mock('app/stores/configStore', () => {
@@ -25,7 +25,7 @@ describe('Avatar', function() {
           avatarUuid: '2d641b5d-8c74-44de-9cb6-fbd54701b35e',
         },
       });
-      const avatar = mount(<Avatar user={user} />);
+      const avatar = mountWithTheme(<Avatar user={user} />);
       expect(avatar.find('span.avatar')).toHaveLength(1);
     });
 
@@ -36,7 +36,7 @@ describe('Avatar', function() {
           avatarUuid: '2d641b5d-8c74-44de-9cb6-fbd54701b35e',
         },
       });
-      const avatar = mount(<Avatar user={user} />);
+      const avatar = mountWithTheme(<Avatar user={user} />);
 
       expect(avatar.find('BaseAvatar').prop('type')).toBe('gravatar');
 
@@ -56,7 +56,7 @@ describe('Avatar', function() {
           avatarUuid: '2d641b5d-8c74-44de-9cb6-fbd54701b35e',
         },
       });
-      const avatar = mount(<Avatar user={user} />);
+      const avatar = mountWithTheme(<Avatar user={user} />);
       expect(avatar.find('BaseAvatar').prop('type')).toBe('upload');
       expect(avatar.find('BaseAvatar').prop('uploadId')).toBe(
         '2d641b5d-8c74-44de-9cb6-fbd54701b35e'
@@ -73,22 +73,22 @@ describe('Avatar', function() {
           avatarUuid: '2d641b5d-8c74-44de-9cb6-fbd54701b35e',
         },
       });
-      let avatar = mount(<Avatar user={user} size={76} />);
+      let avatar = mountWithTheme(<Avatar user={user} size={76} />);
       expect(avatar.find('BaseAvatar img').prop('src')).toMatch(
         '/avatar/2d641b5d-8c74-44de-9cb6-fbd54701b35e/?s=120'
       );
 
-      avatar = mount(<Avatar user={user} size={121} />);
+      avatar = mountWithTheme(<Avatar user={user} size={121} />);
       expect(avatar.find('BaseAvatar img').prop('src')).toMatch(
         '/avatar/2d641b5d-8c74-44de-9cb6-fbd54701b35e/?s=120'
       );
 
-      avatar = mount(<Avatar user={user} size={32} />);
+      avatar = mountWithTheme(<Avatar user={user} size={32} />);
       expect(avatar.find('BaseAvatar img').prop('src')).toMatch(
         '/avatar/2d641b5d-8c74-44de-9cb6-fbd54701b35e/?s=120'
       );
 
-      avatar = mount(<Avatar user={user} size={1} />);
+      avatar = mountWithTheme(<Avatar user={user} size={1} />);
       expect(avatar.find('BaseAvatar img').prop('src')).toMatch(
         '/avatar/2d641b5d-8c74-44de-9cb6-fbd54701b35e/?s=120'
       );
@@ -101,38 +101,38 @@ describe('Avatar', function() {
           avatarUuid: '2d641b5d-8c74-44de-9cb6-fbd54701b35e',
         },
       });
-      const avatar = mount(<Avatar user={user} />);
+      const avatar = mountWithTheme(<Avatar user={user} />);
       expect(avatar.find('BaseAvatar').prop('type')).toBe('letter_avatar');
     });
 
     it('use letter avatar by default, when no avatar type is set and user has an email address', function() {
-      const avatar = mount(<Avatar user={USER} />);
+      const avatar = mountWithTheme(<Avatar user={USER} />);
       expect(avatar.find('BaseAvatar').prop('type')).toBe('letter_avatar');
     });
 
     it('should show a gravatar when no avatar type is set and user has an email address', function() {
-      const avatar = mount(<Avatar gravatar user={USER} />);
+      const avatar = mountWithTheme(<Avatar gravatar user={USER} />);
       expect(avatar.find('BaseAvatar').prop('type')).toBe('gravatar');
     });
 
     it('should not show a gravatar when no avatar type is set and user has no email address', function() {
       const user = Object.assign({}, USER);
       delete user.email;
-      const avatar = mount(<Avatar gravatar user={user} />);
+      const avatar = mountWithTheme(<Avatar gravatar user={user} />);
 
       expect(avatar.find('BaseAvatar').prop('type')).toBe('letter_avatar');
     });
 
     it('can display a team Avatar', function() {
       const team = TestStubs.Team({slug: 'test-team_test'});
-      const avatar = mount(<Avatar team={team} />);
+      const avatar = mountWithTheme(<Avatar team={team} />);
       expect(avatar.find('LetterAvatar').prop('displayName')).toBe('test team test');
       expect(avatar.find('LetterAvatar').prop('identifier')).toBe('test-team_test');
     });
 
     it('can display an organization Avatar', function() {
       const organization = TestStubs.Organization({slug: 'test-organization'});
-      const avatar = mount(<Avatar organization={organization} />);
+      const avatar = mountWithTheme(<Avatar organization={organization} />);
       expect(avatar.find('LetterAvatar').prop('displayName')).toBe('test organization');
       expect(avatar.find('LetterAvatar').prop('identifier')).toBe('test-organization');
     });
@@ -142,18 +142,18 @@ describe('Avatar', function() {
         platforms: ['python', 'javascript'],
         platform: 'java',
       });
-      const avatar = mount(<Avatar project={project} />);
+      const avatar = mountWithTheme(<Avatar project={project} />);
       expect(avatar.find('PlatformList').prop('platforms')).toEqual(['java']);
     });
 
     it('displays a fallback platform list for project Avatar using the `platform` specified during onboarding', function() {
       const project = TestStubs.Project({platform: 'java'});
-      const avatar = mount(<Avatar project={project} />);
+      const avatar = mountWithTheme(<Avatar project={project} />);
       expect(avatar.find('PlatformList').prop('platforms')).toEqual(['java']);
     });
     it('uses onboarding project when platforms is an empty array', function() {
       const project = TestStubs.Project({platforms: [], platform: 'java'});
-      const avatar = mount(<Avatar project={project} />);
+      const avatar = mountWithTheme(<Avatar project={project} />);
       expect(avatar.find('PlatformList').prop('platforms')).toEqual(['java']);
     });
   });

--- a/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
+++ b/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import {openCommandPalette} from 'app/actionCreators/modal';
 import App from 'app/views/app';
 import FormSearchStore from 'app/stores/formSearchStore';
@@ -60,7 +60,7 @@ describe('Command Palette Modal', function() {
   });
 
   it('can open command palette modal and search', async function() {
-    const wrapper = mount(
+    const wrapper = mountWithTheme(
       <App params={{orgId: 'org-slug'}}>{<div>placeholder content</div>}</App>,
       TestStubs.routerContext([
         {

--- a/tests/js/spec/components/modals/helpSearchModal.spec.jsx
+++ b/tests/js/spec/components/modals/helpSearchModal.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import {openHelpSearchModal} from 'app/actionCreators/modal';
 import App from 'app/views/app';
 
@@ -53,7 +53,7 @@ describe('Docs Search Modal', function() {
 
   it('can open help search modal and complete a search', async function() {
     jest.mock('algoliasearch', () => {
-      const search = jest.fn(params => {
+      const search = jest.fn(() => {
         const docHits = [
           {
             url: '/doc_result',
@@ -83,7 +83,7 @@ describe('Docs Search Modal', function() {
       return () => ({search});
     });
 
-    const wrapper = mount(
+    const wrapper = mountWithTheme(
       <App params={{orgId: 'org-slug'}}>{<div>placeholder content</div>}</App>,
       TestStubs.routerContext([
         {

--- a/tests/js/spec/components/platformList.spec.jsx
+++ b/tests/js/spec/components/platformList.spec.jsx
@@ -1,18 +1,18 @@
 import React from 'react';
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import PlatformList from 'app/components/platformList';
 
 describe('PlatformList', function() {
   it('renders max of three icons from platforms', function() {
     const platforms = ['java', 'php', 'javascript', 'cocoa', 'ruby'];
-    const wrapper = mount(<PlatformList platforms={platforms} />);
+    const wrapper = mountWithTheme(<PlatformList platforms={platforms} />);
     const icons = wrapper.find('StyledPlatformIcon');
     expect(icons).toHaveLength(3);
   });
 
   it('renders default if no platforms', function() {
     const platforms = [];
-    const wrapper = mount(<PlatformList platforms={platforms} />);
+    const wrapper = mountWithTheme(<PlatformList platforms={platforms} />);
     const icons = wrapper.find('StyledPlatformIcon');
     expect(icons.first().prop('platform')).toBe('default');
     expect(icons).toHaveLength(1);

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 
 import {SettingsSearch} from 'app/views/settings/components/settingsSearch';
 import FormSearchStore from 'app/stores/formSearchStore';
@@ -57,7 +57,10 @@ describe('SettingsSearch', function() {
   });
 
   it('renders', async function() {
-    const wrapper = mount(<SettingsSearch params={{orgId: 'org-slug'}} />, routerContext);
+    const wrapper = mountWithTheme(
+      <SettingsSearch params={{orgId: 'org-slug'}} />,
+      routerContext
+    );
 
     // renders input
     expect(wrapper.find('SearchInput')).toHaveLength(1);
@@ -65,7 +68,10 @@ describe('SettingsSearch', function() {
   });
 
   it('can focus when `handleFocusSearch` is called and target is not search input', function() {
-    const wrapper = mount(<SettingsSearch params={{orgId: 'org-slug'}} />, routerContext);
+    const wrapper = mountWithTheme(
+      <SettingsSearch params={{orgId: 'org-slug'}} />,
+      routerContext
+    );
     const searchInput = wrapper.find('SearchInput input').instance();
     const focusSpy = jest.spyOn(searchInput, 'focus');
 
@@ -78,7 +84,10 @@ describe('SettingsSearch', function() {
   });
 
   it('does not focus search input if it is current target and `handleFocusSearch` is called', function() {
-    const wrapper = mount(<SettingsSearch params={{orgId: 'org-slug'}} />, routerContext);
+    const wrapper = mountWithTheme(
+      <SettingsSearch params={{orgId: 'org-slug'}} />,
+      routerContext
+    );
     const searchInput = wrapper.find('SearchInput input').instance();
     const focusSpy = jest.spyOn(searchInput, 'focus');
 
@@ -91,7 +100,10 @@ describe('SettingsSearch', function() {
   });
 
   it('can search', async function() {
-    const wrapper = mount(<SettingsSearch params={{orgId: 'org-slug'}} />, routerContext);
+    const wrapper = mountWithTheme(
+      <SettingsSearch params={{orgId: 'org-slug'}} />,
+      routerContext
+    );
 
     wrapper.find('input').simulate('change', {target: {value: 'bil'}});
 


### PR DESCRIPTION
This uses `mountWithTheme` to wrap tests with `CacheProvider` so we do not get warnings about `first-child` since we do not use SSR.  See https://github.com/emotion-js/emotion/issues/1105 for more info.