### PR TITLE
fix(discoverV1): Properly pass the date range when fetching DiscoverV1 queries

### DIFF
--- a/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
+++ b/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
@@ -150,7 +150,7 @@ export default function createQueryBuilder(
     const projects = query.projects.length ? query.projects : defaultProjectIds;
 
     // Default to DEFAULT_STATS_PERIOD when no date range selected (either relative or absolute)
-    const {statsPeriod, start, end} = getParams(query);
+    const {statsPeriod, start, end} = getParams({...query, statsPeriod: query.range});
     const hasAbsolute = start && end;
     const daterange = {
       ...(hasAbsolute && {start, end}),
@@ -247,7 +247,7 @@ export default function createQueryBuilder(
       return Promise.reject(new Error('Start date cannot be after end date'));
     }
 
-    const {start, end, statsPeriod} = getParams(data);
+    const {start, end, statsPeriod} = getParams({...data, statsPeriod: data.range});
 
     if (start && end) {
       data.start = start;
@@ -296,7 +296,7 @@ export default function createQueryBuilder(
       return Promise.reject(new Error('Start date cannot be after end date'));
     }
 
-    const {start, end, statsPeriod} = getParams(data);
+    const {start, end, statsPeriod} = getParams({...data, statsPeriod: data.range});
 
     if (start && end) {
       data.start = start;

--- a/tests/js/spec/views/dashboards/overviewDashboard.spec.jsx
+++ b/tests/js/spec/views/dashboards/overviewDashboard.spec.jsx
@@ -206,7 +206,7 @@ describe('OverviewDashboard', function() {
         data: expect.objectContaining({
           environments: [],
           projects: [2, 3],
-          range: '14d',
+          range: '7d',
 
           fields: [],
           conditions: [],

--- a/tests/js/spec/views/discover/index.spec.jsx
+++ b/tests/js/spec/views/discover/index.spec.jsx
@@ -243,7 +243,7 @@ describe('DiscoverContainer', function() {
         expect.anything(),
         expect.objectContaining({
           data: expect.objectContaining({
-            range: '14d',
+            range: '7d',
             start: null,
             end: null,
             utc: null,

--- a/tests/js/spec/views/discover/queryBuilder.spec.jsx
+++ b/tests/js/spec/views/discover/queryBuilder.spec.jsx
@@ -71,7 +71,7 @@ describe('Query Builder', function() {
             aggregations: [['count()', null, 'count']],
             orderby: '-count',
             projects: [2],
-            range: '14d',
+            range: '90d',
             turbo: true,
           }),
         })
@@ -116,7 +116,7 @@ describe('Query Builder', function() {
             aggregations: [['count()', null, 'count']],
             orderby: '-count',
             projects: [1, 2],
-            range: '14d',
+            range: '90d',
             turbo: true,
           }),
         })
@@ -162,7 +162,7 @@ describe('Query Builder', function() {
             aggregations: [['count()', null, 'count']],
             orderby: '-count',
             projects: [1, 2],
-            range: '14d',
+            range: '90d',
             turbo: true,
           }),
         })


### PR DESCRIPTION

Follow up to https://github.com/getsentry/sentry/pull/15400

Regarding the changes for the tests, I had made a comment (https://github.com/getsentry/sentry/pull/15400#issuecomment-550492504) that some tests looked funny and I would address them later on. Fortunately, this PR reverts some of the changes in the tests made in https://github.com/getsentry/sentry/pull/15400

Closes ISSUE-653