### PR TITLE
docs(workflow): Fix link to screenshots in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ in realtime. The server is in Python, but it contains a full API for
 sending events from any language, in any application.
 
 <p align="center">
-  <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-1.png" width="290">
-  <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-2.png" width="290">
-  <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/product/thumb-3.png" width="290">
+  <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/screenshots/thumb-1.png" width="290">
+  <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/screenshots/thumb-2.png" width="290">
+  <img src="https://github.com/getsentry/sentry/raw/master/src/sentry/static/sentry/images/screenshots/thumb-3.png" width="290">
 </p>
 
 ## Official Sentry SDKs


### PR DESCRIPTION
Fixes links to screenshots in README.md broken by 983c8c6