### PR TITLE
fix(issue search) Handle invalid search queries cleanly

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -22,7 +22,9 @@ from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import get_date_range_from_params, InvalidParams
 from sentry.models import Group, GroupStatus
 from sentry.search.snuba.backend import EventsDatasetSnubaSearchBackend
+from sentry.snuba import discover
 from sentry.utils.validators import normalize_event_id
+
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
 
@@ -175,7 +177,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                 environments,
                 {"count_hits": True, "date_to": end, "date_from": start},
             )
-        except ValidationError as exc:
+        except (ValidationError, discover.InvalidSearchQuery) as exc:
             return Response({"detail": six.text_type(exc)}, status=400)
 
         results = list(cursor_result)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -117,6 +117,18 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400
         assert "Invalid format for numeric search" in response.data["detail"]
 
+    def test_invalid_search_query(self):
+        now = timezone.now()
+        self.create_group(checksum="a" * 32, last_seen=now - timedelta(seconds=1))
+        self.login_as(user=self.user)
+
+        response = self.get_response(sort_by="date", query="trace:123")
+        assert response.status_code == 400
+        assert (
+            "Invalid value for the trace condition. Value must be a hexadecimal UUID string."
+            in response.data["detail"]
+        )
+
     def test_simple_pagination(self):
         event1 = self.store_event(
             data={"timestamp": iso_format(before_now(seconds=2)), "fingerprint": ["group-1"]},


### PR DESCRIPTION
Add an exception handler for InvalidSearchQuery when a user searches issues.