### PR TITLE
fix(tests) Fix flaky notification test

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -76,6 +76,8 @@ def attach_state(project, groups, rules, event_counts, user_counts):
     for id, group in six.iteritems(groups):
         assert group.project_id == project.id, "Group must belong to Project"
         group.project = project
+        group.event_count = 0
+        group.user_count = 0
 
     for id, rule in six.iteritems(rules):
         assert rule.project_id == project.id, "Rule must belong to Project"


### PR DESCRIPTION
This test would occasionally fail if TSDB didn't update immediately. Initializing the properties that are tacked onto the groups will prevent the attribute errors.