### PR TITLE
chore: gitignore pip-wheel-metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ junit.xml
 *.codestyle.xml
 package-lock.json
 .webpack.meta
+pip-wheel-metadata/

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,7 @@ from setuptools.command.develop import develop as DevelopCommand
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 
-# add sentry to path so we can import distutils
-# XXX: consequentially, this means sentry must be pip installed with --no-use-pep517
+# add sentry to path so we can import sentry.utils.distutils
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from sentry.utils.distutils import (


### PR DESCRIPTION
Sometimes this `pip-wheel-metadata/` directory shows up - probably because now we use pep517 but haven't bothered to look into exactly what writes this - gitignore it.