### PR TITLE
ref(ui): Remove `isStyled` props

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownAutoComplete.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoComplete.jsx
@@ -29,7 +29,7 @@ class DropdownAutoComplete extends React.Component {
             //eslint-disable-next-line no-unused-vars
             onClick,
             ...actorProps
-          } = renderProps.getActorProps({isStyled: true});
+          } = renderProps.getActorProps();
 
           return (
             <Actor

--- a/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoCompleteMenu.jsx
@@ -422,7 +422,6 @@ class DropdownAutoCompleteMenu extends React.Component {
                   {...getMenuProps({
                     ...menuProps,
                     style,
-                    isStyled: true,
                     css: this.props.css,
                     itemCount,
                     blendCorner,

--- a/src/sentry/static/sentry/app/components/dropdownControl.jsx
+++ b/src/sentry/static/sentry/app/components/dropdownControl.jsx
@@ -48,10 +48,7 @@ class DropdownControl extends React.Component {
       return button({isOpen, getActorProps});
     }
     return (
-      <StyledDropdownButton
-        {...getActorProps({...buttonProps, isStyled: true})}
-        isOpen={isOpen}
-      >
+      <StyledDropdownButton {...getActorProps(buttonProps)} isOpen={isOpen}>
         {label}
       </StyledDropdownButton>
     );
@@ -75,7 +72,7 @@ class DropdownControl extends React.Component {
               <React.Fragment>
                 {this.renderButton(isOpen, getActorProps)}
                 <MenuContainer
-                  {...getMenuProps({isStyled: true})}
+                  {...getMenuProps()}
                   alignMenu={alignRight ? 'right' : 'left'}
                   width={menuWidth}
                   menuOffset={menuOffset}

--- a/src/sentry/static/sentry/app/components/dropdownMenu.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownMenu.tsx
@@ -9,7 +9,6 @@ type GetActorArgs = {
   onMouseEnter?: (e: React.MouseEvent<Element>) => void;
   onMouseLeave?: (e: React.MouseEvent<Element>) => void;
   onKeyDown?: (e: React.KeyboardEvent<Element>) => void;
-  isStyled?: boolean;
   style?: React.CSSProperties;
 };
 
@@ -17,7 +16,6 @@ type GetMenuArgs = {
   onClick?: (e: React.MouseEvent<Element>) => void;
   onMouseEnter?: (e: React.MouseEvent<Element>) => void;
   onMouseLeave?: (e: React.MouseEvent<Element>) => void;
-  isStyled?: boolean;
 };
 
 // Props for the "actor" element of `<DropdownMenu>`
@@ -35,9 +33,6 @@ type MenuProps = {
   onMouseLeave: (e: React.MouseEvent<Element>) => void;
 };
 
-// XXX(epurkhiser): these types aren't completely correct as it doesn't include
-// the fact that a innerRef / ref is required to be available on the component
-// the props are passed to.
 type GetActorPropsFn = (opts: GetActorArgs) => ActorProps;
 type GetMenuPropsFn = (opts: GetMenuArgs) => MenuProps;
 

--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.jsx
@@ -272,9 +272,7 @@ class MultipleEnvironmentSelector extends React.PureComponent {
                 isOpen={isOpen}
                 hasSelected={value && !!value.length}
                 onClear={this.handleClear}
-                {...getActorProps({
-                  isStyled: true,
-                })}
+                {...getActorProps()}
               >
                 {summary}
               </StyledHeaderItem>

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.jsx
@@ -329,16 +329,13 @@ class TimeRangeSelector extends React.PureComponent {
               hasChanges={this.state.hasChanges}
               onClear={this.handleClear}
               allowClear
-              {...getActorProps({isStyled: true})}
+              {...getActorProps()}
             >
               {getDynamicText({value: summary, fixed: 'start to end'})}
             </StyledHeaderItem>
 
             {isOpen && (
-              <Menu
-                {...getMenuProps({isStyled: true})}
-                isAbsoluteSelected={isAbsoluteSelected}
-              >
+              <Menu {...getMenuProps()} isAbsoluteSelected={isAbsoluteSelected}>
                 <SelectorList isAbsoluteSelected={isAbsoluteSelected}>
                   <SelectorItemsHook
                     {...{

--- a/src/sentry/static/sentry/app/components/sidebar/help.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/help.jsx
@@ -32,12 +32,10 @@ class SidebarHelp extends React.Component {
   render() {
     return (
       <DropdownMenu>
-        {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
+        {({isOpen, getActorProps, getMenuProps}) => {
           return (
             <HelpRoot>
-              <HelpActor
-                {...getActorProps({onClick: this.handleActorClick, isStyled: true})}
-              >
+              <HelpActor {...getActorProps({onClick: this.handleActorClick})}>
                 <SidebarItem
                   orientation={this.props.orientation}
                   collapsed={this.props.collapsed}
@@ -49,7 +47,7 @@ class SidebarHelp extends React.Component {
               </HelpActor>
 
               {isOpen && (
-                <HelpMenu {...getMenuProps({isStyled: true})}>
+                <HelpMenu {...getMenuProps()}>
                   <Hook name="sidebar:help-menu" organization={this.props.organization} />
                   <SidebarMenuItem onClick={this.handleSearchClick}>
                     {t('Search Docs and FAQs')}

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.jsx
@@ -75,11 +75,11 @@ const SidebarDropdown = withApi(
         <DropdownMenu>
           {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
             return (
-              <SidebarDropdownRoot {...getRootProps({isStyled: true})}>
+              <SidebarDropdownRoot {...getRootProps()}>
                 <SidebarDropdownActor
                   type="button"
                   data-test-id="sidebar-dropdown"
-                  {...getActorProps({isStyled: true})}
+                  {...getActorProps()}
                 >
                   {avatar}
                   {!collapsed && orientation !== 'top' && (
@@ -96,7 +96,7 @@ const SidebarDropdown = withApi(
                 </SidebarDropdownActor>
 
                 {isOpen && (
-                  <OrgAndUserMenu {...getMenuProps({isStyled: true, org})}>
+                  <OrgAndUserMenu {...getMenuProps()}>
                     {hasOrganization && (
                       <React.Fragment>
                         <SidebarOrgSummary organization={org} />

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.jsx
@@ -33,9 +33,7 @@ class SwitchOrganization extends React.Component {
             <React.Fragment>
               <SwitchOrganizationMenuActor
                 data-test-id="sidebar-switch-org"
-                {...getActorProps({
-                  isStyled: true,
-                })}
+                {...getActorProps()}
                 onClick={e => {
                   // This overwrites `DropdownMenu.getActorProps.onClick` which normally handles clicks on actor
                   // to toggle visibility of menu. Instead, do nothing because it is nested and we only want it
@@ -56,7 +54,7 @@ class SwitchOrganization extends React.Component {
               {isOpen && (
                 <SwitchOrganizationMenu
                   data-test-id="sidebar-switch-org-menu"
-                  {...getMenuProps({isStyled: true})}
+                  {...getMenuProps()}
                 >
                   <OrganizationList>
                     {organizations.map(organization => {

--- a/src/sentry/static/sentry/app/views/dashboards/exploreWidget.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/exploreWidget.jsx
@@ -53,7 +53,7 @@ class ExploreWidget extends React.Component {
                   <Chevron isOpen={isOpen} src="icon-chevron-right" />
                 </ExploreButton>
               </div>
-              <ExploreMenu {...getMenuProps({isStyled: true, isOpen})}>
+              <ExploreMenu {...getMenuProps({isOpen})}>
                 {discoverQueries.map(query => (
                   <ExploreRow key={query.name}>
                     <QueryName>{query.name}</QueryName>

--- a/src/sentry/static/sentry/app/views/events/yAxisSelector.jsx
+++ b/src/sentry/static/sentry/app/views/events/yAxisSelector.jsx
@@ -14,11 +14,7 @@ const YAxisSelector = props => {
       <DropdownControl
         menuOffset="29px"
         button={({isOpen, getActorProps}) => (
-          <StyledDropdownButton
-            {...getActorProps({isStyled: true})}
-            size="zero"
-            isOpen={isOpen}
-          >
+          <StyledDropdownButton {...getActorProps()} size="zero" isOpen={isOpen}>
             {selectedOption.label}
           </StyledDropdownButton>
         )}

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -199,7 +199,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
         button={({isOpen, getActorProps}) => (
           <ButtonSaveAs
             data-test-id="button-save-as"
-            {...getActorProps({isStyled: true})}
+            {...getActorProps()}
             isOpen={isOpen}
             showChevron={false}
           >

--- a/src/sentry/static/sentry/app/views/issueList/savedSearchSelector.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchSelector.jsx
@@ -96,7 +96,7 @@ export default class SavedSearchSelector extends React.Component {
           menuWidth="35vw"
           blendWithActor
           button={({isOpen, getActorProps}) => (
-            <StyledDropdownButton {...getActorProps({isStyled: true})} isOpen={isOpen}>
+            <StyledDropdownButton {...getActorProps()} isOpen={isOpen}>
               <ButtonTitle>{this.getTitle()}</ButtonTitle>
             </StyledDropdownButton>
           )}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/datePickerField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/datePickerField.jsx
@@ -26,7 +26,7 @@ export default class DatePickerField extends React.Component {
     return (
       <InputField
         {...this.props}
-        field={({onChange, onBlur, value, disabled, name, id}) => {
+        field={({onChange, onBlur, value, disabled, id}) => {
           const dateObj = new Date(value);
           const inputValue = !isNaN(dateObj.getTime()) ? dateObj : new Date();
           const dateString = moment(inputValue).format('LL');
@@ -34,13 +34,8 @@ export default class DatePickerField extends React.Component {
           return (
             <DropdownMenu keepMenuOpen>
               {({isOpen, getRootProps, getActorProps, getMenuProps, actions}) => (
-                <DatePickerWrapper {...getRootProps({isStyled: true})}>
-                  <InputWrapper
-                    name={id}
-                    id={id}
-                    {...getActorProps({isStyled: true})}
-                    isOpen={isOpen}
-                  >
+                <DatePickerWrapper {...getRootProps()}>
+                  <InputWrapper name={id} id={id} {...getActorProps()} isOpen={isOpen}>
                     <StyledInput readOnly value={dateString} />
                     <CalendarIcon>
                       <InlineSvg src="icon-calendar" />
@@ -48,7 +43,7 @@ export default class DatePickerField extends React.Component {
                   </InputWrapper>
 
                   {isOpen && (
-                    <CalendarMenu {...getMenuProps({isStyled: true})}>
+                    <CalendarMenu {...getMenuProps()}>
                       <Calendar
                         disabled={disabled}
                         date={inputValue}

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.jsx
@@ -43,7 +43,7 @@ class BreadcrumbDropdown extends React.Component {
   handleStateChange = () => {};
 
   // Adds a delay when mouse hovers on actor (in this case the breadcrumb)
-  handleMouseEnterActor = (actions, e) => {
+  handleMouseEnterActor = () => {
     if (this.leaving) {
       clearTimeout(this.leaving);
     }
@@ -52,7 +52,7 @@ class BreadcrumbDropdown extends React.Component {
   };
 
   // handles mouseEnter event on actor and menu, should clear the leaving timeout and keep menu open
-  handleMouseEnter = (actions, e) => {
+  handleMouseEnter = () => {
     if (this.leaving) {
       clearTimeout(this.leaving);
     }
@@ -62,7 +62,7 @@ class BreadcrumbDropdown extends React.Component {
 
   // handles mouseLeave event on actor and menu, adds a timeout before updating state to account for
   // mouseLeave into
-  handleMouseLeave = (actions, e) => {
+  handleMouseLeave = () => {
     if (this.entering) {
       clearTimeout(this.entering);
     }
@@ -71,12 +71,12 @@ class BreadcrumbDropdown extends React.Component {
   };
 
   // Close immediately when actor is clicked clicked
-  handleClickActor = (actions, e) => {
+  handleClickActor = () => {
     this.close();
   };
 
   // Close immediately when clicked outside
-  handleClose = actions => {
+  handleClose = () => {
     this.close();
   };
 
@@ -95,14 +95,12 @@ class BreadcrumbDropdown extends React.Component {
         }}
         items={items}
         onSelect={onSelect}
-        isStyled
         virtualizedHeight={41}
       >
         {({getActorProps, actions, isOpen}) => {
           return (
             <Crumb
               {...getActorProps({
-                isStyled: true,
                 hasMenu,
                 onClick: this.handleClickActor.bind(this, actions),
                 onMouseEnter: this.handleMouseEnterActor.bind(this, actions),

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -205,10 +205,7 @@ export default class RequestLog extends AsyncComponent<Props, State> {
               label={eventType}
               menuWidth="220px"
               button={({isOpen, getActorProps}) => (
-                <StyledDropdownButton
-                  {...getActorProps({isStyled: true})}
-                  isOpen={isOpen}
-                >
+                <StyledDropdownButton {...getActorProps()} isOpen={isOpen}>
                   {eventType}
                 </StyledDropdownButton>
               )}

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -169,7 +169,7 @@ class OrganizationMembersList extends AsyncView<Props, State> {
         <DropdownMenu closeOnEscape>
           {({getActorProps, isOpen}) => (
             <FilterWrapper>
-              <Button size="small" icon="icon-sliders" {...getActorProps()}>
+              <Button size="small" icon="icon-sliders" {...getActorProps({})}>
                 {t('Search Filters')}
               </Button>
               {isOpen && (

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -169,11 +169,7 @@ class OrganizationMembersList extends AsyncView<Props, State> {
         <DropdownMenu closeOnEscape>
           {({getActorProps, isOpen}) => (
             <FilterWrapper>
-              <Button
-                size="small"
-                icon="icon-sliders"
-                {...getActorProps({isStyled: true})}
-              >
+              <Button size="small" icon="icon-sliders" {...getActorProps()}>
                 {t('Search Filters')}
               </Button>
               {isOpen && (

--- a/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/dropdownAutoCompleteMenu.spec.jsx.snap
@@ -96,7 +96,6 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
                 }
               }
               blendCorner={true}
-              isStyled={true}
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseEnter={[Function]}
@@ -105,7 +104,6 @@ exports[`DropdownAutoCompleteMenu renders with a group 1`] = `
               <BubbleWithMinWidth
                 blendCorner={true}
                 className="css-0"
-                isStyled={true}
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseEnter={[Function]}
@@ -312,7 +310,6 @@ exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
                 }
               }
               blendCorner={true}
-              isStyled={true}
               onClick={[Function]}
               onMouseDown={[Function]}
               onMouseEnter={[Function]}
@@ -321,7 +318,6 @@ exports[`DropdownAutoCompleteMenu renders without a group 1`] = `
               <BubbleWithMinWidth
                 blendCorner={true}
                 className="css-0"
-                isStyled={true}
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onMouseEnter={[Function]}

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -3,7 +3,6 @@
 exports[`Sidebar SidebarDropdown can open "Switch Organization" sub-menu 1`] = `
 <SwitchOrganizationMenu
   data-test-id="sidebar-switch-org-menu"
-  isStyled={true}
   onClick={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
@@ -128,38 +127,9 @@ exports[`Sidebar SidebarDropdown can open "Switch Organization" sub-menu 1`] = `
 
 exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
 <OrgAndUserMenu
-  isStyled={true}
   onClick={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
-  org={
-    Object {
-      "access": Array [
-        "org:read",
-        "org:write",
-        "org:admin",
-        "org:integrations",
-        "project:read",
-        "project:write",
-        "project:admin",
-        "team:read",
-        "team:write",
-        "team:admin",
-      ],
-      "features": Array [],
-      "id": "3",
-      "name": "Organization Name",
-      "onboardingTasks": Array [],
-      "projects": Array [],
-      "scrapeJavaScript": true,
-      "slug": "org-slug",
-      "status": Object {
-        "id": "active",
-        "name": "active",
-      },
-      "teams": Array [],
-    }
-  }
 >
   <div
     className="css-yvb5my-OrgAndUserMenu-SidebarDropdownMenu e1fowdfw9"
@@ -474,7 +444,6 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                     >
                       <SwitchOrganizationMenuActor
                         data-test-id="sidebar-switch-org"
-                        isStyled={true}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         onMouseEnter={[Function]}
@@ -907,7 +876,6 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
 
 exports[`Sidebar SidebarHelp can toggle help menu 1`] = `
 <HelpMenu
-  isStyled={true}
   onClick={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
@@ -3238,11 +3206,9 @@ exports[`Sidebar can have onboarding feature 1`] = `
 
 exports[`Sidebar renders without org and router 1`] = `
 <OrgAndUserMenu
-  isStyled={true}
   onClick={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
-  org={null}
 >
   <div
     className="css-yvb5my-OrgAndUserMenu-SidebarDropdownMenu e1fowdfw9"

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -150,7 +150,6 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                           >
                             <Actor
                               isOpen={false}
-                              isStyled={true}
                               onClick={[Function]}
                               onKeyDown={[Function]}
                               onMouseEnter={[Function]}

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -578,7 +578,6 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                 >
                                   <Actor
                                     isOpen={false}
-                                    isStyled={true}
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
                                     onMouseEnter={[Function]}


### PR DESCRIPTION
This was required before the days of `forwardRef`, emotion9, and `innerRef` - but since upgrading to emotion10, we no longer need to use `innerRef` which makes this prop obsolete.