### PR TITLE
fix(discover) Go to 10 facets

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -30,7 +30,6 @@ class OrganizationEventsFacetsEndpoint(OrganizationEventsEndpointBase):
             facets = discover.get_facets(
                 query=request.GET.get("query"),
                 params=params,
-                limit=20,
                 referrer="api.organization-events-facets.top-tags",
             )
         except discover.InvalidSearchQuery as error:


### PR DESCRIPTION
20 makes for a really long list of facets. 10 is the default limit defined in the get_facets() method.