### PR TITLE
fix(GlobalSelectionHeader): Fix switch org bug

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -323,12 +323,7 @@ class GlobalSelectionHeader extends React.Component {
     } else if (requestedProjects && requestedProjects.length > 0) {
       // If there is a list of projects from URL params, select first project from that list
       newProject = [requestedProjects[0]];
-    } else if (
-      organization &&
-      params &&
-      organization.slug &&
-      organization.slug === params.orgId
-    ) {
+    } else if (organization?.slug && organization?.slug === params?.orgId) {
       // When we have finished loading the organization into the props,  i.e. the organization slug is consistent with
       // the URL param--Sentry will get the first project from the organization that the user is a member of.
       newProject = this.getFirstProject();

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.jsx
@@ -316,14 +316,21 @@ class GlobalSelectionHeader extends React.Component {
       return;
     }
 
+    const {organization, params} = this.props;
     if (forceProject) {
       // this takes precendence over the other options
       newProject = [getProjectIdFromProject(forceProject)];
     } else if (requestedProjects && requestedProjects.length > 0) {
       // If there is a list of projects from URL params, select first project from that list
       newProject = [requestedProjects[0]];
-    } else {
-      // Otherwise, get first project from org that the user is a member of
+    } else if (
+      organization &&
+      params &&
+      organization.slug &&
+      organization.slug === params.orgId
+    ) {
+      // When we have finished loading the organization into the props,  i.e. the organization slug is consistent with
+      // the URL param--Sentry will get the first project from the organization that the user is a member of.
       newProject = this.getFirstProject();
     }
 

--- a/tests/acceptance/test_organization_switch.py
+++ b/tests/acceptance/test_organization_switch.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from django.utils import timezone
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 
 
@@ -17,7 +16,7 @@ class OrganizationSwitchTest(AcceptanceTestCase, SnubaTestCase):
         self.project_3 = self.create_project(
             organization=self.organization, teams=[self.team], name="Siberian"
         )
-        self.PRIMARY_PROJECTS_COUNT = 4
+        self.PRIMARY_PROJECTS_COUNT = 3
         self.secondary_org = self.create_organization(owner=self.user, name="Banana Duck")
 
         self.secondary_team = self.create_team(
@@ -69,7 +68,6 @@ class OrganizationSwitchTest(AcceptanceTestCase, SnubaTestCase):
         with self.settings(SENTRY_SINGLE_ORGANIZATION=False), self.feature(
             "organizations:discover"
         ):
-            self.project.update(first_event=timezone.now())
             for transition_url in transition_urls:
                 self.browser.get(origin_url)
                 self.browser.wait_until_not(".loading-indicator")

--- a/tests/acceptance/test_organization_switch.py
+++ b/tests/acceptance/test_organization_switch.py
@@ -1,0 +1,97 @@
+from __future__ import absolute_import
+
+from django.utils import timezone
+from sentry.testutils import AcceptanceTestCase, SnubaTestCase
+
+
+class OrganizationSwitchTest(AcceptanceTestCase, SnubaTestCase):
+    def setUp(self):
+        super(OrganizationSwitchTest, self).setUp()
+
+        self.project_1 = self.create_project(
+            organization=self.organization, teams=[self.team], name="Bengal"
+        )
+        self.project_2 = self.create_project(
+            organization=self.organization, teams=[self.team], name="Sumatra"
+        )
+        self.project_3 = self.create_project(
+            organization=self.organization, teams=[self.team], name="Siberian"
+        )
+        self.PRIMARY_PROJECTS_COUNT = 4
+        self.secondary_org = self.create_organization(owner=self.user, name="Banana Duck")
+
+        self.secondary_team = self.create_team(
+            organization=self.secondary_org, name="Second", members=[self.user]
+        )
+
+        self.project_4 = self.create_project(
+            organization=self.secondary_org, teams=[self.secondary_team], name="Gone Goose"
+        )
+
+        self.project_5 = self.create_project(
+            organization=self.secondary_org, teams=[self.secondary_team], name="Peaceful Platypus"
+        )
+
+        self.SECONDARY_PROJECTS_COUNT = 2
+
+        self.login_as(self.user)
+
+    def test_organization_switches(self):
+        issues_url_creator = lambda org_slug: u"organizations/{org_id}/issues/".format(
+            org_id=org_slug
+        )
+        releases_url_creator = lambda org_slug: u"organizations/{org_id}/releases/".format(
+            org_id=org_slug
+        )
+        discover_url_creator = lambda org_slug: u"organizations/{org_id}/discover/".format(
+            org_id=org_slug
+        )
+        user_feedback_url_creator = lambda org_slug: u"organizations/{org_id}/user-feedback/".format(
+            org_id=org_slug
+        )
+
+        primary_slug = self.organization.slug
+        secondary_slug = self.secondary_org.slug
+
+        origin_url = issues_url_creator(primary_slug)
+        destination_url = issues_url_creator(secondary_slug)
+
+        transition_urls = [
+            url_creator(primary_slug)
+            for url_creator in [
+                issues_url_creator,
+                releases_url_creator,
+                discover_url_creator,
+                user_feedback_url_creator,
+            ]
+        ]
+
+        with self.settings(SENTRY_SINGLE_ORGANIZATION=False), self.feature(
+            "organizations:discover"
+        ):
+            self.project.update(first_event=timezone.now())
+            for transition_url in transition_urls:
+                self.browser.get(origin_url)
+                self.browser.wait_until_not(".loading-indicator")
+                self.browser.click_when_visible(
+                    selector='[data-test-id="global-header-project-selector"]', timeout=10
+                )
+                primary_count = len(
+                    self.browser.driver.find_elements_by_css_selector(
+                        "[data-test-id=badge-display-name]"
+                    )
+                )
+                assert primary_count == self.PRIMARY_PROJECTS_COUNT
+
+                self.browser.get(transition_url)
+                self.browser.wait_until_not(".loading-indicator")
+
+                self.browser.get(destination_url)
+                self.browser.wait_until_not(".loading-indicator")
+                self.browser.click('[data-test-id="global-header-project-selector"]')
+                secondary_count = len(
+                    self.browser.driver.find_elements_by_css_selector(
+                        "[data-test-id=badge-display-name]"
+                    )
+                )
+                assert secondary_count == self.SECONDARY_PROJECTS_COUNT


### PR DESCRIPTION
Context: This configuration of Sentry has
Multiple Organizations: Enabled
Multiple Project Selection: Disabled

Switching organizations between lightweight and heavyweight routes
sometimes causes a project that does not belong to the organization to
be force loaded. With Multiple Project Selection disabled, GSH tries
to enforce a single project. Therefore loading projects from the current
organization before the new organization has been loaded from the
switch. Thus the URL is updated with a project ID of a current project
that does not belong to the new organization to be loaded.

For example, Org-A has projects: [1,2,3]; Org-B has  projects: [4,5,6].
From  http://localhost:8000/organizations/Org-B/eventsv2/?project=6
we switch to Org-A from the sidebar, effectively loading the below URL:
http://localhost:8000/organizations/Org-A/issues/
which will be updated to
http://localhost:8000/organizations/Org-A/issues/?project=4
as Sentry tries to load and enforce a single project from the outdated
Org-B details.

Change:
Added a new guard to prevent the loading of a new project from
organization before the organization details is consistent with the URL.