### PR TITLE
ref: Remove "eventstore.use-nodestore" feature switch

### DIFF
--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -4,7 +4,7 @@ import six
 
 from django.http import HttpResponse, StreamingHttpResponse
 
-from sentry import eventstore, options
+from sentry import eventstore
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.lang.native.applecrashreport import AppleCrashReport
@@ -23,9 +23,6 @@ class EventAppleCrashReportEndpoint(ProjectEndpoint):
         event = eventstore.get_event_by_id(project.id, event_id)
         if event is None:
             raise ResourceDoesNotExist
-
-        if not options.get("eventstore.use-nodestore"):
-            event.bind_node_data()
 
         if event.platform not in ("cocoa", "native"):
             return HttpResponse(

--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
-from sentry import eventstore, options
+from sentry import eventstore
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.models import Commit, Release
 from sentry.utils.committers import get_serialized_event_file_committers
@@ -25,10 +25,6 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
         event = eventstore.get_event_by_id(project.id, event_id)
         if event is None:
             return Response({"detail": "Event not found"}, status=404)
-
-        # populate event data
-        if not options.get("eventstore.use-nodestore"):
-            event.bind_node_data()
 
         try:
             committers = get_serialized_event_file_committers(

--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -4,7 +4,7 @@ import six
 
 from django.http import HttpResponse
 
-from sentry import eventstore, options
+from sentry import eventstore
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.grouping.api import GroupingConfigNotFound
@@ -23,9 +23,6 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
         event = eventstore.get_event_by_id(project.id, event_id)
         if event is None:
             raise ResourceDoesNotExist
-
-        if not options.get("eventstore.use-nodestore"):
-            event.bind_node_data()
 
         rv = {}
         config_name = request.GET.get("config") or None

--- a/src/sentry/api/endpoints/event_owners.py
+++ b/src/sentry/api/endpoints/event_owners.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 from rest_framework.response import Response
 
-from sentry import eventstore, options
+from sentry import eventstore
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.fields.actor import Actor
 from sentry.api.serializers import serialize
@@ -25,10 +25,6 @@ class EventOwnersEndpoint(ProjectEndpoint):
         event = eventstore.get_event_by_id(project.id, event_id)
         if event is None:
             return Response({"detail": "Event not found"}, status=404)
-
-        # populate event data
-        if not options.get("eventstore.use-nodestore"):
-            event.bind_node_data()
 
         owners, rules = ProjectOwnership.get_owners(project.id, event.data)
 

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -5,7 +5,7 @@ import functools
 import six
 from rest_framework.response import Response
 
-from sentry import analytics, eventstore, options, search
+from sentry import analytics, eventstore, search
 from sentry.api.base import DocSection, EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.helpers.group_index import (
@@ -151,9 +151,6 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                     pass
                 else:
                     matching_event = eventstore.get_event_by_id(project.id, event_id)
-                    if matching_event is not None:
-                        if not options.get("eventstore.use-nodestore"):
-                            matching_event.bind_node_data()
             elif matching_group is None:
                 matching_group = get_by_short_id(
                     project.organization_id, request.GET.get("shortIdLookup"), query

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -117,14 +117,13 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
-    def get_event_by_id(self, project_id, event_id, additional_columns=None):
+    def get_event_by_id(self, project_id, event_id):
         """
         Gets a single event given a project_id and event_id.
 
         Arguments:
         project_id (int): Project ID
         event_id (str): Event ID
-        additional_columns: (Sequence[Column]) - List of addition columns to fetch - default None
         """
         raise NotImplementedError
 

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -5,7 +5,6 @@ import six
 from copy import deepcopy
 from datetime import datetime, timedelta
 
-from sentry import options
 from sentry.eventstore.base import EventStorage
 from sentry.snuba.events import Columns
 from sentry.utils import snuba
@@ -76,7 +75,7 @@ class SnubaEventStorage(EventStorage):
 
         return []
 
-    def get_event_by_id(self, project_id, event_id, additional_columns=None):
+    def get_event_by_id(self, project_id, event_id):
         """
         Get an event given a project ID and event ID
         Returns None if an event cannot be found
@@ -86,22 +85,6 @@ class SnubaEventStorage(EventStorage):
         if not event_id:
             return None
 
-        if options.get("eventstore.use-nodestore"):
-            return self.__get_event_by_id_nodestore(project_id, event_id)
-
-        cols = self.__get_columns(additional_columns)
-
-        result = snuba.raw_query(
-            selected_columns=cols,
-            filter_keys={"event_id": [event_id], "project_id": [project_id]},
-            referrer="eventstore.get_event_by_id",
-            limit=1,
-        )
-        if "error" not in result and len(result["data"]) == 1:
-            return self.__make_event(result["data"][0])
-        return None
-
-    def __get_event_by_id_nodestore(self, project_id, event_id):
         event = Event(project_id=project_id, event_id=event_id)
         event.bind_node_data()
 

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import logging
 import six
 
-from sentry import features, options
+from sentry import features
 from sentry.integrations.exceptions import ApiError, IntegrationError
 from sentry.models import Activity, ExternalIssue, Group, GroupLink, GroupStatus, Organization
 from sentry.utils.http import absolute_uri
@@ -58,9 +58,6 @@ class IssueBasicMixin(object):
         in Jira, VSTS, GitHub, etc
         """
         event = group.get_latest_event()
-        if event is not None:
-            if not options.get("eventstore.use-nodestore"):
-                event.bind_node_data()
 
         return [
             {

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -152,8 +152,6 @@ class ErrorPageEmbedView(View):
             event = eventstore.get_event_by_id(report.project.id, report.event_id)
 
             if event is not None:
-                if not options.get("eventstore.use-nodestore"):
-                    event.bind_node_data()
                 report.environment = event.get_environment()
                 report.group = event.group
 

--- a/src/sentry/web/frontend/group_event_json.py
+++ b/src/sentry/web/frontend/group_event_json.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division
 
 from django.http import Http404, HttpResponse
 
-from sentry import eventstore, options
+from sentry import eventstore
 from sentry.models import Group, GroupMeta, get_group_with_redirect
 
 from sentry.utils import json
@@ -27,9 +27,6 @@ class GroupEventJsonView(OrganizationView):
 
         if event is None:
             raise Http404
-
-        if event_id_or_latest != "latest" and not options.get("eventstore.use-nodestore"):
-            event.bind_node_data()
 
         GroupMeta.objects.populate_cache([group])
 

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -176,7 +176,7 @@ class SentryRemoteTest(SnubaTestCase):
         return reverse("sentry-api-store")
 
     def get_event(self, event_id):
-        instance = eventstore.get_event_by_id(self.project.id, event_id, eventstore.full_columns)
+        instance = eventstore.get_event_by_id(self.project.id, event_id)
         instance.bind_node_data()
         return instance
 

--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -88,20 +88,12 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
         assert events == []
 
     def test_get_event_by_id(self):
-        # Get event with default columns
+        # Get valid event
         event = self.eventstore.get_event_by_id(self.project1.id, "a" * 32)
 
         assert event.id == "a" * 32
         assert event.event_id == "a" * 32
         assert event.project_id == self.project1.id
-
-        # Get all columns
-        event = self.eventstore.get_event_by_id(
-            self.project2.id, "b" * 32, self.eventstore.full_columns
-        )
-        assert event.id == "b" * 32
-        assert event.event_id == "b" * 32
-        assert event.project_id == self.project2.id
 
         # Get non existent event
         event = self.eventstore.get_event_by_id(self.project2.id, "f" * 32)

--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -3,8 +3,6 @@ from __future__ import absolute_import
 import six
 import pytest
 
-from django.conf import settings
-
 from sentry.testutils import TestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.eventstore.snuba.backend import SnubaEventStorage
@@ -117,22 +115,19 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
         assert event.project_id == self.project2.id
 
     def test_get_event_by_id_nodestore(self):
-        options = settings.SENTRY_OPTIONS.copy()
-        options["eventstore.use-nodestore"] = True
-        with self.settings(SENTRY_OPTIONS=options):
-            event = self.eventstore.get_event_by_id(self.project1.id, "a" * 32)
-            assert event
-            assert event.group_id == event.group.id
+        event = self.eventstore.get_event_by_id(self.project1.id, "a" * 32)
+        assert event
+        assert event.group_id == event.group.id
 
-            # Transaction event
-            event = self.eventstore.get_event_by_id(self.project2.id, "d" * 32)
-            assert event
-            assert not event.group_id
-            assert not event.group
+        # Transaction event
+        event = self.eventstore.get_event_by_id(self.project2.id, "d" * 32)
+        assert event
+        assert not event.group_id
+        assert not event.group
 
-            # Non existent event
-            event = self.eventstore.get_event_by_id(self.project.id, "f" * 32)
-            assert not event
+        # Non existent event
+        event = self.eventstore.get_event_by_id(self.project.id, "f" * 32)
+        assert not event
 
     def test_get_next_prev_event_id(self):
         event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)


### PR DESCRIPTION
This feature has been rolled out in production, and we are now fetching
from Nodestore instead of Snuba. We don't want to keep this option
anymore.