### PR TITLE
fix(eventstore): Return None if Nodestore event is not yet in Snuba

### DIFF
--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -4,6 +4,7 @@ import six
 
 from copy import deepcopy
 from datetime import datetime, timedelta
+import logging
 
 from sentry import options
 from sentry.eventstore.base import EventStorage
@@ -21,6 +22,8 @@ DESC_ORDERING = ["-{}".format(TIMESTAMP), "-{}".format(EVENT_ID)]
 ASC_ORDERING = [TIMESTAMP, EVENT_ID]
 DEFAULT_LIMIT = 100
 DEFAULT_OFFSET = 0
+
+logger = logging.getLogger(__name__)
 
 
 def get_before_event_condition(event):
@@ -122,7 +125,14 @@ class SnubaEventStorage(EventStorage):
                 referrer="eventstore.get_event_by_id_nodestore",
             )
 
-            assert len(result["data"]) == 1
+            # Return None if the event from Nodestore was not yet written to Snuba
+            if len(result["data"]) != 1:
+                logger.warning(
+                    "eventstore.missing-snuba-event",
+                    extra={"project_id": project_id, "event_id": event_id},
+                )
+                return None
+
             event.group_id = result["data"][0]["group_id"]
 
         return event


### PR DESCRIPTION
Since events are written into Nodestore before Snuba, just return None
if a requested event has not made it all the way into Snuba yet.

This can come up on the embedded error page where user feedback can be
submitted before the event makes it all the way through.

Fixes SENTRY-E59