### PR TITLE
ref(discover) Move functions only used by discover1 out of general utils

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -10,6 +10,7 @@ from sentry import features
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventsError, NoProjects
 from sentry.api.event_search import resolve_field_list, InvalidSearchQuery
 from sentry.api.serializers.snuba import SnubaTSResultSerializer
+from sentry.discover.utils import transform_aliases_and_query
 from sentry.snuba import discover
 from sentry.utils import snuba
 from sentry.utils.dates import parse_stats_period
@@ -62,7 +63,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
         rollup = self.get_rollup(request)
         snuba_args = self.get_field(request, snuba_args)
 
-        result = snuba.transform_aliases_and_query(
+        result = transform_aliases_and_query(
             aggregations=snuba_args.get("aggregations"),
             conditions=snuba_args.get("conditions"),
             filter_keys=snuba_args.get("filter_keys"),

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -10,6 +10,7 @@ from sentry.api.bases import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.utils import snuba
+from sentry.discover.utils import transform_aliases_and_query
 from sentry import features
 
 from .serializers import DiscoverQuerySerializer
@@ -83,7 +84,7 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
 
         if not kwargs["aggregations"]:
 
-            data_fn = partial(snuba.transform_aliases_and_query, referrer="discover", **kwargs)
+            data_fn = partial(transform_aliases_and_query, referrer="discover", **kwargs)
             return self.paginate(
                 request=request,
                 on_results=lambda results: self.handle_results(results, requested_query, projects),
@@ -91,7 +92,7 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
                 max_per_page=1000,
             )
         else:
-            snuba_results = snuba.transform_aliases_and_query(referrer="discover", **kwargs)
+            snuba_results = transform_aliases_and_query(referrer="discover", **kwargs)
             return Response(
                 self.handle_results(snuba_results, requested_query, projects), status=200
             )

--- a/src/sentry/discover/utils.py
+++ b/src/sentry/discover/utils.py
@@ -1,0 +1,147 @@
+from __future__ import absolute_import
+
+import six
+
+from sentry.utils.snuba import Dataset, dataset_query, get_snuba_column_name, get_function_index
+
+# TODO(mark) Once this import is removed, transform_results should not
+# be exported.
+from sentry.snuba.discover import transform_results
+
+
+def parse_columns_in_functions(col, context=None, index=None):
+    """
+    Checks expressions for arguments that should be considered a column while
+    ignoring strings that represent clickhouse function names
+
+    if col is a list, means the expression has functions and we need
+    to parse for arguments that should be considered column names.
+
+    Assumptions here:
+     * strings that represent clickhouse function names are always followed by a list or tuple
+     * strings that are quoted with single quotes are used as string literals for CH
+     * otherwise we should attempt to get the snuba column name (or custom tag)
+    """
+
+    function_name_index = get_function_index(col)
+
+    if function_name_index is not None:
+        # if this is non zero, that means there are strings before this index
+        # that should be converted to snuba column names
+        # e.g. ['func1', ['column', 'func2', ['arg1']]]
+        if function_name_index > 0:
+            for i in six.moves.xrange(0, function_name_index):
+                if context is not None:
+                    context[i] = get_snuba_column_name(col[i])
+
+        args = col[function_name_index + 1]
+
+        # check for nested functions in args
+        if get_function_index(args):
+            # look for columns
+            return parse_columns_in_functions(args, args)
+
+        # check each argument for column names
+        else:
+            for (i, arg) in enumerate(args):
+                parse_columns_in_functions(arg, args, i)
+    else:
+        # probably a column name
+        if context is not None and index is not None:
+            context[index] = get_snuba_column_name(col)
+
+
+def transform_aliases_and_query(**kwargs):
+    """
+    Convert aliases in selected_columns, groupby, aggregation, conditions,
+    orderby and arrayjoin fields to their internal Snuba format and post the
+    query to Snuba. Convert back translated aliases before returning snuba
+    results.
+
+    :deprecated: This method is deprecated. You should use sentry.snuba.discover instead.
+    """
+
+    arrayjoin_map = {"error": "exception_stacks", "stack": "exception_frames"}
+
+    translated_columns = {}
+    derived_columns = set()
+
+    selected_columns = kwargs.get("selected_columns")
+    groupby = kwargs.get("groupby")
+    aggregations = kwargs.get("aggregations")
+    conditions = kwargs.get("conditions")
+    filter_keys = kwargs["filter_keys"]
+    arrayjoin = kwargs.get("arrayjoin")
+    orderby = kwargs.get("orderby")
+    having = kwargs.get("having", [])
+    dataset = Dataset.Events
+
+    if selected_columns:
+        for (idx, col) in enumerate(selected_columns):
+            if isinstance(col, list):
+                # if list, means there are potentially nested functions and need to
+                # iterate and translate potential columns
+                parse_columns_in_functions(col)
+                selected_columns[idx] = col
+                translated_columns[col[2]] = col[2]
+                derived_columns.add(col[2])
+            else:
+                name = get_snuba_column_name(col)
+                selected_columns[idx] = name
+                translated_columns[name] = col
+
+    if groupby:
+        for (idx, col) in enumerate(groupby):
+            if col not in derived_columns:
+                name = get_snuba_column_name(col)
+            else:
+                name = col
+
+            groupby[idx] = name
+            translated_columns[name] = col
+
+    for aggregation in aggregations or []:
+        derived_columns.add(aggregation[2])
+        if isinstance(aggregation[1], six.string_types):
+            aggregation[1] = get_snuba_column_name(aggregation[1])
+        elif isinstance(aggregation[1], (set, tuple, list)):
+            aggregation[1] = [get_snuba_column_name(col) for col in aggregation[1]]
+
+    for col in filter_keys.keys():
+        name = get_snuba_column_name(col)
+        filter_keys[name] = filter_keys.pop(col)
+
+    if conditions:
+        aliased_conditions = []
+        for condition in conditions:
+            field = condition[0]
+            if not isinstance(field, (list, tuple)) and field in derived_columns:
+                having.append(condition)
+            else:
+                aliased_conditions.append(condition)
+        kwargs["conditions"] = aliased_conditions
+
+    if having:
+        kwargs["having"] = having
+
+    if orderby:
+        orderby = orderby if isinstance(orderby, (list, tuple)) else [orderby]
+        translated_orderby = []
+
+        for field_with_order in orderby:
+            field = field_with_order.lstrip("-")
+            translated_orderby.append(
+                u"{}{}".format(
+                    "-" if field_with_order.startswith("-") else "",
+                    field if field in derived_columns else get_snuba_column_name(field),
+                )
+            )
+
+        kwargs["orderby"] = translated_orderby
+
+    kwargs["arrayjoin"] = arrayjoin_map.get(arrayjoin, arrayjoin)
+    kwargs["dataset"] = dataset
+
+    result = dataset_query(**kwargs)
+
+    return transform_results(result, translated_columns, kwargs)

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -33,6 +33,7 @@ from sentry.incidents.models import (
     IncidentType,
     TimeSeriesSnapshot,
 )
+from sentry.snuba.discover import zerofill
 from sentry.models import Commit, Integration, Project, Release
 from sentry.snuba.models import QueryAggregations, QueryDatasets
 from sentry.snuba.subscriptions import (
@@ -42,7 +43,7 @@ from sentry.snuba.subscriptions import (
     query_aggregation_to_snuba,
 )
 from sentry.utils.committers import get_event_file_committers
-from sentry.utils.snuba import bulk_raw_query, raw_query, SnubaQueryParams, SnubaTSResult, zerofill
+from sentry.utils.snuba import bulk_raw_query, raw_query, SnubaQueryParams, SnubaTSResult
 
 MAX_INITIAL_INCIDENT_PERIOD = timedelta(days=7)
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -251,31 +251,6 @@ def to_naive_timestamp(value):
     return (value - epoch_naive).total_seconds()
 
 
-def zerofill(data, start, end, rollup, orderby):
-    rv = []
-    start = int(to_naive_timestamp(naiveify_datetime(start)) / rollup) * rollup
-    end = (int(to_naive_timestamp(naiveify_datetime(end)) / rollup) * rollup) + rollup
-    data_by_time = {}
-
-    for obj in data:
-        if obj["time"] in data_by_time:
-            data_by_time[obj["time"]].append(obj)
-        else:
-            data_by_time[obj["time"]] = [obj]
-
-    for key in six.moves.xrange(start, end, rollup):
-        if key in data_by_time and len(data_by_time[key]) > 0:
-            rv = rv + data_by_time[key]
-            data_by_time[key] = []
-        else:
-            rv.append({"time": key})
-
-    if "-time" in orderby:
-        return list(reversed(rv))
-
-    return rv
-
-
 def get_snuba_column_name(name, dataset=Dataset.Events):
     """
     Get corresponding Snuba column name from Sentry snuba map, if not found
@@ -330,174 +305,10 @@ def get_function_index(column_expr, depth=0):
         return None
 
 
-def parse_columns_in_functions(col, context=None, index=None):
-    """
-    Checks expressions for arguments that should be considered a column while
-    ignoring strings that represent clickhouse function names
-
-    if col is a list, means the expression has functions and we need
-    to parse for arguments that should be considered column names.
-
-    Assumptions here:
-     * strings that represent clickhouse function names are always followed by a list or tuple
-     * strings that are quoted with single quotes are used as string literals for CH
-     * otherwise we should attempt to get the snuba column name (or custom tag)
-    """
-
-    function_name_index = get_function_index(col)
-
-    if function_name_index is not None:
-        # if this is non zero, that means there are strings before this index
-        # that should be converted to snuba column names
-        # e.g. ['func1', ['column', 'func2', ['arg1']]]
-        if function_name_index > 0:
-            for i in six.moves.xrange(0, function_name_index):
-                if context is not None:
-                    context[i] = get_snuba_column_name(col[i])
-
-        args = col[function_name_index + 1]
-
-        # check for nested functions in args
-        if get_function_index(args):
-            # look for columns
-            return parse_columns_in_functions(args, args)
-
-        # check each argument for column names
-        else:
-            for (i, arg) in enumerate(args):
-                parse_columns_in_functions(arg, args, i)
-    else:
-        # probably a column name
-        if context is not None and index is not None:
-            context[index] = get_snuba_column_name(col)
-
-
 def get_arrayjoin(column):
     match = re.match(r"^(exception_stacks|exception_frames|contexts)\..+$", column)
     if match:
         return match.groups()[0]
-
-
-def transform_aliases_and_query(**kwargs):
-    """
-    Convert aliases in selected_columns, groupby, aggregation, conditions,
-    orderby and arrayjoin fields to their internal Snuba format and post the
-    query to Snuba. Convert back translated aliases before returning snuba
-    results.
-
-    :deprecated: This method is deprecated. You should use sentry.snuba.discover instead.
-    """
-
-    arrayjoin_map = {"error": "exception_stacks", "stack": "exception_frames"}
-
-    translated_columns = {}
-    derived_columns = set()
-
-    selected_columns = kwargs.get("selected_columns")
-    groupby = kwargs.get("groupby")
-    aggregations = kwargs.get("aggregations")
-    conditions = kwargs.get("conditions")
-    filter_keys = kwargs["filter_keys"]
-    arrayjoin = kwargs.get("arrayjoin")
-    orderby = kwargs.get("orderby")
-    having = kwargs.get("having", [])
-    dataset = Dataset.Events
-
-    if selected_columns:
-        for (idx, col) in enumerate(selected_columns):
-            if isinstance(col, list):
-                # if list, means there are potentially nested functions and need to
-                # iterate and translate potential columns
-                parse_columns_in_functions(col)
-                selected_columns[idx] = col
-                translated_columns[col[2]] = col[2]
-                derived_columns.add(col[2])
-            else:
-                name = get_snuba_column_name(col)
-                selected_columns[idx] = name
-                translated_columns[name] = col
-
-    if groupby:
-        for (idx, col) in enumerate(groupby):
-            if col not in derived_columns:
-                name = get_snuba_column_name(col)
-            else:
-                name = col
-
-            groupby[idx] = name
-            translated_columns[name] = col
-
-    for aggregation in aggregations or []:
-        derived_columns.add(aggregation[2])
-        if isinstance(aggregation[1], six.string_types):
-            aggregation[1] = get_snuba_column_name(aggregation[1])
-        elif isinstance(aggregation[1], (set, tuple, list)):
-            aggregation[1] = [get_snuba_column_name(col) for col in aggregation[1]]
-
-    for col in filter_keys.keys():
-        name = get_snuba_column_name(col)
-        filter_keys[name] = filter_keys.pop(col)
-
-    if conditions:
-        aliased_conditions = []
-        for condition in conditions:
-            field = condition[0]
-            if not isinstance(field, (list, tuple)) and field in derived_columns:
-                having.append(condition)
-            else:
-                aliased_conditions.append(condition)
-        kwargs["conditions"] = aliased_conditions
-
-    if having:
-        kwargs["having"] = having
-
-    if orderby:
-        orderby = orderby if isinstance(orderby, (list, tuple)) else [orderby]
-        translated_orderby = []
-
-        for field_with_order in orderby:
-            field = field_with_order.lstrip("-")
-            translated_orderby.append(
-                u"{}{}".format(
-                    "-" if field_with_order.startswith("-") else "",
-                    field if field in derived_columns else get_snuba_column_name(field),
-                )
-            )
-
-        kwargs["orderby"] = translated_orderby
-
-    kwargs["arrayjoin"] = arrayjoin_map.get(arrayjoin, arrayjoin)
-    kwargs["dataset"] = dataset
-
-    result = dataset_query(**kwargs)
-
-    return transform_results(result, translated_columns, kwargs)
-
-
-def transform_results(result, translated_columns, snuba_args):
-    """
-    Transform internal names back to the public schema ones.
-
-    When getting timeseries results via rollup, this function will
-    zerofill the output results.
-    """
-    # Translate back columns that were converted to snuba format
-    for col in result["meta"]:
-        col["name"] = translated_columns.get(col["name"], col["name"])
-
-    def get_row(row):
-        return {translated_columns.get(key, key): value for key, value in row.items()}
-
-    if len(translated_columns):
-        result["data"] = [get_row(row) for row in result["data"]]
-
-    rollup = snuba_args.get("rollup")
-    if rollup and rollup > 0:
-        result["data"] = zerofill(
-            result["data"], snuba_args["start"], snuba_args["end"], rollup, snuba_args["orderby"]
-        )
-
-    return result
 
 
 def get_query_params_to_update_for_projects(query_params):
@@ -948,13 +759,13 @@ def dataset_query(
     """
     Wrapper around raw_query that selects the dataset based on the
     selected_columns, conditions and groupby parameters.
-    Useful for taking arbitrary end user queries and searching
-    either error or transaction events.
+    Useful for taking arbitrary end user queries and running
+    them on one of the snuba datasets.
 
-    This function will also re-alias columns to match the selected dataset
+    This function will also resolve column aliases to match the selected dataset
 
-    :deprecated: This method and the automatic dataset resolution is deprecated.
-    You should use sentry.snuba.discover instead.
+    This method should be used sparingly. Instead prefer to use sentry.eventstore
+    sentry.tagstore, or sentry.snuba.discover instead when reading data.
     """
     if dataset is None:
         raise ValueError("A dataset is required, and is no longer automatically detected.")

--- a/tests/sentry/discover/test_utils.py
+++ b/tests/sentry/discover/test_utils.py
@@ -1,0 +1,104 @@
+from __future__ import absolute_import
+
+from sentry.testutils import TestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format, before_now
+from sentry.discover.utils import transform_aliases_and_query
+
+
+class TransformAliasesAndQueryTest(SnubaTestCase, TestCase):
+    def setUp(self):
+        super(TransformAliasesAndQueryTest, self).setUp()
+        self.environment = self.create_environment(self.project, name="prod")
+        self.release = self.create_release(self.project, version="first-release")
+
+        self.store_event(
+            data={
+                "message": "oh no",
+                "release": "first-release",
+                "environment": "prod",
+                "platform": "python",
+                "user": {"id": "99", "email": "bruce@example.com", "username": "brucew"},
+                "timestamp": iso_format(before_now(minutes=1)),
+            },
+            project_id=self.project.id,
+        )
+
+    def test_field_aliasing_in_selected_columns(self):
+        result = transform_aliases_and_query(
+            selected_columns=["project.id", "user.email", "release"],
+            filter_keys={"project_id": [self.project.id]},
+        )
+        data = result["data"]
+        assert len(data) == 1
+        assert data[0]["project.id"] == self.project.id
+        assert data[0]["user.email"] == "bruce@example.com"
+        assert data[0]["release"] == "first-release"
+
+    def test_field_aliasing_in_aggregate_functions_and_groupby(self):
+        result = transform_aliases_and_query(
+            selected_columns=["project.id"],
+            aggregations=[["uniq", "user.email", "uniq_email"]],
+            filter_keys={"project_id": [self.project.id]},
+            groupby=["project.id"],
+        )
+        data = result["data"]
+        assert len(data) == 1
+        assert data[0]["project.id"] == self.project.id
+        assert data[0]["uniq_email"] == 1
+
+    def test_field_aliasing_in_conditions(self):
+        result = transform_aliases_and_query(
+            selected_columns=["project.id", "user.email"],
+            conditions=[["user.email", "=", "bruce@example.com"]],
+            filter_keys={"project_id": [self.project.id]},
+        )
+        data = result["data"]
+        assert len(data) == 1
+        assert data[0]["project.id"] == self.project.id
+        assert data[0]["user.email"] == "bruce@example.com"
+
+    def test_autoconversion_of_time_column(self):
+        result = transform_aliases_and_query(
+            aggregations=[["count", "", "count"]],
+            filter_keys={"project_id": [self.project.id]},
+            start=before_now(minutes=5),
+            end=before_now(),
+            groupby=["time"],
+            orderby=["time"],
+            rollup=3600,
+        )
+        data = result["data"]
+        assert isinstance(data[-1]["time"], int)
+        assert data[-1]["count"] == 1
+
+    def test_conversion_of_release_filter_key(self):
+        result = transform_aliases_and_query(
+            selected_columns=["id", "message"],
+            filter_keys={
+                "release": [self.create_release(self.project).id],
+                "project_id": [self.project.id],
+            },
+        )
+        assert len(result["data"]) == 0
+
+        result = transform_aliases_and_query(
+            selected_columns=["id", "message"],
+            filter_keys={"release": [self.release.id], "project_id": [self.project.id]},
+        )
+        assert len(result["data"]) == 1
+
+    def test_conversion_of_environment_filter_key(self):
+        result = transform_aliases_and_query(
+            selected_columns=["id", "message"],
+            filter_keys={
+                "environment": [self.create_environment(self.project).id],
+                "project_id": [self.project.id],
+            },
+        )
+        assert len(result["data"]) == 0
+
+        result = transform_aliases_and_query(
+            selected_columns=["id", "message"],
+            filter_keys={"environment": [self.environment.id], "project_id": [self.project.id]},
+        )
+        assert len(result["data"]) == 1


### PR DESCRIPTION
Move a few discover1 functions out of the utils/snuba and into modules that are proximal to the endpoints that use them. I've moved `zerofill` into discover2 code as that is a better long term home for it with discover1 going away in 'the future'.