### PR TITLE
feat(py3): conditional backport installation

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -16,7 +16,7 @@ Django>=1.10,<1.11
 djangorestframework==3.6.4
 email-reply-parser>=0.2.0,<0.3.0
 enum34>=1.1.6,<1.2.0
-functools32>=3.2.3,<3.3
+functools32>=3.2.3,<3.3 ; python_version < "3.2"
 futures>=3.2.0,<4.0.0
 # optional but needed for google stuff below
 google-api-core==1.14.3

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -31,7 +31,7 @@ google-cloud-pubsub==0.35.4
 google-cloud-storage==1.13.3
 # broken on python3
 hiredis>=0.1.0,<0.2.0
-ipaddress>=1.0.16,<1.1.0
+ipaddress>=1.0.16,<1.1.0 ; python_version < "3.3"
 jsonschema==2.6.0
 kombu==3.0.35
 loremipsum>=1.0.5,<1.1.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -15,7 +15,7 @@ django-sudo>=3.0.0,<4.0.0
 Django>=1.10,<1.11
 djangorestframework==3.6.4
 email-reply-parser>=0.2.0,<0.3.0
-enum34>=1.1.6,<1.2.0
+enum34>=1.1.6,<1.2.0 ; python_version < "3.4"
 functools32>=3.2.3,<3.3 ; python_version < "3.2"
 futures>=3.2.0,<4.0.0 ; python_version < "3.2"
 # optional but needed for google stuff below

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -17,7 +17,7 @@ djangorestframework==3.6.4
 email-reply-parser>=0.2.0,<0.3.0
 enum34>=1.1.6,<1.2.0
 functools32>=3.2.3,<3.3 ; python_version < "3.2"
-futures>=3.2.0,<4.0.0
+futures>=3.2.0,<4.0.0 ; python_version < "3.2"
 # optional but needed for google stuff below
 google-api-core==1.14.3
 google-auth==1.6.3

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import
 
-from functools32 import lru_cache
+try:
+    # TODO: remove when we drop Python 2.7 compat
+    from functools32 import lru_cache
+except ImportError:
+    from functools import lru_cache
 from itertools import groupby
 import jsonschema
 import six

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from functools32 import lru_cache
+from sentry.utils.compat.functools import lru_cache
 from itertools import groupby
 import jsonschema
 import six

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -1,10 +1,6 @@
 from __future__ import absolute_import
 
-try:
-    # TODO: remove when we drop Python 2.7 compat
-    from functools32 import lru_cache
-except ImportError:
-    from functools import lru_cache
+from functools32 import lru_cache
 from itertools import groupby
 import jsonschema
 import six

--- a/src/sentry/interfaces/schemas.py
+++ b/src/sentry/interfaces/schemas.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from sentry.utils.compat.functools import lru_cache
+from sentry.utils.compat import functools
 from itertools import groupby
 import jsonschema
 import six
@@ -585,7 +585,7 @@ INTERFACE_SCHEMAS = {
 }
 
 
-@lru_cache(maxsize=100)
+@functools.lru_cache(maxsize=100)
 def validator_for_interface(name):
     if name not in INTERFACE_SCHEMAS:
         return None

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -7,7 +7,12 @@ import json
 import six
 
 from pkg_resources import parse_version
-from functools32 import lru_cache
+
+try:
+    # TODO: remove when we drop Python 2.7 compat
+    from functools32 import lru_cache
+except ImportError:
+    from functools import lru_cache
 
 import sentry
 

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -7,7 +7,7 @@ import json
 import six
 
 from pkg_resources import parse_version
-from functools32 import lru_cache
+from sentry.utils.compat.functools import lru_cache
 
 import sentry
 

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -7,7 +7,7 @@ import json
 import six
 
 from pkg_resources import parse_version
-from sentry.utils.compat.functools import lru_cache
+from sentry.utils.compat import functools
 
 import sentry
 
@@ -19,7 +19,7 @@ _version_regexp = re.compile(r"^\d+\.\d+\.\d+$")  # We really only want stable r
 LOADER_FOLDER = os.path.abspath(os.path.join(os.path.dirname(sentry.__file__), "loader"))
 
 
-@lru_cache(maxsize=10)
+@functools.lru_cache(maxsize=10)
 def load_registry(path):
     if "/" in path:
         return None

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -7,12 +7,7 @@ import json
 import six
 
 from pkg_resources import parse_version
-
-try:
-    # TODO: remove when we drop Python 2.7 compat
-    from functools32 import lru_cache
-except ImportError:
-    from functools import lru_cache
+from functools32 import lru_cache
 
 import sentry
 

--- a/src/sentry/net/socket.py
+++ b/src/sentry/net/socket.py
@@ -3,7 +3,12 @@ from __future__ import absolute_import
 import six
 import ipaddress
 import socket
-from functools32 import lru_cache
+
+try:
+    # TODO: remove when we drop Python 2.7 compat
+    from functools32 import lru_cache
+except ImportError:
+    from functools import lru_cache
 from ssl import wrap_socket
 from six.moves.urllib.parse import urlparse
 

--- a/src/sentry/net/socket.py
+++ b/src/sentry/net/socket.py
@@ -3,12 +3,7 @@ from __future__ import absolute_import
 import six
 import ipaddress
 import socket
-
-try:
-    # TODO: remove when we drop Python 2.7 compat
-    from functools32 import lru_cache
-except ImportError:
-    from functools import lru_cache
+from functools32 import lru_cache
 from ssl import wrap_socket
 from six.moves.urllib.parse import urlparse
 

--- a/src/sentry/net/socket.py
+++ b/src/sentry/net/socket.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 import ipaddress
 import socket
-from functools32 import lru_cache
+from sentry.utils.compat.functools import lru_cache
 from ssl import wrap_socket
 from six.moves.urllib.parse import urlparse
 

--- a/src/sentry/net/socket.py
+++ b/src/sentry/net/socket.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 import ipaddress
 import socket
-from sentry.utils.compat.functools import lru_cache
+from sentry.utils.compat import functools
 from ssl import wrap_socket
 from six.moves.urllib.parse import urlparse
 
@@ -18,7 +18,7 @@ DISALLOWED_IPS = frozenset(
 )
 
 
-@lru_cache(maxsize=100)
+@functools.lru_cache(maxsize=100)
 def is_ipaddress_allowed(ip):
     """
     Test if a given IP address is allowed or not

--- a/src/sentry/utils/compat/__init__.py
+++ b/src/sentry/utils/compat/__init__.py
@@ -7,6 +7,12 @@ try:
 except ImportError:
     import pickle  # NOQA
 
+try:
+    # TODO: remove when we drop Python 2.7 compat
+    import functools32 as functools
+except ImportError:
+    import functools  # NOQA
+
 
 def _identity(x):
     return x


### PR DESCRIPTION
These are the backports we use that are shared between sentry and getsentry. In preparation for Python 3, this PR pins installation to the appropriate Python version ranges using [PEP 508 dependency specifers](https://www.python.org/dev/peps/pep-0508/#specification).

In the special case of `functools32`, where the import name is different, I've added ImportError tries.

- functools32 - stable api usage since 3.2
- futures - we reference some private variables: `from concurrent.futures._base import RUNNING, FINISHED`, but I've confirmed the values are the same in the backport compared to 3.6.x and 3.7.x.
- enum34 - our api usage is stable since 3.4
- ipaddress - our api usage is stable since 3.3

The only other backport we use is `mock` (`unittest.mock`) - we're pinned to 2.0.0, and I'm excluding it from this PR since we should upgrade to 3.0.0 (it's a rolling backport that we have an == pin for) for better Python 3.6+ compatibility.

Getsentry specific backports are here: https://github.com/getsentry/getsentry/pull/3464
