### PR TITLE
fix(pagerduty): Only show services added by current organization

### DIFF
--- a/tests/sentry/integrations/pagerduty/test_notify_action.py
+++ b/tests/sentry/integrations/pagerduty/test_notify_action.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import responses
 
 from sentry.utils import json
-from sentry.models import Integration, PagerDutyService, GroupStatus
+from sentry.models import Integration, PagerDutyService, GroupStatus, OrganizationIntegration
 from sentry.testutils.cases import RuleTestCase
 from sentry.integrations.pagerduty.notify_action import PagerDutyNotifyServiceAction
 
@@ -75,6 +75,29 @@ class PagerDutyNotifyActionTest(RuleTestCase):
 
         label = rule.render_label()
         assert label == "Send a notification to PagerDuty account [removed] and service [removed]"
+
+    def test_valid_service_options(self):
+        # create new org that has the same pd account but different a service added
+        new_org = self.create_organization(name="New Org", owner=self.user)
+
+        # need to create a new project and set it as self.project because rules are
+        # project based and we want the project in this case to be associated with the
+        # new organization when we call `self.get_rule()`
+        new_project = self.create_project(name="new proj", organization=new_org)
+        self.project = new_project
+
+        self.integration.add_organization(new_org, self.user)
+        oi = OrganizationIntegration.objects.get(organization=new_org)
+        new_service = PagerDutyService.objects.create(
+            service_name="New Service",
+            integration_key="new_service_key",
+            organization_integration=oi,
+        )
+
+        rule = self.get_rule(data={"account": self.integration.id})
+
+        service_options = rule.get_services()
+        assert service_options == [(new_service.id, new_service.service_name)]
 
     @responses.activate
     def test_valid_service_selected(self):


### PR DESCRIPTION
**Problem:**
When creating an alert rule, we were grabbing all the services that were associated with an `Integration`. However, since we allow multiple sentry orgs to be associated with an `Integration`, this meant that we were grabbing services that were added in different organizations (although they were tied to same PD account).

**Solution:**
Filter on the `OrganizationIntegration` (and not the`integration.organizationintegration_set`) to make sure we are only showing the services that were added for that specific organization. 