### PR TITLE
fix(workflow): Fix unsubscribe from issue notifications

### DIFF
--- a/src/sentry/templates/sentry/unsubscribe-notifications.html
+++ b/src/sentry/templates/sentry/unsubscribe-notifications.html
@@ -13,7 +13,7 @@
         <p>You are about to unsubscribe from notifications for the <a href="{{ instance_link }}">selected {{ object_type }}</a>.</p>
 
         <fieldset class="form-actions">
-            <button type="submit" class="btn btn-primary">{% trans "Unsubscribe" %}</button>
+            <button type="submit" name="op" value="unsubscribe" class="btn btn-primary">{% trans "Unsubscribe" %}</button>
             <button type="submit" name="cancel" class="btn btn-default">{% trans "Cancel" %}</button>
         </fieldset>
     </form>

--- a/src/sentry/web/frontend/unsubscribe_issue_notifications.py
+++ b/src/sentry/web/frontend/unsubscribe_issue_notifications.py
@@ -21,5 +21,5 @@ class UnsubscribeIssueNotificationsView(UnsubscribeBaseView):
 
     def unsubscribe(self, instance, user):
         GroupSubscription.objects.create_or_update(
-            group=instance, project=instance.project, user=user, is_active=False
+            group=instance, project=instance.project, user=user, values={"is_active": False}
         )

--- a/tests/sentry/web/frontend/test_unsubscribe_notifications.py
+++ b/tests/sentry/web/frontend/test_unsubscribe_notifications.py
@@ -50,7 +50,11 @@ class UnsubscribeIssueNotificationsTest(UnsubscribeNotificationsBaseTest, TestCa
     view_name = "sentry-account-email-unsubscribe-issue"
 
     def create_instance(self):
-        return self.create_group()
+        group = self.create_group()
+        GroupSubscription.objects.create(
+            project=self.project, group=group, user=self.user, is_active=True
+        )
+        return group
 
     def assert_unsubscribed(self, instance, user):
         assert GroupSubscription.objects.filter(user=user, group=instance, is_active=False).exists()


### PR DESCRIPTION
This fixes unsubscribing from Issue (and Incidents as a consequence) from email notifications.

The problem was in the email template not passing the `op` param (there
also was an issue with the Issue notifications test not having an
initial GroupSubscription).