### PR TITLE
fix: do not error when user already exists

### DIFF
--- a/src/sentry/runner/commands/createuser.py
+++ b/src/sentry/runner/commands/createuser.py
@@ -84,7 +84,7 @@ def createuser(email, password, superuser, no_password, no_input, force_update):
             click.echo("User updated: %s" % (email,))
         else:
             click.echo("User: %s exists, use --force-update to force" % (email,))
-            sys.exit(2)
+            sys.exit(3)
     else:
         user.save()
         click.echo("User created: %s" % (email,))

--- a/src/sentry/runner/commands/createuser.py
+++ b/src/sentry/runner/commands/createuser.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function
 
 import click
+import sys
 from sentry.runner.decorators import configuration
 
 
@@ -42,9 +43,9 @@ def _get_superuser():
 @click.option("--superuser/--no-superuser", default=None, is_flag=True)
 @click.option("--no-password", default=False, is_flag=True)
 @click.option("--no-input", default=False, is_flag=True)
-@click.option("--force", default=False, is_flag=True)
+@click.option("--force-update", default=False, is_flag=True)
 @configuration
-def createuser(email, password, superuser, no_password, no_input, force):
+def createuser(email, password, superuser, no_password, no_input, force_update):
     "Create a new user."
     if not no_input:
         if not email:
@@ -78,11 +79,12 @@ def createuser(email, password, superuser, no_password, no_input, force):
         user.set_password(password)
 
     if User.objects.filter(username=email).exists():
-        if force:
-            user.save(force_update=True)
+        if force_update:
+            user.save(force_update=force_update)
             click.echo("User updated: %s" % (email,))
         else:
-            click.echo("User: %s exists, use --force to force an update" % (email,))
+            click.echo("User: %s exists, use --force-update to force" % (email,))
+            sys.exit(2)
     else:
         user.save()
         click.echo("User created: %s" % (email,))

--- a/src/sentry/runner/commands/createuser.py
+++ b/src/sentry/runner/commands/createuser.py
@@ -76,24 +76,26 @@ def createuser(email, password, superuser, no_password, no_input):
     if password:
         user.set_password(password)
 
-    user.save()
+    if User.objects.filter(username=email).exists():
+        click.echo("Exising user not created: %s" % (email,))
+    else:
+        user.save()
+        click.echo("User created: %s" % (email,))
 
-    click.echo("User created: %s" % (email,))
+        # TODO(dcramer): kill this when we improve flows
+        if settings.SENTRY_SINGLE_ORGANIZATION:
+            from sentry.models import Organization, OrganizationMember, OrganizationMemberTeam, Team
 
-    # TODO(dcramer): kill this when we improve flows
-    if settings.SENTRY_SINGLE_ORGANIZATION:
-        from sentry.models import Organization, OrganizationMember, OrganizationMemberTeam, Team
+            org = Organization.get_default()
+            if superuser:
+                role = roles.get_top_dog().id
+            else:
+                role = org.default_role
+            member = OrganizationMember.objects.create(organization=org, user=user, role=role)
 
-        org = Organization.get_default()
-        if superuser:
-            role = roles.get_top_dog().id
-        else:
-            role = org.default_role
-        member = OrganizationMember.objects.create(organization=org, user=user, role=role)
-
-        # if we've only got a single team let's go ahead and give
-        # access to that team as its likely the desired outcome
-        teams = list(Team.objects.filter(organization=org)[0:2])
-        if len(teams) == 1:
-            OrganizationMemberTeam.objects.create(team=teams[0], organizationmember=member)
-        click.echo("Added to organization: %s" % (org.slug,))
+            # if we've only got a single team let's go ahead and give
+            # access to that team as its likely the desired outcome
+            teams = list(Team.objects.filter(organization=org)[0:2])
+            if len(teams) == 1:
+                OrganizationMemberTeam.objects.create(team=teams[0], organizationmember=member)
+            click.echo("Added to organization: %s" % (org.slug,))

--- a/src/sentry/runner/commands/createuser.py
+++ b/src/sentry/runner/commands/createuser.py
@@ -42,8 +42,9 @@ def _get_superuser():
 @click.option("--superuser/--no-superuser", default=None, is_flag=True)
 @click.option("--no-password", default=False, is_flag=True)
 @click.option("--no-input", default=False, is_flag=True)
+@click.option("--force", default=False, is_flag=True)
 @configuration
-def createuser(email, password, superuser, no_password, no_input):
+def createuser(email, password, superuser, no_password, no_input, force):
     "Create a new user."
     if not no_input:
         if not email:
@@ -77,7 +78,11 @@ def createuser(email, password, superuser, no_password, no_input):
         user.set_password(password)
 
     if User.objects.filter(username=email).exists():
-        click.echo("Exising user not created: %s" % (email,))
+        if force:
+            user.save(force_update=True)
+            click.echo("User updated: %s" % (email,))
+        else:
+            click.echo("User: %s exists, use --force to force an update" % (email,))
     else:
         user.save()
         click.echo("User created: %s" % (email,))


### PR DESCRIPTION
Fixes #6763

This solution fixes the issue in the simplest way possible, when the user exists skip the creation and adding to the organization.

I tried an approach to also add checks for the organization but I decided against it since it might break existing functionality. This script now assumes when a user exists, everything already is as it is supposed to be. Which should be true in the most cases.