### PR TITLE
fix(discover2) Scale results up when sampling is enabled

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -479,7 +479,7 @@ def get_facets(query, params, limit=10, referrer=None):
     # using turbo could cause results to be wrong if the value of turbo is changed in snuba.
     sample_rate = 0.1 if key_names["data"][0]["count"] > 10000 else None
     # Rescale the results if we're sampling
-    multiplier = 10 if sample_rate is not None else 1
+    multiplier = 1 / sample_rate if sample_rate is not None else 1
 
     fetch_projects = False
     if len(params.get("project_id", [])) > 1:


### PR DESCRIPTION
The results in production when sampling is on are far too low. With a sampling of 0.1 (turbo mode) the results appear to be 1/10th of what they should be. Multiplying results back up should get us closer to 100% in the tag bars vs. the <10% we have today.