### PR TITLE
feat(discoverv2) - Add a download as CSV button

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -20,6 +20,7 @@ import {
   Header,
   HeaderTitle,
   HeaderButton,
+  HeaderButtonContainer,
   Body,
   Grid,
   GridRow,
@@ -496,15 +497,17 @@ class GridEditable<
           {/* TODO(leedongwei): This is ugly but I need to move it to work on
           resizing columns. It will be refactored in a upcoming PR */}
           <div style={{display: 'flex', flexDirection: 'row'}}>
-            <HeaderButton onClick={downloadAsCsv} data-test-id="grid-add-column">
-              <InlineSvg src="icon-download" />
-              {t('Download CSV')}
-            </HeaderButton>
-            <div style={{marginLeft: '16px'}}>{this.renderHeaderButton()}</div>
+            <HeaderButtonContainer>
+              <HeaderButton onClick={downloadAsCsv} data-test-id="grid-download-csv">
+                <InlineSvg src="icon-download" />
+                {t('Download CSV')}
+              </HeaderButton>
+            </HeaderButtonContainer>
+            <HeaderButtonContainer>{this.renderHeaderButton()}</HeaderButtonContainer>
 
-            <div style={{marginLeft: '16px'}}>
+            <HeaderButtonContainer>
               {isEditable && this.renderGridHeadEditButtons()}
-            </div>
+            </HeaderButtonContainer>
           </div>
         </Header>
 

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -352,6 +352,19 @@ class GridEditable<
     );
   };
 
+  renderDownloadCsvButton = () => {
+    if (this.props.isLoading) {
+      return null;
+    }
+
+    return (
+      <HeaderButton onClick={this.props.downloadAsCsv} data-test-id="grid-download-csv">
+        <InlineSvg src="icon-download" />
+        {t('Download CSV')}
+      </HeaderButton>
+    );
+  };
+
   renderGridHeadEditButtons = () => {
     if (!this.props.isEditable) {
       return null;
@@ -486,7 +499,7 @@ class GridEditable<
   };
 
   render() {
-    const {isEditable, downloadAsCsv} = this.props;
+    const {isEditable} = this.props;
 
     return (
       <React.Fragment>
@@ -497,10 +510,7 @@ class GridEditable<
           resizing columns. It will be refactored in a upcoming PR */}
           <div style={{display: 'flex', flexDirection: 'row'}}>
             <HeaderButtonContainer>
-              <HeaderButton onClick={downloadAsCsv} data-test-id="grid-download-csv">
-                <InlineSvg src="icon-download" />
-                {t('Download CSV')}
-              </HeaderButton>
+              {this.renderDownloadCsvButton()}
             </HeaderButtonContainer>
             <HeaderButtonContainer>{this.renderHeaderButton()}</HeaderButtonContainer>
 

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -113,6 +113,8 @@ type GridEditableProps<DataRow, ColumnKey> = {
     ) => void;
     deleteColumn: (index: number) => void;
   };
+
+  downloadAsCsv: () => void;
 };
 
 type GridEditableState = {
@@ -484,7 +486,7 @@ class GridEditable<
   };
 
   render() {
-    const {isEditable} = this.props;
+    const {isEditable, downloadAsCsv} = this.props;
 
     return (
       <React.Fragment>
@@ -494,7 +496,11 @@ class GridEditable<
           {/* TODO(leedongwei): This is ugly but I need to move it to work on
           resizing columns. It will be refactored in a upcoming PR */}
           <div style={{display: 'flex', flexDirection: 'row'}}>
-            {this.renderHeaderButton()}
+            <HeaderButton onClick={downloadAsCsv} data-test-id="grid-add-column">
+              <InlineSvg src="icon-download" />
+              {t('Download CSV')}
+            </HeaderButton>
+            <div style={{marginLeft: '16px'}}>{this.renderHeaderButton()}</div>
 
             <div style={{marginLeft: '16px'}}>
               {isEditable && this.renderGridHeadEditButtons()}

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -65,6 +65,7 @@ type GridEditableProps<DataRow, ColumnKey> = {
   columnOrder: GridColumnOrder<ColumnKey>[];
   columnSortBy: GridColumnSortBy<ColumnKey>[];
   data: DataRow[];
+  downloadAsCsv: () => void;
 
   /**
    * GridEditable allows the parent component to determine how to display the
@@ -114,8 +115,6 @@ type GridEditableProps<DataRow, ColumnKey> = {
     ) => void;
     deleteColumn: (index: number) => void;
   };
-
-  downloadAsCsv: () => void;
 };
 
 type GridEditableState = {

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -60,6 +60,10 @@ export const HeaderButton = styled('div')`
   }
 `;
 
+export const HeaderButtonContainer = styled('div')`
+  margin-left: ${space(2)};
+`;
+
 const PanelWithProtectedBorder = styled(Panel)`
   overflow: hidden;
   z-index: ${Z_INDEX_PANEL};

--- a/src/sentry/static/sentry/app/views/discover/result/utils.tsx
+++ b/src/sentry/static/sentry/app/views/discover/result/utils.tsx
@@ -368,7 +368,7 @@ export function downloadAsCsv(result: SnubaResult) {
   window.location.assign(encodedDataUrl);
 }
 
-function disableMacros(value: string | null | boolean | number) {
+export function disableMacros(value: string | null | boolean | number) {
   const unsafeCharacterRegex = /^[\=\+\-\@]/;
 
   if (typeof value === 'string' && `${value}`.match(unsafeCharacterRegex)) {

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -111,6 +111,7 @@ class Results extends React.Component<Props, State> {
     const {organization, location, router} = this.props;
     const {eventView} = this.state;
     const query = location.query.query || '';
+    const title = this.getDocumentTitle();
 
     // Make option set and add the default options in.
     const yAxisOptions = uniqBy(
@@ -128,7 +129,7 @@ class Results extends React.Component<Props, State> {
     );
 
     return (
-      <SentryDocumentTitle title={this.getDocumentTitle()} objSlug={organization.slug}>
+      <SentryDocumentTitle title={title} objSlug={organization.slug}>
         <React.Fragment>
           <GlobalSelectionHeader organization={organization} />
           <NoProjectMessage organization={organization}>
@@ -169,6 +170,7 @@ class Results extends React.Component<Props, State> {
                   organization={organization}
                   eventView={eventView}
                   location={location}
+                  title={title}
                 />
               </Main>
               <Side eventView={eventView}>{this.renderTagsTable()}</Side>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -21,6 +21,7 @@ type TableProps = {
   location: Location;
   eventView: EventView;
   organization: Organization;
+  title: string;
 };
 type TableState = {
   isLoading: boolean;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -13,6 +13,7 @@ import {assert} from 'app/types/utils';
 import Link from 'app/components/links/link';
 
 import {
+  downloadAsCsv,
   getAggregateAlias,
   getFieldRenderer,
   pushEventViewToLocation,
@@ -39,6 +40,7 @@ export type TableViewProps = {
   eventView: EventView;
   tableData: TableData | null | undefined;
   tagKeys: null | string[];
+  title: string;
 };
 
 /**
@@ -360,7 +362,15 @@ class TableView extends React.Component<TableViewProps> {
   };
 
   render() {
-    const {organization, isLoading, error, tableData, tagKeys, eventView} = this.props;
+    const {
+      organization,
+      isLoading,
+      error,
+      tableData,
+      tagKeys,
+      eventView,
+      title,
+    } = this.props;
 
     const columnOrder = eventView.getColumns();
     const columnSortBy = eventView.getSorts();
@@ -420,6 +430,7 @@ class TableView extends React.Component<TableViewProps> {
                 moveColumnCommit: this._moveColumnCommit,
                 onDragStart: startColumnDrag,
               }}
+              downloadAsCsv={() => downloadAsCsv(tableData, title)}
             />
           );
         }}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -411,6 +411,7 @@ class TableView extends React.Component<TableViewProps> {
               isLoading={isLoading}
               error={error}
               data={tableData ? tableData.data : []}
+              downloadAsCsv={() => downloadAsCsv(tableData, columnOrder, title)}
               columnOrder={this.generateColumnOrder({
                 initialColumnIndex: draggingColumnIndex,
                 destinationColumnIndex,
@@ -430,7 +431,6 @@ class TableView extends React.Component<TableViewProps> {
                 moveColumnCommit: this._moveColumnCommit,
                 onDragStart: startColumnDrag,
               }}
-              downloadAsCsv={() => downloadAsCsv(tableData, title)}
             />
           );
         }}

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -407,4 +407,5 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
   link.setAttribute('href', encodedDataUrl);
   link.setAttribute('download', `${filename} ${getUtcDateString(now)}.csv`);
   link.click();
+  link.remove();
 }

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -382,23 +382,24 @@ export function decodeScalar(
 
 export function downloadAsCsv(tableData, filename) {
   const {meta, data} = tableData;
-  if (meta !== undefined) {
-    const headings = Object.keys(meta);
-
-    const csvContent = Papa.unparse({
-      fields: headings,
-      data: data.map(row => {
-        return headings.map(col => disableMacros(row[col]));
-      }),
-    });
-
-    const encodedDataUrl = encodeURI(`data:text/csv;charset=utf8,${csvContent}`);
-
-    // Create a download link then click it, this is so we can get a filename
-    const link = document.createElement('a');
-    const now = new Date();
-    link.setAttribute('href', encodedDataUrl);
-    link.setAttribute('download', `${filename} ${getUtcDateString(now)}.csv`);
-    link.click();
+  if (meta === undefined) {
+    return;
   }
+  const headings = Object.keys(meta);
+
+  const csvContent = Papa.unparse({
+    fields: headings,
+    data: data.map(row => {
+      return headings.map(col => disableMacros(row[col]));
+    }),
+  });
+
+  const encodedDataUrl = encodeURI(`data:text/csv;charset=utf8,${csvContent}`);
+
+  // Create a download link then click it, this is so we can get a filename
+  const link = document.createElement('a');
+  const now = new Date();
+  link.setAttribute('href', encodedDataUrl);
+  link.setAttribute('download', `${filename} ${getUtcDateString(now)}.csv`);
+  link.click();
 }

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -1,3 +1,4 @@
+import Papa from 'papaparse';
 import partial from 'lodash/partial';
 import pick from 'lodash/pick';
 import isString from 'lodash/isString';
@@ -8,7 +9,9 @@ import {t} from 'app/locale';
 import {Event, Organization} from 'app/types';
 import {Client} from 'app/api';
 import {getTitle} from 'app/utils/events';
+import {getUtcDateString} from 'app/utils/dates';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
+import {disableMacros} from 'app/views/discover/result/utils';
 import {generateQueryWithTag} from 'app/utils';
 import {
   COL_WIDTH_UNDEFINED,
@@ -375,4 +378,27 @@ export function decodeScalar(
       ? value
       : undefined;
   return isString(unwrapped) ? unwrapped : undefined;
+}
+
+export function downloadAsCsv(tableData, filename) {
+  const {meta, data} = tableData;
+  if (meta !== undefined) {
+    const headings = Object.keys(meta);
+
+    const csvContent = Papa.unparse({
+      fields: headings,
+      data: data.map(row => {
+        return headings.map(col => disableMacros(row[col]));
+      }),
+    });
+
+    const encodedDataUrl = encodeURI(`data:text/csv;charset=utf8,${csvContent}`);
+
+    // Create a download link then click it, this is so we can get a filename
+    const link = document.createElement('a');
+    const now = new Date();
+    link.setAttribute('href', encodedDataUrl);
+    link.setAttribute('download', `${filename} ${getUtcDateString(now)}.csv`);
+    link.click();
+  }
 }

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -381,10 +381,7 @@ export function decodeScalar(
 }
 
 export function downloadAsCsv(tableData, columnOrder, filename) {
-  const {meta, data} = tableData;
-  if (!meta) {
-    return;
-  }
+  const {data} = tableData;
   const headings = columnOrder.map(column => column.name);
 
   const csvContent = Papa.unparse({

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -380,17 +380,25 @@ export function decodeScalar(
   return isString(unwrapped) ? unwrapped : undefined;
 }
 
-export function downloadAsCsv(tableData, filename) {
+export function downloadAsCsv(tableData, columnOrder, filename) {
   const {meta, data} = tableData;
-  if (meta === undefined) {
+  if (!meta) {
     return;
   }
-  const headings = Object.keys(meta);
+  const headings = columnOrder.map(column => column.name);
 
   const csvContent = Papa.unparse({
     fields: headings,
     data: data.map(row => {
-      return headings.map(col => disableMacros(row[col]));
+      return headings.map(col => {
+        // alias for project doesn't match the table data name
+        if (col === 'project') {
+          col = 'project.name';
+        } else {
+          col = getAggregateAlias(col);
+        }
+        return disableMacros(row[col]);
+      });
     }),
   });
 


### PR DESCRIPTION
- Added a downloadAsCsv function that's mostly identical to the v1
  version, I wanted to have it separate to not impact v1 at all.
- Using the page title as the csv filename, eg. if you're on project
  summary the export will include that in the filename.
- TODO: need to change the export icon still
![download as csv](https://user-images.githubusercontent.com/4205004/72370972-562bd780-36d1-11ea-997d-7e866e3573a9.gif)