### PR TITLE
ref: Deregister DjangoEvent from event serializer

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -8,7 +8,7 @@ from semaphore import meta_with_chunks
 
 from sentry import eventstore
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.models import Event as DjangoEvent, EventAttachment, EventError, Release, UserReport
+from sentry.models import EventAttachment, EventError, Release, UserReport
 from sentry.search.utils import convert_user_tag_to_query
 from sentry.utils.safe import get_path
 from sentry.sdk_updates import get_suggested_updates, SdkSetupState
@@ -29,7 +29,6 @@ def get_crash_files(events):
     return rv
 
 
-@register(DjangoEvent)
 @register(Event)
 class EventSerializer(Serializer):
     _reserved_keys = frozenset(["user", "sdk", "device", "contexts"])


### PR DESCRIPTION
We no longer need to serialize Django events