### PR TITLE
ref(social auth): remove unused identity disconnector

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -265,11 +265,6 @@ urlpatterns += [
                     ),
                 ),
                 url(
-                    r"^settings/identities/(?P<identity_id>[^\/]+)/disconnect/$",
-                    accounts.disconnect_identity,
-                    name="sentry-account-disconnect-identity",
-                ),
-                url(
                     r"^settings/identities/associate/(?P<organization_slug>[^\/]+)/(?P<provider_key>[^\/]+)/(?P<external_id>[^\/]+)/$",
                     AccountIdentityAssociateView.as_view(),
                     name="sentry-account-associate-identity",


### PR DESCRIPTION
Disconnection of identities happens like this: `"DELETE /api/0/users/me/social-identities/2/ HTTP/1.1" 204`

Which maps to the `sentry-api-0-user-social-identity-details` urlname. This was introduced in https://github.com/getsentry/sentry/pull/6913.

If you look at `src/sentry/api/endpoints/user_social_identity_details.py` you'll see duplicated code with `disconnect_identity` in `src/sentry/web/frontend/accounts.py`, which maps to the `sentry-account-disconnect-identity` urlname, usage of which introduced [here](https://github.com/getsentry/sentry/pull/4247/files#diff-20fe7d69ca81d5f0f40867ded857e19bR30) and was removed [here](https://github.com/getsentry/sentry/pull/9028/files#diff-20fe7d69ca81d5f0f40867ded857e19bL30).