### PR TITLE
ref(discover2) Use date conditions when looking for reference events

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -28,11 +28,13 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         if orderby:
             return orderby
 
-    def reference_event(self, request, organization):
+    def reference_event(self, request, organization, params):
         fields = request.GET.getlist("field")[:]
         reference_event_id = request.GET.get("referenceEvent")
         if reference_event_id:
-            return ReferenceEvent(organization, reference_event_id, fields)
+            return ReferenceEvent(
+                organization, reference_event_id, fields, params.get("start"), params.get("end")
+            )
 
     def get_snuba_query_args_legacy(self, request, organization):
         params = self.get_filter_params(request, organization)

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -28,13 +28,11 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         if orderby:
             return orderby
 
-    def reference_event(self, request, organization, params):
+    def reference_event(self, request, organization, start, end):
         fields = request.GET.getlist("field")[:]
         reference_event_id = request.GET.get("referenceEvent")
         if reference_event_id:
-            return ReferenceEvent(
-                organization, reference_event_id, fields, params.get("start"), params.get("end")
-            )
+            return ReferenceEvent(organization, reference_event_id, fields, start, end)
 
     def get_snuba_query_args_legacy(self, request, organization):
         params = self.get_filter_params(request, organization)

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -47,7 +47,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         if fields:
             event_slug = u"{}:{}".format(project.slug, event_id)
             reference = discover.ReferenceEvent(
-                organization, event_slug, fields, event.timestamp, event.timestamp
+                organization, event_slug, fields, event.datetime, event.datetime
             )
         try:
             pagination = discover.get_pagination_ids(

--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -46,7 +46,9 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
         fields = request.query_params.getlist("field")
         if fields:
             event_slug = u"{}:{}".format(project.slug, event_id)
-            reference = discover.ReferenceEvent(organization, event_slug, fields)
+            reference = discover.ReferenceEvent(
+                organization, event_slug, fields, event.timestamp, event.timestamp
+            )
         try:
             pagination = discover.get_pagination_ids(
                 event=event,

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -113,7 +113,9 @@ class OrganizationEventsV2Endpoint(OrganizationEventsEndpointBase):
                 selected_columns=request.GET.getlist("field")[:],
                 query=request.GET.get("query"),
                 params=params,
-                reference_event=self.reference_event(request, organization, params),
+                reference_event=self.reference_event(
+                    request, organization, params.get("start"), params.get("end")
+                ),
                 orderby=self.get_orderby(request),
                 offset=offset,
                 limit=limit,

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -113,7 +113,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsEndpointBase):
                 selected_columns=request.GET.getlist("field")[:],
                 query=request.GET.get("query"),
                 params=params,
-                reference_event=self.reference_event(request, organization),
+                reference_event=self.reference_event(request, organization, params),
                 orderby=self.get_orderby(request),
                 offset=offset,
                 limit=limit,

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -38,7 +38,9 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                 query=request.GET.get("query"),
                 params=params,
                 rollup=self.get_rollup(request),
-                reference_event=self.reference_event(request, organization, params),
+                reference_event=self.reference_event(
+                    request, organization, params.get("start"), params.get("end")
+                ),
                 referrer="api.organization-event-stats",
             )
         except InvalidSearchQuery as err:

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -38,7 +38,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
                 query=request.GET.get("query"),
                 params=params,
                 rollup=self.get_rollup(request),
-                reference_event=self.reference_event(request, organization),
+                reference_event=self.reference_event(request, organization, params),
                 referrer="api.organization-event-stats",
             )
         except InvalidSearchQuery as err:


### PR DESCRIPTION
I originally wanted to remove the reference event query entirely. This wasn't feasible because the data in nodestore and snuba differ dramatically in how they are structured, and traversing into nodestore data to find public event fields would require non-trivial amounts of code that would be fragile and hard to test in the future.

By applying date conditions we can give better hints to clickhouse about where to look for the requested event.