### PR TITLE
test: upgrade mock backport

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -41,7 +41,7 @@ maxminddb==1.4.1
 # for vsts repo
 mistune>0.7,<0.9
 mmh3>=2.3.1,<2.4
-mock==2.0.0
+mock==3.0.5
 msgpack>=0.6.1,<0.7.0
 oauth2>=1.5.167
 parsimonious==0.8.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -41,7 +41,7 @@ maxminddb==1.4.1
 # for vsts repo
 mistune>0.7,<0.9
 mmh3>=2.3.1,<2.4
-mock==3.0.5
+mock==3.0.5 ; python_version < "3.3"
 msgpack>=0.6.1,<0.7.0
 oauth2>=1.5.167
 parsimonious==0.8.0

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -43,7 +43,7 @@ from django.test import override_settings, TestCase, TransactionTestCase
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from exam import before, fixture, Exam
-from mock import patch
+from sentry.utils.compat.mock import patch
 from pkg_resources import iter_entry_points
 from rest_framework.test import APITestCase as BaseAPITestCase
 from six.moves.urllib.parse import urlencode

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -27,7 +27,7 @@ import pytest
 import requests
 import six
 import types
-import mock
+from sentry.utils.compat import mock
 
 from click.testing import CliRunner
 from datetime import datetime

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -5,7 +5,7 @@ __all__ = ["Feature", "with_feature"]
 import six
 import collections
 from contextlib import contextmanager
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 
 @contextmanager

--- a/src/sentry/testutils/helpers/options.py
+++ b/src/sentry/testutils/helpers/options.py
@@ -4,7 +4,7 @@ __all__ = ["override_options"]
 
 from django.test.utils import override_settings
 from contextlib import contextmanager
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 
 @contextmanager

--- a/src/sentry/utils/compat/__init__.py
+++ b/src/sentry/utils/compat/__init__.py
@@ -7,12 +7,6 @@ try:
 except ImportError:
     import pickle  # NOQA
 
-try:
-    # TODO: remove when we drop Python 2.7 compat
-    import mock
-except ImportError:
-    from unittest import mock
-
 
 def _identity(x):
     return x

--- a/src/sentry/utils/compat/__init__.py
+++ b/src/sentry/utils/compat/__init__.py
@@ -7,6 +7,12 @@ try:
 except ImportError:
     import pickle  # NOQA
 
+try:
+    # TODO: remove when we drop Python 2.7 compat
+    import mock
+except ImportError:
+    from unittest import mock
+
 
 def _identity(x):
     return x

--- a/src/sentry/utils/compat/mock.py
+++ b/src/sentry/utils/compat/mock.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+
+try:
+    # TODO: remove when we drop Python 2.7 compat
+    from mock import *  # NOQA
+except ImportError:
+    from unittest.mock import *  # NOQA

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import os
 
 from django.conf import settings

--- a/tests/acceptance/test_create_project.py
+++ b/tests/acceptance/test_create_project.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from sentry.testutils import AcceptanceTestCase
 from sentry.models import Project
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 
 class CreateProjectTest(AcceptanceTestCase):

--- a/tests/acceptance/test_onboarding.py
+++ b/tests/acceptance/test_onboarding.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 from selenium.common.exceptions import TimeoutException
 
 from sentry.models import Project

--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import pytz
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -5,7 +5,7 @@ import six
 import pytest
 import pytz
 import time
-from mock import patch
+from sentry.utils.compat.mock import patch
 from datetime import timedelta
 
 from six.moves.urllib.parse import urlencode

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -9,7 +9,7 @@ from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 from tests.acceptance.page_objects.issue_list import IssueListPage
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 
 event_time = before_now(days=3).replace(tzinfo=pytz.utc)

--- a/tests/acceptance/test_organization_rate_limits.py
+++ b/tests/acceptance/test_organization_rate_limits.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.utils import timezone
-from mock import Mock, patch
+from sentry.utils.compat.mock import Mock, patch
 
 from sentry.testutils import AcceptanceTestCase
 

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -6,7 +6,7 @@ import os
 import datetime
 import json
 import logging
-import mock
+from sentry.utils.compat import mock
 import six
 from time import sleep
 import zlib

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from datetime import datetime
-from mock import patch
+from sentry.utils.compat.mock import patch
 import pytest
 import pytz
 

--- a/tests/sentry/api/bases/test_endpoint.py
+++ b/tests/sentry/api/bases/test_endpoint.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from mock import Mock
+from sentry.utils.compat.mock import Mock
 
 from sentry.testutils import TestCase
 

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.http import Http404
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.testutils import TestCase
 from sentry.api.bases.sentryapps import (

--- a/tests/sentry/api/endpoints/test_auth_login.py
+++ b/tests/sentry/api/endpoints/test_auth_login.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import six
 from django.core.urlresolvers import reverse
-from mock import patch
+from sentry.utils.compat.mock import patch
 from exam import fixture
 
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from hashlib import sha1
 
 from django.core.urlresolvers import reverse

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-import mock
+from sentry.utils.compat import mock
 import six
 from base64 import b64encode
 

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import six
-import mock
+from sentry.utils.compat import mock
 import copy
 
 from sentry.integrations.example.integration import ExampleIntegration

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import responses
 
 from exam import fixture
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.models import Activity, ExternalIssue, Group, GroupLink, Integration
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -5,7 +5,7 @@ import six
 from base64 import b64encode
 from django.core.urlresolvers import reverse
 from django.core import mail
-from mock import patch
+from sentry.utils.compat.mock import patch
 from exam import fixture
 from pprint import pprint
 

--- a/tests/sentry/api/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/api/endpoints/test_organization_incident_details.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from datetime import datetime
 
-import mock
+from sentry.utils.compat import mock
 import pytz
 import six
 from django.utils import timezone

--- a/tests/sentry/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repos.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from sentry.models import Integration
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_organization_invite_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_details.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from exam import fixture
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.models import (
     AuditLogEntry,

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from exam import fixture
-from mock import patch
+from sentry.utils.compat.mock import patch
 from django.core import mail
 
 from sentry.models import AuthProvider, InviteStatus, OrganizationOption, OrganizationMember

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -5,7 +5,7 @@ import six
 from django.core import mail
 from django.core.urlresolvers import reverse
 from django.db.models import F
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.models import (
     Authenticator,

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from django.core.urlresolvers import reverse
 from django.core import mail

--- a/tests/sentry/api/endpoints/test_organization_release_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_release_assemble.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from hashlib import sha1
 
 from django.core.urlresolvers import reverse

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import unittest
-from mock import patch
+from sentry.utils.compat.mock import patch
 from datetime import datetime
 
 import pytz

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from base64 import b64encode
 from datetime import datetime, timedelta

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import six
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from django.core.urlresolvers import reverse
 

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from django.core.urlresolvers import reverse
 

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.testutils import APITestCase
 import responses

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import six
 
 from django.core.urlresolvers import reverse

--- a/tests/sentry/api/endpoints/test_project_plugin_details.py
+++ b/tests/sentry/api/endpoints/test_project_plugin_details.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 from django.core.urlresolvers import reverse
 
 from sentry.plugins.base import plugins

--- a/tests/sentry/api/endpoints/test_project_plugins.py
+++ b/tests/sentry/api/endpoints/test_project_plugins.py
@@ -4,7 +4,7 @@ from django.core.urlresolvers import reverse
 
 from sentry.plugins.base import plugins
 from sentry.testutils import APITestCase
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 
 class ProjectPluginsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 
 from django.core.urlresolvers import reverse
 

--- a/tests/sentry/api/endpoints/test_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_project_transfer.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 
 from django.core import mail
 from django.core.urlresolvers import reverse

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 from django.core.urlresolvers import reverse
-from mock import patch, call
+from sentry.utils.compat.mock import patch, call
 
 from sentry.coreapi import APIError
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -6,7 +6,7 @@ from sentry.models import SentryApp, OrganizationMember
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import with_feature
 from sentry.utils import json
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 
 class SentryAppDetailsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 
-import mock
+from sentry.utils.compat import mock
 from sentry.testutils import APITestCase
 from sentry.constants import SentryAppStatus
 

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 import re
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from django.core.urlresolvers import reverse
 
 from sentry.constants import SentryAppStatus

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 from django.core.urlresolvers import reverse
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.models import AuditLogEntry, AuditLogEntryEvent, Team, TeamStatus, DeletedTeam
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_user_authenticator_details.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_details.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import datetime
-import mock
+from sentry.utils.compat import mock
 import six
 
 from django.core.urlresolvers import reverse

--- a/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 
 from six.moves.urllib.parse import parse_qsl
 from django.core.urlresolvers import reverse

--- a/tests/sentry/api/endpoints/test_user_emails_confirm.py
+++ b/tests/sentry/api/endpoints/test_user_emails_confirm.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 
 from django.core.urlresolvers import reverse
 

--- a/tests/sentry/api/endpoints/test_user_password.py
+++ b/tests/sentry/api/endpoints/test_user_password.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 
 from django.core.urlresolvers import reverse
 

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch, Mock
+from sentry.utils.compat.mock import patch, Mock
 from django.http import QueryDict
 
 from sentry.models import GroupStatus

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -8,7 +8,7 @@ import six
 from datetime import timedelta
 
 from django.utils import timezone
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializer

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import six
 
 from datetime import timedelta

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import zlib
 import pytest
 

--- a/tests/sentry/auth/providers/test_saml2.py
+++ b/tests/sentry/auth/providers/test_saml2.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, print_function
 
 import pytest
-import mock
+from sentry.utils.compat import mock
 
 from sentry.auth.providers.saml2.provider import SAML2Provider, Attributes
 

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.contrib.auth.models import AnonymousUser
-from mock import Mock
+from sentry.utils.compat.mock import Mock
 
 from sentry.auth import access
 from sentry.models import AuthProvider, AuthIdentity, Organization, ObjectStatus

--- a/tests/sentry/auth/test_superuser.py
+++ b/tests/sentry/auth/test_superuser.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from django.contrib.auth.models import AnonymousUser
 from django.core import signing
 from django.utils import timezone
-from mock import Mock
+from sentry.utils.compat.mock import Mock
 
 from sentry.auth.superuser import (
     COOKIE_DOMAIN,

--- a/tests/sentry/buffer/base/tests.py
+++ b/tests/sentry/buffer/base/tests.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 
 from datetime import timedelta
 from django.utils import timezone

--- a/tests/sentry/buffer/redis/tests.py
+++ b/tests/sentry/buffer/redis/tests.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 import pytest
-import mock
+from sentry.utils.compat import mock
 
 from datetime import datetime
 from django.utils import timezone

--- a/tests/sentry/coreapi/test_auth_from_request.py
+++ b/tests/sentry/coreapi/test_auth_from_request.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import pytest
 
 from django.core.exceptions import SuspiciousOperation

--- a/tests/sentry/db/test_mixin.py
+++ b/tests/sentry/db/test_mixin.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.models import OrganizationOption, Repository
 from sentry.testutils import TestCase

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 from uuid import uuid4
 
 from sentry.models import (

--- a/tests/sentry/deletions/test_repository.py
+++ b/tests/sentry/deletions/test_repository.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from django.core import mail
 

--- a/tests/sentry/event_manager/interfaces/test_stacktrace.py
+++ b/tests/sentry/event_manager/interfaces/test_stacktrace.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 
 import pytest
-import mock
+from sentry.utils.compat import mock
 from django.conf import settings
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, print_function
 
 import logging
-import mock
+from sentry.utils.compat import mock
 import pytest
 import uuid
 

--- a/tests/sentry/eventstore/test_base.py
+++ b/tests/sentry/eventstore/test_base.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import logging
-import mock
+from sentry.utils.compat import mock
 import pytest
 import six
 

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import pickle
 import pytest
 

--- a/tests/sentry/eventstream/kafka/test_state.py
+++ b/tests/sentry/eventstream/kafka/test_state.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import pytest
-import mock
+from sentry.utils.compat import mock
 from sentry.eventstream.kafka.state import (
     InvalidState,
     InvalidStateTransition,

--- a/tests/sentry/features/test_helpers.py
+++ b/tests/sentry/features/test_helpers.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from contextlib import contextmanager
 from django.http import HttpRequest
 from rest_framework.response import Response
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry import features
 from sentry.features import OrganizationFeature

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import responses
 from exam import fixture
-from mock import Mock
+from sentry.utils.compat.mock import Mock
 from requests.exceptions import SSLError
 
 import sentry.identity

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -8,7 +8,7 @@ from django.db import IntegrityError, transaction
 from django.utils import timezone
 from exam import patcher
 from freezegun import freeze_time
-from mock import Mock, patch
+from sentry.utils.compat.mock import Mock, patch
 
 from sentry.db.models.manager import BaseManager
 from sentry.incidents.models import AlertRuleTriggerAction, Incident, IncidentStatus

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -10,7 +10,7 @@ import six
 from django.utils import timezone
 from exam import fixture, patcher
 from freezegun import freeze_time
-from mock import call, Mock
+from sentry.utils.compat.mock import call, Mock
 
 from sentry.incidents.logic import (
     create_alert_rule,

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -4,7 +4,7 @@ import six
 from django.core.urlresolvers import reverse
 from exam import fixture, patcher
 from freezegun import freeze_time
-from mock import Mock, patch
+from sentry.utils.compat.mock import Mock, patch
 
 from sentry.incidents.logic import (
     create_alert_rule_trigger,

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import responses
-import mock
+from sentry.utils.compat import mock
 
 from sentry.testutils import TestCase
 from sentry.models import Integration

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import responses
 import sentry
 
-from mock import MagicMock
+from sentry.utils.compat.mock import MagicMock
 from six.moves.urllib.parse import urlencode, urlparse
 
 from sentry.constants import ObjectStatus

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import responses
 import six
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from exam import fixture
 from django.test import RequestFactory
 

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import datetime
-import mock
+from sentry.utils.compat import mock
 import responses
 import pytest
 

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -17,7 +17,7 @@ from .testutils import (
 )
 from sentry import options
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 
 class WebhookTest(APITestCase):

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import responses
 import six
-from mock import patch
+from sentry.utils.compat.mock import patch
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse
 
 from sentry.integrations.github_enterprise import GitHubEnterpriseIntegrationProvider

--- a/tests/sentry/integrations/github_enterprise/test_issues.py
+++ b/tests/sentry/integrations/github_enterprise/test_issues.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import responses
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from exam import fixture
 from django.test import RequestFactory
 

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -16,7 +16,7 @@ from .testutils import (
     PULL_REQUEST_CLOSED_EVENT_EXAMPLE,
 )
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 
 class WebhookTest(APITestCase):

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -4,7 +4,7 @@ import responses
 import six
 
 from six.moves.urllib.parse import parse_qs, urlencode, urlparse
-from mock import patch, Mock
+from sentry.utils.compat.mock import patch, Mock
 
 from sentry.integrations.gitlab import GitlabIntegrationProvider
 from sentry.models import (

--- a/tests/sentry/integrations/jira/test_configure.py
+++ b/tests/sentry/integrations/jira/test_configure.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from jwt import ExpiredSignatureError
 
 from django.core.urlresolvers import reverse

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -9,7 +9,7 @@ import copy
 
 from django.core.urlresolvers import reverse
 from exam import fixture
-from mock import Mock
+from sentry.utils.compat.mock import Mock
 
 from sentry.integrations.exceptions import IntegrationError
 from sentry.models import (

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import json
-import mock
+from sentry.utils.compat import mock
 import responses
 import six
 import pytest

--- a/tests/sentry/integrations/jira/test_uninstalled.py
+++ b/tests/sentry/integrations/jira/test_uninstalled.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.constants import ObjectStatus
 from sentry.models import Integration

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import json
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from django.core.urlresolvers import reverse
 

--- a/tests/sentry/integrations/jira_server/test_webhooks.py
+++ b/tests/sentry/integrations/jira_server/test_webhooks.py
@@ -5,7 +5,7 @@ import responses
 
 from django.core.urlresolvers import reverse
 from exam import fixture
-from mock import patch
+from sentry.utils.compat.mock import patch
 from requests.exceptions import ConnectionError
 
 from sentry.integrations.jira_server.integration import JiraServerIntegration

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import copy
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.api.serializers import serialize, ExternalEventSerializer
 from sentry.testutils import APITestCase

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import responses
 
 from six.moves.urllib.parse import parse_qs
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.api import client
 from sentry import options

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import responses
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.models import (
     Identity,

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import json
-import mock
+from sentry.utils.compat import mock
 
 from sentry import options
 from sentry.utils.cache import memoize

--- a/tests/sentry/integrations/test_client.py
+++ b/tests/sentry/integrations/test_client.py
@@ -4,7 +4,7 @@ import pytest
 import responses
 
 from time import time
-from mock import Mock
+from sentry.utils.compat.mock import Mock
 from sentry.testutils import TestCase
 
 from sentry.integrations.exceptions import (

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.models import IdentityProvider, Identity, Integration, OrganizationIntegration
 from sentry.testutils import IntegrationTestCase

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import pytest
 import six
 import responses
-from mock import patch, Mock
+from sentry.utils.compat.mock import patch, Mock
 
 from sentry.identity.vsts import VSTSIdentityProvider
 from sentry.integrations.exceptions import IntegrationError

--- a/tests/sentry/integrations/vsts/test_provider.py
+++ b/tests/sentry/integrations/vsts/test_provider.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-from mock import Mock, patch
+from sentry.utils.compat.mock import Mock, patch
 import responses
 from django.http import HttpRequest
 from sentry.identity.vsts.provider import VSTSOAuth2CallbackView, VSTSIdentityProvider

--- a/tests/sentry/integrations/vsts/test_webhooks.py
+++ b/tests/sentry/integrations/vsts/test_webhooks.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import responses
-from mock import patch
+from sentry.utils.compat.mock import patch
 from time import time
 
 from sentry.testutils import APITestCase

--- a/tests/sentry/integrations/vsts_extension/test_provider.py
+++ b/tests/sentry/integrations/vsts_extension/test_provider.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
-from mock import patch
+from sentry.utils.compat.mock import patch
 from six.moves.urllib.parse import urlparse, parse_qs
 
 from sentry.integrations.vsts import VstsIntegrationProvider

--- a/tests/sentry/lang/javascript/test_plugin.py
+++ b/tests/sentry/lang/javascript/test_plugin.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 import os.path
 import responses
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry import eventstore
 from sentry.models import File, Release, ReleaseFile

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -8,7 +8,7 @@ import unittest
 from symbolic import SourceMapTokenMatch
 
 from copy import deepcopy
-from mock import patch
+from sentry.utils.compat.mock import patch
 from requests.exceptions import RequestException
 
 from sentry import http, options

--- a/tests/sentry/loader/test_browsersdkversion.py
+++ b/tests/sentry/loader/test_browsersdkversion.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 
 from django.conf import settings
 from sentry.testutils import TestCase

--- a/tests/sentry/logging/test_handler.py
+++ b/tests/sentry/logging/test_handler.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import pytest
 import logging
-import mock
+from sentry.utils.compat import mock
 
 from sentry.logging.handlers import StructLogHandler
 

--- a/tests/sentry/mediators/sentry_app_components/test_preparer.py
+++ b/tests/sentry/mediators/sentry_app_components/test_preparer.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch, call
+from sentry.utils.compat.mock import patch, call
 
 from sentry.mediators.sentry_app_components import Preparer
 from sentry.testutils import TestCase

--- a/tests/sentry/mediators/sentry_app_installation_tokens/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installation_tokens/test_creator.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from datetime import date
 
 from sentry.mediators.sentry_app_installation_tokens import Creator

--- a/tests/sentry/mediators/sentry_app_installation_tokens/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installation_tokens/test_destroyer.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.mediators.sentry_app_installation_tokens import Destroyer
 from sentry.models import AuditLogEntry, ApiToken, SentryAppInstallationToken, SentryAppInstallation

--- a/tests/sentry/mediators/sentry_app_installations/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_creator.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import responses
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.constants import SentryAppInstallationStatus
 from sentry.mediators.sentry_app_installations import Creator

--- a/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import responses
 
 from django.db import connection
-from mock import patch
+from sentry.utils.compat.mock import patch
 from requests.exceptions import RequestException
 
 from sentry.mediators.sentry_app_installations import Creator, Destroyer

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from collections import namedtuple
 
 from sentry.coreapi import APIUnauthorized

--- a/tests/sentry/mediators/sentry_apps/test_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_creator.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from django.db import IntegrityError
 
 from sentry.mediators.sentry_apps import Creator

--- a/tests/sentry/mediators/sentry_apps/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_apps/test_destroyer.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.db import connection
-from mock import patch
+from sentry.utils.compat.mock import patch
 import responses
 
 from sentry.mediators.sentry_apps import Destroyer

--- a/tests/sentry/mediators/sentry_apps/test_internal_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_internal_creator.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch, MagicMock
+from sentry.utils.compat.mock import patch, MagicMock
 
 from sentry.mediators.sentry_apps import InternalCreator
 from sentry.models import AuditLogEntryEvent, SentryApp, SentryAppInstallation

--- a/tests/sentry/mediators/test_mediator.py
+++ b/tests/sentry/mediators/test_mediator.py
@@ -4,7 +4,7 @@ import logging
 import six
 import types
 
-from mock import patch, PropertyMock
+from sentry.utils.compat.mock import patch, PropertyMock
 
 from sentry.mediators import Mediator, Param
 from sentry.models import User

--- a/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
+++ b/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from datetime import datetime, timedelta
 
 from sentry.coreapi import APIUnauthorized

--- a/tests/sentry/mediators/token_exchange/test_refresher.py
+++ b/tests/sentry/mediators/token_exchange/test_refresher.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.coreapi import APIUnauthorized
 from sentry.models import ApiApplication, ApiToken, SentryApp, SentryAppInstallation

--- a/tests/sentry/mediators/token_exchange/test_validator.py
+++ b/tests/sentry/mediators/token_exchange/test_validator.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.token_exchange import Validator

--- a/tests/sentry/metrics/test_datadog.py
+++ b/tests/sentry/metrics/test_datadog.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from datadog.util.hostname import get_hostname
 

--- a/tests/sentry/metrics/test_statsd.py
+++ b/tests/sentry/metrics/test_statsd.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.metrics.statsd import StatsdMetricsBackend
 from sentry.testutils import TestCase

--- a/tests/sentry/middleware/test_health.py
+++ b/tests/sentry/middleware/test_health.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.test import RequestFactory
 from exam import fixture
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.middleware.health import HealthCheck
 from sentry.status_checks import Problem

--- a/tests/sentry/middleware/test_stats.py
+++ b/tests/sentry/middleware/test_stats.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.test import RequestFactory
 from exam import fixture
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.middleware.stats import RequestTimingMiddleware, add_request_metric_tags
 from sentry.testutils import TestCase

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import pytest
 import six
 

--- a/tests/sentry/models/test_groupsnooze.py
+++ b/tests/sentry/models/test_groupsnooze.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import itertools
-import mock
+from sentry.utils.compat import mock
 import pytest
 
 from datetime import datetime, timedelta

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import copy
-import mock
+from sentry.utils.compat import mock
 
 from sentry.models import (
     ApiKey,

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from datetime import timedelta
 from django.core import mail
 from django.utils import timezone
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.auth import manager
 from sentry.models import InviteStatus, OrganizationMember, INVITE_DAYS_VALID

--- a/tests/sentry/models/test_recentsearch.py
+++ b/tests/sentry/models/test_recentsearch.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from datetime import timedelta
 
 from django.utils import timezone
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.testutils import TestCase
 from sentry.models.recentsearch import RecentSearch, remove_excess_recent_searches

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -5,7 +5,7 @@ import six
 
 from django.utils import timezone
 from freezegun import freeze_time
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.api.exceptions import InvalidRepository
 from sentry.models import (

--- a/tests/sentry/net/test_socket.py
+++ b/tests/sentry/net/test_socket.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import pytest
-from mock import patch
+from sentry.utils.compat.mock import patch
 from django.core.exceptions import SuspiciousOperation
 
 from sentry.testutils import TestCase

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 from exam import fixture, around
-from mock import patch
+from sentry.utils.compat.mock import patch
 from django.conf import settings
 from django.core.cache.backends.locmem import LocMemCache
 

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -6,7 +6,7 @@ from uuid import uuid1
 
 import pytest
 from exam import before, fixture
-from mock import patch
+from sentry.utils.compat.mock import patch
 from django.core.cache.backends.locmem import LocMemCache
 
 from sentry.models import Option

--- a/tests/sentry/plugins/bases/issue/tests.py
+++ b/tests/sentry/plugins/bases/issue/tests.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 
 from social_auth.models import UserSocialAuth
 

--- a/tests/sentry/plugins/bases/test_issue2.py
+++ b/tests/sentry/plugins/bases/test_issue2.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 import json
-import mock
+from sentry.utils.compat import mock
 
 from social_auth.models import UserSocialAuth
 

--- a/tests/sentry/plugins/helpers/tests.py
+++ b/tests/sentry/plugins/helpers/tests.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 from sentry.plugins.helpers import set_option, unset_option, get_option
 from sentry.testutils import TestCase
 

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from datetime import datetime
 
-import mock
+from sentry.utils.compat import mock
 import pytz
 import six
 from django.contrib.auth.models import AnonymousUser

--- a/tests/sentry/plugins/mail/tests.py
+++ b/tests/sentry/plugins/mail/tests.py
@@ -12,7 +12,7 @@ from django.core import mail
 from django.db.models import F
 from django.utils import timezone
 from exam import fixture
-from mock import Mock
+from sentry.utils.compat.mock import Mock
 
 from sentry.api.serializers import serialize, UserReportWithGroupSerializer
 from sentry.digests.notifications import build_digest, event_to_record

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 import pytest
-import mock
+from sentry.utils.compat import mock
 import six
 import time
 

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import six
 from hashlib import sha1
-from mock import patch
+from sentry.utils.compat.mock import patch
 from uuid import uuid4
 
 from sentry.models import (

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.models import Commit, GroupAssignee, GroupLink, Repository, Release
 from sentry.testutils import APITestCase

--- a/tests/sentry/rules/actions/test_notify_event.py
+++ b/tests/sentry/rules/actions/test_notify_event.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import MagicMock
+from sentry.utils.compat.mock import MagicMock
 
 from sentry.testutils.cases import RuleTestCase
 from sentry.rules.actions.notify_event import NotifyEventAction

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import MagicMock, patch
+from sentry.utils.compat.mock import MagicMock, patch
 
 from sentry.testutils.cases import RuleTestCase
 from sentry.rules.actions.notify_event_service import NotifyEventServiceAction

--- a/tests/sentry/rules/conditions/test_event_frequency.py
+++ b/tests/sentry/rules/conditions/test_event_frequency.py
@@ -4,7 +4,7 @@ import itertools
 import pytz
 from datetime import datetime, timedelta
 
-import mock
+from sentry.utils.compat import mock
 import six
 
 from sentry import tsdb

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import pytest
-import mock
+from sentry.utils.compat import mock
 from datetime import datetime, timedelta
 from django.utils import timezone
 

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 import pytest
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from datetime import datetime, timedelta
 
 from sentry import eventstore

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -5,7 +5,7 @@ import unittest
 from copy import deepcopy
 
 from exam import fixture, patcher
-from mock import Mock
+from sentry.utils.compat.mock import Mock
 
 from sentry.snuba.models import QuerySubscription
 from sentry.snuba.query_subscription_consumer import (

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 
 from datetime import timedelta
 from django.utils import timezone
-from mock import Mock, patch, ANY
+from sentry.utils.compat.mock import Mock, patch, ANY
 
 from sentry.models import Group, GroupSnooze, GroupStatus, ProjectOwnership
 from sentry.ownership.grammar import Rule, Matcher, Owner, dump_schema

--- a/tests/sentry/tasks/process_buffer/tests.py
+++ b/tests/sentry/tasks/process_buffer/tests.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 
 from sentry.tasks.process_buffer import process_incr, process_pending
 from sentry.testutils import TestCase

--- a/tests/sentry/tasks/test_activity.py
+++ b/tests/sentry/tasks/test_activity.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 
 from sentry.plugins.bases.notify import NotificationPlugin
 from sentry.testutils import PluginTestCase

--- a/tests/sentry/tasks/test_auto_resolve_issues.py
+++ b/tests/sentry/tasks/test_auto_resolve_issues.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from datetime import timedelta
 from django.utils import timezone

--- a/tests/sentry/tasks/test_beacon.py
+++ b/tests/sentry/tasks/test_beacon.py
@@ -4,7 +4,7 @@ import json
 import responses
 import sentry
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from uuid import uuid4
 
 from sentry import options

--- a/tests/sentry/tasks/test_check_auth.py
+++ b/tests/sentry/tasks/test_check_auth.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function
 
 from datetime import timedelta
 from django.utils import timezone
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.auth.providers.dummy import DummyProvider

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.core import mail
-from mock import patch
+from sentry.utils.compat.mock import patch
 from social_auth.models import UserSocialAuth
 
 from sentry.exceptions import InvalidIdentity, PluginError

--- a/tests/sentry/tasks/test_deletion.py
+++ b/tests/sentry/tasks/test_deletion.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from datetime import datetime, timedelta
-from mock import patch
+from sentry.utils.compat.mock import patch
 from uuid import uuid4
 
 import pytest

--- a/tests/sentry/tasks/test_enqueue_scheduled_jobs.py
+++ b/tests/sentry/tasks/test_enqueue_scheduled_jobs.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function
 from datetime import timedelta
 from django.utils import timezone
 from django.core.exceptions import ValidationError
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 import pytest
 

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.tasks.merge import merge_groups
 from sentry.models import Group, GroupEnvironment, GroupMeta, GroupRedirect, UserReport

--- a/tests/sentry/tasks/test_options.py
+++ b/tests/sentry/tasks/test_options.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from datetime import timedelta
 

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import functools
 from datetime import datetime, timedelta
 
-import mock
+from sentry.utils.compat import mock
 import pytest
 import pytz
 import copy

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -6,7 +6,7 @@ import pytest
 from celery import Task
 from collections import namedtuple
 from django.core.urlresolvers import reverse
-from mock import patch
+from sentry.utils.compat.mock import patch
 from requests.exceptions import RequestException
 
 from sentry.models import Rule, SentryApp, SentryAppInstallation

--- a/tests/sentry/tasks/test_servicehooks.py
+++ b/tests/sentry/tasks/test_servicehooks.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.tasks.servicehooks import get_payload_v0, process_service_hook
 from sentry.testutils import TestCase

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import uuid
 from time import time
 

--- a/tests/sentry/templatetags/test_sentry_assets.py
+++ b/tests/sentry/templatetags/test_sentry_assets.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.template import engines
-from mock import MagicMock
+from sentry.utils.compat.mock import MagicMock
 
 from sentry.testutils import TestCase
 

--- a/tests/sentry/templatetags/test_sentry_plugins.py
+++ b/tests/sentry/templatetags/test_sentry_plugins.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import MagicMock
+from sentry.utils.compat.mock import MagicMock
 from django.template import engines
 
 from sentry.plugins.base.v2 import Plugin2

--- a/tests/sentry/test_constants.py
+++ b/tests/sentry/test_constants.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.constants import (
     get_integration_id_for_marketing_slug,

--- a/tests/sentry/test_http.py
+++ b/tests/sentry/test_http.py
@@ -6,7 +6,7 @@ import pytest
 import tempfile
 
 from django.core.exceptions import SuspiciousOperation
-from mock import patch
+from sentry.utils.compat.mock import patch
 from urllib3.util.connection import HAS_IPV6
 
 from sentry import http

--- a/tests/sentry/testutils/helpers/test_faux.py
+++ b/tests/sentry/testutils/helpers/test_faux.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from unittest import TestCase
 from sentry.testutils.helpers.faux import faux

--- a/tests/sentry/tsdb/test_base.py
+++ b/tests/sentry/tsdb/test_base.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division
 
 import itertools
-import mock
+from sentry.utils.compat import mock
 import pytz
 
 from datetime import datetime, timedelta

--- a/tests/sentry/utils/email/tests.py
+++ b/tests/sentry/utils/email/tests.py
@@ -4,7 +4,7 @@ import functools
 
 import pytest
 from django.core import mail
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry import options
 from sentry.models import GroupEmailThread, User, UserOption

--- a/tests/sentry/utils/http/tests.py
+++ b/tests/sentry/utils/http/tests.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import unittest
 
 from exam import fixture

--- a/tests/sentry/utils/locking/test_lock.py
+++ b/tests/sentry/utils/locking/test_lock.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import pytest
 
 from sentry.testutils import TestCase

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -4,7 +4,7 @@ import unittest
 
 from datetime import timedelta
 from django.utils import timezone
-from mock import Mock
+from sentry.utils.compat.mock import Mock
 from uuid import uuid4
 
 from sentry.models import Commit, CommitAuthor, CommitFileChange, Release, Repository

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import pytest
 import thread
 from Queue import Full

--- a/tests/sentry/utils/test_cursors.py
+++ b/tests/sentry/utils/test_cursors.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import math
 
-from mock import Mock
+from sentry.utils.compat.mock import Mock
 
 from sentry.utils.cursors import build_cursor, Cursor
 

--- a/tests/sentry/utils/test_metrics.py
+++ b/tests/sentry/utils/test_metrics.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import pytest
 
 from sentry.utils import metrics

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import functools
 import logging
-import mock
+from sentry.utils.compat import mock
 import pytest
 
 from sentry.exceptions import InvalidConfiguration

--- a/tests/sentry/utils/test_retries.py
+++ b/tests/sentry/utils/test_retries.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 
 from unittest import TestCase
 from sentry.utils.retries import TimedRetryPolicy, RetryException

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -5,7 +5,7 @@ from functools import partial
 import pytest
 import unittest
 
-from mock import patch, Mock
+from sentry.utils.compat.mock import patch, Mock
 from sentry.testutils import TestCase
 from sentry.utils.canonical import CanonicalKeyDict
 from sentry.utils.safe import safe_execute, trim, trim_dict, get_path, set_path, setdefault_path

--- a/tests/sentry/utils/test_urllib3_timeout.py
+++ b/tests/sentry/utils/test_urllib3_timeout.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import pytest
 
 from urllib3 import HTTPConnectionPool

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -7,7 +7,7 @@ from sentry.utils.compat import mock
 from django.core.urlresolvers import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 from exam import fixture
-from mock import Mock
+from sentry.utils.compat.mock import Mock
 from six import BytesIO
 
 from sentry.coreapi import APIRateLimited

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 
 from django.core.urlresolvers import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import pytest
-import mock
+from sentry.utils.compat import mock
 
 from django.conf import settings
 from django.core.urlresolvers import reverse

--- a/tests/sentry/web/frontend/test_auth_oauth2.py
+++ b/tests/sentry/web/frontend/test_auth_oauth2.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import six
 from exam import fixture
 from six.moves.urllib.parse import urlencode, urlparse, parse_qs

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 import pytest
 import base64
-import mock
+from sentry.utils.compat import mock
 from exam import fixture
 from six.moves.urllib.parse import urlencode, urlparse, parse_qs
 

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from exam import fixture
 from django.conf import settings
 from django.core.urlresolvers import reverse

--- a/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
+++ b/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-import mock
+from sentry.utils.compat import mock
 
 from django.core.urlresolvers import reverse
 

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
 from django.db import models
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.models import (

--- a/tests/sentry/web/frontend/test_release_webhook.py
+++ b/tests/sentry/web/frontend/test_release_webhook.py
@@ -5,7 +5,7 @@ import hmac
 from django.core.urlresolvers import reverse
 from exam import fixture
 from hashlib import sha256
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.models import ProjectOption
 from sentry.testutils import TestCase

--- a/tests/sentry_plugins/amazon_sqs/test_plugin.py
+++ b/tests/sentry_plugins/amazon_sqs/test_plugin.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from botocore.client import ClientError
 from exam import fixture
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.testutils import PluginTestCase
 from sentry.utils import json

--- a/tests/sentry_plugins/github/test_provider.py
+++ b/tests/sentry_plugins/github/test_provider.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import responses
 
 from exam import fixture
-from mock import patch
+from sentry.utils.compat.mock import patch
 from social_auth.models import UserSocialAuth
 from sentry.models import Integration, OrganizationIntegration, Repository
 from sentry.testutils import PluginTestCase

--- a/tests/sentry_plugins/heroku/test_plugin.py
+++ b/tests/sentry_plugins/heroku/test_plugin.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from mock import Mock, patch
+from sentry.utils.compat.mock import Mock, patch
 
 from django.utils import timezone
 

--- a/tests/sentry_plugins/test_client.py
+++ b/tests/sentry_plugins/test_client.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import pytest
 import responses
 
-from mock import Mock
+from sentry.utils.compat.mock import Mock
 from sentry.testutils import TestCase
 
 from sentry_plugins.exceptions import (

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-import mock
+from sentry.utils.compat import mock
 
 from sentry.models import Environment
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 from django.core.urlresolvers import reverse
 from django.utils import timezone
-from mock import patch, Mock
+from sentry.utils.compat.mock import patch, Mock
 
 from sentry.models import (
     Activity,

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 import six
 from django.utils import timezone
 from exam import fixture
-from mock import patch, Mock
+from sentry.utils.compat.mock import patch, Mock
 
 from sentry.models import (
     Activity,

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -8,7 +8,7 @@ import six
 from datetime import timedelta
 
 from django.utils import timezone
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import (

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -2,7 +2,7 @@
 
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import six
 
 from datetime import timedelta

--- a/tests/snuba/eventstream/test_eventstream.py
+++ b/tests/snuba/eventstream/test_eventstream.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import six
 import time
 import logging
-from mock import patch, Mock
+from sentry.utils.compat.mock import patch, Mock
 
 from sentry.event_manager import EventManager
 from sentry.eventstream.kafka import KafkaEventStream

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import mock
+from sentry.utils.compat import mock
 import pytz
 from datetime import datetime, timedelta
 from django.utils import timezone

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -8,7 +8,7 @@ from confluent_kafka import Producer
 from django.conf import settings
 from django.test.utils import override_settings
 from exam import fixture
-from mock import call, Mock
+from sentry.utils.compat.mock import call, Mock
 
 from sentry.snuba.models import QuerySubscription
 from sentry.snuba.query_subscription_consumer import (

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 import pytz
 
-from mock import patch
+from sentry.utils.compat.mock import patch
 from django.utils import timezone
 
 from sentry import eventstream, tagstore

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -8,7 +8,7 @@ import requests
 import six
 
 from django.conf import settings
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from sentry.models import GroupHash, GroupRelease, Release
 from sentry.tsdb.base import TSDBModel

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import pytest
 import zipfile
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from six import BytesIO
 

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import pytest
 import zipfile
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from six import BytesIO
 

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import pytest
 import zipfile
-from mock import patch
+from sentry.utils.compat.mock import patch
 
 from six import BytesIO
 


### PR DESCRIPTION
This bumps the mock backport to latest, which is rolling, so we have more similar parallel py2/3 testing environments in the future. I'm also adding the appropriate dependency specifier.

I originally did

```
$ fastmod --extensions py '^from mock import ?(.*?)\n' '
try:
    # TODO: remove when we drop Python 2.7 compat
    from mock import ${1}
except ImportError:
    from unittest.mock import ${1}
'
```

But that resulted in `+1,353 −198`, and then I realized I can just move this to compat.

