### PR TITLE
ref(ui): Remove direct usage of Indicator store....

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/account.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/account.jsx
@@ -1,6 +1,6 @@
 import {Client} from 'app/api';
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import ConfigStore from 'app/stores/configStore';
-import IndicatorStore from 'app/stores/indicatorStore';
 
 export function disconnectIdentity(identity) {
   const api = new Client();
@@ -10,10 +10,10 @@ export function disconnectIdentity(identity) {
 
   request
     .then(() => {
-      IndicatorStore.addSuccess(`Disconnected ${identity.providerLabel}`);
+      addSuccessMessage(`Disconnected ${identity.providerLabel}`);
     })
     .catch(() => {
-      IndicatorStore.addError('Error disconnecting identity');
+      addErrorMessage('Error disconnecting identity');
     });
 
   return request;

--- a/src/sentry/static/sentry/app/actionCreators/organizations.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/organizations.jsx
@@ -1,8 +1,8 @@
 import {browserHistory} from 'react-router';
 
-import {resetGlobalSelection} from 'app/actionCreators/globalSelection';
 import {Client} from 'app/api';
-import IndicatorStore from 'app/stores/indicatorStore';
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import {resetGlobalSelection} from 'app/actionCreators/globalSelection';
 import OrganizationActions from 'app/actions/organizationActions';
 import OrganizationsActions from 'app/actions/organizationsActions';
 import OrganizationsStore from 'app/stores/organizationsStore';
@@ -39,14 +39,14 @@ export function remove(api, {successMessage, errorMessage, orgId} = {}) {
       OrganizationsActions.removeSuccess(orgId);
 
       if (successMessage) {
-        IndicatorStore.add(successMessage, 'success', {duration: 3000});
+        addSuccessMessage(successMessage);
       }
     })
     .catch(() => {
       OrganizationsActions.removeError();
 
       if (errorMessage) {
-        IndicatorStore.add(errorMessage, 'error', {duration: 3000});
+        addErrorMessage(errorMessage);
       }
     });
 }

--- a/src/sentry/static/sentry/app/actionCreators/plugins.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/plugins.jsx
@@ -1,7 +1,11 @@
+import {Client} from 'app/api';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
 import PluginActions from 'app/actions/pluginActions';
-import IndicatorStore from 'app/stores/indicatorStore';
-import {Client} from 'app/api';
 
 const activeFetch = {};
 // PluginsStore always exists, so api client should be independent of component lifecycle
@@ -85,10 +89,10 @@ export function fetchPlugins({orgId, projectId}, options) {
  * @return Promise
  */
 export function enablePlugin(params) {
-  IndicatorStore.add(t('Enabling...'));
+  addLoadingMessage(t('Enabling...'));
   return doUpdate({...params, update: {enabled: true}, method: 'POST'})
-    .then(() => IndicatorStore.addSuccess(t('Plugin was enabled')))
-    .catch(() => IndicatorStore.addError(t('Unable to enable plugin')));
+    .then(() => addSuccessMessage(t('Plugin was enabled')))
+    .catch(() => addErrorMessage(t('Unable to enable plugin')));
 }
 
 /**
@@ -100,8 +104,8 @@ export function enablePlugin(params) {
  * @param {string} params.pluginId Plugin ID
  */
 export function disablePlugin(params) {
-  IndicatorStore.add(t('Disabling...'));
+  addLoadingMessage(t('Disabling...'));
   return doUpdate({...params, update: {enabled: false}, method: 'DELETE'})
-    .then(() => IndicatorStore.addSuccess(t('Plugin was disabled')))
-    .catch(() => IndicatorStore.addError(t('Unable to disable plugin')));
+    .then(() => addSuccessMessage(t('Plugin was disabled')))
+    .catch(() => addErrorMessage(t('Unable to disable plugin')));
 }

--- a/src/sentry/static/sentry/app/components/bases/pluginComponentBase.jsx
+++ b/src/sentry/static/sentry/app/components/bases/pluginComponentBase.jsx
@@ -3,7 +3,12 @@ import isFunction from 'lodash/isFunction';
 
 import {Client} from 'app/api';
 import {FormState, GenericField} from 'app/components/forms';
-import IndicatorStore from 'app/stores/indicatorStore';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+  clearIndicators,
+} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
 
 const callbackWithArgs = function(callback, ...args) {
@@ -74,9 +79,7 @@ class PluginComponentBase extends React.Component {
       },
       callbackWithArgs(callback, ...args)
     );
-    IndicatorStore.add(t('An error occurred.'), 'error', {
-      duration: 3000,
-    });
+    addErrorMessage(t('An error occurred.'));
   }
 
   onSave(callback, ...args) {
@@ -89,7 +92,7 @@ class PluginComponentBase extends React.Component {
         state: FormState.SAVING,
       },
       () => {
-        this._loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+        addLoadingMessage(t('Saving changes..'));
         callback && callback();
       }
     );
@@ -102,9 +105,7 @@ class PluginComponentBase extends React.Component {
       },
       callbackWithArgs(callback, ...args)
     );
-    IndicatorStore.add(t('Success!'), 'success', {
-      duration: 3000,
-    });
+    addSuccessMessage(t('Success!'));
   }
 
   onSaveError(callback, ...args) {
@@ -114,16 +115,14 @@ class PluginComponentBase extends React.Component {
         state: FormState.ERROR,
       },
       () => {
-        IndicatorStore.add(t('Unable to save changes. Please try again.'), 'error', {
-          duration: 3000,
-        });
+        addErrorMessage(t('Unable to save changes. Please try again.'));
         callback && callback();
       }
     );
   }
 
   onSaveComplete(callback, ...args) {
-    IndicatorStore.remove(this._loadingIndicator);
+    clearIndicators();
     callback = callbackWithArgs(callback, ...args);
     callback && callback();
   }

--- a/src/sentry/static/sentry/app/components/clipboard.tsx
+++ b/src/sentry/static/sentry/app/components/clipboard.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import IndicatorStore from 'app/stores/indicatorStore';
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 
 type Props = {
   value: string;
@@ -66,7 +66,7 @@ class Clipboard extends React.Component<Props> {
     this.clipboard
       .on('success', () => {
         if (!hideMessages) {
-          IndicatorStore.add(successMessage, 'success', {duration: 2000});
+          addSuccessMessage(successMessage);
         }
         if (onSuccess && hasSuccessCb) {
           onSuccess();
@@ -74,7 +74,7 @@ class Clipboard extends React.Component<Props> {
       })
       .on('error', () => {
         if (!hideMessages) {
-          IndicatorStore.add(errorMessage, 'error', {duration: 2000});
+          addErrorMessage(errorMessage);
         }
         if (onError && hasErrorCb) {
           onError();

--- a/src/sentry/static/sentry/app/components/forms/apiForm.tsx
+++ b/src/sentry/static/sentry/app/components/forms/apiForm.tsx
@@ -1,10 +1,14 @@
 import PropTypes from 'prop-types';
 
-import {Client, APIRequestMethod} from 'app/api';
-import IndicatorStore from 'app/stores/indicatorStore';
+import {APIRequestMethod, Client} from 'app/api';
+import {
+  addLoadingMessage,
+  clearIndicators,
+  addErrorMessage,
+} from 'app/actionCreators/indicator';
+import {t} from 'app/locale';
 import Form from 'app/components/forms/form';
 import FormState from 'app/components/forms/state';
-import {t} from 'app/locale';
 
 type Props = Form['props'] & {
   onSubmit?: (data: object) => void;
@@ -51,17 +55,16 @@ export default class ApiForm extends Form<Props> {
         state: FormState.SAVING,
       },
       () => {
-        const loadingIndicator = IndicatorStore.add(this.props.submitLoadingMessage);
+        addLoadingMessage(this.props.submitLoadingMessage);
         this.api.request(this.props.apiEndpoint, {
           method: this.props.apiMethod,
           data,
           success: result => {
-            IndicatorStore.remove(loadingIndicator);
+            clearIndicators();
             this.onSubmitSuccess(result);
           },
           error: error => {
-            IndicatorStore.remove(loadingIndicator);
-            IndicatorStore.add(this.props.submitErrorMessage, 'error');
+            addErrorMessage(this.props.submitErrorMessage);
             this.onSubmitError(error);
           },
         });

--- a/src/sentry/static/sentry/app/components/group/sidebar.jsx
+++ b/src/sentry/static/sentry/app/components/group/sidebar.jsx
@@ -1,23 +1,22 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import isEqual from 'lodash/isEqual';
-import pickBy from 'lodash/pickBy';
-import keyBy from 'lodash/keyBy';
 import isObject from 'lodash/isObject';
+import keyBy from 'lodash/keyBy';
+import pickBy from 'lodash/pickBy';
 
+import {addLoadingMessage, clearIndicators} from 'app/actionCreators/indicator';
+import {t, tct} from 'app/locale';
 import ErrorBoundary from 'app/components/errorBoundary';
-import SentryTypes from 'app/sentryTypes';
-import withApi from 'app/utils/withApi';
-import SuggestedOwners from 'app/components/group/suggestedOwners';
+import ExternalIssueList from 'app/components/group/externalIssuesList';
 import GroupParticipants from 'app/components/group/participants';
 import GroupReleaseStats from 'app/components/group/releaseStats';
-import IndicatorStore from 'app/stores/indicatorStore';
 import GroupTagDistributionMeter from 'app/components/group/tagDistributionMeter';
 import LoadingError from 'app/components/loadingError';
+import SentryTypes from 'app/sentryTypes';
 import SubscribeButton from 'app/components/subscribeButton';
-import {t, tct} from 'app/locale';
-
-import ExternalIssueList from 'app/components/group/externalIssuesList';
+import SuggestedOwners from 'app/components/group/suggestedOwners';
+import withApi from 'app/utils/withApi';
 
 const SUBSCRIPTION_REASONS = {
   commented: t("You're receiving updates because you have commented on this issue."),
@@ -111,7 +110,7 @@ class GroupSidebar extends React.Component {
 
   toggleSubscription() {
     const {api, group, project, organization} = this.props;
-    const loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+    addLoadingMessage(t('Saving changes..'));
 
     api.bulkUpdate(
       {
@@ -130,13 +129,13 @@ class GroupSidebar extends React.Component {
                 participants: data,
                 error: false,
               });
-              IndicatorStore.remove(loadingIndicator);
+              clearIndicators();
             },
             error: () => {
               this.setState({
                 error: true,
               });
-              IndicatorStore.remove(loadingIndicator);
+              clearIndicators();
             },
           });
         },

--- a/src/sentry/static/sentry/app/components/issues/compactIssue.jsx
+++ b/src/sentry/static/sentry/app/components/issues/compactIssue.jsx
@@ -5,12 +5,12 @@ import createReactClass from 'create-react-class';
 import styled from '@emotion/styled';
 
 import {PanelItem} from 'app/components/panels';
+import {addLoadingMessage, clearIndicators} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
 import DropdownLink from 'app/components/dropdownLink';
 import ErrorLevel from 'app/components/events/errorLevel';
 import GroupChart from 'app/components/stream/groupChart';
 import GroupStore from 'app/stores/groupStore';
-import IndicatorStore from 'app/stores/indicatorStore';
 import Link from 'app/components/links/link';
 import SentryTypes from 'app/sentryTypes';
 import SnoozeAction from 'app/components/issues/snoozeAction';
@@ -166,7 +166,7 @@ const CompactIssue = createReactClass({
 
   onUpdate(data) {
     const issue = this.state.issue;
-    const loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+    addLoadingMessage(t('Saving changes..'));
 
     this.props.api.bulkUpdate(
       {
@@ -177,7 +177,7 @@ const CompactIssue = createReactClass({
       },
       {
         complete: () => {
-          IndicatorStore.remove(loadingIndicator);
+          clearIndicators();
         },
       }
     );

--- a/src/sentry/static/sentry/app/components/projects/missingProjectMembership.jsx
+++ b/src/sentry/static/sentry/app/components/projects/missingProjectMembership.jsx
@@ -2,14 +2,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 
-import EmptyMessage from 'app/views/settings/components/emptyMessage';
-import IndicatorStore from 'app/stores/indicatorStore';
+import {addErrorMessage} from 'app/actionCreators/indicator';
 import {joinTeam} from 'app/actionCreators/teams';
+import {t} from 'app/locale';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import HeroIcon from 'app/components/heroIcon';
 import Well from 'app/components/well';
-import withApi from 'app/utils/withApi';
 import space from 'app/styles/space';
-import {t} from 'app/locale';
+import withApi from 'app/utils/withApi';
 
 class MissingProjectMembership extends React.Component {
   static propTypes = {
@@ -54,10 +54,7 @@ class MissingProjectMembership extends React.Component {
             loading: false,
             error: true,
           });
-          IndicatorStore.add(
-            t('There was an error while trying to leave the team.'),
-            'error'
-          );
+          addErrorMessage(t('There was an error while trying to leave the team.'));
         },
       }
     );

--- a/src/sentry/static/sentry/app/stores/groupingStore.jsx
+++ b/src/sentry/static/sentry/app/stores/groupingStore.jsx
@@ -1,8 +1,12 @@
 import Reflux from 'reflux';
 import pick from 'lodash/pick';
 
-import IndicatorStore from 'app/stores/indicatorStore';
 import {Client} from 'app/api';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'app/actionCreators/indicator';
 import GroupingActions from 'app/actions/groupingActions';
 
 const api = new Client();
@@ -249,18 +253,16 @@ const GroupingStore = Reflux.createStore({
         busy: true,
       });
       this.triggerUnmergeState();
-      const loadingIndicator = IndicatorStore.add(loadingMessage);
+      addLoadingMessage(loadingMessage);
 
       api.request(`/issues/${groupId}/hashes/`, {
         method: 'DELETE',
         query: {
           id: ids,
         },
-        success: (data, _, jqXHR) => {
-          IndicatorStore.remove(loadingIndicator);
-          IndicatorStore.add(successMessage, 'success', {
-            duration: 5000,
-          });
+        success: () => {
+          addSuccessMessage(successMessage);
+
           // Busy rows after successful merge
           this.setStateForId(this.unmergeState, ids, {
             checked: false,
@@ -269,8 +271,7 @@ const GroupingStore = Reflux.createStore({
           this.unmergeList.clear();
         },
         error: () => {
-          IndicatorStore.remove(loadingIndicator);
-          IndicatorStore.add(errorMessage, 'error');
+          addErrorMessage(errorMessage);
           this.setStateForId(this.unmergeState, ids, {
             checked: true,
             busy: false,
@@ -295,7 +296,7 @@ const GroupingStore = Reflux.createStore({
     });
     this.triggerMergeState();
 
-    const promise = new Promise((resolve, reject) => {
+    const promise = new Promise(resolve => {
       // Disable merge button
 
       if (params) {
@@ -308,7 +309,7 @@ const GroupingStore = Reflux.createStore({
             query,
           },
           {
-            success: (data, _, jqXHR) => {
+            success: data => {
               if (data && data.merge && data.merge.parent) {
                 this.trigger({
                   mergedParent: data.merge.parent,

--- a/src/sentry/static/sentry/app/views/integrationInstallation.tsx
+++ b/src/sentry/static/sentry/app/views/integrationInstallation.tsx
@@ -1,19 +1,19 @@
+import {RouteComponentProps} from 'react-router/lib/Router';
 import React from 'react';
 import styled from '@emotion/styled';
-import {RouteComponentProps} from 'react-router/lib/Router';
 
+import {Organization, IntegrationProvider, Integration} from 'app/types';
+import {addErrorMessage} from 'app/actionCreators/indicator';
 import {t, tct} from 'app/locale';
+import {trackIntegrationEvent} from 'app/utils/integrationUtil';
 import AddIntegration from 'app/views/organizationIntegrations/addIntegration';
 import Alert from 'app/components/alert';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import Field from 'app/views/settings/components/forms/field';
 import HookStore from 'app/stores/hookStore';
-import IndicatorStore from 'app/stores/indicatorStore';
 import NarrowLayout from 'app/components/narrowLayout';
 import SelectControl from 'app/components/forms/selectControl';
-import {Organization, IntegrationProvider, Integration} from 'app/types';
-import {trackIntegrationEvent} from 'app/utils/integrationUtil';
 
 type Props = RouteComponentProps<{providerId: string; installationId: string}, {}>;
 
@@ -85,7 +85,7 @@ export default class IntegrationInstallation extends AsyncView<Props, State> {
         this.setState({organization, reloading}, this.trackOpened),
       error: () => {
         this.setState({reloading});
-        IndicatorStore.addError(t('Failed to retrieve organization details'));
+        addErrorMessage(t('Failed to retrieve organization details'));
       },
     });
 
@@ -94,7 +94,7 @@ export default class IntegrationInstallation extends AsyncView<Props, State> {
         this.setState({providers: providers.providers, reloading}),
       error: () => {
         this.setState({reloading});
-        IndicatorStore.addError(t('Failed to retrieve integration provider details'));
+        addErrorMessage(t('Failed to retrieve integration provider details'));
       },
     });
   };

--- a/src/sentry/static/sentry/app/views/issueList/actions.jsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.jsx
@@ -6,6 +6,7 @@ import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import styled from '@emotion/styled';
 
+import {addLoadingMessage, clearIndicators} from 'app/actionCreators/indicator';
 import {t, tct, tn} from 'app/locale';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
@@ -15,7 +16,6 @@ import DropdownLink from 'app/components/dropdownLink';
 import ExternalLink from 'app/components/links/externalLink';
 import GroupStore from 'app/stores/groupStore';
 import IgnoreActions from 'app/components/actions/ignore';
-import IndicatorStore from 'app/stores/indicatorStore';
 import MenuItem from 'app/components/menuItem';
 import Projects from 'app/utils/projects';
 import ResolveActions from 'app/components/actions/resolve';
@@ -236,7 +236,7 @@ const IssueListActions = createReactClass({
   handleUpdate(data) {
     const {selection} = this.props;
     this.actionSelectedGroups(itemIds => {
-      const loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+      addLoadingMessage(t('Saving changes..'));
 
       // If `itemIds` is undefined then it means we expect to bulk update all items
       // that match the query.
@@ -258,7 +258,7 @@ const IssueListActions = createReactClass({
         },
         {
           complete: () => {
-            IndicatorStore.remove(loadingIndicator);
+            clearIndicators();
           },
         }
       );
@@ -266,8 +266,9 @@ const IssueListActions = createReactClass({
   },
 
   handleDelete() {
-    const loadingIndicator = IndicatorStore.add(t('Removing events..'));
     const {selection} = this.props;
+
+    addLoadingMessage(t('Removing events..'));
 
     this.actionSelectedGroups(itemIds => {
       this.props.api.bulkDelete(
@@ -281,7 +282,7 @@ const IssueListActions = createReactClass({
         },
         {
           complete: () => {
-            IndicatorStore.remove(loadingIndicator);
+            clearIndicators();
           },
         }
       );
@@ -289,8 +290,9 @@ const IssueListActions = createReactClass({
   },
 
   handleMerge() {
-    const loadingIndicator = IndicatorStore.add(t('Merging events..'));
     const {selection} = this.props;
+
+    addLoadingMessage(t('Merging events..'));
 
     this.actionSelectedGroups(itemIds => {
       this.props.api.merge(
@@ -304,7 +306,7 @@ const IssueListActions = createReactClass({
         },
         {
           complete: () => {
-            IndicatorStore.remove(loadingIndicator);
+            clearIndicators();
           },
         }
       );

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
@@ -3,29 +3,32 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 
-import GroupActions from 'app/actions/groupActions';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  clearIndicators,
+} from 'app/actionCreators/indicator';
+import {analytics} from 'app/utils/analytics';
 import {openModal} from 'app/actionCreators/modal';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
-import IndicatorStore from 'app/stores/indicatorStore';
-import {analytics} from 'app/utils/analytics';
 import {uniqueId} from 'app/utils/guid';
-import withApi from 'app/utils/withApi';
-import withOrganization from 'app/utils/withOrganization';
-import EventView from 'app/views/eventsV2/eventView';
-
-import Feature from 'app/components/acl/feature';
-import FeatureDisabled from 'app/components/acl/featureDisabled';
-import IgnoreActions from 'app/components/actions/ignore';
-import ResolveActions from 'app/components/actions/resolve';
-import GuideAnchor from 'app/components/assistant/guideAnchor';
 import Button from 'app/components/button';
 import DropdownLink from 'app/components/dropdownLink';
+import EventView from 'app/views/eventsV2/eventView';
+import Feature from 'app/components/acl/feature';
+import FeatureDisabled from 'app/components/acl/featureDisabled';
+import GroupActions from 'app/actions/groupActions';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
+import IgnoreActions from 'app/components/actions/ignore';
 import Link from 'app/components/links/link';
 import LinkWithConfirmation from 'app/components/links/linkWithConfirmation';
 import MenuItem from 'app/components/menuItem';
+import ResolveActions from 'app/components/actions/resolve';
+import SentryTypes from 'app/sentryTypes';
 import ShareIssue from 'app/components/shareIssue';
 import space from 'app/styles/space';
+import withApi from 'app/utils/withApi';
+import withOrganization from 'app/utils/withOrganization';
 
 class DeleteActions extends React.Component {
   static propTypes = {
@@ -162,7 +165,7 @@ const GroupDetailsActions = createReactClass({
 
   onDelete() {
     const {group, project, organization} = this.props;
-    const loadingIndicator = IndicatorStore.add(t('Delete event..'));
+    addLoadingMessage(t('Delete event..'));
 
     this.props.api.bulkDelete(
       {
@@ -172,7 +175,7 @@ const GroupDetailsActions = createReactClass({
       },
       {
         complete: () => {
-          IndicatorStore.remove(loadingIndicator);
+          clearIndicators();
 
           browserHistory.push(`/${organization.slug}/${project.slug}/`);
         },
@@ -182,7 +185,7 @@ const GroupDetailsActions = createReactClass({
 
   onUpdate(data) {
     const {group, project, organization} = this.props;
-    const loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+    addLoadingMessage(t('Saving changes..'));
 
     this.props.api.bulkUpdate(
       {
@@ -193,7 +196,7 @@ const GroupDetailsActions = createReactClass({
       },
       {
         complete: () => {
-          IndicatorStore.remove(loadingIndicator);
+          clearIndicators();
         },
       }
     );
@@ -215,7 +218,7 @@ const GroupDetailsActions = createReactClass({
       },
       {
         error: () => {
-          IndicatorStore.add(t('Error sharing'), 'error');
+          addErrorMessage(t('Error sharing'));
         },
         complete: () => {
           this.setState({shareBusy: false});
@@ -235,7 +238,7 @@ const GroupDetailsActions = createReactClass({
   onDiscard() {
     const {group, project, organization} = this.props;
     const id = uniqueId();
-    const loadingIndicator = IndicatorStore.add(t('Discarding event..'));
+    addLoadingMessage(t('Discarding event..'));
 
     GroupActions.discard(id, group.id);
 
@@ -250,7 +253,7 @@ const GroupDetailsActions = createReactClass({
         GroupActions.discardError(id, group.id, error);
       },
       complete: () => {
-        IndicatorStore.remove(loadingIndicator);
+        clearIndicators();
       },
     });
   },

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/SplitInstallationIdModal.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/SplitInstallationIdModal.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import Button from 'app/components/button';
 
 import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
-import IndicatorStore from 'app/stores/indicatorStore';
+import {addSuccessMessage} from 'app/actionCreators/indicator';
 
 type Props = {
   installationId: string;
@@ -30,7 +30,7 @@ export default class SplitInstallationIdModal extends React.Component<Props> {
   handleContinue = () => {
     const delay = 2000;
     this.onCopy();
-    IndicatorStore.add('Copied to clipboard', 'success', {duration: delay});
+    addSuccessMessage('Copied to clipboard');
     setTimeout(() => {
       window.open('https://app.split.io/org/admin/integrations');
     }, delay);

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegration.tsx
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import queryString from 'query-string';
 
-import {t} from 'app/locale';
-import IndicatorStore from 'app/stores/indicatorStore';
 import {IntegrationProvider, Integration} from 'app/types';
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import {t} from 'app/locale';
 
 type Props = {
   children: (
@@ -96,7 +96,7 @@ export default class AddIntegration extends React.Component<Props> {
     this.dialog = null;
 
     if (!success) {
-      IndicatorStore.addError(data.error);
+      addErrorMessage(data.error);
       return;
     }
 
@@ -104,7 +104,7 @@ export default class AddIntegration extends React.Component<Props> {
       return;
     }
     this.props.onInstall(data);
-    IndicatorStore.addSuccess(t(`${this.props.provider.name} added`));
+    addSuccessMessage(t('%s added', this.props.provider.name));
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseArtifacts.jsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseArtifacts.jsx
@@ -1,14 +1,18 @@
 import {Flex} from 'reflexbox';
-import omit from 'lodash/omit';
 import PropTypes from 'prop-types';
 import React from 'react';
+import omit from 'lodash/omit';
 
 import {Panel, PanelHeader, PanelBody, PanelItem} from 'app/components/panels';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import FileSize from 'app/components/fileSize';
-import IndicatorStore from 'app/stores/indicatorStore';
 import LinkWithConfirmation from 'app/components/links/linkWithConfirmation';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -75,7 +79,7 @@ class ReleaseArtifacts extends React.Component {
   };
 
   handleRemove(id) {
-    const loadingIndicator = IndicatorStore.add(t('Removing artifact..'));
+    addLoadingMessage(t('Removing artifact..'));
 
     this.props.api.request(this.getFilesEndpoint() + `${id}/`, {
       method: 'DELETE',
@@ -88,17 +92,10 @@ class ReleaseArtifacts extends React.Component {
           fileList,
         });
 
-        IndicatorStore.add(t('Artifact removed.'), 'success', {
-          duration: 4000,
-        });
+        addSuccessMessage(t('Artifact removed.'));
       },
       error: () => {
-        IndicatorStore.add(t('Unable to remove artifact. Please try again.'), 'error', {
-          duration: 4000,
-        });
-      },
-      complete: () => {
-        IndicatorStore.remove(loadingIndicator);
+        addErrorMessage(t('Unable to remove artifact. Please try again.'));
       },
     });
   }

--- a/src/sentry/static/sentry/app/views/sentryAppExternalInstallation.tsx
+++ b/src/sentry/static/sentry/app/views/sentryAppExternalInstallation.tsx
@@ -12,7 +12,6 @@ import {
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
 import {installSentryApp} from 'app/actionCreators/sentryAppInstallations';
-import {recordInteraction} from 'app/utils/recordSentryAppInteraction';
 import {t, tct} from 'app/locale';
 import Alert from 'app/components/alert';
 import AsyncView from 'app/views/asyncView';

--- a/src/sentry/static/sentry/app/views/sentryAppExternalInstallation.tsx
+++ b/src/sentry/static/sentry/app/views/sentryAppExternalInstallation.tsx
@@ -1,25 +1,26 @@
-import React from 'react';
 import {RouteComponentProps} from 'react-router/lib/Router';
-import styled from '@emotion/styled';
+import React from 'react';
 import get from 'lodash/get';
+import styled from '@emotion/styled';
 
-import {t, tct} from 'app/locale';
-import Alert from 'app/components/alert';
-import AsyncView from 'app/views/asyncView';
-import Field from 'app/views/settings/components/forms/field';
-import IndicatorStore from 'app/stores/indicatorStore';
-import NarrowLayout from 'app/components/narrowLayout';
-import SelectControl from 'app/components/forms/selectControl';
-import OrganizationAvatar from 'app/components/avatar/organizationAvatar';
-import SentryAppDetailsModal from 'app/components/modals/sentryAppDetailsModal';
-import {installSentryApp} from 'app/actionCreators/sentryAppInstallations';
-import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
 import {
   LightWeightOrganization,
   Organization,
   SentryApp,
   SentryAppInstallation,
 } from 'app/types';
+import {addErrorMessage} from 'app/actionCreators/indicator';
+import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
+import {installSentryApp} from 'app/actionCreators/sentryAppInstallations';
+import {recordInteraction} from 'app/utils/recordSentryAppInteraction';
+import {t, tct} from 'app/locale';
+import Alert from 'app/components/alert';
+import AsyncView from 'app/views/asyncView';
+import Field from 'app/views/settings/components/forms/field';
+import NarrowLayout from 'app/components/narrowLayout';
+import OrganizationAvatar from 'app/components/avatar/organizationAvatar';
+import SelectControl from 'app/components/forms/selectControl';
+import SentryAppDetailsModal from 'app/components/modals/sentryAppDetailsModal';
 
 type Props = RouteComponentProps<{sentryAppSlug: string}, {}>;
 
@@ -126,9 +127,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
       //all state fields should be set at the same time so analytics in SentryAppDetailsModal works properly
       this.setState({organization, isInstalled, reloading: false});
     } catch (err) {
-      IndicatorStore.addError(
-        t('Failed to retrieve organization or integration details')
-      );
+      addErrorMessage(t('Failed to retrieve organization or integration details'));
       this.setState({reloading: false});
     }
   };

--- a/src/sentry/static/sentry/app/views/settings/account/accountSubscriptions.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSubscriptions.jsx
@@ -2,15 +2,15 @@ import {Box} from 'reflexbox';
 import React from 'react';
 import styled from '@emotion/styled';
 
+import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import DateTime from 'app/components/dateTime';
-import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import Switch from 'app/components/switch';
-import IndicatorStore from 'app/stores/indicatorStore';
 import TextBlock from 'app/views/settings/components/text/textBlock';
-import EmptyMessage from 'app/views/settings/components/emptyMessage';
 
 const ENDPOINT = '/users/me/subscriptions/';
 
@@ -36,7 +36,7 @@ class AccountSubscriptions extends AsyncView {
     return 'Subscriptions';
   }
 
-  handleToggle = (subscription, index, e) => {
+  handleToggle = (subscription, index, _e) => {
     const subscribed = !subscription.subscribed;
     const oldSubscriptions = this.state.subscriptions;
 
@@ -59,13 +59,13 @@ class AccountSubscriptions extends AsyncView {
         listId: subscription.listId,
         subscribed,
       },
-      success: data => {
-        IndicatorStore.addSuccess(
+      success: () => {
+        addSuccessMessage(
           `${subscribed ? 'Subscribed' : 'Unsubscribed'} to ${subscription.listName}`
         );
       },
-      error: err => {
-        IndicatorStore.addError(
+      error: () => {
+        addErrorMessage(
           `Unable to ${subscribed ? '' : 'un'}subscribe to ${subscription.listName}`
         );
         this.setState({subscriptions: oldSubscriptions});

--- a/src/sentry/static/sentry/app/views/settings/components/forms/apiForm.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/apiForm.jsx
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {Client} from 'app/api';
-import IndicatorStore from 'app/stores/indicatorStore';
-import Form from 'app/views/settings/components/forms/form';
+import {addLoadingMessage, clearIndicators} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
+import Form from 'app/views/settings/components/forms/form';
 
 export default class ApiForm extends React.Component {
   static propTypes = {
@@ -25,16 +25,16 @@ export default class ApiForm extends React.Component {
 
   onSubmit = (data, onSuccess, onError) => {
     this.props.onSubmit && this.props.onSubmit(data);
-    const loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+    addLoadingMessage(t('Saving changes..'));
     this.api.request(this.props.apiEndpoint, {
       method: this.props.apiMethod,
       data,
       success: (...args) => {
-        IndicatorStore.remove(loadingIndicator);
+        clearIndicators();
         onSuccess(...args);
       },
       error: (...args) => {
-        IndicatorStore.remove(loadingIndicator);
+        clearIndicators();
         onError(...args);
       },
     });

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/index.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
-import IndicatorStore from 'app/stores/indicatorStore';
 import SentryTypes from 'app/sentryTypes';
 import routeTitleGen from 'app/utils/routeTitle';
 
@@ -13,7 +13,7 @@ class OrganizationAuth extends AsyncView {
     organization: SentryTypes.Organization,
   };
 
-  componentWillUpdate(nextProps, nextState) {
+  componentWillUpdate(_nextProps, nextState) {
     const access = this.context.organization.access;
 
     if (nextState.provider && access.includes('org:admin')) {
@@ -34,7 +34,7 @@ class OrganizationAuth extends AsyncView {
     return routeTitleGen(t('Auth Settings'), this.context.organization.slug, false);
   }
 
-  handleSendReminders = provider => {
+  handleSendReminders = _provider => {
     this.setState({sendRemindersBusy: true});
 
     this.api.request(
@@ -42,8 +42,8 @@ class OrganizationAuth extends AsyncView {
       {
         method: 'POST',
         data: {},
-        success: data => IndicatorStore.add(t('Sent reminders to members'), 'success'),
-        error: err => IndicatorStore.add(t('Failed to send reminders'), 'error'),
+        success: () => addSuccessMessage(t('Sent reminders to members')),
+        error: () => addErrorMessage(t('Failed to send reminders')),
         complete: () => this.setState({sendRemindersBusy: false}),
       }
     );
@@ -64,7 +64,7 @@ class OrganizationAuth extends AsyncView {
           window.location.href = data.auth_url;
         }
       },
-      error: err => {
+      error: () => {
         this.setState({busy: false});
       },
     });
@@ -79,13 +79,13 @@ class OrganizationAuth extends AsyncView {
     this.api.request(`/organizations/${this.props.params.orgId}/auth-provider/`, {
       method: 'DELETE',
       data: {provider},
-      success: data => {
+      success: () => {
         this.setState({
           provider: null,
           disableBusy: false,
         });
       },
-      error: err => {
+      error: () => {
         this.setState({disableBusy: false});
       },
     });

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamMembers.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamMembers.jsx
@@ -1,6 +1,6 @@
-import debounce from 'lodash/debounce';
 import PropTypes from 'prop-types';
 import React from 'react';
+import debounce from 'lodash/debounce';
 import styled from '@emotion/styled';
 
 import {Panel, PanelHeader} from 'app/components/panels';
@@ -17,7 +17,6 @@ import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 import DropdownButton from 'app/components/dropdownButton';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import IdBadge from 'app/components/idBadge';
-import IndicatorStore from 'app/stores/indicatorStore';
 import InlineSvg from 'app/components/inlineSvg';
 import Link from 'app/components/links/link';
 import LoadingError from 'app/components/loadingError';
@@ -89,15 +88,11 @@ class TeamMembers extends React.Component {
               return m.id !== member.id;
             }),
           });
-          IndicatorStore.add(t('Successfully removed member from team.'), 'success', {
-            duration: 2000,
-          });
+          addSuccessMessage(t('Successfully removed member from team.'));
         },
         error: () => {
-          IndicatorStore.add(
-            t('There was an error while trying to remove a member from the team.'),
-            'error',
-            {duration: 2000}
+          addErrorMessage(
+            t('There was an error while trying to remove a member from the team.')
           );
         },
       }

--- a/src/sentry/static/sentry/app/views/settings/project/projectServiceHookDetails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectServiceHookDetails.jsx
@@ -1,21 +1,24 @@
 import {browserHistory} from 'react-router';
 import React from 'react';
 
+import {Panel, PanelAlert, PanelBody, PanelHeader} from 'app/components/panels';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  clearIndicators,
+} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
 import AsyncView from 'app/views/asyncView';
-import {Panel, PanelAlert, PanelBody, PanelHeader} from 'app/components/panels';
 import Button from 'app/components/button';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import ErrorBoundary from 'app/components/errorBoundary';
 import Field from 'app/views/settings/components/forms/field';
-import getDynamicText from 'app/utils/getDynamicText';
-import IndicatorStore from 'app/stores/indicatorStore';
+import ServiceHookSettingsForm from 'app/views/settings/project/serviceHookSettingsForm';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import StackedBarChart from 'app/components/stackedBarChart';
 import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
-
-import ServiceHookSettingsForm from 'app/views/settings/project/serviceHookSettingsForm';
+import getDynamicText from 'app/utils/getDynamicText';
 
 class HookStats extends AsyncComponent {
   getEndpoints() {
@@ -37,7 +40,7 @@ class HookStats extends AsyncComponent {
     ];
   }
 
-  renderTooltip(point, pointIdx, chart) {
+  renderTooltip(point, _pointIdx, chart) {
     const timeLabel = chart.getTimeLabel(point);
     const [total] = point.y;
 
@@ -97,22 +100,15 @@ export default class ProjectServiceHookDetails extends AsyncView {
 
   onDelete = () => {
     const {orgId, projectId, hookId} = this.props.params;
-    const loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+    addLoadingMessage(t('Saving changes..'));
     this.api.request(`/projects/${orgId}/${projectId}/hooks/${hookId}/`, {
       method: 'DELETE',
       success: () => {
-        IndicatorStore.remove(loadingIndicator);
+        clearIndicators();
         browserHistory.push(`/settings/${orgId}/projects/${projectId}/hooks/`);
       },
       error: () => {
-        IndicatorStore.remove(loadingIndicator);
-        IndicatorStore.add(
-          t('Unable to remove application. Please try again.'),
-          'error',
-          {
-            duration: 3000,
-          }
-        );
+        addErrorMessage(t('Unable to remove application. Please try again.'));
       },
     });
   };

--- a/src/sentry/static/sentry/app/views/settings/project/projectServiceHooks.jsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectServiceHooks.jsx
@@ -1,14 +1,18 @@
-import PropTypes from 'prop-types';
 import {Link} from 'react-router';
+import PropTypes from 'prop-types';
 import React from 'react';
 
+import {Panel, PanelAlert, PanelBody, PanelHeader} from 'app/components/panels';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  clearIndicators,
+} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import Field from 'app/views/settings/components/forms/field';
-import IndicatorStore from 'app/stores/indicatorStore';
-import {Panel, PanelAlert, PanelBody, PanelHeader} from 'app/components/panels';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import Switch from 'app/components/switch';
 import Truncate from 'app/components/truncate';
@@ -67,14 +71,16 @@ export default class ProjectServiceHooks extends AsyncView {
 
   onToggleActive = hook => {
     const {orgId, projectId} = this.props.params;
-    const loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+
+    addLoadingMessage(t('Saving changes..'));
+
     this.api.request(`/projects/${orgId}/${projectId}/hooks/${hook.id}/`, {
       method: 'PUT',
       data: {
         isActive: hook.status !== 'active',
       },
       success: data => {
-        IndicatorStore.remove(loadingIndicator);
+        clearIndicators();
         const hookList = this.state.hookList.map(h => {
           if (h.id === data.id) {
             return {
@@ -87,14 +93,7 @@ export default class ProjectServiceHooks extends AsyncView {
         this.setState({hookList});
       },
       error: () => {
-        IndicatorStore.remove(loadingIndicator);
-        IndicatorStore.add(
-          t('Unable to remove application. Please try again.'),
-          'error',
-          {
-            duration: 3000,
-          }
-        );
+        addErrorMessage(t('Unable to remove application. Please try again.'));
       },
     });
   };

--- a/src/sentry/static/sentry/app/views/settings/projectPlugins/details.jsx
+++ b/src/sentry/static/sentry/app/views/settings/projectPlugins/details.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'app/actionCreators/indicator';
 import {disablePlugin, enablePlugin} from 'app/actionCreators/plugins';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
-import IndicatorStore from 'app/stores/indicatorStore';
 import PluginConfig from 'app/components/pluginConfig';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import withPlugins from 'app/utils/withPlugins';
@@ -42,18 +46,18 @@ class ProjectPluginDetails extends AsyncView {
 
   handleReset = () => {
     const {projectId, orgId, pluginId} = this.props.params;
-    const loadingIndicator = IndicatorStore.add(t('Saving changes..'));
+
+    addLoadingMessage(t('Saving changes..'));
     this.api.request(`/projects/${orgId}/${projectId}/plugins/${pluginId}/`, {
       method: 'POST',
       data: {reset: true},
       success: pluginDetails => {
         this.setState({pluginDetails});
-        IndicatorStore.addSuccess(t('Plugin was reset'));
+        addSuccessMessage(t('Plugin was reset'));
       },
       error: () => {
-        IndicatorStore.addError(t('An error occurred'));
+        addErrorMessage(t('An error occurred'));
       },
-      complete: () => IndicatorStore.remove(loadingIndicator),
     });
   };
 


### PR DESCRIPTION
Remove direct usage of Indicator store, use `addLoadingMessage`, `addSuccessMessage`, or `addErrorMessage` instead. This will also give us more consistent defaults for durations.