### PR TITLE
fix(workflow): Fix permissions for editing Metric Alert Rules

### DIFF
--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -15,7 +15,7 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize, CombinedRuleSerializer
-from sentry.incidents.endpoints.serializers import UnifiedAlertRuleSerializer
+from sentry.incidents.endpoints.serializers import AlertRuleSerializer
 from sentry.incidents.models import AlertRule
 from sentry.models import Rule, RuleStatus
 from sentry.utils.cursors import build_cursor, Cursor
@@ -104,7 +104,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
         data = deepcopy(request.data)
         data["projects"] = [project.slug]
 
-        serializer = UnifiedAlertRuleSerializer(
+        serializer = AlertRuleSerializer(
             context={"organization": project.organization, "access": request.access}, data=data
         )
 

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -15,7 +15,7 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize, CombinedRuleSerializer
-from sentry.incidents.endpoints.serializers import AlertRuleSerializer
+from sentry.incidents.endpoints.serializers import UnifiedAlertRuleSerializer
 from sentry.incidents.models import AlertRule
 from sentry.models import Rule, RuleStatus
 from sentry.utils.cursors import build_cursor, Cursor
@@ -103,7 +103,8 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
 
         data = deepcopy(request.data)
         data["projects"] = [project.slug]
-        serializer = AlertRuleSerializer(
+
+        serializer = UnifiedAlertRuleSerializer(
             context={"organization": project.organization, "access": request.access}, data=data
         )
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/actions.tsx
@@ -15,10 +15,11 @@ function isSavedRule(rule: IncidentRule): rule is SavedIncidentRule {
 export async function addOrUpdateRule(
   api: Client,
   orgId: string,
+  projectId: string,
   rule: IncidentRule
 ): Promise<unknown[]> {
   const isExisting = isSavedRule(rule);
-  const endpoint = `/organizations/${orgId}/alert-rules/${
+  const endpoint = `/projects/${orgId}/${projectId}/alert-rules/${
     isSavedRule(rule) ? `${rule.id}/` : ''
   }`;
   const method = isExisting ? 'PUT' : 'POST';

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/details.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/details.tsx
@@ -32,10 +32,10 @@ class IncidentRulesDetails extends AsyncView<Props, State> {
   }
 
   getEndpoints() {
-    const {orgId, incidentRuleId} = this.props.params;
+    const {orgId, projectId, incidentRuleId} = this.props.params;
 
     return [
-      ['rule', `/organizations/${orgId}/alert-rules/${incidentRuleId}/`] as [
+      ['rule', `/projects/${orgId}/${projectId}/alert-rules/${incidentRuleId}/`] as [
         string,
         string
       ],

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -188,13 +188,13 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       return;
     }
 
-    const {organization, rule, onSubmitSuccess} = this.props;
+    const {organization, params, rule, onSubmitSuccess} = this.props;
 
     // form model has all form state data, however we use local state to keep
     // track of the list of triggers (and actions within triggers)
     try {
       addLoadingMessage(t('Saving alert'));
-      const resp = await addOrUpdateRule(this.api, organization.slug, {
+      const resp = await addOrUpdateRule(this.api, organization.slug, params.projectId, {
         ...rule,
         ...model.getTransformedData(),
         triggers: this.state.triggers,
@@ -278,7 +278,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const {query, aggregation, timeWindow, triggers} = this.state;
 
     return (
-      <Access access={['org:write']}>
+      <Access access={['project:write']}>
         {({hasAccess}) => (
           <Form
             apiMethod={incidentRuleId ? 'PUT' : 'POST'}

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -37,7 +37,7 @@ describe('Incident Rules Details', function() {
     const {organization, routerContext} = initializeOrg();
     const rule = TestStubs.IncidentRule();
     const req = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/alert-rules/${rule.id}/`,
+      url: `/projects/${organization.slug}/project-slug/alert-rules/${rule.id}/`,
       body: rule,
     });
 
@@ -47,7 +47,7 @@ describe('Incident Rules Details', function() {
     });
 
     const editRule = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/alert-rules/${rule.id}/`,
+      url: `/projects/${organization.slug}/project-slug/alert-rules/${rule.id}/`,
       method: 'PUT',
       body: rule,
     });
@@ -58,6 +58,7 @@ describe('Incident Rules Details', function() {
         <IncidentRulesDetails
           params={{
             orgId: organization.slug,
+            projectId: 'project-slug',
             incidentRuleId: rule.id,
           }}
           organization={organization}

--- a/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
@@ -9,7 +9,7 @@ describe('Incident Rules Form', function() {
   const createWrapper = props =>
     mountWithTheme(
       <RuleFormContainer
-        params={{orgId: organization.slug}}
+        params={{orgId: organization.slug, projectId: project.slug}}
         organization={organization}
         project={project}
         {...props}
@@ -48,7 +48,7 @@ describe('Incident Rules Form', function() {
     let createRule;
     beforeEach(function() {
       createRule = MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/alert-rules/',
+        url: '/projects/org-slug/project-slug/alert-rules/',
         method: 'POST',
       });
     });
@@ -92,7 +92,7 @@ describe('Incident Rules Form', function() {
 
     beforeEach(function() {
       editRule = MockApiClient.addMockResponse({
-        url: `/organizations/org-slug/alert-rules/${rule.id}/`,
+        url: `/projects/org-slug/project-slug/alert-rules/${rule.id}/`,
         method: 'PUT',
         body: rule,
       });

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -96,7 +96,17 @@ class AlertRuleCreateEndpointTest(APITestCase):
                     "actions": [
                         {"type": "email", "targetType": "team", "targetIdentifier": self.team.id}
                     ],
-                }
+                },
+                {
+                    "label": "warning",
+                    "alertThreshold": 150,
+                    "resolveThreshold": 100,
+                    "thresholdType": 0,
+                    "actions": [
+                        {"type": "email", "targetType": "team", "targetIdentifier": self.team.id},
+                        {"type": "email", "targetType": "user", "targetIdentifier": self.user.id},
+                    ],
+                },
             ],
             "projects": [self.project.slug],
             "name": "JustAValidTestRule",


### PR DESCRIPTION
The UI was never updated to use the "project" scoped endpoint for metric alert rules. The UI also locked the form to require `org:write` access, instead of `project:write`.

Needs https://github.com/getsentry/sentry/pull/16408 and https://github.com/getsentry/sentry/pull/16151