### PR TITLE
fix(relay-projectconfigs): Do not crash on missing projects

### DIFF
--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -76,7 +76,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
 
         configs = {}
         for project_id in project_ids:
-            configs[six.text_type(project_id)] = None
+            configs[six.text_type(project_id)] = {"disabled": True}
 
             project = projects.get(int(project_id))
             if project is None:
@@ -114,6 +114,6 @@ class RelayProjectConfigsEndpoint(Endpoint):
                 )
 
         if full_config_requested:
-            projectconfig_cache.set_many(list(c for c in six.itervalues(configs) if c is not None))
+            projectconfig_cache.set_many(configs)
 
         return Response({"configs": configs}, status=200)

--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -114,6 +114,6 @@ class RelayProjectConfigsEndpoint(Endpoint):
                 )
 
         if full_config_requested:
-            projectconfig_cache.set_many(list(six.itervalues(configs)))
+            projectconfig_cache.set_many(list(c for c in six.itervalues(configs) if c is not None))
 
         return Response({"configs": configs}, status=200)

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -79,7 +79,7 @@ def get_project_config(project, org_options=None, full_config=True, project_keys
                 "piiConfig": _get_pii_config(project),
                 "datascrubbingSettings": _get_datascrubbing_settings(project, org_options),
             },
-            "projectId": project.id,
+            "projectId": project.id,  # XXX: Unused by Relay, required by Python store
         }
 
     if not full_config:

--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import six
+
 from sentry.relay.projectconfig_cache.base import ProjectConfigCache
 from sentry.utils import json
 from sentry.utils.redis import get_dynamic_cluster_from_options, validate_dynamic_cluster
@@ -28,14 +30,14 @@ class RedisProjectConfigCache(ProjectConfigCache):
             return self.cluster.get_local_client_for_key(routing_key)
 
     def set_many(self, configs):
-        for config in configs:
+        for project_id, config in six.iteritems(configs):
             # XXX(markus): Figure out how to do pipelining here. We may have
             # multiple routing keys (-> multiple clients).
             #
             # We cannot route by org, because Relay does not know the org when
             # fetching.
 
-            key = self.__get_redis_key(config["projectId"])
+            key = self.__get_redis_key(project_id)
             client = self.__get_redis_client(key)
             client.setex(key, REDIS_CACHE_TIMEOUT, json.dumps(config))
 

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -48,7 +48,10 @@ def update_config_cache(generate, organization_id=None, project_id=None, update_
 
     if generate:
         projectconfig_cache.set_many(
-            [get_project_config(project, full_config=True).to_dict() for project in projects]
+            {
+                project.id: get_project_config(project, full_config=True).to_dict()
+                for project in projects
+            }
         )
     else:
         projectconfig_cache.delete_many([project.id for project in projects])

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -99,8 +99,8 @@ def test_invalidate(
     redis_cache,
 ):
 
-    cfg = {"projectId": default_project.id, "foo": "bar"}
-    redis_cache.set_many([cfg])
+    cfg = {"foo": "bar"}
+    redis_cache.set_many({default_project.id: cfg})
     assert redis_cache.get(default_project.id) == cfg
 
     if not entire_organization:


### PR DESCRIPTION
If a nonexistant project was requested we should not cache the result in redis for now. ~Eventually we will have to implement negative caching though.~ DONE