### PR TITLE
fix(tasks) Change update_user_reports to use bulk queries

### DIFF
--- a/src/sentry/tasks/update_user_reports.py
+++ b/src/sentry/tasks/update_user_reports.py
@@ -34,7 +34,12 @@ def update_user_reports(**kwargs):
     for project_id, reports in six.iteritems(project_map):
         event_ids = [r.event_id for r in reports]
         report_by_event = {r.event_id: r for r in reports}
-        snuba_filter = eventstore.Filter(project_ids=[project_id], event_ids=event_ids)
+        snuba_filter = eventstore.Filter(
+            project_ids=[project_id],
+            event_ids=event_ids,
+            start=now - timedelta(days=2),
+            end=now + timedelta(minutes=5),  # Just to catch clock skew
+        )
         events = eventstore.get_events(filter=snuba_filter)
 
         for event in events:

--- a/tests/sentry/tasks/test_update_user_reports.py
+++ b/tests/sentry/tasks/test_update_user_reports.py
@@ -16,8 +16,10 @@ class UpdateUserReportTest(TestCase):
         event1 = self.store_event(data={}, project_id=project.id)
         report1 = UserReport.objects.create(project=project, event_id=event1.event_id)
         event2 = self.store_event(data={}, project_id=project.id)
-        report2 = UserReport.objects.create(
-            project=project, event_id=event2.event_id, date_added=now - timedelta(days=2)
+        report2 = UserReport.objects.create(project=project, event_id=event2.event_id)
+        event3 = self.store_event(data={}, project_id=project.id)
+        report3 = UserReport.objects.create(
+            project=project, event_id=event3.event_id, date_added=now - timedelta(days=2)
         )
 
         with self.tasks():
@@ -25,7 +27,10 @@ class UpdateUserReportTest(TestCase):
 
         report1 = UserReport.objects.get(project=project, event_id=event1.id)
         report2 = UserReport.objects.get(project=project, event_id=event2.id)
+        report3 = UserReport.objects.get(project=project, event_id=event3.id)
         assert report1.group_id == event1.group_id
         assert report1.environment == event1.get_environment()
-        assert report2.group is None
-        assert report2.environment is None
+        assert report2.group_id == event2.group_id
+        assert report2.environment == event2.get_environment()
+        assert report3.group is None
+        assert report3.environment is None


### PR DESCRIPTION
I noticed that sometimes this task was failing with timeouts/rate limit errors,
so change it to use bulk queries to hopefully avoid this problem.