### PR TITLE
ref: Make search_message a property of Event

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -8,7 +8,6 @@ import jsonschema
 import six
 
 from datetime import datetime, timedelta
-from django.conf import settings
 from django.core.cache import cache
 from django.db import connection, IntegrityError, router, transaction
 from django.db.models import Func
@@ -438,34 +437,6 @@ class EventManager(object):
             "location": event_type.get_location(event_metadata),
         }
 
-    def get_search_message(self, event_metadata=None, culprit=None):
-        """This generates the internal event.message attribute which is used
-        for search purposes.  It adds a bunch of data from the metadata and
-        the culprit.
-        """
-        if event_metadata is None:
-            event_metadata = self.get_event_type().get_metadata(self._data)
-        if culprit is None:
-            culprit = self.get_culprit()
-
-        data = self._data
-        message = ""
-
-        if data.get("logentry"):
-            message += data["logentry"].get("formatted") or data["logentry"].get("message") or ""
-
-        if event_metadata:
-            for value in six.itervalues(event_metadata):
-                value_u = force_text(value, errors="replace")
-                if value_u not in message:
-                    message = u"{} {}".format(message, value_u)
-
-        if culprit and culprit not in message:
-            culprit_u = force_text(culprit, errors="replace")
-            message = u"{} {}".format(message, culprit_u)
-
-        return trim(message.strip(), settings.SENTRY_MAX_MESSAGE_LENGTH)
-
     def save(self, project_id, raw=False, assume_normalized=False):
         """
         We re-insert events with duplicate IDs into Snuba, which is responsible
@@ -615,13 +586,17 @@ class EventManager(object):
         # however the data is dynamically overridden by Event.title and
         # Event.location (See Event.as_dict)
         materialized_metadata = self.materialize_metadata()
-        event_metadata = materialized_metadata["metadata"]
         data.update(materialized_metadata)
         data["culprit"] = culprit
 
         # index components into ``Event.message``
         # See GH-3248
-        event.message = self.get_search_message(event_metadata, culprit)
+        # TODO: We temporarily save the search message into the message field to
+        # maintain backward compatibility with the Django event model. Once
+        # "store.use-django-event" is turned off for good, we can just reference
+        # event.search_message everywhere.
+        event.message = event.search_message
+
         received_timestamp = event.data.get("received") or float(event.datetime.strftime("%s"))
 
         if not issueless_event:

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -171,12 +171,12 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
-    def create_event(self, project_id=None, event_id=None, group_id=None, message=None, data=None):
+    def create_event(self, project_id=None, event_id=None, group_id=None, data=None):
         """
         Returns an Event from processed data
         """
         return Event(
-            project_id=project_id, event_id=event_id, group_id=group_id, message=message, data=data
+            project_id=project_id, event_id=event_id, group_id=group_id, data=data
         )
 
     def bind_nodes(self, object_list, node_name="data"):

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -1,14 +1,19 @@
 from __future__ import absolute_import
 
 import pytz
+import six
 
 from datetime import datetime
 from dateutil.parser import parse as parse_date
 
+from django.conf import settings
+from django.utils.encoding import force_text
+
+from sentry import eventtypes
 from sentry.models import EventCommon, EventDict
 from sentry.db.models import NodeData
-
 from sentry.snuba.events import Columns
+from sentry.utils.safe import trim
 
 
 def ref_func(x):
@@ -16,13 +21,14 @@ def ref_func(x):
 
 
 class Event(EventCommon):
-    def __init__(
-        self, project_id, event_id, group_id=None, message=None, data=None, snuba_data=None
-    ):
+    """
+    Event backed by nodestore and Snuba.
+    """
+
+    def __init__(self, project_id, event_id, group_id=None, data=None, snuba_data=None):
         self.project_id = project_id
         self.event_id = event_id
         self.group_id = group_id
-        self.message = message
         self.data = data
         self._snuba_data = snuba_data or {}
         super(Event, self).__init__()
@@ -73,9 +79,8 @@ class Event(EventCommon):
 
     @property
     def message(self):
-        if self._message:
+        if hasattr(self, "_message"):
             return self._message
-
         column = self.__get_column_name(Columns.MESSAGE)
         if column in self._snuba_data:
             return self._snuba_data[column]
@@ -85,6 +90,37 @@ class Event(EventCommon):
     @message.setter
     def message(self, value):
         self._message = value
+
+    @property
+    def search_message(self):
+        """This generates the internal event.search_message attribute which is used
+        for search purposes. It adds a bunch of data from the metadata and
+        the culprit.
+        """
+        data = self.data
+        culprit = self.culprit
+
+        event_metadata = self.get_event_metadata()
+
+        if event_metadata is None:
+            event_metadata = eventtypes.get(self.get_event_type())().get_metadata(self.data)
+
+        message = ""
+
+        if data.get("logentry"):
+            message += data["logentry"].get("formatted") or data["logentry"].get("message") or ""
+
+        if event_metadata:
+            for value in six.itervalues(event_metadata):
+                value_u = force_text(value, errors="replace")
+                if value_u not in message:
+                    message = u"{} {}".format(message, value_u)
+
+        if culprit and culprit not in message:
+            culprit_u = force_text(culprit, errors="replace")
+            message = u"{} {}".format(message, culprit_u)
+
+        return trim(message.strip(), settings.SENTRY_MAX_MESSAGE_LENGTH)
 
     @property
     def datetime(self):

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -97,9 +97,9 @@ class Event(EventCommon):
 
     @property
     def search_message(self):
-        """This generates the internal event.search_message attribute which is used
-        for search purposes. It adds a bunch of data from the metadata and
-        the culprit.
+        """
+        The internal search_message attribute is only used for search purposes.
+        It adds a bunch of data from the metadata and the culprit.
         """
         data = self.data
         culprit = self.culprit

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -89,6 +89,10 @@ class Event(EventCommon):
 
     @message.setter
     def message(self, value):
+        """
+        This can be removed once Django Event is removed and we no longer need to manually
+        update this field in event_manager.save().
+        """
         self._message = value
 
     @property

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -4,8 +4,10 @@ import six
 import string
 
 from collections import OrderedDict
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 from hashlib import md5
 
@@ -27,6 +29,7 @@ from sentry.utils.cache import memoize
 from sentry.utils.canonical import CanonicalKeyDict, CanonicalKeyView
 from sentry.utils.safe import get_path
 from sentry.utils.strings import truncatechars
+from sentry.utils.safe import trim
 
 
 class EventDict(CanonicalKeyDict):
@@ -351,6 +354,37 @@ class EventCommon(object):
         node_data = nodestore.get(node_id) or {}
         ref = self.data.get_ref(self)
         self.data.bind_data(node_data, ref=ref)
+
+    @property
+    def search_message(self):
+        """
+        The internal search_message attribute is only used for search purposes.
+        It adds a bunch of data from the metadata and the culprit.
+        """
+        data = self.data
+        culprit = self.culprit
+
+        event_metadata = self.get_event_metadata()
+
+        if event_metadata is None:
+            event_metadata = eventtypes.get(self.get_event_type())().get_metadata(self.data)
+
+        message = ""
+
+        if data.get("logentry"):
+            message += data["logentry"].get("formatted") or data["logentry"].get("message") or ""
+
+        if event_metadata:
+            for value in six.itervalues(event_metadata):
+                value_u = force_text(value, errors="replace")
+                if value_u not in message:
+                    message = u"{} {}".format(message, value_u)
+
+        if culprit and culprit not in message:
+            culprit_u = force_text(culprit, errors="replace")
+            message = u"{} {}".format(message, culprit_u)
+
+        return trim(message.strip(), settings.SENTRY_MAX_MESSAGE_LENGTH)
 
 
 def ref_func(x):

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -23,7 +23,6 @@ from sentry.models import (
     EventAttachment,
 )
 from sentry.similarity import features
-from sentry.snuba.events import Columns
 from sentry.tasks.base import instrumented_task
 from six.moves import reduce
 
@@ -99,7 +98,7 @@ initial_fields = {
     },
     "last_seen": lambda event: event.datetime,
     "level": lambda event: LOG_LEVELS_MAP.get(event.get_tag("level"), logging.ERROR),
-    "message": lambda event: event.message,
+    "message": lambda event: event.search_message,
     "times_seen": lambda event: 0,
 }
 
@@ -505,9 +504,6 @@ def unmerge(
         filter=eventstore.Filter(
             project_ids=[project_id], group_ids=[source.id], conditions=conditions
         ),
-        # We need the text-only "search message" from Snuba, not the raw message
-        # dict field from nodestore.
-        additional_columns=[Columns.MESSAGE],
         limit=batch_size,
         referrer="unmerge",
         orderby=["-timestamp", "-event_id"],

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -194,12 +194,12 @@ class ActivityMailDebugView(View):
         data = event_manager.get_data()
         event_type = event_manager.get_event_type()
 
-        group.message = event_manager.get_search_message()
-        group.data = {"type": event_type.key, "metadata": event_type.get_metadata(data)}
-
         event = eventstore.create_event(
             event_id="a" * 32, group_id=group.id, project_id=project.id, data=data.data
         )
+
+        group.message = event.search_message
+        group.data = {"type": event_type.key, "metadata": event_type.get_metadata(data)}
 
         activity = Activity(group=group, project=event.project, **self.get_activity(request, event))
 
@@ -244,7 +244,7 @@ def alert(request):
         event.data["timestamp"] = 1504656000.0  # datetime(2017, 9, 6, 0, 0)
     event_type = event_manager.get_event_type()
 
-    group.message = event_manager.get_search_message()
+    group.message = event.search_message
     group.data = {"type": event_type.key, "metadata": event_type.get_metadata(data)}
 
     rule = Rule(label="An example rule")


### PR DESCRIPTION
Since search_message is distinct from message, we should have them as
separate properties of Event, rather than use them interchangably.

Search_message is the internal only property for search, while message is
the publicly exposed property.

We temporarily save search_message into the message field in
event_manager.save() to maintain backward compatibility with Django
event format.