### PR TITLE
fix(discover) Tag sidebar should go to a new result set

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -181,7 +181,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
             {event.groupID && (
               <LinkedIssue groupId={event.groupID} eventId={event.eventID} />
             )}
-            <TagsTable tags={event.tags} />
+            <TagsTable tags={event.tags} organization={organization} />
           </div>
         </ContentBox>
       </div>

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -105,11 +105,16 @@ class Tags extends React.Component<Props, State> {
   };
 
   renderTag(tag: Tag) {
-    const {location} = this.props;
+    const {organization, location} = this.props;
     const {totalValues} = this.state;
 
     const segments: TagTopValue[] = tag.topValues.map(segment => {
-      segment.url = getEventTagSearchUrl(tag.key, segment.value, location);
+      segment.url = getEventTagSearchUrl(
+        tag.key,
+        segment.value,
+        organization,
+        location.query
+      );
 
       return segment;
     });

--- a/src/sentry/static/sentry/app/views/eventsV2/tagsTable.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tagsTable.tsx
@@ -8,17 +8,18 @@ import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
-import {EventTag} from 'app/types';
+import {EventTag, OrganizationSummary} from 'app/types';
 
 import {getEventTagSearchUrl} from './utils';
 import {SectionHeading} from './styles';
 
 type Props = {
+  organization: OrganizationSummary;
   tags: Array<EventTag>;
 } & ReactRouter.WithRouterProps;
 
 const TagsTable = (props: Props) => {
-  const {location, tags} = props;
+  const {location, organization, tags} = props;
   return (
     <StyledTagsTable>
       <SectionHeading>{t('Event Tag Details')}</SectionHeading>
@@ -36,7 +37,14 @@ const TagsTable = (props: Props) => {
                       <span>{tag.value}</span>
                     </Tooltip>
                   ) : (
-                    <Link to={getEventTagSearchUrl(tag.key, tag.value, location)}>
+                    <Link
+                      to={getEventTagSearchUrl(
+                        tag.key,
+                        tag.value,
+                        organization,
+                        location.query
+                      )}
+                    >
                       {tag.value}
                     </Link>
                   )}

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -5,7 +5,7 @@ import {Location, Query} from 'history';
 import {browserHistory} from 'react-router';
 
 import {t} from 'app/locale';
-import {Event, Organization} from 'app/types';
+import {Event, Organization, OrganizationSummary} from 'app/types';
 import {Client} from 'app/api';
 import {getTitle} from 'app/utils/events';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
@@ -95,27 +95,24 @@ export function isAggregateField(field: string): boolean {
 }
 
 /**
- * Return a location object for the current pathname
+ * Return a location object for the search results pathname
  * with a query string reflected the provided tag.
  *
  * @param {String} tagKey
  * @param {String} tagValue
- * @param {Object} browser location object.
+ * @param {OrganizationSummary} organization
+ * @param {Query} browser location query.
  * @return {Object} router target
  */
 export function getEventTagSearchUrl(
   tagKey: string,
   tagValue: string,
-  location: Location
+  organization: OrganizationSummary,
+  query: Query
 ) {
-  const query = generateQueryWithTag(location.query, {key: tagKey, value: tagValue});
-
-  // Remove the event slug so the user sees new search results.
-  delete query.eventSlug;
-
   return {
-    pathname: location.pathname,
-    query,
+    pathname: `/organizations/${organization.slug}/eventsv2/results/`,
+    query: generateQueryWithTag(query, {key: tagKey, value: tagValue}),
   };
 }
 

--- a/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
@@ -209,10 +209,8 @@ describe('EventsV2 > EventDetails', function() {
       organization: TestStubs.Organization({projects: [TestStubs.Project()]}),
       router: {
         location: {
-          pathname: '/organizations/org-slug/events/',
-          query: {
-            eventSlug: 'project-slug:deadbeef',
-          },
+          pathname: '/organizations/org-slug/eventsv2/project-slug:deadbeef',
+          query: {},
         },
       },
     });
@@ -233,7 +231,7 @@ describe('EventsV2 > EventDetails', function() {
     // Should remove eventSlug and append new tag value causing
     // the view to re-render
     expect(tagLink.props().to).toEqual({
-      pathname: '/organizations/org-slug/events/',
+      pathname: '/organizations/org-slug/eventsv2/results/',
       query: {query: 'browser:Firefox'},
     });
   });
@@ -243,10 +241,9 @@ describe('EventsV2 > EventDetails', function() {
       organization: TestStubs.Organization({projects: [TestStubs.Project()]}),
       router: {
         location: {
-          pathname: '/organizations/org-slug/events/',
+          pathname: '/organizations/org-slug/eventsv2/project-slug:deadbeef',
           query: {
             query: 'Dumpster',
-            eventSlug: 'project-slug:deadbeef',
           },
         },
       },
@@ -268,7 +265,7 @@ describe('EventsV2 > EventDetails', function() {
     // Should remove eventSlug and append new tag value causing
     // the view to re-render
     expect(tagLink.props().to).toEqual({
-      pathname: '/organizations/org-slug/events/',
+      pathname: '/organizations/org-slug/eventsv2/results/',
       query: {query: 'Dumpster browser:Firefox'},
     });
   });

--- a/tests/js/spec/views/eventsV2/tags.spec.jsx
+++ b/tests/js/spec/views/eventsV2/tags.spec.jsx
@@ -115,7 +115,7 @@ describe('Tags', function() {
     wrapper.update();
 
     expect(initialData.router.push).toHaveBeenCalledWith({
-      pathname: undefined,
+      pathname: '/organizations/org-slug/eventsv2/results/',
       query: {environment: 'abcd123'},
     });
   });

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -14,8 +14,9 @@ import {
 import {COL_WIDTH_UNDEFINED, COL_WIDTH_NUMBER} from 'app/components/gridEditable';
 
 describe('eventTagSearchUrl()', function() {
-  let location;
+  let location, organization;
   beforeEach(function() {
+    organization = TestStubs.Organization();
     location = {
       pathname: '/organization/org-slug/events/',
       query: {},
@@ -23,25 +24,31 @@ describe('eventTagSearchUrl()', function() {
   });
 
   it('adds a query', function() {
-    expect(getEventTagSearchUrl('browser', 'firefox', location)).toEqual({
-      pathname: location.pathname,
+    expect(
+      getEventTagSearchUrl('browser', 'firefox', organization, location.query)
+    ).toEqual({
+      pathname: `/organizations/${organization.slug}/eventsv2/results/`,
       query: {query: 'browser:firefox'},
-    });
-  });
-
-  it('removes eventSlug', function() {
-    location.query.eventSlug = 'project-slug:deadbeef';
-    expect(getEventTagSearchUrl('browser', 'firefox 69', location)).toEqual({
-      pathname: location.pathname,
-      query: {query: 'browser:"firefox 69"'},
     });
   });
 
   it('appends to an existing query', function() {
     location.query.query = 'failure';
-    expect(getEventTagSearchUrl('browser', 'firefox', location)).toEqual({
-      pathname: location.pathname,
+    expect(
+      getEventTagSearchUrl('browser', 'firefox', organization, location.query)
+    ).toEqual({
+      pathname: `/organizations/${organization.slug}/eventsv2/results/`,
       query: {query: 'failure browser:firefox'},
+    });
+  });
+
+  it('quotes tags with spaces', function() {
+    location.query.query = 'failure';
+    expect(
+      getEventTagSearchUrl('browser', 'fire fox', organization, location.query)
+    ).toEqual({
+      pathname: `/organizations/${organization.slug}/eventsv2/results/`,
+      query: {query: 'failure browser:"fire fox"'},
     });
   });
 });


### PR DESCRIPTION
Clicking tags in the sidebar of event details should go to a new result filtered by the tag. This matches the behavior or clicking on a tag column in the result table.