### PR TITLE
ref: Simplify event for digests

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -10,7 +10,7 @@ from six.moves import reduce
 
 from sentry.app import tsdb
 from sentry.digests import Record
-from sentry.models import Event, Project, Group, GroupStatus, Rule
+from sentry.models import Project, Group, GroupStatus, Rule
 from sentry.utils.dates import to_timestamp
 
 logger = logging.getLogger("sentry.digests")
@@ -29,23 +29,13 @@ def unsplit_key(plugin, project):
     return u"{plugin.slug}:p:{project.id}".format(plugin=plugin, project=project)
 
 
-def strip_for_serialization(instance):
-    cls = type(instance)
-    return cls(**{field.attname: getattr(instance, field.attname) for field in cls._meta.fields})
-
-
 def event_to_record(event, rules):
     if not rules:
         logger.warning("Creating record for %r that does not contain any rules!", event)
 
-    if isinstance(event, Event):
-        event_data = strip_for_serialization(event)
-    else:
-        event_data = event
-
     return Record(
         event.event_id,
-        Notification(event_data, [rule.id for rule in rules]),
+        Notification(event, [rule.id for rule in rules]),
         to_timestamp(event.datetime),
     )
 


### PR DESCRIPTION
Since https://github.com/getsentry/sentry/pull/16285 we are now using
the new Event model here, and don't need to keep this check.