### PR TITLE
feat: disable redundant content-length middleware on django 1.11+

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -251,7 +251,7 @@ USE_TZ = True
 
 # CAVEAT: If you're adding a middleware that modifies a response's content,
 # and appears before CommonMiddleware, you must either reorder your middleware
-# so that responses aren’t modified after Content-Length is set, or have the
+# so that responses aren't modified after Content-Length is set, or have the
 # response modifying middleware reset the Content-Length header.
 # This is because CommonMiddleware Sets the Content-Length header for non-streaming responses.
 MIDDLEWARE_CLASSES = (

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -249,6 +249,11 @@ USE_L10N = True
 
 USE_TZ = True
 
+# CAVEAT: If you're adding a middleware that modifies a response's content,
+# and appears before CommonMiddleware, you must either reorder your middleware
+# so that responses aren’t modified after Content-Length is set, or have the
+# response modifying middleware reset the Content-Length header.
+# This is because CommonMiddleware Sets the Content-Length header for non-streaming responses.
 MIDDLEWARE_CLASSES = (
     "sentry.middleware.proxy.ChunkedMiddleware",
     "sentry.middleware.proxy.DecompressBodyMiddleware",

--- a/tests/sentry/middleware/test_proxy.py
+++ b/tests/sentry/middleware/test_proxy.py
@@ -1,12 +1,16 @@
 from __future__ import absolute_import
 
 from exam import fixture
+from django import VERSION
 from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
+import pytest
 
 from sentry.testutils import TestCase
 from sentry.middleware.proxy import ContentLengthHeaderMiddleware, SetRemoteAddrFromForwardedFor
 
 
+# TODO(joshuarli): we can remove this entirely once we're on 1.11
+@pytest.mark.skipif(VERSION[:2] >= (1, 11), reason="middleware not used on Django 1.11+")
 class ContentLengthHeaderMiddlewareTest(TestCase):
     middleware = fixture(ContentLengthHeaderMiddleware)
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.11/releases/1.11/#requests-and-responses

> CommonMiddleware now sets the Content-Length response header for non-streaming responses.

This means on Django 1.11, our `ContentLengthHeaderMiddleware` will be noop. This PR sets it up for removal when we're fully on 1.11.

> If you have a middleware that modifies a response’s content and appears before CommonMiddleware in the MIDDLEWARE or MIDDLEWARE_CLASSES settings, you must reorder your middleware so that responses aren’t modified after Content-Length is set, or have the response modifying middleware reset the Content-Length header.

I double-checked all the other response-modifying (not request!) sentry and getsentry middlewares above CommonMiddleware - there aren't any. Only some header modifications e.g. in SecurityHeadersMiddleware.