### PR TITLE
chore: Django 1.11 pickling verification

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -400,12 +400,7 @@ model_unpickle = django.db.models.base.model_unpickle
 def __model_unpickle_compat(model_id, attrs=None, factory=None):
     from django import VERSION
 
-    if VERSION[:2] == (1, 9):
-        attrs = [] if attrs is None else attrs
-        factory = django.db.models.base.simple_class_factory if factory is None else factory
-        return model_unpickle(model_id, attrs, factory)
-    # TODO(joshuarli): unverified on 1.11, but i'm doing this to unblock tests for now
-    elif VERSION[:2] in [(1, 10), (1, 11)]:
+    if VERSION[:2] in [(1, 10), (1, 11)]:
         return model_unpickle(model_id)
     else:
         raise NotImplementedError


### PR DESCRIPTION
See branch `tmp/testing-django-1.10-1.11-pickled-models`.

I generated a 1.11 (monkeyed) project pickle, and then `pytest unpickle_project_from_different_dj.py` to assert that 1.11 (monkeyed) can unpickle 1.10 and 1.9. 

Note that I removed the assertion for `self.project.date_added`, since I didn't think it was worth the time to reinstall and regenerate pickles on 1.9 and 1.10. Let me know if you actually want me to take the time to do this though.

I then switched to 1.10, modified unpickle_project_from_different_dj.py to load the 1.11 pickle, and ran the test.