### PR TITLE
ref(ui): Refactor `<Button>` to remove a level of component nesting

### DIFF
--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -157,7 +157,6 @@ class Button extends React.Component<ButtonProps, {}> {
         size={size}
         priority={priority}
         borderless={borderless}
-        shouldForwardProp={prop => isPropValid(prop) && prop !== 'disabled'}
         {...buttonProps}
         onClick={this.handleClick}
         role="button"
@@ -210,7 +209,7 @@ ButtonForwardRef.displayName = 'forwardRef<Button>';
 
 export default ButtonForwardRef;
 
-type StyledButtonProps = ButtonProps;
+type StyledButtonProps = ButtonProps & {theme?: any};
 
 function getButtonElement(props: Pick<ButtonProps, 'to' | 'href' | 'external'>) {
   // Get component to use based on existence of `to` or `href` properties
@@ -298,7 +297,7 @@ const getColors = ({priority, disabled, borderless, theme}: StyledButtonProps) =
 
 const StyledButton = styled('button', {
   shouldForwardProp: prop => isPropValid(prop) && prop !== 'disabled',
-})<Props>`
+})<StyledButtonProps>`
   display: inline-block;
   line-height: 1;
   border-radius: ${p => p.theme.button.borderRadius};

--- a/tests/js/spec/components/__snapshots__/button.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/button.spec.jsx.snap
@@ -15,50 +15,41 @@ exports[`Button renders 1`] = `
     <StyledButton
       aria-disabled={false}
       aria-label="Button"
+      as="button"
       disabled={false}
-      forwardRef={null}
       onClick={[Function]}
       priority="primary"
       role="button"
+      shouldForwardProp={[Function]}
       size="large"
     >
-      <Component
+      <button
         aria-disabled={false}
         aria-label="Button"
         className="css-1bbx5hm-StyledButton edwq9my0"
-        forwardRef={null}
         onClick={[Function]}
         role="button"
         size="large"
       >
-        <button
-          aria-disabled={false}
-          aria-label="Button"
-          className="css-1bbx5hm-StyledButton edwq9my0"
-          onClick={[Function]}
-          role="button"
+        <ButtonLabel
+          align="center"
+          priority="primary"
           size="large"
         >
-          <ButtonLabel
+          <Component
             align="center"
+            className="css-ym5hp1-ButtonLabel edwq9my1"
             priority="primary"
             size="large"
           >
-            <Component
-              align="center"
+            <span
               className="css-ym5hp1-ButtonLabel edwq9my1"
-              priority="primary"
-              size="large"
             >
-              <span
-                className="css-ym5hp1-ButtonLabel edwq9my1"
-              >
-                Button
-              </span>
-            </Component>
-          </ButtonLabel>
-        </button>
-      </Component>
+              Button
+            </span>
+          </Component>
+        </ButtonLabel>
+      </button>
     </StyledButton>
   </Button>
 </forwardRef<Button>>
@@ -77,45 +68,36 @@ exports[`Button renders disabled normal link 1`] = `
     <StyledButton
       aria-disabled={false}
       aria-label="Normal Link"
+      as="a"
       disabled={false}
-      forwardRef={null}
       href="/some/relative/url"
       onClick={[Function]}
       role="button"
+      shouldForwardProp={[Function]}
     >
-      <Component
+      <a
         aria-disabled={false}
         aria-label="Normal Link"
         className="css-1c2phb1-StyledButton edwq9my0"
-        forwardRef={null}
         href="/some/relative/url"
         onClick={[Function]}
         role="button"
       >
-        <a
-          aria-disabled={false}
-          aria-label="Normal Link"
-          className="css-1c2phb1-StyledButton edwq9my0"
-          href="/some/relative/url"
-          onClick={[Function]}
-          role="button"
+        <ButtonLabel
+          align="center"
         >
-          <ButtonLabel
+          <Component
             align="center"
+            className="css-zmpclt-ButtonLabel edwq9my1"
           >
-            <Component
-              align="center"
+            <span
               className="css-zmpclt-ButtonLabel edwq9my1"
             >
-              <span
-                className="css-zmpclt-ButtonLabel edwq9my1"
-              >
-                Normal Link
-              </span>
-            </Component>
-          </ButtonLabel>
-        </a>
-      </Component>
+              Normal Link
+            </span>
+          </Component>
+        </ButtonLabel>
+      </a>
     </StyledButton>
   </Button>
 </forwardRef<Button>>
@@ -134,45 +116,36 @@ exports[`Button renders normal link 1`] = `
     <StyledButton
       aria-disabled={false}
       aria-label="Normal Link"
+      as="a"
       disabled={false}
-      forwardRef={null}
       href="/some/relative/url"
       onClick={[Function]}
       role="button"
+      shouldForwardProp={[Function]}
     >
-      <Component
+      <a
         aria-disabled={false}
         aria-label="Normal Link"
         className="css-1c2phb1-StyledButton edwq9my0"
-        forwardRef={null}
         href="/some/relative/url"
         onClick={[Function]}
         role="button"
       >
-        <a
-          aria-disabled={false}
-          aria-label="Normal Link"
-          className="css-1c2phb1-StyledButton edwq9my0"
-          href="/some/relative/url"
-          onClick={[Function]}
-          role="button"
+        <ButtonLabel
+          align="center"
         >
-          <ButtonLabel
+          <Component
             align="center"
+            className="css-zmpclt-ButtonLabel edwq9my1"
           >
-            <Component
-              align="center"
+            <span
               className="css-zmpclt-ButtonLabel edwq9my1"
             >
-              <span
-                className="css-zmpclt-ButtonLabel edwq9my1"
-              >
-                Normal Link
-              </span>
-            </Component>
-          </ButtonLabel>
-        </a>
-      </Component>
+              Normal Link
+            </span>
+          </Component>
+        </ButtonLabel>
+      </a>
     </StyledButton>
   </Button>
 </forwardRef<Button>>
@@ -191,56 +164,47 @@ exports[`Button renders react-router link 1`] = `
     <StyledButton
       aria-disabled={false}
       aria-label="Router Link"
+      as={[Function]}
       disabled={false}
-      forwardRef={null}
       onClick={[Function]}
       role="button"
+      shouldForwardProp={[Function]}
       to="/some/route"
     >
-      <Component
+      <Link
         aria-disabled={false}
         aria-label="Router Link"
         className="css-1c2phb1-StyledButton edwq9my0"
-        forwardRef={null}
         onClick={[Function]}
+        onlyActiveOnIndex={false}
         role="button"
+        style={Object {}}
         to="/some/route"
       >
-        <Link
+        <a
           aria-disabled={false}
           aria-label="Router Link"
           className="css-1c2phb1-StyledButton edwq9my0"
           onClick={[Function]}
-          onlyActiveOnIndex={false}
           role="button"
           style={Object {}}
-          to="/some/route"
         >
-          <a
-            aria-disabled={false}
-            aria-label="Router Link"
-            className="css-1c2phb1-StyledButton edwq9my0"
-            onClick={[Function]}
-            role="button"
-            style={Object {}}
+          <ButtonLabel
+            align="center"
           >
-            <ButtonLabel
+            <Component
               align="center"
+              className="css-zmpclt-ButtonLabel edwq9my1"
             >
-              <Component
-                align="center"
+              <span
                 className="css-zmpclt-ButtonLabel edwq9my1"
               >
-                <span
-                  className="css-zmpclt-ButtonLabel edwq9my1"
-                >
-                  Router Link
-                </span>
-              </Component>
-            </ButtonLabel>
-          </a>
-        </Link>
-      </Component>
+                Router Link
+              </span>
+            </Component>
+          </ButtonLabel>
+        </a>
+      </Link>
     </StyledButton>
   </Button>
 </forwardRef<Button>>

--- a/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/confirmDelete.spec.jsx.snap
@@ -184,21 +184,21 @@ exports[`ConfirmDelete renders 1`] = `
               <StyledButton
                 aria-disabled={false}
                 aria-label="Cancel"
+                as="button"
                 disabled={false}
-                forwardRef={null}
                 onClick={[Function]}
                 role="button"
+                shouldForwardProp={[Function]}
                 style={
                   Object {
                     "marginRight": 10,
                   }
                 }
               >
-                <Component
+                <button
                   aria-disabled={false}
                   aria-label="Cancel"
                   className="css-1c2phb1-StyledButton edwq9my0"
-                  forwardRef={null}
                   onClick={[Function]}
                   role="button"
                   style={
@@ -207,34 +207,21 @@ exports[`ConfirmDelete renders 1`] = `
                     }
                   }
                 >
-                  <button
-                    aria-disabled={false}
-                    aria-label="Cancel"
-                    className="css-1c2phb1-StyledButton edwq9my0"
-                    onClick={[Function]}
-                    role="button"
-                    style={
-                      Object {
-                        "marginRight": 10,
-                      }
-                    }
+                  <ButtonLabel
+                    align="center"
                   >
-                    <ButtonLabel
+                    <Component
                       align="center"
+                      className="css-zmpclt-ButtonLabel edwq9my1"
                     >
-                      <Component
-                        align="center"
+                      <span
                         className="css-zmpclt-ButtonLabel edwq9my1"
                       >
-                        <span
-                          className="css-zmpclt-ButtonLabel edwq9my1"
-                        >
-                          Cancel
-                        </span>
-                      </Component>
-                    </ButtonLabel>
-                  </button>
-                </Component>
+                        Cancel
+                      </span>
+                    </Component>
+                  </ButtonLabel>
+                </button>
               </StyledButton>
             </Button>
           </forwardRef<Button>>
@@ -257,51 +244,41 @@ exports[`ConfirmDelete renders 1`] = `
               <StyledButton
                 aria-disabled={true}
                 aria-label="Confirm"
+                as="button"
                 autoFocus={true}
                 data-test-id="confirm-button"
                 disabled={true}
-                forwardRef={null}
                 onClick={[Function]}
                 priority="primary"
                 role="button"
+                shouldForwardProp={[Function]}
               >
-                <Component
+                <button
                   aria-disabled={true}
                   aria-label="Confirm"
                   autoFocus={true}
                   className="css-1e3hcbu-StyledButton edwq9my0"
                   data-test-id="confirm-button"
-                  forwardRef={null}
                   onClick={[Function]}
                   role="button"
                 >
-                  <button
-                    aria-disabled={true}
-                    aria-label="Confirm"
-                    autoFocus={true}
-                    className="css-1e3hcbu-StyledButton edwq9my0"
-                    data-test-id="confirm-button"
-                    onClick={[Function]}
-                    role="button"
+                  <ButtonLabel
+                    align="center"
+                    priority="primary"
                   >
-                    <ButtonLabel
+                    <Component
                       align="center"
+                      className="css-zmpclt-ButtonLabel edwq9my1"
                       priority="primary"
                     >
-                      <Component
-                        align="center"
+                      <span
                         className="css-zmpclt-ButtonLabel edwq9my1"
-                        priority="primary"
                       >
-                        <span
-                          className="css-zmpclt-ButtonLabel edwq9my1"
-                        >
-                          Confirm
-                        </span>
-                      </Component>
-                    </ButtonLabel>
-                  </button>
-                </Component>
+                        Confirm
+                      </span>
+                    </Component>
+                  </ButtonLabel>
+                </button>
               </StyledButton>
             </Button>
           </forwardRef<Button>>

--- a/tests/js/spec/components/__snapshots__/createProject.spec.jsx.snap
+++ b/tests/js/spec/components/__snapshots__/createProject.spec.jsx.snap
@@ -1513,83 +1513,74 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
                             >
                               <StyledButton
                                 aria-disabled={false}
+                                as="button"
                                 borderless={true}
                                 data-test-id="create-team"
                                 disabled={false}
-                                forwardRef={null}
                                 onClick={[Function]}
                                 role="button"
+                                shouldForwardProp={[Function]}
                                 type="button"
                               >
-                                <Component
+                                <button
                                   aria-disabled={false}
                                   className="css-e1k74m-StyledButton edwq9my0"
                                   data-test-id="create-team"
-                                  forwardRef={null}
                                   onClick={[Function]}
                                   role="button"
                                   type="button"
                                 >
-                                  <button
-                                    aria-disabled={false}
-                                    className="css-e1k74m-StyledButton edwq9my0"
-                                    data-test-id="create-team"
-                                    onClick={[Function]}
-                                    role="button"
-                                    type="button"
+                                  <ButtonLabel
+                                    align="center"
+                                    borderless={true}
                                   >
-                                    <ButtonLabel
+                                    <Component
                                       align="center"
                                       borderless={true}
+                                      className="css-cmi7y3-ButtonLabel edwq9my1"
                                     >
-                                      <Component
-                                        align="center"
-                                        borderless={true}
+                                      <span
                                         className="css-cmi7y3-ButtonLabel edwq9my1"
                                       >
-                                        <span
-                                          className="css-cmi7y3-ButtonLabel edwq9my1"
+                                        <Icon
+                                          hasChildren={false}
                                         >
-                                          <Icon
+                                          <Component
+                                            className="css-heib7e-Icon edwq9my2"
                                             hasChildren={false}
                                           >
-                                            <Component
+                                            <span
                                               className="css-heib7e-Icon edwq9my2"
-                                              hasChildren={false}
                                             >
-                                              <span
-                                                className="css-heib7e-Icon edwq9my2"
+                                              <StyledInlineSvg
+                                                size="14px"
+                                                src="icon-circle-add"
                                               >
-                                                <StyledInlineSvg
+                                                <ForwardRef
+                                                  className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                                   size="14px"
                                                   src="icon-circle-add"
                                                 >
-                                                  <ForwardRef
+                                                  <svg
                                                     className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                    size="14px"
-                                                    src="icon-circle-add"
+                                                    height="14px"
+                                                    viewBox={Object {}}
+                                                    width="14px"
                                                   >
-                                                    <svg
-                                                      className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                      height="14px"
-                                                      viewBox={Object {}}
-                                                      width="14px"
-                                                    >
-                                                      <use
-                                                        href="#test"
-                                                        xlinkHref="#test"
-                                                      />
-                                                    </svg>
-                                                  </ForwardRef>
-                                                </StyledInlineSvg>
-                                              </span>
-                                            </Component>
-                                          </Icon>
-                                        </span>
-                                      </Component>
-                                    </ButtonLabel>
-                                  </button>
-                                </Component>
+                                                    <use
+                                                      href="#test"
+                                                      xlinkHref="#test"
+                                                    />
+                                                  </svg>
+                                                </ForwardRef>
+                                              </StyledInlineSvg>
+                                            </span>
+                                          </Component>
+                                        </Icon>
+                                      </span>
+                                    </Component>
+                                  </ButtonLabel>
+                                </button>
                               </StyledButton>
                             </Button>
                           </forwardRef<Button>>
@@ -1618,48 +1609,39 @@ exports[`CreateProject should deal with incorrect platform name if its provided 
               <StyledButton
                 aria-disabled={true}
                 aria-label="Create Project"
+                as="button"
                 data-test-id="create-project"
                 disabled={true}
-                forwardRef={null}
                 onClick={[Function]}
                 priority="primary"
                 role="button"
+                shouldForwardProp={[Function]}
               >
-                <Component
+                <button
                   aria-disabled={true}
                   aria-label="Create Project"
                   className="css-1e3hcbu-StyledButton edwq9my0"
                   data-test-id="create-project"
-                  forwardRef={null}
                   onClick={[Function]}
                   role="button"
                 >
-                  <button
-                    aria-disabled={true}
-                    aria-label="Create Project"
-                    className="css-1e3hcbu-StyledButton edwq9my0"
-                    data-test-id="create-project"
-                    onClick={[Function]}
-                    role="button"
+                  <ButtonLabel
+                    align="center"
+                    priority="primary"
                   >
-                    <ButtonLabel
+                    <Component
                       align="center"
+                      className="css-zmpclt-ButtonLabel edwq9my1"
                       priority="primary"
                     >
-                      <Component
-                        align="center"
+                      <span
                         className="css-zmpclt-ButtonLabel edwq9my1"
-                        priority="primary"
                       >
-                        <span
-                          className="css-zmpclt-ButtonLabel edwq9my1"
-                        >
-                          Create Project
-                        </span>
-                      </Component>
-                    </ButtonLabel>
-                  </button>
-                </Component>
+                        Create Project
+                      </span>
+                    </Component>
+                  </ButtonLabel>
+                </button>
               </StyledButton>
             </Button>
           </forwardRef<Button>>
@@ -2130,86 +2112,78 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                       >
                         <StyledButton
                           aria-disabled={false}
+                          as="button"
                           borderless={true}
                           className="css-rqv9pd-ClearButton exv4dm85"
                           disabled={false}
-                          forwardRef={null}
                           onClick={[Function]}
                           role="button"
+                          shouldForwardProp={[Function]}
                           size="xsmall"
                         >
-                          <Component
+                          <button
                             aria-disabled={false}
                             className="exv4dm85 css-4y1t77-StyledButton-ClearButton edwq9my0"
-                            forwardRef={null}
                             onClick={[Function]}
                             role="button"
                             size="xsmall"
                           >
-                            <button
-                              aria-disabled={false}
-                              className="exv4dm85 css-4y1t77-StyledButton-ClearButton edwq9my0"
-                              onClick={[Function]}
-                              role="button"
+                            <ButtonLabel
+                              align="center"
+                              borderless={true}
                               size="xsmall"
                             >
-                              <ButtonLabel
+                              <Component
                                 align="center"
                                 borderless={true}
+                                className="css-12az27u-ButtonLabel edwq9my1"
                                 size="xsmall"
                               >
-                                <Component
-                                  align="center"
-                                  borderless={true}
+                                <span
                                   className="css-12az27u-ButtonLabel edwq9my1"
-                                  size="xsmall"
                                 >
-                                  <span
-                                    className="css-12az27u-ButtonLabel edwq9my1"
+                                  <Icon
+                                    hasChildren={false}
+                                    size="xsmall"
                                   >
-                                    <Icon
+                                    <Component
+                                      className="css-heib7e-Icon edwq9my2"
                                       hasChildren={false}
                                       size="xsmall"
                                     >
-                                      <Component
+                                      <span
                                         className="css-heib7e-Icon edwq9my2"
-                                        hasChildren={false}
                                         size="xsmall"
                                       >
-                                        <span
-                                          className="css-heib7e-Icon edwq9my2"
-                                          size="xsmall"
+                                        <StyledInlineSvg
+                                          size="12px"
+                                          src="icon-circle-close"
                                         >
-                                          <StyledInlineSvg
+                                          <ForwardRef
+                                            className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                             size="12px"
                                             src="icon-circle-close"
                                           >
-                                            <ForwardRef
+                                            <svg
                                               className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                              size="12px"
-                                              src="icon-circle-close"
+                                              height="12px"
+                                              viewBox={Object {}}
+                                              width="12px"
                                             >
-                                              <svg
-                                                className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                height="12px"
-                                                viewBox={Object {}}
-                                                width="12px"
-                                              >
-                                                <use
-                                                  href="#test"
-                                                  xlinkHref="#test"
-                                                />
-                                              </svg>
-                                            </ForwardRef>
-                                          </StyledInlineSvg>
-                                        </span>
-                                      </Component>
-                                    </Icon>
-                                  </span>
-                                </Component>
-                              </ButtonLabel>
-                            </button>
-                          </Component>
+                                              <use
+                                                href="#test"
+                                                xlinkHref="#test"
+                                              />
+                                            </svg>
+                                          </ForwardRef>
+                                        </StyledInlineSvg>
+                                      </span>
+                                    </Component>
+                                  </Icon>
+                                </span>
+                              </Component>
+                            </ButtonLabel>
+                          </button>
                         </StyledButton>
                       </Button>
                     </forwardRef<Button>>
@@ -2509,83 +2483,74 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
                             >
                               <StyledButton
                                 aria-disabled={false}
+                                as="button"
                                 borderless={true}
                                 data-test-id="create-team"
                                 disabled={false}
-                                forwardRef={null}
                                 onClick={[Function]}
                                 role="button"
+                                shouldForwardProp={[Function]}
                                 type="button"
                               >
-                                <Component
+                                <button
                                   aria-disabled={false}
                                   className="css-e1k74m-StyledButton edwq9my0"
                                   data-test-id="create-team"
-                                  forwardRef={null}
                                   onClick={[Function]}
                                   role="button"
                                   type="button"
                                 >
-                                  <button
-                                    aria-disabled={false}
-                                    className="css-e1k74m-StyledButton edwq9my0"
-                                    data-test-id="create-team"
-                                    onClick={[Function]}
-                                    role="button"
-                                    type="button"
+                                  <ButtonLabel
+                                    align="center"
+                                    borderless={true}
                                   >
-                                    <ButtonLabel
+                                    <Component
                                       align="center"
                                       borderless={true}
+                                      className="css-cmi7y3-ButtonLabel edwq9my1"
                                     >
-                                      <Component
-                                        align="center"
-                                        borderless={true}
+                                      <span
                                         className="css-cmi7y3-ButtonLabel edwq9my1"
                                       >
-                                        <span
-                                          className="css-cmi7y3-ButtonLabel edwq9my1"
+                                        <Icon
+                                          hasChildren={false}
                                         >
-                                          <Icon
+                                          <Component
+                                            className="css-heib7e-Icon edwq9my2"
                                             hasChildren={false}
                                           >
-                                            <Component
+                                            <span
                                               className="css-heib7e-Icon edwq9my2"
-                                              hasChildren={false}
                                             >
-                                              <span
-                                                className="css-heib7e-Icon edwq9my2"
+                                              <StyledInlineSvg
+                                                size="14px"
+                                                src="icon-circle-add"
                                               >
-                                                <StyledInlineSvg
+                                                <ForwardRef
+                                                  className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                                   size="14px"
                                                   src="icon-circle-add"
                                                 >
-                                                  <ForwardRef
+                                                  <svg
                                                     className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                    size="14px"
-                                                    src="icon-circle-add"
+                                                    height="14px"
+                                                    viewBox={Object {}}
+                                                    width="14px"
                                                   >
-                                                    <svg
-                                                      className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                      height="14px"
-                                                      viewBox={Object {}}
-                                                      width="14px"
-                                                    >
-                                                      <use
-                                                        href="#test"
-                                                        xlinkHref="#test"
-                                                      />
-                                                    </svg>
-                                                  </ForwardRef>
-                                                </StyledInlineSvg>
-                                              </span>
-                                            </Component>
-                                          </Icon>
-                                        </span>
-                                      </Component>
-                                    </ButtonLabel>
-                                  </button>
-                                </Component>
+                                                    <use
+                                                      href="#test"
+                                                      xlinkHref="#test"
+                                                    />
+                                                  </svg>
+                                                </ForwardRef>
+                                              </StyledInlineSvg>
+                                            </span>
+                                          </Component>
+                                        </Icon>
+                                      </span>
+                                    </Component>
+                                  </ButtonLabel>
+                                </button>
                               </StyledButton>
                             </Button>
                           </forwardRef<Button>>
@@ -2614,48 +2579,39 @@ exports[`CreateProject should fill in platform name if its provided by url 1`] =
               <StyledButton
                 aria-disabled={true}
                 aria-label="Create Project"
+                as="button"
                 data-test-id="create-project"
                 disabled={true}
-                forwardRef={null}
                 onClick={[Function]}
                 priority="primary"
                 role="button"
+                shouldForwardProp={[Function]}
               >
-                <Component
+                <button
                   aria-disabled={true}
                   aria-label="Create Project"
                   className="css-1e3hcbu-StyledButton edwq9my0"
                   data-test-id="create-project"
-                  forwardRef={null}
                   onClick={[Function]}
                   role="button"
                 >
-                  <button
-                    aria-disabled={true}
-                    aria-label="Create Project"
-                    className="css-1e3hcbu-StyledButton edwq9my0"
-                    data-test-id="create-project"
-                    onClick={[Function]}
-                    role="button"
+                  <ButtonLabel
+                    align="center"
+                    priority="primary"
                   >
-                    <ButtonLabel
+                    <Component
                       align="center"
+                      className="css-zmpclt-ButtonLabel edwq9my1"
                       priority="primary"
                     >
-                      <Component
-                        align="center"
+                      <span
                         className="css-zmpclt-ButtonLabel edwq9my1"
-                        priority="primary"
                       >
-                        <span
-                          className="css-zmpclt-ButtonLabel edwq9my1"
-                        >
-                          Create Project
-                        </span>
-                      </Component>
-                    </ButtonLabel>
-                  </button>
-                </Component>
+                        Create Project
+                      </span>
+                    </Component>
+                  </ButtonLabel>
+                </button>
               </StyledButton>
             </Button>
           </forwardRef<Button>>
@@ -3026,86 +2982,78 @@ exports[`CreateProject should fill in project name if its empty when platform is
                       >
                         <StyledButton
                           aria-disabled={false}
+                          as="button"
                           borderless={true}
                           className="css-rqv9pd-ClearButton exv4dm85"
                           disabled={false}
-                          forwardRef={null}
                           onClick={[Function]}
                           role="button"
+                          shouldForwardProp={[Function]}
                           size="xsmall"
                         >
-                          <Component
+                          <button
                             aria-disabled={false}
                             className="exv4dm85 css-4y1t77-StyledButton-ClearButton edwq9my0"
-                            forwardRef={null}
                             onClick={[Function]}
                             role="button"
                             size="xsmall"
                           >
-                            <button
-                              aria-disabled={false}
-                              className="exv4dm85 css-4y1t77-StyledButton-ClearButton edwq9my0"
-                              onClick={[Function]}
-                              role="button"
+                            <ButtonLabel
+                              align="center"
+                              borderless={true}
                               size="xsmall"
                             >
-                              <ButtonLabel
+                              <Component
                                 align="center"
                                 borderless={true}
+                                className="css-12az27u-ButtonLabel edwq9my1"
                                 size="xsmall"
                               >
-                                <Component
-                                  align="center"
-                                  borderless={true}
+                                <span
                                   className="css-12az27u-ButtonLabel edwq9my1"
-                                  size="xsmall"
                                 >
-                                  <span
-                                    className="css-12az27u-ButtonLabel edwq9my1"
+                                  <Icon
+                                    hasChildren={false}
+                                    size="xsmall"
                                   >
-                                    <Icon
+                                    <Component
+                                      className="css-heib7e-Icon edwq9my2"
                                       hasChildren={false}
                                       size="xsmall"
                                     >
-                                      <Component
+                                      <span
                                         className="css-heib7e-Icon edwq9my2"
-                                        hasChildren={false}
                                         size="xsmall"
                                       >
-                                        <span
-                                          className="css-heib7e-Icon edwq9my2"
-                                          size="xsmall"
+                                        <StyledInlineSvg
+                                          size="12px"
+                                          src="icon-circle-close"
                                         >
-                                          <StyledInlineSvg
+                                          <ForwardRef
+                                            className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                             size="12px"
                                             src="icon-circle-close"
                                           >
-                                            <ForwardRef
+                                            <svg
                                               className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                              size="12px"
-                                              src="icon-circle-close"
+                                              height="12px"
+                                              viewBox={Object {}}
+                                              width="12px"
                                             >
-                                              <svg
-                                                className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                height="12px"
-                                                viewBox={Object {}}
-                                                width="12px"
-                                              >
-                                                <use
-                                                  href="#test"
-                                                  xlinkHref="#test"
-                                                />
-                                              </svg>
-                                            </ForwardRef>
-                                          </StyledInlineSvg>
-                                        </span>
-                                      </Component>
-                                    </Icon>
-                                  </span>
-                                </Component>
-                              </ButtonLabel>
-                            </button>
-                          </Component>
+                                              <use
+                                                href="#test"
+                                                xlinkHref="#test"
+                                              />
+                                            </svg>
+                                          </ForwardRef>
+                                        </StyledInlineSvg>
+                                      </span>
+                                    </Component>
+                                  </Icon>
+                                </span>
+                              </Component>
+                            </ButtonLabel>
+                          </button>
                         </StyledButton>
                       </Button>
                     </forwardRef<Button>>
@@ -4205,83 +4153,74 @@ exports[`CreateProject should fill in project name if its empty when platform is
                             >
                               <StyledButton
                                 aria-disabled={false}
+                                as="button"
                                 borderless={true}
                                 data-test-id="create-team"
                                 disabled={false}
-                                forwardRef={null}
                                 onClick={[Function]}
                                 role="button"
+                                shouldForwardProp={[Function]}
                                 type="button"
                               >
-                                <Component
+                                <button
                                   aria-disabled={false}
                                   className="css-e1k74m-StyledButton edwq9my0"
                                   data-test-id="create-team"
-                                  forwardRef={null}
                                   onClick={[Function]}
                                   role="button"
                                   type="button"
                                 >
-                                  <button
-                                    aria-disabled={false}
-                                    className="css-e1k74m-StyledButton edwq9my0"
-                                    data-test-id="create-team"
-                                    onClick={[Function]}
-                                    role="button"
-                                    type="button"
+                                  <ButtonLabel
+                                    align="center"
+                                    borderless={true}
                                   >
-                                    <ButtonLabel
+                                    <Component
                                       align="center"
                                       borderless={true}
+                                      className="css-cmi7y3-ButtonLabel edwq9my1"
                                     >
-                                      <Component
-                                        align="center"
-                                        borderless={true}
+                                      <span
                                         className="css-cmi7y3-ButtonLabel edwq9my1"
                                       >
-                                        <span
-                                          className="css-cmi7y3-ButtonLabel edwq9my1"
+                                        <Icon
+                                          hasChildren={false}
                                         >
-                                          <Icon
+                                          <Component
+                                            className="css-heib7e-Icon edwq9my2"
                                             hasChildren={false}
                                           >
-                                            <Component
+                                            <span
                                               className="css-heib7e-Icon edwq9my2"
-                                              hasChildren={false}
                                             >
-                                              <span
-                                                className="css-heib7e-Icon edwq9my2"
+                                              <StyledInlineSvg
+                                                size="14px"
+                                                src="icon-circle-add"
                                               >
-                                                <StyledInlineSvg
+                                                <ForwardRef
+                                                  className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                                   size="14px"
                                                   src="icon-circle-add"
                                                 >
-                                                  <ForwardRef
+                                                  <svg
                                                     className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                    size="14px"
-                                                    src="icon-circle-add"
+                                                    height="14px"
+                                                    viewBox={Object {}}
+                                                    width="14px"
                                                   >
-                                                    <svg
-                                                      className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                      height="14px"
-                                                      viewBox={Object {}}
-                                                      width="14px"
-                                                    >
-                                                      <use
-                                                        href="#test"
-                                                        xlinkHref="#test"
-                                                      />
-                                                    </svg>
-                                                  </ForwardRef>
-                                                </StyledInlineSvg>
-                                              </span>
-                                            </Component>
-                                          </Icon>
-                                        </span>
-                                      </Component>
-                                    </ButtonLabel>
-                                  </button>
-                                </Component>
+                                                    <use
+                                                      href="#test"
+                                                      xlinkHref="#test"
+                                                    />
+                                                  </svg>
+                                                </ForwardRef>
+                                              </StyledInlineSvg>
+                                            </span>
+                                          </Component>
+                                        </Icon>
+                                      </span>
+                                    </Component>
+                                  </ButtonLabel>
+                                </button>
                               </StyledButton>
                             </Button>
                           </forwardRef<Button>>
@@ -4310,48 +4249,39 @@ exports[`CreateProject should fill in project name if its empty when platform is
               <StyledButton
                 aria-disabled={true}
                 aria-label="Create Project"
+                as="button"
                 data-test-id="create-project"
                 disabled={true}
-                forwardRef={null}
                 onClick={[Function]}
                 priority="primary"
                 role="button"
+                shouldForwardProp={[Function]}
               >
-                <Component
+                <button
                   aria-disabled={true}
                   aria-label="Create Project"
                   className="css-1e3hcbu-StyledButton edwq9my0"
                   data-test-id="create-project"
-                  forwardRef={null}
                   onClick={[Function]}
                   role="button"
                 >
-                  <button
-                    aria-disabled={true}
-                    aria-label="Create Project"
-                    className="css-1e3hcbu-StyledButton edwq9my0"
-                    data-test-id="create-project"
-                    onClick={[Function]}
-                    role="button"
+                  <ButtonLabel
+                    align="center"
+                    priority="primary"
                   >
-                    <ButtonLabel
+                    <Component
                       align="center"
+                      className="css-zmpclt-ButtonLabel edwq9my1"
                       priority="primary"
                     >
-                      <Component
-                        align="center"
+                      <span
                         className="css-zmpclt-ButtonLabel edwq9my1"
-                        priority="primary"
                       >
-                        <span
-                          className="css-zmpclt-ButtonLabel edwq9my1"
-                        >
-                          Create Project
-                        </span>
-                      </Component>
-                    </ButtonLabel>
-                  </button>
-                </Component>
+                        Create Project
+                      </span>
+                    </Component>
+                  </ButtonLabel>
+                </button>
               </StyledButton>
             </Button>
           </forwardRef<Button>>

--- a/tests/js/spec/components/assistant/__snapshots__/guideAnchor.spec.jsx.snap
+++ b/tests/js/spec/components/assistant/__snapshots__/guideAnchor.spec.jsx.snap
@@ -298,49 +298,41 @@ exports[`GuideAnchor renders, advances, and finishes 1`] = `
                                       >
                                         <StyledButton
                                           aria-disabled={false}
+                                          as="button"
                                           disabled={false}
-                                          forwardRef={null}
                                           onClick={[Function]}
                                           priority="success"
                                           role="button"
+                                          shouldForwardProp={[Function]}
                                           size="small"
                                         >
-                                          <Component
+                                          <button
                                             aria-disabled={false}
                                             className="css-1a9qzq-StyledButton edwq9my0"
-                                            forwardRef={null}
                                             onClick={[Function]}
                                             role="button"
                                             size="small"
                                           >
-                                            <button
-                                              aria-disabled={false}
-                                              className="css-1a9qzq-StyledButton edwq9my0"
-                                              onClick={[Function]}
-                                              role="button"
+                                            <ButtonLabel
+                                              align="center"
+                                              priority="success"
                                               size="small"
                                             >
-                                              <ButtonLabel
+                                              <Component
                                                 align="center"
+                                                className="css-19gcr2f-ButtonLabel edwq9my1"
                                                 priority="success"
                                                 size="small"
                                               >
-                                                <Component
-                                                  align="center"
+                                                <span
                                                   className="css-19gcr2f-ButtonLabel edwq9my1"
-                                                  priority="success"
-                                                  size="small"
                                                 >
-                                                  <span
-                                                    className="css-19gcr2f-ButtonLabel edwq9my1"
-                                                  >
-                                                    Next
-                                                     →
-                                                  </span>
-                                                </Component>
-                                              </ButtonLabel>
-                                            </button>
-                                          </Component>
+                                                  Next
+                                                   →
+                                                </span>
+                                              </Component>
+                                            </ButtonLabel>
+                                          </button>
                                         </StyledButton>
                                       </Button>
                                     </forwardRef<Button>>
@@ -607,50 +599,41 @@ exports[`GuideAnchor renders, advances, and finishes 2`] = `
                                         <StyledButton
                                           aria-disabled={false}
                                           aria-label="Done"
+                                          as="button"
                                           disabled={false}
-                                          forwardRef={null}
                                           onClick={[Function]}
                                           priority="success"
                                           role="button"
+                                          shouldForwardProp={[Function]}
                                           size="small"
                                         >
-                                          <Component
+                                          <button
                                             aria-disabled={false}
                                             aria-label="Done"
                                             className="css-1a9qzq-StyledButton edwq9my0"
-                                            forwardRef={null}
                                             onClick={[Function]}
                                             role="button"
                                             size="small"
                                           >
-                                            <button
-                                              aria-disabled={false}
-                                              aria-label="Done"
-                                              className="css-1a9qzq-StyledButton edwq9my0"
-                                              onClick={[Function]}
-                                              role="button"
+                                            <ButtonLabel
+                                              align="center"
+                                              priority="success"
                                               size="small"
                                             >
-                                              <ButtonLabel
+                                              <Component
                                                 align="center"
+                                                className="css-19gcr2f-ButtonLabel edwq9my1"
                                                 priority="success"
                                                 size="small"
                                               >
-                                                <Component
-                                                  align="center"
+                                                <span
                                                   className="css-19gcr2f-ButtonLabel edwq9my1"
-                                                  priority="success"
-                                                  size="small"
                                                 >
-                                                  <span
-                                                    className="css-19gcr2f-ButtonLabel edwq9my1"
-                                                  >
-                                                    Done
-                                                  </span>
-                                                </Component>
-                                              </ButtonLabel>
-                                            </button>
-                                          </Component>
+                                                  Done
+                                                </span>
+                                              </Component>
+                                            </ButtonLabel>
+                                          </button>
                                         </StyledButton>
                                       </Button>
                                     </forwardRef<Button>>

--- a/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/formField.spec.jsx.snap
@@ -294,51 +294,41 @@ exports[`FormField + model renders with Form 1`] = `
                   <StyledButton
                     aria-disabled={false}
                     aria-label="Save Changes"
+                    as="button"
                     data-test-id="form-submit"
                     disabled={false}
-                    forwardRef={null}
                     onClick={[Function]}
                     priority="primary"
                     role="button"
+                    shouldForwardProp={[Function]}
                     type="submit"
                   >
-                    <Component
+                    <button
                       aria-disabled={false}
                       aria-label="Save Changes"
                       className="css-1e05jtd-StyledButton edwq9my0"
                       data-test-id="form-submit"
-                      forwardRef={null}
                       onClick={[Function]}
                       role="button"
                       type="submit"
                     >
-                      <button
-                        aria-disabled={false}
-                        aria-label="Save Changes"
-                        className="css-1e05jtd-StyledButton edwq9my0"
-                        data-test-id="form-submit"
-                        onClick={[Function]}
-                        role="button"
-                        type="submit"
+                      <ButtonLabel
+                        align="center"
+                        priority="primary"
                       >
-                        <ButtonLabel
+                        <Component
                           align="center"
+                          className="css-zmpclt-ButtonLabel edwq9my1"
                           priority="primary"
                         >
-                          <Component
-                            align="center"
+                          <span
                             className="css-zmpclt-ButtonLabel edwq9my1"
-                            priority="primary"
                           >
-                            <span
-                              className="css-zmpclt-ButtonLabel edwq9my1"
-                            >
-                              Save Changes
-                            </span>
-                          </Component>
-                        </ButtonLabel>
-                      </button>
-                    </Component>
+                            Save Changes
+                          </span>
+                        </Component>
+                      </ButtonLabel>
+                    </button>
                   </StyledButton>
                 </Button>
               </forwardRef<Button>>

--- a/tests/js/spec/components/forms/__snapshots__/tableField.spec.jsx.snap
+++ b/tests/js/spec/components/forms/__snapshots__/tableField.spec.jsx.snap
@@ -266,85 +266,76 @@ exports[`TableField renders renders with form context 1`] = `
                                           <StyledButton
                                             aria-disabled={false}
                                             aria-label="Add Thing"
+                                            as="button"
                                             disabled={false}
-                                            forwardRef={null}
                                             onClick={[Function]}
                                             role="button"
+                                            shouldForwardProp={[Function]}
                                             size="xsmall"
                                           >
-                                            <Component
+                                            <button
                                               aria-disabled={false}
                                               aria-label="Add Thing"
                                               className="css-12ogwys-StyledButton edwq9my0"
-                                              forwardRef={null}
                                               onClick={[Function]}
                                               role="button"
                                               size="xsmall"
                                             >
-                                              <button
-                                                aria-disabled={false}
-                                                aria-label="Add Thing"
-                                                className="css-12ogwys-StyledButton edwq9my0"
-                                                onClick={[Function]}
-                                                role="button"
+                                              <ButtonLabel
+                                                align="center"
                                                 size="xsmall"
                                               >
-                                                <ButtonLabel
+                                                <Component
                                                   align="center"
+                                                  className="css-cmi7y3-ButtonLabel edwq9my1"
                                                   size="xsmall"
                                                 >
-                                                  <Component
-                                                    align="center"
+                                                  <span
                                                     className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                    size="xsmall"
                                                   >
-                                                    <span
-                                                      className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                    <Icon
+                                                      hasChildren={true}
+                                                      size="xsmall"
                                                     >
-                                                      <Icon
+                                                      <Component
+                                                        className="css-1299qb2-Icon edwq9my2"
                                                         hasChildren={true}
                                                         size="xsmall"
                                                       >
-                                                        <Component
+                                                        <span
                                                           className="css-1299qb2-Icon edwq9my2"
-                                                          hasChildren={true}
                                                           size="xsmall"
                                                         >
-                                                          <span
-                                                            className="css-1299qb2-Icon edwq9my2"
-                                                            size="xsmall"
+                                                          <StyledInlineSvg
+                                                            size="12px"
+                                                            src="icon-circle-add"
                                                           >
-                                                            <StyledInlineSvg
+                                                            <ForwardRef
+                                                              className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                                               size="12px"
                                                               src="icon-circle-add"
                                                             >
-                                                              <ForwardRef
+                                                              <svg
                                                                 className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                                size="12px"
-                                                                src="icon-circle-add"
+                                                                height="12px"
+                                                                viewBox={Object {}}
+                                                                width="12px"
                                                               >
-                                                                <svg
-                                                                  className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                                  height="12px"
-                                                                  viewBox={Object {}}
-                                                                  width="12px"
-                                                                >
-                                                                  <use
-                                                                    href="#test"
-                                                                    xlinkHref="#test"
-                                                                  />
-                                                                </svg>
-                                                              </ForwardRef>
-                                                            </StyledInlineSvg>
-                                                          </span>
-                                                        </Component>
-                                                      </Icon>
-                                                      Add Thing
-                                                    </span>
-                                                  </Component>
-                                                </ButtonLabel>
-                                              </button>
-                                            </Component>
+                                                                <use
+                                                                  href="#test"
+                                                                  xlinkHref="#test"
+                                                                />
+                                                              </svg>
+                                                            </ForwardRef>
+                                                          </StyledInlineSvg>
+                                                        </span>
+                                                      </Component>
+                                                    </Icon>
+                                                    Add Thing
+                                                  </span>
+                                                </Component>
+                                              </ButtonLabel>
+                                            </button>
                                           </StyledButton>
                                         </Button>
                                       </forwardRef<Button>>
@@ -465,51 +456,41 @@ exports[`TableField renders renders with form context 1`] = `
                   <StyledButton
                     aria-disabled={false}
                     aria-label="Save Changes"
+                    as="button"
                     data-test-id="form-submit"
                     disabled={false}
-                    forwardRef={null}
                     onClick={[Function]}
                     priority="primary"
                     role="button"
+                    shouldForwardProp={[Function]}
                     type="submit"
                   >
-                    <Component
+                    <button
                       aria-disabled={false}
                       aria-label="Save Changes"
                       className="css-1e05jtd-StyledButton edwq9my0"
                       data-test-id="form-submit"
-                      forwardRef={null}
                       onClick={[Function]}
                       role="button"
                       type="submit"
                     >
-                      <button
-                        aria-disabled={false}
-                        aria-label="Save Changes"
-                        className="css-1e05jtd-StyledButton edwq9my0"
-                        data-test-id="form-submit"
-                        onClick={[Function]}
-                        role="button"
-                        type="submit"
+                      <ButtonLabel
+                        align="center"
+                        priority="primary"
                       >
-                        <ButtonLabel
+                        <Component
                           align="center"
+                          className="css-zmpclt-ButtonLabel edwq9my1"
                           priority="primary"
                         >
-                          <Component
-                            align="center"
+                          <span
                             className="css-zmpclt-ButtonLabel edwq9my1"
-                            priority="primary"
                           >
-                            <span
-                              className="css-zmpclt-ButtonLabel edwq9my1"
-                            >
-                              Save Changes
-                            </span>
-                          </Component>
-                        </ButtonLabel>
-                      </button>
-                    </Component>
+                            Save Changes
+                          </span>
+                        </Component>
+                      </ButtonLabel>
+                    </button>
                   </StyledButton>
                 </Button>
               </forwardRef<Button>>
@@ -695,85 +676,76 @@ exports[`TableField renders renders without form context 1`] = `
                                     <StyledButton
                                       aria-disabled={false}
                                       aria-label="Add Item"
+                                      as="button"
                                       disabled={false}
-                                      forwardRef={null}
                                       onClick={[Function]}
                                       role="button"
+                                      shouldForwardProp={[Function]}
                                       size="xsmall"
                                     >
-                                      <Component
+                                      <button
                                         aria-disabled={false}
                                         aria-label="Add Item"
                                         className="css-12ogwys-StyledButton edwq9my0"
-                                        forwardRef={null}
                                         onClick={[Function]}
                                         role="button"
                                         size="xsmall"
                                       >
-                                        <button
-                                          aria-disabled={false}
-                                          aria-label="Add Item"
-                                          className="css-12ogwys-StyledButton edwq9my0"
-                                          onClick={[Function]}
-                                          role="button"
+                                        <ButtonLabel
+                                          align="center"
                                           size="xsmall"
                                         >
-                                          <ButtonLabel
+                                          <Component
                                             align="center"
+                                            className="css-cmi7y3-ButtonLabel edwq9my1"
                                             size="xsmall"
                                           >
-                                            <Component
-                                              align="center"
+                                            <span
                                               className="css-cmi7y3-ButtonLabel edwq9my1"
-                                              size="xsmall"
                                             >
-                                              <span
-                                                className="css-cmi7y3-ButtonLabel edwq9my1"
+                                              <Icon
+                                                hasChildren={true}
+                                                size="xsmall"
                                               >
-                                                <Icon
+                                                <Component
+                                                  className="css-1299qb2-Icon edwq9my2"
                                                   hasChildren={true}
                                                   size="xsmall"
                                                 >
-                                                  <Component
+                                                  <span
                                                     className="css-1299qb2-Icon edwq9my2"
-                                                    hasChildren={true}
                                                     size="xsmall"
                                                   >
-                                                    <span
-                                                      className="css-1299qb2-Icon edwq9my2"
-                                                      size="xsmall"
+                                                    <StyledInlineSvg
+                                                      size="12px"
+                                                      src="icon-circle-add"
                                                     >
-                                                      <StyledInlineSvg
+                                                      <ForwardRef
+                                                        className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                                         size="12px"
                                                         src="icon-circle-add"
                                                       >
-                                                        <ForwardRef
+                                                        <svg
                                                           className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                          size="12px"
-                                                          src="icon-circle-add"
+                                                          height="12px"
+                                                          viewBox={Object {}}
+                                                          width="12px"
                                                         >
-                                                          <svg
-                                                            className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                            height="12px"
-                                                            viewBox={Object {}}
-                                                            width="12px"
-                                                          >
-                                                            <use
-                                                              href="#test"
-                                                              xlinkHref="#test"
-                                                            />
-                                                          </svg>
-                                                        </ForwardRef>
-                                                      </StyledInlineSvg>
-                                                    </span>
-                                                  </Component>
-                                                </Icon>
-                                                Add Item
-                                              </span>
-                                            </Component>
-                                          </ButtonLabel>
-                                        </button>
-                                      </Component>
+                                                          <use
+                                                            href="#test"
+                                                            xlinkHref="#test"
+                                                          />
+                                                        </svg>
+                                                      </ForwardRef>
+                                                    </StyledInlineSvg>
+                                                  </span>
+                                                </Component>
+                                              </Icon>
+                                              Add Item
+                                            </span>
+                                          </Component>
+                                        </ButtonLabel>
+                                      </button>
                                     </StyledButton>
                                   </Button>
                                 </forwardRef<Button>>

--- a/tests/js/spec/components/group/__snapshots__/externalIssueForm.spec.jsx.snap
+++ b/tests/js/spec/components/group/__snapshots__/externalIssueForm.spec.jsx.snap
@@ -142,51 +142,41 @@ exports[`ExternalIssueForm create renders 1`] = `
                     <StyledButton
                       aria-disabled={false}
                       aria-label="Create Issue"
+                      as="button"
                       data-test-id="form-submit"
                       disabled={false}
-                      forwardRef={null}
                       onClick={[Function]}
                       priority="primary"
                       role="button"
+                      shouldForwardProp={[Function]}
                       type="submit"
                     >
-                      <Component
+                      <button
                         aria-disabled={false}
                         aria-label="Create Issue"
                         className="css-1e05jtd-StyledButton edwq9my0"
                         data-test-id="form-submit"
-                        forwardRef={null}
                         onClick={[Function]}
                         role="button"
                         type="submit"
                       >
-                        <button
-                          aria-disabled={false}
-                          aria-label="Create Issue"
-                          className="css-1e05jtd-StyledButton edwq9my0"
-                          data-test-id="form-submit"
-                          onClick={[Function]}
-                          role="button"
-                          type="submit"
+                        <ButtonLabel
+                          align="center"
+                          priority="primary"
                         >
-                          <ButtonLabel
+                          <Component
                             align="center"
+                            className="css-zmpclt-ButtonLabel edwq9my1"
                             priority="primary"
                           >
-                            <Component
-                              align="center"
+                            <span
                               className="css-zmpclt-ButtonLabel edwq9my1"
-                              priority="primary"
                             >
-                              <span
-                                className="css-zmpclt-ButtonLabel edwq9my1"
-                              >
-                                Create Issue
-                              </span>
-                            </Component>
-                          </ButtonLabel>
-                        </button>
-                      </Component>
+                              Create Issue
+                            </span>
+                          </Component>
+                        </ButtonLabel>
+                      </button>
                     </StyledButton>
                   </Button>
                 </forwardRef<Button>>
@@ -2778,51 +2768,41 @@ exports[`ExternalIssueForm link renders 1`] = `
                     <StyledButton
                       aria-disabled={false}
                       aria-label="Link Issue"
+                      as="button"
                       data-test-id="form-submit"
                       disabled={false}
-                      forwardRef={null}
                       onClick={[Function]}
                       priority="primary"
                       role="button"
+                      shouldForwardProp={[Function]}
                       type="submit"
                     >
-                      <Component
+                      <button
                         aria-disabled={false}
                         aria-label="Link Issue"
                         className="css-1e05jtd-StyledButton edwq9my0"
                         data-test-id="form-submit"
-                        forwardRef={null}
                         onClick={[Function]}
                         role="button"
                         type="submit"
                       >
-                        <button
-                          aria-disabled={false}
-                          aria-label="Link Issue"
-                          className="css-1e05jtd-StyledButton edwq9my0"
-                          data-test-id="form-submit"
-                          onClick={[Function]}
-                          role="button"
-                          type="submit"
+                        <ButtonLabel
+                          align="center"
+                          priority="primary"
                         >
-                          <ButtonLabel
+                          <Component
                             align="center"
+                            className="css-zmpclt-ButtonLabel edwq9my1"
                             priority="primary"
                           >
-                            <Component
-                              align="center"
+                            <span
                               className="css-zmpclt-ButtonLabel edwq9my1"
-                              priority="primary"
                             >
-                              <span
-                                className="css-zmpclt-ButtonLabel edwq9my1"
-                              >
-                                Link Issue
-                              </span>
-                            </Component>
-                          </ButtonLabel>
-                        </button>
-                      </Component>
+                              Link Issue
+                            </span>
+                          </Component>
+                        </ButtonLabel>
+                      </button>
                     </StyledButton>
                   </Button>
                 </forwardRef<Button>>

--- a/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
+++ b/tests/js/spec/components/modals/__snapshots__/integrationDetailsModal.spec.jsx.snap
@@ -370,50 +370,40 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
           <StyledButton
             aria-disabled={false}
             aria-label="Cancel"
+            as="button"
             data-test-id="cancel-button"
             disabled={false}
-            forwardRef={null}
             onClick={[Function]}
             role="button"
+            shouldForwardProp={[Function]}
             size="small"
           >
-            <Component
+            <button
               aria-disabled={false}
               aria-label="Cancel"
               className="css-12ogwys-StyledButton edwq9my0"
               data-test-id="cancel-button"
-              forwardRef={null}
               onClick={[Function]}
               role="button"
               size="small"
             >
-              <button
-                aria-disabled={false}
-                aria-label="Cancel"
-                className="css-12ogwys-StyledButton edwq9my0"
-                data-test-id="cancel-button"
-                onClick={[Function]}
-                role="button"
+              <ButtonLabel
+                align="center"
                 size="small"
               >
-                <ButtonLabel
+                <Component
                   align="center"
+                  className="css-19gcr2f-ButtonLabel edwq9my1"
                   size="small"
                 >
-                  <Component
-                    align="center"
+                  <span
                     className="css-19gcr2f-ButtonLabel edwq9my1"
-                    size="small"
                   >
-                    <span
-                      className="css-19gcr2f-ButtonLabel edwq9my1"
-                    >
-                      Cancel
-                    </span>
-                  </Component>
-                </ButtonLabel>
-              </button>
-            </Component>
+                    Cancel
+                  </span>
+                </Component>
+              </ButtonLabel>
+            </button>
           </StyledButton>
         </Button>
       </forwardRef<Button>>
@@ -676,12 +666,13 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                           <StyledButton
                             aria-disabled={false}
                             aria-label="Add Installation"
+                            as="button"
                             data-test-id="add-button"
                             disabled={false}
-                            forwardRef={null}
                             onClick={[Function]}
                             priority="primary"
                             role="button"
+                            shouldForwardProp={[Function]}
                             size="small"
                             style={
                               Object {
@@ -689,12 +680,11 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                               }
                             }
                           >
-                            <Component
+                            <button
                               aria-disabled={false}
                               aria-label="Add Installation"
                               className="css-z8at1v-StyledButton edwq9my0"
                               data-test-id="add-button"
-                              forwardRef={null}
                               onClick={[Function]}
                               role="button"
                               size="small"
@@ -704,40 +694,25 @@ exports[`IntegrationDetailsModal renders simple integration 1`] = `
                                 }
                               }
                             >
-                              <button
-                                aria-disabled={false}
-                                aria-label="Add Installation"
-                                className="css-z8at1v-StyledButton edwq9my0"
-                                data-test-id="add-button"
-                                onClick={[Function]}
-                                role="button"
+                              <ButtonLabel
+                                align="center"
+                                priority="primary"
                                 size="small"
-                                style={
-                                  Object {
-                                    "marginLeft": "8px",
-                                  }
-                                }
                               >
-                                <ButtonLabel
+                                <Component
                                   align="center"
+                                  className="css-19gcr2f-ButtonLabel edwq9my1"
                                   priority="primary"
                                   size="small"
                                 >
-                                  <Component
-                                    align="center"
+                                  <span
                                     className="css-19gcr2f-ButtonLabel edwq9my1"
-                                    priority="primary"
-                                    size="small"
                                   >
-                                    <span
-                                      className="css-19gcr2f-ButtonLabel edwq9my1"
-                                    >
-                                      Add Installation
-                                    </span>
-                                  </Component>
-                                </ButtonLabel>
-                              </button>
-                            </Component>
+                                    Add Installation
+                                  </span>
+                                </Component>
+                              </ButtonLabel>
+                            </button>
                           </StyledButton>
                         </Button>
                       </forwardRef<Button>>

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -1139,19 +1139,23 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
               <StyledButton
                 aria-disabled={false}
                 aria-label="Learn more"
+                as={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "render": [Function],
+                  }
+                }
                 disabled={false}
-                external={true}
-                forwardRef={null}
                 href="https://status.sentry.io"
                 onClick={[Function]}
                 role="button"
+                shouldForwardProp={[Function]}
                 size="small"
               >
-                <Component
+                <ForwardRef
                   aria-disabled={false}
                   aria-label="Learn more"
                   className="css-12ogwys-StyledButton edwq9my0"
-                  forwardRef={null}
                   href="https://status.sentry.io"
                   onClick={[Function]}
                   role="button"
@@ -1163,8 +1167,10 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                     className="css-12ogwys-StyledButton edwq9my0"
                     href="https://status.sentry.io"
                     onClick={[Function]}
+                    rel="noreferrer noopener"
                     role="button"
                     size="small"
+                    target="_blank"
                   >
                     <ButtonLabel
                       align="center"
@@ -1183,7 +1189,7 @@ exports[`Sidebar SidebarPanel can show Incidents in Sidebar Panel 1`] = `
                       </Component>
                     </ButtonLabel>
                   </a>
-                </Component>
+                </ForwardRef>
               </StyledButton>
             </Button>
           </forwardRef<Button>>
@@ -1425,49 +1431,40 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         <StyledButton
                                           aria-disabled={false}
                                           aria-label="Skip task"
+                                          as="button"
                                           className="css-13i4fqu-SkipButton e1a4o5477"
                                           disabled={false}
-                                          forwardRef={null}
                                           hide={true}
                                           onClick={[Function]}
                                           role="button"
+                                          shouldForwardProp={[Function]}
                                           size="xsmall"
                                         >
-                                          <Component
+                                          <button
                                             aria-disabled={false}
                                             aria-label="Skip task"
                                             className="e1a4o5477 css-1gw4trp-StyledButton-SkipButton edwq9my0"
-                                            forwardRef={null}
                                             onClick={[Function]}
                                             role="button"
                                             size="xsmall"
                                           >
-                                            <button
-                                              aria-disabled={false}
-                                              aria-label="Skip task"
-                                              className="e1a4o5477 css-1gw4trp-StyledButton-SkipButton edwq9my0"
-                                              onClick={[Function]}
-                                              role="button"
+                                            <ButtonLabel
+                                              align="center"
                                               size="xsmall"
                                             >
-                                              <ButtonLabel
+                                              <Component
                                                 align="center"
+                                                className="css-cmi7y3-ButtonLabel edwq9my1"
                                                 size="xsmall"
                                               >
-                                                <Component
-                                                  align="center"
+                                                <span
                                                   className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                  size="xsmall"
                                                 >
-                                                  <span
-                                                    className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                  >
-                                                    Skip task
-                                                  </span>
-                                                </Component>
-                                              </ButtonLabel>
-                                            </button>
-                                          </Component>
+                                                  Skip task
+                                                </span>
+                                              </Component>
+                                            </ButtonLabel>
+                                          </button>
                                         </StyledButton>
                                       </Button>
                                     </forwardRef<Button>>
@@ -1544,59 +1541,50 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             <StyledButton
                                               aria-disabled={false}
                                               aria-label="Go to Support"
+                                              as={[Function]}
                                               disabled={false}
-                                              forwardRef={null}
                                               onClick={[Function]}
                                               priority="link"
                                               role="button"
+                                              shouldForwardProp={[Function]}
                                               to="/settings/org-slug/support/"
                                             >
-                                              <Component
+                                              <Link
                                                 aria-disabled={false}
                                                 aria-label="Go to Support"
                                                 className="css-1ilrgbi-StyledButton edwq9my0"
-                                                forwardRef={null}
                                                 onClick={[Function]}
+                                                onlyActiveOnIndex={false}
                                                 role="button"
+                                                style={Object {}}
                                                 to="/settings/org-slug/support/"
                                               >
-                                                <Link
+                                                <a
                                                   aria-disabled={false}
                                                   aria-label="Go to Support"
                                                   className="css-1ilrgbi-StyledButton edwq9my0"
                                                   onClick={[Function]}
-                                                  onlyActiveOnIndex={false}
                                                   role="button"
                                                   style={Object {}}
-                                                  to="/settings/org-slug/support/"
                                                 >
-                                                  <a
-                                                    aria-disabled={false}
-                                                    aria-label="Go to Support"
-                                                    className="css-1ilrgbi-StyledButton edwq9my0"
-                                                    onClick={[Function]}
-                                                    role="button"
-                                                    style={Object {}}
+                                                  <ButtonLabel
+                                                    align="center"
+                                                    priority="link"
                                                   >
-                                                    <ButtonLabel
+                                                    <Component
                                                       align="center"
+                                                      className="css-1igyjbb-ButtonLabel edwq9my1"
                                                       priority="link"
                                                     >
-                                                      <Component
-                                                        align="center"
+                                                      <span
                                                         className="css-1igyjbb-ButtonLabel edwq9my1"
-                                                        priority="link"
                                                       >
-                                                        <span
-                                                          className="css-1igyjbb-ButtonLabel edwq9my1"
-                                                        >
-                                                          Go to Support
-                                                        </span>
-                                                      </Component>
-                                                    </ButtonLabel>
-                                                  </a>
-                                                </Link>
-                                              </Component>
+                                                        Go to Support
+                                                      </span>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </a>
+                                              </Link>
                                             </StyledButton>
                                           </Button>
                                         </forwardRef<Button>>
@@ -1751,49 +1739,40 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         <StyledButton
                                           aria-disabled={false}
                                           aria-label="Skip task"
+                                          as="button"
                                           className="css-13i4fqu-SkipButton e1a4o5477"
                                           disabled={false}
-                                          forwardRef={null}
                                           hide={true}
                                           onClick={[Function]}
                                           role="button"
+                                          shouldForwardProp={[Function]}
                                           size="xsmall"
                                         >
-                                          <Component
+                                          <button
                                             aria-disabled={false}
                                             aria-label="Skip task"
                                             className="e1a4o5477 css-1gw4trp-StyledButton-SkipButton edwq9my0"
-                                            forwardRef={null}
                                             onClick={[Function]}
                                             role="button"
                                             size="xsmall"
                                           >
-                                            <button
-                                              aria-disabled={false}
-                                              aria-label="Skip task"
-                                              className="e1a4o5477 css-1gw4trp-StyledButton-SkipButton edwq9my0"
-                                              onClick={[Function]}
-                                              role="button"
+                                            <ButtonLabel
+                                              align="center"
                                               size="xsmall"
                                             >
-                                              <ButtonLabel
+                                              <Component
                                                 align="center"
+                                                className="css-cmi7y3-ButtonLabel edwq9my1"
                                                 size="xsmall"
                                               >
-                                                <Component
-                                                  align="center"
+                                                <span
                                                   className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                  size="xsmall"
                                                 >
-                                                  <span
-                                                    className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                  >
-                                                    Skip task
-                                                  </span>
-                                                </Component>
-                                              </ButtonLabel>
-                                            </button>
-                                          </Component>
+                                                  Skip task
+                                                </span>
+                                              </Component>
+                                            </ButtonLabel>
+                                          </button>
                                         </StyledButton>
                                       </Button>
                                     </forwardRef<Button>>
@@ -1870,59 +1849,50 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             <StyledButton
                                               aria-disabled={false}
                                               aria-label="Go to Support"
+                                              as={[Function]}
                                               disabled={false}
-                                              forwardRef={null}
                                               onClick={[Function]}
                                               priority="link"
                                               role="button"
+                                              shouldForwardProp={[Function]}
                                               to="/settings/org-slug/support/"
                                             >
-                                              <Component
+                                              <Link
                                                 aria-disabled={false}
                                                 aria-label="Go to Support"
                                                 className="css-1ilrgbi-StyledButton edwq9my0"
-                                                forwardRef={null}
                                                 onClick={[Function]}
+                                                onlyActiveOnIndex={false}
                                                 role="button"
+                                                style={Object {}}
                                                 to="/settings/org-slug/support/"
                                               >
-                                                <Link
+                                                <a
                                                   aria-disabled={false}
                                                   aria-label="Go to Support"
                                                   className="css-1ilrgbi-StyledButton edwq9my0"
                                                   onClick={[Function]}
-                                                  onlyActiveOnIndex={false}
                                                   role="button"
                                                   style={Object {}}
-                                                  to="/settings/org-slug/support/"
                                                 >
-                                                  <a
-                                                    aria-disabled={false}
-                                                    aria-label="Go to Support"
-                                                    className="css-1ilrgbi-StyledButton edwq9my0"
-                                                    onClick={[Function]}
-                                                    role="button"
-                                                    style={Object {}}
+                                                  <ButtonLabel
+                                                    align="center"
+                                                    priority="link"
                                                   >
-                                                    <ButtonLabel
+                                                    <Component
                                                       align="center"
+                                                      className="css-1igyjbb-ButtonLabel edwq9my1"
                                                       priority="link"
                                                     >
-                                                      <Component
-                                                        align="center"
+                                                      <span
                                                         className="css-1igyjbb-ButtonLabel edwq9my1"
-                                                        priority="link"
                                                       >
-                                                        <span
-                                                          className="css-1igyjbb-ButtonLabel edwq9my1"
-                                                        >
-                                                          Go to Support
-                                                        </span>
-                                                      </Component>
-                                                    </ButtonLabel>
-                                                  </a>
-                                                </Link>
-                                              </Component>
+                                                        Go to Support
+                                                      </span>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </a>
+                                              </Link>
                                             </StyledButton>
                                           </Button>
                                         </forwardRef<Button>>
@@ -2073,49 +2043,40 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         <StyledButton
                                           aria-disabled={false}
                                           aria-label="Skip task"
+                                          as="button"
                                           className="css-13i4fqu-SkipButton e1a4o5477"
                                           disabled={false}
-                                          forwardRef={null}
                                           hide={true}
                                           onClick={[Function]}
                                           role="button"
+                                          shouldForwardProp={[Function]}
                                           size="xsmall"
                                         >
-                                          <Component
+                                          <button
                                             aria-disabled={false}
                                             aria-label="Skip task"
                                             className="e1a4o5477 css-1gw4trp-StyledButton-SkipButton edwq9my0"
-                                            forwardRef={null}
                                             onClick={[Function]}
                                             role="button"
                                             size="xsmall"
                                           >
-                                            <button
-                                              aria-disabled={false}
-                                              aria-label="Skip task"
-                                              className="e1a4o5477 css-1gw4trp-StyledButton-SkipButton edwq9my0"
-                                              onClick={[Function]}
-                                              role="button"
+                                            <ButtonLabel
+                                              align="center"
                                               size="xsmall"
                                             >
-                                              <ButtonLabel
+                                              <Component
                                                 align="center"
+                                                className="css-cmi7y3-ButtonLabel edwq9my1"
                                                 size="xsmall"
                                               >
-                                                <Component
-                                                  align="center"
+                                                <span
                                                   className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                  size="xsmall"
                                                 >
-                                                  <span
-                                                    className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                  >
-                                                    Skip task
-                                                  </span>
-                                                </Component>
-                                              </ButtonLabel>
-                                            </button>
-                                          </Component>
+                                                  Skip task
+                                                </span>
+                                              </Component>
+                                            </ButtonLabel>
+                                          </button>
                                         </StyledButton>
                                       </Button>
                                     </forwardRef<Button>>
@@ -2192,59 +2153,50 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             <StyledButton
                                               aria-disabled={false}
                                               aria-label="Go to Support"
+                                              as={[Function]}
                                               disabled={false}
-                                              forwardRef={null}
                                               onClick={[Function]}
                                               priority="link"
                                               role="button"
+                                              shouldForwardProp={[Function]}
                                               to="/settings/org-slug/support/"
                                             >
-                                              <Component
+                                              <Link
                                                 aria-disabled={false}
                                                 aria-label="Go to Support"
                                                 className="css-1ilrgbi-StyledButton edwq9my0"
-                                                forwardRef={null}
                                                 onClick={[Function]}
+                                                onlyActiveOnIndex={false}
                                                 role="button"
+                                                style={Object {}}
                                                 to="/settings/org-slug/support/"
                                               >
-                                                <Link
+                                                <a
                                                   aria-disabled={false}
                                                   aria-label="Go to Support"
                                                   className="css-1ilrgbi-StyledButton edwq9my0"
                                                   onClick={[Function]}
-                                                  onlyActiveOnIndex={false}
                                                   role="button"
                                                   style={Object {}}
-                                                  to="/settings/org-slug/support/"
                                                 >
-                                                  <a
-                                                    aria-disabled={false}
-                                                    aria-label="Go to Support"
-                                                    className="css-1ilrgbi-StyledButton edwq9my0"
-                                                    onClick={[Function]}
-                                                    role="button"
-                                                    style={Object {}}
+                                                  <ButtonLabel
+                                                    align="center"
+                                                    priority="link"
                                                   >
-                                                    <ButtonLabel
+                                                    <Component
                                                       align="center"
+                                                      className="css-1igyjbb-ButtonLabel edwq9my1"
                                                       priority="link"
                                                     >
-                                                      <Component
-                                                        align="center"
+                                                      <span
                                                         className="css-1igyjbb-ButtonLabel edwq9my1"
-                                                        priority="link"
                                                       >
-                                                        <span
-                                                          className="css-1igyjbb-ButtonLabel edwq9my1"
-                                                        >
-                                                          Go to Support
-                                                        </span>
-                                                      </Component>
-                                                    </ButtonLabel>
-                                                  </a>
-                                                </Link>
-                                              </Component>
+                                                        Go to Support
+                                                      </span>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </a>
+                                              </Link>
                                             </StyledButton>
                                           </Button>
                                         </forwardRef<Button>>
@@ -2401,49 +2353,40 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         <StyledButton
                                           aria-disabled={false}
                                           aria-label="Skip task"
+                                          as="button"
                                           className="css-13i4fqu-SkipButton e1a4o5477"
                                           disabled={false}
-                                          forwardRef={null}
                                           hide={true}
                                           onClick={[Function]}
                                           role="button"
+                                          shouldForwardProp={[Function]}
                                           size="xsmall"
                                         >
-                                          <Component
+                                          <button
                                             aria-disabled={false}
                                             aria-label="Skip task"
                                             className="e1a4o5477 css-1gw4trp-StyledButton-SkipButton edwq9my0"
-                                            forwardRef={null}
                                             onClick={[Function]}
                                             role="button"
                                             size="xsmall"
                                           >
-                                            <button
-                                              aria-disabled={false}
-                                              aria-label="Skip task"
-                                              className="e1a4o5477 css-1gw4trp-StyledButton-SkipButton edwq9my0"
-                                              onClick={[Function]}
-                                              role="button"
+                                            <ButtonLabel
+                                              align="center"
                                               size="xsmall"
                                             >
-                                              <ButtonLabel
+                                              <Component
                                                 align="center"
+                                                className="css-cmi7y3-ButtonLabel edwq9my1"
                                                 size="xsmall"
                                               >
-                                                <Component
-                                                  align="center"
+                                                <span
                                                   className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                  size="xsmall"
                                                 >
-                                                  <span
-                                                    className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                  >
-                                                    Skip task
-                                                  </span>
-                                                </Component>
-                                              </ButtonLabel>
-                                            </button>
-                                          </Component>
+                                                  Skip task
+                                                </span>
+                                              </Component>
+                                            </ButtonLabel>
+                                          </button>
                                         </StyledButton>
                                       </Button>
                                     </forwardRef<Button>>
@@ -2520,59 +2463,50 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             <StyledButton
                                               aria-disabled={false}
                                               aria-label="Go to Support"
+                                              as={[Function]}
                                               disabled={false}
-                                              forwardRef={null}
                                               onClick={[Function]}
                                               priority="link"
                                               role="button"
+                                              shouldForwardProp={[Function]}
                                               to="/settings/org-slug/support/"
                                             >
-                                              <Component
+                                              <Link
                                                 aria-disabled={false}
                                                 aria-label="Go to Support"
                                                 className="css-1ilrgbi-StyledButton edwq9my0"
-                                                forwardRef={null}
                                                 onClick={[Function]}
+                                                onlyActiveOnIndex={false}
                                                 role="button"
+                                                style={Object {}}
                                                 to="/settings/org-slug/support/"
                                               >
-                                                <Link
+                                                <a
                                                   aria-disabled={false}
                                                   aria-label="Go to Support"
                                                   className="css-1ilrgbi-StyledButton edwq9my0"
                                                   onClick={[Function]}
-                                                  onlyActiveOnIndex={false}
                                                   role="button"
                                                   style={Object {}}
-                                                  to="/settings/org-slug/support/"
                                                 >
-                                                  <a
-                                                    aria-disabled={false}
-                                                    aria-label="Go to Support"
-                                                    className="css-1ilrgbi-StyledButton edwq9my0"
-                                                    onClick={[Function]}
-                                                    role="button"
-                                                    style={Object {}}
+                                                  <ButtonLabel
+                                                    align="center"
+                                                    priority="link"
                                                   >
-                                                    <ButtonLabel
+                                                    <Component
                                                       align="center"
+                                                      className="css-1igyjbb-ButtonLabel edwq9my1"
                                                       priority="link"
                                                     >
-                                                      <Component
-                                                        align="center"
+                                                      <span
                                                         className="css-1igyjbb-ButtonLabel edwq9my1"
-                                                        priority="link"
                                                       >
-                                                        <span
-                                                          className="css-1igyjbb-ButtonLabel edwq9my1"
-                                                        >
-                                                          Go to Support
-                                                        </span>
-                                                      </Component>
-                                                    </ButtonLabel>
-                                                  </a>
-                                                </Link>
-                                              </Component>
+                                                        Go to Support
+                                                      </span>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </a>
+                                              </Link>
                                             </StyledButton>
                                           </Button>
                                         </forwardRef<Button>>
@@ -2731,49 +2665,40 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         <StyledButton
                                           aria-disabled={false}
                                           aria-label="Skip task"
+                                          as="button"
                                           className="css-13i4fqu-SkipButton e1a4o5477"
                                           disabled={false}
-                                          forwardRef={null}
                                           hide={true}
                                           onClick={[Function]}
                                           role="button"
+                                          shouldForwardProp={[Function]}
                                           size="xsmall"
                                         >
-                                          <Component
+                                          <button
                                             aria-disabled={false}
                                             aria-label="Skip task"
                                             className="e1a4o5477 css-1gw4trp-StyledButton-SkipButton edwq9my0"
-                                            forwardRef={null}
                                             onClick={[Function]}
                                             role="button"
                                             size="xsmall"
                                           >
-                                            <button
-                                              aria-disabled={false}
-                                              aria-label="Skip task"
-                                              className="e1a4o5477 css-1gw4trp-StyledButton-SkipButton edwq9my0"
-                                              onClick={[Function]}
-                                              role="button"
+                                            <ButtonLabel
+                                              align="center"
                                               size="xsmall"
                                             >
-                                              <ButtonLabel
+                                              <Component
                                                 align="center"
+                                                className="css-cmi7y3-ButtonLabel edwq9my1"
                                                 size="xsmall"
                                               >
-                                                <Component
-                                                  align="center"
+                                                <span
                                                   className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                  size="xsmall"
                                                 >
-                                                  <span
-                                                    className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                  >
-                                                    Skip task
-                                                  </span>
-                                                </Component>
-                                              </ButtonLabel>
-                                            </button>
-                                          </Component>
+                                                  Skip task
+                                                </span>
+                                              </Component>
+                                            </ButtonLabel>
+                                          </button>
                                         </StyledButton>
                                       </Button>
                                     </forwardRef<Button>>
@@ -2850,59 +2775,50 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             <StyledButton
                                               aria-disabled={false}
                                               aria-label="Go to Support"
+                                              as={[Function]}
                                               disabled={false}
-                                              forwardRef={null}
                                               onClick={[Function]}
                                               priority="link"
                                               role="button"
+                                              shouldForwardProp={[Function]}
                                               to="/settings/org-slug/support/"
                                             >
-                                              <Component
+                                              <Link
                                                 aria-disabled={false}
                                                 aria-label="Go to Support"
                                                 className="css-1ilrgbi-StyledButton edwq9my0"
-                                                forwardRef={null}
                                                 onClick={[Function]}
+                                                onlyActiveOnIndex={false}
                                                 role="button"
+                                                style={Object {}}
                                                 to="/settings/org-slug/support/"
                                               >
-                                                <Link
+                                                <a
                                                   aria-disabled={false}
                                                   aria-label="Go to Support"
                                                   className="css-1ilrgbi-StyledButton edwq9my0"
                                                   onClick={[Function]}
-                                                  onlyActiveOnIndex={false}
                                                   role="button"
                                                   style={Object {}}
-                                                  to="/settings/org-slug/support/"
                                                 >
-                                                  <a
-                                                    aria-disabled={false}
-                                                    aria-label="Go to Support"
-                                                    className="css-1ilrgbi-StyledButton edwq9my0"
-                                                    onClick={[Function]}
-                                                    role="button"
-                                                    style={Object {}}
+                                                  <ButtonLabel
+                                                    align="center"
+                                                    priority="link"
                                                   >
-                                                    <ButtonLabel
+                                                    <Component
                                                       align="center"
+                                                      className="css-1igyjbb-ButtonLabel edwq9my1"
                                                       priority="link"
                                                     >
-                                                      <Component
-                                                        align="center"
+                                                      <span
                                                         className="css-1igyjbb-ButtonLabel edwq9my1"
-                                                        priority="link"
                                                       >
-                                                        <span
-                                                          className="css-1igyjbb-ButtonLabel edwq9my1"
-                                                        >
-                                                          Go to Support
-                                                        </span>
-                                                      </Component>
-                                                    </ButtonLabel>
-                                                  </a>
-                                                </Link>
-                                              </Component>
+                                                        Go to Support
+                                                      </span>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </a>
+                                              </Link>
                                             </StyledButton>
                                           </Button>
                                         </forwardRef<Button>>
@@ -3061,49 +2977,40 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                         <StyledButton
                                           aria-disabled={false}
                                           aria-label="Skip task"
+                                          as="button"
                                           className="css-13i4fqu-SkipButton e1a4o5477"
                                           disabled={false}
-                                          forwardRef={null}
                                           hide={true}
                                           onClick={[Function]}
                                           role="button"
+                                          shouldForwardProp={[Function]}
                                           size="xsmall"
                                         >
-                                          <Component
+                                          <button
                                             aria-disabled={false}
                                             aria-label="Skip task"
                                             className="e1a4o5477 css-1gw4trp-StyledButton-SkipButton edwq9my0"
-                                            forwardRef={null}
                                             onClick={[Function]}
                                             role="button"
                                             size="xsmall"
                                           >
-                                            <button
-                                              aria-disabled={false}
-                                              aria-label="Skip task"
-                                              className="e1a4o5477 css-1gw4trp-StyledButton-SkipButton edwq9my0"
-                                              onClick={[Function]}
-                                              role="button"
+                                            <ButtonLabel
+                                              align="center"
                                               size="xsmall"
                                             >
-                                              <ButtonLabel
+                                              <Component
                                                 align="center"
+                                                className="css-cmi7y3-ButtonLabel edwq9my1"
                                                 size="xsmall"
                                               >
-                                                <Component
-                                                  align="center"
+                                                <span
                                                   className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                  size="xsmall"
                                                 >
-                                                  <span
-                                                    className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                  >
-                                                    Skip task
-                                                  </span>
-                                                </Component>
-                                              </ButtonLabel>
-                                            </button>
-                                          </Component>
+                                                  Skip task
+                                                </span>
+                                              </Component>
+                                            </ButtonLabel>
+                                          </button>
                                         </StyledButton>
                                       </Button>
                                     </forwardRef<Button>>
@@ -3180,59 +3087,50 @@ exports[`Sidebar can have onboarding feature 1`] = `
                                             <StyledButton
                                               aria-disabled={false}
                                               aria-label="Go to Support"
+                                              as={[Function]}
                                               disabled={false}
-                                              forwardRef={null}
                                               onClick={[Function]}
                                               priority="link"
                                               role="button"
+                                              shouldForwardProp={[Function]}
                                               to="/settings/org-slug/support/"
                                             >
-                                              <Component
+                                              <Link
                                                 aria-disabled={false}
                                                 aria-label="Go to Support"
                                                 className="css-1ilrgbi-StyledButton edwq9my0"
-                                                forwardRef={null}
                                                 onClick={[Function]}
+                                                onlyActiveOnIndex={false}
                                                 role="button"
+                                                style={Object {}}
                                                 to="/settings/org-slug/support/"
                                               >
-                                                <Link
+                                                <a
                                                   aria-disabled={false}
                                                   aria-label="Go to Support"
                                                   className="css-1ilrgbi-StyledButton edwq9my0"
                                                   onClick={[Function]}
-                                                  onlyActiveOnIndex={false}
                                                   role="button"
                                                   style={Object {}}
-                                                  to="/settings/org-slug/support/"
                                                 >
-                                                  <a
-                                                    aria-disabled={false}
-                                                    aria-label="Go to Support"
-                                                    className="css-1ilrgbi-StyledButton edwq9my0"
-                                                    onClick={[Function]}
-                                                    role="button"
-                                                    style={Object {}}
+                                                  <ButtonLabel
+                                                    align="center"
+                                                    priority="link"
                                                   >
-                                                    <ButtonLabel
+                                                    <Component
                                                       align="center"
+                                                      className="css-1igyjbb-ButtonLabel edwq9my1"
                                                       priority="link"
                                                     >
-                                                      <Component
-                                                        align="center"
+                                                      <span
                                                         className="css-1igyjbb-ButtonLabel edwq9my1"
-                                                        priority="link"
                                                       >
-                                                        <span
-                                                          className="css-1igyjbb-ButtonLabel edwq9my1"
-                                                        >
-                                                          Go to Support
-                                                        </span>
-                                                      </Component>
-                                                    </ButtonLabel>
-                                                  </a>
-                                                </Link>
-                                              </Component>
+                                                        Go to Support
+                                                      </span>
+                                                    </Component>
+                                                  </ButtonLabel>
+                                                </a>
+                                              </Link>
                                             </StyledButton>
                                           </Button>
                                         </forwardRef<Button>>

--- a/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/organizationTeamProjects.spec.jsx.snap
@@ -208,77 +208,68 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                                         >
                                           <StyledButton
                                             aria-disabled={false}
+                                            as="button"
                                             className="css-1k1xa0j-StyledButton e1yghndz1"
                                             disabled={false}
-                                            forwardRef={null}
                                             isOpen={false}
                                             onClick={[Function]}
                                             role="button"
+                                            shouldForwardProp={[Function]}
                                             size="xsmall"
                                             type="button"
                                           >
-                                            <Component
+                                            <button
                                               aria-disabled={false}
                                               className="e1yghndz1 css-ssbzqs-StyledButton-StyledButton edwq9my0"
-                                              forwardRef={null}
                                               onClick={[Function]}
                                               role="button"
                                               size="xsmall"
                                               type="button"
                                             >
-                                              <button
-                                                aria-disabled={false}
-                                                className="e1yghndz1 css-ssbzqs-StyledButton-StyledButton edwq9my0"
-                                                onClick={[Function]}
-                                                role="button"
+                                              <ButtonLabel
+                                                align="center"
                                                 size="xsmall"
-                                                type="button"
                                               >
-                                                <ButtonLabel
+                                                <Component
                                                   align="center"
+                                                  className="css-cmi7y3-ButtonLabel edwq9my1"
                                                   size="xsmall"
                                                 >
-                                                  <Component
-                                                    align="center"
+                                                  <span
                                                     className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                    size="xsmall"
                                                   >
-                                                    <span
-                                                      className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                    >
-                                                      Add Project
-                                                      <StyledChevronDown>
-                                                        <Component
+                                                    Add Project
+                                                    <StyledChevronDown>
+                                                      <Component
+                                                        className="css-1jdzfs8-StyledChevronDown e1yghndz0"
+                                                      >
+                                                        <InlineSvg
                                                           className="css-1jdzfs8-StyledChevronDown e1yghndz0"
+                                                          src="icon-chevron-down"
                                                         >
-                                                          <InlineSvg
-                                                            className="css-1jdzfs8-StyledChevronDown e1yghndz0"
+                                                          <ForwardRef
+                                                            className="e1yghndz0 css-eqsg9h-InlineSvg-StyledChevronDown enyz4ql0"
                                                             src="icon-chevron-down"
                                                           >
-                                                            <ForwardRef
+                                                            <svg
                                                               className="e1yghndz0 css-eqsg9h-InlineSvg-StyledChevronDown enyz4ql0"
-                                                              src="icon-chevron-down"
+                                                              height="1em"
+                                                              viewBox={Object {}}
+                                                              width="1em"
                                                             >
-                                                              <svg
-                                                                className="e1yghndz0 css-eqsg9h-InlineSvg-StyledChevronDown enyz4ql0"
-                                                                height="1em"
-                                                                viewBox={Object {}}
-                                                                width="1em"
-                                                              >
-                                                                <use
-                                                                  href="#test"
-                                                                  xlinkHref="#test"
-                                                                />
-                                                              </svg>
-                                                            </ForwardRef>
-                                                          </InlineSvg>
-                                                        </Component>
-                                                      </StyledChevronDown>
-                                                    </span>
-                                                  </Component>
-                                                </ButtonLabel>
-                                              </button>
-                                            </Component>
+                                                              <use
+                                                                href="#test"
+                                                                xlinkHref="#test"
+                                                              />
+                                                            </svg>
+                                                          </ForwardRef>
+                                                        </InlineSvg>
+                                                      </Component>
+                                                    </StyledChevronDown>
+                                                  </span>
+                                                </Component>
+                                              </ButtonLabel>
+                                            </button>
                                           </StyledButton>
                                         </Button>
                                       </forwardRef<Button>>
@@ -617,73 +608,65 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                       >
                         <StyledButton
                           aria-disabled={false}
+                          as="button"
                           disabled={false}
-                          forwardRef={null}
                           onClick={[Function]}
                           role="button"
+                          shouldForwardProp={[Function]}
                           size="small"
                         >
-                          <Component
+                          <button
                             aria-disabled={false}
                             className="css-12ogwys-StyledButton edwq9my0"
-                            forwardRef={null}
                             onClick={[Function]}
                             role="button"
                             size="small"
                           >
-                            <button
-                              aria-disabled={false}
-                              className="css-12ogwys-StyledButton edwq9my0"
-                              onClick={[Function]}
-                              role="button"
+                            <ButtonLabel
+                              align="center"
                               size="small"
                             >
-                              <ButtonLabel
+                              <Component
                                 align="center"
+                                className="css-19gcr2f-ButtonLabel edwq9my1"
                                 size="small"
                               >
-                                <Component
-                                  align="center"
+                                <span
                                   className="css-19gcr2f-ButtonLabel edwq9my1"
-                                  size="small"
                                 >
-                                  <span
-                                    className="css-19gcr2f-ButtonLabel edwq9my1"
-                                  >
-                                    <RemoveIcon>
-                                      <Component
+                                  <RemoveIcon>
+                                    <Component
+                                      className="css-1d2szfl-RemoveIcon eqsa6vb0"
+                                    >
+                                      <InlineSvg
                                         className="css-1d2szfl-RemoveIcon eqsa6vb0"
+                                        src="icon-circle-subtract"
                                       >
-                                        <InlineSvg
-                                          className="css-1d2szfl-RemoveIcon eqsa6vb0"
+                                        <ForwardRef
+                                          className="eqsa6vb0 css-hoycps-InlineSvg-RemoveIcon enyz4ql0"
                                           src="icon-circle-subtract"
                                         >
-                                          <ForwardRef
+                                          <svg
                                             className="eqsa6vb0 css-hoycps-InlineSvg-RemoveIcon enyz4ql0"
-                                            src="icon-circle-subtract"
+                                            height="1em"
+                                            viewBox={Object {}}
+                                            width="1em"
                                           >
-                                            <svg
-                                              className="eqsa6vb0 css-hoycps-InlineSvg-RemoveIcon enyz4ql0"
-                                              height="1em"
-                                              viewBox={Object {}}
-                                              width="1em"
-                                            >
-                                              <use
-                                                href="#test"
-                                                xlinkHref="#test"
-                                              />
-                                            </svg>
-                                          </ForwardRef>
-                                        </InlineSvg>
-                                      </Component>
-                                    </RemoveIcon>
-                                     
-                                    Remove
-                                  </span>
-                                </Component>
-                              </ButtonLabel>
-                            </button>
-                          </Component>
+                                            <use
+                                              href="#test"
+                                              xlinkHref="#test"
+                                            />
+                                          </svg>
+                                        </ForwardRef>
+                                      </InlineSvg>
+                                    </Component>
+                                  </RemoveIcon>
+                                   
+                                  Remove
+                                </span>
+                              </Component>
+                            </ButtonLabel>
+                          </button>
                         </StyledButton>
                       </Button>
                     </forwardRef<Button>>
@@ -979,73 +962,65 @@ exports[`OrganizationTeamProjects Should render 1`] = `
                       >
                         <StyledButton
                           aria-disabled={false}
+                          as="button"
                           disabled={false}
-                          forwardRef={null}
                           onClick={[Function]}
                           role="button"
+                          shouldForwardProp={[Function]}
                           size="small"
                         >
-                          <Component
+                          <button
                             aria-disabled={false}
                             className="css-12ogwys-StyledButton edwq9my0"
-                            forwardRef={null}
                             onClick={[Function]}
                             role="button"
                             size="small"
                           >
-                            <button
-                              aria-disabled={false}
-                              className="css-12ogwys-StyledButton edwq9my0"
-                              onClick={[Function]}
-                              role="button"
+                            <ButtonLabel
+                              align="center"
                               size="small"
                             >
-                              <ButtonLabel
+                              <Component
                                 align="center"
+                                className="css-19gcr2f-ButtonLabel edwq9my1"
                                 size="small"
                               >
-                                <Component
-                                  align="center"
+                                <span
                                   className="css-19gcr2f-ButtonLabel edwq9my1"
-                                  size="small"
                                 >
-                                  <span
-                                    className="css-19gcr2f-ButtonLabel edwq9my1"
-                                  >
-                                    <RemoveIcon>
-                                      <Component
+                                  <RemoveIcon>
+                                    <Component
+                                      className="css-1d2szfl-RemoveIcon eqsa6vb0"
+                                    >
+                                      <InlineSvg
                                         className="css-1d2szfl-RemoveIcon eqsa6vb0"
+                                        src="icon-circle-subtract"
                                       >
-                                        <InlineSvg
-                                          className="css-1d2szfl-RemoveIcon eqsa6vb0"
+                                        <ForwardRef
+                                          className="eqsa6vb0 css-hoycps-InlineSvg-RemoveIcon enyz4ql0"
                                           src="icon-circle-subtract"
                                         >
-                                          <ForwardRef
+                                          <svg
                                             className="eqsa6vb0 css-hoycps-InlineSvg-RemoveIcon enyz4ql0"
-                                            src="icon-circle-subtract"
+                                            height="1em"
+                                            viewBox={Object {}}
+                                            width="1em"
                                           >
-                                            <svg
-                                              className="eqsa6vb0 css-hoycps-InlineSvg-RemoveIcon enyz4ql0"
-                                              height="1em"
-                                              viewBox={Object {}}
-                                              width="1em"
-                                            >
-                                              <use
-                                                href="#test"
-                                                xlinkHref="#test"
-                                              />
-                                            </svg>
-                                          </ForwardRef>
-                                        </InlineSvg>
-                                      </Component>
-                                    </RemoveIcon>
-                                     
-                                    Remove
-                                  </span>
-                                </Component>
-                              </ButtonLabel>
-                            </button>
-                          </Component>
+                                            <use
+                                              href="#test"
+                                              xlinkHref="#test"
+                                            />
+                                          </svg>
+                                        </ForwardRef>
+                                      </InlineSvg>
+                                    </Component>
+                                  </RemoveIcon>
+                                   
+                                  Remove
+                                </span>
+                              </Component>
+                            </ButtonLabel>
+                          </button>
                         </StyledButton>
                       </Button>
                     </forwardRef<Button>>

--- a/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ownershipInput.spec.jsx.snap
@@ -893,86 +893,78 @@ exports[`Project Ownership Input renders 1`] = `
             >
               <StyledButton
                 aria-disabled={true}
+                as="button"
                 className="css-f6y09s-AddButton e1hyuoc710"
                 disabled={true}
-                forwardRef={null}
                 onClick={[Function]}
                 priority="primary"
                 role="button"
+                shouldForwardProp={[Function]}
                 size="small"
               >
-                <Component
+                <button
                   aria-disabled={true}
                   className="e1hyuoc710 css-1vf07fg-StyledButton-AddButton edwq9my0"
-                  forwardRef={null}
                   onClick={[Function]}
                   role="button"
                   size="small"
                 >
-                  <button
-                    aria-disabled={true}
-                    className="e1hyuoc710 css-1vf07fg-StyledButton-AddButton edwq9my0"
-                    onClick={[Function]}
-                    role="button"
+                  <ButtonLabel
+                    align="center"
+                    priority="primary"
                     size="small"
                   >
-                    <ButtonLabel
+                    <Component
                       align="center"
+                      className="css-19gcr2f-ButtonLabel edwq9my1"
                       priority="primary"
                       size="small"
                     >
-                      <Component
-                        align="center"
+                      <span
                         className="css-19gcr2f-ButtonLabel edwq9my1"
-                        priority="primary"
-                        size="small"
                       >
-                        <span
-                          className="css-19gcr2f-ButtonLabel edwq9my1"
+                        <Icon
+                          hasChildren={false}
+                          size="small"
                         >
-                          <Icon
+                          <Component
+                            className="css-heib7e-Icon edwq9my2"
                             hasChildren={false}
                             size="small"
                           >
-                            <Component
+                            <span
                               className="css-heib7e-Icon edwq9my2"
-                              hasChildren={false}
                               size="small"
                             >
-                              <span
-                                className="css-heib7e-Icon edwq9my2"
-                                size="small"
+                              <StyledInlineSvg
+                                size="12px"
+                                src="icon-circle-add"
                               >
-                                <StyledInlineSvg
+                                <ForwardRef
+                                  className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                   size="12px"
                                   src="icon-circle-add"
                                 >
-                                  <ForwardRef
+                                  <svg
                                     className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                    size="12px"
-                                    src="icon-circle-add"
+                                    height="12px"
+                                    viewBox={Object {}}
+                                    width="12px"
                                   >
-                                    <svg
-                                      className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                      height="12px"
-                                      viewBox={Object {}}
-                                      width="12px"
-                                    >
-                                      <use
-                                        href="#test"
-                                        xlinkHref="#test"
-                                      />
-                                    </svg>
-                                  </ForwardRef>
-                                </StyledInlineSvg>
-                              </span>
-                            </Component>
-                          </Icon>
-                        </span>
-                      </Component>
-                    </ButtonLabel>
-                  </button>
-                </Component>
+                                    <use
+                                      href="#test"
+                                      xlinkHref="#test"
+                                    />
+                                  </svg>
+                                </ForwardRef>
+                              </StyledInlineSvg>
+                            </span>
+                          </Component>
+                        </Icon>
+                      </span>
+                    </Component>
+                  </ButtonLabel>
+                </button>
               </StyledButton>
             </Button>
           </forwardRef<Button>>
@@ -1060,50 +1052,41 @@ url:http://example.com/settings/* #product"
                 <StyledButton
                   aria-disabled={false}
                   aria-label="Save Changes"
+                  as="button"
                   disabled={false}
-                  forwardRef={null}
                   onClick={[Function]}
                   priority="primary"
                   role="button"
+                  shouldForwardProp={[Function]}
                   size="small"
                 >
-                  <Component
+                  <button
                     aria-disabled={false}
                     aria-label="Save Changes"
                     className="css-z8at1v-StyledButton edwq9my0"
-                    forwardRef={null}
                     onClick={[Function]}
                     role="button"
                     size="small"
                   >
-                    <button
-                      aria-disabled={false}
-                      aria-label="Save Changes"
-                      className="css-z8at1v-StyledButton edwq9my0"
-                      onClick={[Function]}
-                      role="button"
+                    <ButtonLabel
+                      align="center"
+                      priority="primary"
                       size="small"
                     >
-                      <ButtonLabel
+                      <Component
                         align="center"
+                        className="css-19gcr2f-ButtonLabel edwq9my1"
                         priority="primary"
                         size="small"
                       >
-                        <Component
-                          align="center"
+                        <span
                           className="css-19gcr2f-ButtonLabel edwq9my1"
-                          priority="primary"
-                          size="small"
                         >
-                          <span
-                            className="css-19gcr2f-ButtonLabel edwq9my1"
-                          >
-                            Save Changes
-                          </span>
-                        </Component>
-                      </ButtonLabel>
-                    </button>
-                  </Component>
+                          Save Changes
+                        </span>
+                      </Component>
+                    </ButtonLabel>
+                  </button>
                 </StyledButton>
               </Button>
             </forwardRef<Button>>

--- a/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectPluginDetails.spec.jsx.snap
@@ -347,10 +347,11 @@ exports[`ProjectPluginDetails renders 1`] = `
                                   <StyledButton
                                     aria-disabled={false}
                                     aria-label="Enable Plugin"
+                                    as="button"
                                     disabled={false}
-                                    forwardRef={null}
                                     onClick={[Function]}
                                     role="button"
+                                    shouldForwardProp={[Function]}
                                     size="small"
                                     style={
                                       Object {
@@ -358,11 +359,10 @@ exports[`ProjectPluginDetails renders 1`] = `
                                       }
                                     }
                                   >
-                                    <Component
+                                    <button
                                       aria-disabled={false}
                                       aria-label="Enable Plugin"
                                       className="css-12ogwys-StyledButton edwq9my0"
-                                      forwardRef={null}
                                       onClick={[Function]}
                                       role="button"
                                       size="small"
@@ -372,37 +372,23 @@ exports[`ProjectPluginDetails renders 1`] = `
                                         }
                                       }
                                     >
-                                      <button
-                                        aria-disabled={false}
-                                        aria-label="Enable Plugin"
-                                        className="css-12ogwys-StyledButton edwq9my0"
-                                        onClick={[Function]}
-                                        role="button"
+                                      <ButtonLabel
+                                        align="center"
                                         size="small"
-                                        style={
-                                          Object {
-                                            "marginRight": "6px",
-                                          }
-                                        }
                                       >
-                                        <ButtonLabel
+                                        <Component
                                           align="center"
+                                          className="css-19gcr2f-ButtonLabel edwq9my1"
                                           size="small"
                                         >
-                                          <Component
-                                            align="center"
+                                          <span
                                             className="css-19gcr2f-ButtonLabel edwq9my1"
-                                            size="small"
                                           >
-                                            <span
-                                              className="css-19gcr2f-ButtonLabel edwq9my1"
-                                            >
-                                              Enable Plugin
-                                            </span>
-                                          </Component>
-                                        </ButtonLabel>
-                                      </button>
-                                    </Component>
+                                            Enable Plugin
+                                          </span>
+                                        </Component>
+                                      </ButtonLabel>
+                                    </button>
                                   </StyledButton>
                                 </Button>
                               </forwardRef<Button>>
@@ -420,47 +406,38 @@ exports[`ProjectPluginDetails renders 1`] = `
                                   <StyledButton
                                     aria-disabled={false}
                                     aria-label="Reset Configuration"
+                                    as="button"
                                     disabled={false}
-                                    forwardRef={null}
                                     onClick={[Function]}
                                     role="button"
+                                    shouldForwardProp={[Function]}
                                     size="small"
                                   >
-                                    <Component
+                                    <button
                                       aria-disabled={false}
                                       aria-label="Reset Configuration"
                                       className="css-12ogwys-StyledButton edwq9my0"
-                                      forwardRef={null}
                                       onClick={[Function]}
                                       role="button"
                                       size="small"
                                     >
-                                      <button
-                                        aria-disabled={false}
-                                        aria-label="Reset Configuration"
-                                        className="css-12ogwys-StyledButton edwq9my0"
-                                        onClick={[Function]}
-                                        role="button"
+                                      <ButtonLabel
+                                        align="center"
                                         size="small"
                                       >
-                                        <ButtonLabel
+                                        <Component
                                           align="center"
+                                          className="css-19gcr2f-ButtonLabel edwq9my1"
                                           size="small"
                                         >
-                                          <Component
-                                            align="center"
+                                          <span
                                             className="css-19gcr2f-ButtonLabel edwq9my1"
-                                            size="small"
                                           >
-                                            <span
-                                              className="css-19gcr2f-ButtonLabel edwq9my1"
-                                            >
-                                              Reset Configuration
-                                            </span>
-                                          </Component>
-                                        </ButtonLabel>
-                                      </button>
-                                    </Component>
+                                            Reset Configuration
+                                          </span>
+                                        </Component>
+                                      </ButtonLabel>
+                                    </button>
                                   </StyledButton>
                                 </Button>
                               </forwardRef<Button>>

--- a/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/projectTags.spec.jsx.snap
@@ -399,85 +399,76 @@ exports[`ProjectTags renders 1`] = `
                                           >
                                             <StyledButton
                                               aria-disabled={false}
+                                              as="button"
                                               data-test-id="delete"
                                               disabled={false}
-                                              forwardRef={null}
                                               onClick={[Function]}
                                               role="button"
+                                              shouldForwardProp={[Function]}
                                               size="xsmall"
                                             >
-                                              <Component
+                                              <button
                                                 aria-disabled={false}
                                                 className="css-12ogwys-StyledButton edwq9my0"
                                                 data-test-id="delete"
-                                                forwardRef={null}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
                                               >
-                                                <button
-                                                  aria-disabled={false}
-                                                  className="css-12ogwys-StyledButton edwq9my0"
-                                                  data-test-id="delete"
-                                                  onClick={[Function]}
-                                                  role="button"
+                                                <ButtonLabel
+                                                  align="center"
                                                   size="xsmall"
                                                 >
-                                                  <ButtonLabel
+                                                  <Component
                                                     align="center"
+                                                    className="css-cmi7y3-ButtonLabel edwq9my1"
                                                     size="xsmall"
                                                   >
-                                                    <Component
-                                                      align="center"
+                                                    <span
                                                       className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                      size="xsmall"
                                                     >
-                                                      <span
-                                                        className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                      <Icon
+                                                        hasChildren={false}
+                                                        size="xsmall"
                                                       >
-                                                        <Icon
+                                                        <Component
+                                                          className="css-heib7e-Icon edwq9my2"
                                                           hasChildren={false}
                                                           size="xsmall"
                                                         >
-                                                          <Component
+                                                          <span
                                                             className="css-heib7e-Icon edwq9my2"
-                                                            hasChildren={false}
                                                             size="xsmall"
                                                           >
-                                                            <span
-                                                              className="css-heib7e-Icon edwq9my2"
-                                                              size="xsmall"
+                                                            <StyledInlineSvg
+                                                              size="12px"
+                                                              src="icon-trash"
                                                             >
-                                                              <StyledInlineSvg
+                                                              <ForwardRef
+                                                                className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                                                 size="12px"
                                                                 src="icon-trash"
                                                               >
-                                                                <ForwardRef
+                                                                <svg
                                                                   className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                                  size="12px"
-                                                                  src="icon-trash"
+                                                                  height="12px"
+                                                                  viewBox={Object {}}
+                                                                  width="12px"
                                                                 >
-                                                                  <svg
-                                                                    className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                                    height="12px"
-                                                                    viewBox={Object {}}
-                                                                    width="12px"
-                                                                  >
-                                                                    <use
-                                                                      href="#test"
-                                                                      xlinkHref="#test"
-                                                                    />
-                                                                  </svg>
-                                                                </ForwardRef>
-                                                              </StyledInlineSvg>
-                                                            </span>
-                                                          </Component>
-                                                        </Icon>
-                                                      </span>
-                                                    </Component>
-                                                  </ButtonLabel>
-                                                </button>
-                                              </Component>
+                                                                  <use
+                                                                    href="#test"
+                                                                    xlinkHref="#test"
+                                                                  />
+                                                                </svg>
+                                                              </ForwardRef>
+                                                            </StyledInlineSvg>
+                                                          </span>
+                                                        </Component>
+                                                      </Icon>
+                                                    </span>
+                                                  </Component>
+                                                </ButtonLabel>
+                                              </button>
                                             </StyledButton>
                                           </Button>
                                         </forwardRef<Button>>
@@ -605,85 +596,76 @@ exports[`ProjectTags renders 1`] = `
                                           >
                                             <StyledButton
                                               aria-disabled={false}
+                                              as="button"
                                               data-test-id="delete"
                                               disabled={false}
-                                              forwardRef={null}
                                               onClick={[Function]}
                                               role="button"
+                                              shouldForwardProp={[Function]}
                                               size="xsmall"
                                             >
-                                              <Component
+                                              <button
                                                 aria-disabled={false}
                                                 className="css-12ogwys-StyledButton edwq9my0"
                                                 data-test-id="delete"
-                                                forwardRef={null}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
                                               >
-                                                <button
-                                                  aria-disabled={false}
-                                                  className="css-12ogwys-StyledButton edwq9my0"
-                                                  data-test-id="delete"
-                                                  onClick={[Function]}
-                                                  role="button"
+                                                <ButtonLabel
+                                                  align="center"
                                                   size="xsmall"
                                                 >
-                                                  <ButtonLabel
+                                                  <Component
                                                     align="center"
+                                                    className="css-cmi7y3-ButtonLabel edwq9my1"
                                                     size="xsmall"
                                                   >
-                                                    <Component
-                                                      align="center"
+                                                    <span
                                                       className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                      size="xsmall"
                                                     >
-                                                      <span
-                                                        className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                      <Icon
+                                                        hasChildren={false}
+                                                        size="xsmall"
                                                       >
-                                                        <Icon
+                                                        <Component
+                                                          className="css-heib7e-Icon edwq9my2"
                                                           hasChildren={false}
                                                           size="xsmall"
                                                         >
-                                                          <Component
+                                                          <span
                                                             className="css-heib7e-Icon edwq9my2"
-                                                            hasChildren={false}
                                                             size="xsmall"
                                                           >
-                                                            <span
-                                                              className="css-heib7e-Icon edwq9my2"
-                                                              size="xsmall"
+                                                            <StyledInlineSvg
+                                                              size="12px"
+                                                              src="icon-trash"
                                                             >
-                                                              <StyledInlineSvg
+                                                              <ForwardRef
+                                                                className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                                                 size="12px"
                                                                 src="icon-trash"
                                                               >
-                                                                <ForwardRef
+                                                                <svg
                                                                   className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                                  size="12px"
-                                                                  src="icon-trash"
+                                                                  height="12px"
+                                                                  viewBox={Object {}}
+                                                                  width="12px"
                                                                 >
-                                                                  <svg
-                                                                    className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                                    height="12px"
-                                                                    viewBox={Object {}}
-                                                                    width="12px"
-                                                                  >
-                                                                    <use
-                                                                      href="#test"
-                                                                      xlinkHref="#test"
-                                                                    />
-                                                                  </svg>
-                                                                </ForwardRef>
-                                                              </StyledInlineSvg>
-                                                            </span>
-                                                          </Component>
-                                                        </Icon>
-                                                      </span>
-                                                    </Component>
-                                                  </ButtonLabel>
-                                                </button>
-                                              </Component>
+                                                                  <use
+                                                                    href="#test"
+                                                                    xlinkHref="#test"
+                                                                  />
+                                                                </svg>
+                                                              </ForwardRef>
+                                                            </StyledInlineSvg>
+                                                          </span>
+                                                        </Component>
+                                                      </Icon>
+                                                    </span>
+                                                  </Component>
+                                                </ButtonLabel>
+                                              </button>
                                             </StyledButton>
                                           </Button>
                                         </forwardRef<Button>>
@@ -811,85 +793,76 @@ exports[`ProjectTags renders 1`] = `
                                           >
                                             <StyledButton
                                               aria-disabled={false}
+                                              as="button"
                                               data-test-id="delete"
                                               disabled={false}
-                                              forwardRef={null}
                                               onClick={[Function]}
                                               role="button"
+                                              shouldForwardProp={[Function]}
                                               size="xsmall"
                                             >
-                                              <Component
+                                              <button
                                                 aria-disabled={false}
                                                 className="css-12ogwys-StyledButton edwq9my0"
                                                 data-test-id="delete"
-                                                forwardRef={null}
                                                 onClick={[Function]}
                                                 role="button"
                                                 size="xsmall"
                                               >
-                                                <button
-                                                  aria-disabled={false}
-                                                  className="css-12ogwys-StyledButton edwq9my0"
-                                                  data-test-id="delete"
-                                                  onClick={[Function]}
-                                                  role="button"
+                                                <ButtonLabel
+                                                  align="center"
                                                   size="xsmall"
                                                 >
-                                                  <ButtonLabel
+                                                  <Component
                                                     align="center"
+                                                    className="css-cmi7y3-ButtonLabel edwq9my1"
                                                     size="xsmall"
                                                   >
-                                                    <Component
-                                                      align="center"
+                                                    <span
                                                       className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                      size="xsmall"
                                                     >
-                                                      <span
-                                                        className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                      <Icon
+                                                        hasChildren={false}
+                                                        size="xsmall"
                                                       >
-                                                        <Icon
+                                                        <Component
+                                                          className="css-heib7e-Icon edwq9my2"
                                                           hasChildren={false}
                                                           size="xsmall"
                                                         >
-                                                          <Component
+                                                          <span
                                                             className="css-heib7e-Icon edwq9my2"
-                                                            hasChildren={false}
                                                             size="xsmall"
                                                           >
-                                                            <span
-                                                              className="css-heib7e-Icon edwq9my2"
-                                                              size="xsmall"
+                                                            <StyledInlineSvg
+                                                              size="12px"
+                                                              src="icon-trash"
                                                             >
-                                                              <StyledInlineSvg
+                                                              <ForwardRef
+                                                                className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                                                 size="12px"
                                                                 src="icon-trash"
                                                               >
-                                                                <ForwardRef
+                                                                <svg
                                                                   className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                                  size="12px"
-                                                                  src="icon-trash"
+                                                                  height="12px"
+                                                                  viewBox={Object {}}
+                                                                  width="12px"
                                                                 >
-                                                                  <svg
-                                                                    className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                                    height="12px"
-                                                                    viewBox={Object {}}
-                                                                    width="12px"
-                                                                  >
-                                                                    <use
-                                                                      href="#test"
-                                                                      xlinkHref="#test"
-                                                                    />
-                                                                  </svg>
-                                                                </ForwardRef>
-                                                              </StyledInlineSvg>
-                                                            </span>
-                                                          </Component>
-                                                        </Icon>
-                                                      </span>
-                                                    </Component>
-                                                  </ButtonLabel>
-                                                </button>
-                                              </Component>
+                                                                  <use
+                                                                    href="#test"
+                                                                    xlinkHref="#test"
+                                                                  />
+                                                                </svg>
+                                                              </ForwardRef>
+                                                            </StyledInlineSvg>
+                                                          </span>
+                                                        </Component>
+                                                      </Icon>
+                                                    </span>
+                                                  </Component>
+                                                </ButtonLabel>
+                                              </button>
                                             </StyledButton>
                                           </Button>
                                         </forwardRef<Button>>
@@ -1038,85 +1011,76 @@ exports[`ProjectTags renders 1`] = `
                                                     >
                                                       <StyledButton
                                                         aria-disabled={true}
+                                                        as="button"
                                                         data-test-id="delete"
                                                         disabled={true}
-                                                        forwardRef={null}
                                                         onClick={[Function]}
                                                         role="button"
+                                                        shouldForwardProp={[Function]}
                                                         size="xsmall"
                                                       >
-                                                        <Component
+                                                        <button
                                                           aria-disabled={true}
                                                           className="css-1lloe1u-StyledButton edwq9my0"
                                                           data-test-id="delete"
-                                                          forwardRef={null}
                                                           onClick={[Function]}
                                                           role="button"
                                                           size="xsmall"
                                                         >
-                                                          <button
-                                                            aria-disabled={true}
-                                                            className="css-1lloe1u-StyledButton edwq9my0"
-                                                            data-test-id="delete"
-                                                            onClick={[Function]}
-                                                            role="button"
+                                                          <ButtonLabel
+                                                            align="center"
                                                             size="xsmall"
                                                           >
-                                                            <ButtonLabel
+                                                            <Component
                                                               align="center"
+                                                              className="css-cmi7y3-ButtonLabel edwq9my1"
                                                               size="xsmall"
                                                             >
-                                                              <Component
-                                                                align="center"
+                                                              <span
                                                                 className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                                size="xsmall"
                                                               >
-                                                                <span
-                                                                  className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                                <Icon
+                                                                  hasChildren={false}
+                                                                  size="xsmall"
                                                                 >
-                                                                  <Icon
+                                                                  <Component
+                                                                    className="css-heib7e-Icon edwq9my2"
                                                                     hasChildren={false}
                                                                     size="xsmall"
                                                                   >
-                                                                    <Component
+                                                                    <span
                                                                       className="css-heib7e-Icon edwq9my2"
-                                                                      hasChildren={false}
                                                                       size="xsmall"
                                                                     >
-                                                                      <span
-                                                                        className="css-heib7e-Icon edwq9my2"
-                                                                        size="xsmall"
+                                                                      <StyledInlineSvg
+                                                                        size="12px"
+                                                                        src="icon-trash"
                                                                       >
-                                                                        <StyledInlineSvg
+                                                                        <ForwardRef
+                                                                          className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                                                           size="12px"
                                                                           src="icon-trash"
                                                                         >
-                                                                          <ForwardRef
+                                                                          <svg
                                                                             className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                                            size="12px"
-                                                                            src="icon-trash"
+                                                                            height="12px"
+                                                                            viewBox={Object {}}
+                                                                            width="12px"
                                                                           >
-                                                                            <svg
-                                                                              className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                                              height="12px"
-                                                                              viewBox={Object {}}
-                                                                              width="12px"
-                                                                            >
-                                                                              <use
-                                                                                href="#test"
-                                                                                xlinkHref="#test"
-                                                                              />
-                                                                            </svg>
-                                                                          </ForwardRef>
-                                                                        </StyledInlineSvg>
-                                                                      </span>
-                                                                    </Component>
-                                                                  </Icon>
-                                                                </span>
-                                                              </Component>
-                                                            </ButtonLabel>
-                                                          </button>
-                                                        </Component>
+                                                                            <use
+                                                                              href="#test"
+                                                                              xlinkHref="#test"
+                                                                            />
+                                                                          </svg>
+                                                                        </ForwardRef>
+                                                                      </StyledInlineSvg>
+                                                                    </span>
+                                                                  </Component>
+                                                                </Icon>
+                                                              </span>
+                                                            </Component>
+                                                          </ButtonLabel>
+                                                        </button>
                                                       </StyledButton>
                                                     </Button>
                                                   </forwardRef<Button>>
@@ -1269,85 +1233,76 @@ exports[`ProjectTags renders 1`] = `
                                                     >
                                                       <StyledButton
                                                         aria-disabled={true}
+                                                        as="button"
                                                         data-test-id="delete"
                                                         disabled={true}
-                                                        forwardRef={null}
                                                         onClick={[Function]}
                                                         role="button"
+                                                        shouldForwardProp={[Function]}
                                                         size="xsmall"
                                                       >
-                                                        <Component
+                                                        <button
                                                           aria-disabled={true}
                                                           className="css-1lloe1u-StyledButton edwq9my0"
                                                           data-test-id="delete"
-                                                          forwardRef={null}
                                                           onClick={[Function]}
                                                           role="button"
                                                           size="xsmall"
                                                         >
-                                                          <button
-                                                            aria-disabled={true}
-                                                            className="css-1lloe1u-StyledButton edwq9my0"
-                                                            data-test-id="delete"
-                                                            onClick={[Function]}
-                                                            role="button"
+                                                          <ButtonLabel
+                                                            align="center"
                                                             size="xsmall"
                                                           >
-                                                            <ButtonLabel
+                                                            <Component
                                                               align="center"
+                                                              className="css-cmi7y3-ButtonLabel edwq9my1"
                                                               size="xsmall"
                                                             >
-                                                              <Component
-                                                                align="center"
+                                                              <span
                                                                 className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                                size="xsmall"
                                                               >
-                                                                <span
-                                                                  className="css-cmi7y3-ButtonLabel edwq9my1"
+                                                                <Icon
+                                                                  hasChildren={false}
+                                                                  size="xsmall"
                                                                 >
-                                                                  <Icon
+                                                                  <Component
+                                                                    className="css-heib7e-Icon edwq9my2"
                                                                     hasChildren={false}
                                                                     size="xsmall"
                                                                   >
-                                                                    <Component
+                                                                    <span
                                                                       className="css-heib7e-Icon edwq9my2"
-                                                                      hasChildren={false}
                                                                       size="xsmall"
                                                                     >
-                                                                      <span
-                                                                        className="css-heib7e-Icon edwq9my2"
-                                                                        size="xsmall"
+                                                                      <StyledInlineSvg
+                                                                        size="12px"
+                                                                        src="icon-trash"
                                                                       >
-                                                                        <StyledInlineSvg
+                                                                        <ForwardRef
+                                                                          className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                                                           size="12px"
                                                                           src="icon-trash"
                                                                         >
-                                                                          <ForwardRef
+                                                                          <svg
                                                                             className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                                            size="12px"
-                                                                            src="icon-trash"
+                                                                            height="12px"
+                                                                            viewBox={Object {}}
+                                                                            width="12px"
                                                                           >
-                                                                            <svg
-                                                                              className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                                              height="12px"
-                                                                              viewBox={Object {}}
-                                                                              width="12px"
-                                                                            >
-                                                                              <use
-                                                                                href="#test"
-                                                                                xlinkHref="#test"
-                                                                              />
-                                                                            </svg>
-                                                                          </ForwardRef>
-                                                                        </StyledInlineSvg>
-                                                                      </span>
-                                                                    </Component>
-                                                                  </Icon>
-                                                                </span>
-                                                              </Component>
-                                                            </ButtonLabel>
-                                                          </button>
-                                                        </Component>
+                                                                            <use
+                                                                              href="#test"
+                                                                              xlinkHref="#test"
+                                                                            />
+                                                                          </svg>
+                                                                        </ForwardRef>
+                                                                      </StyledInlineSvg>
+                                                                    </span>
+                                                                  </Component>
+                                                                </Icon>
+                                                              </span>
+                                                            </Component>
+                                                          </ButtonLabel>
+                                                        </button>
                                                       </StyledButton>
                                                     </Button>
                                                   </forwardRef<Button>>

--- a/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
+++ b/tests/js/spec/views/__snapshots__/ruleBuilder.spec.jsx.snap
@@ -1003,86 +1003,78 @@ exports[`RuleBuilder renders 1`] = `
           >
             <StyledButton
               aria-disabled={true}
+              as="button"
               className="css-f6y09s-AddButton e1hyuoc710"
               disabled={true}
-              forwardRef={null}
               onClick={[Function]}
               priority="primary"
               role="button"
+              shouldForwardProp={[Function]}
               size="small"
             >
-              <Component
+              <button
                 aria-disabled={true}
                 className="e1hyuoc710 css-1vf07fg-StyledButton-AddButton edwq9my0"
-                forwardRef={null}
                 onClick={[Function]}
                 role="button"
                 size="small"
               >
-                <button
-                  aria-disabled={true}
-                  className="e1hyuoc710 css-1vf07fg-StyledButton-AddButton edwq9my0"
-                  onClick={[Function]}
-                  role="button"
+                <ButtonLabel
+                  align="center"
+                  priority="primary"
                   size="small"
                 >
-                  <ButtonLabel
+                  <Component
                     align="center"
+                    className="css-19gcr2f-ButtonLabel edwq9my1"
                     priority="primary"
                     size="small"
                   >
-                    <Component
-                      align="center"
+                    <span
                       className="css-19gcr2f-ButtonLabel edwq9my1"
-                      priority="primary"
-                      size="small"
                     >
-                      <span
-                        className="css-19gcr2f-ButtonLabel edwq9my1"
+                      <Icon
+                        hasChildren={false}
+                        size="small"
                       >
-                        <Icon
+                        <Component
+                          className="css-heib7e-Icon edwq9my2"
                           hasChildren={false}
                           size="small"
                         >
-                          <Component
+                          <span
                             className="css-heib7e-Icon edwq9my2"
-                            hasChildren={false}
                             size="small"
                           >
-                            <span
-                              className="css-heib7e-Icon edwq9my2"
-                              size="small"
+                            <StyledInlineSvg
+                              size="12px"
+                              src="icon-circle-add"
                             >
-                              <StyledInlineSvg
+                              <ForwardRef
+                                className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                 size="12px"
                                 src="icon-circle-add"
                               >
-                                <ForwardRef
+                                <svg
                                   className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                  size="12px"
-                                  src="icon-circle-add"
+                                  height="12px"
+                                  viewBox={Object {}}
+                                  width="12px"
                                 >
-                                  <svg
-                                    className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                    height="12px"
-                                    viewBox={Object {}}
-                                    width="12px"
-                                  >
-                                    <use
-                                      href="#test"
-                                      xlinkHref="#test"
-                                    />
-                                  </svg>
-                                </ForwardRef>
-                              </StyledInlineSvg>
-                            </span>
-                          </Component>
-                        </Icon>
-                      </span>
-                    </Component>
-                  </ButtonLabel>
-                </button>
-              </Component>
+                                  <use
+                                    href="#test"
+                                    xlinkHref="#test"
+                                  />
+                                </svg>
+                              </ForwardRef>
+                            </StyledInlineSvg>
+                          </span>
+                        </Component>
+                      </Icon>
+                    </span>
+                  </Component>
+                </ButtonLabel>
+              </button>
             </StyledButton>
           </Button>
         </forwardRef<Button>>
@@ -2875,86 +2867,78 @@ exports[`RuleBuilder renders with suggestions 1`] = `
           >
             <StyledButton
               aria-disabled={false}
+              as="button"
               className="css-f6y09s-AddButton e1hyuoc710"
               disabled={false}
-              forwardRef={null}
               onClick={[Function]}
               priority="primary"
               role="button"
+              shouldForwardProp={[Function]}
               size="small"
             >
-              <Component
+              <button
                 aria-disabled={false}
                 className="e1hyuoc710 css-cdfv3-StyledButton-AddButton edwq9my0"
-                forwardRef={null}
                 onClick={[Function]}
                 role="button"
                 size="small"
               >
-                <button
-                  aria-disabled={false}
-                  className="e1hyuoc710 css-cdfv3-StyledButton-AddButton edwq9my0"
-                  onClick={[Function]}
-                  role="button"
+                <ButtonLabel
+                  align="center"
+                  priority="primary"
                   size="small"
                 >
-                  <ButtonLabel
+                  <Component
                     align="center"
+                    className="css-19gcr2f-ButtonLabel edwq9my1"
                     priority="primary"
                     size="small"
                   >
-                    <Component
-                      align="center"
+                    <span
                       className="css-19gcr2f-ButtonLabel edwq9my1"
-                      priority="primary"
-                      size="small"
                     >
-                      <span
-                        className="css-19gcr2f-ButtonLabel edwq9my1"
+                      <Icon
+                        hasChildren={false}
+                        size="small"
                       >
-                        <Icon
+                        <Component
+                          className="css-heib7e-Icon edwq9my2"
                           hasChildren={false}
                           size="small"
                         >
-                          <Component
+                          <span
                             className="css-heib7e-Icon edwq9my2"
-                            hasChildren={false}
                             size="small"
                           >
-                            <span
-                              className="css-heib7e-Icon edwq9my2"
-                              size="small"
+                            <StyledInlineSvg
+                              size="12px"
+                              src="icon-circle-add"
                             >
-                              <StyledInlineSvg
+                              <ForwardRef
+                                className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                 size="12px"
                                 src="icon-circle-add"
                               >
-                                <ForwardRef
+                                <svg
                                   className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                  size="12px"
-                                  src="icon-circle-add"
+                                  height="12px"
+                                  viewBox={Object {}}
+                                  width="12px"
                                 >
-                                  <svg
-                                    className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                    height="12px"
-                                    viewBox={Object {}}
-                                    width="12px"
-                                  >
-                                    <use
-                                      href="#test"
-                                      xlinkHref="#test"
-                                    />
-                                  </svg>
-                                </ForwardRef>
-                              </StyledInlineSvg>
-                            </span>
-                          </Component>
-                        </Icon>
-                      </span>
-                    </Component>
-                  </ButtonLabel>
-                </button>
-              </Component>
+                                  <use
+                                    href="#test"
+                                    xlinkHref="#test"
+                                  />
+                                </svg>
+                              </ForwardRef>
+                            </StyledInlineSvg>
+                          </span>
+                        </Component>
+                      </Icon>
+                    </span>
+                  </Component>
+                </ButtonLabel>
+              </button>
             </StyledButton>
           </Button>
         </forwardRef<Button>>

--- a/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
+++ b/tests/js/spec/views/inviteMember/__snapshots__/inviteMember.spec.jsx.snap
@@ -646,79 +646,69 @@ exports[`InviteMember should render roles when available and allowed, and handle
                                                 <StyledButton
                                                   aria-disabled={true}
                                                   aria-label="Add Team"
+                                                  as="button"
                                                   className="css-k164fp-StyledButton e1yghndz1"
                                                   disabled={true}
-                                                  forwardRef={null}
                                                   isOpen={false}
                                                   onClick={[Function]}
                                                   role="button"
+                                                  shouldForwardProp={[Function]}
                                                   size="xsmall"
                                                   type="button"
                                                 >
-                                                  <Component
+                                                  <button
                                                     aria-disabled={true}
                                                     aria-label="Add Team"
                                                     className="e1yghndz1 css-jk8rcx-StyledButton-StyledButton edwq9my0"
-                                                    forwardRef={null}
                                                     onClick={[Function]}
                                                     role="button"
                                                     size="xsmall"
                                                     type="button"
                                                   >
-                                                    <button
-                                                      aria-disabled={true}
-                                                      aria-label="Add Team"
-                                                      className="e1yghndz1 css-jk8rcx-StyledButton-StyledButton edwq9my0"
-                                                      onClick={[Function]}
-                                                      role="button"
+                                                    <ButtonLabel
+                                                      align="center"
                                                       size="xsmall"
-                                                      type="button"
                                                     >
-                                                      <ButtonLabel
+                                                      <Component
                                                         align="center"
+                                                        className="css-cmi7y3-ButtonLabel edwq9my1"
                                                         size="xsmall"
                                                       >
-                                                        <Component
-                                                          align="center"
+                                                        <span
                                                           className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                          size="xsmall"
                                                         >
-                                                          <span
-                                                            className="css-cmi7y3-ButtonLabel edwq9my1"
-                                                          >
-                                                            Add Team
-                                                            <StyledChevronDown>
-                                                              <Component
+                                                          Add Team
+                                                          <StyledChevronDown>
+                                                            <Component
+                                                              className="css-1jdzfs8-StyledChevronDown e1yghndz0"
+                                                            >
+                                                              <InlineSvg
                                                                 className="css-1jdzfs8-StyledChevronDown e1yghndz0"
+                                                                src="icon-chevron-down"
                                                               >
-                                                                <InlineSvg
-                                                                  className="css-1jdzfs8-StyledChevronDown e1yghndz0"
+                                                                <ForwardRef
+                                                                  className="e1yghndz0 css-eqsg9h-InlineSvg-StyledChevronDown enyz4ql0"
                                                                   src="icon-chevron-down"
                                                                 >
-                                                                  <ForwardRef
+                                                                  <svg
                                                                     className="e1yghndz0 css-eqsg9h-InlineSvg-StyledChevronDown enyz4ql0"
-                                                                    src="icon-chevron-down"
+                                                                    height="1em"
+                                                                    viewBox={Object {}}
+                                                                    width="1em"
                                                                   >
-                                                                    <svg
-                                                                      className="e1yghndz0 css-eqsg9h-InlineSvg-StyledChevronDown enyz4ql0"
-                                                                      height="1em"
-                                                                      viewBox={Object {}}
-                                                                      width="1em"
-                                                                    >
-                                                                      <use
-                                                                        href="#test"
-                                                                        xlinkHref="#test"
-                                                                      />
-                                                                    </svg>
-                                                                  </ForwardRef>
-                                                                </InlineSvg>
-                                                              </Component>
-                                                            </StyledChevronDown>
-                                                          </span>
-                                                        </Component>
-                                                      </ButtonLabel>
-                                                    </button>
-                                                  </Component>
+                                                                    <use
+                                                                      href="#test"
+                                                                      xlinkHref="#test"
+                                                                    />
+                                                                  </svg>
+                                                                </ForwardRef>
+                                                              </InlineSvg>
+                                                            </Component>
+                                                          </StyledChevronDown>
+                                                        </span>
+                                                      </Component>
+                                                    </ButtonLabel>
+                                                  </button>
                                                 </StyledButton>
                                               </Button>
                                             </forwardRef<Button>>
@@ -803,47 +793,39 @@ exports[`InviteMember should render roles when available and allowed, and handle
           <StyledButton
             aria-disabled={false}
             aria-label="Add Member"
+            as="button"
             busy={false}
             className="invite-member-submit"
             disabled={false}
-            forwardRef={null}
             onClick={[Function]}
             priority="primary"
             role="button"
+            shouldForwardProp={[Function]}
           >
-            <Component
+            <button
               aria-disabled={false}
               aria-label="Add Member"
               className="invite-member-submit css-1e05jtd-StyledButton edwq9my0"
-              forwardRef={null}
               onClick={[Function]}
               role="button"
             >
-              <button
-                aria-disabled={false}
-                aria-label="Add Member"
-                className="invite-member-submit css-1e05jtd-StyledButton edwq9my0"
-                onClick={[Function]}
-                role="button"
+              <ButtonLabel
+                align="center"
+                priority="primary"
               >
-                <ButtonLabel
+                <Component
                   align="center"
+                  className="css-zmpclt-ButtonLabel edwq9my1"
                   priority="primary"
                 >
-                  <Component
-                    align="center"
+                  <span
                     className="css-zmpclt-ButtonLabel edwq9my1"
-                    priority="primary"
                   >
-                    <span
-                      className="css-zmpclt-ButtonLabel edwq9my1"
-                    >
-                      Add Member
-                    </span>
-                  </Component>
-                </ButtonLabel>
-              </button>
-            </Component>
+                    Add Member
+                  </span>
+                </Component>
+              </ButtonLabel>
+            </button>
           </StyledButton>
         </Button>
       </forwardRef<Button>>

--- a/tests/js/spec/views/issueList/__snapshots__/actions.spec.jsx.snap
+++ b/tests/js/spec/views/issueList/__snapshots__/actions.spec.jsx.snap
@@ -165,21 +165,21 @@ exports[`IssueListActions Bulk Total results < bulk limit bulk resolves 1`] = `
               <StyledButton
                 aria-disabled={false}
                 aria-label="Cancel"
+                as="button"
                 disabled={false}
-                forwardRef={null}
                 onClick={[Function]}
                 role="button"
+                shouldForwardProp={[Function]}
                 style={
                   Object {
                     "marginRight": 10,
                   }
                 }
               >
-                <Component
+                <button
                   aria-disabled={false}
                   aria-label="Cancel"
                   className="css-1c2phb1-StyledButton edwq9my0"
-                  forwardRef={null}
                   onClick={[Function]}
                   role="button"
                   style={
@@ -188,34 +188,21 @@ exports[`IssueListActions Bulk Total results < bulk limit bulk resolves 1`] = `
                     }
                   }
                 >
-                  <button
-                    aria-disabled={false}
-                    aria-label="Cancel"
-                    className="css-1c2phb1-StyledButton edwq9my0"
-                    onClick={[Function]}
-                    role="button"
-                    style={
-                      Object {
-                        "marginRight": 10,
-                      }
-                    }
+                  <ButtonLabel
+                    align="center"
                   >
-                    <ButtonLabel
+                    <Component
                       align="center"
+                      className="css-zmpclt-ButtonLabel edwq9my1"
                     >
-                      <Component
-                        align="center"
+                      <span
                         className="css-zmpclt-ButtonLabel edwq9my1"
                       >
-                        <span
-                          className="css-zmpclt-ButtonLabel edwq9my1"
-                        >
-                          Cancel
-                        </span>
-                      </Component>
-                    </ButtonLabel>
-                  </button>
-                </Component>
+                        Cancel
+                      </span>
+                    </Component>
+                  </ButtonLabel>
+                </button>
               </StyledButton>
             </Button>
           </forwardRef<Button>>
@@ -238,51 +225,41 @@ exports[`IssueListActions Bulk Total results < bulk limit bulk resolves 1`] = `
               <StyledButton
                 aria-disabled={false}
                 aria-label="Bulk resolve issues"
+                as="button"
                 autoFocus={true}
                 data-test-id="confirm-button"
                 disabled={false}
-                forwardRef={null}
                 onClick={[Function]}
                 priority="primary"
                 role="button"
+                shouldForwardProp={[Function]}
               >
-                <Component
+                <button
                   aria-disabled={false}
                   aria-label="Bulk resolve issues"
                   autoFocus={true}
                   className="css-1e05jtd-StyledButton edwq9my0"
                   data-test-id="confirm-button"
-                  forwardRef={null}
                   onClick={[Function]}
                   role="button"
                 >
-                  <button
-                    aria-disabled={false}
-                    aria-label="Bulk resolve issues"
-                    autoFocus={true}
-                    className="css-1e05jtd-StyledButton edwq9my0"
-                    data-test-id="confirm-button"
-                    onClick={[Function]}
-                    role="button"
+                  <ButtonLabel
+                    align="center"
+                    priority="primary"
                   >
-                    <ButtonLabel
+                    <Component
                       align="center"
+                      className="css-zmpclt-ButtonLabel edwq9my1"
                       priority="primary"
                     >
-                      <Component
-                        align="center"
+                      <span
                         className="css-zmpclt-ButtonLabel edwq9my1"
-                        priority="primary"
                       >
-                        <span
-                          className="css-zmpclt-ButtonLabel edwq9my1"
-                        >
-                          Bulk resolve issues
-                        </span>
-                      </Component>
-                    </ButtonLabel>
-                  </button>
-                </Component>
+                        Bulk resolve issues
+                      </span>
+                    </Component>
+                  </ButtonLabel>
+                </button>
               </StyledButton>
             </Button>
           </forwardRef<Button>>
@@ -490,21 +467,21 @@ exports[`IssueListActions Bulk Total results > bulk limit bulk resolves 1`] = `
               <StyledButton
                 aria-disabled={false}
                 aria-label="Cancel"
+                as="button"
                 disabled={false}
-                forwardRef={null}
                 onClick={[Function]}
                 role="button"
+                shouldForwardProp={[Function]}
                 style={
                   Object {
                     "marginRight": 10,
                   }
                 }
               >
-                <Component
+                <button
                   aria-disabled={false}
                   aria-label="Cancel"
                   className="css-1c2phb1-StyledButton edwq9my0"
-                  forwardRef={null}
                   onClick={[Function]}
                   role="button"
                   style={
@@ -513,34 +490,21 @@ exports[`IssueListActions Bulk Total results > bulk limit bulk resolves 1`] = `
                     }
                   }
                 >
-                  <button
-                    aria-disabled={false}
-                    aria-label="Cancel"
-                    className="css-1c2phb1-StyledButton edwq9my0"
-                    onClick={[Function]}
-                    role="button"
-                    style={
-                      Object {
-                        "marginRight": 10,
-                      }
-                    }
+                  <ButtonLabel
+                    align="center"
                   >
-                    <ButtonLabel
+                    <Component
                       align="center"
+                      className="css-zmpclt-ButtonLabel edwq9my1"
                     >
-                      <Component
-                        align="center"
+                      <span
                         className="css-zmpclt-ButtonLabel edwq9my1"
                       >
-                        <span
-                          className="css-zmpclt-ButtonLabel edwq9my1"
-                        >
-                          Cancel
-                        </span>
-                      </Component>
-                    </ButtonLabel>
-                  </button>
-                </Component>
+                        Cancel
+                      </span>
+                    </Component>
+                  </ButtonLabel>
+                </button>
               </StyledButton>
             </Button>
           </forwardRef<Button>>
@@ -563,51 +527,41 @@ exports[`IssueListActions Bulk Total results > bulk limit bulk resolves 1`] = `
               <StyledButton
                 aria-disabled={false}
                 aria-label="Bulk resolve issues"
+                as="button"
                 autoFocus={true}
                 data-test-id="confirm-button"
                 disabled={false}
-                forwardRef={null}
                 onClick={[Function]}
                 priority="primary"
                 role="button"
+                shouldForwardProp={[Function]}
               >
-                <Component
+                <button
                   aria-disabled={false}
                   aria-label="Bulk resolve issues"
                   autoFocus={true}
                   className="css-1e05jtd-StyledButton edwq9my0"
                   data-test-id="confirm-button"
-                  forwardRef={null}
                   onClick={[Function]}
                   role="button"
                 >
-                  <button
-                    aria-disabled={false}
-                    aria-label="Bulk resolve issues"
-                    autoFocus={true}
-                    className="css-1e05jtd-StyledButton edwq9my0"
-                    data-test-id="confirm-button"
-                    onClick={[Function]}
-                    role="button"
+                  <ButtonLabel
+                    align="center"
+                    priority="primary"
                   >
-                    <ButtonLabel
+                    <Component
                       align="center"
+                      className="css-zmpclt-ButtonLabel edwq9my1"
                       priority="primary"
                     >
-                      <Component
-                        align="center"
+                      <span
                         className="css-zmpclt-ButtonLabel edwq9my1"
-                        priority="primary"
                       >
-                        <span
-                          className="css-zmpclt-ButtonLabel edwq9my1"
-                        >
-                          Bulk resolve issues
-                        </span>
-                      </Component>
-                    </ButtonLabel>
-                  </button>
-                </Component>
+                        Bulk resolve issues
+                      </span>
+                    </Component>
+                  </ButtonLabel>
+                </button>
               </StyledButton>
             </Button>
           </forwardRef<Button>>

--- a/tests/js/spec/views/projectsDashboard/__snapshots__/projectCard.spec.jsx.snap
+++ b/tests/js/spec/views/projectsDashboard/__snapshots__/projectCard.spec.jsx.snap
@@ -973,19 +973,23 @@ exports[`ProjectCard renders 1`] = `
                           <StyledButton
                             aria-disabled={false}
                             aria-label="Track deploys"
+                            as={
+                              Object {
+                                "$$typeof": Symbol(react.forward_ref),
+                                "render": [Function],
+                              }
+                            }
                             disabled={false}
-                            external={true}
-                            forwardRef={null}
                             href="https://docs.sentry.io/learn/releases/"
                             onClick={[Function]}
                             role="button"
+                            shouldForwardProp={[Function]}
                             size="xsmall"
                           >
-                            <Component
+                            <ForwardRef
                               aria-disabled={false}
                               aria-label="Track deploys"
                               className="css-12ogwys-StyledButton edwq9my0"
-                              forwardRef={null}
                               href="https://docs.sentry.io/learn/releases/"
                               onClick={[Function]}
                               role="button"
@@ -997,8 +1001,10 @@ exports[`ProjectCard renders 1`] = `
                                 className="css-12ogwys-StyledButton edwq9my0"
                                 href="https://docs.sentry.io/learn/releases/"
                                 onClick={[Function]}
+                                rel="noreferrer noopener"
                                 role="button"
                                 size="xsmall"
+                                target="_blank"
                               >
                                 <ButtonLabel
                                   align="center"
@@ -1017,7 +1023,7 @@ exports[`ProjectCard renders 1`] = `
                                   </Component>
                                 </ButtonLabel>
                               </a>
-                            </Component>
+                            </ForwardRef>
                           </StyledButton>
                         </Button>
                       </forwardRef<Button>>

--- a/tests/js/spec/views/projectsDashboard/index.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/index.spec.jsx
@@ -59,7 +59,7 @@ describe('ProjectsDashboard', function() {
         routerContext
       );
 
-      expect(wrapper.find('Button[data-test-id="create-project"]').exists()).toBe(false);
+      expect(wrapper.find('[data-test-id="create-project"]').exists()).toBe(false);
       expect(wrapper.find('NoProjectMessage').exists()).toBe(true);
     });
 
@@ -77,7 +77,7 @@ describe('ProjectsDashboard', function() {
         routerContext
       );
 
-      expect(wrapper.find('Button[data-test-id="create-project"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test-id="create-project"]').exists()).toBe(true);
       expect(wrapper.find('TeamSection').exists()).toBe(true);
       expect(wrapper.find('Resources').exists()).toBe(true);
     });
@@ -110,7 +110,7 @@ describe('ProjectsDashboard', function() {
         routerContext
       );
 
-      expect(wrapper.find('Button[data-test-id="create-project"]').exists()).toBe(true);
+      expect(wrapper.find('[data-test-id="create-project"]').exists()).toBe(true);
       expect(wrapper.find('NoProjectMessage').exists()).toBe(false);
       expect(wrapper.find('TeamSection').exists()).toBe(true);
       expect(wrapper.find('Resources').exists()).toBe(false);

--- a/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationApiKeysList.spec.jsx.snap
@@ -112,88 +112,79 @@ exports[`OrganizationApiKeysList renders 1`] = `
                       <StyledButton
                         aria-disabled={false}
                         aria-label="New API Key"
+                        as="button"
                         disabled={false}
-                        forwardRef={null}
                         onClick={[Function]}
                         priority="primary"
                         role="button"
+                        shouldForwardProp={[Function]}
                         size="small"
                       >
-                        <Component
+                        <button
                           aria-disabled={false}
                           aria-label="New API Key"
                           className="css-z8at1v-StyledButton edwq9my0"
-                          forwardRef={null}
                           onClick={[Function]}
                           role="button"
                           size="small"
                         >
-                          <button
-                            aria-disabled={false}
-                            aria-label="New API Key"
-                            className="css-z8at1v-StyledButton edwq9my0"
-                            onClick={[Function]}
-                            role="button"
+                          <ButtonLabel
+                            align="center"
+                            priority="primary"
                             size="small"
                           >
-                            <ButtonLabel
+                            <Component
                               align="center"
+                              className="css-19gcr2f-ButtonLabel edwq9my1"
                               priority="primary"
                               size="small"
                             >
-                              <Component
-                                align="center"
+                              <span
                                 className="css-19gcr2f-ButtonLabel edwq9my1"
-                                priority="primary"
-                                size="small"
                               >
-                                <span
-                                  className="css-19gcr2f-ButtonLabel edwq9my1"
+                                <Icon
+                                  hasChildren={true}
+                                  size="small"
                                 >
-                                  <Icon
+                                  <Component
+                                    className="css-1299qb2-Icon edwq9my2"
                                     hasChildren={true}
                                     size="small"
                                   >
-                                    <Component
+                                    <span
                                       className="css-1299qb2-Icon edwq9my2"
-                                      hasChildren={true}
                                       size="small"
                                     >
-                                      <span
-                                        className="css-1299qb2-Icon edwq9my2"
-                                        size="small"
+                                      <StyledInlineSvg
+                                        size="12px"
+                                        src="icon-circle-add"
                                       >
-                                        <StyledInlineSvg
+                                        <ForwardRef
+                                          className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                           size="12px"
                                           src="icon-circle-add"
                                         >
-                                          <ForwardRef
+                                          <svg
                                             className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                            size="12px"
-                                            src="icon-circle-add"
+                                            height="12px"
+                                            viewBox={Object {}}
+                                            width="12px"
                                           >
-                                            <svg
-                                              className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                              height="12px"
-                                              viewBox={Object {}}
-                                              width="12px"
-                                            >
-                                              <use
-                                                href="#test"
-                                                xlinkHref="#test"
-                                              />
-                                            </svg>
-                                          </ForwardRef>
-                                        </StyledInlineSvg>
-                                      </span>
-                                    </Component>
-                                  </Icon>
-                                  New API Key
-                                </span>
-                              </Component>
-                            </ButtonLabel>
-                          </button>
-                        </Component>
+                                            <use
+                                              href="#test"
+                                              xlinkHref="#test"
+                                            />
+                                          </svg>
+                                        </ForwardRef>
+                                      </StyledInlineSvg>
+                                    </span>
+                                  </Component>
+                                </Icon>
+                                New API Key
+                              </span>
+                            </Component>
+                          </ButtonLabel>
+                        </button>
                       </StyledButton>
                     </Button>
                   </forwardRef<Button>>

--- a/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/organizationProjects.spec.jsx.snap
@@ -136,103 +136,93 @@ exports[`OrganizationProjects should render the projects in the store 1`] = `
                             <StyledButton
                               aria-disabled={false}
                               aria-label="Create Project"
+                              as={[Function]}
                               disabled={false}
-                              forwardRef={null}
                               onClick={[Function]}
                               priority="primary"
                               role="button"
+                              shouldForwardProp={[Function]}
                               size="small"
                               to="/organizations/org-slug/projects/new/"
                             >
-                              <Component
+                              <Link
                                 aria-disabled={false}
                                 aria-label="Create Project"
                                 className="css-z8at1v-StyledButton edwq9my0"
-                                forwardRef={null}
                                 onClick={[Function]}
+                                onlyActiveOnIndex={false}
                                 role="button"
                                 size="small"
+                                style={Object {}}
                                 to="/organizations/org-slug/projects/new/"
                               >
-                                <Link
+                                <a
                                   aria-disabled={false}
                                   aria-label="Create Project"
                                   className="css-z8at1v-StyledButton edwq9my0"
                                   onClick={[Function]}
-                                  onlyActiveOnIndex={false}
                                   role="button"
                                   size="small"
                                   style={Object {}}
-                                  to="/organizations/org-slug/projects/new/"
                                 >
-                                  <a
-                                    aria-disabled={false}
-                                    aria-label="Create Project"
-                                    className="css-z8at1v-StyledButton edwq9my0"
-                                    onClick={[Function]}
-                                    role="button"
+                                  <ButtonLabel
+                                    align="center"
+                                    priority="primary"
                                     size="small"
-                                    style={Object {}}
                                   >
-                                    <ButtonLabel
+                                    <Component
                                       align="center"
+                                      className="css-19gcr2f-ButtonLabel edwq9my1"
                                       priority="primary"
                                       size="small"
                                     >
-                                      <Component
-                                        align="center"
+                                      <span
                                         className="css-19gcr2f-ButtonLabel edwq9my1"
-                                        priority="primary"
-                                        size="small"
                                       >
-                                        <span
-                                          className="css-19gcr2f-ButtonLabel edwq9my1"
+                                        <Icon
+                                          hasChildren={true}
+                                          size="small"
                                         >
-                                          <Icon
+                                          <Component
+                                            className="css-1299qb2-Icon edwq9my2"
                                             hasChildren={true}
                                             size="small"
                                           >
-                                            <Component
+                                            <span
                                               className="css-1299qb2-Icon edwq9my2"
-                                              hasChildren={true}
                                               size="small"
                                             >
-                                              <span
-                                                className="css-1299qb2-Icon edwq9my2"
-                                                size="small"
+                                              <StyledInlineSvg
+                                                size="12px"
+                                                src="icon-circle-add"
                                               >
-                                                <StyledInlineSvg
+                                                <ForwardRef
+                                                  className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                                   size="12px"
                                                   src="icon-circle-add"
                                                 >
-                                                  <ForwardRef
+                                                  <svg
                                                     className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                    size="12px"
-                                                    src="icon-circle-add"
+                                                    height="12px"
+                                                    viewBox={Object {}}
+                                                    width="12px"
                                                   >
-                                                    <svg
-                                                      className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                      height="12px"
-                                                      viewBox={Object {}}
-                                                      width="12px"
-                                                    >
-                                                      <use
-                                                        href="#test"
-                                                        xlinkHref="#test"
-                                                      />
-                                                    </svg>
-                                                  </ForwardRef>
-                                                </StyledInlineSvg>
-                                              </span>
-                                            </Component>
-                                          </Icon>
-                                          Create Project
-                                        </span>
-                                      </Component>
-                                    </ButtonLabel>
-                                  </a>
-                                </Link>
-                              </Component>
+                                                    <use
+                                                      href="#test"
+                                                      xlinkHref="#test"
+                                                    />
+                                                  </svg>
+                                                </ForwardRef>
+                                              </StyledInlineSvg>
+                                            </span>
+                                          </Component>
+                                        </Icon>
+                                        Create Project
+                                      </span>
+                                    </Component>
+                                  </ButtonLabel>
+                                </a>
+                              </Link>
                             </StyledButton>
                           </Button>
                         </forwardRef<Button>>

--- a/tests/js/spec/views/settings/__snapshots__/projectEnvironments.spec.jsx.snap
+++ b/tests/js/spec/views/settings/__snapshots__/projectEnvironments.spec.jsx.snap
@@ -1239,48 +1239,39 @@ exports[`ProjectEnvironments render hidden renders environment list 1`] = `
                                     <StyledButton
                                       aria-disabled={false}
                                       aria-label="Show"
+                                      as="button"
                                       className="css-1g4cmym-EnvironmentButton e1pnz46f0"
                                       disabled={false}
-                                      forwardRef={null}
                                       onClick={[Function]}
                                       role="button"
+                                      shouldForwardProp={[Function]}
                                       size="xsmall"
                                     >
-                                      <Component
+                                      <button
                                         aria-disabled={false}
                                         aria-label="Show"
                                         className="e1pnz46f0 css-kzdej5-StyledButton-EnvironmentButton edwq9my0"
-                                        forwardRef={null}
                                         onClick={[Function]}
                                         role="button"
                                         size="xsmall"
                                       >
-                                        <button
-                                          aria-disabled={false}
-                                          aria-label="Show"
-                                          className="e1pnz46f0 css-kzdej5-StyledButton-EnvironmentButton edwq9my0"
-                                          onClick={[Function]}
-                                          role="button"
+                                        <ButtonLabel
+                                          align="center"
                                           size="xsmall"
                                         >
-                                          <ButtonLabel
+                                          <Component
                                             align="center"
+                                            className="css-cmi7y3-ButtonLabel edwq9my1"
                                             size="xsmall"
                                           >
-                                            <Component
-                                              align="center"
+                                            <span
                                               className="css-cmi7y3-ButtonLabel edwq9my1"
-                                              size="xsmall"
                                             >
-                                              <span
-                                                className="css-cmi7y3-ButtonLabel edwq9my1"
-                                              >
-                                                Show
-                                              </span>
-                                            </Component>
-                                          </ButtonLabel>
-                                        </button>
-                                      </Component>
+                                              Show
+                                            </span>
+                                          </Component>
+                                        </ButtonLabel>
+                                      </button>
                                     </StyledButton>
                                   </Button>
                                 </forwardRef<Button>>

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/__snapshots__/index.spec.jsx.snap
@@ -201,103 +201,93 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                         <StyledButton
                           aria-disabled={false}
                           aria-label="New Public Integration"
+                          as={[Function]}
                           disabled={false}
-                          forwardRef={null}
                           onClick={[Function]}
                           priority="primary"
                           role="button"
+                          shouldForwardProp={[Function]}
                           size="small"
                           to="/settings/org-slug/developer-settings/new-public/"
                         >
-                          <Component
+                          <Link
                             aria-disabled={false}
                             aria-label="New Public Integration"
                             className="css-z8at1v-StyledButton edwq9my0"
-                            forwardRef={null}
                             onClick={[Function]}
+                            onlyActiveOnIndex={false}
                             role="button"
                             size="small"
+                            style={Object {}}
                             to="/settings/org-slug/developer-settings/new-public/"
                           >
-                            <Link
+                            <a
                               aria-disabled={false}
                               aria-label="New Public Integration"
                               className="css-z8at1v-StyledButton edwq9my0"
                               onClick={[Function]}
-                              onlyActiveOnIndex={false}
                               role="button"
                               size="small"
                               style={Object {}}
-                              to="/settings/org-slug/developer-settings/new-public/"
                             >
-                              <a
-                                aria-disabled={false}
-                                aria-label="New Public Integration"
-                                className="css-z8at1v-StyledButton edwq9my0"
-                                onClick={[Function]}
-                                role="button"
+                              <ButtonLabel
+                                align="center"
+                                priority="primary"
                                 size="small"
-                                style={Object {}}
                               >
-                                <ButtonLabel
+                                <Component
                                   align="center"
+                                  className="css-19gcr2f-ButtonLabel edwq9my1"
                                   priority="primary"
                                   size="small"
                                 >
-                                  <Component
-                                    align="center"
+                                  <span
                                     className="css-19gcr2f-ButtonLabel edwq9my1"
-                                    priority="primary"
-                                    size="small"
                                   >
-                                    <span
-                                      className="css-19gcr2f-ButtonLabel edwq9my1"
+                                    <Icon
+                                      hasChildren={true}
+                                      size="small"
                                     >
-                                      <Icon
+                                      <Component
+                                        className="css-1299qb2-Icon edwq9my2"
                                         hasChildren={true}
                                         size="small"
                                       >
-                                        <Component
+                                        <span
                                           className="css-1299qb2-Icon edwq9my2"
-                                          hasChildren={true}
                                           size="small"
                                         >
-                                          <span
-                                            className="css-1299qb2-Icon edwq9my2"
-                                            size="small"
+                                          <StyledInlineSvg
+                                            size="12px"
+                                            src="icon-circle-add"
                                           >
-                                            <StyledInlineSvg
+                                            <ForwardRef
+                                              className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                               size="12px"
                                               src="icon-circle-add"
                                             >
-                                              <ForwardRef
+                                              <svg
                                                 className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                size="12px"
-                                                src="icon-circle-add"
+                                                height="12px"
+                                                viewBox={Object {}}
+                                                width="12px"
                                               >
-                                                <svg
-                                                  className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                  height="12px"
-                                                  viewBox={Object {}}
-                                                  width="12px"
-                                                >
-                                                  <use
-                                                    href="#test"
-                                                    xlinkHref="#test"
-                                                  />
-                                                </svg>
-                                              </ForwardRef>
-                                            </StyledInlineSvg>
-                                          </span>
-                                        </Component>
-                                      </Icon>
-                                      New Public Integration
-                                    </span>
-                                  </Component>
-                                </ButtonLabel>
-                              </a>
-                            </Link>
-                          </Component>
+                                                <use
+                                                  href="#test"
+                                                  xlinkHref="#test"
+                                                />
+                                              </svg>
+                                            </ForwardRef>
+                                          </StyledInlineSvg>
+                                        </span>
+                                      </Component>
+                                    </Icon>
+                                    New Public Integration
+                                  </span>
+                                </Component>
+                              </ButtonLabel>
+                            </a>
+                          </Link>
                         </StyledButton>
                       </Button>
                     </forwardRef<Button>>
@@ -382,103 +372,93 @@ exports[`Organization Developer Settings when no Apps exist displays empty state
                         <StyledButton
                           aria-disabled={false}
                           aria-label="New Internal Integration"
+                          as={[Function]}
                           disabled={false}
-                          forwardRef={null}
                           onClick={[Function]}
                           priority="primary"
                           role="button"
+                          shouldForwardProp={[Function]}
                           size="small"
                           to="/settings/org-slug/developer-settings/new-internal/"
                         >
-                          <Component
+                          <Link
                             aria-disabled={false}
                             aria-label="New Internal Integration"
                             className="css-z8at1v-StyledButton edwq9my0"
-                            forwardRef={null}
                             onClick={[Function]}
+                            onlyActiveOnIndex={false}
                             role="button"
                             size="small"
+                            style={Object {}}
                             to="/settings/org-slug/developer-settings/new-internal/"
                           >
-                            <Link
+                            <a
                               aria-disabled={false}
                               aria-label="New Internal Integration"
                               className="css-z8at1v-StyledButton edwq9my0"
                               onClick={[Function]}
-                              onlyActiveOnIndex={false}
                               role="button"
                               size="small"
                               style={Object {}}
-                              to="/settings/org-slug/developer-settings/new-internal/"
                             >
-                              <a
-                                aria-disabled={false}
-                                aria-label="New Internal Integration"
-                                className="css-z8at1v-StyledButton edwq9my0"
-                                onClick={[Function]}
-                                role="button"
+                              <ButtonLabel
+                                align="center"
+                                priority="primary"
                                 size="small"
-                                style={Object {}}
                               >
-                                <ButtonLabel
+                                <Component
                                   align="center"
+                                  className="css-19gcr2f-ButtonLabel edwq9my1"
                                   priority="primary"
                                   size="small"
                                 >
-                                  <Component
-                                    align="center"
+                                  <span
                                     className="css-19gcr2f-ButtonLabel edwq9my1"
-                                    priority="primary"
-                                    size="small"
                                   >
-                                    <span
-                                      className="css-19gcr2f-ButtonLabel edwq9my1"
+                                    <Icon
+                                      hasChildren={true}
+                                      size="small"
                                     >
-                                      <Icon
+                                      <Component
+                                        className="css-1299qb2-Icon edwq9my2"
                                         hasChildren={true}
                                         size="small"
                                       >
-                                        <Component
+                                        <span
                                           className="css-1299qb2-Icon edwq9my2"
-                                          hasChildren={true}
                                           size="small"
                                         >
-                                          <span
-                                            className="css-1299qb2-Icon edwq9my2"
-                                            size="small"
+                                          <StyledInlineSvg
+                                            size="12px"
+                                            src="icon-circle-add"
                                           >
-                                            <StyledInlineSvg
+                                            <ForwardRef
+                                              className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                               size="12px"
                                               src="icon-circle-add"
                                             >
-                                              <ForwardRef
+                                              <svg
                                                 className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                size="12px"
-                                                src="icon-circle-add"
+                                                height="12px"
+                                                viewBox={Object {}}
+                                                width="12px"
                                               >
-                                                <svg
-                                                  className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                  height="12px"
-                                                  viewBox={Object {}}
-                                                  width="12px"
-                                                >
-                                                  <use
-                                                    href="#test"
-                                                    xlinkHref="#test"
-                                                  />
-                                                </svg>
-                                              </ForwardRef>
-                                            </StyledInlineSvg>
-                                          </span>
-                                        </Component>
-                                      </Icon>
-                                      New Internal Integration
-                                    </span>
-                                  </Component>
-                                </ButtonLabel>
-                              </a>
-                            </Link>
-                          </Component>
+                                                <use
+                                                  href="#test"
+                                                  xlinkHref="#test"
+                                                />
+                                              </svg>
+                                            </ForwardRef>
+                                          </StyledInlineSvg>
+                                        </span>
+                                      </Component>
+                                    </Icon>
+                                    New Internal Integration
+                                  </span>
+                                </Component>
+                              </ButtonLabel>
+                            </a>
+                          </Link>
                         </StyledButton>
                       </Button>
                     </forwardRef<Button>>

--- a/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallationDetail.spec.jsx.snap
+++ b/tests/js/spec/views/settings/organizationIntegrations/__snapshots__/sentryAppInstallationDetail.spec.jsx.snap
@@ -293,86 +293,77 @@ exports[`Sentry App Installations displays all Apps owned by the Org 1`] = `
                         <StyledButton
                           aria-disabled={false}
                           aria-label="Install"
+                          as="button"
                           className="btn btn-default"
                           disabled={false}
-                          forwardRef={null}
                           onClick={[Function]}
                           role="button"
+                          shouldForwardProp={[Function]}
                           size="small"
                         >
-                          <Component
+                          <button
                             aria-disabled={false}
                             aria-label="Install"
                             className="btn btn-default css-12ogwys-StyledButton edwq9my0"
-                            forwardRef={null}
                             onClick={[Function]}
                             role="button"
                             size="small"
                           >
-                            <button
-                              aria-disabled={false}
-                              aria-label="Install"
-                              className="btn btn-default css-12ogwys-StyledButton edwq9my0"
-                              onClick={[Function]}
-                              role="button"
+                            <ButtonLabel
+                              align="center"
                               size="small"
                             >
-                              <ButtonLabel
+                              <Component
                                 align="center"
+                                className="css-19gcr2f-ButtonLabel edwq9my1"
                                 size="small"
                               >
-                                <Component
-                                  align="center"
+                                <span
                                   className="css-19gcr2f-ButtonLabel edwq9my1"
-                                  size="small"
                                 >
-                                  <span
-                                    className="css-19gcr2f-ButtonLabel edwq9my1"
+                                  <Icon
+                                    hasChildren={true}
+                                    size="small"
                                   >
-                                    <Icon
+                                    <Component
+                                      className="css-1299qb2-Icon edwq9my2"
                                       hasChildren={true}
                                       size="small"
                                     >
-                                      <Component
+                                      <span
                                         className="css-1299qb2-Icon edwq9my2"
-                                        hasChildren={true}
                                         size="small"
                                       >
-                                        <span
-                                          className="css-1299qb2-Icon edwq9my2"
-                                          size="small"
+                                        <StyledInlineSvg
+                                          size="12px"
+                                          src="icon-circle-add"
                                         >
-                                          <StyledInlineSvg
+                                          <ForwardRef
+                                            className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
                                             size="12px"
                                             src="icon-circle-add"
                                           >
-                                            <ForwardRef
+                                            <svg
                                               className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                              size="12px"
-                                              src="icon-circle-add"
+                                              height="12px"
+                                              viewBox={Object {}}
+                                              width="12px"
                                             >
-                                              <svg
-                                                className="css-nc0ns5-InlineSvg-StyledInlineSvg edwq9my3"
-                                                height="12px"
-                                                viewBox={Object {}}
-                                                width="12px"
-                                              >
-                                                <use
-                                                  href="#test"
-                                                  xlinkHref="#test"
-                                                />
-                                              </svg>
-                                            </ForwardRef>
-                                          </StyledInlineSvg>
-                                        </span>
-                                      </Component>
-                                    </Icon>
-                                    Install
-                                  </span>
-                                </Component>
-                              </ButtonLabel>
-                            </button>
-                          </Component>
+                                              <use
+                                                href="#test"
+                                                xlinkHref="#test"
+                                              />
+                                            </svg>
+                                          </ForwardRef>
+                                        </StyledInlineSvg>
+                                      </span>
+                                    </Component>
+                                  </Icon>
+                                  Install
+                                </span>
+                              </Component>
+                            </ButtonLabel>
+                          </button>
                         </StyledButton>
                       </Button>
                     </forwardRef<Button>>

--- a/tests/js/spec/views/settings/projectAlertRules.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlertRules.spec.jsx
@@ -22,7 +22,8 @@ describe('projectAlertRules', function() {
     MockApiClient.clearMockResponses();
   });
 
-  it('deletes', function() {
+  //eslint-disable-next-line
+  it.skip('deletes', function() {
     const wrapper = mountWithTheme(
       <ProjectAlertRules routes={[]} params={{orgId: 'org1', projectId: 'project1'}} />,
       TestStubs.routerContext()

--- a/tests/js/spec/views/settings/projectAlertRules.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlertRules.spec.jsx
@@ -22,8 +22,7 @@ describe('projectAlertRules', function() {
     MockApiClient.clearMockResponses();
   });
 
-  //eslint-disable-next-line
-  it.skip('deletes', function() {
+  it('deletes', function() {
     const wrapper = mountWithTheme(
       <ProjectAlertRules routes={[]} params={{orgId: 'org1', projectId: 'project1'}} />,
       TestStubs.routerContext()


### PR DESCRIPTION
This refactors `<Button>` a bit to use the `as` prop (from `emotion`) to
determine which component to use to render the `<Button>`.