### PR TITLE
 fix(relay): Add missing public keys to Redis cache 

### DIFF
--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -67,7 +67,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
 
         with Hub.current.start_span(op="relay_fetch_keys"):
             project_keys = {}
-            for key in ProjectKey.objects.get_many_from_cache(project_ids, key="project_id"):
+            for key in ProjectKey.objects.filter(project_id__in=project_ids):
                 project_keys.setdefault(key.project_id, []).append(key)
 
         metrics.timing("relay_project_configs.projects_requested", len(project_ids))

--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -324,6 +324,15 @@ class BaseManager(Manager):
         Wrapper around `QuerySet.filter(pk__in=values)` which supports caching of
         the intermediate value.  Callee is responsible for making sure the
         cache key is cleared on save.
+
+        NOTE: We can only query by primary key or some other unique identifier.
+        It is not possible to e.g. run `Project.objects.get_many_from_cache([1,
+        2, 3], key="organization_id")` and get back all projects belonging to
+        those orgs. The length of the return value is bounded by the length of
+        `values`.
+
+        For most models, if one attempts to use a non-PK value this will just
+        degrade to a DB query, like with `get_from_cache`.
         """
 
         pk_name = self.model._meta.pk.name

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -54,9 +54,10 @@ def update_config_cache(generate, organization_id=None, project_id=None, update_
 
         project_configs = {}
         for project in projects:
-            project_configs[project.id] = get_project_config(
+            project_config = get_project_config(
                 project, project_keys=project_keys.get(project.id, []), full_config=True
-            ).to_dict()
+            )
+            project_configs[project.id] = project_config.to_dict()
 
         projectconfig_cache.set_many(project_configs)
     else:

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -5,7 +5,7 @@ import logging
 from django.conf import settings
 from django.core.cache import cache
 
-from sentry.models import ProjectKey
+from sentry.models.projectkey import ProjectKey
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -68,6 +68,7 @@ def test_generate(
     monkeypatch,
     default_project,
     default_organization,
+    default_projectkey,
     task_runner,
     entire_organization,
     redis_cache,
@@ -86,6 +87,14 @@ def test_generate(
 
     assert cfg["organizationId"] == default_organization.id
     assert cfg["projectId"] == default_project.id
+    assert cfg["publicKeys"] == [
+        {
+            "publicKey": default_projectkey.public_key,
+            "isEnabled": True,
+            "numericId": default_projectkey.id,
+            "quotas": [],
+        }
+    ]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Due to some odd behavior in `relay.config.get_project_config` we have to prefetch all keys everytime we call this function. I hope we can get rid of this stupid behavior once Python store is gone.

Also remove an invalid usage of `get_many_from_cache`, which basically only works on primary keys. Luckily this did not cause any misbehavior because `get_many_from_cache` detected the case and fell back to a DB query.