### PR TITLE
fix: Allow more connections to redis clusters

### DIFF
--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -117,7 +117,11 @@ class _RedisCluster(object):
         def cluster_factory():
             if config.get("is_redis_cluster", False):
                 return RetryingStrictRedisCluster(
-                    startup_nodes=hosts, decode_responses=True, skip_full_coverage_check=True
+                    startup_nodes=hosts,
+                    decode_responses=True,
+                    skip_full_coverage_check=True,
+                    max_connections=1024,
+                    max_connections_per_node=True,
                 )
             else:
                 host = hosts[0].copy()

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -120,7 +120,7 @@ class _RedisCluster(object):
                     startup_nodes=hosts,
                     decode_responses=True,
                     skip_full_coverage_check=True,
-                    max_connections=1024,
+                    max_connections=16,
                     max_connections_per_node=True,
                 )
             else:


### PR DESCRIPTION
By default, StrictRedisCluster has `max_connections` set to 32, which proved to be quite small e.g. when there are more nodes in the respective redis cluster:
https://github.com/Grokzen/redis-py-cluster/blob/2669f0159cc04843c22ef97192eca448e21ef72c/rediscluster/client.py#L128

~Let's set this limit to a higher value.~
Additionally, we're setting `max_connections_per_node` to True:

"Added optional max_connections_per_node parameter to ClusterConnectionPool which changes behavior of max_connections so that it applies per-node rather than across the whole cluster. The new feature is opt-in, and the existing default behavior is unchanged. Users are recommended to opt-in as the feature fixes two important problems. First is that some nodes could be starved for connections after max_connections is used up by connecting to other nodes. Second is that the asymmetric number of connections across nodes makes it challenging to configure file descriptor and redis max client settings."


(src: https://github.com/Grokzen/redis-py-cluster/blob/27392f931b9ac994ea5f48dad95328ce6fa1ffe6/docs/upgrading.rst#100----110)

#sync-getsentry