### PR TITLE
fix(discoverv2) - Cache even when project ids aren't passed

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/tags.jsx
+++ b/src/sentry/static/sentry/app/actionCreators/tags.jsx
@@ -68,7 +68,10 @@ export function fetchOrganizationTags(api, orgId, projectIds = null) {
   TagActions.loadTags();
 
   const url = `/organizations/${orgId}/tags/`;
-  const query = projectIds ? {project: projectIds, use_cache: 1} : null;
+  const query = {use_cache: 1};
+  if (projectIds) {
+    query.project = projectIds;
+  }
 
   const promise = api
     .requestPromise(url, {


### PR DESCRIPTION
- This is actually the most important case to cache, looks like
  projectIds aren't passed from discover's table view which meant the
  use_cache flag wasn't being passed in this case.
  - This should be fine since the api call is equivalent to what happens
    on the issues page, I missed this cause the issues Page passed an
    empty array instead of null.