### PR TITLE
fix(releases) - Only update author name when it changes

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -409,8 +409,7 @@ class Release(Model):
                             defaults=author_data,
                         )
                         if author.name != author_data["name"]:
-                            author.name = author_data["name"]
-                            author.save(update_fields=["name"])
+                            author.update(name=author_data["name"])
                         authors[author_email] = author
                     else:
                         author = authors[author_email]

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -403,15 +403,14 @@ class Release(Model):
                         author = None
                     elif author_email not in authors:
                         author_data = {"name": data.get("author_name")}
-                        author, created = CommitAuthor.objects.create_or_update(
+                        author, created = CommitAuthor.objects.get_or_create(
                             organization_id=self.organization_id,
                             email=author_email,
-                            values=author_data,
+                            defaults=author_data,
                         )
-                        if not created:
-                            author = CommitAuthor.objects.get(
-                                organization_id=self.organization_id, email=author_email
-                            )
+                        if author.name != author_data["name"]:
+                            author.name = author_data["name"]
+                            author.save(update_fields=["name"])
                         authors[author_email] = author
                     else:
                         author = authors[author_email]


### PR DESCRIPTION
- Switch from `create_or_update` to `get_or_create`, since
  `create_or_update` will run an update everytime even if the data is
  the same.
- With these changes we should only update when the name has changed.