### PR TITLE
test: annoyance fixes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -52,8 +52,10 @@ def install_sentry_plugins():
     settings.SENTRY_OPTIONS["github.integration-hook-secret"] = "b3002c3e321d4b7880360d397db2ccfd"
 
 
-def pytest_collection_modifyitems(items):
+def pytest_collection_modifyitems(config, items):
     for item in items:
         total_groups = int(os.environ.get("TOTAL_TEST_GROUPS", 1))
         group_num = int(md5(item.location[0]).hexdigest(), 16) % total_groups
-        item.add_marker(getattr(pytest.mark, "group_%s" % group_num))
+        marker = "group_%s" % group_num
+        config.addinivalue_line("markers", marker)
+        item.add_marker(getattr(pytest.mark, marker))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 python_files = test*.py
-addopts = --tb=native -p no:doctest -p no:warnings --strict-markers
+addopts = --tb=native -p no:doctest -p no:warnings
 norecursedirs = bin dist docs htmlcov script hooks node_modules .* {args}
 looponfailroots = src tests
 selenium_driver = chrome

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 python_files = test*.py
-addopts = --tb=native -p no:doctest -p no:warnings
+addopts = --tb=native -p no:doctest -p no:warnings --strict-markers
 norecursedirs = bin dist docs htmlcov script hooks node_modules .* {args}
 looponfailroots = src tests
 selenium_driver = chrome

--- a/tests/sentry/api/validators/sentry_apps/test_schema.py
+++ b/tests/sentry/api/validators/sentry_apps/test_schema.py
@@ -1,10 +1,5 @@
 from __future__ import absolute_import
 
-import pytest
-
-# needed so we can see the full assertion errror in util
-pytest.register_assert_rewrite("tests.sentry.api.validators.sentry_apps.util")
-
 from .util import invalid_schema_with_error_message
 from sentry.testutils import TestCase
 from sentry.api.validators.sentry_apps.schema import validate_ui_element_schema

--- a/tests/sentry/plugins/bases/test_issue2.py
+++ b/tests/sentry/plugins/bases/test_issue2.py
@@ -14,13 +14,13 @@ from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
-class TestPluginWithFields(IssueTrackingPlugin2):
+class PluginWithFields(IssueTrackingPlugin2):
     slug = "test-plugin-with-fields"
     conf_key = slug
     issue_fields = frozenset(["id", "title", "url"])
 
 
-class TestPluginWithoutFields(IssueTrackingPlugin2):
+class PluginWithoutFields(IssueTrackingPlugin2):
     slug = "test-plugin-without-fields"
     conf_key = slug
     issue_fields = None
@@ -28,17 +28,17 @@ class TestPluginWithoutFields(IssueTrackingPlugin2):
 
 class IssueTrackingPlugin2Test(TestCase):
     def test_issue_label_as_dict(self):
-        plugin = TestPluginWithFields()
+        plugin = PluginWithFields()
         result = plugin.get_issue_label(mock.Mock(), {"id": "1"})
         assert result == "#1"
 
     def test_issue_label_legacy(self):
-        plugin = TestPluginWithoutFields()
+        plugin = PluginWithoutFields()
         result = plugin.get_issue_label(mock.Mock(), "1")
         assert result == "#1"
 
     def test_issue_field_map_with_fields(self):
-        plugin = TestPluginWithFields()
+        plugin = PluginWithFields()
         result = plugin.get_issue_field_map()
         assert result == {
             "id": "test-plugin-with-fields:issue_id",
@@ -47,7 +47,7 @@ class IssueTrackingPlugin2Test(TestCase):
         }
 
     def test_issue_field_map_without_fields(self):
-        plugin = TestPluginWithoutFields()
+        plugin = PluginWithoutFields()
         result = plugin.get_issue_field_map()
         assert result == {"id": "test-plugin-without-fields:tid"}
 


### PR DESCRIPTION
I got tired of seeing all this stuff. This PR makes these things go away by pytesting better.

```
/Users/joshua.li/dev/sentry/sentry/tests/sentry/plugins/bases/test_issue2.py:17: PytestCollectionWarning: cannot collect test class 'TestPluginWithFields' because it has a __new__ constructor (from: tests/sentry/plugins/bases/test_issue2.py)
  class TestPluginWithFields(IssueTrackingPlugin2):
/Users/joshua.li/dev/sentry/sentry/tests/sentry/plugins/bases/test_issue2.py:23: PytestCollectionWarning: cannot collect test class 'TestPluginWithoutFields' because it has a __new__ constructor (from: tests/sentry/plugins/bases/test_issue2.py)
  class TestPluginWithoutFields(IssueTrackingPlugin2):
/Users/joshua.li/.local/share/virtualenvs/sentry2/lib/python2.7/site-packages/_pytest/mark/structures.py:334: PytestUnknownMarkWarning: Unknown pytest.mark.group_0 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
  PytestUnknownMarkWarning,
```

```
=============================== warnings summary ===============================

tests/sentry/api/validators/sentry_apps/test_schema.py:6

  /root/.pip/sentry-dev/tests/sentry/api/validators/sentry_apps/test_schema.py:6: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: tests.sentry.api.validators.sentry_apps.util

    pytest.register_assert_rewrite("tests.sentry.api.validators.sentry_apps.util")

-- Docs: https://docs.pytest.org/en/latest/warnings.html

---- generated xml file: /root/.pip/sentry-dev/.artifacts/python.junit.xml -----
```

Regarding ^, looks like it was introduced by @scefali, but I feel like it's a noop because "Module already imported so cannot be rewritten".
