### PR TITLE
fix: Fallback images for installed integrations

### DIFF
--- a/src/sentry/static/sentry/app/plugins/components/pluginIcon.tsx
+++ b/src/sentry/static/sentry/app/plugins/components/pluginIcon.tsx
@@ -34,7 +34,7 @@ import vsts from 'app/../images/logos/logo-azure.svg';
 import youtrack from 'app/../images/logos/logo-youtrack.svg';
 
 // Map of plugin id -> logo filename
-const DEFAULT_ICON = placeholder;
+export const DEFAULT_ICON = placeholder;
 export const ICON_PATHS = {
   _default: DEFAULT_ICON,
   sentry,

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationIcon.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationIcon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
-import PluginIcon from 'app/plugins/components/pluginIcon';
+import PluginIcon, {ICON_PATHS, DEFAULT_ICON} from 'app/plugins/components/pluginIcon';
 import {Integration} from 'app/types';
 
 type Props = {
@@ -25,7 +25,10 @@ const IntegrationIcon = ({integration, size}: Props) =>
       size={size}
       src={integration.icon}
       onError={e => {
-        (e.target as HTMLImageElement).src = integration.provider.key;
+        (e.target as HTMLImageElement).src =
+          (integration.provider.key !== undefined &&
+            ICON_PATHS[integration.provider.key]) ||
+          DEFAULT_ICON;
       }}
     />
   ) : (

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationIcon.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationIcon.tsx
@@ -21,7 +21,13 @@ const Icon = styled('img')<IconProps>`
 
 const IntegrationIcon = ({integration, size}: Props) =>
   integration.icon ? (
-    <Icon size={size} src={integration.icon} />
+    <Icon
+      size={size}
+      src={integration.icon}
+      onError={e => {
+        (e.target as HTMLImageElement).src = integration.provider.key;
+      }}
+    />
   ) : (
     <PluginIcon size={size} pluginId={integration.provider.key} />
   );

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationIcon.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationIcon.tsx
@@ -35,7 +35,7 @@ class Icon extends React.Component<Props> {
       <StyledIcon
         size={size}
         src={this.state.imgSrc}
-        onError={_ => {
+        onError={() => {
           this.setState({imgSrc: ICON_PATHS[integration.provider.key] || DEFAULT_ICON});
         }}
       />

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationIcon.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationIcon.tsx
@@ -12,25 +12,40 @@ type Props = {
 
 type IconProps = Pick<Props, 'size'>;
 
-const Icon = styled('img')<IconProps>`
+const StyledIcon = styled('img')<IconProps>`
   height: ${p => p.size}px;
   width: ${p => p.size}px;
   border-radius: 2px;
   display: block;
 `;
 
+class Icon extends React.Component<Props> {
+  state = {
+    imgSrc: '',
+  };
+
+  componentDidMount() {
+    const {integration} = this.props;
+    this.setState({imgSrc: integration.icon});
+  }
+  render() {
+    const {integration, size} = this.props;
+
+    return (
+      <StyledIcon
+        size={size}
+        src={this.state.imgSrc}
+        onError={_ => {
+          this.setState({imgSrc: ICON_PATHS[integration.provider.key] || DEFAULT_ICON});
+        }}
+      />
+    );
+  }
+}
+
 const IntegrationIcon = ({integration, size}: Props) =>
   integration.icon ? (
-    <Icon
-      size={size}
-      src={integration.icon}
-      onError={e => {
-        (e.target as HTMLImageElement).src =
-          (integration.provider.key !== undefined &&
-            ICON_PATHS[integration.provider.key]) ||
-          DEFAULT_ICON;
-      }}
-    />
+    <Icon size={size} integration={integration} />
   ) : (
     <PluginIcon size={size} pluginId={integration.provider.key} />
   );

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationIcon.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationIcon.tsx
@@ -21,13 +21,9 @@ const StyledIcon = styled('img')<IconProps>`
 
 class Icon extends React.Component<Props> {
   state = {
-    imgSrc: '',
+    imgSrc: this.props.integration.icon,
   };
 
-  componentDidMount() {
-    const {integration} = this.props;
-    this.setState({imgSrc: integration.icon});
-  }
   render() {
     const {integration, size} = this.props;
 


### PR DESCRIPTION
Before: 
![Screen Shot 2019-10-10 at 12 36 50 PM](https://user-images.githubusercontent.com/10491193/72557360-6a98dd00-3855-11ea-9678-4d5caa6f9bd6.png)

After:
<img width="522" alt="Screen Shot 2020-01-16 at 11 43 44 AM" src="https://user-images.githubusercontent.com/10491193/72557382-784e6280-3855-11ea-990e-ca747fcb5dda.png">
