### PR TITLE
feat: pep517-valid pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=40.2.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length=100
 target-version=['py27']


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/16184.

We currently only use pyproject.toml to configure black, but `build-system` should be specified for a pep517-valid pyproject.toml. For starters, we can just explicitly list the default setuptools pep517 build backend - these are [the fallback settings](https://github.com/pypa/pip/pull/5743/files#diff-63ae2beb4199cfa5d3953329544eb9fdR154) that pip assumes, if build-system isn't specified. This has functionally no difference with the way things are now.