### PR TITLE
ref(plugins): Add more logging for legacy plugin

### DIFF
--- a/src/sentry_plugins/pagerduty/plugin.py
+++ b/src/sentry_plugins/pagerduty/plugin.py
@@ -97,4 +97,15 @@ class PagerDutyPlugin(CorePluginMixin, NotifyPlugin):
             )
             assert response["status"] == "success"
         except Exception as e:
+            self.logger.info(
+                "notification-plugin.notify-failed.pagerduty",
+                extra={
+                    "error": six.text_type(e),
+                    # Log out all the required attributes noted https://v2.developer.pagerduty.com/docs/trigger-events
+                    # incase any are missing or blank, except for event_type since we hard code that above to "trigger".
+                    "description": description,
+                    "incident_key": six.text_type(group.id),
+                    "service_key": service_key,
+                },
+            )
             self.raise_error(e)


### PR DESCRIPTION
When the legacy PagerDuty plugin fails, specifically 400s, it's hard to tell what's going on because we just log the following error via the base `NotifyPlugin`.
```
'Error Communicating with PagerDuty (HTTP 400): Event object is invalid'
```
PagerDuty actually gives us back more information ( e.g. `error=u'{"status":"invalid event","message":"Event object is invalid","errors":["Description is missing or blank"]}'` but we are just taking the message. 

This pr logs the full error (not just the message) and all of the required attribute so that we can see if they are missing or blank. It might be a little redundant since they error will now tell us that, but just to confirm. 

cc @ceorourke 