### PR TITLE
fix(apm): Improve acceptance test for transaction span view

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -240,8 +240,8 @@ class SpanTree extends React.Component<PropType> {
           trace={this.props.trace}
           generateBounds={generateBounds}
           treeDepth={treeDepth}
-          numOfSpanChildren={spanChildren.length}
-          renderedSpanChildren={reduced.renderedSpanChildren}
+          numOfSpanChildren={0}
+          renderedSpanChildren={[]}
           isCurrentSpanFilteredOut={isCurrentSpanFilteredOut}
           spanBarHatch
         />

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -233,7 +233,7 @@ class SpanTree extends React.Component<PropType> {
           eventView={eventView}
           orgId={orgId}
           spanNumber={spanNumber}
-          isLast={isLast}
+          isLast={false}
           continuingTreeDepths={continuingTreeDepths}
           isRoot={isRoot}
           span={spanGap}

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -80,21 +80,21 @@ def generate_transaction():
     parent_span_id = reference_span["parent_span_id"]
 
     span_tree_blueprint = {
-        "a": {"aa": {"aaa": {"aaaa": "aaaaa"}}},
-        "b": {},
+        "a": {},
+        "b": {"bb": {"bbb": {"bbbb": "bbbbb"}}},
         "c": {},
         "d": {},
         "e": {},
     }
 
     time_offsets = {
-        "a": (timedelta(), timedelta(milliseconds=250)),
-        "aa": (timedelta(milliseconds=10), timedelta(milliseconds=20)),
-        "aaa": (timedelta(milliseconds=15), timedelta(milliseconds=30)),
-        "aaaa": (timedelta(milliseconds=20), timedelta(milliseconds=50)),
-        "aaaaa": (timedelta(milliseconds=25), timedelta(milliseconds=50)),
-        "b": (timedelta(milliseconds=100), timedelta(milliseconds=100)),
-        "c": (timedelta(milliseconds=350), timedelta(milliseconds=50)),
+        "a": (timedelta(), timedelta(milliseconds=10)),
+        "b": (timedelta(milliseconds=120), timedelta(milliseconds=250)),
+        "bb": (timedelta(milliseconds=130), timedelta(milliseconds=10)),
+        "bbb": (timedelta(milliseconds=140), timedelta(milliseconds=10)),
+        "bbbb": (timedelta(milliseconds=150), timedelta(milliseconds=10)),
+        "bbbbb": (timedelta(milliseconds=160), timedelta(milliseconds=90)),
+        "c": (timedelta(milliseconds=260), timedelta(milliseconds=100)),
         "d": (timedelta(milliseconds=375), timedelta(milliseconds=50)),
         "e": (timedelta(milliseconds=400), timedelta(milliseconds=100)),
     }


### PR DESCRIPTION
Fixes:

- missing instrumentation span shouldn't have descendants
- missing instrumentation span can never be the last span

<img width="813" alt="Screen Shot 2020-01-16 at 6 50 28 PM" src="https://user-images.githubusercontent.com/139499/72572617-16135300-3891-11ea-9f3d-e0a76eb49b4b.png">
