### PR TITLE
ref: Remove option to use Django event model in event_manager.save()

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -7,14 +7,13 @@ import ipaddress
 import jsonschema
 import six
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from django.core.cache import cache
 from django.db import connection, IntegrityError, router, transaction
 from django.db.models import Func
-from django.utils import timezone
 from django.utils.encoding import force_text
 
-from sentry import buffer, eventstore, eventtypes, eventstream, options, tsdb
+from sentry import buffer, eventstore, eventtypes, eventstream, tsdb
 from sentry.constants import (
     DEFAULT_STORE_NORMALIZER_ARGS,
     LOG_LEVELS,
@@ -45,7 +44,6 @@ from sentry.interfaces.base import get_interface
 from sentry.models import (
     Activity,
     Environment,
-    Event,
     EventDict,
     EventError,
     EventUser,
@@ -378,36 +376,15 @@ class EventManager(object):
         return self._data
 
     def _get_event_instance(self, project_id=None):
-        if options.get("store.use-django-event"):
-            data = self._data
-            event_id = data.get("event_id")
-            platform = data.get("platform")
+        data = self._data
+        event_id = data.get("event_id")
 
-            recorded_timestamp = data.get("timestamp")
-            date = datetime.fromtimestamp(recorded_timestamp)
-            date = date.replace(tzinfo=timezone.utc)
-            time_spent = data.get("time_spent")
-
-            data["node_id"] = Event.generate_node_id(project_id, event_id)
-
-            return Event(
-                project_id=project_id or self._project.id,
-                event_id=event_id,
-                data=EventDict(data, skip_renormalization=True),
-                time_spent=time_spent,
-                datetime=date,
-                platform=platform,
-            )
-        else:
-            data = self._data
-            event_id = data.get("event_id")
-
-            return eventstore.create_event(
-                project_id=project_id or self._project.id,
-                event_id=event_id,
-                group_id=None,
-                data=EventDict(data, skip_renormalization=True),
-            )
+        return eventstore.create_event(
+            project_id=project_id or self._project.id,
+            event_id=event_id,
+            group_id=None,
+            data=EventDict(data, skip_renormalization=True),
+        )
 
     def get_culprit(self):
         """Helper to calculate the default culprit"""

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -16,7 +16,7 @@ from django.views.generic import View
 from loremipsum import Generator
 from random import Random
 
-from sentry import eventstore, options
+from sentry import eventstore
 from sentry.app import tsdb
 from sentry.constants import LOG_LEVELS
 from sentry.digests import Record
@@ -238,10 +238,7 @@ def alert(request):
     data = event_manager.get_data()
     event = event_manager.save(project.id)
     # Prevent Percy screenshot from constantly changing
-    if options.get("store.use-django-event"):
-        event.datetime = datetime(2017, 9, 6, 0, 0)
-    else:
-        event.data["timestamp"] = 1504656000.0  # datetime(2017, 9, 6, 0, 0)
+    event.data["timestamp"] = 1504656000.0  # datetime(2017, 9, 6, 0, 0)
     event_type = event_manager.get_event_type()
 
     group.message = event.search_message


### PR DESCRIPTION
This flag has been set to False in prod, we can remove the old code
path.