### PR TITLE
feat(ui): C# breadcrumbs width adjustments

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/crumbTable.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/crumbTable.jsx
@@ -2,11 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import map from 'lodash/map';
 import isObject from 'lodash/isObject';
-import styled from '@emotion/styled';
 
 import Category from 'app/components/events/interfaces/breadcrumbs/category';
-import {PlatformContext} from 'app/components/events/interfaces/breadcrumbs/platformContext';
-import theme from 'app/utils/theme';
 
 class CrumbTable extends React.Component {
   static propTypes = {
@@ -14,7 +11,6 @@ class CrumbTable extends React.Component {
     kvData: PropTypes.object,
     summary: PropTypes.object,
   };
-  static contextType = PlatformContext;
 
   renderData = () => {
     if (!this.props.kvData) {
@@ -33,16 +29,13 @@ class CrumbTable extends React.Component {
   };
 
   render() {
-    const platform = this.context;
-    const widerCategory = platform === 'csharp';
-
     return (
       <table className="table key-value">
         <thead>
           <tr>
-            <TableData className="key" wide={widerCategory}>
+            <td className="key">
               <Category value={this.props.crumb.category} />
-            </TableData>
+            </td>
             <td className="value">{this.props.summary}</td>
           </tr>
         </thead>
@@ -54,12 +47,5 @@ class CrumbTable extends React.Component {
     );
   }
 }
-
-const TableData = styled('td')`
-  @media (min-width: ${theme.breakpoints[2]}) {
-    max-width: ${p => (p.wide ? '215px !important' : null)};
-    width: ${p => (p.wide ? '215px !important' : null)};
-  }
-`;
 
 export default CrumbTable;


### PR DESCRIPTION
Two weeks ago we shipped UI improvements for C# issue detail. https://github.com/getsentry/sentry/pull/16199
One of the goals there was to make breadcrumbs with long category names more useful.

We achieved this by doing two changes(only for C#):
1) making category column wider
2) overflowEllipsis from LEFT, because oftentimes the beginning of the string is the same and the only thing that changes are the few characters at the very end

![image](https://user-images.githubusercontent.com/9060071/72613086-e2870600-392e-11ea-973b-006a8b4d655a.png)

The second thing proved to be so helpful, that we can change the width adjustment to its original size and therefore stay consistent across other platforms.

This PR basically reverts change in this file: https://github.com/getsentry/sentry/pull/16199/files#diff-3
