### PR TITLE
ref(plugins): Add more logging to PagerDuty to debug logging

### DIFF
--- a/src/sentry_plugins/pagerduty/plugin.py
+++ b/src/sentry_plugins/pagerduty/plugin.py
@@ -18,6 +18,14 @@ class PagerDutyPlugin(CorePluginMixin, NotifyPlugin):
     conf_key = slug
     conf_title = title
 
+    def error_message_from_json(self, data):
+        message = data.get("message", "unknown error")
+        errors = data.get("errors", None)
+        if errors:
+            return "%s: %s" % (message, " ".join(errors))
+
+        return message
+
     def is_configured(self, project, **kwargs):
         return bool(self.get_option("service_key", project))
 
@@ -97,6 +105,14 @@ class PagerDutyPlugin(CorePluginMixin, NotifyPlugin):
             )
             assert response["status"] == "success"
         except Exception as e:
+            # XXX(Meredith): The original logging statement below doesn't seem to be logging in
+            # production so adding a couple other variations to see if it's the payload we are
+            # trying to log or something else. Removed once testing is done.
+            self.logger.info("notification-plugin.notify-failed.pagerduty-failed")
+            self.logger.info(
+                "notification-plugin.notify-failed.pagerduty-error: %s" % six.text_type(e)
+            )
+
             self.logger.info(
                 "notification-plugin.notify-failed.pagerduty",
                 extra={


### PR DESCRIPTION
So https://github.com/getsentry/sentry/pull/16496 was a bust. 

This PR adds more (temporary) logging to test what might be wrong and why it's not getting logged currently.

Additionally, I've overridden `error_message_from_json` in another attempt to get the actual useful part of the PagerDuty error in our logs. 🤞 