### PR TITLE
ref: Rename dataset_query to aliased_query

### DIFF
--- a/src/sentry/discover/utils.py
+++ b/src/sentry/discover/utils.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import six
 
-from sentry.utils.snuba import Dataset, dataset_query, get_snuba_column_name, get_function_index
+from sentry.utils.snuba import Dataset, aliased_query, get_snuba_column_name, get_function_index
 
 # TODO(mark) Once this import is removed, transform_results should not
 # be exported.
@@ -142,6 +142,6 @@ def transform_aliases_and_query(**kwargs):
     kwargs["arrayjoin"] = arrayjoin_map.get(arrayjoin, arrayjoin)
     kwargs["dataset"] = dataset
 
-    result = dataset_query(**kwargs)
+    result = aliased_query(**kwargs)
 
     return transform_results(result, translated_columns, kwargs)

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -97,7 +97,7 @@ class SnubaEventStorage(EventStorage):
         cols = self.__get_columns()
         orderby = orderby or DESC_ORDERING
 
-        result = snuba.dataset_query(
+        result = snuba.aliased_query(
             selected_columns=cols,
             start=filter.start,
             end=filter.end,
@@ -224,7 +224,7 @@ class SnubaEventStorage(EventStorage):
             # This query uses the discover dataset to enable
             # getting events across both errors and transactions, which is
             # required when doing pagination in discover
-            result = snuba.dataset_query(
+            result = snuba.aliased_query(
                 selected_columns=columns,
                 conditions=filter.conditions,
                 filter_keys=filter.filter_keys,

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -174,7 +174,7 @@ class AbstractQueryExecutor:
             ]  # ensure stable sort within the same score
             referrer = "search"
 
-        snuba_results = snuba.dataset_query(
+        snuba_results = snuba.aliased_query(
             dataset=self.dataset,
             start=start,
             end=end,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -742,7 +742,7 @@ def constrain_condition_to_dataset(cond, dataset):
     raise ValueError("Unexpected condition format %s" % cond)
 
 
-def dataset_query(
+def aliased_query(
     start=None,
     end=None,
     groupby=None,


### PR DESCRIPTION
Both raw_query and aliased_query can use the dataset parameter. The difference between the two is how they handling aliasing. This rename makes that clearer.