### PR TITLE
fix(drf): don't attempt to use QueryDict api on new null value of request.data

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -86,13 +86,15 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         logger = logging.getLogger("sentry.files")
         logger.info("chunkupload.start")
 
-        if not request.data:
+        files = []
+        if request.data:
+            files = request.data.getlist("file")
+            files += [GzipChunk(chunk) for chunk in request.data.getlist("file_gzip")]
+
+        if len(files) == 0:
             # No files uploaded is ok
             logger.info("chunkupload.end", extra={"status": status.HTTP_200_OK})
             return Response(status=status.HTTP_200_OK)
-
-        files = request.data.getlist("file")
-        files += [GzipChunk(chunk) for chunk in request.data.getlist("file_gzip")]
 
         logger.info("chunkupload.post.files", extra={"len": len(files)})
 

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -86,12 +86,13 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         logger = logging.getLogger("sentry.files")
         logger.info("chunkupload.start")
 
-        files = request.data.getlist("file")
-        files += [GzipChunk(chunk) for chunk in request.data.getlist("file_gzip")]
-        if len(files) == 0:
+        if not request.data:
             # No files uploaded is ok
             logger.info("chunkupload.end", extra={"status": status.HTTP_200_OK})
             return Response(status=status.HTTP_200_OK)
+
+        files = request.data.getlist("file")
+        files += [GzipChunk(chunk) for chunk in request.data.getlist("file_gzip")]
 
         logger.info("chunkupload.post.files", extra={"len": len(files)})
 

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -87,6 +87,15 @@ class ChunkUploadTest(APITestCase):
         assert file_blobs[0].checksum == checksum1
         assert file_blobs[1].checksum == checksum2
 
+    def test_empty_upload(self):
+        response = self.client.post(
+            self.url, HTTP_AUTHORIZATION=u"Bearer {}".format(self.token.token), format="multipart"
+        )
+        assert response.status_code == 200
+
+        file_blobs = FileBlob.objects.all()
+        assert len(file_blobs) == 0
+
     def test_too_many_chunks(self):
         files = []
 


### PR DESCRIPTION
Sometime in between drf 3.4.7-3.6.4, this was changed: https://github.com/encode/django-rest-framework/pull/4566/files#diff-6dc9b019ec1d96c56e0e31dac3bba51cR304-R305

Meaning `request.data` is an empty dict rather than an empty QueryDict (which you can call `getlist` on), if there's no data.

Fixes SENTRY-E73.