### PR TITLE
fix(searchbar) - Prevent more requests when clicking the searchbar

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.jsx
@@ -221,6 +221,7 @@ class SmartSearchBar extends React.Component {
 
     this.state = {
       query: props.query !== null ? addSpace(props.query) : props.defaultQuery,
+      previousQuery: undefined,
       noValueQuery: undefined,
 
       searchTerm: '',
@@ -633,6 +634,12 @@ class SmartSearchBar extends React.Component {
 
     const cursor = this.getCursorPosition();
     let query = this.state.query;
+    // Don't continue if the query hasn't changed
+    if (query === this.state.previousQuery) {
+      return;
+    } else {
+      this.setState({previousQuery: query});
+    }
 
     const lastTermIndex = SmartSearchBar.getLastTermIndex(query, cursor);
     const terms = SmartSearchBar.getQueryTerms(query.slice(0, lastTermIndex));


### PR DESCRIPTION
- With this clicking the searchbar still shows the autocomplete, but won't cause any queries to fire
- Before:
![before](https://user-images.githubusercontent.com/4205004/72651984-2ee43d00-3953-11ea-94c5-9b2d94fe045a.gif)
