### PR TITLE
feat(workflow): Add environment selector to Metric Alert Rule editor

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -326,7 +326,12 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
               timeWindow={timeWindow}
             />
 
-            <RuleConditionsForm organization={organization} disabled={!hasAccess} />
+            <RuleConditionsForm
+              api={api}
+              projectSlug={params.projectId}
+              organization={organization}
+              disabled={!hasAccess}
+            />
 
             <Triggers
               disabled={!hasAccess}

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -327,7 +327,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
             />
 
             <RuleConditionsForm
-              api={api}
+              api={this.api}
               projectSlug={params.projectId}
               organization={organization}
               disabled={!hasAccess}

--- a/tests/js/spec/views/settings/incidentRules/create.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/create.spec.jsx
@@ -16,6 +16,10 @@ describe('Incident Rules Create', function() {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/environments/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: TestStubs.EventsStats(),
     });
@@ -36,7 +40,7 @@ describe('Incident Rules Create', function() {
     const {organization, project, routerContext} = initializeOrg();
     mountWithTheme(
       <IncidentRulesCreate
-        params={{orgId: organization.slug}}
+        params={{orgId: organization.slug, projectId: project.slug}}
         organization={organization}
         project={project}
       />,

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -17,6 +17,10 @@ describe('Incident Rules Details', function() {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/environments/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: null,
     });
@@ -34,7 +38,7 @@ describe('Incident Rules Details', function() {
   });
 
   it('renders and adds and edits trigger', async function() {
-    const {organization, routerContext} = initializeOrg();
+    const {organization, project, routerContext} = initializeOrg();
     const rule = TestStubs.IncidentRule();
     const req = MockApiClient.addMockResponse({
       url: `/projects/${organization.slug}/project-slug/alert-rules/${rule.id}/`,
@@ -58,7 +62,7 @@ describe('Incident Rules Details', function() {
         <IncidentRulesDetails
           params={{
             orgId: organization.slug,
-            projectId: 'project-slug',
+            projectId: project.slug,
             incidentRuleId: rule.id,
           }}
           organization={organization}

--- a/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
@@ -28,6 +28,10 @@ describe('Incident Rules Form', function() {
       body: [],
     });
     MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/environments/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: TestStubs.EventsStats(),
     });


### PR DESCRIPTION
This adds an environment selector to the Metric Alert Rule editor.