### PR TITLE
fix: Add exact search to BitbucketAPI search function

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -104,20 +104,15 @@ class BitbucketIntegration(IntegrationInstallation, BitbucketIssueBasicMixin, Re
         exact_search_resp = self.get_client().search_repositories(self.username, exact_query)
         fuzzy_search_resp = self.get_client().search_repositories(self.username, fuzzy_query)
 
-        if len(exact_search_resp.get("values", [])) == 0:
-            return [
-                {"identifier": i["full_name"], "name": i["full_name"]}
-                for i in fuzzy_search_resp.get("values", [])
-            ]
-        else:
-            result = OrderedSet()
-            exact_result = exact_search_resp.get("values")[0]["full_name"]
-            result.add(exact_result)
+        result = OrderedSet()
 
-            for i in fuzzy_search_resp.get("values", []):
-                result.add(i["full_name"])
+        for j in exact_search_resp.get("values", []):
+            result.add(j["full_name"])
 
-            return [{"identifier": full_name, "name": full_name} for full_name in result]
+        for i in fuzzy_search_resp.get("values", []):
+            result.add(i["full_name"])
+
+        return [{"identifier": full_name, "name": full_name} for full_name in result]
 
     def has_repo_access(self, repo):
         client = self.get_client()

--- a/src/sentry/integrations/bitbucket/search.py
+++ b/src/sentry/integrations/bitbucket/search.py
@@ -9,8 +9,6 @@ from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.integrations.exceptions import ApiError
 from sentry.models import Integration
 
-from django.utils.datastructures import OrderedSet
-
 logger = logging.getLogger("sentry.integrations.bitbucket")
 
 
@@ -58,24 +56,8 @@ class BitbucketSearchEndpoint(IntegrationEndpoint):
             )
 
         if field == "repo":
-            exact_query = (u'name="%s"' % (query)).encode("utf-8")
-            fuzzy_query = (u'name~"%s"' % (query)).encode("utf-8")
 
-            exact_search_resp = installation.get_client().search_repositories(
-                installation.username, exact_query
-            )
-            fuzzy_search_resp = installation.get_client().search_repositories(
-                installation.username, fuzzy_query
-            )
-
-            result = OrderedSet()
-
-            for j in exact_search_resp.get("values", []):
-                result.add(j["full_name"])
-
-            for i in fuzzy_search_resp.get("values", []):
-                result.add(i["full_name"])
-
-            return Response([{"label": full_name, "value": full_name} for full_name in result])
+            result = installation.get_repositories(query)
+            return Response([{"label": i["name"], "value": i["name"]} for i in result])
 
         return Response(status=400)

--- a/tests/sentry/integrations/bitbucket/test_integration.py
+++ b/tests/sentry/integrations/bitbucket/test_integration.py
@@ -1,0 +1,121 @@
+from __future__ import absolute_import
+
+import responses
+
+from django.core.urlresolvers import reverse
+
+from sentry.models import Integration
+from sentry.testutils import APITestCase
+
+
+class BitbucketIntegrationTest(APITestCase):
+    def setUp(self):
+        self.base_url = "https://api.bitbucket.org"
+        self.shared_secret = "234567890"
+        self.subject = "connect:1234567"
+        self.integration = Integration.objects.create(
+            provider="bitbucket",
+            external_id=self.subject,
+            name="sentryuser",
+            metadata={
+                "base_url": self.base_url,
+                "shared_secret": self.shared_secret,
+                "subject": self.subject,
+            },
+        )
+        self.login_as(self.user)
+        self.integration.add_organization(self.organization, self.user)
+        self.path = reverse(
+            "sentry-extensions-bitbucket-search", args=[self.organization.slug, self.integration.id]
+        )
+
+    @responses.activate
+    def test_get_repositories_exact_match(self):
+        responses.add(
+            responses.GET,
+            "https://api.bitbucket.org/2.0/repositories/sentryuser?name=stuf",
+            json={"values": [{"full_name": "sentryuser/stuf"}]},
+        )
+
+        responses.add(
+            responses.GET,
+            "https://api.bitbucket.org/2.0/repositories/sentryuser?name~stuf",
+            json={
+                "values": [
+                    {"full_name": "sentryuser/stuff"},
+                    {"full_name": "sentryuser/stuff-2010"},
+                    {"full_name": "sentryuser/stuff-2011"},
+                    {"full_name": "sentryuser/stuff-2012"},
+                    {"full_name": "sentryuser/stuff-2013"},
+                    {"full_name": "sentryuser/stuff-2014"},
+                    {"full_name": "sentryuser/stuff-2015"},
+                    {"full_name": "sentryuser/stuff-2016"},
+                    {"full_name": "sentryuser/stuff-2016"},
+                    {"full_name": "sentryuser/stuff-2017"},
+                    {"full_name": "sentryuser/stuff-2018"},
+                    {"full_name": "sentryuser/stuff-2019"},
+                ]
+            },
+        )
+
+        installation = self.integration.get_installation(self.organization)
+        result = installation.get_repositories("stuf")
+        assert result == [
+            {"identifier": "sentryuser/stuf", "name": "sentryuser/stuf"},
+            {"identifier": "sentryuser/stuff", "name": "sentryuser/stuff"},
+            {"identifier": "sentryuser/stuff-2010", "name": "sentryuser/stuff-2010"},
+            {"identifier": "sentryuser/stuff-2011", "name": "sentryuser/stuff-2011"},
+            {"identifier": "sentryuser/stuff-2012", "name": "sentryuser/stuff-2012"},
+            {"identifier": "sentryuser/stuff-2013", "name": "sentryuser/stuff-2013"},
+            {"identifier": "sentryuser/stuff-2014", "name": "sentryuser/stuff-2014"},
+            {"identifier": "sentryuser/stuff-2015", "name": "sentryuser/stuff-2015"},
+            {"identifier": "sentryuser/stuff-2016", "name": "sentryuser/stuff-2016"},
+            {"identifier": "sentryuser/stuff-2017", "name": "sentryuser/stuff-2017"},
+            {"identifier": "sentryuser/stuff-2018", "name": "sentryuser/stuff-2018"},
+            {"identifier": "sentryuser/stuff-2019", "name": "sentryuser/stuff-2019"},
+        ]
+
+    @responses.activate
+    def test_get_repositories_no_exact_match(self):
+        responses.add(
+            responses.GET,
+            "https://api.bitbucket.org/2.0/repositories/sentryuser?name~stuf",
+            json={
+                "values": [
+                    {"full_name": "sentryuser/stuff"},
+                    {"full_name": "sentryuser/stuff-2010"},
+                    {"full_name": "sentryuser/stuff-2011"},
+                    {"full_name": "sentryuser/stuff-2012"},
+                    {"full_name": "sentryuser/stuff-2013"},
+                    {"full_name": "sentryuser/stuff-2014"},
+                    {"full_name": "sentryuser/stuff-2015"},
+                    {"full_name": "sentryuser/stuff-2016"},
+                    {"full_name": "sentryuser/stuff-2016"},
+                    {"full_name": "sentryuser/stuff-2017"},
+                    {"full_name": "sentryuser/stuff-2018"},
+                    {"full_name": "sentryuser/stuff-2019"},
+                ]
+            },
+        )
+
+        responses.add(
+            responses.GET,
+            "https://api.bitbucket.org/2.0/repositories/sentryuser?name=stuf",
+            json={"values": []},
+        )
+
+        installation = self.integration.get_installation(self.organization)
+        result = installation.get_repositories("stu")
+        assert result == [
+            {"identifier": "sentryuser/stuff", "name": "sentryuser/stuff"},
+            {"identifier": "sentryuser/stuff-2010", "name": "sentryuser/stuff-2010"},
+            {"identifier": "sentryuser/stuff-2011", "name": "sentryuser/stuff-2011"},
+            {"identifier": "sentryuser/stuff-2012", "name": "sentryuser/stuff-2012"},
+            {"identifier": "sentryuser/stuff-2013", "name": "sentryuser/stuff-2013"},
+            {"identifier": "sentryuser/stuff-2014", "name": "sentryuser/stuff-2014"},
+            {"identifier": "sentryuser/stuff-2015", "name": "sentryuser/stuff-2015"},
+            {"identifier": "sentryuser/stuff-2016", "name": "sentryuser/stuff-2016"},
+            {"identifier": "sentryuser/stuff-2017", "name": "sentryuser/stuff-2017"},
+            {"identifier": "sentryuser/stuff-2018", "name": "sentryuser/stuff-2018"},
+            {"identifier": "sentryuser/stuff-2019", "name": "sentryuser/stuff-2019"},
+        ]


### PR DESCRIPTION
## Problem
After having installed the Bitbucket integration for a particular team in Bitbucket, only 10 repositories are shown in the dropdown. A user can search to narrow it down but in the event the query parameter is used more than 10 times in the name of repositories (perhaps in the form of a prefix) it's possible to not be able to find that repository. See following screenshot for an example - it's not possible to find the `stuf` repository. 

<img width="321" alt="Screen Shot 2020-01-24 at 10 13 50 AM" src="https://user-images.githubusercontent.com/10491193/73092865-40b56b00-3e92-11ea-8951-53f689fac54b.png">

## Solution
Make 2 API requests to Bitbucket, 1 fuzzy search and 1 exact search, to get all repositories related to query string. Then de-duplicate results.

## Tests
Wrote new tests for Bitbucket integration that mocks the case of a query with an exact match and another query with **no** exact match