### PR TITLE
feat(workflow): Change Metric Alert status badges

### DIFF
--- a/src/sentry/static/sentry/app/views/incidents/details/header.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/details/header.tsx
@@ -49,12 +49,13 @@ export default class DetailsHeader extends React.Component<Props> {
         <DropdownControl
           data-test-id="status-dropdown"
           label={incident && <Status incident={incident} />}
-          menuWidth="160px"
+          menuWidth="180px"
           alignRight
+          disabled={!isIncidentOpen}
           buttonProps={{size: 'small', disabled: !incident}}
         >
           <StyledMenuItem onSelect={onStatusChange}>
-            {isIncidentOpen ? t('Close this incident') : t('Reopen this incident')}
+            <ResolveIcon src="icon-circle-check" /> {t('Resolve this incident')}
           </StyledMenuItem>
         </DropdownControl>
       </Access>
@@ -241,7 +242,8 @@ const Chevron = styled(InlineSvg)`
 const StyledMenuItem = styled(MenuItem)`
   font-size: ${p => p.theme.fontSizeMedium};
   text-align: left;
-  padding: ${space(1)};
+  padding: ${space(1)} 12px; /* To match dropdown */
+  white-space: nowrap;
 `;
 
 const OpenLink = styled(Link)`
@@ -249,4 +251,9 @@ const OpenLink = styled(Link)`
   font-size: ${p => p.theme.fontSizeLarge};
   color: ${p => p.theme.gray2};
   margin-left: ${space(1)};
+`;
+
+const ResolveIcon = styled(InlineSvg)`
+  color: ${p => p.theme.greenLight};
+  margin-right: ${space(0.5)};
 `;

--- a/src/sentry/static/sentry/app/views/incidents/details/header.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/details/header.tsx
@@ -44,11 +44,13 @@ export default class DetailsHeader extends React.Component<Props> {
     return (
       <Access
         access={['org:write']}
-        renderNoAccessMessage={() => (incident ? <Status incident={incident} /> : null)}
+        renderNoAccessMessage={() =>
+          incident ? <Status isSmall incident={incident} /> : null
+        }
       >
         <DropdownControl
           data-test-id="status-dropdown"
-          label={incident && <Status incident={incident} />}
+          label={incident && <Status isSmall incident={incident} />}
           menuWidth="180px"
           alignRight
           disabled={!isIncidentOpen}

--- a/src/sentry/static/sentry/app/views/incidents/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/list/index.tsx
@@ -67,7 +67,7 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
             </Link>
             <SparkLine incident={incident} />
           </TitleAndSparkLine>
-          <Status badge incident={incident} />
+          <Status incident={incident} />
           <div>
             {started.format('L')}
             <LightDuration seconds={getDynamicText({value: duration, fixed: 1200})} />

--- a/src/sentry/static/sentry/app/views/incidents/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/list/index.tsx
@@ -67,7 +67,7 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
             </Link>
             <SparkLine incident={incident} />
           </TitleAndSparkLine>
-          <Status incident={incident} />
+          <Status badge incident={incident} />
           <div>
             {started.format('L')}
             <LightDuration seconds={getDynamicText({value: duration, fixed: 1200})} />

--- a/src/sentry/static/sentry/app/views/incidents/status.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/status.tsx
@@ -1,27 +1,21 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
 import InlineSvg from 'app/components/inlineSvg';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 
 import {Incident, IncidentStatus} from './types';
 
 type Props = {
+  badge?: boolean;
   className?: string;
   incident: Incident;
 };
 
 export default class Status extends React.Component<Props> {
-  static propTypes = {
-    className: PropTypes.string,
-    incident: SentryTypes.Incident,
-  };
-
   render() {
-    const {className, incident} = this.props;
+    const {badge, className, incident} = this.props;
     const isIncidentOpen = incident.status !== IncidentStatus.CLOSED;
 
     // TODO(incidents): Make this work
@@ -42,7 +36,7 @@ export default class Status extends React.Component<Props> {
     const text = isResolved ? t('Resolved') : isCritical ? t('Critical') : t('Warning');
 
     return (
-      <Wrapper status={status} className={className}>
+      <Wrapper badge={badge} status={status} className={className}>
         <Icon src={icon} status={status} isOpen={isIncidentOpen} />
         {text}
       </Wrapper>
@@ -52,7 +46,7 @@ export default class Status extends React.Component<Props> {
 
 type StatusType = 'warning' | 'critical' | 'resolved';
 
-type WrapperProps = {status: StatusType};
+type WrapperProps = {status: StatusType; badge?: boolean};
 
 function getHighlight({theme, status}) {
   if (status === 'resolved') {
@@ -78,13 +72,18 @@ const Wrapper = styled('div')<WrapperProps>`
   display: flex;
   align-items: center;
   justify-self: flex-start;
-  background-color: ${getColor};
-  border: 1px solid ${getHighlight};
-  border-radius: ${p => p.theme.borderRadius};
   color: ${getHighlight};
-  padding: 0 ${space(0.5)};
   font-size: ${p => p.theme.fontSizeSmall};
   text-transform: uppercase;
+
+  ${p =>
+    p.badge &&
+    `
+      background-color: ${getColor};
+      border: 1px solid ${getHighlight};
+      border-radius: ${p.theme.borderRadius};
+      padding: ${space(0.5)};
+    `}
 `;
 
 const Icon = styled(InlineSvg)<WrapperProps & {isOpen: boolean}>`

--- a/src/sentry/static/sentry/app/views/incidents/status.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/status.tsx
@@ -79,10 +79,10 @@ const Wrapper = styled('div')<WrapperProps>`
   ${p =>
     p.badge &&
     `
-      background-color: ${getColor};
-      border: 1px solid ${getHighlight};
+      background-color: ${getColor(p)};
+      border: 1px solid ${getHighlight(p)};
       border-radius: ${p.theme.borderRadius};
-      padding: ${space(0.5)};
+      padding: ${space(0.25)} ${space(1)};
     `}
 `;
 

--- a/src/sentry/static/sentry/app/views/incidents/status.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/status.tsx
@@ -8,47 +8,46 @@ import space from 'app/styles/space';
 import {Incident, IncidentStatus} from './types';
 
 type Props = {
-  badge?: boolean;
   className?: string;
   incident: Incident;
+  isSmall?: boolean;
 };
 
-export default class Status extends React.Component<Props> {
-  render() {
-    const {badge, className, incident} = this.props;
-    const isIncidentOpen = incident.status !== IncidentStatus.CLOSED;
+const Status: React.FC<Props> = ({className, incident, isSmall}: Props) => {
+  const isIncidentOpen = incident.status !== IncidentStatus.CLOSED;
 
-    // TODO(incidents): Make this work
-    const status = !isIncidentOpen
-      ? 'resolved'
-      : incident.status === IncidentStatus.CREATED
-      ? 'critical'
-      : 'warning';
-    const isResolved = status === 'resolved';
-    const isCritical = status === 'critical';
+  // TODO(incidents): Make this work
+  const status = !isIncidentOpen
+    ? 'resolved'
+    : incident.status === IncidentStatus.CREATED
+    ? 'critical'
+    : 'warning';
+  const isResolved = status === 'resolved';
+  const isCritical = status === 'critical';
 
-    const icon = isResolved
-      ? 'icon-circle-check'
-      : isCritical
-      ? 'icon-circle-exclamation'
-      : 'icon-warning-sm';
+  const icon = isResolved
+    ? 'icon-circle-check'
+    : isCritical
+    ? 'icon-circle-exclamation'
+    : 'icon-warning-sm';
 
-    const text = isResolved ? t('Resolved') : isCritical ? t('Critical') : t('Warning');
+  const text = isResolved ? t('Resolved') : isCritical ? t('Critical') : t('Warning');
 
-    return (
-      <Wrapper badge={badge} status={status} className={className}>
-        <Icon src={icon} status={status} isOpen={isIncidentOpen} />
-        {text}
-      </Wrapper>
-    );
-  }
-}
+  return (
+    <Wrapper status={status} className={className} isSmall={!!isSmall}>
+      <Icon src={icon} status={status} isOpen={isIncidentOpen} />
+      {text}
+    </Wrapper>
+  );
+};
+
+export default Status;
 
 type StatusType = 'warning' | 'critical' | 'resolved';
 
-type WrapperProps = {status: StatusType; badge?: boolean};
+type WrapperProps = {status: StatusType};
 
-function getHighlight({theme, status}) {
+function getColor({theme, status}) {
   if (status === 'resolved') {
     return theme.greenDark;
   } else if (status === 'warning') {
@@ -58,36 +57,15 @@ function getHighlight({theme, status}) {
   return theme.redDark;
 }
 
-function getColor({theme, status}) {
-  if (status === 'resolved') {
-    return theme.greenLightest;
-  } else if (status === 'warning') {
-    return theme.yellowLightest;
-  }
-
-  return theme.redLightest;
-}
-
-const Wrapper = styled('div')<WrapperProps>`
+const Wrapper = styled('div')<WrapperProps & {isSmall: boolean}>`
   display: flex;
   align-items: center;
   justify-self: flex-start;
-  color: ${getHighlight};
-  font-size: ${p => p.theme.fontSizeSmall};
-  text-transform: uppercase;
-
-  ${p =>
-    p.badge &&
-    `
-      background-color: ${getColor(p)};
-      border: 1px solid ${getHighlight(p)};
-      border-radius: ${p.theme.borderRadius};
-      padding: ${space(0.25)} ${space(1)};
-    `}
+  ${p => p.isSmall && `font-size: ${p.theme.fontSizeSmall};`};
 `;
 
 const Icon = styled(InlineSvg)<WrapperProps & {isOpen: boolean}>`
-  color: ${getHighlight};
+  color: ${getColor};
   margin-right: ${space(0.5)};
   font-size: ${p => p.theme.fontSizeMedium};
 `;


### PR DESCRIPTION
Add a prop to make the status ~either text or a "badge" which includes
border and background~ have a smaller text size.

Reverts badge changes to match designs.

![image](https://user-images.githubusercontent.com/79684/72852657-1aaa8380-3c64-11ea-87ab-3bc47814eef1.png)


![image](https://user-images.githubusercontent.com/79684/72852637-0ebec180-3c64-11ea-9db9-c4575ef9eff6.png)
