### PR TITLE
feat(ui): C# filepath input direction rtl

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
@@ -98,6 +98,7 @@ const FilePathInfo = styled('div')`
     padding-top: 0;
     padding-bottom: 0;
     line-height: 1.5;
+    direction: rtl;
     @media (max-width: ${theme.breakpoints[1]}) {
       width: auto;
     }


### PR DESCRIPTION
It makes more sense to see the ending of the path in file path input, so we right aligned it.