### PR TITLE
fix(ui) Fix IdBadge for pending members

### DIFF
--- a/docs-ui/components/idBadge.stories.js
+++ b/docs-ui/components/idBadge.stories.js
@@ -39,12 +39,20 @@ storiesOf('UI|IdBadge', module).add(
     const organization = {
       slug: 'organization-slug',
     };
+    const member = {
+      name: 'Pending Member',
+      email: 'member@example.org',
+    };
 
     return (
       <React.Fragment>
         <Header>User Badge</Header>
         <Item>
           <IdBadge user={user} />
+        </Item>
+        <Header>Member Badge</Header>
+        <Item>
+          <IdBadge member={member} />
         </Item>
         <Header>Team Badge</Header>
         <Item>

--- a/src/sentry/static/sentry/app/components/idBadge/index.jsx
+++ b/src/sentry/static/sentry/app/components/idBadge/index.jsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import ErrorBoundary from 'app/components/errorBoundary';
 import BaseBadge from 'app/components/idBadge/baseBadge';
+import MemberBadge from 'app/components/idBadge/memberBadge';
 import UserBadge from 'app/components/idBadge/userBadge';
 import TeamBadge from 'app/components/idBadge/teamBadge';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
@@ -11,7 +12,7 @@ import OrganizationBadge from 'app/components/idBadge/organizationBadge';
 const COMPONENT_MAP = new Map([
   ['organization', OrganizationBadge],
   ['project', ProjectBadge],
-  ['member', UserBadge],
+  ['member', MemberBadge],
   ['user', UserBadge],
   ['team', TeamBadge],
 ]);

--- a/src/sentry/static/sentry/app/components/idBadge/memberBadge.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/memberBadge.tsx
@@ -50,13 +50,13 @@ const MemberBadge = ({
   const user = getUser(member);
   const title =
     displayName ||
-    (user.name ||
-      user.email ||
-      user.username ||
-      user.ipAddress ||
-      // Because this can be used to render EventUser models, or User *interface*
-      // objects from serialized Event models. we try both ipAddress and ip_address.
-      user.ip_address);
+    user.name ||
+    user.email ||
+    user.username ||
+    user.ipAddress ||
+    // Because this can be used to render EventUser models, or User *interface*
+    // objects from serialized Event models. we try both ipAddress and ip_address.
+    user.ip_address;
 
   return (
     <StyledUserBadge className={className}>

--- a/src/sentry/static/sentry/app/components/idBadge/memberBadge.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/memberBadge.tsx
@@ -1,0 +1,131 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from '@emotion/styled';
+import {AvatarUser, Member} from 'app/types';
+import UserAvatar from 'app/components/avatar/userAvatar';
+import Link from 'app/components/links/link';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
+import space from 'app/styles/space';
+import SentryTypes from 'app/sentryTypes';
+import omit from 'lodash/omit';
+
+const defaultProps = {
+  useLink: true,
+  hideEmail: false,
+};
+
+type Props = {
+  avatarSize: UserAvatar['props']['size'];
+  member: Member;
+  className?: string;
+  displayName?: string;
+  displayEmail?: string;
+  orgId?: string;
+} & Partial<typeof defaultProps>;
+
+function getUser(member: Member): AvatarUser {
+  if (member.user) {
+    return member.user;
+  }
+  // Adapt the member into a AvatarUser
+  return {
+    id: '',
+    name: member.name,
+    email: member.email,
+    username: '',
+    ip_address: '',
+  };
+}
+
+const MemberBadge = ({
+  className,
+  displayName,
+  displayEmail,
+  member,
+  orgId,
+  avatarSize,
+  useLink,
+  hideEmail,
+}: Props) => {
+  const user = getUser(member);
+  const title =
+    displayName ||
+    (user.name ||
+      user.email ||
+      user.username ||
+      user.ipAddress ||
+      // Because this can be used to render EventUser models, or User *interface*
+      // objects from serialized Event models. we try both ipAddress and ip_address.
+      user.ip_address);
+
+  return (
+    <StyledUserBadge className={className}>
+      <StyledAvatar user={user} size={avatarSize} />
+      <StyledNameAndEmail>
+        <StyledName
+          useLink={useLink && orgId}
+          hideEmail={hideEmail}
+          to={member && orgId && `/settings/${orgId}/members/${member.id}/`}
+        >
+          {title}
+        </StyledName>
+        {!hideEmail && <StyledEmail>{displayEmail || user.email}</StyledEmail>}
+      </StyledNameAndEmail>
+    </StyledUserBadge>
+  );
+};
+
+MemberBadge.propTypes = {
+  displayName: PropTypes.node,
+  displayEmail: PropTypes.node,
+  avatarSize: PropTypes.number,
+  /**
+   * This is a Sentry member (not the user object that is a child of the member object)
+   */
+  member: SentryTypes.Member,
+  orgId: PropTypes.string,
+  useLink: PropTypes.bool,
+  hideEmail: PropTypes.bool,
+};
+
+MemberBadge.defaultProps = defaultProps;
+
+const StyledUserBadge = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledNameAndEmail = styled('div')`
+  flex-shrink: 1;
+  min-width: 0;
+  line-height: 1;
+`;
+
+const StyledEmail = styled('div')`
+  font-size: 0.875em;
+  margin-top: ${space(0.25)};
+  color: ${p => p.theme.gray2};
+  ${overflowEllipsis};
+`;
+
+type NameProps = {
+  useLink: boolean;
+  hideEmail: boolean;
+} & Link['props'];
+
+const StyledName = styled<NameProps>(({useLink, to, ...props}) => {
+  const forwardProps = omit(props, 'hideEmail');
+  return useLink ? <Link to={to} {...forwardProps} /> : <span {...forwardProps} />;
+})`
+  font-weight: ${(p: NameProps) => (p.hideEmail ? 'inherit' : 'bold')};
+  line-height: 1.15em;
+  ${overflowEllipsis};
+`;
+
+const StyledAvatar = styled(UserAvatar)`
+  min-width: ${space(3)};
+  min-height: ${space(3)};
+  margin-right: ${space(1)};
+`;
+
+export default MemberBadge;

--- a/src/sentry/static/sentry/app/components/idBadge/userBadge.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/userBadge.tsx
@@ -1,16 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from '@emotion/styled';
-import {AvatarUser, Member} from 'app/types';
+import {AvatarUser} from 'app/types';
 import UserAvatar from 'app/components/avatar/userAvatar';
-import Link from 'app/components/links/link';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import SentryTypes from 'app/sentryTypes';
-import omit from 'lodash/omit';
 
 const defaultProps = {
-  useLink: true,
   hideEmail: false,
 };
 
@@ -20,32 +17,16 @@ type Props = {
   displayName?: string;
   displayEmail?: string;
   user?: AvatarUser;
-  member?: Member;
-  orgId?: string;
 } & Partial<typeof defaultProps>;
-
-function getUser(props: {user?: AvatarUser; member?: Member}): AvatarUser | undefined {
-  if (props.user) {
-    return props.user;
-  }
-  if (props.member && props.member.user) {
-    return props.member.user;
-  }
-  return undefined;
-}
 
 const UserBadge = ({
   className,
   displayName,
   displayEmail,
-  orgId,
   avatarSize,
-  useLink,
   hideEmail,
-  ...props
+  user,
 }: Props) => {
-  const user = getUser(props);
-  const member = props.member;
   const title =
     displayName ||
     (user &&
@@ -55,20 +36,13 @@ const UserBadge = ({
         user.ipAddress ||
         // Because this can be used to render EventUser models, or User *interface*
         // objects from serialized Event models. we try both ipAddress and ip_address.
-        user.ip_address)) ||
-    (member && member.name);
+        user.ip_address));
 
   return (
     <StyledUserBadge className={className}>
       <StyledAvatar user={user} size={avatarSize} />
       <StyledNameAndEmail>
-        <StyledName
-          useLink={useLink && orgId && member}
-          hideEmail={hideEmail}
-          to={member && orgId && `/settings/${orgId}/members/${member.id}/`}
-        >
-          {title}
-        </StyledName>
+        <StyledName hideEmail={!!hideEmail}>{title}</StyledName>
         {!hideEmail && <StyledEmail>{displayEmail || (user && user.email)}</StyledEmail>}
       </StyledNameAndEmail>
     </StyledUserBadge>
@@ -84,12 +58,6 @@ UserBadge.propTypes = {
    * is an user, not a member)
    */
   user: SentryTypes.User,
-  /**
-   * This is a Sentry member (not the user object that is a child of the member object)
-   */
-  member: SentryTypes.Member,
-  orgId: PropTypes.string,
-  useLink: PropTypes.bool,
   hideEmail: PropTypes.bool,
 };
 
@@ -113,16 +81,8 @@ const StyledEmail = styled('div')`
   ${overflowEllipsis};
 `;
 
-type NameProps = {
-  useLink: boolean;
-  hideEmail: boolean;
-} & Link['props'];
-
-const StyledName = styled<NameProps>(({useLink, to, ...props}) => {
-  const forwardProps = omit(props, 'hideEmail');
-  return useLink ? <Link to={to} {...forwardProps} /> : <span {...forwardProps} />;
-})`
-  font-weight: ${(p: NameProps) => (p.hideEmail ? 'inherit' : 'bold')};
+const StyledName = styled('span')<{hideEmail: boolean}>`
+  font-weight: ${p => (p.hideEmail ? 'inherit' : 'bold')};
   line-height: 1.15em;
   ${overflowEllipsis};
 `;

--- a/src/sentry/static/sentry/app/views/eventsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/data.tsx
@@ -416,9 +416,7 @@ export const SPECIAL_FIELDS: SpecialFields = {
         ip_address: data['user.ip'],
       };
 
-      const badge = (
-        <UserBadge useLink={false} user={userObj} hideEmail avatarSize={16} />
-      );
+      const badge = <UserBadge user={userObj} hideEmail avatarSize={16} />;
 
       if (!data.user) {
         return <Container>{badge}</Container>;

--- a/tests/js/spec/components/idBadge/memberBadge.spec.jsx
+++ b/tests/js/spec/components/idBadge/memberBadge.spec.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {mount, shallow} from 'sentry-test/enzyme';
+
+import MemberBadge from 'app/components/idBadge/memberBadge';
+
+describe('MemberBadge', function() {
+  let member;
+  beforeEach(() => {
+    member = TestStubs.Member();
+  });
+
+  it('renders with link when member and orgId are supplied', function() {
+    const wrapper = mount(<MemberBadge member={member} orgId="orgId" />);
+
+    expect(wrapper.find('StyledName').prop('children')).toBe('Foo Bar');
+    expect(wrapper.find('StyledEmail').prop('children')).toBe('foo@example.com');
+    expect(wrapper.find('StyledName Link')).toHaveLength(1);
+    expect(wrapper.find('StyledAvatar')).toHaveLength(1);
+  });
+
+  it('does not use a link when useLink = false', function() {
+    const wrapper = mount(<MemberBadge member={member} useLink={false} orgId="orgId" />);
+
+    expect(wrapper.find('StyledName Link')).toHaveLength(0);
+  });
+
+  it('does not use a link when orgId = null', function() {
+    const wrapper = mount(<MemberBadge member={member} useLink />);
+
+    expect(wrapper.find('StyledName Link')).toHaveLength(0);
+  });
+
+  it('can display alternate display names/emails', function() {
+    const wrapper = shallow(
+      <MemberBadge
+        member={member}
+        displayName="Other Display Name"
+        displayEmail="Other Display Email"
+      />
+    );
+
+    expect(wrapper.find('StyledName').prop('children')).toBe('Other Display Name');
+    expect(wrapper.find('StyledEmail').prop('children')).toBe('Other Display Email');
+    expect(wrapper.find('StyledAvatar')).toHaveLength(1);
+  });
+
+  it('can coalesce using username', function() {
+    member.user = TestStubs.User({
+      name: null,
+      email: null,
+      username: 'the-batman',
+    });
+
+    const wrapper = shallow(<MemberBadge member={member} />);
+
+    expect(wrapper.find('StyledName').prop('children')).toBe(member.user.username);
+    expect(wrapper.find('StyledEmail').prop('children')).toBe(null);
+    expect(wrapper.find('StyledAvatar')).toHaveLength(1);
+  });
+
+  it('can coalesce using ipaddress', function() {
+    member.user = TestStubs.User({
+      name: null,
+      email: null,
+      username: null,
+      ipAddress: '127.0.0.1',
+    });
+    const wrapper = shallow(<MemberBadge member={member} />);
+
+    expect(wrapper.find('StyledName').prop('children')).toBe(member.user.ipAddress);
+    expect(wrapper.find('StyledEmail').prop('children')).toBe(null);
+  });
+
+  it('can hide email address', function() {
+    const wrapper = mount(<MemberBadge member={member} hideEmail />);
+
+    expect(wrapper.find('StyledEmail')).toHaveLength(0);
+  });
+
+  it('renders when a member without a user to passed to member', function() {
+    const wrapper = mount(<MemberBadge member={{...member, user: null}} />);
+
+    expect(wrapper.find('StyledName').prop('children')).toBe('Sentry 1 Name');
+    expect(wrapper.find('StyledAvatar')).toHaveLength(1);
+    expect(wrapper.find('StyledAvatar').prop('user').email).toBe(member.email);
+  });
+});

--- a/tests/js/spec/components/idBadge/userBadge.spec.jsx
+++ b/tests/js/spec/components/idBadge/userBadge.spec.jsx
@@ -4,20 +4,10 @@ import {mount, shallow} from 'sentry-test/enzyme';
 import UserBadge from 'app/components/idBadge/userBadge';
 
 describe('UserBadge', function() {
-  const member = TestStubs.Member();
   const user = TestStubs.User();
 
-  it('renders with link when member is supplied', function() {
-    const wrapper = mount(<UserBadge member={member} orgId="orgId" />);
-
-    expect(wrapper.find('StyledUserBadge')).toHaveLength(1);
-    expect(wrapper.find('StyledName').prop('children')).toBe('Foo Bar');
-    expect(wrapper.find('StyledEmail').prop('children')).toBe('foo@example.com');
-    expect(wrapper.find('StyledName Link')).toHaveLength(1);
-  });
-
   it('renders with no link when user is supplied', function() {
-    const wrapper = mount(<UserBadge user={user} orgId="orgId" />);
+    const wrapper = mount(<UserBadge user={user} />);
 
     expect(wrapper.find('StyledUserBadge')).toHaveLength(1);
     expect(wrapper.find('StyledName').prop('children')).toBe('Foo Bar');
@@ -63,21 +53,9 @@ describe('UserBadge', function() {
     expect(wrapper.find('StyledEmail').prop('children')).toBe(null);
   });
 
-  it('does not use a link for member name', function() {
-    const wrapper = mount(<UserBadge user={user} useLink={false} />);
-
-    expect(wrapper.find('StyledName Link')).toHaveLength(0);
-  });
-
   it('can hide email address', function() {
     const wrapper = mount(<UserBadge user={user} hideEmail />);
 
     expect(wrapper.find('StyledEmail')).toHaveLength(0);
-  });
-
-  it('renders when a member without a user to passed to member', function() {
-    const wrapper = mount(<UserBadge member={{...member, user: null}} />);
-
-    expect(wrapper.find('StyledName').prop('children')).toBe('Sentry 1 Name');
   });
 });

--- a/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
+++ b/tests/js/spec/components/sidebar/__snapshots__/index.spec.jsx.snap
@@ -563,7 +563,6 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                       avatarSize={32}
                       className="css-1b4dtj5-UserBadgeNoOverflow e1fowdfw2"
                       hideEmail={false}
-                      useLink={true}
                       user={
                         Object {
                           "email": "foo@example.com",
@@ -725,16 +724,11 @@ exports[`Sidebar SidebarDropdown can open Sidebar org/name dropdown menu 1`] = `
                               <StyledName
                                 hideEmail={false}
                               >
-                                <Component
+                                <span
                                   className="css-19h2nhd-StyledName e31z2f83"
-                                  hideEmail={false}
                                 >
-                                  <span
-                                    className="css-19h2nhd-StyledName e31z2f83"
-                                  >
-                                    Foo Bar
-                                  </span>
-                                </Component>
+                                  Foo Bar
+                                </span>
                               </StyledName>
                               <StyledEmail>
                                 <div
@@ -3286,7 +3280,6 @@ exports[`Sidebar renders without org and router 1`] = `
                       avatarSize={32}
                       className="css-1b4dtj5-UserBadgeNoOverflow e1fowdfw2"
                       hideEmail={false}
-                      useLink={true}
                       user={
                         Object {
                           "email": "foo@example.com",
@@ -3448,16 +3441,11 @@ exports[`Sidebar renders without org and router 1`] = `
                               <StyledName
                                 hideEmail={false}
                               >
-                                <Component
+                                <span
                                   className="css-19h2nhd-StyledName e31z2f83"
-                                  hideEmail={false}
                                 >
-                                  <span
-                                    className="css-19h2nhd-StyledName e31z2f83"
-                                  >
-                                    Foo Bar
-                                  </span>
-                                </Component>
+                                  Foo Bar
+                                </span>
                               </StyledName>
                               <StyledEmail>
                                 <div


### PR DESCRIPTION
When converting the UserBadge to typescript I accidentally broke badges for pending members. Instead of complecting the UserBadge further I decided to extract out a MemberBadge as the IdBadge entry point can handle choose the correct badge implementation based on the properties it receives.