### PR TITLE
feat(discover2) Event detail tags links should go to ungrouped results

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -181,7 +181,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
             {event.groupID && (
               <LinkedIssue groupId={event.groupID} eventId={event.eventID} />
             )}
-            <TagsTable tags={event.tags} organization={organization} />
+            <TagsTable eventView={eventView} event={event} organization={organization} />
           </div>
         </ContentBox>
       </div>

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -1,4 +1,4 @@
-import {Location, Query} from 'history';
+import {Location, LocationDescriptor, Query} from 'history';
 import isString from 'lodash/isString';
 import cloneDeep from 'lodash/cloneDeep';
 import pick from 'lodash/pick';
@@ -7,7 +7,7 @@ import omit from 'lodash/omit';
 import moment from 'moment';
 
 import {DEFAULT_PER_PAGE} from 'app/constants';
-import {SavedQuery, NewQuery} from 'app/types';
+import {OrganizationSummary, SavedQuery, NewQuery} from 'app/types';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
 
@@ -863,6 +863,13 @@ class EventView {
     }
 
     return eventQuery;
+  }
+
+  getResultsViewUrlTarget(organization: OrganizationSummary): LocationDescriptor {
+    return {
+      pathname: `/organizations/${organization.slug}/eventsv2/results/`,
+      query: this.generateQueryStringObject(),
+    };
   }
 
   isFieldSorted(field: Field, tableMeta: MetaType): Sort | undefined {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -4,11 +4,6 @@ import {Location} from 'history';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
-import {
-  tokenizeSearch,
-  stringifyQueryObject,
-  QueryResults,
-} from 'app/utils/tokenizeSearch';
 import {assert} from 'app/types/utils';
 import Link from 'app/components/links/link';
 
@@ -16,11 +11,12 @@ import {
   downloadAsCsv,
   getAggregateAlias,
   getFieldRenderer,
+  getExpandedResults,
   pushEventViewToLocation,
   explodeField,
   MetaType,
 } from '../utils';
-import EventView, {pickRelevantLocationQueryStrings, Field} from '../eventView';
+import EventView, {pickRelevantLocationQueryStrings} from '../eventView';
 import SortLink, {Alignments} from '../sortLink';
 import renderTableModalEditColumnFactory from './tableModalEditColumn';
 import {TableColumn, TableData, TableDataRow} from './types';
@@ -28,7 +24,6 @@ import {ColumnValueType} from '../eventQueryParams';
 import DraggableColumns, {
   DRAGGABLE_COLUMN_CLASSNAME_IDENTIFIER,
 } from './draggableColumns';
-import {AGGREGATE_ALIASES} from '../data';
 
 export type TableViewProps = {
   location: Location;
@@ -439,8 +434,6 @@ class TableView extends React.Component<TableViewProps> {
   }
 }
 
-const UNSEARCHABLE_FIELDS: string[] = [...AGGREGATE_ALIASES];
-
 const ExpandAggregateRow = (props: {
   children: ({willExpand: boolean}) => React.ReactNode;
   eventView: EventView;
@@ -449,81 +442,18 @@ const ExpandAggregateRow = (props: {
   location: Location;
   tableMeta: MetaType;
 }) => {
-  const {children, column, dataRow, eventView, location, tableMeta} = props;
+  const {children, column, dataRow, eventView, location} = props;
   const {eventViewField} = column;
 
   const exploded = explodeField(eventViewField);
   const {aggregation} = exploded;
 
   if (aggregation === 'count') {
-    let nextEventView = eventView.clone();
-
-    const additionalSearchConditions: {[key: string]: string[]} = {};
-
-    const indicesToUpdate: number[] = [];
-    nextEventView.fields.forEach((field: Field, index: number) => {
-      if (eventViewField.field === field.field) {
-        // invariant: this is count(exploded.field)
-        // convert all instances of count(exploded.field) to exploded.field
-        indicesToUpdate.push(index);
-        return;
-      }
-
-      const currentExplodedField = explodeField(field);
-      if (currentExplodedField.aggregation) {
-        // this is a column with an aggregation; we skip this
-        return;
-      }
-
-      if (UNSEARCHABLE_FIELDS.includes(currentExplodedField.field)) {
-        return;
-      }
-
-      // add this field to the search conditions
-      const dataKey = getAggregateAlias(field.field);
-      const value = dataRow[dataKey];
-
-      if (value) {
-        additionalSearchConditions[currentExplodedField.field] = [String(value).trim()];
-      }
-    });
-
-    nextEventView = indicesToUpdate.reduce(
-      (currentEventView: EventView, indexToUpdate: number) => {
-        const updatedColumn = {
-          aggregation: '',
-          field: exploded.field,
-          width: exploded.width,
-        };
-
-        return currentEventView.withUpdatedColumn(
-          indexToUpdate,
-          updatedColumn,
-          tableMeta
-        );
-      },
-      nextEventView
-    );
-
-    const tokenized: QueryResults = tokenizeSearch(nextEventView.query);
-
-    // merge tokenized and additionalSearchConditions together
-    Object.keys(additionalSearchConditions).forEach(key => {
-      const hasCommonKey =
-        Array.isArray(tokenized[key]) && Array.isArray(additionalSearchConditions[key]);
-      if (hasCommonKey) {
-        tokenized[key] = [...tokenized[key], ...additionalSearchConditions[key]];
-        return;
-      }
-
-      tokenized[key] = additionalSearchConditions[key];
-    });
-
-    nextEventView.query = stringifyQueryObject(tokenized);
+    const nextView = getExpandedResults(eventView, {}, dataRow);
 
     const target = {
       pathname: location.pathname,
-      query: nextEventView.generateQueryStringObject(),
+      query: nextView.generateQueryStringObject(),
     };
 
     return <Link to={target}>{children({willExpand: true})}</Link>;

--- a/src/sentry/static/sentry/app/views/eventsV2/tagsTable.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tagsTable.tsx
@@ -1,33 +1,42 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
-import * as ReactRouter from 'react-router';
 
 import Link from 'app/components/links/link';
 import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
-import {EventTag, OrganizationSummary} from 'app/types';
+import {Event, OrganizationSummary} from 'app/types';
 
-import {getEventTagSearchUrl} from './utils';
+import EventView from './eventView';
+import {getExpandedResults} from './utils';
 import {SectionHeading} from './styles';
 
 type Props = {
   organization: OrganizationSummary;
-  tags: Array<EventTag>;
-} & ReactRouter.WithRouterProps;
+  event: Event;
+  eventView: EventView;
+};
 
 const TagsTable = (props: Props) => {
-  const {location, organization, tags} = props;
+  const {organization, event, eventView} = props;
+  const tags = event.tags;
   return (
     <StyledTagsTable>
       <SectionHeading>{t('Event Tag Details')}</SectionHeading>
       <StyledTable>
         <tbody>
           {tags.map(tag => {
-            const tagInQuery =
-              location.query.query && location.query.query.indexOf(`${tag.key}:`) !== -1;
+            let target;
+            const tagInQuery = eventView.query.includes(`${tag.key}:`);
+            if (!tagInQuery) {
+              const nextView = getExpandedResults(
+                eventView,
+                {[tag.key]: tag.value},
+                event
+              );
+              target = nextView.getResultsViewUrlTarget(organization);
+            }
             return (
               <StyledTr key={tag.key}>
                 <TagKey>{tag.key}</TagKey>
@@ -37,16 +46,7 @@ const TagsTable = (props: Props) => {
                       <span>{tag.value}</span>
                     </Tooltip>
                   ) : (
-                    <Link
-                      to={getEventTagSearchUrl(
-                        tag.key,
-                        tag.value,
-                        organization,
-                        location.query
-                      )}
-                    >
-                      {tag.value}
-                    </Link>
+                    <Link to={target}>{tag.value}</Link>
                   )}
                 </TagValue>
               </StyledTr>
@@ -57,11 +57,6 @@ const TagsTable = (props: Props) => {
     </StyledTagsTable>
   );
 };
-
-TagsTable.propTypes = {
-  tags: PropTypes.array.isRequired,
-  location: PropTypes.object,
-} as any;
 
 const StyledTagsTable = styled('div')`
   margin-bottom: ${space(3)};
@@ -93,4 +88,4 @@ const TagValue = styled(TagKey)`
   ${overflowEllipsis};
 `;
 
-export default ReactRouter.withRouter(TagsTable);
+export default TagsTable;

--- a/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
@@ -231,12 +231,10 @@ describe('EventsV2 > EventDetails', function() {
     // Get the first link as we wrap react-router's link
     const tagLink = wrapper.find('EventDetails TagsTable TagValue Link').first();
 
-    // Should remove eventSlug and append new tag value causing
-    // the view to re-render
-    expect(tagLink.props().to).toEqual({
-      pathname: '/organizations/org-slug/eventsv2/results/',
-      query: {query: 'browser:Firefox'},
-    });
+    // Should append tag value and other event attributes to results view query.
+    const target = tagLink.props().to;
+    expect(target.pathname).toEqual('/organizations/org-slug/eventsv2/results/');
+    expect(target.query.query).toEqual('browser:Firefox title:"Oh no something bad"');
   });
 
   it('appends tag value to existing query when clicked', async function() {
@@ -245,9 +243,7 @@ describe('EventsV2 > EventDetails', function() {
       router: {
         location: {
           pathname: '/organizations/org-slug/eventsv2/project-slug:deadbeef',
-          query: {
-            query: 'Dumpster',
-          },
+          query: {},
         },
       },
     });
@@ -255,7 +251,9 @@ describe('EventsV2 > EventDetails', function() {
       <EventDetails
         organization={organization}
         params={{eventSlug: 'project-slug:deadbeef'}}
-        location={{query: allEventsView.generateQueryStringObject()}}
+        location={{
+          query: {...allEventsView.generateQueryStringObject(), query: 'Dumpster'},
+        }}
       />,
       routerContext
     );
@@ -265,11 +263,11 @@ describe('EventsV2 > EventDetails', function() {
     // Get the first link as we wrap react-router's link
     const tagLink = wrapper.find('EventDetails TagsTable TagValue Link').first();
 
-    // Should remove eventSlug and append new tag value causing
-    // the view to re-render
-    expect(tagLink.props().to).toEqual({
-      pathname: '/organizations/org-slug/eventsv2/results/',
-      query: {query: 'Dumpster browser:Firefox'},
-    });
+    // Should append tag value and other event attributes to results view query.
+    const target = tagLink.props().to;
+    expect(target.pathname).toEqual('/organizations/org-slug/eventsv2/results/');
+    expect(target.query.query).toEqual(
+      'Dumpster browser:Firefox title:"Oh no something bad"'
+    );
   });
 });

--- a/tests/js/spec/views/eventsV2/eventView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventView.spec.jsx
@@ -1803,87 +1803,49 @@ describe('EventView.isEqualTo()', function() {
       yAxis: 'fam',
     };
 
+    const differences = {
+      id: '12',
+      name: 'new query',
+      fields: [{field: 'project.id'}, {field: 'count()'}],
+      sorts: [{field: 'count', kind: 'asc'}],
+      query: 'event.type:transaction',
+      project: [24],
+      start: '2019-09-01T00:00:00',
+      end: '2020-09-01T00:00:00',
+      statsPeriod: '24d',
+      environment: [],
+      yAxis: 'ok boomer',
+    };
     const eventView = new EventView(state);
 
-    // id differs
+    for (const key in differences) {
+      const eventView2 = new EventView({...state, [key]: differences[key]});
+      expect(eventView.isEqualTo(eventView2)).toBe(false);
+    }
+  });
+});
 
-    let eventView2 = new EventView({...state, id: '12'});
-    expect(eventView.isEqualTo(eventView2)).toBe(false);
+describe('EventView.getResultsViewUrlTarget()', function() {
+  const state = {
+    id: '1234',
+    name: 'best query',
+    fields: [{field: 'count()'}, {field: 'project.id'}],
+    sorts: generateSorts(['count']),
+    query: 'event.type:error',
+    project: [42],
+    start: '2019-10-01T00:00:00',
+    end: '2019-10-02T00:00:00',
+    statsPeriod: '14d',
+    environment: ['staging'],
+  };
+  const organization = TestStubs.Organization();
 
-    // name differs
-
-    eventView2 = new EventView({...state, name: 'new query'});
-    expect(eventView.isEqualTo(eventView2)).toBe(false);
-
-    // field differs
-
-    eventView2 = new EventView({
-      ...state,
-      fields: [
-        // swapped columns
-        {field: 'project.id'},
-        {field: 'count()'},
-      ],
-    });
-    expect(eventView.isEqualTo(eventView2)).toBe(false);
-
-    // sort differs
-
-    eventView2 = new EventView({
-      ...state,
-      sorts: [
-        {
-          field: 'count',
-          kind: 'asc',
-        },
-      ],
-    });
-    expect(eventView.isEqualTo(eventView2)).toBe(false);
-
-    // query differs
-    eventView2 = new EventView({
-      ...state,
-      query: 'event.type:transaction',
-    });
-    expect(eventView.isEqualTo(eventView2)).toBe(false);
-
-    // project differs
-    eventView2 = new EventView({
-      ...state,
-      project: [24],
-    });
-    expect(eventView.isEqualTo(eventView2)).toBe(false);
-
-    // date time differs
-    eventView2 = new EventView({
-      ...state,
-      start: '2019-09-01T00:00:00',
-    });
-    expect(eventView.isEqualTo(eventView2)).toBe(false);
-
-    eventView2 = new EventView({
-      ...state,
-      end: '2020-09-01T00:00:00',
-    });
-    expect(eventView.isEqualTo(eventView2)).toBe(false);
-
-    eventView2 = new EventView({
-      ...state,
-      statsPeriod: '24d',
-    });
-    expect(eventView.isEqualTo(eventView2)).toBe(false);
-
-    // environment differs
-    eventView2 = new EventView({
-      ...state,
-      environment: [],
-    });
-    expect(eventView.isEqualTo(eventView2)).toBe(false);
-
-    // yaxis differs
-
-    eventView2 = new EventView({...state, yAxis: 'ok boomer'});
-    expect(eventView.isEqualTo(eventView2)).toBe(false);
+  it('generates a URL', function() {
+    const view = new EventView(state);
+    const result = view.getResultsViewUrlTarget(organization);
+    expect(result.pathname).toEqual('/organizations/org-slug/eventsv2/results/');
+    expect(result.query.query).toEqual(state.query);
+    expect(result.query.project).toEqual(state.project);
   });
 });
 

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -10,6 +10,7 @@ import {
   isAggregateField,
   decodeColumnOrder,
   pushEventViewToLocation,
+  getExpandedResults,
 } from 'app/views/eventsV2/utils';
 import {COL_WIDTH_UNDEFINED, COL_WIDTH_NUMBER} from 'app/components/gridEditable';
 
@@ -403,5 +404,84 @@ describe('isAggregateField', function() {
     expect(isAggregateField('thing(')).toBe(false);
     expect(isAggregateField('count()')).toBe(true);
     expect(isAggregateField('unique_count(user)')).toBe(true);
+  });
+});
+
+describe('getExpandedResults()', function() {
+  const state = {
+    id: '1234',
+    name: 'best query',
+    fields: [
+      {field: 'count()'},
+      {field: 'last_seen'},
+      {field: 'title'},
+      {field: 'custom_tag'},
+    ],
+    sorts: [{field: 'count', kind: 'desc'}],
+    query: 'event.type:error',
+    project: [42],
+    start: '2019-10-01T00:00:00',
+    end: '2019-10-02T00:00:00',
+    statsPeriod: '14d',
+    environment: ['staging'],
+  };
+
+  it('removes aggregate fields from result view', () => {
+    const view = new EventView(state);
+    const result = getExpandedResults(view, {}, {});
+
+    expect(result.fields).toEqual([{field: 'title'}, {field: 'custom_tag'}]);
+    expect(result.query).toEqual('event.type:error');
+  });
+
+  it('applies provided conditions', () => {
+    const view = new EventView(state);
+    let result = getExpandedResults(view, {extra: 'condition'}, {});
+    expect(result.query).toEqual('event.type:error extra:condition');
+
+    // quotes value
+    result = getExpandedResults(view, {extra: 'has space'}, {});
+    expect(result.query).toEqual('event.type:error extra:"has space"');
+
+    // appends to existing conditions
+    result = getExpandedResults(view, {'event.type': 'csp'}, {});
+    expect(result.query).toEqual('event.type:error event.type:csp');
+  });
+
+  it('applies conditions from dataRow map structure based on fields', () => {
+    const view = new EventView(state);
+    const result = getExpandedResults(view, {extra: 'condition'}, {title: 'Event title'});
+    expect(result.query).toEqual('event.type:error extra:condition title:"Event title"');
+  });
+
+  it('applies tag key conditions from event data', () => {
+    const view = new EventView(state);
+    const event = {
+      type: 'error',
+      tags: [
+        {key: 'nope', value: 'nope'},
+        {key: 'custom_tag', value: 'tag_value'},
+      ],
+    };
+    const result = getExpandedResults(view, {}, event);
+    expect(result.query).toEqual('event.type:error custom_tag:tag_value');
+  });
+
+  it('applies project condition to project property', () => {
+    const view = new EventView(state);
+    let result = getExpandedResults(view, {project: 1});
+    expect(result.query).toEqual('event.type:error');
+    expect(result.project).toEqual([42, 1]);
+
+    result = getExpandedResults(view, {'project.id': 1});
+    expect(result.query).toEqual('event.type:error');
+    expect(result.project).toEqual([42, 1]);
+  });
+
+  it('applies environment condition to environment property', () => {
+    const view = new EventView(state);
+    const result = getExpandedResults(view, {environment: 'dev'});
+    expect(result.query).toEqual('event.type:error');
+    expect(result.environment).toEqual(['staging', 'dev']);
   });
 });


### PR DESCRIPTION
Clicking a tag link on the event details should take the user to a new
result set that unpacks the current aggregate group. This behaves
similar to how clicking a count() field on the result table does.

I've refactored out the 'zoom in' condition building from the result
table as I didn't want to duplicate it. In the process I've removed the
addition of the `id` field as it was generally noisy and not helpful.

Tag table 'zooming' is a best effort right now. If the user's previous
query includes array fields, or fields from contexts that are not
exposed as tags those fields will not be included in the generated
conditions. This is because traversing the event object is not simple
for many paths.