### PR TITLE
ref(discover2): Consolidate route generation of Discover2 URLs

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -21,6 +21,7 @@ import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import withLatestContext from 'app/utils/withLatestContext';
+import {generateDiscoverLandingPageRoute} from 'app/views/eventsV2/utils';
 
 import Broadcasts from './broadcasts';
 import ServiceIncidents from './serviceIncidents';
@@ -289,13 +290,13 @@ class Sidebar extends React.Component {
                       {...sidebarItemProps}
                       onClick={(_id, evt) =>
                         this.navigateWithGlobalSelection(
-                          `/organizations/${organization.slug}/eventsv2/`,
+                          generateDiscoverLandingPageRoute(organization.slug),
                           evt
                         )
                       }
                       icon={<InlineSvg src="icon-telescope" />}
                       label={t('Discover v2')}
-                      to={`/organizations/${organization.slug}/eventsv2/`}
+                      to={generateDiscoverLandingPageRoute(organization.slug)}
                       id="discover-v2"
                     />
                   </Feature>

--- a/src/sentry/static/sentry/app/views/eventsV2/breadcrumb.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/breadcrumb.tsx
@@ -11,6 +11,7 @@ import space from 'app/styles/space';
 
 import EventView from './eventView';
 import {generateDiscoverResultsRoute} from './results';
+import {generateDiscoverLandingPageRoute} from './utils';
 
 type Props = {
   eventView: EventView;
@@ -29,7 +30,7 @@ class DiscoverBreadcrumb extends React.Component<Props> {
     const crumbs: React.ReactNode[] = [];
 
     const discoverTarget = {
-      pathname: `/organizations/${organization.slug}/eventsv2/`,
+      pathname: generateDiscoverLandingPageRoute(organization.slug),
       query: {
         ...location.query,
         ...eventView.generateBlankQueryStringObject(),

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -300,9 +300,11 @@ class EventView {
       .map(field => {
         return getSortKeyFromField(field, undefined);
       })
-      .filter((sortKey): sortKey is string => {
-        return !!sortKey;
-      });
+      .filter(
+        (sortKey): sortKey is string => {
+          return !!sortKey;
+        }
+      );
 
     const sort = sorts.find(currentSort => {
       return sortKeys.includes(currentSort.field);

--- a/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventView.tsx
@@ -300,11 +300,9 @@ class EventView {
       .map(field => {
         return getSortKeyFromField(field, undefined);
       })
-      .filter(
-        (sortKey): sortKey is string => {
-          return !!sortKey;
-        }
-      );
+      .filter((sortKey): sortKey is string => {
+        return !!sortKey;
+      });
 
     const sort = sorts.find(currentSort => {
       return sortKeys.includes(currentSort.field);

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -185,7 +185,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     const eventView = EventView.fromNewQueryWithLocation(DEFAULT_EVENT_VIEW, location);
 
     const to = {
-      pathname: `/organizations/${organization.slug}/eventsV2/results`,
+      pathname: generateDiscoverResultsRoute(organization.slug),
       query: {
         ...eventView.generateQueryStringObject(),
       },

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -16,6 +16,7 @@ import Input from 'app/components/forms/input';
 import space from 'app/styles/space';
 
 import EventView from '../eventView';
+import {generateDiscoverLandingPageRoute} from '../utils';
 import {handleCreateQuery, handleUpdateQuery, handleDeleteQuery} from './utils';
 
 type Props = {
@@ -170,11 +171,11 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
     event.preventDefault();
     event.stopPropagation();
 
-    const {api, location, organization, eventView} = this.props;
+    const {api, organization, eventView} = this.props;
 
     handleDeleteQuery(api, organization, eventView).then(() => {
       browserHistory.push({
-        pathname: location.pathname,
+        pathname: generateDiscoverLandingPageRoute(organization.slug),
         query: {},
       });
     });

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -406,3 +406,7 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
   link.click();
   link.remove();
 }
+
+export function generateDiscoverLandingPageRoute(orgSlug: string): string {
+  return `/organizations/${orgSlug}/eventsv2/`;
+}

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -35,6 +35,7 @@ import {
 import EventView, {Field as FieldType} from './eventView';
 import {Aggregation, Field, AGGREGATIONS, FIELDS} from './eventQueryParams';
 import {TableColumn} from './table/types';
+import {generateDiscoverResultsRoute} from './results';
 
 export type EventQuery = {
   field: string[];
@@ -114,7 +115,7 @@ export function getEventTagSearchUrl(
   query: Query
 ) {
   return {
-    pathname: `/organizations/${organization.slug}/eventsv2/results/`,
+    pathname: generateDiscoverResultsRoute(organization.slug),
     query: generateQueryWithTag(query, {key: tagKey, value: tagValue}),
   };
 }

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
@@ -15,6 +15,7 @@ import {uniqueId} from 'app/utils/guid';
 import Button from 'app/components/button';
 import DropdownLink from 'app/components/dropdownLink';
 import EventView from 'app/views/eventsV2/eventView';
+import {generateDiscoverResultsRoute} from 'app/views/eventsV2/results';
 import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
 import GroupActions from 'app/actions/groupActions';
@@ -158,7 +159,7 @@ const GroupDetailsActions = createReactClass({
     const discoverView = EventView.fromSavedQuery(discoverQuery);
 
     return {
-      pathname: `/organizations/${organization.slug}/eventsv2/results/`,
+      pathname: generateDiscoverResultsRoute(organization.slug),
       query: discoverView.generateQueryStringObject(),
     };
   },

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -3,7 +3,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
-import Results from 'app/views/eventsV2/results';
+import Results, {generateDiscoverResultsRoute} from 'app/views/eventsV2/results';
 
 const FIELDS = [
   {
@@ -146,5 +146,13 @@ describe('EventsV2 > Results', function() {
         statsPeriod: '14d',
       },
     });
+  });
+});
+
+describe('generateDiscoverResultsRoute', function() {
+  it('generateDiscoverResultsRoute', function() {
+    expect(generateDiscoverResultsRoute('sentry')).toBe(
+      '/organizations/sentry/eventsv2/results/'
+    );
   });
 });

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -10,6 +10,7 @@ import {
   isAggregateField,
   decodeColumnOrder,
   pushEventViewToLocation,
+  generateDiscoverLandingPageRoute,
 } from 'app/views/eventsV2/utils';
 import {COL_WIDTH_UNDEFINED, COL_WIDTH_NUMBER} from 'app/components/gridEditable';
 
@@ -403,5 +404,13 @@ describe('isAggregateField', function() {
     expect(isAggregateField('thing(')).toBe(false);
     expect(isAggregateField('count()')).toBe(true);
     expect(isAggregateField('unique_count(user)')).toBe(true);
+  });
+});
+
+describe('generateDiscoverLandingPageRoute', function() {
+  it('generateDiscoverLandingPageRoute', function() {
+    expect(generateDiscoverLandingPageRoute('sentry')).toBe(
+      '/organizations/sentry/eventsv2/'
+    );
   });
 });


### PR DESCRIPTION
Consolidate route generation of Discover2 URLs so that they're easier to refactor later on.

In addition, deleting a saved query does not redirect to the Discover2 Landing Page; this PR fixes that.