### PR TITLE
fix(discover2) Remove having clause from meta endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -121,6 +121,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsEndpointBase):
                 limit=limit,
                 referrer="api.organization-events-v2",
                 auto_fields=True,
+                use_aggregate_conditions=True,
             )
 
         try:

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -24,6 +24,7 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
                 params=params,
                 query=request.query_params.get("query"),
                 referrer="api.organization-events-meta",
+                ignore_aggregate_conditions=True,
             )
         except discover.InvalidSearchQuery as err:
             raise ParseError(detail=six.text_type(err))

--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -24,7 +24,6 @@ class OrganizationEventsMetaEndpoint(OrganizationEventsEndpointBase):
                 params=params,
                 query=request.query_params.get("query"),
                 referrer="api.organization-events-meta",
-                ignore_aggregate_conditions=True,
             )
         except discover.InvalidSearchQuery as err:
             raise ParseError(detail=six.text_type(err))

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -280,6 +280,7 @@ def query(
     reference_event=None,
     referrer=None,
     auto_fields=False,
+    ignore_aggregate_conditions=False,
 ):
     """
     High-level API for doing arbitrary user queries against events.
@@ -328,6 +329,10 @@ def query(
 
     # Resolve the public aliases into the discover dataset names.
     snuba_args, translated_columns = resolve_discover_aliases(snuba_args)
+
+    # Some queries want to ignore the aggregate conditions (meta/facets)
+    if ignore_aggregate_conditions:
+        snuba_args["having"] = []
 
     # Make sure that any aggregate conditions are also in the selected columns
     for having_clause in snuba_args.get("having"):
@@ -483,7 +488,6 @@ def get_facets(query, params, limit=10, referrer=None):
         "end": snuba_filter.end,
         "conditions": snuba_filter.conditions,
         "filter_keys": snuba_filter.filter_keys,
-        "having": snuba_filter.having,
     }
     # Resolve the public aliases into the discover dataset names.
     snuba_args, translated_columns = resolve_discover_aliases(snuba_args)
@@ -504,7 +508,7 @@ def get_facets(query, params, limit=10, referrer=None):
         filter_keys=snuba_args.get("filter_keys"),
         orderby=["-count", "tags_key"],
         groupby="tags_key",
-        having=[excluded_tags] + snuba_args.get("having"),
+        having=[excluded_tags],
         dataset=Dataset.Discover,
         limit=limit,
         referrer=referrer,

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -609,6 +609,7 @@ class QueryTransformTest(TestCase):
             selected_columns=["transaction", "avg(transaction.duration)"],
             query="http.method:GET avg(transaction.duration):>5",
             params={"project_id": [self.project.id], "start": start_time, "end": end_time},
+            use_aggregate_conditions=True,
         )
         mock_query.assert_called_with(
             selected_columns=["transaction"],
@@ -638,6 +639,7 @@ class QueryTransformTest(TestCase):
             selected_columns=["transaction", "p95"],
             query="http.method:GET p95:>5",
             params={"project_id": [self.project.id], "start": start_time, "end": end_time},
+            use_aggregate_conditions=True,
         )
 
         mock_query.assert_called_with(
@@ -669,6 +671,7 @@ class QueryTransformTest(TestCase):
             selected_columns=["transaction", "avg(transaction.duration)", "max(time)"],
             query="http.method:GET max(time):>5",
             params={"project_id": [self.project.id], "start": start_time, "end": end_time},
+            use_aggregate_conditions=True,
         )
         mock_query.assert_called_with(
             selected_columns=["transaction"],
@@ -703,6 +706,7 @@ class QueryTransformTest(TestCase):
                 selected_columns=["transaction"],
                 query="http.method:GET max(time):>5",
                 params={"project_id": [self.project.id], "start": start_time, "end": end_time},
+                use_aggregate_conditions=True,
             )
 
 

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1295,6 +1295,36 @@ class GetFacetsTest(SnubaTestCase, TestCase):
         assert "color" in keys
         assert "toy" not in keys
 
+    def test_query_string_with_aggregate_condition(self):
+        self.store_event(
+            data={
+                "message": "very bad",
+                "type": "default",
+                "timestamp": iso_format(before_now(minutes=2)),
+                "tags": {"color": "red"},
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "message": "oh my",
+                "type": "default",
+                "timestamp": iso_format(before_now(minutes=2)),
+                "tags": {"toy": "train"},
+            },
+            project_id=self.project.id,
+        )
+        params = {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago}
+        result = discover.get_facets("bad", params)
+        keys = {r.key for r in result}
+        assert "color" in keys
+        assert "toy" not in keys
+
+        result = discover.get_facets("color:red p95:>1", params)
+        keys = {r.key for r in result}
+        assert "color" in keys
+        assert "toy" not in keys
+
     def test_date_params(self):
         self.store_event(
             data={


### PR DESCRIPTION
Some endpoints use the search filter, but don't actually have aggregate columns.
So remove any passed in aggregate conditions to avoid messing these up. This is
really confusing since we have one search query that now has to be treated three
different ways by the backend.