### PR TITLE
feat(workflow): Supporting Incident severity levels

### DIFF
--- a/src/sentry/api/endpoints/organization_incident_index.py
+++ b/src/sentry/api/endpoints/organization_incident_index.py
@@ -74,6 +74,8 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
             incidents = incidents.filter(status=IncidentStatus.WARNING.value)
         elif query_status == "closed":
             incidents = incidents.filter(status=IncidentStatus.CLOSED.value)
+        elif query_status == "open":
+            incidents = incidents.exclude(status=IncidentStatus.CLOSED.value)
 
         return self.paginate(
             request,

--- a/src/sentry/api/endpoints/organization_incident_index.py
+++ b/src/sentry/api/endpoints/organization_incident_index.py
@@ -68,8 +68,10 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
 
         query_status = request.GET.get("status")
 
-        if query_status == "open":
-            incidents = incidents.filter(status=IncidentStatus.OPEN.value)
+        if query_status == "critical":
+            incidents = incidents.filter(status=IncidentStatus.CRITICAL.value)
+        elif query_status == "warning":
+            incidents = incidents.filter(status=IncidentStatus.WARNING.value)
         elif query_status == "closed":
             incidents = incidents.filter(status=IncidentStatus.CLOSED.value)
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -91,7 +91,6 @@ def create_incident(
         incident = Incident.objects.create(
             organization=organization,
             detection_uuid=detection_uuid,
-            # TODO: Should this function receieve the trigger, and we use the trigger type to set incident status?
             status=IncidentStatus.OPEN.value,
             type=type.value,
             title=title,

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -259,6 +259,13 @@ def update_incident_status(incident, status, user=None, comment=None):
         kwargs = {"status": status.value}
         if status == IncidentStatus.CLOSED:
             kwargs["date_closed"] = timezone.now()
+        elif status == IncidentStatus.OPEN:
+            # If we're moving back out of closed status then unset the closed
+            # date
+            kwargs["date_closed"] = None
+            # Remove the snapshot since it's only used after the incident is
+            # closed.
+            IncidentSnapshot.objects.filter(incident=incident).delete()
 
         incident.update(**kwargs)
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -91,6 +91,7 @@ def create_incident(
         incident = Incident.objects.create(
             organization=organization,
             detection_uuid=detection_uuid,
+            # TODO: Should this function receieve the trigger, and we use the trigger type to set incident status?
             status=IncidentStatus.OPEN.value,
             type=type.value,
             title=title,
@@ -259,13 +260,6 @@ def update_incident_status(incident, status, user=None, comment=None):
         kwargs = {"status": status.value}
         if status == IncidentStatus.CLOSED:
             kwargs["date_closed"] = timezone.now()
-        elif status == IncidentStatus.OPEN:
-            # If we're moving back out of closed status then unset the closed
-            # date
-            kwargs["date_closed"] = None
-            # Remove the snapshot since it's only used after the incident is
-            # closed.
-            IncidentSnapshot.objects.filter(incident=incident).delete()
 
         incident.update(**kwargs)
 

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -108,7 +108,7 @@ class Incident(Model):
     identifier = models.IntegerField()
     # Identifier used to match incoming events from the detection algorithm
     detection_uuid = UUIDField(null=True, db_index=True)
-    status = models.PositiveSmallIntegerField(default=IncidentStatus.CLOSED.value)
+    status = models.PositiveSmallIntegerField(default=IncidentStatus.OPEN.value)
     type = models.PositiveSmallIntegerField(default=IncidentType.CREATED.value)
     aggregation = models.PositiveSmallIntegerField(default=QueryAggregations.TOTAL.value)
     title = models.TextField()

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -89,6 +89,8 @@ class IncidentType(Enum):
 class IncidentStatus(Enum):
     OPEN = 1
     CLOSED = 2
+    WARNING = 10
+    CRITICAL = 20
 
 
 class Incident(Model):
@@ -106,7 +108,7 @@ class Incident(Model):
     identifier = models.IntegerField()
     # Identifier used to match incoming events from the detection algorithm
     detection_uuid = UUIDField(null=True, db_index=True)
-    status = models.PositiveSmallIntegerField(default=IncidentStatus.OPEN.value)
+    status = models.PositiveSmallIntegerField(default=IncidentStatus.CLOSED.value)
     type = models.PositiveSmallIntegerField(default=IncidentType.CREATED.value)
     aggregation = models.PositiveSmallIntegerField(default=QueryAggregations.TOTAL.value)
     title = models.TextField()

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -69,12 +69,15 @@ class SubscriptionProcessor(object):
         if not hasattr(self, "_active_incident"):
             try:
                 # Fetch the active incident if one exists for this alert rule.
-                self._active_incident = Incident.objects.filter(
-                    type=IncidentType.ALERT_TRIGGERED.value,
-                    status=IncidentStatus.OPEN.value,
-                    alert_rule=self.alert_rule,
-                    projects=self.subscription.project,
-                ).order_by("-date_added")[0]
+                self._active_incident = (
+                    Incident.objects.filter(
+                        type=IncidentType.ALERT_TRIGGERED.value,
+                        alert_rule=self.alert_rule,
+                        projects=self.subscription.project,
+                    )
+                    .exclude(status=IncidentStatus.CLOSED.value)
+                    .order_by("-date_added")[0]
+                )
             except IndexError:
                 self._active_incident = None
         return self._active_incident

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -214,24 +214,6 @@ class UpdateIncidentStatus(TestCase):
         ):
             self.run_test(incident, IncidentStatus.CLOSED, timezone.now())
 
-    def test_reopened(self):
-        incident = create_incident(
-            self.organization,
-            IncidentType.CREATED,
-            "Test",
-            "",
-            QueryAggregations.TOTAL,
-            timezone.now(),
-            projects=[self.project],
-        )
-        update_incident_status(incident, IncidentStatus.CLOSED)
-        with self.assertChanges(
-            lambda: IncidentSnapshot.objects.filter(incident=incident).exists(),
-            before=True,
-            after=False,
-        ):
-            self.run_test(incident, IncidentStatus.WARNING, None)
-
     def test_all_params(self):
         incident = self.create_incident()
         self.run_test(

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -165,9 +165,9 @@ class UpdateIncidentStatus(TestCase):
         return IncidentActivity.objects.filter(incident=incident).order_by("-id")[:1].get()
 
     def test_status_already_set(self):
-        incident = self.create_incident(status=IncidentStatus.OPEN.value)
+        incident = self.create_incident(status=IncidentStatus.WARNING.value)
         with self.assertRaises(StatusAlreadyChangedError):
-            update_incident_status(incident, IncidentStatus.OPEN)
+            update_incident_status(incident, IncidentStatus.WARNING)
 
     def run_test(self, incident, status, expected_date_closed, user=None, comment=None):
         prev_status = incident.status
@@ -230,7 +230,7 @@ class UpdateIncidentStatus(TestCase):
             before=True,
             after=False,
         ):
-            self.run_test(incident, IncidentStatus.OPEN, None)
+            self.run_test(incident, IncidentStatus.WARNING, None)
 
     def test_all_params(self):
         incident = self.create_incident()
@@ -444,13 +444,13 @@ class CreateIncidentActivityTest(TestCase, BaseIncidentsTest):
             IncidentActivityType.STATUS_CHANGE,
             user=self.user,
             value=six.text_type(IncidentStatus.CLOSED.value),
-            previous_value=six.text_type(IncidentStatus.OPEN.value),
+            previous_value=six.text_type(IncidentStatus.WARNING.value),
         )
         assert activity.incident == incident
         assert activity.type == IncidentActivityType.STATUS_CHANGE.value
         assert activity.user == self.user
         assert activity.value == six.text_type(IncidentStatus.CLOSED.value)
-        assert activity.previous_value == six.text_type(IncidentStatus.OPEN.value)
+        assert activity.previous_value == six.text_type(IncidentStatus.WARNING.value)
         self.assert_notifications_sent(activity)
         assert not self.record_event.called
 

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -200,7 +200,7 @@ class ProcessUpdateTest(TestCase):
         return list(
             Incident.objects.filter(
                 type=IncidentType.ALERT_TRIGGERED.value,
-                status=IncidentStatus.OPEN.value,
+                status=IncidentStatus.WARNING.value,
                 alert_rule=rule,
                 projects=subscription.project,
             )

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -200,10 +200,9 @@ class ProcessUpdateTest(TestCase):
         return list(
             Incident.objects.filter(
                 type=IncidentType.ALERT_TRIGGERED.value,
-                status=IncidentStatus.WARNING.value,
                 alert_rule=rule,
                 projects=subscription.project,
-            )
+            ).exclude(status=IncidentStatus.CLOSED.value)
         )
 
     def assert_trigger_counts(self, processor, trigger, alert_triggers=0, resolve_triggers=0):

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -138,12 +138,12 @@ class TestBuildActivityContext(BaseIncidentActivityTest, TestCase):
         )
         activity.type = IncidentActivityType.STATUS_CHANGE
         activity.value = six.text_type(IncidentStatus.CLOSED.value)
-        activity.previous_value = six.text_type(IncidentStatus.OPEN.value)
+        activity.previous_value = six.text_type(IncidentStatus.WARNING.value)
         self.run_test(
             activity,
             expected_username=activity.user.name,
             expected_action="changed status from %s to %s"
-            % (IncidentStatus.OPEN.name.lower(), IncidentStatus.CLOSED.name.lower()),
+            % (IncidentStatus.WARNING.name.lower(), IncidentStatus.CLOSED.name.lower()),
             expected_comment=activity.comment,
             expected_recipient=recipient,
         )

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -130,10 +130,8 @@ class HandleSnubaQueryUpdateTest(TestCase):
 
         def active_incident():
             return Incident.objects.filter(
-                type=IncidentType.ALERT_TRIGGERED.value,
-                status=IncidentStatus.WARNING.value,
-                alert_rule=self.rule,
-            )
+                type=IncidentType.ALERT_TRIGGERED.value, alert_rule=self.rule
+            ).exclude(status=IncidentStatus.CLOSED.value)
 
         consumer = QuerySubscriptionConsumer("hi", topic=self.topic)
         with self.assertChanges(

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -131,7 +131,7 @@ class HandleSnubaQueryUpdateTest(TestCase):
         def active_incident():
             return Incident.objects.filter(
                 type=IncidentType.ALERT_TRIGGERED.value,
-                status=IncidentStatus.OPEN.value,
+                status=IncidentStatus.WARNING.value,
                 alert_rule=self.rule,
             )
 


### PR DESCRIPTION
This PR introduces a warning and critical alert status. It adjusts the API to be able to return alerts in this status - but does not do anything to assign the status' to alerts (the old open/closed system remains in place currently)