### PR TITLE
Allow Snuba to parse the impact aggregate

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -806,7 +806,11 @@ FIELD_ALIASES = {
         "result_type": "number",
         "aggregations": [
             [
-                "(1 - ((countIf(duration < 300) + (countIf((duration > 300) AND (duration < 1200)) / 2)) / count())) + ((1 - 1 / sqrt(uniq(user))) * 3)",
+                # Snuba is not able to parse Clickhouse infix expressions. We should pass aggregations
+                # in a format Snuba can parse so query optimizations can be applied.
+                # It has a minimal prefix parser though to bridge the gap between the current state
+                # and when we will have an easier syntax.
+                "plus(minus(1, divide(plus(countIf(less(duration, 300)),divide(countIf(and(greater(duration, 300),less(duration, 1200))),2)),count())),multiply(minus(1,divide(1,sqrt(uniq(user)))),3))",
                 None,
                 "impact",
             ]

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1118,7 +1118,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["avg", "transaction.duration", "avg_transaction_duration"],
             ["apdex(duration, 300)", None, "apdex"],
             [
-                "(1 - ((countIf(duration < 300) + (countIf((duration > 300) AND (duration < 1200)) / 2)) / count())) + ((1 - 1 / sqrt(uniq(user))) * 3)",
+                "plus(minus(1, divide(plus(countIf(less(duration, 300)),divide(countIf(and(greater(duration, 300),less(duration, 1200))),2)),count())),multiply(minus(1,divide(1,sqrt(uniq(user)))),3))",
                 None,
                 "impact",
             ],


### PR DESCRIPTION
Snuba does not support the infix Clickhouse syntax when parsing aggregations. This means that the impact expression (seems the only case in Sentry) gets just passed to Clickhouse as it is. This has a few issues:
1) it smells of SQL injection, which is going to be fixed on Snuba side as soon as we enforce the new AST parsing
2) it prevents snuba from knowing which columns are used in the expressions, thus making the work of query processors futile 
3) it prevents query optimizations since it does not know what is inside the expressions.

Since this behavior is widespread in the Sentry codebase we provided a basic Clickhouse expression parser in the Snuba code base that is capable of parsing Clickhouse prefix notation.  So I turned this into a prefix expression as a stop gap solution before we have a better syntax on Snuba or we move the impact function into snuba itself.