### PR TITLE
fix(init): Fix default TSDB config

### DIFF
--- a/src/sentry/data/config/sentry.conf.py.default
+++ b/src/sentry/data/config/sentry.conf.py.default
@@ -103,7 +103,7 @@ SENTRY_QUOTAS = 'sentry.quotas.redis.RedisQuota'
 # The TSDB is used for building charts as well as making things like per-rate
 # alerts possible.
 
-SENTRY_TSDB = 'sentry.tsdb.redis.RedisTSDB'
+SENTRY_TSDB = 'sentry.tsdb.redissnuba.RedisSnubaTSDB'
 
 ###########
 # Digests #


### PR DESCRIPTION
The default config generated for `SENTRY_TSDB` is RedisTSDB, which is incompatible with the default eventstream. Switching that to RedisSnubaTSDB should solve this problem.