### PR TITLE
ref(discover) Add hover bar to headers

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -138,6 +138,9 @@ export const GridHeadCell = styled('th')`
     border-top-right-radius: ${p => p.theme.borderRadius};
     border-right: none;
   }
+  &:hover {
+    border-right: 1px solid ${p => p.theme.borderDark};
+  }
 `;
 export const GridHeadCellButton = styled('div')<GridEditableProps>`
   min-width: 24px; /* Ensure that edit/remove buttons are never hidden */


### PR DESCRIPTION
Column resize handles are really hard to find right now, as they don't display until you are right on top of them. This change adds a 1px border that lets users know where the handle will be.

![header-hover](https://user-images.githubusercontent.com/24086/72832615-38bbb800-3c53-11ea-9296-f46247da9cf4.gif)
