### PR TITLE
fix(ops-genie): Use event.title when event.message is empty

### DIFF
--- a/src/sentry_plugins/opsgenie/plugin.py
+++ b/src/sentry_plugins/opsgenie/plugin.py
@@ -54,7 +54,7 @@ class OpsGeniePlugin(notify.NotificationPlugin):
 
     def build_payload(self, group, event, triggering_rules):
         payload = {
-            "message": event.message,
+            "message": event.message or event.title,
             "alias": "sentry: %d" % group.id,
             "source": "Sentry",
             "details": {


### PR DESCRIPTION
Looks like Ops Genie got hit with the same problem the Legacy PagerDuty plugin did (https://github.com/getsentry/sentry/pull/16527). 

The `event.message` can be empty but it's required for Ops Genie to accept the payload ([docs here](https://docs.opsgenie.com/docs/alert-api))