### PR TITLE
fix(discover) - Change condition to tag when incompatible

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -157,9 +157,9 @@ def resolve_column(col):
 
 
 def resolve_column_with_transaction_type(col):
-    # If the query includes type=transaction, certain other conditions must be excluded
+    # If the query includes type=transaction, certain other conditions are incompatible
     if col.startswith(INCOMPATIBLE_CONDITION_PREFIXES):
-        col = "tags[{}]".format(col)
+        raise InvalidSearchQuery("Combining %s with event.type:transaction has no results" % col)
     return resolve_column(col)
 
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -705,8 +705,6 @@ def resolve_condition(cond, column_resolver):
         # Condition is [col, operator, value]
         if isinstance(cond[0], six.string_types) and len(cond) == 3:
             cond[0] = column_resolver(cond[0])
-            if cond[0].startswith("tags["):
-                cond[2] = six.binary_type(cond[2])
             return cond
         if isinstance(cond[0], (list, tuple)):
             if get_function_index(cond[0]) is not None:

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -705,6 +705,8 @@ def resolve_condition(cond, column_resolver):
         # Condition is [col, operator, value]
         if isinstance(cond[0], six.string_types) and len(cond) == 3:
             cond[0] = column_resolver(cond[0])
+            if cond[0].startswith("tags["):
+                cond[2] = six.binary_type(cond[2])
             return cond
         if isinstance(cond[0], (list, tuple)):
             if get_function_index(cond[0]) is not None:

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -193,54 +193,28 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
             )
 
     def test_query_with_type_transaction_and_stack_condition(self):
-        event_data = load_data("transaction")
-        # Cheat a bit, and create a tag with what the stack conditions will become
-        event_data["tags"].append(["stack.abs_path", "test"])
-        self.store_event(data=event_data, project_id=self.project.id)
-
-        results = discover.query(
-            selected_columns=["count()"],
-            query="stack.abs_path:test event.type:transaction",
-            params={"project_id": [self.project.id]},
-        )
-        assert results["data"][0]["count"] == 1
+        with pytest.raises(InvalidSearchQuery):
+            discover.query(
+                selected_columns=["count()"],
+                query="stack.abs_path:test event.type:transaction",
+                params={"project_id": [self.project.id]},
+            )
 
     def test_query_with_type_transaction_and_error_condition(self):
-        event_data = load_data("transaction")
-        # Cheat a bit, and create a tag with what the stack conditions will become
-        event_data["tags"].append(["error.mechanism", "test"])
-        self.store_event(data=event_data, project_id=self.project.id)
-
-        results = discover.query(
-            selected_columns=["count()"],
-            query="error.mechanism:test event.type:transaction",
-            params={"project_id": [self.project.id]},
-        )
-        assert results["data"][0]["count"] == 1
+        with self.assertRaises(InvalidSearchQuery):
+            discover.query(
+                selected_columns=["count()"],
+                query="error.mechanism:test event.type:transaction",
+                params={"project_id": [self.project.id]},
+            )
 
     def test_query_with_type_transaction_and_negated_incompatible_condition(self):
-        event_data = load_data("transaction")
-        self.store_event(data=event_data, project_id=self.project.id)
-
-        results = discover.query(
-            selected_columns=["count()"],
-            query="!error.mechanism:test event.type:transaction",
-            params={"project_id": [self.project.id]},
-        )
-        assert results["data"][0]["count"] == 1
-
-    def test_query_with_type_transaction_and_numeric_incompatible_condition(self):
-        event_data = load_data("transaction")
-        # Cheat a bit, and create a tag with what the stack conditions will become
-        event_data["tags"].append(["stack.stack_level", "1"])
-        self.store_event(data=event_data, project_id=self.project.id)
-
-        results = discover.query(
-            selected_columns=["count()"],
-            query="stack.stack_level:1 event.type:transaction",
-            params={"project_id": [self.project.id]},
-        )
-        assert results["data"][0]["count"] == 1
+        with self.assertRaises(InvalidSearchQuery):
+            discover.query(
+                selected_columns=["count()"],
+                query="!error.mechanism:test event.type:transaction",
+                params={"project_id": [self.project.id]},
+            )
 
 
 class QueryTransformTest(TestCase):

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -192,6 +192,56 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
                 params={"project_id": [self.project.id]},
             )
 
+    def test_query_with_type_transaction_and_stack_condition(self):
+        event_data = load_data("transaction")
+        # Cheat a bit, and create a tag with what the stack conditions will become
+        event_data["tags"].append(["stack.abs_path", "test"])
+        self.store_event(data=event_data, project_id=self.project.id)
+
+        results = discover.query(
+            selected_columns=["count()"],
+            query="stack.abs_path:test event.type:transaction",
+            params={"project_id": [self.project.id]},
+        )
+        assert results["data"][0]["count"] == 1
+
+    def test_query_with_type_transaction_and_error_condition(self):
+        event_data = load_data("transaction")
+        # Cheat a bit, and create a tag with what the stack conditions will become
+        event_data["tags"].append(["error.mechanism", "test"])
+        self.store_event(data=event_data, project_id=self.project.id)
+
+        results = discover.query(
+            selected_columns=["count()"],
+            query="error.mechanism:test event.type:transaction",
+            params={"project_id": [self.project.id]},
+        )
+        assert results["data"][0]["count"] == 1
+
+    def test_query_with_type_transaction_and_negated_incompatible_condition(self):
+        event_data = load_data("transaction")
+        self.store_event(data=event_data, project_id=self.project.id)
+
+        results = discover.query(
+            selected_columns=["count()"],
+            query="!error.mechanism:test event.type:transaction",
+            params={"project_id": [self.project.id]},
+        )
+        assert results["data"][0]["count"] == 1
+
+    def test_query_with_type_transaction_and_numeric_incompatible_condition(self):
+        event_data = load_data("transaction")
+        # Cheat a bit, and create a tag with what the stack conditions will become
+        event_data["tags"].append(["stack.stack_level", "1"])
+        self.store_event(data=event_data, project_id=self.project.id)
+
+        results = discover.query(
+            selected_columns=["count()"],
+            query="stack.stack_level:1 event.type:transaction",
+            params={"project_id": [self.project.id]},
+        )
+        assert results["data"][0]["count"] == 1
+
 
 class QueryTransformTest(TestCase):
     """


### PR DESCRIPTION
- When a query includes "event.type=transaction" certain other
  conditions become incompatible since the transaction table doesn't
  have those fields (eg. `stack.stack_level` or `error.handled`)
- In these situations change those fields to be tags so that snuba can
  handle it. Most of the time this will result in nothing.