### PR TITLE
fix(incidents): Fix snuba subscription creation code

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -787,8 +787,8 @@ def update_alert_rule(
                 existing_subs,
                 alert_rule.query,
                 QueryAggregations(alert_rule.aggregation),
-                alert_rule.time_window,
-                DEFAULT_ALERT_RULE_RESOLUTION,
+                timedelta(minutes=alert_rule.time_window),
+                timedelta(minutes=DEFAULT_ALERT_RULE_RESOLUTION),
             )
 
     return alert_rule
@@ -805,8 +805,8 @@ def subscribe_projects_to_alert_rule(alert_rule, projects):
         QueryDatasets(alert_rule.dataset),
         alert_rule.query,
         QueryAggregations(alert_rule.aggregation),
-        alert_rule.time_window,
-        alert_rule.resolution,
+        timedelta(minutes=alert_rule.time_window),
+        timedelta(minutes=alert_rule.resolution),
     )
     subscription_links = [
         AlertRuleQuerySubscription(query_subscription=subscription, alert_rule=alert_rule)

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -873,7 +873,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         for subscription in updated_subscriptions:
             assert subscription.query == query
             assert subscription.aggregation == aggregation.value
-            assert subscription.time_window == time_window
+            assert subscription.time_window == int(timedelta(minutes=time_window).total_seconds())
         assert self.alert_rule.query == query
         assert self.alert_rule.aggregation == aggregation.value
         assert self.alert_rule.time_window == time_window

--- a/tests/sentry/snuba/test_subscriptions.py
+++ b/tests/sentry/snuba/test_subscriptions.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from datetime import timedelta
+
 from sentry.snuba.models import QueryAggregations, QueryDatasets, QuerySubscription
 from sentry.snuba.subscriptions import (
     bulk_delete_snuba_subscriptions,
@@ -16,8 +18,8 @@ class CreateSnubaSubscriptionTest(TestCase):
         dataset = QueryDatasets.EVENTS
         query = "level:error"
         aggregation = QueryAggregations.TOTAL
-        time_window = 10
-        resolution = 1
+        time_window = timedelta(minutes=10)
+        resolution = timedelta(minutes=1)
         subscription = create_snuba_subscription(
             self.project, type, dataset, query, aggregation, time_window, resolution
         )
@@ -27,8 +29,8 @@ class CreateSnubaSubscriptionTest(TestCase):
         assert subscription.dataset == dataset.value
         assert subscription.query == query
         assert subscription.aggregation == aggregation.value
-        assert subscription.time_window == time_window
-        assert subscription.resolution == resolution
+        assert subscription.time_window == int(time_window.total_seconds())
+        assert subscription.resolution == int(resolution.total_seconds())
 
 
 class UpdateSnubaSubscriptionTest(TestCase):
@@ -39,21 +41,21 @@ class UpdateSnubaSubscriptionTest(TestCase):
             QueryDatasets.EVENTS,
             "level:error",
             QueryAggregations.TOTAL,
-            10,
-            1,
+            timedelta(minutes=10),
+            timedelta(minutes=1),
         )
 
         query = "level:warning"
         aggregation = QueryAggregations.UNIQUE_USERS
-        time_window = 20
-        resolution = 2
+        time_window = timedelta(minutes=20)
+        resolution = timedelta(minutes=2)
         old_subscription_id = subscription.subscription_id
         update_snuba_subscription(subscription, query, aggregation, time_window, resolution)
         assert subscription.subscription_id != old_subscription_id
         assert subscription.query == query
         assert subscription.aggregation == aggregation.value
-        assert subscription.time_window == time_window
-        assert subscription.resolution == resolution
+        assert subscription.time_window == int(time_window.total_seconds())
+        assert subscription.resolution == int(resolution.total_seconds())
 
 
 class BulkDeleteSnubaSubscriptionTest(TestCase):
@@ -64,8 +66,8 @@ class BulkDeleteSnubaSubscriptionTest(TestCase):
             QueryDatasets.EVENTS,
             "level:error",
             QueryAggregations.TOTAL,
-            10,
-            1,
+            timedelta(minutes=10),
+            timedelta(minutes=1),
         )
         other_subscription = create_snuba_subscription(
             self.create_project(organization=self.organization),
@@ -73,8 +75,8 @@ class BulkDeleteSnubaSubscriptionTest(TestCase):
             QueryDatasets.EVENTS,
             "level:error",
             QueryAggregations.TOTAL,
-            10,
-            1,
+            timedelta(minutes=10),
+            timedelta(minutes=1),
         )
         subscription_ids = [subscription.id, other_subscription.id]
         bulk_delete_snuba_subscriptions([subscription, other_subscription])
@@ -89,8 +91,8 @@ class DeleteSnubaSubscriptionTest(TestCase):
             QueryDatasets.EVENTS,
             "level:error",
             QueryAggregations.TOTAL,
-            10,
-            1,
+            timedelta(minutes=10),
+            timedelta(minutes=1),
         )
         subscription_id = subscription.id
         delete_snuba_subscription(subscription)


### PR DESCRIPTION
This fixes the snuba subscription creation code to match the signature in Snuba. I also changed the
snuba subscription related modules to accept timedeltas rather than arbitrary ints, and store
subscription periods as seconds rather than minutes (should have done this to begin with). This
doesn't change the format we store time periods in for AlertRules, I might clean that up later.