### PR TITLE
fix(django 1.11): update vendored social_auth to ignore request posarg

### DIFF
--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -97,7 +97,7 @@ class SocialAuthBackend(object):
             kwargs["uid"] = self.get_user_id(kwargs["details"], response)
             kwargs["is_new"] = False
 
-        out = self.pipeline(pipeline, *args, **kwargs)
+        out = self.pipeline(pipeline, request, *args, **kwargs)
         if not isinstance(out, dict):
             return out
 
@@ -110,7 +110,7 @@ class SocialAuthBackend(object):
             user.is_new = out.get("is_new")
             return user
 
-    def pipeline(self, pipeline, *args, **kwargs):
+    def pipeline(self, pipeline, request, *args, **kwargs):
         """Pipeline"""
         out = kwargs.copy()
 
@@ -126,7 +126,11 @@ class SocialAuthBackend(object):
             func = getattr(mod, func_name, None)
 
             try:
-                result = func(*args, **out) or {}
+                result = {}
+                if func_name == "save_status_to_session":
+                    result = func(request, *args, **out) or {}
+                else:
+                    result = func(*args, **out) or {}
             except StopPipeline:
                 # Clean partial pipeline on stop
                 if "request" in kwargs:

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -71,7 +71,7 @@ class SocialAuthBackend(object):
     name = ""  # provider name, it's stored in database
     supports_inactive_user = False
 
-    def authenticate(self, *args, **kwargs):
+    def authenticate(self, request, *args, **kwargs):
         """Authenticate user using social credentials
 
         Authentication is made if this is the correct backend, backend


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.11/releases/1.11/#django-contrib-auth

> The HttpRequest is now passed to authenticate() which in turn passes it to the authentication backend if it accepts a request argument.

All identity association flows from legacy plugins are broken, because Django 1.11 introduces the request posarg and it bubbles up all the way to conflicting with social auth pipeline function signatures.

Upstream has a `clean_authenticate_args` for a "django strategy": https://github.com/python-social-auth/social-app-django/commit/7b8d4455bee8611845b5c485a0fd12ebe50589eb. But we can't really easily patch since those strategies are used by updated pipeline machinery. (We should just remove the existing strategy stuff we have checked in; it's not used.)

So to fix, we have to accept the additional request arg and don't pass it along to social auth pipeline functions, with the exception of save_status_to_session which did use a `request` from *args.

This is another great example of why we should try to just switch over to upstream/new social auth, before we upgrade Django in the future.

I verified the regression and the fix locally by going through the Asana identity association flow, but unsure whether or not the timeline for removing vendored social auth makes it worth to write a test for this.

Fixes SENTRY-E86.