### PR TITLE
fix(discover) Fix error in transaction detail page

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -55,7 +55,7 @@ def is_real_column(col):
     Return true if col corresponds to an actual column to be fetched
     (not an aggregate function or field alias)
     """
-    if col in FIELD_ALIASES:
+    if col in FIELD_ALIASES or col.strip("()") in FIELD_ALIASES:
         return False
 
     match = AGGREGATE_PATTERN.search(col)


### PR DESCRIPTION
When the transaction detail page loads, it passes all the same fields from the
transactions filter page previously. Add a fix so that those fields are proprely
ignored in the query.