### PR TITLE
feat(integrations): adds analytics events for sentry apps

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
@@ -87,6 +87,7 @@ export default class SentryAppDetailsModal extends AsyncComponent<Props, State> 
         integration: sentryApp.slug,
         already_installed: isInstalled,
         view,
+        integration_status: sentryApp.status,
       },
       organization,
       {startSession: view === 'external_install'} //new session on external installs

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -42,6 +42,7 @@ type OtherSingleIntegrationEvents = {
 
 type SentryAppEvent = {
   integration_type: 'sentry_app';
+  //include the status since people might do weird things testing unpublished integrations
   integration_status: 'published' | 'unpublished' | 'internal';
 };
 

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -81,7 +81,15 @@ export const trackIntegrationEvent = (
   options?: {startSession: boolean}
 ) => {
   const {startSession} = options || {};
-  const sessionId = startSession ? startAnalyticsSession() : getAnalyticsSessionId();
+  let sessionId = startSession ? startAnalyticsSession() : getAnalyticsSessionId();
+
+  //we should always have a session id but if we don't, we should generate one
+  if (!sessionId) {
+    // eslint-disable-next-line no-console
+    console.warn(`analytics_session_id absent from event ${analtyicsParams.eventName}`);
+    sessionId = startAnalyticsSession();
+  }
+
   const params = {
     analytics_session_id: sessionId,
     organization_id: org?.id,

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -82,13 +82,17 @@ export const trackIntegrationEvent = (
 ) => {
   const {startSession} = options || {};
   const sessionId = startSession ? startAnalyticsSession() : getAnalyticsSessionId();
-  const fullParams = {
+  const params = {
     analytics_session_id: sessionId,
     organization_id: org?.id,
     role: org?.role,
     integration_directory_active: false, //TODO: should be configurable
-    integration_status: undefined, //dummy value to get TS to type things correctly
     ...analtyicsParams,
+  };
+
+  //add the integration_status to the type of params so TS doesn't complain about what we do below
+  const fullParams = params as typeof params & {
+    integration_status?: string;
   };
 
   //Reload expects integration_status even though it's not relevant for non-sentry apps

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -76,7 +76,7 @@ type IntegrationsEventParams = (MultipleIntegrationsEvent | SingleIntegrationEve
  * Uses the current session ID or generates a new one if startSession == true
  */
 export const trackIntegrationEvent = (
-  analtyicsParams: IntegrationsEventParams,
+  analyticsParams: IntegrationsEventParams,
   org?: Organization, //we should pass in org whenever we can but not every place guarantees this
   options?: {startSession: boolean}
 ) => {
@@ -86,7 +86,7 @@ export const trackIntegrationEvent = (
   //we should always have a session id but if we don't, we should generate one
   if (!sessionId) {
     // eslint-disable-next-line no-console
-    console.warn(`analytics_session_id absent from event ${analtyicsParams.eventName}`);
+    console.warn(`analytics_session_id absent from event ${analyticsParams.eventName}`);
     sessionId = startAnalyticsSession();
   }
 
@@ -95,7 +95,7 @@ export const trackIntegrationEvent = (
     organization_id: org?.id,
     role: org?.role,
     integration_directory_active: false, //TODO: should be configurable
-    ...analtyicsParams,
+    ...analyticsParams,
   };
 
   //add the integration_status to the type of params so TS doesn't complain about what we do below
@@ -105,14 +105,14 @@ export const trackIntegrationEvent = (
 
   //Reload expects integration_status even though it's not relevant for non-sentry apps
   //Passing in a dummy value of published in those cases
-  if (analtyicsParams.integration && analtyicsParams.integration_type !== 'sentry_app') {
+  if (analyticsParams.integration && analyticsParams.integration_type !== 'sentry_app') {
     fullParams.integration_status = 'published';
   }
 
   //TODO(steve): remove once we pass in org always
   if (!org) {
     // eslint-disable-next-line no-console
-    console.warn(`Organization absent from event ${analtyicsParams.eventName}`);
+    console.warn(`Organization absent from event ${analyticsParams.eventName}`);
   }
 
   //could put this into a debug method or for the main trackAnalyticsEvent event

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -87,8 +87,15 @@ export const trackIntegrationEvent = (
     organization_id: org?.id,
     role: org?.role,
     integration_directory_active: false, //TODO: should be configurable
+    integration_status: undefined, //dummy value to get TS to type things correctly
     ...analtyicsParams,
   };
+
+  //Reload expects integration_status even though it's not relevant for non-sentry apps
+  //Passing in a dummy value of published in those cases
+  if (analtyicsParams.integration && analtyicsParams.integration_type !== 'sentry_app') {
+    fullParams.integration_status = 'published';
+  }
 
   //TODO(steve): remove once we pass in org always
   if (!org) {

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -91,9 +91,9 @@ export const trackIntegrationEvent = (
   };
 
   //add the integration_status to the type of params so TS doesn't complain about what we do below
-  const fullParams = params as typeof params & {
+  const fullParams: typeof params & {
     integration_status?: string;
-  };
+  } = params;
 
   //Reload expects integration_status even though it's not relevant for non-sentry apps
   //Passing in a dummy value of published in those cases

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -40,10 +40,19 @@ type OtherSingleIntegrationEvents = {
     | 'Integrations: Uninstall Completed';
 };
 
-type SingleIntegrationEvent = (ModalOpenEvent | OtherSingleIntegrationEvents) & {
-  integration: string; //the slug
-  integration_type: 'sentry_app' | 'plugin' | 'first_party';
+type SentryAppEvent = {
+  integration_type: 'sentry_app';
+  integration_status: 'published' | 'unpublished' | 'internal';
 };
+
+type NonSentryAppEvent = {
+  integration_type: 'plugin' | 'first_party';
+};
+
+type SingleIntegrationEvent = (ModalOpenEvent | OtherSingleIntegrationEvents) &
+  (SentryAppEvent | NonSentryAppEvent) & {
+    integration: string; //the slug
+  };
 
 //TODO(Steve): hook up events
 type MultipleIntegrationsEvent = {

--- a/src/sentry/static/sentry/app/views/sentryAppExternalInstallation.tsx
+++ b/src/sentry/static/sentry/app/views/sentryAppExternalInstallation.tsx
@@ -20,6 +20,7 @@ import NarrowLayout from 'app/components/narrowLayout';
 import OrganizationAvatar from 'app/components/avatar/organizationAvatar';
 import SelectControl from 'app/components/forms/selectControl';
 import SentryAppDetailsModal from 'app/components/modals/sentryAppDetailsModal';
+import {trackIntegrationEvent} from 'app/utils/integrationUtil';
 
 type Props = RouteComponentProps<{sentryAppSlug: string}, {}>;
 
@@ -96,7 +97,34 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
     if (!organization || !sentryApp) {
       return undefined;
     }
+    trackIntegrationEvent(
+      {
+        eventKey: 'integrations.installation_start',
+        eventName: 'Integrations: Installation Start',
+        integration_type: 'sentry_app',
+        integration: sentryApp.slug,
+        view: 'external_install',
+        integration_status: sentryApp.status,
+      },
+      organization
+    );
+
     const install = await installSentryApp(this.api, organization.slug, sentryApp);
+    //installation is complete if the status is installed
+    if (install.status === 'installed') {
+      trackIntegrationEvent(
+        {
+          eventKey: 'integrations.installation_complete',
+          eventName: 'Integrations: Installation Complete',
+          integration_type: 'sentry_app',
+          integration: sentryApp.slug,
+          view: 'external_install',
+          integration_status: sentryApp.status,
+        },
+        organization
+      );
+    }
+
     if (sentryApp.redirectUrl) {
       const queryParams = {
         installationId: install.uuid,


### PR DESCRIPTION
This PR adds analytics events for Sentry Apps which were added for First Party integrations in a previous PR (https://github.com/getsentry/sentry/pull/16508). It also adds the field `integration_status` which corresponds to the status of the Sentry app. The reason I did this is that someone testing the installation flow on an unpublished app numerous times could throw off the numbers. Here are the events we capture for Sentry Apps:

- integrations.installation_start
- integrations.installation_complete
- integrations.uninstall_clicked
- integrations.uninstall_completed

Note that we are not capturing the `integrations.installation_complete` event for Sentry Apps that require a redirect. This is because that event can only be captured on the backend and passing the `analytics_session_id` to the backend requires a model change.

Reload PR: https://github.com/getsentry/reload/pull/137