### PR TITLE
chore: remove obsolete ContentLengthHeaderMiddleware

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -257,7 +257,6 @@ USE_TZ = True
 MIDDLEWARE_CLASSES = (
     "sentry.middleware.proxy.ChunkedMiddleware",
     "sentry.middleware.proxy.DecompressBodyMiddleware",
-    "sentry.middleware.proxy.ContentLengthHeaderMiddleware",
     "sentry.middleware.security.SecurityHeadersMiddleware",
     "sentry.middleware.maintenance.ServicesUnavailableMiddleware",
     "sentry.middleware.env.SentryEnvMiddleware",

--- a/src/sentry/middleware/proxy.py
+++ b/src/sentry/middleware/proxy.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 import io
 import logging
-import six
 import zlib
 
 try:
@@ -12,7 +11,6 @@ try:
 except ImportError:
     has_uwsgi = False
 
-from django import VERSION
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 
@@ -179,23 +177,3 @@ class DecompressBodyMiddleware(object):
             # remove the header. Otherwise, LazyData will attempt to re-decode
             # the body.
             del request.META["HTTP_CONTENT_ENCODING"]
-
-
-class ContentLengthHeaderMiddleware(object):
-    """
-    Ensure that we have a proper Content-Length/Transfer-Encoding header
-    """
-
-    def __init__(self):
-        # TODO(joshuarli): we can remove this middleware entirely once we're on 1.11
-        if VERSION[:2] >= (1, 11):
-            raise MiddlewareNotUsed
-
-    def process_response(self, request, response):
-        if "Transfer-Encoding" in response or "Content-Length" in response:
-            return response
-
-        if not response.streaming:
-            response["Content-Length"] = six.text_type(len(response.content))
-
-        return response

--- a/tests/sentry/middleware/test_proxy.py
+++ b/tests/sentry/middleware/test_proxy.py
@@ -1,28 +1,10 @@
 from __future__ import absolute_import
 
 from exam import fixture
-from django import VERSION
-from django.http import HttpRequest, HttpResponse, StreamingHttpResponse
-import pytest
+from django.http import HttpRequest
 
 from sentry.testutils import TestCase
-from sentry.middleware.proxy import ContentLengthHeaderMiddleware, SetRemoteAddrFromForwardedFor
-
-
-# TODO(joshuarli): we can remove this entirely once we're on 1.11
-@pytest.mark.skipif(VERSION[:2] >= (1, 11), reason="middleware not used on Django 1.11+")
-class ContentLengthHeaderMiddlewareTest(TestCase):
-    middleware = fixture(ContentLengthHeaderMiddleware)
-
-    def test_simple(self):
-        response = self.middleware.process_response(None, HttpResponse("lol"))
-        assert response["Content-Length"] == "3"
-        assert "Transfer-Encoding" not in response
-
-    def test_streaming(self):
-        response = self.middleware.process_response(None, StreamingHttpResponse())
-        assert "Transfer-Encoding" not in response
-        assert "Content-Length" not in response
+from sentry.middleware.proxy import SetRemoteAddrFromForwardedFor
 
 
 class SetRemoteAddrFromForwardedForTestCase(TestCase):


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/16478.