### PR TITLE
fix(ui:stackView): Fixes default preselected stack view

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads.jsx
@@ -48,11 +48,6 @@ function findThreadException(thread, event) {
 }
 
 function findThreadStacktrace(thread, event, raw) {
-  if (raw && thread.rawStacktrace) {
-    return thread.rawStacktrace;
-  } else if (thread.stacktrace) {
-    return thread.stacktrace;
-  }
   const exc = findThreadException(thread, event);
   if (exc) {
     let rv = null;
@@ -63,6 +58,15 @@ function findThreadStacktrace(thread, event, raw) {
     }
     return rv;
   }
+
+  if (raw && thread.rawStacktrace) {
+    return thread.rawStacktrace;
+  }
+
+  if (thread.stacktrace) {
+    return thread.stacktrace;
+  }
+
   return null;
 }
 


### PR DESCRIPTION
Sometimes the stackview button group has wrong option preselected by default.

Like for example in this case, `App Only` should be preselected, as there are 2 `in_app` frames present.
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/9060071/72990350-4bb7bf00-3df0-11ea-9f96-a23ed6091097.png">

Repro issue here: https://sentry.io/organizations/sentry-test/issues/1402878535/?project=1808954

After some inspection, I reordered the logic for getting stacktrace to match the one in `<CrashContent>` itself:
https://github.com/getsentry/sentry/blob/849dccb960d3013bc3287dafc0552362cb69222c/src/sentry/static/sentry/app/components/events/interfaces/crashContent.jsx#L62-L70

Do you see any unwanted implications, that I am not aware of?