### PR TITLE
ref(ts) Convert AutoSelectText to typescript

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/access.tsx
+++ b/src/sentry/static/sentry/app/components/acl/access.tsx
@@ -7,6 +7,7 @@ import Alert from 'app/components/alert';
 import SentryTypes from 'app/sentryTypes';
 import withConfig from 'app/utils/withConfig';
 import withOrganization from 'app/utils/withOrganization';
+import {isRenderFunc} from 'app/utils/isRenderFunc';
 
 const DEFAULT_NO_ACCESS_MESSAGE = (
   <Alert type="error" icon="icon-circle-info">
@@ -21,11 +22,6 @@ export type ChildRenderProps = {
 };
 
 type ChildFunction = (props: ChildRenderProps) => React.ReactNode;
-
-// Type guard for render func.
-function isRenderFunc(func: React.ReactNode | Function): func is ChildFunction {
-  return typeof func === 'function';
-}
 
 type DefaultProps = {
   /**
@@ -119,7 +115,7 @@ class Access extends React.Component<Props> {
       return DEFAULT_NO_ACCESS_MESSAGE;
     }
 
-    if (isRenderFunc(children)) {
+    if (isRenderFunc<ChildFunction>(children)) {
       return children(renderProps);
     }
 

--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.tsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.tsx
@@ -102,7 +102,7 @@ class FeatureDisabled extends React.Component<Props, State> {
                 }
               )}
             </p>
-            <pre onClick={e => selectText(e.target)}>
+            <pre onClick={e => selectText(e.target as HTMLElement)}>
               <code>{installText(features, featureName)}</code>
             </pre>
           </HelpDescription>

--- a/src/sentry/static/sentry/app/components/autoSelectText.tsx
+++ b/src/sentry/static/sentry/app/components/autoSelectText.tsx
@@ -1,20 +1,36 @@
-import React from 'react';
+import React, {CSSProperties} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import {selectText} from 'app/utils/selectText';
+import {isRenderFunc} from 'app/utils/isRenderFunc';
 
-class AutoSelectText extends React.Component {
+type ChildRenderProps = {
+  doSelect: () => void;
+  doMount: (el: HTMLElement) => void;
+};
+
+type ChildFunction = (props: ChildRenderProps) => React.ReactNode;
+
+type Props = {
+  /**
+   * Can be a `node` for a simple auto select div container.
+   * When children is a render function, it is passed 2 functions:
+   * - `doMount` - should be applied on parent element's `ref` whose
+   * children is the text to be copied
+   * - `doSelect` - selects text
+   */
+  children: React.ReactNode | ChildFunction;
+  className?: string;
+  style?: CSSProperties;
+};
+
+class AutoSelectText extends React.Component<Props> {
   static propTypes = {
-    /**
-     * Can be a `node` for a simple auto select div container.
-     * When children is a render function, it is passed 2 functions:
-     * - `doMount` - should be applied on parent element's `ref` whose
-     * children is the text to be copied
-     * - `doSelect` - selects text
-     */
     children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   };
+
+  private el: HTMLElement | undefined;
 
   selectText = () => {
     if (!this.el) {
@@ -24,14 +40,14 @@ class AutoSelectText extends React.Component {
     selectText(this.el);
   };
 
-  handleMount = el => {
+  handleMount = (el: HTMLElement) => {
     this.el = el;
   };
 
   render() {
     const {children, className, ...props} = this.props;
 
-    if (typeof children === 'function') {
+    if (isRenderFunc<ChildFunction>(children)) {
       return children({
         doMount: this.handleMount,
         doSelect: this.selectText,

--- a/src/sentry/static/sentry/app/utils/isRenderFunc.tsx
+++ b/src/sentry/static/sentry/app/utils/isRenderFunc.tsx
@@ -1,0 +1,6 @@
+/**
+ * Generic type guard for children a function patterns.
+ */
+export function isRenderFunc<T>(func: React.ReactNode | Function): func is T {
+  return typeof func === 'function';
+}

--- a/src/sentry/static/sentry/app/utils/selectText.tsx
+++ b/src/sentry/static/sentry/app/utils/selectText.tsx
@@ -1,4 +1,4 @@
-export function selectText(node: EventTarget): void {
+export function selectText(node: HTMLElement): void {
   if (node instanceof HTMLInputElement && node.type === 'text') {
     node.select();
   } else if (node instanceof Node && window.getSelection) {


### PR DESCRIPTION
Update the types for selectText() as it internally type checks against HTML element types which EventTarget is not one of. This does mean that we need to cast `e.target` as typescript types that as EventTarget and not the HTMLElement it is supposed to be.

I've pulled out an `isRenderFunc` type guard method as we have a few children-as-function style components and we'll need something like this for those components.