### PR TITLE
feat(discover) Add additional feature flags for discover

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -60,6 +60,8 @@ default_manager.add("organizations:discover", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:transaction-events", OrganizationFeature)  # NOQA
+default_manager.add("organizations:discover-basic", OrganizationFeature)  # NOQA
+default_manager.add("organizations:discover-query", OrganizationFeature)  # NOQA
 default_manager.add("organizations:event-attachments", OrganizationFeature)  # NOQA
 default_manager.add("organizations:symbol-sources", OrganizationFeature)  # NOQA
 default_manager.add("organizations:custom-symbol-sources", OrganizationFeature)  # NOQA


### PR DESCRIPTION
Adding two new feature flags for discover as we want to change how discover is offered in the saas plans.

* `discover-basic` will give access to the UI and pre-built queries. No
  saved queries or UI to build custom queries.
* `discover-query` will give access to custom queries and saved queries.

Users in the current alpha group will be moved to having both of these new feature flags until the feature is enabled for all users.