### PR TITLE
ref(discover) Use the new discover-basic feature flag

### DIFF
--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -14,7 +14,7 @@ from sentry.api.serializers import serialize
 
 class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization, project_slug, event_id):
-        if not features.has("organizations:events-v2", organization, actor=request.user):
+        if not features.has("organizations:discover-basic", organization, actor=request.user):
             return Response(status=404)
 
         try:

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -92,7 +92,7 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
 class OrganizationEventsV2Endpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
-        if not features.has("organizations:events-v2", organization, actor=request.user):
+        if not features.has("organizations:discover-basic", organization, actor=request.user):
             return Response(status=404)
 
         try:

--- a/src/sentry/api/endpoints/organization_events_facets.py
+++ b/src/sentry/api/endpoints/organization_events_facets.py
@@ -13,7 +13,7 @@ from sentry import features, tagstore
 
 class OrganizationEventsFacetsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
-        if not features.has("organizations:events-v2", organization, actor=request.user):
+        if not features.has("organizations:discover-basic", organization, actor=request.user):
             return Response(status=404)
         try:
             params = self.get_filter_params(request, organization)

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -18,7 +18,7 @@ from sentry.utils.dates import parse_stats_period
 
 class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
-        if not features.has("organizations:events-v2", organization, actor=request.user):
+        if not features.has("organizations:discover-basic", organization, actor=request.user):
             return self.get_v1_results(request, organization)
 
         try:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -825,6 +825,10 @@ SENTRY_FEATURES = {
     "organizations:events": False,
     # Enable events v2 instead of the events stream
     "organizations:events-v2": False,
+    # Enable discover 2 basic functions
+    "organizations:discover-basic": False,
+    # Enable discover 2 custom queries and saved queries
+    "organizations:discover-query": False,
     # Enable multi project selection
     "organizations:global-views": False,
     # Turns on grouping info.

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -19,7 +19,7 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
     def has_feature(self, organization, request):
         return features.has(
             "organizations:discover", organization, actor=request.user
-        ) or features.has("organizations:events-v2", organization, actor=request.user)
+        ) or features.has("organizations:discover-basic", organization, actor=request.user)
 
     def get(self, request, organization):
         """

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -16,7 +16,7 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
     def has_feature(self, organization, request):
         return features.has(
             "organizations:discover", organization, actor=request.user
-        ) or features.has("organizations:events-v2", organization, actor=request.user)
+        ) or features.has("organizations:discover-basic", organization, actor=request.user)
 
     def get(self, request, organization, query_id):
         """

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -285,7 +285,7 @@ class Sidebar extends React.Component {
                     />
                   </Feature>
 
-                  <Feature features={['events-v2']} organization={organization}>
+                  <Feature features={['discover-basic']} organization={organization}>
                     <SidebarItem
                       {...sidebarItemProps}
                       onClick={(_id, evt) =>

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -30,7 +30,7 @@ class DiscoverContainer extends React.Component<Props> {
 
     return (
       <Feature
-        features={['events-v2']}
+        features={['discover-basic']}
         organization={organization}
         renderDisabled={this.renderNoAccess}
       >

--- a/src/sentry/static/sentry/app/views/incidents/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/details/body.tsx
@@ -109,7 +109,7 @@ export default class DetailsBody extends React.Component<Props> {
 
               <SideHeader>
                 <span>{t('Query')}</span>
-                <Feature features={['events-v2']}>
+                <Feature features={['discover-basic']}>
                   <Projects slugs={incident && incident.projects} orgId={params.orgId}>
                     {({initiallyLoaded, projects, fetching}) => (
                       <DiscoverLink

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions.jsx
@@ -318,7 +318,7 @@ const GroupDetailsActions = createReactClass({
           </div>
         )}
 
-        {orgFeatures.has('events-v2') && (
+        {orgFeatures.has('discover-basic') && (
           <div className="btn-group">
             <Link
               className={buttonClassName}

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -16,7 +16,7 @@ from sentry.utils.samples import load_data
 from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
-FEATURE_NAMES = ["organizations:events-v2", "organizations:transaction-events"]
+FEATURE_NAMES = ["organizations:discover-basic", "organizations:transaction-events"]
 
 
 def all_events_query(**kwargs):

--- a/tests/js/spec/views/eventsV2/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/index.spec.jsx
@@ -5,7 +5,7 @@ import {DiscoverLanding} from 'app/views/eventsV2/landing';
 
 describe('EventsV2 > Landing', function() {
   const eventTitle = 'Oh no something bad';
-  const features = ['events-v2'];
+  const features = ['discover-basic'];
 
   beforeEach(function() {
     MockApiClient.addMockResponse({

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -25,7 +25,7 @@ const generateFields = () => {
 
 describe('EventsV2 > Results', function() {
   const eventTitle = 'Oh no something bad';
-  const features = ['events-v2'];
+  const features = ['discover-basic'];
 
   beforeEach(function() {
     MockApiClient.addMockResponse({

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -219,7 +219,7 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
 
 
 class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
-    feature_name = "organizations:events-v2"
+    feature_name = "organizations:discover-basic"
 
     def test_post_invalid_conditions(self):
         with self.feature(self.feature_name):

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -57,7 +57,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
             },
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -86,7 +86,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
             },
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 url,
                 data={"field": ["title", "count_unique(user)"], "statsPeriod": "24h"},
@@ -122,7 +122,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 "event_id": event.event_id,
             },
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(url, format="json")
         assert response.status_code == 200
 
@@ -159,7 +159,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 "event_id": "a" * 32,
             },
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
 
@@ -167,7 +167,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         self.organization.flags.allow_joinleave = False
         self.organization.save()
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(url, format="json")
         assert response.status_code == 404, response.content
 
@@ -181,7 +181,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
             },
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(url, format="json")
 
         assert response.status_code == 404, response.content
@@ -222,7 +222,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 "event_id": "b" * 32,
             },
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(url, format="json", data={"field": ["message", "count()"]})
         assert response.data["eventID"] == "b" * 32
         assert response.data["nextEventID"] == "c" * 32, "c is newer & matches message"
@@ -251,7 +251,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 "event_id": "b" * 32,
             },
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 url, format="json", data={"field": ["message", "count()"], "statsPeriod": "7d"}
             )
@@ -303,7 +303,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 "event_id": "1" * 32,
             },
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(url, format="json", data={"field": ["important", "count()"]})
         assert response.data["eventID"] == "1" * 32
         assert response.data["previousEventID"] is None, "no matching tags"
@@ -339,7 +339,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 "event_id": "e" * 32,
             },
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 url,
                 format="json",
@@ -377,7 +377,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 "event_id": "e" * 32,
             },
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 url,
                 format="json",
@@ -418,7 +418,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
                 "event_id": "e" * 32,
             },
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 url,
                 format="json",

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -10,7 +10,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
 class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
-    feature_list = ("organizations:events-v2", "organizations:global-views")
+    feature_list = ("organizations:discover-basic", "organizations:global-views")
 
     def setUp(self):
         super(OrganizationEventsFacetsEndpointTest, self).setUp()
@@ -231,7 +231,7 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
         url = reverse(
             "sentry-api-0-organization-events-facets", kwargs={"organization_slug": org.slug}
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(url, format="json")
         assert response.status_code == 400, response.content
         assert response.data == {"detail": "A valid project must be included."}
@@ -240,7 +240,7 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
         self.store_event(data={"event_id": uuid4().hex}, project_id=self.project.id)
         self.store_event(data={"event_id": uuid4().hex}, project_id=self.project2.id)
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(self.url, format="json")
         assert response.status_code == 400, response.content
         assert response.data == {"detail": "You cannot view events from multiple projects."}

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -134,7 +134,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         ]
 
     def test_discover2_backwards_compatibility(self):
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 data={
@@ -148,7 +148,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             assert response.status_code == 200, response.content
             assert len(response.data["data"]) > 0
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 data={
@@ -182,7 +182,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         ]
 
     def test_aggregate_function_count(self):
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -201,7 +201,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         ]
 
     def test_invalid_aggregate(self):
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -215,7 +215,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400, response.content
 
     def test_aggregate_function_user_count(self):
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -234,7 +234,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         ]
 
     def test_aggregate_invalid(self):
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -248,7 +248,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400, response.content
 
     def test_with_field_and_reference_event_invalid(self):
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -275,7 +275,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             },
             project_id=self.project.id,
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -307,7 +307,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             },
             project_id=self.project.id,
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -347,7 +347,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             data["start_timestamp"] = iso_format(fixture[1] - timedelta(seconds=1))
             self.store_event(data=data, project_id=self.project.id)
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -366,7 +366,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         assert len(items) >= 3
 
     def test_project_id_query_filter(self):
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -20,7 +20,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
     def test_no_projects(self):
         self.login_as(user=self.user)
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(self.url, format="json")
 
         assert response.status_code == 200, response.content
@@ -43,7 +43,9 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         )
 
         query = {"field": ["id", "project.id"], "project": [project.id, project2.id]}
-        with self.feature({"organizations:events-v2": True, "organizations:global-views": False}):
+        with self.feature(
+            {"organizations:discover-basic": True, "organizations:global-views": False}
+        ):
             response = self.client.get(self.url, query, format="json")
         assert response.status_code == 400
         assert "events from multiple projects" in response.data["detail"]
@@ -57,7 +59,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url, {"field": ["id"], "query": "hi \n there"}, format="json"
             )
@@ -90,7 +92,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -121,7 +123,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url, format="json", data={"field": ["project.name", "environment"]}
             )
@@ -148,7 +150,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -187,7 +189,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(self.url, format="json", data={"field": ["count(id)"]})
 
         assert response.status_code == 200, response.content
@@ -215,7 +217,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         self.store_event(
             data={"event_id": "c" * 32, "timestamp": self.min_ago}, project_id=project.id
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -243,7 +245,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             data={"event_id": "c" * 32, "message": "first", "timestamp": self.min_ago},
             project_id=project.id,
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url, format="json", data={"field": ["id", "title"], "sort": "title"}
             )
@@ -260,7 +262,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         self.store_event(
             data={"event_id": "a" * 32, "timestamp": self.two_min_ago}, project_id=project.id
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url, format="json", data={"field": ["id"], "sort": "garbage"}
             )
@@ -298,7 +300,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -371,7 +373,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -404,7 +406,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=3))
         event = self.store_event(data, project_id=project.id)
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -436,7 +438,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=3))
         event = self.store_event(data, project_id=project.id)
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -497,7 +499,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -559,7 +561,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -584,7 +586,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(self.url, format="json", data={"field": ["issue_world.id"]})
         assert response.status_code == 200, response.content
         assert response.data["data"][0]["issue_world.id"] == ""
@@ -598,7 +600,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(self.url, format="json", data={"query": "test"})
         assert response.status_code == 400, response.content
         assert response.data["detail"] == "No fields provided"
@@ -616,7 +618,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=project.id,
         )
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -657,7 +659,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             },
             project_id=project.id,
         )
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -681,7 +683,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         data["timestamp"] = self.min_ago
         self.store_event(data=data, project_id=project.id)
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -700,7 +702,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
         self.store_event(data=data, project_id=project.id)
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",
@@ -724,7 +726,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         data["start_timestamp"] = iso_format(before_now(minutes=1, seconds=5))
         self.store_event(data=data, project_id=project.id)
 
-        with self.feature("organizations:events-v2"):
+        with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
                 format="json",


### PR DESCRIPTION
Update the UI and endpoint checks to use the discover-basic flag instead of events-v2. Saved query code will be moved to `discover-query` as a separate change.