### PR TITLE
fix(ui): Fix <GlobalModal> CSS

### DIFF
--- a/src/sentry/static/sentry/app/components/globalModal.tsx
+++ b/src/sentry/static/sentry/app/components/globalModal.tsx
@@ -1,5 +1,6 @@
-import Modal from 'react-bootstrap/lib/Modal';
+import {ClassNames} from '@emotion/core';
 import {browserHistory} from 'react-router';
+import Modal from 'react-bootstrap/lib/Modal';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Reflux from 'reflux';
@@ -81,16 +82,22 @@ class GlobalModal extends React.Component<Props> {
     }
 
     return (
-      <Modal
-        className={options && options.modalClassName}
-        css={options && options.modalCss}
-        dialogClassName={options && options.dialogClassName}
-        show={visible}
-        animation={false}
-        onHide={this.handleCloseModal}
-      >
-        {renderedChild}
-      </Modal>
+      <ClassNames>
+        {({css, cx}) => (
+          <Modal
+            className={cx(
+              options && options.modalClassName,
+              options && options.modalCss && css(options.modalCss)
+            )}
+            dialogClassName={options && options.dialogClassName}
+            show={visible}
+            animation={false}
+            onHide={this.handleCloseModal}
+          >
+            {renderedChild}
+          </Modal>
+        )}
+      </ClassNames>
     );
   }
 }


### PR DESCRIPTION
This fixes the `css` prop not working with `<Modal>`, instead use emotion `ClassNames` to generate a class name to pass to the bootstrap `<Modal>`