### PR TITLE
feat(monitors): Improve event context for monitor failures

### DIFF
--- a/src/sentry/api/serializers/models/monitor.py
+++ b/src/sentry/api/serializers/models/monitor.py
@@ -3,10 +3,7 @@ from __future__ import absolute_import
 import six
 
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.models import Monitor, Project, ScheduleType
-
-
-SCHEDULE_TYPES = dict(ScheduleType.as_choices())
+from sentry.models import Monitor, Project
 
 
 @register(Monitor)
@@ -28,7 +25,7 @@ class MonitorSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         config = obj.config.copy()
         if "schedule_type" in config:
-            config["schedule_type"] = SCHEDULE_TYPES.get(config["schedule_type"], "unknown")
+            config["schedule_type"] = obj.get_schedule_type_display()
         return {
             "id": six.text_type(obj.guid),
             "status": obj.get_status_display(),

--- a/tests/sentry/models/test_monitor.py
+++ b/tests/sentry/models/test_monitor.py
@@ -1,8 +1,11 @@
 from __future__ import absolute_import, print_function
 
+import six
+
 from datetime import datetime
 from django.utils import timezone
-from sentry.models import Monitor, ScheduleType
+from mock import patch
+from sentry.models import Monitor, MonitorFailure, MonitorType, ScheduleType
 from sentry.testutils import TestCase
 
 
@@ -43,3 +46,77 @@ class MonitorTestCase(TestCase):
         assert monitor.get_next_scheduled_checkin() == datetime(
             2019, 2, 1, 1, 10, 20, tzinfo=timezone.utc
         )
+
+    @patch("sentry.coreapi.ClientApiHelper.insert_data_to_database")
+    def test_mark_failed_default_params(self, mock_insert_data_to_database):
+        monitor = Monitor.objects.create(
+            name="test monitor",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            type=MonitorType.CRON_JOB,
+            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+        )
+        assert monitor.mark_failed()
+
+        assert len(mock_insert_data_to_database.mock_calls) == 1
+
+        event = mock_insert_data_to_database.mock_calls[0].args[0]
+
+        assert dict(
+            event,
+            **{
+                "level": "error",
+                "project": self.project.id,
+                "platform": "other",
+                "contexts": {
+                    "monitor": {
+                        "status": "active",
+                        "type": "cron_job",
+                        "config": {"schedule_type": 2, "schedule": [1, u"month"]},
+                        "id": six.text_type(monitor.guid),
+                        "name": monitor.name,
+                    }
+                },
+                "logentry": {"formatted": "Monitor failure: test monitor (unknown)"},
+                "fingerprint": ["monitor", six.text_type(monitor.guid), u"unknown"],
+                "logger": "",
+                "type": "default",
+            }
+        ) == dict(event)
+
+    @patch("sentry.coreapi.ClientApiHelper.insert_data_to_database")
+    def test_mark_failed_with_reason(self, mock_insert_data_to_database):
+        monitor = Monitor.objects.create(
+            name="test monitor",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            type=MonitorType.CRON_JOB,
+            config={"schedule": [1, "month"], "schedule_type": ScheduleType.INTERVAL},
+        )
+        assert monitor.mark_failed(reason=MonitorFailure.DURATION)
+
+        assert len(mock_insert_data_to_database.mock_calls) == 1
+
+        event = mock_insert_data_to_database.mock_calls[0].args[0]
+
+        assert dict(
+            event,
+            **{
+                "level": "error",
+                "project": self.project.id,
+                "platform": "other",
+                "contexts": {
+                    "monitor": {
+                        "status": "active",
+                        "type": "cron_job",
+                        "config": {"schedule_type": 2, "schedule": [1, u"month"]},
+                        "id": six.text_type(monitor.guid),
+                        "name": monitor.name,
+                    }
+                },
+                "logentry": {"formatted": "Monitor failure: test monitor (duration)"},
+                "fingerprint": ["monitor", six.text_type(monitor.guid), u"duration"],
+                "logger": "",
+                "type": "default",
+            }
+        ) == dict(event)


### PR DESCRIPTION
This adds additional context to monitor events including:

- a reason for the failure (used to fingerprint/differentiate failures)
- config/name/status/type attributes on the monitor context (useful for building different kinds of alerts)