### PR TITLE
WIP: Split up acceptance tests again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,8 +146,11 @@ matrix:
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1
 
     - <<: *acceptance_default
-      name: 'Acceptance'
-      env: TEST_SUITE=acceptance USE_SNUBA=1
+      name: 'Acceptance (1/2)'
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=0 PERCY_PARALLEL_NONCE=${TRAVIS_BUILD_ID} PERCY_PARALLEL_TOTAL=2
+    - <<: *acceptance_default
+      name: 'Acceptance (2/2)'
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=1 PERCY_PARALLEL_NONCE=${TRAVIS_BUILD_ID} PERCY_PARALLEL_TOTAL=2
 
     - <<: *acceptance_default
       name: 'Plugins'

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,8 @@ base_acceptance: &acceptance_default
     - psql -c 'create database sentry;' -U postgres
 
 
+stages: [test, finish]
+
 # each job in the matrix inherits `env/global` and uses everything above,
 # but custom `services`, `before_install`, `install`, and `before_script` directives
 # may be defined to define and setup individual job environments with more precision.
@@ -123,6 +125,7 @@ matrix:
     # Lint python and javascript together
     - python: 2.7
       name: 'Linter'
+      stage: test
       env: TEST_SUITE=lint
       install:
         - python setup.py install_egg_info
@@ -134,23 +137,29 @@ matrix:
     # Proactive linting on 3.7 during the porting process
     - python: 3.7
       name: 'Linter (Python 3.7)'
+      stage: test
       install: pip install 'sentry-flake8>=0.2.0,<0.3.0'
       # configuration for flake8 can be found in setup.cfg
       script: flake8
 
     - <<: *postgres_default
       name: 'Backend with migrations [Postgres] (1/2)'
+      stage: test
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0 MIGRATIONS_TEST_MIGRATE=1
     - <<: *postgres_default
       name: 'Backend with migrations [Postgres] (2/2)'
+      stage: test
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1
 
     - <<: *acceptance_default
       name: 'Acceptance (1/2)'
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=0 PERCY_PARALLEL_NONCE=${TRAVIS_BUILD_ID} PERCY_PARALLEL_TOTAL=2
+      stage: test
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=0 PERCY_PARALLEL_TOTAL=-1
+
     - <<: *acceptance_default
       name: 'Acceptance (2/2)'
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=1 PERCY_PARALLEL_NONCE=${TRAVIS_BUILD_ID} PERCY_PARALLEL_TOTAL=2
+      stage: test
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=1 PERCY_PARALLEL_TOTAL=-1
 
     - <<: *acceptance_default
       name: 'Plugins'
@@ -158,6 +167,7 @@ matrix:
 
     - python: 2.7
       name: 'Frontend'
+      stage: test
       env: TEST_SUITE=js
       before_install:
         - *pip_install
@@ -168,6 +178,7 @@ matrix:
 
     - python: 2.7
       name: 'Command Line'
+      stage: test
       env: TEST_SUITE=cli
       services:
         - postgresql
@@ -180,6 +191,7 @@ matrix:
 
     - python: 2.7
       name: 'Distribution build'
+      stage: test
       env: TEST_SUITE=dist
       before_install:
         - *pip_install
@@ -188,6 +200,7 @@ matrix:
 
     - <<: *postgres_default
       name: 'Symbolicator Integration'
+      stage: test
       env: TEST_SUITE=symbolicator
       before_install:
         - docker run -d --network host --name clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server:19.11
@@ -197,6 +210,7 @@ matrix:
 
     - python: 2.7
       name: 'Snuba Integration with migrations'
+      stage: test
       env: TEST_SUITE=snuba USE_SNUBA=1 SENTRY_ZOOKEEPER_HOSTS=localhost:2181 SENTRY_KAFKA_HOSTS=localhost:9092 MIGRATIONS_TEST_MIGRATE=1
       services:
         - docker
@@ -218,8 +232,9 @@ matrix:
         - psql -c 'create database sentry;' -U postgres
 
     # Deploy 'storybook' (component & style guide) - allowed to fail
-    - name: 'Storybook Deploy'
-      language: node_js
+    - language: node_js
+      name: 'Storybook Deploy'
+      stage: test
       env: STORYBOOK_BUILD=1
       before_install:
          # Decrypt the credentials we added to the repo using the key we added with the Travis command line tool
@@ -235,6 +250,14 @@ matrix:
       script: bash .travis/deploy-storybook.sh
       after_success: skip
       after_failure: skip
+
+    - language: node_js
+      name: 'Finish Percy Build'
+      stage: finish
+      script: npx percy finalize --all
+      after_success: skip
+      after_failure: skip
+
 
   allow_failures:
     - name: 'Storybook Deploy'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,7 @@ env:
     # node's version is pinned by .nvmrc and is autodetected by `nvm install`.
     - NODE_DIR="${HOME}/.nvm/versions/node/v$(< .nvmrc)"
     - NODE_OPTIONS=--max-old-space-size=4096
-    - PERCY_PARALLEL_NONCE2="$(($(date +%s)))"
-    - PERCY_PARALLEL_NONCE3="$TRAVIS_BUILD_ID.$(($(date +%s)))"
+    - PERCY_PARALLEL_NONCE="$TRAVIS_BUILD_ID.$(($(date +%s)))"
 
 before_install:
   - &pip_install pip install "pip==${PYTHON_PIP_VERSION}"
@@ -150,11 +149,11 @@ matrix:
 
     - <<: *acceptance_default
       name: 'Acceptance (1/2)'
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=0 PERCY_PARALLEL_NONCE="$(($(date +%s)))" PERCY_PARALLEL_TOTAL=2
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=0 PERCY_PARALLEL_TOTAL=2
 
     - <<: *acceptance_default
       name: 'Acceptance (2/2)'
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=1 PERCY_PARALLEL_NONCE="$(($(date +%s)))" PERCY_PARALLEL_TOTAL=2
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=1 PERCY_PARALLEL_TOTAL=2
 
     - <<: *acceptance_default
       name: 'Plugins'

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,6 @@ base_acceptance: &acceptance_default
     - psql -c 'create database sentry;' -U postgres
 
 
-stages: [test, finish]
 
 # each job in the matrix inherits `env/global` and uses everything above,
 # but custom `services`, `before_install`, `install`, and `before_script` directives
@@ -125,7 +124,6 @@ matrix:
     # Lint python and javascript together
     - python: 2.7
       name: 'Linter'
-      stage: test
       env: TEST_SUITE=lint
       install:
         - python setup.py install_egg_info
@@ -137,29 +135,24 @@ matrix:
     # Proactive linting on 3.7 during the porting process
     - python: 3.7
       name: 'Linter (Python 3.7)'
-      stage: test
       install: pip install 'sentry-flake8>=0.2.0,<0.3.0'
       # configuration for flake8 can be found in setup.cfg
       script: flake8
 
     - <<: *postgres_default
       name: 'Backend with migrations [Postgres] (1/2)'
-      stage: test
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0 MIGRATIONS_TEST_MIGRATE=1
     - <<: *postgres_default
       name: 'Backend with migrations [Postgres] (2/2)'
-      stage: test
       env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1
 
     - <<: *acceptance_default
       name: 'Acceptance (1/2)'
-      stage: test
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=0 PERCY_PARALLEL_TOTAL=-1
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=0 PERCY_PARALLEL_NONCE="$(($(date +%s)/60))" PERCY_PARALLEL_TOTAL=2
 
     - <<: *acceptance_default
       name: 'Acceptance (2/2)'
-      stage: test
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=1 PERCY_PARALLEL_TOTAL=-1
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=1 PERCY_PARALLEL_NONCE="$(($(date +%s)/60))" PERCY_PARALLEL_TOTAL=2
 
     - <<: *acceptance_default
       name: 'Plugins'
@@ -167,7 +160,6 @@ matrix:
 
     - python: 2.7
       name: 'Frontend'
-      stage: test
       env: TEST_SUITE=js
       before_install:
         - *pip_install
@@ -178,7 +170,6 @@ matrix:
 
     - python: 2.7
       name: 'Command Line'
-      stage: test
       env: TEST_SUITE=cli
       services:
         - postgresql
@@ -191,7 +182,6 @@ matrix:
 
     - python: 2.7
       name: 'Distribution build'
-      stage: test
       env: TEST_SUITE=dist
       before_install:
         - *pip_install
@@ -200,7 +190,6 @@ matrix:
 
     - <<: *postgres_default
       name: 'Symbolicator Integration'
-      stage: test
       env: TEST_SUITE=symbolicator
       before_install:
         - docker run -d --network host --name clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server:19.11
@@ -210,7 +199,6 @@ matrix:
 
     - python: 2.7
       name: 'Snuba Integration with migrations'
-      stage: test
       env: TEST_SUITE=snuba USE_SNUBA=1 SENTRY_ZOOKEEPER_HOSTS=localhost:2181 SENTRY_KAFKA_HOSTS=localhost:9092 MIGRATIONS_TEST_MIGRATE=1
       services:
         - docker
@@ -234,7 +222,6 @@ matrix:
     # Deploy 'storybook' (component & style guide) - allowed to fail
     - language: node_js
       name: 'Storybook Deploy'
-      stage: test
       env: STORYBOOK_BUILD=1
       before_install:
          # Decrypt the credentials we added to the repo using the key we added with the Travis command line tool
@@ -248,13 +235,6 @@ matrix:
         - ./bin/yarn install --pure-lockfile
         - gcloud version
       script: bash .travis/deploy-storybook.sh
-      after_success: skip
-      after_failure: skip
-
-    - language: node_js
-      name: 'Finish Percy Build'
-      stage: finish
-      script: npx percy finalize --all
       after_success: skip
       after_failure: skip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ env:
     # node's version is pinned by .nvmrc and is autodetected by `nvm install`.
     - NODE_DIR="${HOME}/.nvm/versions/node/v$(< .nvmrc)"
     - NODE_OPTIONS=--max-old-space-size=4096
+    - PERCY_PARALLEL_NONCE2="$(($(date +%s)))"
+    - PERCY_PARALLEL_NONCE3="$(TRAVIS_BUILD_NUMBER).$(($(date +%s)))"
 
 before_install:
   - &pip_install pip install "pip==${PYTHON_PIP_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
     - NODE_DIR="${HOME}/.nvm/versions/node/v$(< .nvmrc)"
     - NODE_OPTIONS=--max-old-space-size=4096
     - PERCY_PARALLEL_NONCE2="$(($(date +%s)))"
-    - PERCY_PARALLEL_NONCE3="$(TRAVIS_BUILD_NUMBER).$(($(date +%s)))"
+    - PERCY_PARALLEL_NONCE3="$TRAVIS_BUILD_ID.$(($(date +%s)))"
 
 before_install:
   - &pip_install pip install "pip==${PYTHON_PIP_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -148,11 +148,11 @@ matrix:
 
     - <<: *acceptance_default
       name: 'Acceptance (1/2)'
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=0 PERCY_PARALLEL_NONCE="$(($(date +%s)/60))" PERCY_PARALLEL_TOTAL=2
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=0 PERCY_PARALLEL_NONCE="$(($(date +%s)))" PERCY_PARALLEL_TOTAL=2
 
     - <<: *acceptance_default
       name: 'Acceptance (2/2)'
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=1 PERCY_PARALLEL_NONCE="$(($(date +%s)/60))" PERCY_PARALLEL_TOTAL=2
+      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=2 TEST_GROUP=1 PERCY_PARALLEL_NONCE="$(($(date +%s)))" PERCY_PARALLEL_TOTAL=2
 
     - <<: *acceptance_default
       name: 'Plugins'

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,8 @@ test-symbolicator:
 
 test-acceptance: node-version-check
 	echo $(PERCY_PARALLEL_NONCE)
+	echo $(PERCY_PARALLEL_NONCE2)
+	echo $(PERCY_PARALLEL_NONCE3)
 	sentry init
 	@echo "--> Building static assets"
 	@$(WEBPACK) --display errors-only

--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ test-symbolicator:
 	@echo ""
 
 test-acceptance: node-version-check
+	echo $(PERCY_PARALLEL_NONCE)
 	sentry init
 	@echo "--> Building static assets"
 	@$(WEBPACK) --display errors-only

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -45,7 +45,7 @@ mock==3.0.5 ; python_version < "3.3"
 msgpack>=0.6.1,<0.7.0
 oauth2>=1.5.167
 parsimonious==0.8.0
-percy>=1.1.2
+percy>=2.0.2,<3.0
 petname>=2.6,<2.7
 phonenumberslite<8.0
 Pillow>=6.2.1,<7.0.0


### PR DESCRIPTION
We had a problem where failed builds couldn't be retried, since percy
considered the build finalized. This changes the percy build to only
finalize if the test run was successful. This change probably means we
don't get screenshots on failed tests, not sure if that's something people
care about?

We also use build id + build run so that if someone re-runs all builds then
they'll successfully get new snapshots.