### PR TITLE
ref(nodefield): Remove the skip_nodestore_save flag

### DIFF
--- a/src/sentry/db/models/fields/node.py
+++ b/src/sentry/db/models/fields/node.py
@@ -162,9 +162,6 @@ class NodeField(GzippedDictField):
         self.ref_version = kwargs.pop("ref_version", None)
         self.wrapper = kwargs.pop("wrapper", None)
         self.id_func = kwargs.pop("id_func", lambda: b64encode(uuid4().bytes))
-        # We only automatically save data to nodestore for RawEvent
-        # Event performs saving node data as a separate step
-        self.skip_nodestore_save = kwargs.pop("skip_nodestore_save", False)
         super(NodeField, self).__init__(*args, **kwargs)
 
     def contribute_to_class(self, cls, name):
@@ -234,6 +231,5 @@ class NodeField(GzippedDictField):
         if value.id is None:
             value.id = self.id_func()
 
-        if not self.skip_nodestore_save:
-            value.save()
+        value.save()
         return compress(pickle.dumps({"node_id": value.id}))


### PR DESCRIPTION
This was used to toggle saving behavior between Event/RawEvent.
Since Event no longer uses NodeField we don't need it anymore.