### PR TITLE
fix(ui:frame): Better message for <redacted> with missing_symbol

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame.jsx
@@ -447,9 +447,6 @@ export class Frame extends React.Component {
     if (func.match(/^@objc\s/)) {
       return [t('Objective-C -> Swift shim frame'), warningType];
     }
-    if (func === '<redacted>') {
-      return [t('Unknown system frame. Usually from beta SDKs'), warningType];
-    }
     if (func.match(/^__?hidden#\d+/)) {
       return [t('Hidden function from bitcode build'), errorType];
     }
@@ -458,7 +455,10 @@ export class Frame extends React.Component {
       return [t('No function name was supplied by the client SDK.'), warningType];
     }
 
-    if (func === '<unknown>') {
+    if (
+      func === '<unknown>' ||
+      (func === '<redacted>' && symbolicatorStatus === SymbolicatorStatus.MISSING_SYMBOL)
+    ) {
       switch (symbolicatorStatus) {
         case SymbolicatorStatus.MISSING_SYMBOL:
           return [t('The symbol was not found within the debug file.'), warningType];
@@ -473,6 +473,10 @@ export class Frame extends React.Component {
           return [t('The retrieved debug file could not be processed.'), errorType];
         default:
       }
+    }
+
+    if (func === '<redacted>') {
+      return [t('Unknown system frame. Usually from beta SDKs'), warningType];
     }
 
     return [null, null];


### PR DESCRIPTION
This PR provides better info message on `<redacted>` frames with symbolicator status `missing_symbol`

Before:
![image](https://user-images.githubusercontent.com/9060071/73062932-e4584880-3e9d-11ea-80bb-5ca4bd1ba6dd.png)

After:
![image](https://user-images.githubusercontent.com/9060071/73063071-339e7900-3e9e-11ea-8e03-dfb812d7c3b9.png)
