### PR TITLE
Add default source in Sessionstack integration

### DIFF
--- a/src/sentry_plugins/sessionstack/client.py
+++ b/src/sentry_plugins/sessionstack/client.py
@@ -8,6 +8,7 @@ from sentry.http import safe_urlopen
 from .utils import get_basic_auth, remove_trailing_slashes, add_query_params
 
 ACCESS_TOKEN_NAME = "Sentry"
+DEFAULT_SENTRY_SOURCE = 'sentry'
 
 API_URL = "https://api.sessionstack.com"
 PLAYER_URL = "https://app.sessionstack.com/player"
@@ -56,6 +57,7 @@ class SessionStackClient(object):
 
         player_url = self.player_url + SESSION_URL_PATH + session_id
         query_params = {}
+        query_params['source'] = DEFAULT_SENTRY_SOURCE
 
         access_token = self._get_access_token(session_id)
         if access_token is not None:


### PR DESCRIPTION
Sessionstack is adding query parameter to track when the player is opened from external integration.