### PR TITLE
feat(switch): Add new feature switch for alerts

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -808,8 +808,6 @@ SENTRY_FEATURES = {
     "organizations:advanced-search": True,
     # Enable obtaining and using API keys.
     "organizations:api-keys": False,
-    # Enable customization of issue alerts.
-    "organizations:customizable-issue-alerts": False,
     # Enable explicit use of AND and OR in search.
     "organizations:boolean-search": False,
     # Enable creating organizations within sentry (if SENTRY_SINGLE_ORGANIZATION
@@ -852,6 +850,8 @@ SENTRY_FEATURES = {
     "organizations:internal-catchall": False,
     # Enable inviting members to organizations.
     "organizations:invite-members": True,
+    # Enable different issue alerts on new project creation.
+    "organizations:new-project-custom-issue-alert": False,
     # Enable org-wide saved searches and user pinned search
     "organizations:org-saved-searches": False,
     # Enable access to more advanced (alpha) datascrubbing settings.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -851,7 +851,7 @@ SENTRY_FEATURES = {
     # Enable inviting members to organizations.
     "organizations:invite-members": True,
     # Enable different issue alerts on new project creation.
-    "organizations:new-project-custom-issue-alert": False,
+    "organizations:new-project-issue-alert-options": False,
     # Enable org-wide saved searches and user pinned search
     "organizations:org-saved-searches": False,
     # Enable access to more advanced (alpha) datascrubbing settings.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -808,6 +808,8 @@ SENTRY_FEATURES = {
     "organizations:advanced-search": True,
     # Enable obtaining and using API keys.
     "organizations:api-keys": False,
+    # Enable customization of issue alerts.
+    "organizations:customizable-issue-alerts": False,
     # Enable explicit use of AND and OR in search.
     "organizations:boolean-search": False,
     # Enable creating organizations within sentry (if SENTRY_SINGLE_ORGANIZATION

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -55,6 +55,7 @@ default_manager.add("organizations:create")
 # Organization scoped features
 default_manager.add("organizations:advanced-search", OrganizationFeature)  # NOQA
 default_manager.add("organizations:boolean-search", OrganizationFeature)  # NOQA
+default_manager.add("organizations:customizable-issue-alerts", OrganizationFeature)  # NOQA
 default_manager.add("organizations:api-keys", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events", OrganizationFeature)  # NOQA

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -55,7 +55,6 @@ default_manager.add("organizations:create")
 # Organization scoped features
 default_manager.add("organizations:advanced-search", OrganizationFeature)  # NOQA
 default_manager.add("organizations:boolean-search", OrganizationFeature)  # NOQA
-default_manager.add("organizations:customizable-issue-alerts", OrganizationFeature)  # NOQA
 default_manager.add("organizations:api-keys", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events", OrganizationFeature)  # NOQA
@@ -77,6 +76,7 @@ default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members", OrganizationFeature)  # NOQA
 default_manager.add("organizations:large-debug-files", OrganizationFeature)  # NOQA
 default_manager.add("organizations:monitors", OrganizationFeature)  # NOQA
+default_manager.add("organizations:new-project-custom-issue-alert", OrganizationFeature)  # NOQA
 default_manager.add("organizations:onboarding", OrganizationFeature)  # NOQA
 default_manager.add("organizations:org-saved-searches", OrganizationFeature)  # NOQA
 default_manager.add("organizations:relay", OrganizationFeature)  # NOQA

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -76,7 +76,7 @@ default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members", OrganizationFeature)  # NOQA
 default_manager.add("organizations:large-debug-files", OrganizationFeature)  # NOQA
 default_manager.add("organizations:monitors", OrganizationFeature)  # NOQA
-default_manager.add("organizations:new-project-custom-issue-alert", OrganizationFeature)  # NOQA
+default_manager.add("organizations:new-project-issue-alert-options", OrganizationFeature)  # NOQA
 default_manager.add("organizations:onboarding", OrganizationFeature)  # NOQA
 default_manager.add("organizations:org-saved-searches", OrganizationFeature)  # NOQA
 default_manager.add("organizations:relay", OrganizationFeature)  # NOQA


### PR DESCRIPTION
Context:https://www.notion.so/sentry/Default-Alert-Options-450bbbc6f83b4ba29350fb9a59cf5746

Only working on the first part of the proposal, this feature switch will not be guarding the audit page.

Please scrutinize the name of this feature switch.