### PR TITLE
feat(nodestore): Register options for caching functionality

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -202,5 +202,6 @@ register("transaction-events.force-disable-internal-project", default=False)
 register("outcomes.signals-in-consumer-sample-rate", default=0.0)
 register("outcomes.tsdb-in-consumer-sample-rate", default=0.0)
 
-# Eventstore uses Nodestore instead of Snuba for get_event_by_id
-register("eventstore.use-nodestore", default=True, flags=FLAG_PRIORITIZE_DISK)
+# Node data save rate
+register("nodedata.cache-sample-rate", default=0.0, flags=FLAG_PRIORITIZE_DISK)
+register("nodedata.cache-on-save", default=False, flags=FLAG_PRIORITIZE_DISK)


### PR DESCRIPTION
Register option for https://github.com/getsentry/sentry/pull/16599.

Also removes an old unused option.