### PR TITLE
ref: makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,6 @@ init-config:
 run-dependent-services:
 	sentry devservices up
 
-test: develop lint test-js test-python test-cli
-
 build: locale
 
 drop-db:
@@ -218,7 +216,7 @@ publish:
 	python setup.py sdist bdist_wheel upload
 
 
-.PHONY: develop develop-only test build test reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale update-transifex build-platform-assets test-cli test-js test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js publish
+.PHONY: develop develop-only build reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale update-transifex build-platform-assets test-cli test-js test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js publish
 
 
 ############################

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ bootstrap: develop init-config run-dependent-services create-db apply-migrations
 
 develop: ensure-venv setup-git develop-only
 
-develop-only: ensure-venv update-submodules install-yarn-pkgs install-sentry-dev
+develop-only: ensure-venv install-yarn-pkgs install-sentry-dev
 
 init-config:
 	sentry init --dev
@@ -77,12 +77,6 @@ setup-git: ensure-latest-pip
 	cd .git/hooks && ln -sf ../../config/hooks/* ./
 	$(PIP) install "pre-commit==1.18.2" $(PIP_OPTS)
 	pre-commit install --install-hooks
-	@echo ""
-
-update-submodules:
-	@echo "--> Updating git submodules"
-	git submodule init
-	git submodule update
 	@echo ""
 
 node-version-check:
@@ -224,7 +218,7 @@ publish:
 	python setup.py sdist bdist_wheel upload
 
 
-.PHONY: develop develop-only test build test reset-db clean setup-git update-submodules node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale update-transifex build-platform-assets test-cli test-js test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js publish
+.PHONY: develop develop-only test build test reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale update-transifex build-platform-assets test-cli test-js test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js publish
 
 
 ############################

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,9 @@ ifneq "$(wildcard /usr/local/opt/openssl/lib)" ""
 	LDFLAGS += -L/usr/local/opt/openssl/lib
 endif
 
-PIP := LDFLAGS="$(LDFLAGS)" python -m pip
+PIP := LDFLAGS="$(LDFLAGS)" python -m pip --disable-pip-version-check
 # Note: this has to be synced with the pip version in .travis.yml.
 PIP_VERSION := 19.2.3
-PIP_OPTS := --disable-pip-version-check
 WEBPACK := NODE_ENV=production ./bin/yarn webpack
 YARN := ./bin/yarn
 
@@ -67,7 +66,7 @@ setup-git:
 	git config branch.autosetuprebase always
 	git config core.ignorecase false
 	cd .git/hooks && ln -sf ../../config/hooks/* ./
-	$(PIP) install "pre-commit==1.18.2" $(PIP_OPTS)
+	$(PIP) install "pre-commit==1.18.2"
 	pre-commit install --install-hooks
 	@echo ""
 
@@ -87,7 +86,7 @@ install-yarn-pkgs: node-version-check
 
 install-sentry-dev:
 	@echo "--> Installing Sentry (for development)"
-	$(PIP) install -e ".[dev]" $(PIP_OPTS)
+	$(PIP) install -e ".[dev]"
 
 build-js-po: node-version-check
 	mkdir -p build
@@ -102,7 +101,7 @@ locale: build-js-po
 	cd src/sentry && sentry django compilemessages
 
 update-transifex: build-js-po
-	$(PIP) install transifex-client $(PIP_OPTS)
+	$(PIP) install transifex-client
 	cd src/sentry && sentry django makemessages -i static -l en
 	./bin/merge-catalogs en
 	tx push -s
@@ -245,7 +244,7 @@ travis-test-dist:
 .PHONY: scan-python travis-scan-postgres travis-scan-acceptance travis-scan-snuba travis-scan-symbolicator travis-scan-js travis-scan-cli travis-scan-dist travis-scan-lint
 scan-python:
 	@echo "--> Running Python vulnerability scanner"
-	$(PIP) install safety $(PIP_OPTS)
+	$(PIP) install safety
 	bin/scan
 	@echo ""
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-STATIC_DIR = src/sentry/static/sentry
-
 ifneq "$(wildcard /usr/local/opt/libxmlsec1/lib)" ""
 	LDFLAGS += -L/usr/local/opt/libxmlsec1/lib
 endif

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ setup-git: ensure-latest-pip
 node-version-check:
 	@test "$$(node -v)" = v"$$(cat .nvmrc)" || (echo 'node version does not match .nvmrc. Recommended to use https://github.com/creationix/nvm'; exit 1)
 
-install-yarn-pkgs:
+install-yarn-pkgs: node-version-check
 	@echo "--> Installing Yarn packages (for development)"
 	@command -v $(YARN) 2>&1 > /dev/null || (echo 'yarn not found. Please install it before proceeding.'; exit 1)
 	# Use NODE_ENV=development so that yarn installs both dependencies + devDependencies

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,4 @@
-ifneq "$(wildcard /usr/local/opt/libxmlsec1/lib)" ""
-	LDFLAGS += -L/usr/local/opt/libxmlsec1/lib
-endif
-ifneq "$(wildcard /usr/local/opt/openssl/lib)" ""
-	LDFLAGS += -L/usr/local/opt/openssl/lib
-endif
-
-PIP := LDFLAGS="$(LDFLAGS)" python -m pip --disable-pip-version-check
+PIP := python -m pip --disable-pip-version-check
 # Note: this has to be synced with the pip version in .travis.yml.
 PIP_VERSION := 19.2.3
 WEBPACK := NODE_ENV=production ./bin/yarn webpack

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ YARN := ./bin/yarn
 
 bootstrap: develop init-config run-dependent-services create-db apply-migrations
 
-develop: ensure-venv setup-git install-yarn-pkgs install-sentry-dev
+develop: ensure-venv ensure-pinned-pip setup-git install-yarn-pkgs install-sentry-dev
 
 clean:
 	@echo "--> Cleaning static cache"
@@ -59,10 +59,10 @@ reset-db: drop-db create-db apply-migrations
 ensure-venv:
 	@./scripts/ensure-venv.sh
 
-ensure-latest-pip:
+ensure-pinned-pip:
 	$(PIP) install "pip==$(PIP_VERSION)"
 
-setup-git: ensure-latest-pip
+setup-git:
 	@echo "--> Installing git hooks"
 	git config branch.autosetuprebase always
 	git config core.ignorecase false

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,7 @@ endif
 
 bootstrap: develop init-config run-dependent-services create-db apply-migrations
 
-develop: ensure-venv setup-git develop-only
-
-develop-only: ensure-venv install-yarn-pkgs install-sentry-dev
+develop: ensure-venv setup-git install-yarn-pkgs install-sentry-dev
 
 init-config:
 	sentry init --dev
@@ -216,7 +214,7 @@ publish:
 	python setup.py sdist bdist_wheel upload
 
 
-.PHONY: develop develop-only build reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale update-transifex build-platform-assets test-cli test-js test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js publish
+.PHONY: develop build reset-db clean setup-git node-version-check install-yarn-pkgs install-sentry-dev build-js-po locale update-transifex build-platform-assets test-cli test-js test-styleguide test-python test-snuba test-symbolicator test-acceptance lint lint-python lint-js publish
 
 
 ############################


### PR DESCRIPTION
Removes some unused stuff (`update-submodules`, `STATIC_DIR`) and targets that I feel like no one uses (`test`, `develop-only` - I double checked dev docs and no one's instructed to run these), and some reordering and small refactoring for better readability. (So you might want to look at individual commits, the diff'll be ugly.)

Also, I removed the hardcoded LDFLAGS - the `xmlsec` wheel builds from scratch just fine without it, as long as pkg-config is installed in the system. The xmlsec wheel requires and uses the pkgconfig wheel.

```
$ pkg-config --libs xmlsec1
-L/usr/local/Cellar/libxmlsec1/1.2.29/lib -L/usr/local/opt/openssl@1.1/lib -lxmlsec1-openssl -lxmlsec1 -lcrypto -lxslt -lxml2 -lz -lpthread -licucore -lm -lxml2
```

If for some reason people start to have problems building xmlsec, I'll add `LDFLAGS = $(shell pkg-config --libs xmlsec1)`.
