### PR TITLE
feat(discover) Add restrictions for discover-query flag

### DIFF
--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -19,7 +19,7 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
     def has_feature(self, organization, request):
         return features.has(
             "organizations:discover", organization, actor=request.user
-        ) or features.has("organizations:discover-basic", organization, actor=request.user)
+        ) or features.has("organizations:discover-query", organization, actor=request.user)
 
     def get(self, request, organization):
         """

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -16,7 +16,7 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
     def has_feature(self, organization, request):
         return features.has(
             "organizations:discover", organization, actor=request.user
-        ) or features.has("organizations:discover-basic", organization, actor=request.user)
+        ) or features.has("organizations:discover-query", organization, actor=request.user)
 
     def get(self, request, organization, query_id):
         """

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -507,19 +507,11 @@ class GridEditable<
       <React.Fragment>
         <Header>
           <HeaderTitle>{t('Results')}</HeaderTitle>
-
-          {/* TODO(leedongwei): This is ugly but I need to move it to work on
-          resizing columns. It will be refactored in a upcoming PR */}
-          <div style={{display: 'flex', flexDirection: 'row'}}>
-            <HeaderButtonContainer>
-              {this.renderDownloadCsvButton()}
-            </HeaderButtonContainer>
-            <HeaderButtonContainer>{this.renderHeaderButton()}</HeaderButtonContainer>
-
-            <HeaderButtonContainer>
-              {isEditable && this.renderGridHeadEditButtons()}
-            </HeaderButtonContainer>
-          </div>
+          <HeaderButtonContainer>
+            {this.renderDownloadCsvButton()}
+            {this.renderHeaderButton()}
+            {isEditable && this.renderGridHeadEditButtons()}
+          </HeaderButtonContainer>
         </Header>
 
         <Body>

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -43,12 +43,24 @@ export const HeaderTitle = styled('h4')`
   color: ${p => p.theme.gray3};
 `;
 
-export const HeaderButton = styled('div')`
+export const HeaderButtonContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+
+  /* Hovercard anchor element when features are disabled. */
+  & > span {
+    display: flex;
+    flex-direction: row;
+  }
+`;
+
+export const HeaderButton = styled('div')<{disabled?: boolean}>`
   display: flex;
   align-items: center;
-  color: ${p => p.theme.gray3};
-  cursor: pointer;
+  color: ${p => (p.disabled ? p.theme.gray6 : p.theme.gray3)};
+  cursor: ${p => (p.disabled ? 'default' : 'pointer')};
   font-size: ${p => p.theme.fontSizeSmall};
+  margin-left: ${space(2)};
 
   > svg {
     margin-right: ${space(0.5)};
@@ -56,15 +68,7 @@ export const HeaderButton = styled('div')`
 
   &:hover,
   &:active {
-    color: ${p => p.theme.gray4};
-  }
-`;
-
-export const HeaderButtonContainer = styled('div')`
-  display: flex;
-  flex-direction: row;
-  & > * {
-    margin-left: ${space(2)};
+    color: ${p => (p.disabled ? p.theme.gray6 : p.theme.gray4)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -61,7 +61,11 @@ export const HeaderButton = styled('div')`
 `;
 
 export const HeaderButtonContainer = styled('div')`
-  margin-left: ${space(2)};
+  display: flex;
+  flex-direction: row;
+  & > * {
+    margin-left: ${space(2)};
+  }
 `;
 
 const PanelWithProtectedBorder = styled(Panel)`

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -22,7 +22,7 @@ import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import localStorage from 'app/utils/localStorage';
 import withLatestContext from 'app/utils/withLatestContext';
-import {generateDiscoverLandingPageRoute} from 'app/views/eventsV2/utils';
+import {getDiscoverLandingUrl} from 'app/views/eventsV2/utils';
 
 import Broadcasts from './broadcasts';
 import ServiceIncidents from './serviceIncidents';
@@ -30,13 +30,6 @@ import OnboardingStatus from './onboardingStatus';
 import SidebarDropdown from './sidebarDropdown';
 import SidebarHelp from './help';
 import SidebarItem from './sidebarItem';
-
-function getDiscoverUrl(organization) {
-  if (organization.features.includes('discover-query')) {
-    return generateDiscoverLandingPageRoute(organization.slug);
-  }
-  return `/organizations/${organization.slug}/eventsv2/results/`;
-}
 
 class Sidebar extends React.Component {
   static propTypes = {
@@ -307,13 +300,13 @@ class Sidebar extends React.Component {
                         {...sidebarItemProps}
                         onClick={(_id, evt) =>
                           this.navigateWithGlobalSelection(
-                            getDiscoverUrl(organization),
+                            getDiscoverLandingUrl(organization),
                             evt
                           )
                         }
                         icon={<InlineSvg src="icon-telescope" />}
                         label={t('Discover')}
-                        to={getDiscoverUrl(organization)}
+                        to={getDiscoverLandingUrl(organization)}
                         id="discover-v2"
                       />
                     </Feature>

--- a/src/sentry/static/sentry/app/components/sidebar/index.jsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.jsx
@@ -31,6 +31,13 @@ import SidebarDropdown from './sidebarDropdown';
 import SidebarHelp from './help';
 import SidebarItem from './sidebarItem';
 
+function getDiscoverUrl(organization) {
+  if (organization.features.includes('discover-query')) {
+    return generateDiscoverLandingPageRoute(organization.slug);
+  }
+  return `/organizations/${organization.slug}/eventsv2/results/`;
+}
+
 class Sidebar extends React.Component {
   static propTypes = {
     router: PropTypes.object,
@@ -300,13 +307,13 @@ class Sidebar extends React.Component {
                         {...sidebarItemProps}
                         onClick={(_id, evt) =>
                           this.navigateWithGlobalSelection(
-                            generateDiscoverLandingPageRoute(organization.slug),
+                            getDiscoverUrl(organization),
                             evt
                           )
                         }
                         icon={<InlineSvg src="icon-telescope" />}
                         label={t('Discover')}
-                        to={generateDiscoverLandingPageRoute(organization.slug)}
+                        to={getDiscoverUrl(organization)}
                         id="discover-v2"
                       />
                     </Feature>

--- a/src/sentry/static/sentry/app/stores/hookStore.tsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.tsx
@@ -29,6 +29,7 @@ const validHookNames = new Set<HookName>([
   'feature-disabled:sso-basic',
   'feature-disabled:sso-rippling',
   'feature-disabled:sso-saml2',
+  'feature-disabled:grid-editable-actions',
   'footer',
   'integrations:feature-gates',
   'member-invite-modal:customization',

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -94,6 +94,7 @@ export type FeatureDisabledHooks = {
   'feature-disabled:discover-sidebar-item': FeatureDisabledHook;
   'feature-disabled:project-selector-checkbox': FeatureDisabledHook;
   'feature-disabled:custom-symbol-sources': FeatureDisabledHook;
+  'feature-disabled:grid-editable-actions': FeatureDisabledHook;
 };
 
 /**

--- a/src/sentry/static/sentry/app/views/discover/discover.tsx
+++ b/src/sentry/static/sentry/app/views/discover/discover.tsx
@@ -14,7 +14,7 @@ import PageHeading from 'app/components/pageHeading';
 import {Organization} from 'app/types';
 import space from 'app/styles/space';
 import localStorage from 'app/utils/localStorage';
-import {generateDiscoverLandingPageRoute} from 'app/views/eventsV2/utils';
+import {getDiscoverLandingUrl} from 'app/views/eventsV2/utils';
 
 import {
   DiscoverContainer,
@@ -459,7 +459,7 @@ export default class Discover extends React.Component<Props, State> {
             organization={organization}
           >
             <SwitchLink
-              href={generateDiscoverLandingPageRoute(organization.slug)}
+              href={getDiscoverLandingUrl(organization)}
               onClick={this.onGoLegacyDiscover}
             >
               {t('Go to New Discover')}

--- a/src/sentry/static/sentry/app/views/eventsV2/breadcrumb.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/breadcrumb.tsx
@@ -10,7 +10,7 @@ import InlineSvg from 'app/components/inlineSvg';
 import space from 'app/styles/space';
 
 import EventView from './eventView';
-import {generateDiscoverLandingPageRoute} from './utils';
+import {getDiscoverLandingUrl} from './utils';
 
 type Props = {
   eventView: EventView;
@@ -28,14 +28,16 @@ class DiscoverBreadcrumb extends React.Component<Props> {
     const {eventView, event, organization, location} = this.props;
     const crumbs: React.ReactNode[] = [];
 
-    const discoverTarget = {
-      pathname: generateDiscoverLandingPageRoute(organization.slug),
-      query: {
-        ...location.query,
-        ...eventView.generateBlankQueryStringObject(),
-        ...eventView.getGlobalSelection(),
-      },
-    };
+    const discoverTarget = organization.features.includes('discover-query')
+      ? {
+          pathname: getDiscoverLandingUrl(organization),
+          query: {
+            ...location.query,
+            ...eventView.generateBlankQueryStringObject(),
+            ...eventView.getGlobalSelection(),
+          },
+        }
+      : null;
 
     crumbs.push(
       <BreadcrumbItem to={discoverTarget} key="eventview-home">

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -12,6 +12,7 @@ import {trackAnalyticsEvent} from 'app/utils/analytics';
 import SentryTypes from 'app/sentryTypes';
 import {Organization, SavedQuery} from 'app/types';
 import localStorage from 'app/utils/localStorage';
+import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import BetaTag from 'app/components/betaTag';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
@@ -243,6 +244,14 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     });
   };
 
+  renderNoAccess() {
+    return (
+      <PageContent>
+        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+      </PageContent>
+    );
+  }
+
   render() {
     let body;
     const {location, organization} = this.props;
@@ -281,12 +290,18 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     }
 
     return (
-      <SentryDocumentTitle title={t('Discover')} objSlug={organization.slug}>
-        <React.Fragment>
-          <GlobalSelectionHeader organization={organization} />
-          <NoProjectMessage organization={organization}>{body}</NoProjectMessage>
-        </React.Fragment>
-      </SentryDocumentTitle>
+      <Feature
+        organization={organization}
+        features={['discover-query']}
+        renderDisabled={this.renderNoAccess}
+      >
+        <SentryDocumentTitle title={t('Discover')} objSlug={organization.slug}>
+          <React.Fragment>
+            <GlobalSelectionHeader organization={organization} />
+            <NoProjectMessage organization={organization}>{body}</NoProjectMessage>
+          </React.Fragment>
+        </SentryDocumentTitle>
+      </Feature>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
@@ -6,6 +6,7 @@ import {Organization, SavedQuery} from 'app/types';
 import {fetchSavedQuery} from 'app/actionCreators/discoverSavedQueries';
 
 import {Client} from 'app/api';
+import Feature from 'app/components/acl/feature';
 import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 
@@ -71,13 +72,15 @@ class ResultsHeader extends React.Component<Props, State> {
           eventView={eventView}
         />
         <Controller>
-          <SavedQueryButtonGroup
-            location={location}
-            organization={organization}
-            eventView={eventView}
-            savedQuery={savedQuery}
-            savedQueryLoading={loading}
-          />
+          <Feature organization={organization} features={['discover-query']}>
+            <SavedQueryButtonGroup
+              location={location}
+              organization={organization}
+              eventView={eventView}
+              savedQuery={savedQuery}
+              savedQueryLoading={loading}
+            />
+          </Feature>
         </Controller>
       </HeaderBox>
     );

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -16,7 +16,7 @@ import Input from 'app/components/forms/input';
 import space from 'app/styles/space';
 
 import EventView from '../eventView';
-import {generateDiscoverLandingPageRoute} from '../utils';
+import {getDiscoverLandingUrl} from '../utils';
 import {handleCreateQuery, handleUpdateQuery, handleDeleteQuery} from './utils';
 
 type Props = {
@@ -169,7 +169,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
 
     handleDeleteQuery(api, organization, eventView).then(() => {
       browserHistory.push({
-        pathname: generateDiscoverLandingPageRoute(organization.slug),
+        pathname: getDiscoverLandingUrl(organization),
         query: {},
       });
     });

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -51,15 +51,8 @@ class Table extends React.PureComponent<TableProps, TableState> {
   };
 
   componentDidMount() {
-    const {location, organization, eventView} = this.props;
-
-    if (!eventView.isValid()) {
-      const nextEventView = EventView.fromNewQueryWithLocation(
-        DEFAULT_EVENT_VIEW,
-        location
-      );
-
-      browserHistory.replace(nextEventView.getResultsViewUrlTarget(organization.slug));
+    if (!this.props.eventView.isValid()) {
+      this.goToAllEvents();
       return;
     }
 
@@ -70,6 +63,20 @@ class Table extends React.PureComponent<TableProps, TableState> {
     if (!this.state.isLoading && this.shouldRefetchData(prevProps)) {
       this.fetchData();
     }
+    if (!this.props.eventView.isValid()) {
+      this.goToAllEvents();
+      return;
+    }
+  }
+
+  goToAllEvents() {
+    const {location, organization} = this.props;
+    const nextEventView = EventView.fromNewQueryWithLocation(
+      DEFAULT_EVENT_VIEW,
+      location
+    );
+
+    browserHistory.replace(nextEventView.getResultsViewUrlTarget(organization.slug));
   }
 
   shouldRefetchData = (prevProps: TableProps): boolean => {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -4,6 +4,7 @@ import {Location} from 'history';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
+import {t} from 'app/locale';
 import {assert} from 'app/types/utils';
 import Link from 'app/components/links/link';
 
@@ -399,14 +400,14 @@ class TableView extends React.Component<TableViewProps> {
         }) => {
           return (
             <GridEditable
-              isEditable
+              editFeatures={['organizations:discover-query']}
+              noEditMessage={t('Requires discover query feature.')}
               onToggleEdit={this.onToggleEdit}
               isColumnDragging={isColumnDragging}
               gridHeadCellButtonProps={{className: DRAGGABLE_COLUMN_CLASSNAME_IDENTIFIER}}
               isLoading={isLoading}
               error={error}
               data={tableData ? tableData.data : []}
-              downloadAsCsv={() => downloadAsCsv(tableData, columnOrder, title)}
               columnOrder={this.generateColumnOrder({
                 initialColumnIndex: draggingColumnIndex,
                 destinationColumnIndex,
@@ -425,6 +426,7 @@ class TableView extends React.Component<TableViewProps> {
                 deleteColumn: this._deleteColumn,
                 moveColumnCommit: this._moveColumnCommit,
                 onDragStart: startColumnDrag,
+                downloadAsCsv: () => downloadAsCsv(tableData, columnOrder, title),
               }}
             />
           );

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -6,7 +6,7 @@ import {Location, Query} from 'history';
 import {browserHistory} from 'react-router';
 
 import {t} from 'app/locale';
-import {Event, Organization} from 'app/types';
+import {Event, Organization, OrganizationSummary} from 'app/types';
 import {Client} from 'app/api';
 import {getTitle} from 'app/utils/events';
 import {getUtcDateString} from 'app/utils/dates';
@@ -453,6 +453,9 @@ export function getExpandedResults(
   return nextView;
 }
 
-export function generateDiscoverLandingPageRoute(orgSlug: string): string {
-  return `/organizations/${orgSlug}/discover/queries/`;
+export function getDiscoverLandingUrl(organization: OrganizationSummary): string {
+  if (organization.features.includes('discover-query')) {
+    return `/organizations/${organization.slug}/discover/queries/`;
+  }
+  return `/organizations/${organization.slug}/discover/results/`;
 }

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -16,7 +16,11 @@ from sentry.utils.samples import load_data
 from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
-FEATURE_NAMES = ["organizations:discover-basic", "organizations:transaction-events"]
+FEATURE_NAMES = [
+    "organizations:discover-basic",
+    "organizations:discover-query",
+    "organizations:transaction-events",
+]
 
 
 def all_events_query(**kwargs):

--- a/tests/js/spec/views/eventsV2/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/index.spec.jsx
@@ -5,7 +5,7 @@ import {DiscoverLanding} from 'app/views/eventsV2/landing';
 
 describe('EventsV2 > Landing', function() {
   const eventTitle = 'Oh no something bad';
-  const features = ['discover-basic'];
+  const features = ['discover-basic', 'discover-query'];
 
   beforeEach(function() {
     MockApiClient.addMockResponse({
@@ -72,5 +72,19 @@ describe('EventsV2 > Landing', function() {
 
     const content = wrapper.find('SentryDocumentTitle');
     expect(content.text()).toContain('You need at least one project to use this view');
+  });
+
+  it('denies access on missing feature', function() {
+    const wrapper = mountWithTheme(
+      <DiscoverLanding
+        organization={TestStubs.Organization()}
+        location={{query: {}}}
+        router={{}}
+      />,
+      TestStubs.routerContext()
+    );
+
+    const content = wrapper.find('PageContent');
+    expect(content.text()).toContain("You don't have access to this feature");
   });
 });

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -10,7 +10,7 @@ import {
   decodeColumnOrder,
   pushEventViewToLocation,
   getExpandedResults,
-  generateDiscoverLandingPageRoute,
+  getDiscoverLandingUrl,
 } from 'app/views/eventsV2/utils';
 import {COL_WIDTH_UNDEFINED, COL_WIDTH_NUMBER} from 'app/components/gridEditable';
 
@@ -446,10 +446,14 @@ describe('getExpandedResults()', function() {
   });
 });
 
-describe('generateDiscoverLandingPageRoute', function() {
-  it('generateDiscoverLandingPageRoute', function() {
-    expect(generateDiscoverLandingPageRoute('sentry')).toBe(
-      '/organizations/sentry/discover/queries/'
-    );
+describe('getDiscoverLandingUrl', function() {
+  it('is correct for with discover-query and discover-basic features', function() {
+    const org = TestStubs.Organization({features: ['discover-query', 'discover-basic']});
+    expect(getDiscoverLandingUrl(org)).toBe('/organizations/org-slug/discover/queries/');
+  });
+
+  it('is correct for with only discover-basic feature', function() {
+    const org = TestStubs.Organization({features: ['discover-basic']});
+    expect(getDiscoverLandingUrl(org)).toBe('/organizations/org-slug/discover/results/');
   });
 });

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -219,7 +219,7 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
 
 
 class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
-    feature_name = "organizations:discover-basic"
+    feature_name = "organizations:discover-query"
 
     def test_post_invalid_conditions(self):
         with self.feature(self.feature_name):

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -50,6 +50,20 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
         assert response.data["conditions"] == []
         assert response.data["limit"] == 10
 
+    def test_get_discover_query_flag(self):
+        with self.feature("organizations:discover-query"):
+            url = reverse(
+                "sentry-api-0-discover-saved-query-detail", args=[self.org.slug, self.query_id]
+            )
+            response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == six.text_type(self.query_id)
+        assert set(response.data["projects"]) == set(self.project_ids)
+        assert response.data["fields"] == ["test"]
+        assert response.data["conditions"] == []
+        assert response.data["limit"] == 10
+
     def test_get_version(self):
         query = {"fields": ["event_id"], "query": "event.type:error", "limit": 10, "version": 2}
         model = DiscoverSavedQuery.objects.create(


### PR DESCRIPTION
Add the conditional logic for the `discover-query` flag. This flag will only be on business tier plans and gates access to:

* Creating saved queries
* Using pre-made queries or saved queries
* Using the custom query builder UI.

When discover-query is not enabled users will be directed to the default discover view.