### PR TITLE
fix(discover2): Be able to apply aggregate functions on tags with hyphens

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -854,7 +854,7 @@ VALID_AGGREGATES = {
     "sum": {"snuba_name": "sum", "fields": ["transaction.duration"]},
 }
 
-AGGREGATE_PATTERN = re.compile(r"^(?P<function>[^\(]+)\((?P<column>[a-z\._-]*)\)$")
+AGGREGATE_PATTERN = re.compile(r"^(?P<function>[^\(]+)\((?P<column>.*)\)$")
 
 
 def get_json_meta_type(field, snuba_type):

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -854,7 +854,7 @@ VALID_AGGREGATES = {
     "sum": {"snuba_name": "sum", "fields": ["transaction.duration"]},
 }
 
-AGGREGATE_PATTERN = re.compile(r"^(?P<function>[^\(]+)\((?P<column>[a-z\._]*)\)$")
+AGGREGATE_PATTERN = re.compile(r"^(?P<function>[^\(]+)\((?P<column>[a-z\._-]*)\)$")
 
 
 def get_json_meta_type(field, snuba_type):

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -222,9 +222,8 @@ export function getAggregateAlias(field: string): string {
   }
   return field
     .replace(AGGREGATE_PATTERN, '$1_$2')
-    .replace('.', '_')
-    .replace(/_+$/, '')
-    .toLowerCase();
+    .replace(/\./g, '_')
+    .replace(/_+$/, '');
 }
 
 export type QueryWithColumnState =

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -44,6 +44,7 @@ export type EventQuery = {
   per_page?: number;
 };
 
+// edit this
 const AGGREGATE_PATTERN = /^([^\(]+)\(([a-z\._+]*)\)$/;
 const ROUND_BRACKETS_PATTERN = /[\(\)]/;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -44,8 +44,7 @@ export type EventQuery = {
   per_page?: number;
 };
 
-// edit this
-const AGGREGATE_PATTERN = /^([^\(]+)\(([a-z\._+]*)\)$/;
+const AGGREGATE_PATTERN = /^([^\(]+)\((.*)\)$/;
 const ROUND_BRACKETS_PATTERN = /[\(\)]/;
 
 function explodeFieldString(field: string): {aggregation: string; field: string} {

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -20,6 +20,9 @@ describe('getAggregateAlias', function() {
   it('no-ops simple fields', function() {
     expect(getAggregateAlias('field')).toEqual('field');
     expect(getAggregateAlias('under_field')).toEqual('under_field');
+    expect(getAggregateAlias('foo.bar.is-Enterprise_42')).toEqual(
+      'foo.bar.is-Enterprise_42'
+    );
   });
 
   it('handles 0 arg functions', function() {
@@ -31,6 +34,9 @@ describe('getAggregateAlias', function() {
     expect(getAggregateAlias('count(id)')).toEqual('count_id');
     expect(getAggregateAlias('count_unique(user)')).toEqual('count_unique_user');
     expect(getAggregateAlias('count_unique(issue.id)')).toEqual('count_unique_issue_id');
+    expect(getAggregateAlias('count(foo.bar.is-Enterprise_42)')).toEqual(
+      'count_foo_bar_is-Enterprise_42'
+    );
   });
 });
 

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -273,7 +273,7 @@ describe('isAggregateField', function() {
   it('detects aliases', function() {
     expect(isAggregateField('p888')).toBe(false);
     expect(isAggregateField('other_field')).toBe(false);
-    expect(isAggregateField('foo.bar.is-Enterprise-42')).toBe(false);
+    expect(isAggregateField('foo.bar.is-Enterprise_42')).toBe(false);
     expect(isAggregateField('p75')).toBe(true);
     expect(isAggregateField('last_seen')).toBe(true);
   });
@@ -282,7 +282,7 @@ describe('isAggregateField', function() {
     expect(isAggregateField('thing(')).toBe(false);
     expect(isAggregateField('count()')).toBe(true);
     expect(isAggregateField('unique_count(user)')).toBe(true);
-    expect(isAggregateField('unique_count(foo.bar.is-Enterprise-42)')).toBe(true);
+    expect(isAggregateField('unique_count(foo.bar.is-Enterprise_42)')).toBe(true);
   });
 });
 
@@ -400,16 +400,16 @@ describe('explodeField', function() {
     });
 
     // custom tag
-    expect(explodeField({field: 'foo.bar.is-Enterprise-42', width: 123})).toEqual({
+    expect(explodeField({field: 'foo.bar.is-Enterprise_42', width: 123})).toEqual({
       aggregation: '',
-      field: 'foo.bar.is-Enterprise-42',
+      field: 'foo.bar.is-Enterprise_42',
       width: 123,
     });
 
     // custom tag with aggregation
-    expect(explodeField({field: 'count(foo.bar.is-Enterprise-42)', width: 123})).toEqual({
+    expect(explodeField({field: 'count(foo.bar.is-Enterprise_42)', width: 123})).toEqual({
       aggregation: 'count',
-      field: 'foo.bar.is-Enterprise-42',
+      field: 'foo.bar.is-Enterprise_42',
       width: 123,
     });
   });
@@ -428,7 +428,7 @@ describe('hasAggregateField', function() {
     expect(hasAggregateField(eventView)).toBe(false);
 
     eventView = new EventView({
-      fields: [{field: 'count(foo.bar.is-Enterprise-42)'}],
+      fields: [{field: 'count(foo.bar.is-Enterprise_42)'}],
       sorts: [],
       query: '',
       project: [],

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -11,6 +11,7 @@ import {
   getExpandedResults,
   getFieldRenderer,
   getDiscoverLandingUrl,
+  explodeField,
 } from 'app/views/eventsV2/utils';
 import {COL_WIDTH_UNDEFINED, COL_WIDTH_NUMBER} from 'app/components/gridEditable';
 
@@ -364,5 +365,43 @@ describe('getDiscoverLandingUrl', function() {
   it('is correct for with only discover-basic feature', function() {
     const org = TestStubs.Organization({features: ['discover-basic']});
     expect(getDiscoverLandingUrl(org)).toBe('/organizations/org-slug/discover/results/');
+  });
+});
+
+describe('explodeField', function() {
+  it('explodes fields', function() {
+    expect(explodeField({field: 'foobar'})).toEqual({
+      aggregation: '',
+      field: 'foobar',
+      width: 300,
+    });
+
+    // has width
+    expect(explodeField({field: 'foobar', width: 123})).toEqual({
+      aggregation: '',
+      field: 'foobar',
+      width: 123,
+    });
+
+    // has aggregation
+    expect(explodeField({field: 'count(foobar)', width: 123})).toEqual({
+      aggregation: 'count',
+      field: 'foobar',
+      width: 123,
+    });
+
+    // custom tag
+    expect(explodeField({field: 'foo.bar.is-Enterprise-42', width: 123})).toEqual({
+      aggregation: '',
+      field: 'foo.bar.is-Enterprise-42',
+      width: 123,
+    });
+
+    // custom tag with aggregation
+    expect(explodeField({field: 'count(foo.bar.is-Enterprise-42)', width: 123})).toEqual({
+      aggregation: 'count',
+      field: 'foo.bar.is-Enterprise-42',
+      width: 123,
+    });
   });
 });

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -12,6 +12,7 @@ import {
   getFieldRenderer,
   getDiscoverLandingUrl,
   explodeField,
+  hasAggregateField,
 } from 'app/views/eventsV2/utils';
 import {COL_WIDTH_UNDEFINED, COL_WIDTH_NUMBER} from 'app/components/gridEditable';
 
@@ -403,5 +404,29 @@ describe('explodeField', function() {
       field: 'foo.bar.is-Enterprise-42',
       width: 123,
     });
+  });
+});
+
+describe('hasAggregateField', function() {
+  it('ensures an eventview has an aggregate field', function() {
+    let eventView = new EventView({
+      fields: [{field: 'foobar'}],
+      sorts: [],
+      query: '',
+      project: [],
+      environment: [],
+    });
+
+    expect(hasAggregateField(eventView)).toBe(false);
+
+    eventView = new EventView({
+      fields: [{field: 'count(foo.bar.is-Enterprise-42)'}],
+      sorts: [],
+      query: '',
+      project: [],
+      environment: [],
+    });
+
+    expect(hasAggregateField(eventView)).toBe(true);
   });
 });

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -267,6 +267,7 @@ describe('isAggregateField', function() {
   it('detects aliases', function() {
     expect(isAggregateField('p888')).toBe(false);
     expect(isAggregateField('other_field')).toBe(false);
+    expect(isAggregateField('foo.bar.is-Enterprise-42')).toBe(false);
     expect(isAggregateField('p75')).toBe(true);
     expect(isAggregateField('last_seen')).toBe(true);
   });
@@ -275,6 +276,7 @@ describe('isAggregateField', function() {
     expect(isAggregateField('thing(')).toBe(false);
     expect(isAggregateField('count()')).toBe(true);
     expect(isAggregateField('unique_count(user)')).toBe(true);
+    expect(isAggregateField('unique_count(foo.bar.is-Enterprise-42)')).toBe(true);
   });
 });
 

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -377,7 +377,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_1"],
                 "user": {"email": "foo@example.com"},
                 "environment": "prod",
-                "tags": {"sub_customer.is-enterprise": "1"},
+                "tags": {"sub_customer.is-Enterprise-42": "1"},
             },
             project_id=project.id,
         )
@@ -388,7 +388,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_2"],
                 "user": {"email": "foo@example.com"},
                 "environment": "staging",
-                "tags": {"sub_customer.is-enterprise": "1"},
+                "tags": {"sub_customer.is-Enterprise-42": "1"},
             },
             project_id=project.id,
         )
@@ -399,7 +399,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_2"],
                 "user": {"email": "foo@example.com"},
                 "environment": "prod",
-                "tags": {"sub_customer.is-enterprise": "0"},
+                "tags": {"sub_customer.is-Enterprise-42": "0"},
             },
             project_id=project.id,
         )
@@ -410,7 +410,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_2"],
                 "user": {"email": "foo@example.com"},
                 "environment": "prod",
-                "tags": {"sub_customer.is-enterprise": "1"},
+                "tags": {"sub_customer.is-Enterprise-42": "1"},
             },
             project_id=project.id,
         )
@@ -420,16 +420,19 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 self.url,
                 format="json",
                 data={
-                    "field": ["sub_customer.is-enterprise", "count(sub_customer.is-enterprise)"],
-                    "orderby": "sub_customer.is-enterprise",
+                    "field": [
+                        "sub_customer.is-Enterprise-42",
+                        "count(sub_customer.is-Enterprise-42)",
+                    ],
+                    "orderby": "sub_customer.is-Enterprise-42",
                 },
             )
 
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 2
         data = response.data["data"]
-        assert data[0]["count_sub_customer_is-enterprise"] == 1
-        assert data[1]["count_sub_customer_is-enterprise"] == 3
+        assert data[0]["count_sub_customer_is-Enterprise-42"] == 1
+        assert data[1]["count_sub_customer_is-Enterprise-42"] == 3
 
     def test_aggregation_comparison(self):
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -370,14 +370,14 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
     def test_aggregation(self):
         self.login_as(user=self.user)
         project = self.create_project()
-        event = self.store_event(
+        self.store_event(
             data={
                 "event_id": "a" * 32,
                 "timestamp": self.min_ago,
                 "fingerprint": ["group_1"],
                 "user": {"email": "foo@example.com"},
                 "environment": "prod",
-                "tags": {"sub_customer.is-enterprise)": "1"},
+                "tags": {"sub_customer.is-enterprise": "1"},
             },
             project_id=project.id,
         )
@@ -388,7 +388,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_2"],
                 "user": {"email": "foo@example.com"},
                 "environment": "staging",
-                "tags": {"sub_customer.is-enterprise)": "1"},
+                "tags": {"sub_customer.is-enterprise": "1"},
             },
             project_id=project.id,
         )
@@ -399,7 +399,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_2"],
                 "user": {"email": "foo@example.com"},
                 "environment": "prod",
-                "tags": {"sub_customer.is-enterprise)": "0"},
+                "tags": {"sub_customer.is-enterprise": "0"},
             },
             project_id=project.id,
         )
@@ -410,7 +410,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_2"],
                 "user": {"email": "foo@example.com"},
                 "environment": "prod",
-                "tags": {"sub_customer.is-enterprise)": "1"},
+                "tags": {"sub_customer.is-enterprise": "1"},
             },
             project_id=project.id,
         )
@@ -420,8 +420,8 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 self.url,
                 format="json",
                 data={
-                    "field": ["sub_customer.is-enterprise)", "count(sub_customer.is-enterprise))"],
-                    "orderby": "sub_customer.is-enterprise)",
+                    "field": ["sub_customer.is-enterprise", "count(sub_customer.is-enterprise)"],
+                    "orderby": "sub_customer.is-enterprise",
                 },
             )
 

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -377,7 +377,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_1"],
                 "user": {"email": "foo@example.com"},
                 "environment": "prod",
-                "tags": {"sub_customer.is-enterprise": "1"},
+                "tags": {"sub_customer.is-enterprise)": "1"},
             },
             project_id=project.id,
         )
@@ -388,7 +388,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_2"],
                 "user": {"email": "foo@example.com"},
                 "environment": "staging",
-                "tags": {"sub_customer.is-enterprise": "1"},
+                "tags": {"sub_customer.is-enterprise)": "1"},
             },
             project_id=project.id,
         )
@@ -399,7 +399,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_2"],
                 "user": {"email": "foo@example.com"},
                 "environment": "prod",
-                "tags": {"sub_customer.is-enterprise": "0"},
+                "tags": {"sub_customer.is-enterprise)": "0"},
             },
             project_id=project.id,
         )
@@ -410,7 +410,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "fingerprint": ["group_2"],
                 "user": {"email": "foo@example.com"},
                 "environment": "prod",
-                "tags": {"sub_customer.is-enterprise": "1"},
+                "tags": {"sub_customer.is-enterprise)": "1"},
             },
             project_id=project.id,
         )
@@ -420,8 +420,8 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 self.url,
                 format="json",
                 data={
-                    "field": ["sub_customer.is-enterprise", "count(sub_customer.is-enterprise)"],
-                    "orderby": "sub_customer.is-enterprise",
+                    "field": ["sub_customer.is-enterprise)", "count(sub_customer.is-enterprise))"],
+                    "orderby": "sub_customer.is-enterprise)",
                 },
             )
 

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -367,6 +367,70 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert data[0]["transaction"] == event.transaction
         assert data[0]["error_rate"] == 0.75
 
+    def test_aggregation(self):
+        self.login_as(user=self.user)
+        project = self.create_project()
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "timestamp": self.min_ago,
+                "fingerprint": ["group_1"],
+                "user": {"email": "foo@example.com"},
+                "environment": "prod",
+                "tags": {"sub_customer.is-enterprise": "1"},
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "timestamp": self.min_ago,
+                "fingerprint": ["group_2"],
+                "user": {"email": "foo@example.com"},
+                "environment": "staging",
+                "tags": {"sub_customer.is-enterprise": "1"},
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "timestamp": self.min_ago,
+                "fingerprint": ["group_2"],
+                "user": {"email": "foo@example.com"},
+                "environment": "prod",
+                "tags": {"sub_customer.is-enterprise": "0"},
+            },
+            project_id=project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "d" * 32,
+                "timestamp": self.min_ago,
+                "fingerprint": ["group_2"],
+                "user": {"email": "foo@example.com"},
+                "environment": "prod",
+                "tags": {"sub_customer.is-enterprise": "1"},
+            },
+            project_id=project.id,
+        )
+
+        with self.feature("organizations:discover-basic"):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "field": ["sub_customer.is-enterprise", "count(sub_customer.is-enterprise)"],
+                    "orderby": "sub_customer.is-enterprise",
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 2
+        data = response.data["data"]
+        assert data[0]["count_sub_customer_is-enterprise"] == 1
+        assert data[1]["count_sub_customer_is-enterprise"] == 3
+
     def test_aggregation_comparison(self):
         self.login_as(user=self.user)
         project = self.create_project()


### PR DESCRIPTION
I added a test with events with tags that makes use of special characters: period, underscore, and hyphen.