### PR TITLE
fix(ui): Fix LightweightOrg loading last used project

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationContext.jsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.jsx
@@ -203,6 +203,7 @@ const OrganizationContext = createReactClass({
       // We do not want to load the user's last used env/project in this case, otherwise will
       // lead to very confusing behavior.
       if (
+        organization.projects &&
         !this.props.routes.find(
           ({path}) => path && path.includes('/organizations/:orgId/issues/:groupId/')
         )


### PR DESCRIPTION
LightweightOrganization would attempt to intialize global selection store with last selected project if projects request takes too long to fetch.

#sync-getsentry