### PR TITLE
feat(workfow): Change Alerts Stream beta tooltip

### DIFF
--- a/src/sentry/static/sentry/app/views/incidents/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/list/index.tsx
@@ -147,7 +147,8 @@ class IncidentsListContainer extends React.Component<Props> {
         <PageContent>
           <PageHeader>
             <PageHeading>
-              {t('Alerts')} <BetaTag />
+              {t('Alerts')}{' '}
+              <BetaTag title={t('Alert stream only shows metric alerts while in beta')} />
             </PageHeading>
 
             <Actions>

--- a/src/sentry/static/sentry/app/views/incidents/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/list/index.tsx
@@ -148,7 +148,11 @@ class IncidentsListContainer extends React.Component<Props> {
           <PageHeader>
             <PageHeading>
               {t('Alerts')}{' '}
-              <BetaTag title={t('Alert stream only shows metric alerts while in beta')} />
+              <BetaTag
+                title={t(
+                  'This feature may change in the future and currently only shows metric alerts'
+                )}
+              />
             </PageHeading>
 
             <Actions>


### PR DESCRIPTION
Changes the Alert Stream beta tooltip to mention that only Metric Alerts are in the stream during the beta period.


See https://app.asana.com/0/1143846759074121/1158452746363785