### PR TITLE
feat(workflow): Add link to Alert Rule settings from stream

### DIFF
--- a/src/sentry/static/sentry/app/views/incidents/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/list/index.tsx
@@ -160,7 +160,7 @@ class IncidentsListContainer extends React.Component<Props> {
             <Actions>
               <Button
                 onClick={this.handleNavigateToSettings}
-                href={`/settings/${orgId}/`}
+                href="#"
                 size="small"
                 icon="icon-settings"
               >

--- a/src/sentry/static/sentry/app/views/incidents/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/incidents/list/index.tsx
@@ -1,13 +1,13 @@
-import {Location} from 'history';
-import {Params} from 'react-router/lib/Router';
-import omit from 'lodash/omit';
+import {RouteComponentProps} from 'react-router/lib/Router';
 import DocumentTitle from 'react-document-title';
 import React from 'react';
 import moment from 'moment';
+import omit from 'lodash/omit';
 import styled from '@emotion/styled';
 
 import {PageContent, PageHeader} from 'app/styles/organization';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
+import {navigateTo} from 'app/actionCreators/navigation';
 import {t} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
 import BetaTag from 'app/components/betaTag';
@@ -22,16 +22,13 @@ import Pagination from 'app/components/pagination';
 import getDynamicText from 'app/utils/getDynamicText';
 import space from 'app/styles/space';
 
-import Status from '../status';
-import SparkLine from './sparkLine';
 import {Incident} from '../types';
+import SparkLine from './sparkLine';
+import Status from '../status';
 
 const DEFAULT_QUERY_STATUS = '';
 
-type Props = {
-  params: Params;
-  location: Location;
-};
+type Props = RouteComponentProps<{orgId: string}, {}>;
 
 type State = {
   incidentList: Incident[];
@@ -131,6 +128,16 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
 }
 
 class IncidentsListContainer extends React.Component<Props> {
+  /**
+   * Incidents list is currently at the organization level, but the link needs to
+   * go down to a specific project scope.
+   */
+  handleNavigateToSettings = (e: React.MouseEvent) => {
+    e.preventDefault();
+
+    navigateTo('/settings/:orgId/projects/:projectId/alerts-v2/', this.props.router);
+  };
+
   render() {
     const {params, location} = this.props;
     const {pathname, query} = location;
@@ -151,6 +158,15 @@ class IncidentsListContainer extends React.Component<Props> {
             </PageHeading>
 
             <Actions>
+              <Button
+                onClick={this.handleNavigateToSettings}
+                href={`/settings/${orgId}/`}
+                size="small"
+                icon="icon-settings"
+              >
+                {t('Settings')}
+              </Button>
+
               <div className="btn-group">
                 <Button
                   to={{pathname, query: allIncidentsQuery}}


### PR DESCRIPTION
This adds a "Settings" button to the top of Alerts Stream that will have the user choose a project before redirecting them to the Alert Rule Settings list.

See https://app.asana.com/0/1143846759074121/1158223387107073